### PR TITLE
Report only injected pods after enforcing pod limit

### DIFF
--- a/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor.go
+++ b/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor.go
@@ -23,7 +23,6 @@ import (
 )
 
 const (
-
 	// InjectedMetricsLabel is the label for unschedulable pods metric for injected pods.
 	InjectedMetricsLabel = "injected"
 	// SkippedInjectionMetricsLabel is the label for unschedulable pods metric for pods that was not injected due to limit.
@@ -52,11 +51,11 @@ func (p *EnforceInjectedPodsLimitProcessor) Process(ctx *context.AutoscalingCont
 
 	for _, pod := range unschedulablePods {
 		if IsFake(pod) {
-			injectedFakePodsCount += 1
 			if removedFakePodsCount < numberOfFakePodsToRemove {
 				removedFakePodsCount += 1
 				continue
 			}
+			injectedFakePodsCount += 1
 		}
 
 		unschedulablePodsAfterProcessing = append(unschedulablePodsAfterProcessing, pod)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Makes sure that injected pods metric includes only the number of pods that were injected after enforcing the pod limit.
(i.e. If 10 pods were injected but 3 got removed because we've gone over the pod limit, 7 should be the reported metric not 10)

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
