### PR TITLE
Clear up the docs about evict-after-oom-threshold

### DIFF
--- a/vertical-pod-autoscaler/FAQ.md
+++ b/vertical-pod-autoscaler/FAQ.md
@@ -221,7 +221,7 @@ Name | Type | Description | Default
 |-|-|-|-|
 `pod-update-threshold` | Float64 | Ignore updates that have priority lower than the value of this flag | 0.1
 `in-recommendation-bounds-eviction-lifetime-threshold` | Duration | Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range | time.Hour*12
-`evict-after-oom-threshold` | Duration | Evict pod that has only one container and it OOMed in less than evict-after-oom-threshold since start. | 10*time.Minute
+`evict-after-oom-threshold` | Duration | Evict pod that has OOMed in less than evict-after-oom-threshold since start. | 10*time.Minute
 `updater-interval` | Duration | How often updater should run | 1*time.Minute
 `min-replicas` | Int | Minimum number of replicas to perform update | 2
 `eviction-tolerance` | Float64 | Fraction of replica count that can be evicted for update, if more than one pod can be evicted. | 0.5

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -38,8 +38,7 @@ var (
 	podLifetimeUpdateThreshold = flag.Duration("in-recommendation-bounds-eviction-lifetime-threshold", time.Hour*12, "Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range")
 
 	evictAfterOOMThreshold = flag.Duration("evict-after-oom-threshold", 10*time.Minute,
-		`Evict pod that has only one container and it OOMed in less than
-		evict-after-oom-threshold since start.`)
+		`Evict pod that has OOMed in less than evict-after-oom-threshold since start.`)
 )
 
 // UpdatePriorityCalculator is responsible for prioritizing updates on pods.


### PR DESCRIPTION
See this thread: https://kubernetes.slack.com/archives/C09R1LV8S/p1730712087622319

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The docs are outdated and lead to confusion. See https://kubernetes.slack.com/archives/C09R1LV8S/p1730712087622319

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
