### PR TITLE
fix(exoscale): enhance UX around SKS nodepools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # VSCode project files
 **/.vscode
 *.code-workspace
+__debug_bin*
 
 # Emacs save files
 *~

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -212,9 +212,9 @@ func (n *instancePoolNodeGroup) GetOptions(_ config.NodeGroupAutoscalingOptions)
 
 func (n *instancePoolNodeGroup) waitUntilRunning(ctx context.Context) error {
 	return pollCmd(ctx, func() (bool, error) {
-		instancePool, err := n.m.client.GetInstancePool(ctx, n.m.zone, n.Id())
+		instancePool, err := n.m.client.GetInstancePool(ctx, n.m.zone, *n.instancePool.ID)
 		if err != nil {
-			errorf("unable to retrieve Instance Pool %s: %s", n.Id(), err)
+			errorf("unable to retrieve Instance Pool %s: %s", *n.instancePool.ID, err)
 			return false, err
 		}
 

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
@@ -151,7 +151,7 @@ func (n *sksNodepoolNodeGroup) DecreaseTargetSize(_ int) error {
 
 // Id returns an unique identifier of the node group.
 func (n *sksNodepoolNodeGroup) Id() string {
-	return *n.sksNodepool.InstancePoolID
+	return *n.sksNodepool.ID
 }
 
 // Debug returns a string containing all information regarding this node group.
@@ -229,9 +229,9 @@ func (n *sksNodepoolNodeGroup) GetOptions(_ config.NodeGroupAutoscalingOptions) 
 
 func (n *sksNodepoolNodeGroup) waitUntilRunning(ctx context.Context) error {
 	return pollCmd(ctx, func() (bool, error) {
-		instancePool, err := n.m.client.GetInstancePool(ctx, n.m.zone, n.Id())
+		instancePool, err := n.m.client.GetInstancePool(ctx, n.m.zone, *n.sksNodepool.InstancePoolID)
 		if err != nil {
-			errorf("unable to retrieve Instance Pool %s: %s", n.Id(), err)
+			errorf("unable to retrieve Instance Pool %s: %s", *n.sksNodepool.InstancePoolID, err)
 			return false, err
 		}
 

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool_test.go
@@ -206,7 +206,7 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_Id() {
 		maxSize: int(testComputeInstanceQuotaLimit),
 	}
 
-	ts.Require().Equal(testInstancePoolID, nodeGroup.Id())
+	ts.Require().Equal(testSKSNodepoolID, nodeGroup.Id())
 }
 
 func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_Nodes() {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Hello, i'm a exoscale team member. I'm not sure about the kind command as it's more a UX improvement for our end users

In the 1.31.0 and lower version SKS nodepools where discovered through exoscale instance pools. Whereas it works as expected, end user experience is not very convenient, especially when end users use priority based expander. On our portal SKS nodepools are shown with their ID and the instancepool is hidden in the SKS nodepool page itself. People trying to use priority based expander put SKS nodepool ID instead of our generic compute API InstancePool ID. For convenience, starting with this commit we are using SKS nodepool ID and we add retro compatibility for already cluster autoscaler managed SKS clusters. This will reduce a bit our support on it, and make priority based expander UX more convenient.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix(exoscale): enhance UX around SKS nodepools and priority based expander
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
