### PR TITLE
azure: StrictCacheUpdates to disable proactive vmss cache updates

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -94,6 +94,9 @@ type Config struct {
 
 	// (DEPRECATED, DO NOT USE) GetVmssSizeRefreshPeriod (seconds) defines how frequently to call GET VMSS API to fetch VMSS info per nodegroup instance
 	GetVmssSizeRefreshPeriod int `json:"getVmssSizeRefreshPeriod,omitempty" yaml:"getVmssSizeRefreshPeriod,omitempty"`
+
+	// StrictCacheUpdates updates cache values only after positive validation from Azure APIs
+	StrictCacheUpdates bool `json:"strictCacheUpdates,omitempty" yaml:"strictCacheUpdates,omitempty"`
 }
 
 // These are only here for backward compabitility. Their equivalent exists in providerazure.Config with a different name.
@@ -122,6 +125,7 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	cfg.CloudProviderBackoffJitter = providerazureconsts.BackoffJitterDefault
 	cfg.VMType = providerazureconsts.VMTypeVMSS
 	cfg.MaxDeploymentsCount = int64(defaultMaxDeploymentsCount)
+	cfg.StrictCacheUpdates = false
 
 	// Config file overrides defaults
 	if configReader != nil {
@@ -245,6 +249,9 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 		return nil, err
 	}
 	if _, err = assignBoolFromEnvIfExists(&cfg.EnableForceDelete, "AZURE_ENABLE_FORCE_DELETE"); err != nil {
+		return nil, err
+	}
+	if _, err = assignBoolFromEnvIfExists(&cfg.StrictCacheUpdates, "AZURE_STRICT_CACHE_UPDATES"); err != nil {
 		return nil, err
 	}
 	if _, err = assignBoolFromEnvIfExists(&cfg.EnableDynamicInstanceList, "AZURE_ENABLE_DYNAMIC_INSTANCE_LIST"); err != nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -530,6 +530,24 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 		return rerr.Error()
 	}
 
+	if !scaleSet.manager.config.StrictCacheUpdates {
+		// Proactively decrement scale set size so that we don't
+		// go below minimum node count if cache data is stale
+		// only do it for non-unregistered nodes
+
+		if !hasUnregisteredNodes {
+			scaleSet.sizeMutex.Lock()
+			scaleSet.curSize -= int64(len(instanceIDs))
+			scaleSet.lastSizeRefresh = time.Now()
+			scaleSet.sizeMutex.Unlock()
+		}
+
+		// Proactively set the status of the instances to be deleted in cache
+		for _, instance := range instancesToDelete {
+			scaleSet.setInstanceStatusByProviderID(instance.Name, cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting})
+		}
+	}
+
 	go scaleSet.waitForDeleteInstances(future, requiredIds)
 	return nil
 }
@@ -543,8 +561,17 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(future *azure.Future, requiredI
 	isSuccess, err := isSuccessHTTPResponse(httpResponse, err)
 	if isSuccess {
 		klog.V(3).Infof(".WaitForDeleteInstancesResult(%v) for %s success", requiredIds.InstanceIds, scaleSet.Name)
-		scaleSet.invalidateInstanceCache()
+		if scaleSet.manager.config.StrictCacheUpdates {
+			if err := scaleSet.manager.forceRefresh(); err != nil {
+				klog.Errorf("forceRefresh failed with error: %v", err)
+			}
+			scaleSet.invalidateInstanceCache()
+		}
 		return
+	}
+	if !scaleSet.manager.config.StrictCacheUpdates {
+		// On failure, invalidate the instanceCache - cannot have instances in deletingState
+		scaleSet.invalidateInstanceCache()
 	}
 	klog.Errorf("WaitForDeleteInstancesResult(%v) for %s failed with error: %v", requiredIds.InstanceIds, scaleSet.Name, err)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -530,21 +530,6 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 		return rerr.Error()
 	}
 
-	// Proactively decrement scale set size so that we don't
-	// go below minimum node count if cache data is stale
-	// only do it for non-unregistered nodes
-	if !hasUnregisteredNodes {
-		scaleSet.sizeMutex.Lock()
-		scaleSet.curSize -= int64(len(instanceIDs))
-		scaleSet.lastSizeRefresh = time.Now()
-		scaleSet.sizeMutex.Unlock()
-	}
-
-	// Proactively set the status of the instances to be deleted in cache
-	for _, instance := range instancesToDelete {
-		scaleSet.setInstanceStatusByProviderID(instance.Name, cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting})
-	}
-
 	go scaleSet.waitForDeleteInstances(future, requiredIds)
 	return nil
 }
@@ -558,11 +543,9 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(future *azure.Future, requiredI
 	isSuccess, err := isSuccessHTTPResponse(httpResponse, err)
 	if isSuccess {
 		klog.V(3).Infof(".WaitForDeleteInstancesResult(%v) for %s success", requiredIds.InstanceIds, scaleSet.Name)
-		// No need to invalidateInstanceCache because instanceStates were proactively set to "deleting"
+		scaleSet.invalidateInstanceCache()
 		return
 	}
-	// On failure, invalidate the instanceCache - cannot have instances in deletingState
-	scaleSet.invalidateInstanceCache()
 	klog.Errorf("WaitForDeleteInstancesResult(%v) for %s failed with error: %v", requiredIds.InstanceIds, scaleSet.Name, err)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR adds a `StrictCacheUpdates` configuration for the Azure cluster-autoscaler provider (triggered by the `AZURE_STRICT_CACHE_UPDATES` runtime environment variable) that enables a modified Azure VMSS delete flow so that the local CA cache representation of node pool replica count is only updated upon a successful delete.

The current predictive cache update implementation was originally implemented here:

- https://github.com/kubernetes/autoscaler/pull/3036

The above works in most cases, but in situations where VMSS delete operations repeatedly fail, we see the the local CA cache gradually decrementing itself during each subsequent delete operation, which has the side-effect of eventually sending a VMSS replica update with a significantly reduced replica count when Azure API errors cease.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7432

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
azure: StrictCacheUpdates to disable proactive vmss cache updates
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
