### PR TITLE
Synchronize access to scale-ups in AsyncNodeGroupInitializer

### DIFF
--- a/cluster-autoscaler/processors/nodegroups/nodegroup_manager.go
+++ b/cluster-autoscaler/processors/nodegroups/nodegroup_manager.go
@@ -60,6 +60,11 @@ type AsyncNodeGroupInitializer interface {
 	// Note that the node group may be different than the initialized node group, if node group creation
 	// results in creation of multiple node groups.
 	SetTargetSize(nodeGroupId string, size int64)
+	// ChangeTargetSize changes by given delta a size to which the provided node goup will be initialized.
+	// Delta may be positive or negative value.
+	// Note that the node group may be different than the initialized node group, if node group creation
+	// results in creation of multiple node groups.
+	ChangeTargetSize(nodeGroup string, delta int64)
 }
 
 // NoOpNodeGroupManager is a no-op implementation of NodeGroupManager.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Synchronizes access to target sizes stored in AsyncNodeGroupInitializer. AsyncNodeGroupInitializer is designed to be used from different goroutines so synchronization is required. I'm marking this PR as a cleanup (not a bug), as this mechanism is not used ATM.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

cc: @x13n 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
