### PR TITLE
allow CA working even with a wrong oci nodepoolid provided

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
@@ -40,11 +40,11 @@ func (c *nodePoolCache) nodePools() map[string]*oke.NodePool {
 	return result
 }
 
-func (c *nodePoolCache) rebuild(staticNodePools map[string]NodePool, maxGetNodepoolRetries int) (httpStatusCode int, err error) {
+func (c *nodePoolCache) rebuild(staticNodePools map[string]NodePool, maxGetNodepoolRetries int) (err error) {
 	klog.Infof("rebuilding cache")
-	var statusCode int
 	for id := range staticNodePools {
 		var resp oke.GetNodePoolResponse
+		var err error
 		for i := 1; i <= maxGetNodepoolRetries; i++ {
 			// prevent us from getting a node pool at the same time that we're performing delete actions on the node pool.
 			c.mu.Lock()
@@ -52,8 +52,6 @@ func (c *nodePoolCache) rebuild(staticNodePools map[string]NodePool, maxGetNodep
 				NodePoolId: common.String(id),
 			})
 			c.mu.Unlock()
-			httpResp := resp.HTTPResponse()
-			statusCode = httpResp.StatusCode
 			if err != nil {
 				klog.Errorf("Failed to fetch the nodepool : %v. Retries available : %v", id, maxGetNodepoolRetries-i)
 			} else {
@@ -68,7 +66,7 @@ func (c *nodePoolCache) rebuild(staticNodePools map[string]NodePool, maxGetNodep
 			c.set(&resp.NodePool)
 		}
 	}
-	return statusCode, nil
+	return nil
 }
 
 // removeInstance tries to remove the instance from the node pool.

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
@@ -62,10 +62,8 @@ func (c *nodePoolCache) rebuild(staticNodePools map[string]NodePool, maxGetNodep
 		}
 		if err != nil {
 			// in order to let cluster autoscaler still do its work even with a wrong nodepoolid,
-			// we avoid returning an error but instead log and remove it from nodepool list
-			klog.Errorf("Failed to fetch the nodepool : %v", id)
-			klog.Errorf("Removing nodepool from the list to avoid further issues : %v", id)
-			delete(staticNodePools, id)
+			// we avoid returning an error but instead log and do not add it to cache so it won't be used for scaling.
+			klog.Errorf("The nodepool will not be considered for scaling until next check : %v", id)
 		} else {
 			c.set(&resp.NodePool)
 		}

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
@@ -44,7 +44,6 @@ func (c *nodePoolCache) rebuild(staticNodePools map[string]NodePool, maxGetNodep
 	klog.Infof("rebuilding cache")
 	for id := range staticNodePools {
 		var resp oke.GetNodePoolResponse
-		var err error
 		for i := 1; i <= maxGetNodepoolRetries; i++ {
 			// prevent us from getting a node pool at the same time that we're performing delete actions on the node pool.
 			c.mu.Lock()

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
@@ -61,10 +61,14 @@ func (c *nodePoolCache) rebuild(staticNodePools map[string]NodePool, maxGetNodep
 			}
 		}
 		if err != nil {
+			// in order to let cluster autoscaler still do its work even with a wrong nodepoolid,
+			// we avoid returning an error but instead log and remove it from nodepool list
 			klog.Errorf("Failed to fetch the nodepool : %v", id)
-			return statusCode, err
+			klog.Errorf("Removing nodepool from the list to avoid further issues : %v", id)
+			delete(staticNodePools, id)
+		} else {
+			c.set(&resp.NodePool)
 		}
-		c.set(&resp.NodePool)
 	}
 	return statusCode, nil
 }

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -257,7 +257,7 @@ func (m *ociManagerImpl) forceRefresh() error {
 	if err != nil {
 		return err
 	}
-	
+
 	m.lastRefresh = time.Now()
 	klog.Infof("Refreshed NodePool list, next refresh after %v", m.lastRefresh.Add(m.cfg.Global.RefreshInterval))
 	return nil

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -253,15 +253,11 @@ func (m *ociManagerImpl) TaintToPreventFurtherSchedulingOnRestart(nodes []*apiv1
 }
 
 func (m *ociManagerImpl) forceRefresh() error {
-	httpStatusCode, err := m.nodePoolCache.rebuild(m.staticNodePools, maxGetNodepoolRetries)
+	err := m.nodePoolCache.rebuild(m.staticNodePools, maxGetNodepoolRetries)
 	if err != nil {
-		if httpStatusCode == 404 {
-			m.lastRefresh = time.Now()
-			klog.Errorf("Failed to fetch the nodepools. Retrying after %v", m.lastRefresh.Add(m.cfg.Global.RefreshInterval))
-			return err
-		}
 		return err
 	}
+	
 	m.lastRefresh = time.Now()
 	klog.Infof("Refreshed NodePool list, next refresh after %v", m.lastRefresh.Add(m.cfg.Global.RefreshInterval))
 	return nil

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -276,7 +276,10 @@ func (m *ociManagerImpl) Cleanup() error {
 func (m *ociManagerImpl) GetNodePools() []NodePool {
 	var nodePools []NodePool
 	for _, np := range m.staticNodePools {
-		nodePools = append(nodePools, np)
+		nodePoolInCache := m.nodePoolCache.cache[np.Id()]
+		if nodePoolInCache != nil {
+			nodePools = append(nodePools, np)
+		}
 	}
 	return nodePools
 }


### PR DESCRIPTION
#### What type of PR is this?
bug

#### What this PR does / why we need it:
When a nodepool was deleted and no more exists in OCI, cluster autoscaler wouldn't work as expected until nodepoolid was removed from config and pod was restarted. We need this code change to ensure cluster autoscaler would still work even with a wrong nodepoolid was provided. In such a scenario, cluster autoscaler will remove the nodepoolid from the list and write logs. It will still work as expected with the remaining nodepools in the list. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Tests are done on a OCI cluster. If nodepool doesn't exist, it prints a log and removes it from the nodepool list. Below is the cluster autoscaler pod logs from the test.
```
gkazanci@gkazanci-mac clusterAutoscaler % kubectl logs cluster-autoscaler-85b78cfc45-pvl66  -n kube-system
I0913 09:25:38.536420       1 leaderelection.go:250] attempting to acquire leader lease kube-system/cluster-autoscaler...
I0913 09:25:54.112026       1 leaderelection.go:260] successfully acquired lease kube-system/cluster-autoscaler
W0913 09:25:54.254022       1 client_config.go:659] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0913 09:25:54.254671       1 oci_manager.go:93] using instance principal provider
I0913 09:25:59.744078       1 oci_manager.go:203] static node spec constructed: &{manager:<nil> kubeClient:<nil> id:ocid1.nodepoolinteg.oc1.phx.aaaaaaaap4ebay3amh6hdzloiu5o2wo5eul5lppr7fc4vzjmgnxir3n3wxpa minSize:1 maxSize:3}
I0913 09:25:59.827270       1 oci_manager.go:203] static node spec constructed: &{manager:<nil> kubeClient:<nil> id:ocid1.nodepoolinteg.oc1.phx.aaaaaaaa5pt3lg43imtxgavovxc22hmfptk4hkhpjnnec3pqpnpiji123456 minSize:1 maxSize:3}
I0913 09:25:59.827396       1 cache.go:44] rebuilding cache
E0913 09:25:59.957544       1 cache.go:58] Failed to fetch the nodepool : ocid1.nodepoolinteg.oc1.phx.aaaaaaaa5pt3lg43imtxgavovxc22hmfptk4hkhpjnnec3pqpnpiji123456. Retries available : 2
E0913 09:25:59.977935       1 cache.go:58] Failed to fetch the nodepool : ocid1.nodepoolinteg.oc1.phx.aaaaaaaa5pt3lg43imtxgavovxc22hmfptk4hkhpjnnec3pqpnpiji123456. Retries available : 1
E0913 09:26:00.045887       1 cache.go:58] Failed to fetch the nodepool : ocid1.nodepoolinteg.oc1.phx.aaaaaaaa5pt3lg43imtxgavovxc22hmfptk4hkhpjnnec3pqpnpiji123456. Retries available : 0
E0913 09:26:00.045993       1 cache.go:66] Failed to fetch the nodepool and stop retrying : ocid1.nodepoolinteg.oc1.phx.aaaaaaaa5pt3lg43imtxgavovxc22hmfptk4hkhpjnnec3pqpnpiji123456
E0913 09:26:00.046018       1 cache.go:67] Removing nodepool from the list to avoid further issues : ocid1.nodepoolinteg.oc1.phx.aaaaaaaa5pt3lg43imtxgavovxc22hmfptk4hkhpjnnec3pqpnpiji123456
I0913 09:26:00.046097       1 oci_manager.go:263] Refreshed NodePool list, next refresh after 2024-09-13 09:27:00.04609002 +0000 UTC m=+85.908964851
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
