### PR TITLE
Remove usage of placeholder require versions for k8s.io/* packages

### DIFF
--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -42,18 +42,18 @@ require (
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v2 v2.4.0
-	k8s.io/api v0.32.0-alpha.1
-	k8s.io/apimachinery v0.32.0-alpha.1
-	k8s.io/apiserver v0.32.0-alpha.1
+	k8s.io/api v0.32.0-alpha.0
+	k8s.io/apimachinery v0.32.0-alpha.0
+	k8s.io/apiserver v0.32.0-alpha.0
 	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
-	k8s.io/client-go v0.32.0-alpha.1
-	k8s.io/cloud-provider v0.30.1
+	k8s.io/client-go v0.32.0-alpha.0
+	k8s.io/cloud-provider v0.32.0-alpha.0
 	k8s.io/cloud-provider-aws v1.27.0
 	k8s.io/cloud-provider-gcp/providers v0.28.2
-	k8s.io/component-base v0.32.0-alpha.1
-	k8s.io/component-helpers v0.32.0-alpha.1
+	k8s.io/component-base v0.32.0-alpha.0
+	k8s.io/component-helpers v0.32.0-alpha.0
 	k8s.io/klog/v2 v2.130.1
-	k8s.io/kubelet v0.32.0-alpha.1
+	k8s.io/kubelet v0.32.0-alpha.0
 	k8s.io/kubernetes v1.32.0-alpha.0
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/cloud-provider-azure v1.29.4
@@ -207,19 +207,19 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.0.0 // indirect
-	k8s.io/code-generator v0.32.0-alpha.1 // indirect
-	k8s.io/controller-manager v0.32.0-alpha.1 // indirect
-	k8s.io/cri-api v0.32.0-alpha.1 // indirect
-	k8s.io/cri-client v0.0.0 // indirect
-	k8s.io/csi-translation-lib v0.27.0 // indirect
-	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
+	k8s.io/apiextensions-apiserver v0.32.0-alpha.0 // indirect
+	k8s.io/code-generator v0.32.0-alpha.0 // indirect
+	k8s.io/controller-manager v0.32.0-alpha.0 // indirect
+	k8s.io/cri-api v0.32.0-alpha.0 // indirect
+	k8s.io/cri-client v0.32.0-alpha.0 // indirect
+	k8s.io/csi-translation-lib v0.32.0-alpha.0 // indirect
+	k8s.io/dynamic-resource-allocation v0.32.0-alpha.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
-	k8s.io/kms v0.32.0-alpha.1 // indirect
+	k8s.io/kms v0.32.0-alpha.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20240827152857-f7e401e7b4c2 // indirect
-	k8s.io/kube-scheduler v0.0.0 // indirect
-	k8s.io/kubectl v0.28.0 // indirect
-	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
+	k8s.io/kube-scheduler v0.32.0-alpha.0 // indirect
+	k8s.io/kubectl v0.32.0-alpha.0 // indirect
+	k8s.io/mount-utils v0.32.0-alpha.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.4 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/cluster-autoscaler/hack/update-deps.sh
+++ b/cluster-autoscaler/hack/update-deps.sh
@@ -88,10 +88,9 @@ cluster_autoscaler:update_deps() {
     mod_version=$(echo "${gomod_json}" | "${SED}" -n 's|.*"Version": "\(.*\)".*|\1|p')
     if [ "${pkg}" = "./cluster-autoscaler" ]; then
       go mod edit "-replace=${mod}=${mod}@${mod_version}"
-    else
-      go get "${mod}@${mod_version}"
-      go mod tidy
     fi
+    go get "${mod}@${mod_version}"
+    go mod tidy
   done
 
   if [ "${pkg}" = "./cluster-autoscaler" ]; then


### PR DESCRIPTION
#### What type of PR is this?

 /kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR changes the way how k8s.io/* dependencies are stored in a go.mod via adding real version numbers into require section instead of having those only as part of replace directives

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
