### PR TITLE
docs(rancher): clarify single RKE2 target

### DIFF
--- a/cluster-autoscaler/cloudprovider/rancher/README.md
+++ b/cluster-autoscaler/cloudprovider/rancher/README.md
@@ -6,11 +6,13 @@ underlying cluster-api types of RKE2.
 
 ## Configuration
 
-The `cluster-autoscaler` for Rancher needs a configuration file to work by
-using `--cloud-config` parameter. An up-to-date example can be found in
-[examples/config.yaml](./examples/config.yaml).
+The `cluster-autoscaler` for Rancher needs a configuration file to work by using
+`--cloud-config` parameter. A `cluster-autoscaler` instance can target a single
+downstream RKE2 cluster specified in the config. An up-to-date example can be
+found in [examples/config.yaml](./examples/config.yaml).
 
 ### Configuration via environment variables
+
 In order to override URL, token or clustername use following environment variables:
  - RANCHER_URL
  - RANCHER_TOKEN


### PR DESCRIPTION
Clarify that a cluster-autoscaler instance can target a single RKE2 cluster.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7148

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
