### PR TITLE
[WIP] enable per-node dynamic headroom

### DIFF
--- a/cluster-autoscaler/clusterstate/api/types.go
+++ b/cluster-autoscaler/clusterstate/api/types.go
@@ -62,6 +62,8 @@ const (
 	ClusterAutoscalerNoActivity ClusterAutoscalerConditionStatus = "NoActivity"
 	// ClusterAutoscalerBackoff status means that due to a recently failed scale-up no further scale-ups attempts will be made for some time.
 	ClusterAutoscalerBackoff ClusterAutoscalerConditionStatus = "Backoff"
+	// ClusterAutoscalerHasDynamicHeadroom status means that one or more nodes in a node group has available headroom for vertical scaling which should be preferred over adding more nodes.
+	ClusterAutoscalerHasDynamicHeadroom ClusterAutoscalerConditionStatus = "HasDynamicHeadroom"
 )
 
 // RegisteredUnreadyNodeCount contains node counts of registered but unready nodes.

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -631,6 +631,9 @@ func (o *ScaleUpOrchestrator) IsNodeGroupReadyToScaleUp(nodeGroup cloudprovider.
 		}
 		klog.Warningf("Node group %s is not ready for scaleup - backoff with status: %v", nodeGroup.Id(), scaleUpSafety.BackoffStatus)
 		return BackoffReason
+	} else if scaleUpSafety.HasDynamicHeadroom {
+		klog.Warningf("Node group %s is not ready for scaleup - vertical node scaling is still possible", nodeGroup.Id())
+		return NotReadyReason
 	}
 	return nil
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons.go
@@ -43,6 +43,8 @@ var (
 	MaxLimitReachedReason = NewSkippedReasons("max node group size reached")
 	// NotReadyReason node group is not ready.
 	NotReadyReason = NewSkippedReasons("not ready for scale-up")
+	// HasDynamicHeadroomReason node group has per-node vertical scaling headroom.
+	HasDynamicHeadroomReason = NewSkippedReasons("at least one node can be vertically scaled")
 )
 
 // MaxResourceLimitReached contains information why given node group was skipped.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR demonstrates how a cooperative vertical node scaling actor could integration w/ cluster-autoscaler to enable vertical scale out operations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
enable per-node dynamic headroom
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
