### PR TITLE
Add new error mappings to autoscaling GCE client

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -215,6 +215,18 @@ func TestErrors(t *testing.T) {
 			expectedErrorCode:  "INVALID_RESERVATION",
 			expectedErrorClass: cloudprovider.OtherErrorClass,
 		},
+		{
+			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "Unsupported TPU configuration",
+			expectedErrorCode:  ErrorUnsupportedTpuConfiguration,
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
+		{
+			errorCodes:         []string{"SPECIFIC_ALLOCATION"},
+			errorMessage:       "Specified reservations [this-reservation-does-not-exist] do not exist. (when acting as",
+			expectedErrorCode:  ErrorInvalidReservation,
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
 	}
 	for _, tc := range testCases {
 		for _, errorCode := range tc.errorCodes {


### PR DESCRIPTION
In the scope of this commit new error mappings were added to the autoscaling GCE client, to cover the following errors on the GCE side:
- Reservation out of resources,
- Reservation does not exist (extended INVALID_RESERVATION),
- Unsupported TPU configuration.

Additionally removed the code smell in two functions, to which a parameter, errorCode, was unnecessarily passed (wasn't used by the functions).

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
see #7302 

#### Which issue(s) this PR fixes:
Fixes #7302 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```