### PR TITLE
exclude self-managed nodes from being processed

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/common/oci_ref.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_ref.go
@@ -21,6 +21,7 @@ type OciRef struct {
 	PrivateIPAddress   string
 	PublicIPAddress    string
 	Shape              string
+	IsNodeSelfManaged  bool
 }
 
 // NodeToOciRef converts a node object into an oci reference
@@ -36,6 +37,7 @@ func NodeToOciRef(n *apiv1.Node) (OciRef, error) {
 		PrivateIPAddress:   getNodeInternalAddress(n),
 		PublicIPAddress:    getNodeExternalAddress(n),
 		Shape:              getNodeShape(n),
+		IsNodeSelfManaged:  n.Labels["oci.oraclecloud.com/node.info.byon"] != "",
 	}, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/oci/common/oci_ref.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_ref.go
@@ -37,7 +37,7 @@ func NodeToOciRef(n *apiv1.Node) (OciRef, error) {
 		PrivateIPAddress:   getNodeInternalAddress(n),
 		PublicIPAddress:    getNodeExternalAddress(n),
 		Shape:              getNodeShape(n),
-		IsNodeSelfManaged:  n.Labels["oci.oraclecloud.com/node.info.byon"] != "",
+		IsNodeSelfManaged:  n.Labels["oci.oraclecloud.com/node.info.byon"] == "true",
 	}, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_cloud_provider.go
@@ -54,6 +54,10 @@ func (ocp *OciCloudProvider) NodeGroupForNode(n *apiv1.Node) (cloudprovider.Node
 		return nil, err
 	}
 
+	// self-managed-nodes aren't expected to be managed by cluster-autoscaler
+	if ociRef.IsNodeSelfManaged {
+		return nil, nil
+	}
 	ng, err := ocp.manager.GetNodePoolForInstance(ociRef)
 
 	// this instance may be part of a node pool that the autoscaler does not handle
@@ -74,6 +78,9 @@ func (ocp *OciCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	instance, err := ocicommon.NodeToOciRef(node)
 	if err != nil {
 		return true, err
+	}
+	if instance.IsNodeSelfManaged {
+		return false, nil
 	}
 	np, err := ocp.manager.GetNodePoolForInstance(instance)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When a mixture of self-managed-nodes and nodepools are created in a cluster, it breaks the cluster-autoscaler because self-managed-nodes don't have a nodepoolid, but oci-cloud provider tries to find and match nodes by nodepoolids. This PR fixes the issue as it marks the self-managed-nodes by **oci.oraclecloud.com/node.info.byon** label and excludes it from being processed.

#### Which issue(s) this PR fixes:
NA

#### Special notes for your reviewer:
Before change cluster-autoscaler was failing with these error logs.
```
E1101 11:30:17.654871       1 static_autoscaler.go:995] Failed to get a node group node node: node pool not found for node in cache
E1101 11:30:17.655449       1 static_autoscaler.go:380] Failed to get node infos for groups: node pool not found for node in cache
```
After fix, it started to work as expected and see that it can scale up in the logs.
```
I1101 13:24:05.951786       1 node_instances_cache.go:156] Start refreshing cloud provider node instances cache
I1101 13:24:05.953044       1 node_instances_cache.go:168] Refresh cloud provider node instances cache finished, refresh took 508.004µs
I1101 13:24:07.148972       1 request.go:698] Waited for 1.197565618s due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/api/v1/namespaces?limit=500&resourceVersion=0
W1101 13:24:15.954166       1 clusterstate.go:480] AcceptableRanges have not been populated yet. Skip checking
I1101 13:25:06.020792       1 cache.go:44] rebuilding cache
I1101 13:25:06.134899       1 oci_manager.go:410] Refreshed NodePool list, next refresh after 2024-11-01 13:26:06.134886409 +0000 UTC m=+143.908393353
I1101 13:25:46.257684       1 executor.go:166] Scale-up: setting group ocid1.nodepoolinteg.oc1.phx.aaaaaaaaz5ou5ntsm5nsooingymjqomnrddeizfuurbqkprhyna4s6f3r5wa size to 3
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
