### PR TITLE
VPA: Create event for VPA object when Pod is evicted

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
@@ -315,14 +315,14 @@ func TestEvictReplicatedByReplicaSet(t *testing.T) {
 		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&rs.ObjectMeta, &rs.TypeMeta).Get()
 	}
 
+	basicVpa := getBasicVpa()
 	factory, _ := getEvictionRestrictionFactory(nil, &rs, nil, nil, 2, 0.5)
-	eviction := factory.NewPodsEvictionRestriction(pods, getBasicVpa())
+	eviction := factory.NewPodsEvictionRestriction(pods, basicVpa)
 
 	for _, pod := range pods {
 		assert.True(t, eviction.CanEvict(pod))
 	}
 
-	basicVpa := getBasicVpa()
 	for _, pod := range pods[:2] {
 		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should evict with no error")
@@ -355,19 +355,20 @@ func TestEvictReplicatedByStatefulSet(t *testing.T) {
 		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&ss.ObjectMeta, &ss.TypeMeta).Get()
 	}
 
+	basicVpa := getBasicVpa()
 	factory, _ := getEvictionRestrictionFactory(nil, nil, &ss, nil, 2, 0.5)
-	eviction := factory.NewPodsEvictionRestriction(pods, getBasicVpa())
+	eviction := factory.NewPodsEvictionRestriction(pods, basicVpa)
 
 	for _, pod := range pods {
 		assert.True(t, eviction.CanEvict(pod))
 	}
 
 	for _, pod := range pods[:2] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should evict with no error")
 	}
 	for _, pod := range pods[2:] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Error(t, err, "Error expected")
 	}
 }
@@ -392,19 +393,21 @@ func TestEvictReplicatedByDaemonSet(t *testing.T) {
 	for i := range pods {
 		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&ds.ObjectMeta, &ds.TypeMeta).Get()
 	}
+
+	basicVpa := getBasicVpa()
 	factory, _ := getEvictionRestrictionFactory(nil, nil, nil, &ds, 2, 0.5)
-	eviction := factory.NewPodsEvictionRestriction(pods, getBasicVpa())
+	eviction := factory.NewPodsEvictionRestriction(pods, basicVpa)
 
 	for _, pod := range pods {
 		assert.True(t, eviction.CanEvict(pod))
 	}
 
 	for _, pod := range pods[:2] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should evict with no error")
 	}
 	for _, pod := range pods[2:] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Error(t, err, "Error expected")
 	}
 }
@@ -427,19 +430,20 @@ func TestEvictReplicatedByJob(t *testing.T) {
 		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&job.ObjectMeta, &job.TypeMeta).Get()
 	}
 
+	basicVpa := getBasicVpa()
 	factory, _ := getEvictionRestrictionFactory(nil, nil, nil, nil, 2, 0.5)
-	eviction := factory.NewPodsEvictionRestriction(pods, getBasicVpa())
+	eviction := factory.NewPodsEvictionRestriction(pods, basicVpa)
 
 	for _, pod := range pods {
 		assert.True(t, eviction.CanEvict(pod))
 	}
 
 	for _, pod := range pods[:2] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should evict with no error")
 	}
 	for _, pod := range pods[2:] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Error(t, err, "Error expected")
 	}
 }
@@ -466,15 +470,16 @@ func TestEvictTooFewReplicas(t *testing.T) {
 		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get()
 	}
 
+	basicVpa := getBasicVpa()
 	factory, _ := getEvictionRestrictionFactory(&rc, nil, nil, nil, 10, 0.5)
-	eviction := factory.NewPodsEvictionRestriction(pods, getBasicVpa())
+	eviction := factory.NewPodsEvictionRestriction(pods, basicVpa)
 
 	for _, pod := range pods {
 		assert.False(t, eviction.CanEvict(pod))
 	}
 
 	for _, pod := range pods {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Error(t, err, "Error expected")
 	}
 }
@@ -502,19 +507,20 @@ func TestEvictionTolerance(t *testing.T) {
 		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get()
 	}
 
+	basicVpa := getBasicVpa()
 	factory, _ := getEvictionRestrictionFactory(&rc, nil, nil, nil, 2 /*minReplicas*/, tolerance)
