### PR TITLE
Introduce ScaleUpNodeProcessor

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -342,6 +342,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		klog.Errorf("Failed to refresh cloud provider config: %v", err)
 		return caerrors.ToAutoscalerError(caerrors.CloudProviderError, err)
 	}
+	allNodes, readyNodes = a.processors.ScaleUpNodeProcessor.Process(a.AutoscalingContext, allNodes, readyNodes)
 	a.loopStartNotifier.Refresh()
 
 	// Update node groups min/max and maximum number of nodes being set for all node groups after cloud provider refresh

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -198,6 +198,7 @@ func NewTestProcessors(context *context.AutoscalingContext) *processors.Autoscal
 		ScaleDownCandidatesNotifier: scaledowncandidates.NewObserversList(),
 		ScaleStateNotifier:          nodegroupchange.NewNodeGroupChangeObserversList(),
 		AsyncNodeGroupStateChecker:  asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(),
+		ScaleUpNodeProcessor:        nodes.NewDefaultScaleUpNodeProcessor(),
 	}
 }
 

--- a/cluster-autoscaler/processors/nodes/scale_up_node_processor.go
+++ b/cluster-autoscaler/processors/nodes/scale_up_node_processor.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodes
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+// ScaleUpNodeProcessor is used to process the nodes of the cluster after cloud provider is refreshed and before scale-up.
+type ScaleUpNodeProcessor interface {
+	// Process processes the nodes of the cluster after cloud provider is refreshed and before scale-up.
+	Process(context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node)
+	// CleanUp is called at CA termination
+	CleanUp()
+}
+
+// NewDefaultScaleUpNodeProcessor creates a default instance of ScaleUpNodeProcessor that does not alter the nodes when processing.
+func NewDefaultScaleUpNodeProcessor() ScaleUpNodeProcessor {
+	return &defaultScaleUpNodeProcessor{}
+}
+
+type defaultScaleUpNodeProcessor struct{}
+
+func (p *defaultScaleUpNodeProcessor) Process(context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
+	return allNodes, readyNodes
+}
+
+func (p *defaultScaleUpNodeProcessor) CleanUp() {}

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -46,6 +46,8 @@ type AutoscalingProcessors struct {
 	NodeGroupSetProcessor nodegroupset.NodeGroupSetProcessor
 	// ScaleUpStatusProcessor is used to process the state of the cluster after a scale-up.
 	ScaleUpStatusProcessor status.ScaleUpStatusProcessor
+	// ScaleUpNodeProcessor is used to process the nodes of the cluster before scale-up.
+	ScaleUpNodeProcessor nodes.ScaleUpNodeProcessor
 	// ScaleDownNodeProcessor is used to process the nodes of the cluster before scale-down.
 	ScaleDownNodeProcessor nodes.ScaleDownNodeProcessor
 	// ScaleDownSetProcessor is used to make final selection of nodes to scale-down.
@@ -88,6 +90,7 @@ func DefaultProcessors(options config.AutoscalingOptions) *AutoscalingProcessors
 			MaxFreeDifferenceRatio:           config.DefaultMaxFreeDifferenceRatio,
 		}),
 		ScaleUpStatusProcessor: status.NewDefaultScaleUpStatusProcessor(),
+		ScaleUpNodeProcessor:   nodes.NewDefaultScaleUpNodeProcessor(),
 		ScaleDownNodeProcessor: nodes.NewPreFilteringScaleDownNodeProcessor(),
 		ScaleDownSetProcessor: nodes.NewCompositeScaleDownSetProcessor(
 			[]nodes.ScaleDownSetProcessor{
@@ -114,6 +117,7 @@ func (ap *AutoscalingProcessors) CleanUp() {
 	ap.NodeGroupListProcessor.CleanUp()
 	ap.NodeGroupSetProcessor.CleanUp()
 	ap.ScaleUpStatusProcessor.CleanUp()
+	ap.ScaleUpNodeProcessor.CleanUp()
 	ap.ScaleDownSetProcessor.CleanUp()
 	ap.ScaleDownStatusProcessor.CleanUp()
 	ap.AutoscalingStatusProcessor.CleanUp()


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

PR introduces a processor that can filter nodes before scale-up. The processor is executed after cloudProvider is refreshed making it possible to alter the nodes used in scale-up simulations based on cloud provider logic. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:
cc: @x13n 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
