### PR TITLE
Added webhook-annotations flag to VPA admission-controller

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/README.md
+++ b/vertical-pod-autoscaler/pkg/admission-controller/README.md
@@ -35,6 +35,7 @@ up the changes: ```sudo systemctl restart kubelet.service```
 1. You can specify a minimum TLS version with `--min-tls-version` with acceptable values being `tls1_2` (default), or `tls1_3`.
 1. You can also specify a comma or colon separated list of ciphers for the server to use with `--tls-ciphers` if `--min-tls-version` is set to `tls1_2`.
 1. You can specify a comma separated list to set webhook labels with `--webhook-labels`, example format: key1:value1,key2:value2.
+1. You can specify a comma separated list to set webhook annotations with `--webhook-annotations`, example format: key1:value1,key2:value2.
 
 ## Implementation
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/config_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config_test.go
@@ -40,7 +40,7 @@ func TestSelfRegistrationBase(t *testing.T) {
 	selectedNamespace := ""
 	ignoredNamespaces := []string{}
 
-	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "key1:value1,key2:value2")
+	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "key1:value1,key2:value2", "key3:value3,key4:value4")
 
 	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	webhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
@@ -48,6 +48,7 @@ func TestSelfRegistrationBase(t *testing.T) {
 	assert.NoError(t, err, "expected no error fetching webhook configuration")
 	assert.Equal(t, webhookConfigName, webhookConfig.Name, "expected webhook configuration name to match")
 	assert.Equal(t, webhookConfig.Labels, map[string]string{"key1": "value1", "key2": "value2"}, "expected webhook configuration labels to match")
+	assert.Equal(t, webhookConfig.Annotations, map[string]string{"key3": "value3", "key4": "value4"}, "expected webhook configuration annotations to match")
 
 	assert.Len(t, webhookConfig.Webhooks, 1, "expected one webhook configuration")
 	webhook := webhookConfig.Webhooks[0]
@@ -84,7 +85,7 @@ func TestSelfRegistrationWithURL(t *testing.T) {
 	selectedNamespace := ""
 	ignoredNamespaces := []string{}
 
-	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "")
+	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "", "")
 
 	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	webhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
@@ -112,7 +113,7 @@ func TestSelfRegistrationWithOutURL(t *testing.T) {
 	selectedNamespace := ""
 	ignoredNamespaces := []string{}
 
-	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "")
+	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "", "")
 
 	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	webhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
@@ -142,7 +143,7 @@ func TestSelfRegistrationWithIgnoredNamespaces(t *testing.T) {
 	selectedNamespace := ""
 	ignoredNamespaces := []string{"test"}
 
-	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "")
+	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "", "")
 
 	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	webhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
@@ -173,7 +174,7 @@ func TestSelfRegistrationWithSelectedNamespaces(t *testing.T) {
 	selectedNamespace := "test"
 	ignoredNamespaces := []string{}
 
-	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "")
+	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "", "")
 
 	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	webhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
@@ -205,7 +206,7 @@ func TestSelfRegistrationWithFailurePolicy(t *testing.T) {
 	selectedNamespace := "test"
 	ignoredNamespaces := []string{}
 
-	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, true, "")
+	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, true, "", "")
 
 	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	webhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
@@ -232,7 +233,7 @@ func TestSelfRegistrationWithOutFailurePolicy(t *testing.T) {
 	selectedNamespace := "test"
 	ignoredNamespaces := []string{}
 
-	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "")
+	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "", "")
 
 	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	webhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
@@ -259,7 +260,7 @@ func TestSelfRegistrationWithInvalidLabels(t *testing.T) {
 	selectedNamespace := ""
 	ignoredNamespaces := []string{}
 
-	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "foo,bar")
+	selfRegistration(testClientSet, caCert, webHookDelay, namespace, serviceName, url, registerByURL, timeoutSeconds, selectedNamespace, ignoredNamespaces, false, "foo,bar", "bar,foo")
 
 	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	webhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
