### PR TITLE
[v1.31] fix(hetzner): deprecated server type will break on 2024-09-06

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -41,7 +41,6 @@ const (
 	providerIDPrefix           = "hcloud://"
 	nodeGroupLabel             = hcloudLabelNamespace + "/node-group"
 	hcloudLabelNamespace       = "hcloud"
-	drainingNodePoolId         = "draining-node-pool"
 	serverCreateTimeoutDefault = 5 * time.Minute
 	serverRegisterTimeout      = 10 * time.Minute
 	defaultPodAmountsLimit     = 110

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -206,16 +206,6 @@ func newManager() (*hetznerManager, error) {
 		cachedServers:    newServersCache(ctx, client),
 	}
 
-	m.nodeGroups[drainingNodePoolId] = &hetznerNodeGroup{
-		manager:      m,
-		instanceType: "cx11",
-		region:       "fsn1",
-		targetSize:   0,
-		maxSize:      0,
-		minSize:      0,
-		id:           drainingNodePoolId,
-	}
-
 	return m, nil
 }
 
@@ -250,11 +240,6 @@ func (m *hetznerManager) deleteByNode(node *apiv1.Node) error {
 func (m *hetznerManager) deleteServer(server *hcloud.Server) error {
 	_, err := m.client.Server.Delete(m.apiCallContext, server)
 	return err
-}
-
-func (m *hetznerManager) addNodeToDrainingPool(node *apiv1.Node) (*hetznerNodeGroup, error) {
-	m.nodeGroups[drainingNodePoolId].targetSize += 1
-	return m.nodeGroups[drainingNodePoolId], nil
 }
 
 func (m *hetznerManager) validProviderID(providerID string) bool {

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -287,7 +287,7 @@ func (n *hetznerNodeGroup) TemplateNodeInfo() (*schedulerframework.NodeInfo, err
 	}
 	node.Labels = cloudprovider.JoinStringMaps(node.Labels, nodeGroupLabels)
 
-	if n.manager.clusterConfig.IsUsingNewFormat && n.id != drainingNodePoolId {
+	if n.manager.clusterConfig.IsUsingNewFormat {
 		for _, taint := range n.manager.clusterConfig.NodeConfigs[n.id].Taints {
 			node.Spec.Taints = append(node.Spec.Taints, apiv1.Taint{
 				Key:    taint.Key,
@@ -391,7 +391,7 @@ func buildNodeGroupLabels(n *hetznerNodeGroup) (map[string]string, error) {
 		nodeGroupLabel:               n.id,
 	}
 
-	if n.manager.clusterConfig.IsUsingNewFormat && n.id != drainingNodePoolId {
+	if n.manager.clusterConfig.IsUsingNewFormat {
 		maps.Copy(labels, n.manager.clusterConfig.NodeConfigs[n.id].Labels)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

The `cx11` server type was deprecated on 2024-06-06 and will be removed from the API on 2024-09-06. Once it is removed, the cluster-autoscaler provider hetzner will not start anymore with the following error message:

    Failed to get node infos for groups: failed to create resource list for node group draining-node-pool error: failed to get machine type cx11 info error: server type not found

As the node pool `draining-node-pool` is not being used anywhere, this commit removes it and the hard coded reference to the deprecated server type.

Backport of #7211 to `1.31` branch.

#### Which issue(s) this PR 

Related to #7210

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix Hetzner Provider not starting after 2024-09-07
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Hetzner Cloud Changelog](https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated)
```
