### PR TITLE
fix: Generate certs for VPA on kubectl apply or create

### DIFF
--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -64,6 +64,7 @@ fi
 for i in $COMPONENTS; do
   if [ $i == admission-controller-deployment ] ; then
     if [ ${ACTION} == create -o ${ACTION} == update] ; then
+      # Allow gencerts to fail silently if certs already exist
       (bash ${SCRIPT_ROOT}/pkg/admission-controller/gencerts.sh || true)
     elif [ ${ACTION} == delete ] ; then
       (bash ${SCRIPT_ROOT}/pkg/admission-controller/rmcerts.sh || true)

--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -63,7 +63,7 @@ fi
 
 for i in $COMPONENTS; do
   if [ $i == admission-controller-deployment ] ; then
-    if [ ${ACTION} == create ] ; then
+    if [ ${ACTION} == create -o ${ACTION} == update] ; then
       (bash ${SCRIPT_ROOT}/pkg/admission-controller/gencerts.sh || true)
     elif [ ${ACTION} == delete ] ; then
       (bash ${SCRIPT_ROOT}/pkg/admission-controller/rmcerts.sh || true)

--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -63,7 +63,7 @@ fi
 
 for i in $COMPONENTS; do
   if [ $i == admission-controller-deployment ] ; then
-    if [ ${ACTION} == create -o ${ACTION} == update] ; then
+    if [[ ${ACTION} == create || ${ACTION} == update ]] ; then
       # Allow gencerts to fail silently if certs already exist
       (bash ${SCRIPT_ROOT}/pkg/admission-controller/gencerts.sh || true)
     elif [ ${ACTION} == delete ] ; then


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes https://github.com/kubernetes/autoscaler/issues/7270

The gencert.sh is run with a `|| true`, so it doesn't matter if it fails: https://github.com/kubernetes/autoscaler/blob/59aba2b4063ad195075636e371345c2f75c7522a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh#L67

And gencert uses `kubectl create` (see
https://github.com/kubernetes/autoscaler/blob/59aba2b4063ad195075636e371345c2f75c7522a/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh#L58-L65) so if it were run multiple times, it would fail.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/7270

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
