### PR TITLE
Add metrics-server annotation for kwok-provider managed nodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/kwok/kwok_nodegroups.go
+++ b/cluster-autoscaler/cloudprovider/kwok/kwok_nodegroups.go
@@ -76,6 +76,10 @@ func (nodeGroup *NodeGroup) IncreaseSize(delta int) error {
 	for i := 0; i < delta; i++ {
 		node := schedNode.Node()
 		node.Name = fmt.Sprintf("%s-%s", nodeGroup.name, rand.String(5))
+		if node.Annotations == nil {
+			node.Annotations = map[string]string{}
+		}
+		node.Annotations["metrics.k8s.io/resource-metrics-path"] = fmt.Sprintf("/metrics/nodes/%s/metrics/resource", node.Name)
 		node.Spec.ProviderID = getProviderID(node.Name)
 		_, err := nodeGroup.kubeClient.CoreV1().Nodes().Create(context.Background(), node, v1.CreateOptions{})
 		if err != nil {

--- a/cluster-autoscaler/cloudprovider/kwok/kwok_nodegroups_test.go
+++ b/cluster-autoscaler/cloudprovider/kwok/kwok_nodegroups_test.go
@@ -71,6 +71,7 @@ func TestIncreaseSize(t *testing.T) {
 	for _, n := range nodes {
 		assert.Contains(t, n.Spec.ProviderID, "kwok")
 		assert.Contains(t, n.GetName(), ng.name)
+		assert.Contains(t, n.Annotations["metrics.k8s.io/resource-metrics-path"], fmt.Sprintf("/metrics/nodes/%s/metrics/resource", n.GetName()))
 	}
 
 	// delta is negative


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
In order for kwok to correctly simulate metrics usage the following annotation must be set on the nodes:
```
metrics.k8s.io/resource-metrics-path: /metrics/nodes/<node name>/metrics/resource
```

This only used if:
 - kwok is configured to simulate resource usage of pods.
 - the cluster is running metrics-server version >= 0.7.0,

Otherwise adding this annotation is a noop.

#### Does this PR introduce a user-facing change?
```release-note
cluster-autoscaler kwok cloudprovider automatically annotates nodes with metrics-server path
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [Other doc] https://github.com/kubernetes-sigs/metrics-server/pull/1253: metrics-server support for the path annotation.
- [Other Doc] https://kwok.sigs.k8s.io/docs/user/resource-usage-configuration: kwok documentation on overriding the path to collect resource usage.
```
