### PR TITLE
Added single scaleup for besteffortatomic PRs that can fit on single node group

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -307,6 +307,10 @@ type AutoscalingOptions struct {
 	CheckCapacityProvisioningRequestMaxBatchSize int
 	// CheckCapacityProvisioningRequestBatchTimebox is the maximum time to spend processing a batch of provisioning requests
 	CheckCapacityProvisioningRequestBatchTimebox time.Duration
+	// PodShardingEnabled indicates if pod sharding is enabled
+	PodShardingEnabled bool
+	// PodShardingLabels is a list of labels to use when comparing if two node groups are similar for pod sharding.
+	PodShardingNodeSelectors []string
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -311,6 +311,10 @@ type AutoscalingOptions struct {
 	PodShardingEnabled bool
 	// PodShardingLabels is a list of labels to use when comparing if two node groups are similar for pod sharding.
 	PodShardingNodeSelectors []string
+	// BestEffortAtomicProvisioningRequestShardedMaxInjectionQuantity is the maximum number of BestEffortAtomic ProvisioningRequests that can be injected into the cluster in a single loop iteration when pod sharding is enabled.
+	BestEffortAtomicProvisioningRequestShardedMaxInjectionQuantity int
+	// BestEffortAtomicProvisioningRequestShardedSimulationTimebox is the maximum time that can be spent on BestEffortAtomic ProvisioningRequest simulation when pod sharding is enabled.
+	BestEffortAtomicProvisioningRequestShardedSimulationTimebox time.Duration
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/core/scaleup/equivalence/groups.go
+++ b/cluster-autoscaler/core/scaleup/equivalence/groups.go
@@ -55,6 +55,15 @@ type equivalenceGroup struct {
 	representant *apiv1.Pod
 }
 
+// PodsFromPodGroup returns all pods from the equivalence group.
+func PodsFromPodGroup(podGroups []*PodGroup) []*apiv1.Pod {
+	var pods []*apiv1.Pod
+	for _, podGroup := range podGroups {
+		pods = append(pods, podGroup.Pods...)
+	}
+	return pods
+}
+
 const maxEquivalenceGroupsByController = 10
 
 // groupPodsBySchedulingProperties groups pods based on scheduling properties. Group ID is meaningless.

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -395,7 +395,6 @@ func (o *ScaleUpOrchestrator) ExecuteScaleUp(
 		PodsAwaitEvaluation:     podsAwaitEvaluation,
 	}, nil
 }
-
 func (o *ScaleUpOrchestrator) applyLimits(newNodes int, resourcesLeft resource.Limits, nodeGroup cloudprovider.NodeGroup, nodeInfos map[string]*framework.NodeInfo) (int, errors.AutoscalerError) {
 	nodeInfo, found := nodeInfos[nodeGroup.Id()]
 	if !found {
@@ -589,7 +588,7 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 		o.autoscalingContext.ClusterSnapshot,
 		estimator.NewEstimationContext(o.autoscalingContext.MaxNodesTotal, option.SimilarNodeGroups, currentNodeCount),
 	)
-	option.NodeCount, option.Pods = expansionEstimator.Estimate(podGroups, nodeInfo, nodeGroup)
+	option.NodeCount, option.Pods, option.SnapshotExport = expansionEstimator.Estimate(podGroups, nodeInfo, nodeGroup)
 	metrics.UpdateDurationFromStart(metrics.Estimate, estimateStart)
 
 	autoscalingOptions, err := nodeGroup.GetOptions(o.autoscalingContext.NodeGroupDefaults)

--- a/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/skippedreasons.go
@@ -27,8 +27,8 @@ type SkippedReasons struct {
 }
 
 // NewSkippedReasons creates new SkippedReason object.
-func NewSkippedReasons(m string) *SkippedReasons {
-	return &SkippedReasons{[]string{m}}
+func NewSkippedReasons(m ...string) *SkippedReasons {
+	return &SkippedReasons{m}
 }
 
 // Reasons returns a slice of reasons why the node group was not considered for scale up.

--- a/cluster-autoscaler/estimator/binpacking_estimator_test.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator_test.go
@@ -224,7 +224,7 @@ func TestBinpackingEstimate(t *testing.T) {
 			node := makeNode(tc.millicores, tc.memory, 10, "template", "zone-mars")
 			nodeInfo := framework.NewTestNodeInfo(node)
 
-			estimatedNodes, estimatedPods := estimator.Estimate(tc.podsEquivalenceGroup, nodeInfo, nil)
+			estimatedNodes, estimatedPods, _ := estimator.Estimate(tc.podsEquivalenceGroup, nodeInfo, nil)
 			assert.Equal(t, tc.expectNodeCount, estimatedNodes)
 			assert.Equal(t, tc.expectPodCount, len(estimatedPods))
 			if tc.expectProcessedPods != nil {
@@ -278,7 +278,7 @@ func BenchmarkBinpackingEstimate(b *testing.B) {
 		node := makeNode(millicores, memory, podsPerNode, "template", "zone-mars")
 		nodeInfo := framework.NewTestNodeInfo(node)
 
-		estimatedNodes, estimatedPods := estimator.Estimate(podsEquivalenceGroup, nodeInfo, nil)
+		estimatedNodes, estimatedPods, _ := estimator.Estimate(podsEquivalenceGroup, nodeInfo, nil)
 		assert.Equal(b, expectNodeCount, estimatedNodes)
 		assert.Equal(b, expectPodCount, len(estimatedPods))
 	}

--- a/cluster-autoscaler/estimator/estimator.go
+++ b/cluster-autoscaler/estimator/estimator.go
@@ -53,7 +53,7 @@ func (p *PodEquivalenceGroup) Exemplar() *apiv1.Pod {
 // to schedule on those nodes.
 type Estimator interface {
 	// Estimate estimates how many nodes are needed to provision pods coming from the given equivalence groups.
-	Estimate([]PodEquivalenceGroup, *framework.NodeInfo, cloudprovider.NodeGroup) (int, []*apiv1.Pod)
+	Estimate([]PodEquivalenceGroup, *framework.NodeInfo, cloudprovider.NodeGroup) (int, []*apiv1.Pod, clustersnapshot.ClusterSnapshot)
 }
 
 // EstimatorBuilder creates a new estimator object.

--- a/cluster-autoscaler/expander/expander.go
+++ b/cluster-autoscaler/expander/expander.go
@@ -19,6 +19,7 @@ package expander
 import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 )
 
@@ -49,6 +50,7 @@ type Option struct {
 	NodeCount         int
 	Debug             string
 	Pods              []*apiv1.Pod
+	SnapshotExport    clustersnapshot.ClusterSnapshot
 }
 
 // Strategy describes an interface for selecting the best option when scaling up

--- a/cluster-autoscaler/processors/provreq/injector_test.go
+++ b/cluster-autoscaler/processors/provreq/injector_test.go
@@ -131,7 +131,7 @@ func TestProvisioningRequestPodsInjector(t *testing.T) {
 		client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, tc.provReqs...)
 		backoffTime := lru.New(100)
 		backoffTime.Add(key(notProvisionedRecentlyProvReqB), 2*time.Minute)
-		injector := ProvisioningRequestPodsInjector{1 * time.Minute, 10 * time.Minute, backoffTime, clock.NewFakePassiveClock(now), client, now}
+		injector := ProvisioningRequestPodsInjector{1 * time.Minute, 10 * time.Minute, backoffTime, clock.NewFakePassiveClock(now), client, now, false, 1}
 		getUnscheduledPods, err := injector.Process(nil, provreqwrapper.BuildTestPods("ns", "pod", tc.existingUnsUnschedulablePodCount))
 		if err != nil {
 			t.Errorf("%s failed: injector.Process return error %v", tc.name, err)

--- a/cluster-autoscaler/processors/status/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_up_status_processor.go
@@ -17,6 +17,10 @@ limitations under the License.
 package status
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 
@@ -142,4 +146,240 @@ func UpdateScaleUpError(s *ScaleUpStatus, err errors.AutoscalerError) (*ScaleUpS
 	s.ScaleUpError = &err
 	s.Result = ScaleUpError
 	return s, err
+}
+
+// combinedStatusSet is a helper struct to combine multiple ScaleUpStatuses into one. It keeps track of the best result and all errors that occurred during the ScaleUp process.
+type combinedStatusSet struct {
+	Result                      ScaleUpResult
+	ScaleupErrors               map[*errors.AutoscalerError]bool
+	ScaleUpInfosSet             map[nodegroupset.ScaleUpInfo]bool
+	PodsTriggeredScaleUpSet     map[*apiv1.Pod]bool
+	PodsRemainUnschedulableSet  map[*NoScaleUpInfo]bool
+	PodsAwaitEvaluationSet      map[*apiv1.Pod]bool
+	CreateNodeGroupResultsSet   map[*nodegroups.CreateNodeGroupResult]bool
+	ConsideredNodeGroupsSet     map[cloudprovider.NodeGroup]bool
+	FailedCreationNodeGroupsSet map[cloudprovider.NodeGroup]bool
+	FailedResizeNodeGroupsSet   map[cloudprovider.NodeGroup]bool
+}
+
+// Add adds a ScaleUpStatus to the combinedStatusSet.
+func (c *combinedStatusSet) Add(status *ScaleUpStatus) {
+	resultPriority := map[ScaleUpResult]int{
+		ScaleUpNotTried:           0,
+		ScaleUpNotNeeded:          1,
+		ScaleUpNoOptionsAvailable: 2,
+		ScaleUpError:              3,
+		ScaleUpSuccessful:         4,
+	}
+
+	// If even one scaleUpSuccessful is present, the final result is ScaleUpSuccessful.
+	// If no ScaleUpSuccessful is present, and even one ScaleUpError is present, the final result is ScaleUpError.
+	// If no ScaleUpSuccessful or ScaleUpError is present, and even one ScaleUpNoOptionsAvailable is present, the final result is ScaleUpNoOptionsAvailable.
+	// If no ScaleUpSuccessful, ScaleUpError or ScaleUpNoOptionsAvailable is present, the final result is ScaleUpNotTried.
+	if resultPriority[c.Result] < resultPriority[status.Result] {
+		c.Result = status.Result
+	}
+	if status.ScaleUpError != nil {
+		if _, found := c.ScaleupErrors[status.ScaleUpError]; !found {
+			c.ScaleupErrors[status.ScaleUpError] = true
+		}
+	}
+	if status.ScaleUpInfos != nil {
+		for _, scaleUpInfo := range status.ScaleUpInfos {
+			if _, found := c.ScaleUpInfosSet[scaleUpInfo]; !found {
+				c.ScaleUpInfosSet[scaleUpInfo] = true
+			}
+		}
+	}
+	if status.PodsTriggeredScaleUp != nil {
+		for _, pod := range status.PodsTriggeredScaleUp {
+			if _, found := c.PodsTriggeredScaleUpSet[pod]; !found {
+				c.PodsTriggeredScaleUpSet[pod] = true
+			}
+		}
+	}
+	if status.PodsRemainUnschedulable != nil {
+		for _, pod := range status.PodsRemainUnschedulable {
+			if _, found := c.PodsRemainUnschedulableSet[&pod]; !found {
+				c.PodsRemainUnschedulableSet[&pod] = true
+			}
+		}
+	}
+	if status.PodsAwaitEvaluation != nil {
+		for _, pod := range status.PodsAwaitEvaluation {
+			if _, found := c.PodsAwaitEvaluationSet[pod]; !found {
+				c.PodsAwaitEvaluationSet[pod] = true
+			}
+		}
+	}
+	if status.CreateNodeGroupResults != nil {
+		for _, createNodeGroupResult := range status.CreateNodeGroupResults {
+			if _, found := c.CreateNodeGroupResultsSet[&createNodeGroupResult]; !found {
+				c.CreateNodeGroupResultsSet[&createNodeGroupResult] = true
+			}
+		}
+	}
+	if status.ConsideredNodeGroups != nil {
+		for _, nodeGroup := range status.ConsideredNodeGroups {
+			if _, found := c.ConsideredNodeGroupsSet[nodeGroup]; !found {
+				c.ConsideredNodeGroupsSet[nodeGroup] = true
+			}
+		}
+	}
+	if status.FailedCreationNodeGroups != nil {
+		for _, nodeGroup := range status.FailedCreationNodeGroups {
+			if _, found := c.FailedCreationNodeGroupsSet[nodeGroup]; !found {
+				c.FailedCreationNodeGroupsSet[nodeGroup] = true
+			}
+		}
+	}
+	if status.FailedResizeNodeGroups != nil {
+		for _, nodeGroup := range status.FailedResizeNodeGroups {
+			if _, found := c.FailedResizeNodeGroupsSet[nodeGroup]; !found {
+				c.FailedResizeNodeGroupsSet[nodeGroup] = true
+			}
+		}
+	}
+}
+
+// formatMessageFromBatchErrors formats a message from a list of errors.
+func (c *combinedStatusSet) formatMessageFromBatchErrors(errs []errors.AutoscalerError, printErrorTypes bool) string {
+	firstErr := errs[0]
+	var builder strings.Builder
+	builder.WriteString(firstErr.Error())
+	builder.WriteString(" ...and other concurrent errors: [")
+	formattedErrs := map[errors.AutoscalerError]bool{
+		firstErr: true,
+	}
+	for _, err := range errs {
+		if _, has := formattedErrs[err]; has {
+			continue
+		}
+		formattedErrs[err] = true
+		var message string
+		if printErrorTypes {
+			message = fmt.Sprintf("[%s] %s", err.Type(), err.Error())
+		} else {
+			message = err.Error()
+		}
+		if len(formattedErrs) > 2 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(fmt.Sprintf("%q", message))
+	}
+	builder.WriteString("]")
+	return builder.String()
+}
+
+// combineBatchScaleUpErrors combines multiple errors into one. If there is only one error, it returns that error. If there are multiple errors, it combines them into one error with a message that contains all the errors.
+func (c *combinedStatusSet) combineBatchScaleUpErrors() *errors.AutoscalerError {
+	if len(c.ScaleupErrors) == 0 {
+		return nil
+	}
+	if len(c.ScaleupErrors) == 1 {
+		for err := range c.ScaleupErrors {
+			return err
+		}
+	}
+	uniqueMessages := make(map[string]bool)
+	uniqueTypes := make(map[errors.AutoscalerErrorType]bool)
+	for err := range c.ScaleupErrors {
+		uniqueTypes[(*err).Type()] = true
+		uniqueMessages[(*err).Error()] = true
+	}
+	if len(uniqueTypes) == 1 && len(uniqueMessages) == 1 {
+		for err := range c.ScaleupErrors {
+			return err
+		}
+	}
+	// sort to stabilize the results and easier log aggregation
+	errs := make([]errors.AutoscalerError, 0, len(c.ScaleupErrors))
+	for err := range c.ScaleupErrors {
+		errs = append(errs, *err)
+	}
+	sort.Slice(errs, func(i, j int) bool {
+		errA := errs[i]
+		errB := errs[j]
+		if errA.Type() == errB.Type() {
+			return errs[i].Error() < errs[j].Error()
+		}
+		return errA.Type() < errB.Type()
+	})
+	firstErr := errs[0]
+	printErrorTypes := len(uniqueTypes) > 1
+	message := c.formatMessageFromBatchErrors(errs, printErrorTypes)
+	combinedErr := errors.NewAutoscalerError(firstErr.Type(), message)
+	return &combinedErr
+}
+
+// Export converts the combinedStatusSet into a ScaleUpStatus.
+func (c *combinedStatusSet) Export() (*ScaleUpStatus, errors.AutoscalerError) {
+	result := &ScaleUpStatus{Result: c.Result}
+	if len(c.ScaleupErrors) > 0 {
+		result.ScaleUpError = c.combineBatchScaleUpErrors()
+	}
+	if len(c.ScaleUpInfosSet) > 0 {
+		for scaleUpInfo := range c.ScaleUpInfosSet {
+			result.ScaleUpInfos = append(result.ScaleUpInfos, scaleUpInfo)
+		}
+	}
+	if len(c.PodsTriggeredScaleUpSet) > 0 {
+		for pod := range c.PodsTriggeredScaleUpSet {
+			result.PodsTriggeredScaleUp = append(result.PodsTriggeredScaleUp, pod)
+		}
+	}
+	if len(c.PodsRemainUnschedulableSet) > 0 {
+		for pod := range c.PodsRemainUnschedulableSet {
+			result.PodsRemainUnschedulable = append(result.PodsRemainUnschedulable, *pod)
+		}
+	}
+	if len(c.PodsAwaitEvaluationSet) > 0 {
+		for pod := range c.PodsAwaitEvaluationSet {
+			result.PodsAwaitEvaluation = append(result.PodsAwaitEvaluation, pod)
+		}
+	}
+	if len(c.CreateNodeGroupResultsSet) > 0 {
+		for createNodeGroupResult := range c.CreateNodeGroupResultsSet {
+			result.CreateNodeGroupResults = append(result.CreateNodeGroupResults, *createNodeGroupResult)
+		}
+	}
+	if len(c.ConsideredNodeGroupsSet) > 0 {
+		for nodeGroup := range c.ConsideredNodeGroupsSet {
+			result.ConsideredNodeGroups = append(result.ConsideredNodeGroups, nodeGroup)
+		}
+	}
+	if len(c.FailedCreationNodeGroupsSet) > 0 {
+		for nodeGroup := range c.FailedCreationNodeGroupsSet {
+			result.FailedCreationNodeGroups = append(result.FailedCreationNodeGroups, nodeGroup)
+		}
+	}
+	if len(c.FailedResizeNodeGroupsSet) > 0 {
+		for nodeGroup := range c.FailedResizeNodeGroupsSet {
+			result.FailedResizeNodeGroups = append(result.FailedResizeNodeGroups, nodeGroup)
+		}
+	}
+
+	var resErr errors.AutoscalerError
+
+	if result.Result == ScaleUpError {
+		resErr = *result.ScaleUpError
+	}
+
+	return result, resErr
+}
+
+// NewCombinedStatusSet creates a new combinedStatusSet.
+func NewCombinedStatusSet() combinedStatusSet {
+	return combinedStatusSet{
+		Result:                      ScaleUpNotTried,
+		ScaleupErrors:               make(map[*errors.AutoscalerError]bool),
+		ScaleUpInfosSet:             make(map[nodegroupset.ScaleUpInfo]bool),
+		PodsTriggeredScaleUpSet:     make(map[*apiv1.Pod]bool),
+		PodsRemainUnschedulableSet:  make(map[*NoScaleUpInfo]bool),
+		PodsAwaitEvaluationSet:      make(map[*apiv1.Pod]bool),
+		CreateNodeGroupResultsSet:   make(map[*nodegroups.CreateNodeGroupResult]bool),
+		ConsideredNodeGroupsSet:     make(map[cloudprovider.NodeGroup]bool),
+		FailedCreationNodeGroupsSet: make(map[cloudprovider.NodeGroup]bool),
+		FailedResizeNodeGroupsSet:   make(map[cloudprovider.NodeGroup]bool),
+	}
 }

--- a/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
+++ b/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
@@ -17,6 +17,9 @@ limitations under the License.
 package besteffortatomic
 
 import (
+	"reflect"
+	"time"
+
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,14 +28,19 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
-	"k8s.io/autoscaler/cluster-autoscaler/core/scaleup"
+
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaleup/equivalence"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaleup/orchestrator"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/conditions"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqclient"
+	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqwrapper"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -47,8 +55,8 @@ import (
 type bestEffortAtomicProvClass struct {
 	context             *context.AutoscalingContext
 	client              *provreqclient.ProvisioningRequestClient
-	injector            *scheduling.HintingSimulator
-	scaleUpOrchestrator scaleup.Orchestrator
+	schedulingSimulator *scheduling.HintingSimulator
+	scaleUpOrchestrator *orchestrator.ScaleUpOrchestrator
 }
 
 // New creates best effort atomic provisioning class supporting create capacity scale-up mode.
@@ -64,10 +72,10 @@ func (o *bestEffortAtomicProvClass) Initialize(
 	clusterStateRegistry *clusterstate.ClusterStateRegistry,
 	estimatorBuilder estimator.EstimatorBuilder,
 	taintConfig taints.TaintConfig,
-	injector *scheduling.HintingSimulator,
+	schedulingSimulator *scheduling.HintingSimulator,
 ) {
 	o.context = autoscalingContext
-	o.injector = injector
+	o.schedulingSimulator = schedulingSimulator
 	o.scaleUpOrchestrator.Initialize(autoscalingContext, processors, clusterStateRegistry, estimatorBuilder, taintConfig)
 }
 
@@ -81,62 +89,237 @@ func (o *bestEffortAtomicProvClass) Provision(
 	if len(unschedulablePods) == 0 {
 		return &status.ScaleUpStatus{Result: status.ScaleUpNotTried}, nil
 	}
-	prs := provreqclient.ProvisioningRequestsForPods(o.client, unschedulablePods)
-	prs = provreqclient.FilterOutProvisioningClass(prs, v1.ProvisioningClassBestEffortAtomicScaleUp)
-	if len(prs) == 0 {
-		return &status.ScaleUpStatus{Result: status.ScaleUpNotTried}, nil
-	}
-	// Pick 1 ProvisioningRequest.
-	pr := prs[0]
+
+	combinedStatus := status.NewCombinedStatusSet()
+	simulationResults := make(map[*provreqwrapper.ProvisioningRequest]*orchestrator.ScaleUpSimulationResult)
+
+	bestOptionPods := []*apiv1.Pod{}
+	skippedNodeGroupsMap := make(map[string]status.Reasons)
+	consideredNodeGroupsMap := make(map[string]cloudprovider.NodeGroup)
+	aggregatedPodEquivalenceGroups := []*equivalence.PodGroup{}
+	bestOptionPodsAwaitEvaluation := []*apiv1.Pod{}
+
+	scaleUpInfosMap := make(map[string]nodegroupset.ScaleUpInfo)
+	createNodeGroupResultsMap := make(map[string]nodegroups.CreateNodeGroupResult)
+
+	finalPrs := []*provreqwrapper.ProvisioningRequest{}
+
+	prMap := provreqclient.SegregatePodsByProvisioningRequest(o.client, unschedulablePods)
+
+	var scaleUpStatus *status.ScaleUpStatus
+	startTime := time.Now()
 
 	o.context.ClusterSnapshot.Fork()
 	defer o.context.ClusterSnapshot.Revert()
 
-	// For provisioning requests, unschedulablePods are actually all injected pods. Some may even be schedulable!
-	actuallyUnschedulablePods, err := o.filterOutSchedulable(unschedulablePods)
-	if err != nil {
-		conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.FailedToCheckCapacityReason, conditions.FailedToCheckCapacityMsg, metav1.Now())
-		if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
-			klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+	for _, prPods := range prMap {
+		pr, err := o.client.ProvisioningRequest(prPods[0].Namespace, prPods[0].OwnerReferences[0].Name)
+		if err != nil {
+			klog.Errorf("failed to retrieve ProvisioningRequest from unschedulable pod, err: %v", err)
+			scaleUpStatus, _ = status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+			combinedStatus.Add(scaleUpStatus)
+			continue
 		}
-		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+
+		// Skip ProvisioningRequests with non-best-effort provisioning class
+		if pr.Spec.ProvisioningClassName != v1.ProvisioningClassBestEffortAtomicScaleUp {
+			combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNotTried})
+			continue
+		}
+
+		// Try to schedule pods which can be scheduled without scale-up.
+		unschedulablePrPods, err := o.filterOutSchedulable(prPods)
+		if err != nil {
+			conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.FailedToCheckCapacityReason, conditions.FailedToCheckCapacityMsg, metav1.Now())
+			if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+				klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+			}
+			scaleUpStatus, _ = status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+			combinedStatus.Add(scaleUpStatus)
+			continue
+		}
+
+		if len(unschedulablePrPods) == 0 {
+			// Nothing to do here - everything fits without scale-up.
+			conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+			if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+				klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+				scaleUpStatus, _ = status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "capacity available, but failed to admit workload: %s", updateErr.Error()))
+				combinedStatus.Add(scaleUpStatus)
+				continue
+			}
+			combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNotNeeded})
+			continue
+		}
+
+		if !o.scaleUpOrchestrator.IsInitialized() {
+			scaleUpStatus, _ = status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "scale up orchestrator is not initialized"))
+			combinedStatus.Add(scaleUpStatus)
+			continue
+		}
+
+		klog.V(1).Infof("ProvisioningRequest %s/%s has %d unschedulable pods", pr.Namespace, pr.Name, len(unschedulablePrPods))
+
+		// Build equivalence groups for unschedulable pods
+		podEquivalenceGroups := orchestrator.BuildPodEquivalenceGroups(unschedulablePrPods)
+
+		// Simulation of scale-up and preparation of scale-up plan
+		simulationResult, simulationScaleUpStatus, aErr := o.scaleUpOrchestrator.SimulateScaleUp(podEquivalenceGroups, nodes, nodeInfos, true)
+		if aErr != nil || (simulationScaleUpStatus != nil && simulationResult == nil) {
+			conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
+			if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+				klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+			}
+
+			if aErr != nil {
+				scaleUpStatus, _ = status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", aErr.Error()))
+				combinedStatus.Add(scaleUpStatus)
+				continue
+			}
+
+			combinedStatus.Add(simulationScaleUpStatus)
+			continue
+		}
+
+		// Update snapshot with the exported snapshot from the best option
+		simulationResult.BestOption.SnapshotExport.Rebase(o.context.ClusterSnapshot)
+		if o.context.ClusterSnapshot == nil {
+			klog.Errorf("Cluster snapshot is nil")
+			combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNotTried})
+			continue
+		}
+		reflect.ValueOf(o.context.ClusterSnapshot).Elem().Set(reflect.ValueOf(simulationResult.BestOption.SnapshotExport).Elem())
+
+		// Add simulation result to simulation result array
+		simulationResults[pr] = simulationResult
+
+		if time.Since(startTime) > o.context.BestEffortAtomicProvisioningRequestShardedSimulationTimebox {
+			klog.Info("Simulation timebox exceeded, stopping further simulations")
+			break
+		}
 	}
 
