### PR TITLE
Make reservation errors more granular

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -60,9 +60,13 @@ const (
 	ErrorCodeVmExternalIpAccessPolicyConstraint = "VM_EXTERNAL_IP_ACCESS_POLICY_CONSTRAINT"
 
 	// ErrorInvalidReservation is an error code for InstanceErrorInfo if the node group couldn't
-	// be scaled up because no reservation was found, or the reservation associated with the MIG
-	// was invalid.
+	// be scaled up because the reservation associated with the MIG was invalid.
 	ErrorInvalidReservation = "INVALID_RESERVATION"
+
+	// ErrorReservationNotFound is an error code for InstanceErrorInfo if the node group couldn't
+	// be scaled up because no reservation was found, or the reservation was in different location,
+	// or the reservation was incorrectly shared.
+	ErrorReservationNotFound = "RESERVATION_NOT_FOUND"
 
 	// ErrorReservationNotReady is an error code for InstanceErrorInfo if the node group couldn't
 	// be scaled up because the associated reservation was not ready.
@@ -71,6 +75,10 @@ const (
 	// ErrorReservationCapacityExceeded is an error code for InstanceErrorInfo if the node group couldn't
 	// be scaled up because the associated reservation's capacity has been exceeded.
 	ErrorReservationCapacityExceeded = "RESERVATION_CAPACITY_EXCEEDED"
+
+	// ErrorReservationIncompatible is an error code for InstanceErrorInfo if the node group couldn't
+	// be scaled up because the associated reservation is not compatible with the node group.
+	ErrorReservationIncompatible = "RESERVATION_INCOMPATIBLE"
 
 	// ErrorUnsupportedTpuConfiguration is an error code for InstanceErrorInfo if the
 	// node group couldn't be scaled up because of invalid TPU configuration.
@@ -96,7 +104,6 @@ var (
 		regexp.MustCompile("VM Family: (.*) is not supported for aggregate reservations. It must be one of"),
 		regexp.MustCompile("Reservation (.*) is incorrect for the requested resources"),
 		regexp.MustCompile("Zone does not currently have sufficient capacity for the requested resources"),
-		regexp.MustCompile("Specified reservations (.*) do not exist"),
 	}
 )
 
@@ -583,10 +590,20 @@ func GetErrorInfo(errorCode, errorMessage, instanceStatus string, previousErrorI
 			ErrorClass: cloudprovider.OtherErrorClass,
 			ErrorCode:  ErrorInvalidReservation,
 		}
+	} else if isReservationNotFound(errorMessage) {
+		return &cloudprovider.InstanceErrorInfo{
+			ErrorClass: cloudprovider.OtherErrorClass,
+			ErrorCode:  ErrorReservationNotFound,
+		}
 	} else if isReservationCapacityExceeded(errorMessage) {
 		return &cloudprovider.InstanceErrorInfo{
 			ErrorClass: cloudprovider.OtherErrorClass,
 			ErrorCode:  ErrorReservationCapacityExceeded,
+		}
+	} else if isReservationIncompatible(errorMessage) {
+		return &cloudprovider.InstanceErrorInfo{
+			ErrorClass: cloudprovider.OtherErrorClass,
+			ErrorCode:  ErrorReservationIncompatible,
 		}
 	} else if isTpuConfigurationInvalidError(errorCode, errorMessage) {
 		return &cloudprovider.InstanceErrorInfo{
@@ -669,9 +686,19 @@ func isReservationNotReady(errorMessage string) bool {
 	return strings.Contains(errorMessage, "it requires reservation to be in READY state")
 }
 
+func isReservationNotFound(errorMessage string) bool {
+	re := regexp.MustCompile("Specified reservations? (.*) do(es)? not exist")
+	return re.MatchString(errorMessage)
+}
+
 func isReservationCapacityExceeded(errorMessage string) bool {
 	re := regexp.MustCompile("Specified reservation (.*) does not have available resources for the request.")
 	return re.MatchString(errorMessage)
+}
+
+func isReservationIncompatible(errorMessage string) bool {
+	pattern := "No available resources in specified reservations"
+	return strings.Contains(errorMessage, pattern)
 }
 
 func isInvalidReservationError(errorMessage string) bool {

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -200,6 +200,18 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "Specified reservation 'rsv-name' does not exist.",
+			expectedErrorCode:  "RESERVATION_NOT_FOUND",
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
+		{
+			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "Specified reservations [this-reservation-does-not-exist] do not exist. (when acting as",
+			expectedErrorCode:  "RESERVATION_NOT_FOUND",
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
+		{
+			errorCodes:         []string{"CONDITION_NOT_MET"},
 			errorMessage:       "Cannot insert instance to a reservation with status: CREATING, as it requires reservation to be in READY state.",
 			expectedErrorCode:  "RESERVATION_NOT_READY",
 			expectedErrorClass: cloudprovider.OtherErrorClass,
@@ -217,14 +229,14 @@ func TestErrors(t *testing.T) {
 		},
 		{
 			errorCodes:         []string{"CONDITION_NOT_MET"},
-			errorMessage:       "Unsupported TPU configuration",
-			expectedErrorCode:  ErrorUnsupportedTpuConfiguration,
+			errorMessage:       "No available resources in specified reservations 'rsv-name'",
+			expectedErrorCode:  "RESERVATION_INCOMPATIBLE",
 			expectedErrorClass: cloudprovider.OtherErrorClass,
 		},
 		{
-			errorCodes:         []string{"SPECIFIC_ALLOCATION"},
-			errorMessage:       "Specified reservations [this-reservation-does-not-exist] do not exist. (when acting as",
-			expectedErrorCode:  ErrorInvalidReservation,
+			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "Unsupported TPU configuration",
+			expectedErrorCode:  ErrorUnsupportedTpuConfiguration,
 			expectedErrorClass: cloudprovider.OtherErrorClass,
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:
Add more granular reservation errors to improve visibility


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
