### PR TITLE
Small documentation changes to warn users about deploying VPA with leader election on GKE.

### DIFF
--- a/vertical-pod-autoscaler/FAQ.md
+++ b/vertical-pod-autoscaler/FAQ.md
@@ -205,11 +205,11 @@ Name | Type | Description | Default
 `memory-histogram-decay-half-life` | Duration | The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period. | model.DefaultMemoryHistogramDecayHalfLife
 `cpu-histogram-decay-half-life` | Duration | The amount of time it takes a historical CPU usage sample to lose half of its weight. | model.DefaultCPUHistogramDecayHalfLife
 `cpu-integer-post-processor-enabled` | Bool | Enable the CPU integer recommendation post processor | false
-`leader-elect` | Bool | Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. | false
+`leader-elect` | Bool | Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. **If enabling this in GKE, you MUST also manually set the `--leader-elect-resource-name` flag.** | false
 `leader-elect-lease-duration` | Duration | The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. | 15s
 `leader-elect-renew-deadline` | Duration | The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than the lease duration. This is only applicable if leader election is enabled. | 10s
 `leader-elect-resource-lock` | String | The type of resource object that is used for locking during leader election. Supported options are 'leases', 'endpointsleases' and 'configmapsleases'. | "leases"
-`leader-elect-resource-name` | String | The name of resource object that is used for locking during leader election. | "vpa-recommender"
+`leader-elect-resource-name` | String | The name of resource object that is used for locking during leader election. **If using GKE, you must set this value to something OTHER than "vpa-recommender", for example "vpa-recommender-lease".** | "vpa-recommender"
 `leader-elect-resource-namespace` | String | The namespace of resource object that is used for locking during leader election. | "kube-system"
 `leader-elect-retry-period` | Duration | The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. | 2s
 

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -420,6 +420,10 @@ Using it in conjunction with `--ignored-vpa-object-namespaces=kube-system` or `-
   size, available quota) and cause **pods to go pending**. This can be partly
   addressed by using VPA together with [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#basics).
 * Multiple VPA resources matching the same pod have undefined behavior.
+* Running the vpa-recommender with leader election enabled (`--leader-elect=true`) in a GKE cluster
+  causes contention with a lease called `vpa-recommender` held by the GKE system component of the
+  same name. To run your own VPA in GKE, make sure to specify a different lease name using
+  `--leader-elect-resource-name=vpa-recommender-lease` (or specify your own lease name).
 
 # Related links
 

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -190,6 +190,8 @@ func defaultLeaderElectionConfiguration() componentbaseconfig.LeaderElectionConf
 		RenewDeadline:     metav1.Duration{Duration: defaultRenewDeadline},
 		RetryPeriod:       metav1.Duration{Duration: defaultRetryPeriod},
 		ResourceLock:      resourcelock.LeasesResourceLock,
+		// Note that the following default conflicts with the GKE default system component that also uses a lease with this name.
+		// When deploying in GKE, be sure to use a different lease name!
 		ResourceName:      "vpa-recommender",
 		ResourceNamespace: metav1.NamespaceSystem,
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -185,13 +185,11 @@ const (
 
 func defaultLeaderElectionConfiguration() componentbaseconfig.LeaderElectionConfiguration {
 	return componentbaseconfig.LeaderElectionConfiguration{
-		LeaderElect:   false,
-		LeaseDuration: metav1.Duration{Duration: defaultLeaseDuration},
-		RenewDeadline: metav1.Duration{Duration: defaultRenewDeadline},
-		RetryPeriod:   metav1.Duration{Duration: defaultRetryPeriod},
-		ResourceLock:  resourcelock.LeasesResourceLock,
-		// Note that the following default conflicts with the GKE default system component that also uses a lease with this name.
-		// When deploying in GKE, be sure to use a different lease name!
+		LeaderElect:       false,
+		LeaseDuration:     metav1.Duration{Duration: defaultLeaseDuration},
+		RenewDeadline:     metav1.Duration{Duration: defaultRenewDeadline},
+		RetryPeriod:       metav1.Duration{Duration: defaultRetryPeriod},
+		ResourceLock:      resourcelock.LeasesResourceLock,
 		ResourceName:      "vpa-recommender",
 		ResourceNamespace: metav1.NamespaceSystem,
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -185,11 +185,11 @@ const (
 
 func defaultLeaderElectionConfiguration() componentbaseconfig.LeaderElectionConfiguration {
 	return componentbaseconfig.LeaderElectionConfiguration{
-		LeaderElect:       false,
-		LeaseDuration:     metav1.Duration{Duration: defaultLeaseDuration},
-		RenewDeadline:     metav1.Duration{Duration: defaultRenewDeadline},
-		RetryPeriod:       metav1.Duration{Duration: defaultRetryPeriod},
-		ResourceLock:      resourcelock.LeasesResourceLock,
+		LeaderElect:   false,
+		LeaseDuration: metav1.Duration{Duration: defaultLeaseDuration},
+		RenewDeadline: metav1.Duration{Duration: defaultRenewDeadline},
+		RetryPeriod:   metav1.Duration{Duration: defaultRetryPeriod},
+		ResourceLock:  resourcelock.LeasesResourceLock,
 		// Note that the following default conflicts with the GKE default system component that also uses a lease with this name.
 		// When deploying in GKE, be sure to use a different lease name!
 		ResourceName:      "vpa-recommender",


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates documentation to warn and inform users about how to properly use leader election in GKE when deploying their own VPA recommender.

#### Which issue(s) this PR fixes:

#7461 