-	if len(actuallyUnschedulablePods) == 0 {
-		// Nothing to do here - everything fits without scale-up.
-		conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
-		if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
-			klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
-			return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "capacity available, but failed to admit workload: %s", updateErr.Error()))
-		}
-		return &status.ScaleUpStatus{Result: status.ScaleUpNotNeeded}, nil
+	for _, simRes := range simulationResults {
+		klog.Warning("simRes.BestOption: ", simRes.BestOption)
 	}
 
-	st, err := o.scaleUpOrchestrator.ScaleUp(actuallyUnschedulablePods, nodes, daemonSets, nodeInfos, true)
-	if err == nil && st.Result == status.ScaleUpSuccessful {
-		// Happy path - all is well.
-		conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsProvisionedReason, conditions.CapacityIsProvisionedMsg, metav1.Now())
-		if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
-			klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
-			return st, errors.NewAutoscalerError(errors.InternalError, "scale up requested, but failed to admit workload: %s", updateErr.Error())
+	// Prepare node groups for scale-up
+	for pr, simulationResult := range simulationResults {
+		preparationResult, preparationScaleUpStatus, aErr := o.scaleUpOrchestrator.PrepareNodeGroupsForScaleUp(
+			simulationResult.BestOption,
+			simulationResult.NewNodes,
+			simulationResult.SkippedNodeGroups,
+			simulationResult.NodeGroups,
+			simulationResult.NodeInfos,
+			simulationResult.SchedulablePodGroups,
+			simulationResult.PodEquivalenceGroups,
+			daemonSets,
+			true,
+		)
+		if aErr != nil || (preparationScaleUpStatus != nil && preparationResult == nil) {
+			conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
+			if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+				klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+			}
+
+			if aErr != nil {
+				scaleUpStatus, _ = status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", aErr.Error()))
+				combinedStatus.Add(scaleUpStatus)
+				continue
+			}
+
+			combinedStatus.Add(preparationScaleUpStatus)
+			continue
 		}
