### PR TITLE
feat(hetzner): autoscaler includes new provided-by label

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -384,11 +384,12 @@ func buildNodeGroupLabels(n *hetznerNodeGroup) (map[string]string, error) {
 	klog.V(4).Infof("Build node group label for %s", n.id)
 
 	labels := map[string]string{
-		apiv1.LabelInstanceType:      n.instanceType,
-		apiv1.LabelTopologyRegion:    n.region,
-		apiv1.LabelArchStable:        archLabel,
-		"csi.hetzner.cloud/location": n.region,
-		nodeGroupLabel:               n.id,
+		apiv1.LabelInstanceType:              n.instanceType,
+		apiv1.LabelTopologyRegion:            n.region,
+		apiv1.LabelArchStable:                archLabel,
+		"csi.hetzner.cloud/location":         n.region,
+		"instance.hetzner.cloud/provided-by": "cloud",
+		nodeGroupLabel:                       n.id,
 	}
 
 	if n.manager.clusterConfig.IsUsingNewFormat {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Hetzner introduced a new node label to distinguish between dedicated servers and cloud VMs. This is primarily used to workround the scheduler limitation for CSI volumes. This PR adds the label to `TemplateNodeInfo`.
Further information:
- https://github.com/hetznercloud/hcloud-cloud-controller-manager/pull/764
- https://github.com/hetznercloud/csi-driver/pull/743

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Hetzner: Consider label `instance.hetzner.cloud/provided-by` for scheduling
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
