### PR TITLE
AWS: only cache instance requirements when needed

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -609,11 +609,13 @@ func (m *asgCache) buildAsgFromAWS(g *autoscaling.Group) (*asg, error) {
 			instanceRequirementsOverrides: getInstanceTypeRequirements(g.MixedInstancesPolicy.LaunchTemplate.Overrides),
 		}
 
-		instanceRequirements, err := m.getInstanceRequirementsFromMixedInstancesPolicy(asg.MixedInstancesPolicy)
-		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve instance requirements from mixed instance policy, err: %v", err)
+		if len(asg.MixedInstancesPolicy.instanceTypesOverrides) == 0 {
+			instanceRequirements, err := m.getInstanceRequirementsFromMixedInstancesPolicy(asg.MixedInstancesPolicy)
+			if err != nil {
+				return nil, fmt.Errorf("unable to retrieve instance requirements from mixed instance policy, err: %v", err)
+			}
+			asg.MixedInstancesPolicy.instanceRequirements = instanceRequirements
 		}
-		asg.MixedInstancesPolicy.instanceRequirements = instanceRequirements
 
 		if len(asg.MixedInstancesPolicy.instanceTypesOverrides) != 0 && asg.MixedInstancesPolicy.instanceRequirementsOverrides != nil {
 			return nil, fmt.Errorf("invalid setup of both instance type and instance requirements overrides configured")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

Fixes https://github.com/kubernetes/autoscaler/issues/7102


#### What this PR does / why we need it:

This PR reduces the number of unneeded `DescribeLaunchTemplateVersions` API calls. Previously there was a PR that only looked for instance requirements when needed https://github.com/kubernetes/autoscaler/pull/5550. However this PR https://github.com/kubernetes/autoscaler/pull/6245 introduced a regression where now it looks for instance requirements all the time.

However in the [original fix PR](https://github.com/kubernetes/autoscaler/pull/5550) it was stated:
> But retrieving InstanceRequirements should only be useful when the LT overrides don't already specify an InstanceType, as both are mutually exclusive. The [api reference doc](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_LaunchTemplateOverrides.html) states:
>> If you specify InstanceRequirements, you can't specify InstanceType.

> That mutual exclusion [is already leveraged](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.26.1/cluster-autoscaler/cloudprovider/aws/aws_wrapper.go#L683-L686) by getInstanceTypesForAsgs: we don't look for InstanceRequirements when we have a mixed instance policy specifying instance types overrides. 

This PR makes it so we again only look for instance requirements if instance type overrides are not used.

The screenshot below shows the huge increase in `DescribeLaunchTemplateVersions` API calls when we upgraded our cluster autoscaler to include the bug PR at 16:00 https://github.com/kubernetes/autoscaler/pull/6245
<img width="798" alt="Screenshot 2024-10-11 at 10 34 24 AM" src="https://github.com/user-attachments/assets/12555c66-f54d-4802-8fde-d732d09d0967">

The screenshot below is after I applied this fix at 10:30, and the `DescribeLaunchTemplateVersions` API calls dropped back down.
<img width="1550" alt="Screenshot 2024-10-11 at 11 10 22 AM" src="https://github.com/user-attachments/assets/500819eb-0555-4da9-840e-937b60ad35c1">

The screenshot below shows the main loop duration spiking when the bug was introduced after 15:00 and the duration returned to normal after my fix at 10:30
<img width="849" alt="Screenshot 2024-10-11 at 11 13 38 AM" src="https://github.com/user-attachments/assets/b2fe28a4-4f53-4d15-a174-52ee56759219">






#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
AWS: Only cache instance requirements when needed
```