-		return st, nil
+
+		// Add simulation results to execution values
+		bestOptionPods = append(bestOptionPods, simulationResult.BestOption.Pods...)
+		for nodeGroupName, skippedReasons := range simulationResult.SkippedNodeGroups {
+			skippedNodeGroupsMap[nodeGroupName] = orchestrator.NewSkippedReasons(append(skippedNodeGroupsMap[nodeGroupName].Reasons(), skippedReasons.Reasons()...)...)
+		}
+		for _, nodeGroup := range simulationResult.NodeGroups {
+			consideredNodeGroupsMap[nodeGroup.Id()] = nodeGroup
+		}
+		bestOptionPodsAwaitEvaluation = append(bestOptionPodsAwaitEvaluation, orchestrator.GetPodsAwaitingEvaluation(simulationResult.PodEquivalenceGroups, simulationResult.BestOption.NodeGroup.Id())...)
+		aggregatedPodEquivalenceGroups = append(aggregatedPodEquivalenceGroups, simulationResult.PodEquivalenceGroups...)
+		finalPrs = append(finalPrs, pr)
+
+		// Add preparation result to execution values
+		for _, scaleUpInfo := range preparationResult.ScaleUpInfos {
+			prevScaleUpInfo, found := scaleUpInfosMap[scaleUpInfo.Group.Id()]
+			if found {
+				scaleUpInfo.CurrentSize = prevScaleUpInfo.CurrentSize
+			}
+			scaleUpInfosMap[scaleUpInfo.Group.Id()] = scaleUpInfo
+		}
+		for _, createNodeGroupResult := range preparationResult.CreateNodeGroupResults {
+			createNodeGroupResultsMap[createNodeGroupResult.MainCreatedNodeGroup.Id()] = createNodeGroupResult
+		}
 	}
 
-	// We are not happy with the results.
-	conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
-	if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
-		klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+	consideredNodeGroups := make([]cloudprovider.NodeGroup, 0, len(consideredNodeGroupsMap))
+	for _, nodeGroup := range consideredNodeGroupsMap {
+		consideredNodeGroups = append(consideredNodeGroups, nodeGroup)
 	}
