### PR TITLE
Backport #7335 and #7338[CA]Adds injection metrics for fake pod injection and Report only injected pods after enforcing pod limit into CA1.31

### DIFF
--- a/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor.go
+++ b/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor.go
@@ -19,6 +19,14 @@ package podinjection
 import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+)
+
+const (
+	// InjectedMetricsLabel is the label for unschedulable pods metric for injected pods.
+	InjectedMetricsLabel = "injected"
+	// SkippedInjectionMetricsLabel is the label for unschedulable pods metric for pods that was not injected due to limit.
+	SkippedInjectionMetricsLabel = "skipped_injection"
 )
 
 // EnforceInjectedPodsLimitProcessor is a PodListProcessor used to limit the number of injected fake pods.
@@ -37,16 +45,24 @@ func NewEnforceInjectedPodsLimitProcessor(podLimit int) *EnforceInjectedPodsLimi
 func (p *EnforceInjectedPodsLimitProcessor) Process(ctx *context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 
 	numberOfFakePodsToRemove := len(unschedulablePods) - p.podLimit
+	removedFakePodsCount := 0
+	injectedFakePodsCount := 0
 	var unschedulablePodsAfterProcessing []*apiv1.Pod
 
 	for _, pod := range unschedulablePods {
-		if IsFake(pod) && numberOfFakePodsToRemove > 0 {
-			numberOfFakePodsToRemove -= 1
-			continue
+		if IsFake(pod) {
+			if removedFakePodsCount < numberOfFakePodsToRemove {
+				removedFakePodsCount += 1
+				continue
+			}
+			injectedFakePodsCount += 1
 		}
 
 		unschedulablePodsAfterProcessing = append(unschedulablePodsAfterProcessing, pod)
 	}
+
+	metrics.UpdateUnschedulablePodsCountWithLabel(injectedFakePodsCount, InjectedMetricsLabel)
+	metrics.UpdateUnschedulablePodsCountWithLabel(removedFakePodsCount, SkippedInjectionMetricsLabel)
 
 	return unschedulablePodsAfterProcessing, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR is cherry-picked, which backports  #7335 and #7338 into CA 1.31

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
