### PR TITLE
7435 Support New Alibaba Cloud ENV Variables names for RRSA Authorization

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_config.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_config.go
@@ -17,19 +17,24 @@ limitations under the License.
 package alicloud
 
 import (
+	"os"
+
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/metadata"
 	"k8s.io/klog/v2"
-	"os"
 )
 
 const (
-	accessKeyId       = "ACCESS_KEY_ID"
-	accessKeySecret   = "ACCESS_KEY_SECRET"
-	oidcProviderARN   = "ALICLOUD_OIDC_PROVIDER_ARN"
-	oidcTokenFilePath = "ALICLOUD_OIDC_TOKEN_FILE_PATH"
-	roleARN           = "ALICLOUD_ROLE_ARN"
-	roleSessionName   = "ALICLOUD_SESSION_NAME"
-	regionId          = "REGION_ID"
+	accessKeyId          = "ACCESS_KEY_ID"
+	accessKeySecret      = "ACCESS_KEY_SECRET"
+	oidcProviderARN      = "ALIBABA_CLOUD_OIDC_PROVIDER_ARN"
+	oldOidcProviderARN   = "ALICLOUD_OIDC_PROVIDER_ARN"
+	oidcTokenFilePath    = "ALIBABA_CLOUD_OIDC_TOKEN_FILE"
+	oldOidcTokenFilePath = "ALICLOUD_OIDC_TOKEN_FILE_PATH"
+	roleARN              = "ALIBABA_CLOUD_ROLE_ARN"
+	oldRoleARN           = "ALICLOUD_ROLE_ARN"
+	roleSessionName      = "ALIBABA_CLOUD_SESSION_NAME"
+	oldRoleSessionName   = "ALICLOUD_SESSION_NAME"
+	regionId             = "REGION_ID"
 )
 
 type cloudConfig struct {
@@ -58,19 +63,19 @@ func (cc *cloudConfig) isValid() bool {
 	}
 
 	if cc.OIDCProviderARN == "" {
-		cc.OIDCProviderARN = os.Getenv(oidcProviderARN)
+		cc.OIDCProviderARN = firstNotEmpty(os.Getenv(oidcProviderARN), os.Getenv(oldOidcProviderARN))
 	}
 
 	if cc.OIDCTokenFilePath == "" {
-		cc.OIDCTokenFilePath = os.Getenv(oidcTokenFilePath)
+		cc.OIDCTokenFilePath = firstNotEmpty(os.Getenv(oidcTokenFilePath), os.Getenv(oldOidcTokenFilePath))
 	}
 
 	if cc.RoleARN == "" {
-		cc.RoleARN = os.Getenv(roleARN)
+		cc.RoleARN = firstNotEmpty(os.Getenv(roleARN), os.Getenv(oldRoleARN))
 	}
 
 	if cc.RoleSessionName == "" {
-		cc.RoleSessionName = os.Getenv(roleSessionName)
+		cc.RoleSessionName = firstNotEmpty(os.Getenv(roleSessionName), os.Getenv(oldRoleSessionName))
 	}
 
 	if cc.RegionId != "" && cc.AccessKeyID != "" && cc.AccessKeySecret != "" {
@@ -127,4 +132,16 @@ func (cc *cloudConfig) getRegion() string {
 		klog.Errorf("Failed to get RegionId from metadata.Because of %s\n", err.Error())
 	}
 	return r
+}
+
+// firstNotEmpty returns the first non-empty string from the input list.
+// If all strings are empty or no arguments are provided, it returns an empty string.
+func firstNotEmpty(strs ...string) string {
+	for _, str := range strs {
+		if str != "" {
+			return str
+		}
+	}
+
+	return ""
 }

--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_config_test.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_config_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package alicloud
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccessKeyCloudConfigIsValid(t *testing.T) {
@@ -41,4 +42,38 @@ func TestRRSACloudConfigIsValid(t *testing.T) {
 	cfg := &cloudConfig{}
 	assert.True(t, cfg.isValid())
 	assert.True(t, cfg.RRSAEnabled)
+}
+
+func TestOldRRSACloudConfigIsValid(t *testing.T) {
+	t.Setenv(oldOidcProviderARN, "acs:ram::12345:oidc-provider/ack-rrsa-cb123")
+	t.Setenv(oldOidcTokenFilePath, "/var/run/secrets/tokens/oidc-token")
+	t.Setenv(oldRoleARN, "acs:ram::12345:role/autoscaler-role")
+	t.Setenv(oldRoleSessionName, "session")
+	t.Setenv(regionId, "cn-hangzhou")
+
+	cfg := &cloudConfig{}
+	assert.True(t, cfg.isValid())
+	assert.True(t, cfg.RRSAEnabled)
+}
+
+func TestFirstNotEmpty(t *testing.T) {
+	// Test case where the first non-empty string is at the beginning
+	result := firstNotEmpty("hello", "world", "test")
+	assert.Equal(t, "hello", result)
+
+	// Test case where the first non-empty string is in the middle
+	result = firstNotEmpty("", "foo", "bar")
+	assert.Equal(t, "foo", result)
+
+	// Test case where the first non-empty string is at the end
+	result = firstNotEmpty("", "", "baz")
+	assert.Equal(t, "baz", result)
+
+	// Test case where all strings are empty
+	result = firstNotEmpty("", "", "")
+	assert.Equal(t, "", result)
+
+	// Test case with no arguments
+	result = firstNotEmpty()
+	assert.Equal(t, "", result)
 }

--- a/cluster-autoscaler/cloudprovider/alicloud/examples/cluster-autoscaler-rrsa-standard.yaml
+++ b/cluster-autoscaler/cloudprovider/alicloud/examples/cluster-autoscaler-rrsa-standard.yaml
@@ -165,22 +165,22 @@ spec:
             - --nodes=[min]:[max]:[ASG_ID]
           imagePullPolicy: "Always"
           env:
-          - name: ALICLOUD_OIDC_PROVIDER_ARN
+          - name: ALIBABA_CLOUD_OIDC_PROVIDER_ARN
             valueFrom:
               secretKeyRef:
                 name: cloud-config
                 key: oidc-provider-arn
-          - name: ALICLOUD_OIDC_TOKEN_FILE_PATH
+          - name: ALIBABA_CLOUD_OIDC_TOKEN_FILE
             valueFrom:
               secretKeyRef:
                 name: cloud-config
                 key: oidc-token-file-path
-          - name: ALICLOUD_ROLE_ARN
+          - name: ALIBABA_CLOUD_ROLE_ARN
             valueFrom:
               secretKeyRef:
                 name: cloud-config
                 key: role-arn
-          - name: ALICLOUD_SESSION_NAME
+          - name: ALIBABA_CLOUD_SESSION_NAME
             valueFrom:
               secretKeyRef:
                 name: cloud-config


### PR DESCRIPTION
### Which component this PR applies to?

cluster-autoscaler

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds support for the newly declared official environment variable names by Alibaba Cloud for [RRSA to authorize pods to access different cloud services](https://www.alibabacloud.com/help/en/container-service-for-kubernetes/latest/use-rrsa-to-enforce-access-control). This change enables compatibility with both the existing and new ENV variable names, ensuring seamless authorization for pods accessing various Alibaba Cloud services.
This update is essential for users transitioning to the updated naming conventions while maintaining support for legacy configurations.

#### Which issue(s) this PR fixes:
Fixes #7435

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no


```release-note
NONE
```