-	if err != nil {
-		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+
+	scaleUpInfos := make([]nodegroupset.ScaleUpInfo, 0, len(scaleUpInfosMap))
+	for _, scaleUpInfo := range scaleUpInfosMap {
+		scaleUpInfos = append(scaleUpInfos, scaleUpInfo)
 	}
-	return st, nil
+
+	createNodeGroupResults := make([]nodegroups.CreateNodeGroupResult, 0, len(createNodeGroupResultsMap))
+	for _, createNodeGroupResult := range createNodeGroupResultsMap {
+		createNodeGroupResults = append(createNodeGroupResults, createNodeGroupResult)
+	}
+
+	if len(finalPrs) > 0 && len(bestOptionPods) > 0 {
+		// Execute scale-up
+		combinedExecutionScaleUpStatus, err := o.scaleUpOrchestrator.ExecuteScaleUp(
+			bestOptionPods,
+			skippedNodeGroupsMap,
+			consideredNodeGroups,
+			nodeInfos,
+			aggregatedPodEquivalenceGroups,
+			scaleUpInfos,
+			createNodeGroupResults,
+			bestOptionPodsAwaitEvaluation,
+			true,
+		)
+
+		if err != nil {
+			scaleUpStatus, _ = status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+
+			for _, pr := range finalPrs {
+				conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
+				if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+					klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+				}
+			}
+
+			combinedStatus.Add(scaleUpStatus)
+		} else {
+			for _, pr := range finalPrs {
+				conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+				if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+					klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+					scaleUpStatus, _ = status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "scale up requested, but failed to admit workload: %s", updateErr.Error()))
+					combinedStatus.Add(scaleUpStatus)
+				}
+			}
+
+			combinedStatus.Add(combinedExecutionScaleUpStatus)
+		}
+	}
+
+	return combinedStatus.Export()
 }
 
 func (o *bestEffortAtomicProvClass) filterOutSchedulable(pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
-	statuses, _, err := o.injector.TrySchedulePods(o.context.ClusterSnapshot, pods, scheduling.ScheduleAnywhere, false)
+	o.context.ClusterSnapshot.Fork()
+
+	statuses, _, err := o.schedulingSimulator.TrySchedulePods(o.context.ClusterSnapshot, pods, scheduling.ScheduleAnywhere, false)
 	if err != nil {
+		o.context.ClusterSnapshot.Revert()
 		return nil, err
 	}
 
@@ -151,6 +334,6 @@ func (o *bestEffortAtomicProvClass) filterOutSchedulable(pods []*apiv1.Pod) ([]*
 			unschedulablePods = append(unschedulablePods, pod)
 		}
 	}
+	o.context.ClusterSnapshot.Commit()
 	return unschedulablePods, nil