-	eviction := factory.NewPodsEvictionRestriction(pods, getBasicVpa())
+	eviction := factory.NewPodsEvictionRestriction(pods, basicVpa)
 
 	for _, pod := range pods {
 		assert.True(t, eviction.CanEvict(pod))
 	}
 
 	for _, pod := range pods[:4] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should evict with no error")
 	}
 	for _, pod := range pods[4:] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Error(t, err, "Error expected")
 	}
 }
@@ -542,19 +548,20 @@ func TestEvictAtLeastOne(t *testing.T) {
 		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get()
 	}
 
+	basicVpa := getBasicVpa()
 	factory, _ := getEvictionRestrictionFactory(&rc, nil, nil, nil, 2, tolerance)
-	eviction := factory.NewPodsEvictionRestriction(pods, getBasicVpa())
+	eviction := factory.NewPodsEvictionRestriction(pods, basicVpa)
 
 	for _, pod := range pods {
 		assert.True(t, eviction.CanEvict(pod))
 	}
 
 	for _, pod := range pods[:1] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should evict with no error")
 	}
 	for _, pod := range pods[1:] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Error(t, err, "Error expected")
 	}
 }
@@ -576,6 +583,8 @@ func TestEvictEmitEvent(t *testing.T) {
 		return test.Pod().WithName(fmt.Sprintf("test-%v", index)).WithCreator(&rc.ObjectMeta, &rc.TypeMeta)
 	}
 
