### PR TITLE
Added rebase and export capabilities for all cluster snapshot implementations

### DIFF
--- a/cluster-autoscaler/simulator/clustersnapshot/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/basic.go
@@ -314,6 +314,26 @@ func (snapshot *BasicClusterSnapshot) Clear() {
 	snapshot.data = []*internalBasicSnapshotData{baseData}
 }
 
+// Export returns a shallow copy of the snapshot.
+func (snapshot *BasicClusterSnapshot) Export() ClusterSnapshot {
+	exportedSnapshot := &BasicClusterSnapshot{}
+	exportedSnapshot.data = make([]*internalBasicSnapshotData, len(snapshot.data))
+	for i, data := range snapshot.data {
+		exportedSnapshot.data[i] = data.clone()
+	}
+	return exportedSnapshot
+}
+
+// Rebase rebases the snapshot to a new base snapshot.
+func (snapshot *BasicClusterSnapshot) Rebase(base ClusterSnapshot) error {
+	baseSnapshot, ok := base.(*BasicClusterSnapshot)
+	if !ok {
+		return fmt.Errorf("cannot rebase to different type of snapshot")
+	}
+	snapshot.data = []*internalBasicSnapshotData{baseSnapshot.getInternalData().clone(), snapshot.data[len(snapshot.data)-1]}
+	return nil
+}
+
 // implementation of SharedLister interface
 
 type basicClusterSnapshotNodeLister BasicClusterSnapshot

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -63,6 +63,10 @@ type ClusterSnapshot interface {
 	Commit() error
 	// Clear reset cluster snapshot to empty, unforked state.
 	Clear()
+	// Export returns a shallow copy of the snapshot.
+	Export() ClusterSnapshot
+	// Rebase rebases the snapshot to a new base snapshot.
+	Rebase(base ClusterSnapshot) error
 }
 
 // ErrNodeNotFound means that a node wasn't found in the snapshot.

--- a/cluster-autoscaler/simulator/clustersnapshot/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/delta.go
@@ -32,6 +32,8 @@ import (
 //	fork - O(1)
 //	revert - O(1)
 //	commit - O(n)
+//	rebase - O(1)
+//	export - O(1)
 //	list all pods (no filtering) - O(n), cached
 //	list all pods (with filtering) - O(n)
 //	list node infos - O(n), cached
@@ -503,4 +505,23 @@ func (snapshot *DeltaClusterSnapshot) Commit() error {
 // Time: O(1)
 func (snapshot *DeltaClusterSnapshot) Clear() {
 	snapshot.data = newInternalDeltaSnapshotData()
+}
+
+// Export returns a shallow copy of the changes made to the snapshot.
+// Time: O(1) (shallow copy)
+func (snapshot *DeltaClusterSnapshot) Export() ClusterSnapshot {
+	return &DeltaClusterSnapshot{
+		data: snapshot.data,
+	}
+}
+
+// Rebase rebases the snapshot to a new base snapshot.
+// Time: O(1)
+func (snapshot *DeltaClusterSnapshot) Rebase(base ClusterSnapshot) error {
+	snapshotBase, ok := base.(*DeltaClusterSnapshot)
+	if !ok {
+		return fmt.Errorf("cannot rebase to a different type of snapshot")
+	}
+	snapshot.data.baseData = snapshotBase.data
+	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds the ability to  export (shallow copy of uncommitted changes) and rebase (places a seperate snapshot as base for uncommitted changes) cluster snapshot and its implementations. This will be useful for performing simulations for multiple scaleups sequentially.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
cc: @aleksandra-malinowska @kawych @yaroslava-serdiuk 