### PR TITLE
fix kwok provider docs to use cloudProvider and helm chart

### DIFF
--- a/cluster-autoscaler/cloudprovider/kwok/README.md
+++ b/cluster-autoscaler/cloudprovider/kwok/README.md
@@ -27,9 +27,9 @@ Follow [the official docs to install `kwok`](https://kwok.sigs.k8s.io/docs/user/
 *Using helm chart*:
 ```shell
 helm repo add cluster-autoscaler https://kubernetes.github.io/autoscaler
-helm upgrade --install <release-name> charts/cluster-autoscaler  \
+helm upgrade --install <release-name> cluster-autoscaler/cluster-autoscaler  \
 --set "serviceMonitor.enabled"=true --set "serviceMonitor.namespace"=default \
---set "cloudprovider"=kwok --set "image.tag"="<image-tag>" \
+--set "cloudProvider"=kwok --set "image.tag"="<image-tag>" \
 --set "image.repository"="<image-repo>" \
 --set "autoDiscovery.clusterName"="kind-kind" \
 --set "serviceMonitor.selector.release"="prom"


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
When documenting how to install the kwok provider:
  1. We do not use the added helm repo in the current docs.
  2. The parameter for `cloudProvider` incorrectly uses all lower case causing the default aws provider to be installed.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