@@ -267,6 +268,7 @@ func TestSelfRegistrationWithInvalidLabels(t *testing.T) {
 	assert.NoError(t, err, "expected no error fetching webhook configuration")
 	assert.Equal(t, webhookConfigName, webhookConfig.Name, "expected webhook configuration name to match")
 	assert.Equal(t, webhookConfig.Labels, map[string]string{}, "expected invalid webhook configuration labels to match")
+	assert.Equal(t, webhookConfig.Annotations, map[string]string{}, "expected invalid webhook configuration annotations to match")
 
 	assert.Len(t, webhookConfig.Webhooks, 1, "expected one webhook configuration")
 	webhook := webhookConfig.Webhooks[0]
@@ -290,30 +292,30 @@ func TestSelfRegistrationWithInvalidLabels(t *testing.T) {
 	assert.Equal(t, timeoutSeconds, *webhook.TimeoutSeconds, "expected timeout seconds to match")
 }
 
-func TestConvertLabelsToMap(t *testing.T) {
+func TestConvertLabelsOrAnnotationsToMap(t *testing.T) {
 	testCases := []struct {
 		desc           string
-		labels         string
+		kv             string
 		expectedOutput map[string]string
 		expectedError  bool
 	}{
 		{
 			desc:           "should return empty map when tag is empty",
-			labels:         "",
+			kv:             "",
 			expectedOutput: map[string]string{},
 			expectedError:  false,
 		},
 		{
-			desc:   "single valid tag should be converted",
-			labels: "key:value",
+			desc: "single valid tag should be converted",
+			kv:   "key:value",
 			expectedOutput: map[string]string{
 				"key": "value",
 			},
 			expectedError: false,
 		},
 		{
-			desc:   "multiple valid labels should be converted",
-			labels: "key1:value1,key2:value2",
+			desc: "multiple valid labels or annotations should be converted",
+			kv:   "key1:value1,key2:value2",
 			expectedOutput: map[string]string{
 				"key1": "value1",
 				"key2": "value2",
@@ -321,8 +323,8 @@ func TestConvertLabelsToMap(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			desc:   "whitespaces should be trimmed",
-			labels: "key1:value1, key2:value2",
+			desc: "whitespaces should be trimmed",
+			kv:   "key1:value1, key2:value2",
 			expectedOutput: map[string]string{
 				"key1": "value1",
 				"key2": "value2",
@@ -330,8 +332,8 @@ func TestConvertLabelsToMap(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			desc:   "whitespaces between keys and values should be trimmed",
-			labels: "key1 : value1,key2 : value2",
+			desc: "whitespaces between keys and values should be trimmed",
+			kv:   "key1 : value1,key2 : value2",
 			expectedOutput: map[string]string{
 				"key1": "value1",
 				"key2": "value2",
@@ -340,19 +342,19 @@ func TestConvertLabelsToMap(t *testing.T) {
 		},
 		{
 			desc:           "should return error for invalid format",
-			labels:         "foo,bar",
+			kv:             "foo,bar",
 			expectedOutput: nil,
 			expectedError:  true,
 		},
 		{
 			desc:           "should return error for when key is missed",
-			labels:         "key1:value1,:bar",
+			kv:             "key1:value1,:bar",
 			expectedOutput: nil,
 			expectedError:  true,
 		},
 		{
-			desc:   "should strip additional quotes",
-			labels: "\"key1:value1,key2:value2\"",
+			desc: "should strip additional quotes",
+			kv:   "\"key1:value1,key2:value2\"",
 			expectedOutput: map[string]string{
 				"key1": "value1",
 				"key2": "value2",
@@ -362,7 +364,7 @@ func TestConvertLabelsToMap(t *testing.T) {
 	}
 
 	for i, c := range testCases {
-		m, err := convertLabelsToMap(c.labels)
+		m, err := convertLabelsOrAnnotationsToMap(c.kv)
 		if c.expectedError {
 			assert.NotNil(t, err, "TestCase[%d]: %s", i, c.desc)
 		} else {

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -74,6 +74,7 @@ var (
 	webHookFailurePolicy = flag.Bool("webhook-failure-policy-fail", false, "If set to true, will configure the admission webhook failurePolicy to \"Fail\". Use with caution.")
 	registerWebhook      = flag.Bool("register-webhook", true, "If set to true, admission webhook object will be created on start up to register with the API server.")
 	webhookLabels        = flag.String("webhook-labels", "", "Comma separated list of labels to add to the webhook object. Format: key1:value1,key2:value2")
+	webhookAnnotations   = flag.String("webhook-annotations", "", "Comma separated list of annotations to add to the webhook object. Format: key1:value1,key2:value2")
 	registerByURL        = flag.Bool("register-by-url", false, "If set to true, admission webhook will be registered by URL (webhookAddress:webhookPort) instead of by service name")
 )
 
@@ -144,7 +145,7 @@ func main() {
 	ignoredNamespaces := strings.Split(commonFlags.IgnoredVpaObjectNamespaces, ",")
 	go func() {
 		if *registerWebhook {
-			selfRegistration(kubeClient, readFile(*certsConfiguration.clientCaFile), webHookDelay, namespace, *serviceName, url, *registerByURL, int32(*webhookTimeout), commonFlags.VpaObjectNamespace, ignoredNamespaces, *webHookFailurePolicy, *webhookLabels)
+			selfRegistration(kubeClient, readFile(*certsConfiguration.clientCaFile), webHookDelay, namespace, *serviceName, url, *registerByURL, int32(*webhookTimeout), commonFlags.VpaObjectNamespace, ignoredNamespaces, *webHookFailurePolicy, *webhookLabels, *webhookAnnotations)
 		}
 		// Start status updates after the webhook is initialized.
 		statusUpdater.Run(stopCh)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind feature

#### What this PR does / why we need it:

The VPA admission controller when deployed is bundled with a certificate. The responsibility of certificate renewal can be automatically handled with [cert-manager](https://cert-manager.io/), upon renewal the admission controller reloads the certificate, but the caBundle on the mutatingwebhook managed by the admission controller isn't updated.

Cert-manager comes with a ca-injector that exactly handles updating the CA certificates for mutating webhooks via an annotation `cert-manager.io/inject-ca-from: kube-system/vpa-cert-by-certmanager` see [ca-injector docs](https://cert-manager.io/docs/concepts/ca-injector/). Thanks to @abstrask for coming up with the idea.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to PR https://github.com/kubernetes/autoscaler/pull/7454 and issue #6665

#### Special notes for your reviewer:

I still think the PR https://github.com/kubernetes/autoscaler/pull/7454 is in the end the right approach, but this at least offer a low hanging alternative solution.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added webhook-annotations flag to VPA admission-controller. This is specially useful for having cert-managers ca-injector automatically updating  the CA certificates on the mutating webhook.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
