### PR TITLE
🐛(metrics) Initialize metrics for autoscaler errors, scale events, and pod evictions

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -608,6 +608,9 @@ func buildAutoscaler(context ctx.Context, debuggingSnapshotter debuggingsnapshot
 	metrics.UpdateCPULimitsCores(autoscalingOptions.MinCoresTotal, autoscalingOptions.MaxCoresTotal)
 	metrics.UpdateMemoryLimitsBytes(autoscalingOptions.MinMemoryTotal, autoscalingOptions.MaxMemoryTotal)
 
+	// Initialize metrics.
+	metrics.InitMetrics()
+
 	// Create autoscaler.
 	autoscaler, err := core.NewAutoscaler(opts, informerFactory)
 	if err != nil {

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -473,6 +473,28 @@ func RegisterAll(emitPerNodeGroupMetrics bool) {
 	}
 }
 
+// InitMetrics initializes all metrics
+func InitMetrics() {
+	for _, errorType := range []errors.AutoscalerErrorType{errors.CloudProviderError, errors.ApiCallError, errors.InternalError, errors.TransientError, errors.ConfigurationError, errors.NodeGroupDoesNotExistError, errors.UnexpectedScaleDownStateError} {
+		errorsCount.WithLabelValues(string(errorType)).Add(0)
+	}
+
+	for _, reason := range []FailedScaleUpReason{CloudProviderError, APIError, Timeout} {
+		scaleDownCount.WithLabelValues(string(reason)).Add(0)
+		failedScaleUpCount.WithLabelValues(string(reason)).Add(0)
+	}
+
+	for _, result := range []PodEvictionResult{PodEvictionSucceed, PodEvictionFailed} {
+		evictionsCount.WithLabelValues(string(result)).Add(0)
+	}
+
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, CpuResourceLimit).Add(0)
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, MemoryResourceLimit).Add(0)
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, CpuResourceLimit).Add(0)
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, MemoryResourceLimit).Add(0)
+
+}
+
 // UpdateDurationFromStart records the duration of the step identified by the
 // label using start time
 func UpdateDurationFromStart(label FunctionLabel, start time.Time) {


### PR DESCRIPTION
- Set initial count to zero for various autoscaler error types (e.g., CloudProviderError, ApiCallError)
- Define failed scale-up reasons and initialize metrics (e.g., CloudProviderError, APIError)
- Initialize pod eviction result counters for success and failure cases
- Initialize skipped scale events for CPU and memory resource limits in both scale-up and scale-down directions

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR initializes the failedScaleUpCount and other key metrics at startup, setting their values to zero so they appear in Prometheus even if no events have occurred. By pre-defining these metrics, we ensure comprehensive monitoring and avoid gaps in visibility, particularly for scale-up and scale-down events, error types, and pod evictions.

#### Which issue(s) this PR fixes:
Fixes #7448

#### Special notes for your reviewer:
Certain node metrics have not been initialized in this PR because they require runtime information. These metrics are tied to dynamic node states and cannot be set at startup.

Metrics Log Reference: 
[metrics.txt](https://github.com/user-attachments/files/17606067/metrics.txt)

 
Metrics requiring runtime data include:
```docs
node_group_min_count
node_group_max_count
node_group_target_count
node_group_healthiness
scaled_up_gpu_nodes_total
failed_gpu_scale_ups_total
scaled_down_gpu_nodes_total
unremovable_nodes_count ?
created_node_groups_total
deleted_node_groups_total
node_taints_count
```

#### Does this PR introduce a user-facing change?
NONE

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
