### PR TITLE
Remove obsolete upper bound check

### DIFF
--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -76,9 +76,6 @@ func (n *nodePool) IncreaseSize(delta int) error {
 		return err
 	}
 	targetSize := size + delta
-	if targetSize > n.max {
-		return fmt.Errorf("size increase exceeds upper bound of %d", n.max)
-	}
 	return n.manager.SetNodeGroupSize(n, targetSize)
 }
 

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -71,7 +71,7 @@ func (n *nodePool) IncreaseSize(delta int) error {
 	if delta <= 0 {
 		return errors.New("size increase must be positive")
 	}
-	size, err := n.manager.GetNodeGroupSize(n)
+	size, err := n.manager.GetNodeGroupTargetSize(n)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider_test.go
@@ -117,11 +117,6 @@ func (s *NodeGroupTestSuite) TestIncreaseSize_GetSizeError() {
 	s.Error(s.nodePool.IncreaseSize(2))
 }
 
-func (s *NodeGroupTestSuite) TestIncreaseSize_ExceedMax() {
-	s.manager.On("GetNodeGroupSize", s.nodePool).Return(2, nil).Once()
-	s.Error(s.nodePool.IncreaseSize(2))
-}
-
 func (s *NodeGroupTestSuite) TestIncreaseSize_SetSizeError() {
 	s.manager.On("GetNodeGroupSize", s.nodePool).Return(2, nil).Once()
 	s.manager.On("SetNodeGroupSize", s.nodePool, 3).Return(errors.New("error")).Once()

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider_test.go
@@ -113,18 +113,18 @@ func (s *NodeGroupTestSuite) TestIncreaseSize_InvalidDelta() {
 }
 
 func (s *NodeGroupTestSuite) TestIncreaseSize_GetSizeError() {
-	s.manager.On("GetNodeGroupSize", s.nodePool).Return(0, errors.New("error")).Once()
+	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(0, errors.New("error")).Once()
 	s.Error(s.nodePool.IncreaseSize(2))
 }
 
 func (s *NodeGroupTestSuite) TestIncreaseSize_SetSizeError() {
-	s.manager.On("GetNodeGroupSize", s.nodePool).Return(2, nil).Once()
+	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(2, nil).Once()
 	s.manager.On("SetNodeGroupSize", s.nodePool, 3).Return(errors.New("error")).Once()
 	s.Error(s.nodePool.IncreaseSize(1))
 }
 
 func (s *NodeGroupTestSuite) TestIncreaseSize_OK() {
-	s.manager.On("GetNodeGroupSize", s.nodePool).Return(2, nil).Once()
+	s.manager.On("GetNodeGroupTargetSize", s.nodePool).Return(2, nil).Once()
 	s.manager.On("SetNodeGroupSize", s.nodePool, 3).Return(nil).Once()
 	s.NoError(s.nodePool.IncreaseSize(1))
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This check is already done in https://github.com/kubernetes/autoscaler/blob/92c182feda0a08a7ff594bff17f457713294f61b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go#L437-L447 so we don't have to do it again.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
