### PR TITLE
Handle intentionally empty grpc BestOptions

### DIFF
--- a/cluster-autoscaler/expander/grpcplugin/grpc_client.go
+++ b/cluster-autoscaler/expander/grpcplugin/grpc_client.go
@@ -96,6 +96,10 @@ func (g *grpcclientstrategy) BestOptions(expansionOptions []expander.Option, nod
 		klog.V(4).Info("GRPC returned nil bestOptions, no options filtered")
 		return expansionOptions
 	}
+	if len(bestOptionsResponse.Options) == 0 {
+		// best options is intentionally empty
+		return nil
+	}
 	// Transform back options slice
 	options := transformAndSanitizeOptionsFromGRPC(bestOptionsResponse.Options, nodeGroupIDOptionMap)
 	if options == nil {

--- a/cluster-autoscaler/expander/grpcplugin/grpc_client_test.go
+++ b/cluster-autoscaler/expander/grpcplugin/grpc_client_test.go
@@ -197,6 +197,31 @@ func TestBestOptionsValid(t *testing.T) {
 	assert.Equal(t, resp, []expander.Option{eoT3Large})
 }
 
+func TestBestOptionsEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mocks.NewMockExpanderClient(ctrl)
+	g := &grpcclientstrategy{mockClient}
+
+	nodeInfos := makeFakeNodeInfos()
+	grpcNodeInfoMap := make(map[string]*v1.Node)
+	for i, opt := range options {
+		grpcNodeInfoMap[opt.NodeGroup.Id()] = nodes[i]
+	}
+	expectedBestOptionsReq := &protos.BestOptionsRequest{
+		Options: []*protos.Option{&grpcEoT2Micro, &grpcEoT2Large, &grpcEoT3Large, &grpcEoM44XLarge},
+		NodeMap: grpcNodeInfoMap,
+	}
+
+	mockClient.EXPECT().BestOptions(
+		gomock.Any(), gomock.Eq(expectedBestOptionsReq),
+	).Return(&protos.BestOptionsResponse{Options: []*protos.Option{}}, nil)
+
+	resp := g.BestOptions(options, nodeInfos)
+
+	assert.Empty(t, resp)
+}
+
 // All test cases should error, and no options should be filtered
 func TestBestOptionsErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
When trying to filter out all options from the gRPC expander side, I noticed that the gRPC expander client on cluster autoscaler would return all the expansion options, rather than none of them.

In the case of nil best options, it returns all original options https://github.com/rrangith/autoscaler/blob/721ea01f7f284484fa491ae89e08bded434bcd46/cluster-autoscaler/expander/grpcplugin/grpc_client.go#L95-L98

And if best options is an empty slice, then it still ends up returning all original options https://github.com/rrangith/autoscaler/blob/721ea01f7f284484fa491ae89e08bded434bcd46/cluster-autoscaler/expander/grpcplugin/grpc_client.go#L105-L108

So I added an additional check to see if the best options slice is intentionally empty, and return nil in that case. This is similar to what other expanders do https://github.com/rrangith/autoscaler/blob/721ea01f7f284484fa491ae89e08bded434bcd46/cluster-autoscaler/expander/waste/waste.go#L67-L69

If users want the original behaviour where the client ends up returning all original options, then on the gRPC expander server side they can return `nil`. Whereas if they want this new behaviour that handles an empty list of options, then they should return `[]*protos.Option{}`.