-
 }

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -193,7 +193,7 @@ func (o *checkCapacityProvClass) shouldStopBatchProcessing(prsProcessed int, sta
 
 // getNextPrPods retreives pods from the next CheckCapacity ProvisioningRequest.
 func (o *checkCapacityProvClass) getNextPrPods(provisioningRequestsProcessed map[string]bool) ([]*apiv1.Pod, error) {
-	return o.provreqInjector.GetPodsFromNextRequest(func(pr *provreqwrapper.ProvisioningRequest) bool {
+	pods, _, err := o.provreqInjector.GetPodsFromNextRequest(func(pr *provreqwrapper.ProvisioningRequest) bool {
 		if pr.Spec.ProvisioningClassName != v1.ProvisioningClassCheckCapacity {
 			return false
 		}
@@ -202,6 +202,8 @@ func (o *checkCapacityProvClass) getNextPrPods(provisioningRequestsProcessed map
 		}
 		return true
 	})
+
+	return pods, err
 }
 
 // combinedStatusSet is a helper struct to combine multiple ScaleUpStatuses into one. It keeps track of the best result and all errors that occurred during the ScaleUp process.

--- a/cluster-autoscaler/provisioningrequest/pods/pods.go
+++ b/cluster-autoscaler/provisioningrequest/pods/pods.go
@@ -36,6 +36,20 @@ const (
 	DeprecatedProvisioningClassPodAnnotationKey = "cluster-autoscaler.kubernetes.io/provisioning-class-name"
 )
 
+// ProvisioningClassName checks if pod is consuming ProvReq and returns the name of
+// the ProvisioningClass. If pod is not consuming ProvReq returns false and empty string.
+func ProvisioningClassName(pod *corev1.Pod) (string, bool) {
+	if pod == nil || pod.Annotations == nil {
+		return "", false
+	}
+	provClass, found := pod.Annotations[v1.ProvisioningClassPodAnnotationKey]
+	if !found {
+		provClass, found = pod.Annotations[DeprecatedProvisioningClassPodAnnotationKey]
+	}
+
+	return provClass, found
+}
+
 // PodsForProvisioningRequest returns a list of pods for which Provisioning
 // Request needs to provision resources.
 func PodsForProvisioningRequest(pr *provreqwrapper.ProvisioningRequest) ([]*corev1.Pod, error) {

--- a/cluster-autoscaler/provisioningrequest/provreqclient/client.go
+++ b/cluster-autoscaler/provisioningrequest/provreqclient/client.go
@@ -200,6 +200,21 @@ func ProvisioningRequestsForPods(client *ProvisioningRequestClient, unschedulabl
 	return prList
 }
 
+// SegregatePodsByProvisioningRequest segregates pods by ProvisioningRequest.
+func SegregatePodsByProvisioningRequest(client *ProvisioningRequestClient, pods []*apiv1.Pod) map[string][]*apiv1.Pod {
+	podsByPR := make(map[string][]*apiv1.Pod)
+	for _, pod := range pods {
+		if len(pod.OwnerReferences) == 0 {
+			klog.Errorf("pod %s has no OwnerReference", pod.Name)
+			continue
+		}
+
+		provReq := fmt.Sprintf("%s/%s", pod.Namespace, pod.OwnerReferences[0].Name)
+		podsByPR[provReq] = append(podsByPR[provReq], pod)
+	}
+	return podsByPR
+}
+
 // DeleteProvisioningRequest deletes the given ProvisioningRequest CR using the ProvisioningRequestInterface and returns an error in case of failure.
 func (c *ProvisioningRequestClient) DeleteProvisioningRequest(pr *v1.ProvisioningRequest) error {
 	ctx, cancel := context.WithTimeout(context.Background(), provisioningRequestClientCallTimeout)

--- a/cluster-autoscaler/simulator/clustersnapshot/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/basic.go
@@ -314,6 +314,26 @@ func (snapshot *BasicClusterSnapshot) Clear() {
 	snapshot.data = []*internalBasicSnapshotData{baseData}
 }
 
+// Export returns a shallow copy of the snapshot.
+func (snapshot *BasicClusterSnapshot) Export() ClusterSnapshot {
+	exportedSnapshot := &BasicClusterSnapshot{}
+	exportedSnapshot.data = make([]*internalBasicSnapshotData, len(snapshot.data))
+	for i, data := range snapshot.data {
+		exportedSnapshot.data[i] = data.clone()
+	}
+	return exportedSnapshot
+}
+
+// Rebase rebases the snapshot to a new base snapshot.
+func (snapshot *BasicClusterSnapshot) Rebase(base ClusterSnapshot) error {
+	baseSnapshot, ok := base.(*BasicClusterSnapshot)
+	if !ok {
+		return fmt.Errorf("cannot rebase to different type of snapshot")
+	}
+	snapshot.data = []*internalBasicSnapshotData{baseSnapshot.getInternalData().clone(), snapshot.data[len(snapshot.data)-1]}
+	return nil
+}
+
 // implementation of SharedLister interface
 
 type basicClusterSnapshotNodeLister BasicClusterSnapshot

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -63,6 +63,10 @@ type ClusterSnapshot interface {
 	Commit() error
 	// Clear reset cluster snapshot to empty, unforked state.
 	Clear()
+	// Export returns a shallow copy of the snapshot.
+	Export() ClusterSnapshot
+	// Rebase rebases the snapshot to a new base snapshot.
+	Rebase(base ClusterSnapshot) error
 }
 
 // ErrNodeNotFound means that a node wasn't found in the snapshot.

--- a/cluster-autoscaler/simulator/clustersnapshot/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/delta.go
@@ -32,6 +32,8 @@ import (
 //	fork - O(1)
 //	revert - O(1)
 //	commit - O(n)
+//	rebase - O(1)
+//	export - O(1)
 //	list all pods (no filtering) - O(n), cached
 //	list all pods (with filtering) - O(n)
 //	list node infos - O(n), cached
@@ -503,4 +505,23 @@ func (snapshot *DeltaClusterSnapshot) Commit() error {
 // Time: O(1)
 func (snapshot *DeltaClusterSnapshot) Clear() {
 	snapshot.data = newInternalDeltaSnapshotData()
+}
+
+// Export returns a shallow copy of the changes made to the snapshot.
+// Time: O(1) (shallow copy)
+func (snapshot *DeltaClusterSnapshot) Export() ClusterSnapshot {
+	return &DeltaClusterSnapshot{
+		data: snapshot.data,
+	}
+}
+
+// Rebase rebases the snapshot to a new base snapshot.
+// Time: O(1)
+func (snapshot *DeltaClusterSnapshot) Rebase(base ClusterSnapshot) error {
+	snapshotBase, ok := base.(*DeltaClusterSnapshot)
+	if !ok {
+		return fmt.Errorf("cannot rebase to a different type of snapshot")
+	}
+	snapshot.data.baseData = snapshotBase.data
+	return nil
 }

--- a/cluster-autoscaler/utils/pod/pod.go
+++ b/cluster-autoscaler/utils/pod/pod.go
@@ -50,7 +50,7 @@ func IsMirrorPod(pod *apiv1.Pod) bool {
 // IsStaticPod returns true if the pod is a static pod.
 func IsStaticPod(pod *apiv1.Pod) bool {
 	if pod.Annotations != nil {
-		if source, ok := pod.Annotations[types.ConfigSourceAnnotationKey]; ok == true {
+		if source, ok := pod.Annotations[types.ConfigSourceAnnotationKey]; ok {
 			return source != types.ApiserverSource
 		}
 	}

--- a/cluster-autoscaler/utils/podsharding/composite_pod_sharder.go
+++ b/cluster-autoscaler/utils/podsharding/composite_pod_sharder.go
@@ -1,0 +1,61 @@
+package podsharding
+
+import (
+	"k8s.io/api/core/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+)
+
+// FeatureShardComputeFunction function computes part of shard to which pod belongs, looking at specific feature.
+// If function does not detect that pod should be separated from others based on handled feature it should return empty string
+type FeatureShardComputeFunction struct {
+	// Feature is feature name
+	Feature string
+
+	// Function is used to compute shard value for feature.
+	// Result of computation is mutation done to passed NodeGroupDescriptor.
+	// After mutations for all features are applied for given pod we end up with final NodeGroupDescriptor which represents
+	// a shard pod belongs to.
+	// NodeGroupDescriptor for selected shard is also later used for building NodeInfo to be used for extending set of pods in
+	// shard using predicate checking.
+	Function func(*v1.Pod, *NodeGroupDescriptor)
+}
+
+// CompositePodSharder is an implementation of PodSharder based on list of features with corresponding
+// functions to compute shard value for given feature.
+type CompositePodSharder struct {
+	featureShardComputeFunctions []FeatureShardComputeFunction
+}
+
+// NewCompositePodSharder creates new instance of CompositePodSharder
+func NewCompositePodSharder(computeFunctions []FeatureShardComputeFunction) *CompositePodSharder {
+	return &CompositePodSharder{
+		featureShardComputeFunctions: append([]FeatureShardComputeFunction{}, computeFunctions...),
+	}
+}
+
+// ComputePodShards computes sharding for given set of pods
+func (sharder *CompositePodSharder) ComputePodShards(pods []*v1.Pod) []*PodShard {
+	podShards := make(map[ShardSignature]*PodShard)
+
+	for _, pod := range pods {
+		nodeGroupDescriptor := EmptyNodeGroupDescriptor()
+		for _, computeFunction := range sharder.featureShardComputeFunctions {
+			computeFunction.Function(pod, &nodeGroupDescriptor)
+		}
+
+		shardSignature := nodeGroupDescriptor.signature()
+		if _, found := podShards[shardSignature]; !found {
+			podShards[shardSignature] = &PodShard{
+				PodUids:             make(map[apitypes.UID]bool),
+				NodeGroupDescriptor: nodeGroupDescriptor,
+			}
+		}
+		podShards[shardSignature].PodUids[pod.UID] = true
+	}
+
+	var result []*PodShard
+	for _, podShard := range podShards {
+		result = append(result, podShard)
+	}
+	return result
+}

--- a/cluster-autoscaler/utils/podsharding/composite_pod_sharder.go
+++ b/cluster-autoscaler/utils/podsharding/composite_pod_sharder.go
@@ -19,6 +19,7 @@ package podsharding
 import (
 	"k8s.io/api/core/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 )
 
 // FeatureShardComputeFunction function computes part of shard to which pod belongs, looking at specific feature.
@@ -73,5 +74,8 @@ func (sharder *CompositePodSharder) ComputePodShards(pods []*v1.Pod) []*PodShard
 	for _, podShard := range podShards {
 		result = append(result, podShard)
 	}
+
+	klog.V(4).Infof("Computed %d pod shards", len(result))
+
 	return result
 }

--- a/cluster-autoscaler/utils/podsharding/composite_pod_sharder.go
+++ b/cluster-autoscaler/utils/podsharding/composite_pod_sharder.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (

--- a/cluster-autoscaler/utils/podsharding/composite_pod_sharder_test.go
+++ b/cluster-autoscaler/utils/podsharding/composite_pod_sharder_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package podsharding
 

--- a/cluster-autoscaler/utils/podsharding/composite_pod_sharder_test.go
+++ b/cluster-autoscaler/utils/podsharding/composite_pod_sharder_test.go
@@ -1,0 +1,251 @@
+
+package podsharding
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+)
+
+type shardFeatureParts map[string]string
+
+type podFeatureParts []struct {
+	uid        apitypes.UID
+	nodeLables shardFeatureParts
+}
+type expectedShards map[apitypes.UID][]ShardSignature // uid -> list of shards
+
+func TestCompositePodSharderBasic(t *testing.T) {
+	tests := []struct {
+		name           string
+		podsFeatures   podFeatureParts
+		expectedShards expectedShards
+	}{
+		{
+			name:           "no pods",
+			podsFeatures:   nil,
+			expectedShards: nil,
+		},
+		{
+			name: "only default shard",
+			podsFeatures: podFeatureParts{
+				{"p1", shardFeatureParts{}},
+				{"p2", shardFeatureParts{}},
+				{"p3", shardFeatureParts{}},
+			},
+			expectedShards: expectedShards{
+				"p1": []ShardSignature{"_"},
+				"p2": []ShardSignature{"_"},
+				"p3": []ShardSignature{"_"},
+			},
+		},
+		{
+			name: "only non default shard",
+			podsFeatures: podFeatureParts{
+				{"p1", shardFeatureParts{"f1": "v1", "f2": "v2"}},
+				{"p2", shardFeatureParts{"f1": "v1", "f2": "v2"}},
+				{"p3", shardFeatureParts{"f1": "v1", "f2": "v2"}},
+			},
+			expectedShards: expectedShards{
+				"p1": []ShardSignature{"Labels(f1=v1,f2=v2)"},
+				"p2": []ShardSignature{"Labels(f1=v1,f2=v2)"},
+				"p3": []ShardSignature{"Labels(f1=v1,f2=v2)"},
+			},
+		},
+		{
+			name: "mixed default and non default",
+			podsFeatures: podFeatureParts{
+				{"p1", shardFeatureParts{}},
+				{"p2", shardFeatureParts{"f1": "v1", "f2": "v2"}},
+				{"p3", shardFeatureParts{"f1": "v1", "f2": "v2"}},
+			},
+			expectedShards: expectedShards{
+				"p1": []ShardSignature{"_"},
+				"p2": []ShardSignature{"Labels(f1=v1,f2=v2)"},
+				"p3": []ShardSignature{"Labels(f1=v1,f2=v2)"},
+			},
+		},
+		{
+			name: "different values for one feature",
+			podsFeatures: podFeatureParts{
+				{"p1", shardFeatureParts{"f1": "v1", "f2": "v2"}},
+				{"p2", shardFeatureParts{"f1": "v1", "f2": "v2"}},
+				{"p3", shardFeatureParts{"f1": "v1", "f2": "v3"}},
+				{"p4", shardFeatureParts{"f1": "v1"}},
+			},
+			expectedShards: expectedShards{
+				"p1": []ShardSignature{"Labels(f1=v1,f2=v2)"},
+				"p2": []ShardSignature{"Labels(f1=v1,f2=v2)"},
+				"p3": []ShardSignature{"Labels(f1=v1,f2=v3)"},
+				"p4": []ShardSignature{"Labels(f1=v1)"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var computeFunctions []FeatureShardComputeFunction
+			for _, feature := range getAllFeaturesSorted(tc.podsFeatures) {
+				featureCopy := feature
+				computeFunctions = append(computeFunctions,
+					FeatureShardComputeFunction{
+						Feature: featureCopy,
+						Function: func(pod *v1.Pod, nodeGroupDescriptor *NodeGroupDescriptor) {
+							for _, podFeatures := range tc.podsFeatures {
+								if podFeatures.uid == pod.UID {
+									for k, v := range podFeatures.nodeLables {
+										nodeGroupDescriptor.Labels[k] = v
+									}
+								}
+							}
+						},
+					})
+			}
+
+			podSharder := NewCompositePodSharder(computeFunctions)
+
+			var pods []*v1.Pod
+			for _, podFeaturesEntry := range tc.podsFeatures {
+				pods = append(pods, podForUID(podFeaturesEntry.uid))
+			}
+			podShards := podSharder.ComputePodShards(pods)
+
+			allShardSignatures := allExpectedShardSignatures(tc.expectedShards)
+			resultShardSignatures := getShardSignatures(podShards)
+
+			assert.ElementsMatch(t, allShardSignatures, resultShardSignatures, "List of shards %v does not match expected %v one", resultShardSignatures, allShardSignatures)
+			for _, podShard := range podShards {
+				expectedUidsForShard := expectedUidsForShard(tc.expectedShards, podShard.Signature())
+				assert.ElementsMatch(t, expectedUidsForShard, podShard.PodUidsSlice(), "List of pods does not match expected one for shard %s", podShard.Signature())
+			}
+		})
+	}
+}
+
+func TestCompositePodSharderNodeDescriptor(t *testing.T) {
+	buildComputeFunction := func(labelKey string) FeatureShardComputeFunction {
+		return FeatureShardComputeFunction{
+			Feature: labelKey,
+			Function: func(pod *v1.Pod, nodeGroupDescriptor *NodeGroupDescriptor) {
+				for podLabelKey, podLabelValue := range pod.Labels {
+					if podLabelKey == labelKey {
+						nodeGroupDescriptor.Labels[podLabelKey] = podLabelValue
+
+					}
+				}
+			},
+		}
+	}
+
+	computeFunctions := []FeatureShardComputeFunction{
+		buildComputeFunction("a"),
+		buildComputeFunction("b"),
+	}
+
+	sharder := NewCompositePodSharder(computeFunctions)
+
+	p1 := podForUID("p1")
+	p1.Labels = make(map[string]string)
+	p1.Labels["a"] = "a1"
+	p1.Labels["b"] = "b1"
+
+	p2 := podForUID("p2")
+	p2.Labels = make(map[string]string)
+	p2.Labels["a"] = "a1"
+	p2.Labels["b"] = "b1"
+
+	p3 := podForUID("p3")
+	p3.Labels = make(map[string]string)
+	p3.Labels["a"] = "a1"
+	p3.Labels["b"] = "b2"
+
+	// p1 and p2 are in single shard (a1/b1)
+	// p3 is in separate shard (a1/b2)
+
+	shards := sharder.ComputePodShards([]*v1.Pod{p1, p2, p3})
+	assert.ElementsMatch(t, []ShardSignature{"Labels(a=a1,b=b1)", "Labels(a=a1,b=b2)"}, getShardSignatures(shards))
+
+	shard1 := getShardForSignature("Labels(a=a1,b=b1)", shards)
+	shard2 := getShardForSignature("Labels(a=a1,b=b2)", shards)
+
+	assertNodeGroupDescriptorEqual(t, NodeGroupDescriptor{
+		Labels: map[string]string{
+			"a": "a1",
+			"b": "b1",
+		},
+	}, shard1.NodeGroupDescriptor)
+
+	assertNodeGroupDescriptorEqual(t, NodeGroupDescriptor{
+		Labels: map[string]string{
+			"a": "a1",
+			"b": "b2",
+		},
+	}, shard2.NodeGroupDescriptor)
+}
+
+func getShardSignatures(podShards []*PodShard) []ShardSignature {
+	var resultShardSignatures []ShardSignature
+	for _, podShard := range podShards {
+		resultShardSignatures = append(resultShardSignatures, podShard.Signature())
+	}
+	return resultShardSignatures
+}
+
+func getShardForSignature(signature ShardSignature, podShards []*PodShard) *PodShard {
+	for _, podShard := range podShards {
+		if podShard.Signature() == signature {
+			return podShard
+		}
+	}
+	return nil
+}
+func allExpectedShardSignatures(expectedShards expectedShards) []ShardSignature {
+	allShardSignaturesSet := make(map[ShardSignature]bool)
+	for _, shardSignatures := range expectedShards {
+		for _, shardSignature := range shardSignatures {
+			allShardSignaturesSet[shardSignature] = true
+		}
+	}
+	var allShardSignatures []ShardSignature
+	for shardSignature := range allShardSignaturesSet {
+		allShardSignatures = append(allShardSignatures, shardSignature)
+	}
+	return allShardSignatures
+}
+
+func expectedUidsForShard(expectedShards expectedShards, shardSignature ShardSignature) []apitypes.UID {
+	var uidsForShards []apitypes.UID
+	for uid, shardSignatures := range expectedShards {
+		if containsShard(shardSignatures, shardSignature) {
+			uidsForShards = append(uidsForShards, uid)
+		}
+	}
+	return uidsForShards
+}
+
+func containsShard(slice []ShardSignature, element ShardSignature) bool {
+	for _, sliceElement := range slice {
+		if element == sliceElement {
+			return true
+		}
+	}
+	return false
+}
+
+func getAllFeaturesSorted(features podFeatureParts) []string {
+	allFeaturesSet := make(map[string]bool)
+	for _, podFeaturesEntry := range features {
+		for feature := range podFeaturesEntry.nodeLables {
+			allFeaturesSet[feature] = true
+		}
+	}
+	var allFeatures []string
+	for feature := range allFeaturesSet {
+		allFeatures = append(allFeatures, feature)
+	}
+	sort.Strings(allFeatures)
+	return allFeatures
+}

--- a/cluster-autoscaler/utils/podsharding/lru_shard_selector.go
+++ b/cluster-autoscaler/utils/podsharding/lru_shard_selector.go
@@ -1,0 +1,45 @@
+package podsharding
+
+// LruPodShardSelector is a PodShardSelector which picks shards in least-recently picked order
+type LruPodShardSelector struct {
+	lruMap     map[ShardSignature]uint64
+	useCounter uint64
+}
+
+// NewLruPodShardSelector creates PodShardSelector which picks shards in least-recently picked order
+func NewLruPodShardSelector() PodShardSelector {
+	return &LruPodShardSelector{
+		lruMap: make(map[ShardSignature]uint64),
+	}
+}
+
+// SelectPodShard selects shard with least recently used shard signature
+func (selector *LruPodShardSelector) SelectPodShard(shards []*PodShard) *PodShard {
+	if len(shards) == 0 {
+		return nil
+	}
+
+	var selectedShard *PodShard
+
+	// fill in entries for unknown shards; those are added to the end of the queue
+	for _, shard := range shards {
+		signature := shard.Signature()
+		if _, found := selector.lruMap[signature]; !found {
+			selector.useCounter++
+			selector.lruMap[signature] = selector.useCounter
+		}
+	}
+
+	// select oldest entry
+	selector.useCounter++
+	selectedShardTime := selector.useCounter
+	for _, shard := range shards {
+		shardTime := selector.lruMap[shard.Signature()]
+		if shardTime < selectedShardTime {
+			selectedShard = shard
+			selectedShardTime = shardTime
+		}
+	}
+	selector.lruMap[selectedShard.Signature()] = selector.useCounter
+	return selectedShard
+}

--- a/cluster-autoscaler/utils/podsharding/lru_shard_selector.go
+++ b/cluster-autoscaler/utils/podsharding/lru_shard_selector.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 // LruPodShardSelector is a PodShardSelector which picks shards in least-recently picked order

--- a/cluster-autoscaler/utils/podsharding/lru_shard_selector_test.go
+++ b/cluster-autoscaler/utils/podsharding/lru_shard_selector_test.go
@@ -1,0 +1,56 @@
+package podsharding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLruShardSelector(t *testing.T) {
+	selector := NewLruPodShardSelector()
+	podShards := generatePodShards("a", "b", "c")
+
+	var selectedShards1 []*PodShard
+	for i := 0; i < len(podShards); i++ {
+		selectedShards1 = append(selectedShards1, selector.SelectPodShard(podShards))
+	}
+	assert.ElementsMatch(t, signatures(podShards...), signatures(selectedShards1...), "not all shards selected")
+
+	// another round of selection should be the same (including order)
+	var selectedShards2 []*PodShard
+	for i := 0; i < len(podShards); i++ {
+		selectedShards2 = append(selectedShards2, selector.SelectPodShard(podShards))
+	}
+	assert.EqualValues(t, signatures(selectedShards1...), signatures(selectedShards2...), "different order of shard selection in second round")
+
+	// we add new shard. It should be picked last.
+	podShards = generatePodShards("a", "b", "c", "d")
+	var selectedShards3 []*PodShard
+	for i := 0; i < len(podShards)-1; i++ {
+		selectedShards3 = append(selectedShards3, selector.SelectPodShard(podShards))
+	}
+	assert.EqualValues(t, signatures(selectedShards1...), signatures(selectedShards3...), "different order of shard selection for first 3 queries on third round")
+	assert.Equal(t, ShardSignature("Labels(key=d)"), selector.SelectPodShard(podShards).Signature(), "newly added shard was not picked last")
+}
+
+func generatePodShards(lables ...string) []*PodShard {
+	var result []*PodShard
+	for _, label := range lables {
+		result = append(result, &PodShard{
+			NodeGroupDescriptor: NodeGroupDescriptor{
+				Labels: map[string]string{
+					"key": label,
+				},
+			},
+		})
+	}
+	return result
+}
+
+func signatures(podShards ...*PodShard) []ShardSignature {
+	var result []ShardSignature
+	for _, podShard := range podShards {
+		result = append(result, podShard.Signature())
+	}
+	return result
+}

--- a/cluster-autoscaler/utils/podsharding/lru_shard_selector_test.go
+++ b/cluster-autoscaler/utils/podsharding/lru_shard_selector_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (

--- a/cluster-autoscaler/utils/podsharding/oss_pod_sharder.go
+++ b/cluster-autoscaler/utils/podsharding/oss_pod_sharder.go
@@ -1,0 +1,31 @@
+package podsharding
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+// NewOssPodSharder returns a PodSharder that shards pods based on the podShardingLabels specified.
+func NewOssPodSharder(podShardingLabels map[string]string) PodSharder {
+	computeFunctions := []FeatureShardComputeFunction{
+		{
+			"label",
+			computeLabelNameShard(podShardingLabels),
+		},
+	}
+	return NewCompositePodSharder(computeFunctions)
+}
+
+// computeLabelNameShard returns a function with nodeGroupDescriptor labels updated to contain the podShardingLabels if they are present in the pod.
+func computeLabelNameShard(podShardingLabels map[string]string) func(*v1.Pod, *NodeGroupDescriptor) {
+	return func(pod *v1.Pod, nodeGroupDescriptor *NodeGroupDescriptor) {
+		if len(podShardingLabels) == 0 {
+			return
+		}
+
+		for labelKey, labelValue := range podShardingLabels {
+			if podLabelValue, ok := pod.Spec.NodeSelector[labelKey]; ok && podLabelValue == labelValue {
+				nodeGroupDescriptor.Labels[labelKey] = labelValue
+			}
+		}
+	}
+}

--- a/cluster-autoscaler/utils/podsharding/oss_pod_sharder.go
+++ b/cluster-autoscaler/utils/podsharding/oss_pod_sharder.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (

--- a/cluster-autoscaler/utils/podsharding/oss_pod_sharder_test.go
+++ b/cluster-autoscaler/utils/podsharding/oss_pod_sharder_test.go
@@ -150,7 +150,7 @@ func TestPodSharderWithoutProvReq(t *testing.T) {
 		"anotherSharding": "nodeSelector",
 	}
 
-	testPodSharder(t, NewOssPodSharder(shardingNodeSelectors), testCases)
+	testPodSharder(t, NewOssPodSharder(shardingNodeSelectors, false), testCases)
 }
 
 type shardComputeFunctionTestCase struct {

--- a/cluster-autoscaler/utils/podsharding/oss_pod_sharder_test.go
+++ b/cluster-autoscaler/utils/podsharding/oss_pod_sharder_test.go
@@ -1,0 +1,159 @@
+package podsharding
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestPodSharderWithoutProvReq(t *testing.T) {
+	testCases := []shardComputeFunctionTestCase{
+		{
+			name: "pod without node-selectors",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{},
+					Tolerations:  []v1.Toleration{},
+				},
+			},
+			expectedNodeGroupDescriptor: NodeGroupDescriptor{
+				Labels: map[string]string{},
+				Taints: []v1.Taint{},
+			},
+		},
+		{
+			name: "pod with non-pod-sharding node-selectors",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{
+						"notSharding": "nodeSelector",
+					},
+					Tolerations: []v1.Toleration{},
+				},
+			},
+			expectedNodeGroupDescriptor: NodeGroupDescriptor{
+				Labels: map[string]string{},
+				Taints: []v1.Taint{},
+			},
+		},
+		{
+			name: "pod with non-pod-sharding node-selector",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{
+						"notSharding": "nodeSelector",
+					},
+					Tolerations: []v1.Toleration{},
+				},
+			},
+			expectedNodeGroupDescriptor: NodeGroupDescriptor{
+				Labels: map[string]string{},
+				Taints: []v1.Taint{},
+			},
+		},
+		{
+			name: "pod with pod-sharding node-selector",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{
+						"sharding": "nodeSelector",
+					},
+					Tolerations: []v1.Toleration{},
+				},
+			},
+			expectedNodeGroupDescriptor: NodeGroupDescriptor{
+				Labels: map[string]string{
+					"sharding": "nodeSelector",
+				},
+				Taints: []v1.Taint{},
+			},
+		},
+		{
+			name: "pod with pod-sharding node-selector",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{
+						"sharding": "nodeSelector",
+					},
+					Tolerations: []v1.Toleration{},
+				},
+			},
+			expectedNodeGroupDescriptor: NodeGroupDescriptor{
+				Labels: map[string]string{
+					"sharding": "nodeSelector",
+				},
+				Taints: []v1.Taint{},
+			},
+		},
+		{
+			name: "pod with pod-sharding node-selector and other node-selector",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{
+						"sharding":    "nodeSelector",
+						"notSharding": "nodeSelector",
+					},
+					Tolerations: []v1.Toleration{},
+				},
+			},
+			expectedNodeGroupDescriptor: NodeGroupDescriptor{
+				Labels: map[string]string{
+					"sharding": "nodeSelector",
+				},
+				Taints: []v1.Taint{},
+			},
+		},
+		{
+			name: "pod with pod-sharding node-selector and tolerations",
+			pod: v1.Pod{
+				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{
+						"sharding": "nodeSelector",
+					},
+					Tolerations: []v1.Toleration{
+						{
+							Key:      "key",
+							Operator: "Exists",
+							Value:    "value",
+							Effect:   "NoSchedule",
+						},
+					},
+				},
+			},
+			expectedNodeGroupDescriptor: NodeGroupDescriptor{
+				Labels: map[string]string{
+					"sharding": "nodeSelector",
+				},
+				Taints: []v1.Taint{},
+			},
+		},
+	}
+
+	shardingNodeSelectors := map[string]string{
+		"sharding":        "nodeSelector",
+		"anotherSharding": "nodeSelector",
+	}
+
+	testPodSharder(t, NewOssPodSharder(shardingNodeSelectors), testCases)
+}
+
+type shardComputeFunctionTestCase struct {
+	name                        string
+	pod                         v1.Pod
+	expectedNodeGroupDescriptor NodeGroupDescriptor
+}
+
+func testPodSharder(t *testing.T, sharder PodSharder, testCases []shardComputeFunctionTestCase) {
+	t.Helper()
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			shards := sharder.ComputePodShards([]*v1.Pod{&tc.pod})
+			if len(shards) != 1 {
+				t.Errorf("Expected to get precisely 1 shard, but got %d. Shards: %v", len(shards), shards)
+				return
+			}
+			assertNodeGroupDescriptorEqual(t, tc.expectedNodeGroupDescriptor, shards[0].NodeGroupDescriptor)
+		})
+	}
+}

