### PR TITLE
Remove Docker build warnings

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.23.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.2 AS builder
 
-ENV GOPATH /gopath/
-ENV PATH $GOPATH/bin:$PATH
+ENV GOPATH=/gopath/
+ENV PATH=$GOPATH/bin:$PATH
 
 COPY . /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler
 WORKDIR /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler

--- a/vertical-pod-autoscaler/pkg/recommender/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/recommender/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.23.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.2 AS builder
 
-ENV GOPATH /gopath/
-ENV PATH $GOPATH/bin:$PATH
+ENV GOPATH=/gopath/
+ENV PATH=$GOPATH/bin:$PATH
 
 COPY . /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler
 WORKDIR /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler

--- a/vertical-pod-autoscaler/pkg/updater/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/updater/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.23.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.2 AS builder
 
-ENV GOPATH /gopath/
-ENV PATH $GOPATH/bin:$PATH
+ENV GOPATH=/gopath/
+ENV PATH=$GOPATH/bin:$PATH
 
 COPY . /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler
 WORKDIR /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler


### PR DESCRIPTION
When building these images, Docker warns about these:
```
 3 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 17)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 18)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 15)
```

See:
- https://docs.docker.com/reference/build-checks/legacy-key-value-format/
- https://docs.docker.com/reference/build-checks/from-as-casing/

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Just to remove warnings from the docker build output, related to https://github.com/kubernetes/autoscaler/issues/7455

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/autoscaler/issues/7455

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
