### PR TITLE
Clarify how to run VPA with multiple Pods

### DIFF
--- a/vertical-pod-autoscaler/FAQ.md
+++ b/vertical-pod-autoscaler/FAQ.md
@@ -6,6 +6,7 @@
 - [How can I apply VPA to my Custom Resource?](#how-can-i-apply-vpa-to-my-custom-resource)
 - [How can I use Prometheus as a history provider for the VPA recommender?](#how-can-i-use-prometheus-as-a-history-provider-for-the-vpa-recommender)
 - [I get recommendations for my single pod replicaSet, but they are not applied. Why?](#i-get-recommendations-for-my-single-pod-replicaset-but-they-are-not-applied)
+- [Can I run the VPA in an HA configuration?](#can-i-run-the-vpa-in-an-ha-configuration)
 - [What are the parameters to VPA recommender?](#what-are-the-parameters-to-vpa-recommender)
 - [What are the parameters to VPA updater?](#what-are-the-parameters-to-vpa-updater)
 
@@ -161,6 +162,16 @@ spec:
 ```
 
 and then deploy it manually if your vpa is already configured.
+
+### Can I run the VPA in an HA configuration?
+
+The VPA admission-controller can be run with multiple active Pods at any given time.
+
+Both the updater and recommender can only run a single active Pod at a time. Should you
+want to run a Deployment with more than one pod, it's recommended to enable a lease
+election with the `--leader-elect=true` parameter.
+
+**NOTE**: If using GKE, you must set `--leader-elect-resource-name` to something OTHER than "vpa-recommender", for example "vpa-recommender-lease".
 
 ### What are the parameters to VPA recommender?
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Clarify how the VPA can be run with more than 1 Pod

#### Which issue(s) this PR fixes:
Fixes # https://github.com/kubernetes/autoscaler/issues/7450
Also include some words about the issue described in https://github.com/kubernetes/autoscaler/issues/7461

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