+	basicVpa := getBasicVpa()
+
 	testCases := []struct {
 		name              string
 		replicas          int32
@@ -587,7 +596,7 @@ func TestEvictEmitEvent(t *testing.T) {
 			name:              "Pods that can be evicted",
 			replicas:          4,
 			evictionTolerance: 0.5,
-			vpa:               getBasicVpa(),
+			vpa:               basicVpa,
 			pods: []podWithExpectations{
 				{
 					pod:             generatePod().WithPhase(apiv1.PodPending).Get(),
@@ -605,7 +614,7 @@ func TestEvictEmitEvent(t *testing.T) {
 			name:              "Pod that can not be evicted",
 			replicas:          4,
 			evictionTolerance: 0.5,
-			vpa:               getBasicVpa(),
+			vpa:               basicVpa,
 			pods: []podWithExpectations{
 
 				{

--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
@@ -322,12 +322,13 @@ func TestEvictReplicatedByReplicaSet(t *testing.T) {
 		assert.True(t, eviction.CanEvict(pod))
 	}
 
+	basicVpa := getBasicVpa()
 	for _, pod := range pods[:2] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should evict with no error")
 	}
 	for _, pod := range pods[2:] {
-		err := eviction.Evict(pod, getBasicVpa(), test.FakeEventRecorder())
+		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
 		assert.Error(t, err, "Error expected")
 	}
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -317,7 +317,9 @@ func newEventRecorder(kubeClient kube_client.Interface) record.EventRecorder {
 	}
 
 	vpascheme := scheme.Scheme
-	corescheme.AddToScheme(vpascheme)
+	if err := corescheme.AddToScheme(vpascheme); err != nil {
+		klog.Fatalf("Error adding core scheme: %v", err)
+	}
 
 	return eventBroadcaster.NewRecorder(vpascheme, apiv1.EventSource{Component: "vpa-updater"})
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -29,7 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
+
+	corescheme "k8s.io/client-go/kubernetes/scheme"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	v1lister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -38,6 +39,7 @@ import (
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
@@ -225,7 +227,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 				return
 			}
 			klog.V(2).InfoS("Evicting pod", "pod", klog.KObj(pod))
-			evictErr := evictionLimiter.Evict(pod, u.eventRecorder)
+			evictErr := evictionLimiter.Evict(pod, vpa, u.eventRecorder)
 			if evictErr != nil {
 				klog.V(0).InfoS("Eviction failed", "error", evictErr, "pod", klog.KObj(pod))
 			} else {
@@ -310,6 +312,12 @@ func newEventRecorder(kubeClient kube_client.Interface) record.EventRecorder {
 	eventBroadcaster.StartLogging(klog.V(4).InfoS)
 	if _, isFake := kubeClient.(*fake.Clientset); !isFake {
 		eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: clientv1.New(kubeClient.CoreV1().RESTClient()).Events("")})
+	} else {
+		eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	}
-	return eventBroadcaster.NewRecorder(scheme.Scheme, apiv1.EventSource{Component: "vpa-updater"})
+
+	vpascheme := scheme.Scheme
+	corescheme.AddToScheme(vpascheme)
+
+	return eventBroadcaster.NewRecorder(vpascheme, apiv1.EventSource{Component: "vpa-updater"})
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
@@ -356,4 +358,51 @@ func TestRunOnceIgnoreNamespaceMatching(t *testing.T) {
 
 	updater.RunOnce(context.Background())
 	eviction.AssertNumberOfCalls(t, "Evict", 0)
+}
+
+func TestNewEventRecorder(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	er := newEventRecorder(fakeClient)
+
+	testCases := []struct {
+		reason  string
+		object  runtime.Object
+		message string
+	}{
+		{
+			reason:  "EvictedPod",
+			object:  &apiv1.Pod{},
+			message: "Evicted pod",
+		},
+		{
+			reason:  "EvictedPod",
+			object:  &vpa_types.VerticalPodAutoscaler{},
+			message: "Evicted pod",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.reason, func(t *testing.T) {
+			er.Event(tc.object, apiv1.EventTypeNormal, tc.reason, tc.message)
+
+			var events *apiv1.EventList
+			var err error
+			// Add delay for fake client to catch up due to be being asynchronous
+			for i := 0; i < 5; i++ {
+				events, err = fakeClient.CoreV1().Events("default").List(context.TODO(), metav1.ListOptions{})
+				if err == nil && len(events.Items) > 0 {
+					break
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			assert.NoError(t, err, "should be able to list events")
+			assert.Equal(t, 1, len(events.Items), "should have exactly 1 event")
+
+			event := events.Items[0]
+			assert.Equal(t, tc.reason, event.Reason)
+			assert.Equal(t, tc.message, event.Message)
+			assert.Equal(t, apiv1.EventTypeNormal, event.Type)
+			assert.Equal(t, "vpa-updater", event.Source.Component)
+		})
+	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/listers/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -110,7 +110,7 @@ type PodsEvictionRestrictionMock struct {
 }
 
 // Evict is a mock implementation of PodsEvictionRestriction.Evict
-func (m *PodsEvictionRestrictionMock) Evict(pod *apiv1.Pod, eventRecorder record.EventRecorder) error {
+func (m *PodsEvictionRestrictionMock) Evict(pod *apiv1.Pod, vpa *vpa_types.VerticalPodAutoscaler, eventRecorder record.EventRecorder) error {
 	args := m.Called(pod, eventRecorder)
 	return args.Error(0)
 }
@@ -267,4 +267,31 @@ func (f *fakeEventRecorder) AnnotatedEventf(object runtime.Object, annotations m
 // FakeEventRecorder returns a dummy implementation of record.EventRecorder.
 func FakeEventRecorder() record.EventRecorder {
 	return &fakeEventRecorder{}
+}
+
+// mockedEventRecorder is a dummy implementation of record.EventRecorder.
+type mockedEventRecorder struct {
+	mock.Mock
+}
+
+// Event is a mocked implementation of record.EventRecorder interface.
+func (m *mockedEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	m.Called(object, eventtype, reason, message)
+}
+
+// Eventf is a dummy implementation of record.EventRecorder interface.
+func (m *mockedEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+
+// PastEventf is a dummy implementation of record.EventRecorder interface.
+func (m *mockedEventRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+
+// AnnotatedEventf is a dummy implementation of record.EventRecorder interface.
+func (m *mockedEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+
+// MockEventRecorder returns a dummy implementation of record.EventRecorder.
+func MockEventRecorder() *mockedEventRecorder {
+	return &mockedEventRecorder{}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

A user asked for the VPA to emit an event that is related to the VPA object, in addition to the event related to the Pod object.
This makes sense, I see it as a "log" of sorts of what a particular VPA is up to.

#### Which issue(s) this PR fixes:
Fixes #7149

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Create VPA Event (in addition to a Pod event) when a Pod is evicted
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