--- a/cluster-autoscaler/utils/podsharding/oss_pod_sharder_test.go
+++ b/cluster-autoscaler/utils/podsharding/oss_pod_sharder_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (

--- a/cluster-autoscaler/utils/podsharding/oss_pod_sharding_processor.go
+++ b/cluster-autoscaler/utils/podsharding/oss_pod_sharding_processor.go
@@ -1,0 +1,80 @@
+package podsharding
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	klog "k8s.io/klog/v2"
+)
+
+const (
+	selectPodShardContextKey = "selected-pod-shard.podsharding.cluster-autoscaler"
+)
+
+// PodShardingProcessor is a processor for pre-sharding unschedulable pods. It uses given PodSharder
+// and PodShardSelector to group pods into independent scale-up groups and select one of those for given loop iteration.
+type PodShardingProcessor struct {
+	podSharder       PodSharder
+	podShardSelector PodShardSelector
+	podShardFilter   PodShardFilter
+}
+
+// GetSelectedPodShard returns selected pod shard.
+func GetSelectedPodShard(context *context.AutoscalingContext) *PodShard {
+	value, found := context.ProcessorCallbacks.GetExtraValue(selectPodShardContextKey)
+	if !found {
+		return nil
+	}
+	shard, ok := value.(*PodShard)
+	if !ok {
+		klog.Errorf("Expected *PodShard as value for %v; got %T", selectPodShardContextKey, value)
+		return nil
+	}
+	return shard
+}
+
+// NewPodShardingProcessor creates new instance of PodShardingProcessor
+func NewPodShardingProcessor(
+	podSharder PodSharder,
+	podShardSelector PodShardSelector,
+	podShardFilter PodShardFilter) *PodShardingProcessor {
+	return &PodShardingProcessor{
+		podSharder:       podSharder,
+		podShardSelector: podShardSelector,
+		podShardFilter:   podShardFilter,
+	}
+}
+
+// Process executes pod sharding logic for passed unschedulablePods. Pods are sharded and one of the shards is selected.
+// The allScheduledPods slice is returned not changed.
+func (p *PodShardingProcessor) Process(context *context.AutoscalingContext,
+	unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+
+	if len(unschedulablePods) == 0 {
+		// nothing to be done
+		return unschedulablePods, nil
+	}
+
+	podShards := p.podSharder.ComputePodShards(unschedulablePods)
+
+	podShard := p.podShardSelector.SelectPodShard(podShards)
+
+	if podShard == nil {
+		return []*apiv1.Pod{}, errors.NewAutoscalerError(errors.InternalError, "No shard selected")
+	}
+
+	filteringResult, err := p.podShardFilter.FilterPods(context, podShard, podShards, unschedulablePods)
+	if err != nil {
+		return []*apiv1.Pod{}, errors.ToAutoscalerError(errors.InternalError, err)
+	}
+	klog.Infof("Selected pods shard %v; NodeGroupDescriptor=%#v; shardPodsCount=%v; extendedPodsCount=%v",
+		podShard.Signature(), podShard.NodeGroupDescriptor, len(podShard.PodUids), len(filteringResult.Pods))
+
+	context.ProcessorCallbacks.SetExtraValue(selectPodShardContextKey, podShard)
+
+	return filteringResult.Pods, nil
+}
+
+// CleanUp does nothing for PodShardingProcessor
+func (p *PodShardingProcessor) CleanUp() {
+}

