### PR TITLE
VPA: Try make recommender e2e a little faster

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1/recommender.go
@@ -140,7 +140,18 @@ var _ = RecommenderE2eDescribe("Checkpoints", func() {
 		_, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).Create(context.TODO(), &checkpoint, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		time.Sleep(15 * time.Minute)
+		fmt.Println("Sleeping for up to 15 minutes...")
+
+		maxRetries := 90
+		retryDelay := 10 * time.Second
+		for i := 0; i < maxRetries; i++ {
+			list, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).List(context.TODO(), metav1.ListOptions{})
+			if err == nil && len(list.Items) == 0 {
+				break
+			}
+			fmt.Println("Still waiting...")
+			time.Sleep(retryDelay)
+		}
 
 		list, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).List(context.TODO(), metav1.ListOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -195,7 +206,7 @@ var _ = RecommenderE2eDescribe("VPA CRD object", func() {
 		_ = SetupHamsterDeployment(
 			f,       /* framework */
 			"100m",  /* cpu */
-			"100Mi", /* memeory */
+			"100Mi", /* memory */
 			1,       /* number of replicas */
 		)
 
@@ -238,7 +249,7 @@ var _ = RecommenderE2eDescribe("VPA CRD object", func() {
 		}
 		ginkgo.By("Deleting recommender")
 		gomega.Expect(deleteRecommender(f.ClientSet)).To(gomega.BeNil())
-		ginkgo.By("Accumulating diffs after restart")
+		ginkgo.By("Accumulating diffs after restart, sleeping for 5 minutes...")
 		time.Sleep(5 * time.Minute)
 		changeDetected := false
 	finish:
@@ -272,7 +283,7 @@ var _ = RecommenderE2eDescribe("VPA CRD object", func() {
 		_ = SetupHamsterDeployment(
 			f,       /* framework */
 			"100m",  /* cpu */
-			"100Mi", /* memeory */
+			"100Mi", /* memory */
 			1,       /* number of replicas */
 		)
 

--- a/vertical-pod-autoscaler/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1/recommender.go
@@ -140,7 +140,7 @@ var _ = RecommenderE2eDescribe("Checkpoints", func() {
 		_, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).Create(context.TODO(), &checkpoint, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		fmt.Println("Sleeping for up to 15 minutes...")
+		klog.InfoS("Sleeping for up to 15 minutes...")
 
 		maxRetries := 90
 		retryDelay := 10 * time.Second
@@ -149,7 +149,7 @@ var _ = RecommenderE2eDescribe("Checkpoints", func() {
 			if err == nil && len(list.Items) == 0 {
 				break
 			}
-			fmt.Println("Still waiting...")
+			klog.InfoS("Still waiting...")
 			time.Sleep(retryDelay)
 		}
 

--- a/vertical-pod-autoscaler/e2e/v1beta2/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/recommender.go
@@ -139,7 +139,7 @@ var _ = RecommenderE2eDescribe("Checkpoints", func() {
 		_, err := vpaClientSet.AutoscalingV1beta2().VerticalPodAutoscalerCheckpoints(ns).Create(context.TODO(), &checkpoint, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		fmt.Println("Sleeping for up to 15 minutes...")
+		klog.InfoS("Sleeping for up to 15 minutes...")
 
 		maxRetries := 90
 		retryDelay := 10 * time.Second
@@ -148,7 +148,7 @@ var _ = RecommenderE2eDescribe("Checkpoints", func() {
 			if err == nil && len(list.Items) == 0 {
 				break
 			}
-			fmt.Println("Still waiting...")
+			klog.InfoS("Still waiting...")
 			time.Sleep(retryDelay)
 		}
 

--- a/vertical-pod-autoscaler/e2e/v1beta2/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/recommender.go
@@ -139,7 +139,18 @@ var _ = RecommenderE2eDescribe("Checkpoints", func() {
 		_, err := vpaClientSet.AutoscalingV1beta2().VerticalPodAutoscalerCheckpoints(ns).Create(context.TODO(), &checkpoint, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		time.Sleep(15 * time.Minute)
+		fmt.Println("Sleeping for up to 15 minutes...")
+
+		maxRetries := 90
+		retryDelay := 10 * time.Second
+		for i := 0; i < maxRetries; i++ {
+			list, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).List(context.TODO(), metav1.ListOptions{})
+			if err == nil && len(list.Items) == 0 {
+				break
+			}
+			fmt.Println("Still waiting...")
+			time.Sleep(retryDelay)
+		}
 
 		list, err := vpaClientSet.AutoscalingV1beta2().VerticalPodAutoscalerCheckpoints(ns).List(context.TODO(), metav1.ListOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -186,7 +197,7 @@ var _ = RecommenderE2eDescribe("VPA CRD object", func() {
 		_ = SetupHamsterDeployment(
 			f,       /* framework */
 			"100m",  /* cpu */
-			"100Mi", /* memeory */
+			"100Mi", /* memory */
 			1,       /* number of replicas */
 		)
 
@@ -222,7 +233,7 @@ var _ = RecommenderE2eDescribe("VPA CRD object", func() {
 		}
 		ginkgo.By("Deleting recommender")
 		gomega.Expect(deleteRecommender(f.ClientSet)).To(gomega.BeNil())
-		ginkgo.By("Accumulating diffs after restart")
+		ginkgo.By("Accumulating diffs after restart, sleeping for 5 minutes...")
 		time.Sleep(5 * time.Minute)
 		changeDetected := false
 	finish:
@@ -256,7 +267,7 @@ var _ = RecommenderE2eDescribe("VPA CRD object", func() {
 		_ = SetupHamsterDeployment(
 			f,       /* framework */
 			"100m",  /* cpu */
-			"100Mi", /* memeory */
+			"100Mi", /* memory */
 			1,       /* number of replicas */
 		)
 


### PR DESCRIPTION
By exiting early if the successful state exists

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The e2e tests have a few moments where it sleeps, waiting on a change. It's not obvious to the user if it's stuck or sleeping.
This PR tries to make it clear that it's sleeping.
For the 15 minute sleep, I made it periodically look for the successful state, and exist early if needed.

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/autoscaler/issues/7455


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