--- a/cluster-autoscaler/utils/podsharding/oss_pod_sharding_processor.go
+++ b/cluster-autoscaler/utils/podsharding/oss_pod_sharding_processor.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (

--- a/cluster-autoscaler/utils/podsharding/pod_sharder.go
+++ b/cluster-autoscaler/utils/podsharding/pod_sharder.go
@@ -1,0 +1,149 @@
+package podsharding
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+// ShardSignature represents PodShard signature
+type ShardSignature string
+
+// NodeGroupDescriptor encapsulates limitations for node groups usable for pod shard.
+type NodeGroupDescriptor struct {
+	Labels                map[string]string
+	SystemLabels          map[string]string
+	Taints                []apiv1.Taint
+	ExtraResources        map[string]resource.Quantity
+	ProvisioningClassName string
+}
+
+func (descriptor *NodeGroupDescriptor) signature() ShardSignature {
+	builder := strings.Builder{}
+
+	writeMapSorted := func(header string, m map[string]string) {
+		if len(m) == 0 {
+			return
+		}
+		builder.WriteString(header)
+		builder.WriteString("(")
+		var keys []string
+		for key := range m {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		first := true
+		for _, key := range keys {
+			if !first {
+				builder.WriteString(",")
+			}
+			first = false
+			builder.WriteString(key)
+			builder.WriteString("=")
+			builder.WriteString(m[key])
+		}
+		builder.WriteString(")")
+	}
+
+	writeMapSorted("Labels", descriptor.Labels)
+	writeMapSorted("SystemLabels", descriptor.SystemLabels)
+
+	extraResourcesStringified := make(map[string]string)
+	for k, v := range descriptor.ExtraResources {
+		extraResourcesStringified[k] = v.String()
+	}
+	writeMapSorted("ExtraResources", extraResourcesStringified)
+
+	var taintsStringified []string
+	for _, taint := range descriptor.Taints {
+		taintsStringified = append(taintsStringified, fmt.Sprintf("%v/%v/%v", taint.Key, taint.Value, taint.Effect))
+	}
+	sort.Strings(taintsStringified)
+	if len(taintsStringified) > 0 {
+		builder.WriteString("Taints(")
+		builder.WriteString(strings.Join(taintsStringified, ","))
+		builder.WriteString(")")
+	}
+	if descriptor.ProvisioningClassName != "" {
+		builder.WriteString(fmt.Sprintf("ProvisioningClassName(%s)", descriptor.ProvisioningClassName))
+	}
+	if builder.Len() == 0 {
+		return "_"
+	}
+	return ShardSignature(builder.String())
+}
+
+// PodShard represents a subset of unschedulable pods which can be processed independently from others in scale-up algorithm.
+type PodShard struct {
+	PodUids             map[types.UID]bool
+	NodeGroupDescriptor NodeGroupDescriptor
+}
+
+// Signature computes string signature for pod shard
+func (shard *PodShard) Signature() ShardSignature {
+	return shard.NodeGroupDescriptor.signature()
+}
+
+// PodUidsSlice list all pods with entries in in PodShard.PodUids map (with value equal to True) as a slice.
+func (shard *PodShard) PodUidsSlice() []types.UID {
+	var result []types.UID
+	for uid := range shard.PodUids {
+		result = append(result, uid)
+	}
+	return result
+}
+
+// PodShardSelector is responsible for selecting shard to be used in given loop iteration
+type PodShardSelector interface {
+	// SelectPodShard is responsible for selecting shard to be used in given loop iteration
+	SelectPodShard(podShards []*PodShard) *PodShard
+}
+
+// PodSharder is used to compute sharding for given set of pods
+type PodSharder interface {
+	// ComputePodShards computes sharding for given set of pods
+	ComputePodShards(pods []*apiv1.Pod) []*PodShard
+}
+
+// PodFilteringResult represents return value of PodShardFilter.FilterPods.
+type PodFilteringResult struct {
+	// Pods is the result of filtering
+	Pods []*apiv1.Pod
+}
+
+// PodShardFilter filters pod list against PodShard
+type PodShardFilter interface {
+	// FilterPods filters pod list against selected PodShard
+	FilterPods(context *context.AutoscalingContext, selectedPodShard *PodShard, allPodShards []*PodShard, pods []*apiv1.Pod) (PodFilteringResult, error)
+}
+
+// EmptyNodeGroupDescriptor creates an empty NodeGroupDescriptor
+func EmptyNodeGroupDescriptor() NodeGroupDescriptor {
+	return NodeGroupDescriptor{
+		Labels:         make(map[string]string),
+		SystemLabels:   make(map[string]string),
+		ExtraResources: make(map[string]resource.Quantity),
+	}
+}
+
+// DeepCopy crates a deep copy (with copied maps) of NodeGroupDescriptor
+func (descriptor NodeGroupDescriptor) DeepCopy() NodeGroupDescriptor {
+	copy := EmptyNodeGroupDescriptor()
+	for k, v := range descriptor.Labels {
+		copy.Labels[k] = v
+	}
+	for k, v := range descriptor.SystemLabels {
+		copy.SystemLabels[k] = v
+	}
+	copy.Taints = append(copy.Taints, descriptor.Taints...)
+	for k, v := range descriptor.ExtraResources {
+		copy.ExtraResources[k] = v
+	}
+	copy.ProvisioningClassName = descriptor.ProvisioningClassName
+	return copy
+}

--- a/cluster-autoscaler/utils/podsharding/pod_sharder.go
+++ b/cluster-autoscaler/utils/podsharding/pod_sharder.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (

--- a/cluster-autoscaler/utils/podsharding/pod_sharder_test.go
+++ b/cluster-autoscaler/utils/podsharding/pod_sharder_test.go
@@ -1,0 +1,131 @@
+package podsharding
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestNodeGroupDescriptorSignatureAndDeepCopy(t *testing.T) {
+	type fields struct {
+		Labels                map[string]string
+		SystemLabels          map[string]string
+		Taints                []apiv1.Taint
+		ExtraResources        map[string]resource.Quantity
+		ProvisioningClassName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   ShardSignature
+	}{
+		{
+			name: "simple pod",
+			fields: fields{
+				Labels: map[string]string{
+					"key": "value",
+				},
+				SystemLabels:   map[string]string{},
+				ExtraResources: map[string]resource.Quantity{},
+			},
+			want: ShardSignature("Labels(key=value)"),
+		},
+		{
+			name: "two labels",
+			fields: fields{
+				Labels: map[string]string{
+					"other-key": "another-value",
+					"key":       "value",
+				},
+				SystemLabels:   map[string]string{},
+				ExtraResources: map[string]resource.Quantity{},
+			},
+			want: ShardSignature("Labels(key=value,other-key=another-value)"),
+		},
+		{
+			name: "system labels",
+			fields: fields{
+				Labels: map[string]string{
+					"key": "value",
+				},
+				SystemLabels: map[string]string{
+					"system-key": "system-value",
+					"key":        "value",
+				},
+				ExtraResources: map[string]resource.Quantity{},
+			},
+			want: ShardSignature("Labels(key=value)SystemLabels(key=value,system-key=system-value)"),
+		},
+		{
+			name: "extra resources",
+			fields: fields{
+				Labels: map[string]string{
+					"key": "value",
+				},
+				SystemLabels: map[string]string{
+					"key": "value",
+				},
+				ExtraResources: map[string]resource.Quantity{
+					"resource":         *resource.NewMilliQuantity(1500, resource.DecimalSI),
+					"another-resource": *resource.NewMilliQuantity(500, resource.DecimalSI),
+				},
+			},
+			want: ShardSignature("Labels(key=value)SystemLabels(key=value)ExtraResources(another-resource=500m,resource=1500m)"),
+		},
+		{
+			name: "taints",
+			fields: fields{
+				Labels: map[string]string{
+					"key": "value",
+				},
+				SystemLabels: map[string]string{
+					"key": "value",
+				},
+				ExtraResources: map[string]resource.Quantity{
+					"resource": *resource.NewMilliQuantity(1500, resource.DecimalSI),
+				},
+				Taints: []apiv1.Taint{
+					{
+						Key:    "key",
+						Value:  "value",
+						Effect: apiv1.TaintEffectPreferNoSchedule,
+					},
+					{
+						Key:    "another-key",
+						Value:  "other-value",
+						Effect: apiv1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			want: ShardSignature("Labels(key=value)SystemLabels(key=value)ExtraResources(resource=1500m)Taints(another-key/other-value/NoSchedule,key/value/PreferNoSchedule)"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			descriptor := &NodeGroupDescriptor{
+				Labels:                tt.fields.Labels,
+				SystemLabels:          tt.fields.SystemLabels,
+				Taints:                tt.fields.Taints,
+				ExtraResources:        tt.fields.ExtraResources,
+				ProvisioningClassName: tt.fields.ProvisioningClassName,
+			}
+			if got := descriptor.signature(); got != tt.want {
+				t.Errorf("NodeGroupDescriptor.signature() = %v, want %v", got, tt.want)
+			}
+
+			original := NodeGroupDescriptor{
+				Labels:                tt.fields.Labels,
+				SystemLabels:          tt.fields.SystemLabels,
+				Taints:                tt.fields.Taints,
+				ExtraResources:        tt.fields.ExtraResources,
+				ProvisioningClassName: tt.fields.ProvisioningClassName,
+			}
+			copy := original.DeepCopy()
+			if diff := cmp.Diff(copy, original); diff != "" {
+				t.Errorf("NodeGroupDescriptor.DeepCopy() diff (-copy +original): %v", diff)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/utils/podsharding/pod_sharder_test.go
+++ b/cluster-autoscaler/utils/podsharding/pod_sharder_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (

--- a/cluster-autoscaler/utils/podsharding/predicate_pod_shard_filter.go
+++ b/cluster-autoscaler/utils/podsharding/predicate_pod_shard_filter.go
@@ -1,0 +1,59 @@
+package podsharding
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+)
+
+// PredicatePodShardFilter implements PodShardFilter interface. Initial set of pods is based on list of pod UIDs stored in
+// PodShard. Then list is extended by testing scheduler predicates for other pods on test NodeInfos build via cloudprovider
+// based on PodShard.NodeGroupDescriptor.
+type PredicatePodShardFilter struct{}
+
+// NewPredicatePodShardFilter creates an instance of PredicatePodShardFilter
+func NewPredicatePodShardFilter() *PredicatePodShardFilter {
+	return &PredicatePodShardFilter{}
+}
+
+// FilterPods filters pod list against PodShard
+func (p *PredicatePodShardFilter) FilterPods(context *context.AutoscalingContext, selectedPodShard *PodShard, allPodShards []*PodShard, pods []*apiv1.Pod) (PodFilteringResult, error) {
+	podsByUid := make(map[types.UID]*apiv1.Pod)
+	for _, pod := range pods {
+		podsByUid[pod.UID] = pod
+	}
+
+	if len(selectedPodShard.PodUids) < 1 {
+		return PodFilteringResult{}, fmt.Errorf("not enough pods associated to the selected PodShard")
+	}
+
+	// list of shards for which we want to have
+	finalPodShards := make(map[ShardSignature]bool)
+
+	// add selected shard to list of final shards
+	finalPodShards[selectedPodShard.Signature()] = true
+
+	// iterate over all selected shards and build final set of Pod UIDs
+	selectedPodUids := make(map[types.UID]bool)
+	for _, shard := range allPodShards {
+		if finalPodShards[shard.Signature()] {
+			for podUid := range shard.PodUids {
+				selectedPodUids[podUid] = true
+			}
+		}
+	}
+
+	// translate UIDs of selected Pods to Pods
+	var selectedPods []*apiv1.Pod
+	for _, pod := range pods {
+		if selectedPodUids[pod.UID] {
+			selectedPods = append(selectedPods, pod)
+		}
+	}
+
+	return PodFilteringResult{
+		Pods: selectedPods,
+	}, nil
+}

--- a/cluster-autoscaler/utils/podsharding/predicate_pod_shard_filter.go
+++ b/cluster-autoscaler/utils/podsharding/predicate_pod_shard_filter.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (

--- a/cluster-autoscaler/utils/podsharding/predicate_pod_shard_filter_test.go
+++ b/cluster-autoscaler/utils/podsharding/predicate_pod_shard_filter_test.go
@@ -1,0 +1,95 @@
+package podsharding
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/predicatechecker"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestPredicatePodShardFilterFilterPods(t *testing.T) {
+	tests := []struct {
+		name             string
+		selectedPodShard *PodShard
+		allPodShards     []*PodShard
+		pods             []*apiv1.Pod
+		want             PodFilteringResult
+		wantErr          bool
+	}{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			machineTypes := []string{}
+			machineTempaltes := make(map[string]*framework.NodeInfo, len(machineTypes))
+			for _, machineType := range machineTypes {
+				frameworkNode := framework.NewNodeInfo()
+				frameworkNode.SetNode(test.BuildTestNode(machineType+"-node", 1, 1))
+				machineTempaltes[machineType] = frameworkNode
+			}
+			predicateChecker, err := predicatechecker.NewTestPredicateChecker()
+			assert.NoError(t, err)
+
+			ctx := &context.AutoscalingContext{
+				ClusterSnapshot:  clustersnapshot.NewBasicClusterSnapshot(),
+				PredicateChecker: predicateChecker,
+			}
+			p := NewPredicatePodShardFilter()
+			got, err := p.FilterPods(ctx, tt.selectedPodShard, tt.allPodShards, tt.pods)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PredicatePodShardFilter.FilterPods() error = %v\nwantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PredicatePodShardFilter.FilterPods() = %v\nwant %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func createTestPodShard(provReqClass string, labels []string, podUIDs ...string) *PodShard {
+	podUIDsMap := make(map[types.UID]bool, len(podUIDs))
+	for _, podUID := range podUIDs {
+		podUIDsMap[types.UID(podUID)] = true
+	}
+	labelsMap := make(map[string]string, len(labels))
+	for _, label := range labels {
+		labelsMap[label] = "true"
+	}
+
+	return &PodShard{
+		PodUids: podUIDsMap,
+		NodeGroupDescriptor: NodeGroupDescriptor{
+			Labels:                labelsMap,
+			ProvisioningClassName: provReqClass,
+		},
+	}
+}
+
+func createTestPod(uid string) *apiv1.Pod {
+	pod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:               types.UID(uid),
+			Namespace:         "default",
+			Name:              uid,
+			CreationTimestamp: metav1.NewTime(time.Date(2024, 8, 9, 12, 13, 14, 0, time.UTC)),
+		},
+		Spec: apiv1.PodSpec{
+			Containers: []apiv1.Container{
+				{
+					Resources: apiv1.ResourceRequirements{
+						Requests: apiv1.ResourceList{},
+					},
+				},
+			},
+		},
+	}
+	return pod
+}

--- a/cluster-autoscaler/utils/podsharding/predicate_pod_shard_filter_test.go
+++ b/cluster-autoscaler/utils/podsharding/predicate_pod_shard_filter_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (

--- a/cluster-autoscaler/utils/podsharding/test_helpers.go
+++ b/cluster-autoscaler/utils/podsharding/test_helpers.go
@@ -1,0 +1,45 @@
+package podsharding
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func podForUID(uid apitypes.UID) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: apitypes.UID(uid),
+		},
+	}
+}
+
+func assertNodeGroupDescriptorEqual(t *testing.T, expected, actual NodeGroupDescriptor) {
+	t.Helper()
+	if len(expected.Labels) != 0 || len(actual.Labels) != 0 {
+		assert.Equal(t, expected.Labels, actual.Labels, "Labels")
+	}
+	if len(expected.SystemLabels) != 0 || len(actual.SystemLabels) != 0 {
+		assert.Equal(t, expected.SystemLabels, actual.SystemLabels, "SystemLabels")
+	}
+	assert.ElementsMatch(t, expected.Taints, actual.Taints, "Taints")
+	if len(expected.ExtraResources) != 0 || len(actual.ExtraResources) != 0 {
+		assert.Equal(t, resourcesToIntMap(expected.ExtraResources), resourcesToIntMap(actual.ExtraResources), "ExtraResources")
+	}
+	assert.Equal(t, expected.ProvisioningClassName, actual.ProvisioningClassName, "ProvisioningClassName")
+}
+
+func resourcesToIntMap(quantityMap map[string]resource.Quantity) map[string]int64 {
+	result := make(map[string]int64)
+	for k, v := range quantityMap {
+		valInt64, _ := v.AsInt64()
+		result[k] = valInt64
+	}
+	return result
+}

--- a/cluster-autoscaler/utils/podsharding/test_helpers.go
+++ b/cluster-autoscaler/utils/podsharding/test_helpers.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package podsharding
 
 import (


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Aggregates BestEfforrAtomic PR scaleups on nodegroup to reduce scaleup requests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
cc: @kawych @aleksandra-malinowska @yaroslava-serdiuk 