### PR TITLE
Remove maintainer labels in Dockerfiles since they just get stale

### DIFF
--- a/balancer/Dockerfile
+++ b/balancer/Dockerfile
@@ -1,5 +1,4 @@
 FROM gcr.io/distroless/static:latest
-MAINTAINER Marcin Wielgus "mwielgus@google.com"
 
 COPY balancer /
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM golang:1.23.2
-LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/
 ENV PATH $GOPATH/bin:$PATH

--- a/cluster-autoscaler/Dockerfile.amd64
+++ b/cluster-autoscaler/Dockerfile.amd64
@@ -13,7 +13,6 @@
 # limitations under the License.
 ARG BASEIMAGE=gcr.io/distroless/static:nonroot-amd64
 FROM $BASEIMAGE
-LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 COPY cluster-autoscaler-amd64 /cluster-autoscaler
 WORKDIR /

--- a/cluster-autoscaler/Dockerfile.arm64
+++ b/cluster-autoscaler/Dockerfile.arm64
@@ -13,7 +13,6 @@
 # limitations under the License.
 ARG BASEIMAGE=gcr.io/distroless/static:nonroot-arm64
 FROM $BASEIMAGE
-LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 COPY cluster-autoscaler-arm64 /cluster-autoscaler
 WORKDIR /

--- a/cluster-autoscaler/Dockerfile.s390x
+++ b/cluster-autoscaler/Dockerfile.s390x
@@ -13,7 +13,6 @@
 # limitations under the License.
 ARG BASEIMAGE=gcr.io/distroless/static:nonroot-s390x
 FROM $BASEIMAGE
-LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 COPY cluster-autoscaler-s390x /cluster-autoscaler
 WORKDIR /

--- a/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
@@ -25,7 +25,6 @@ ARG TARGETOS TARGETARCH
 RUN CGO_ENABLED=0 LD_FLAGS=-s GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/admission-controller -mod vendor -o admission-controller-$TARGETARCH
 
 FROM gcr.io/distroless/static:latest
-LABEL maintainer="Tomasz Kulczynski <tkulczynski@google.com>"
 
 ARG TARGETARCH
 

--- a/vertical-pod-autoscaler/pkg/recommender/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/recommender/Dockerfile
@@ -25,7 +25,6 @@ ARG TARGETOS TARGETARCH
 RUN CGO_ENABLED=0 LD_FLAGS=-s GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/recommender -mod vendor -o recommender-$TARGETARCH
 
 FROM gcr.io/distroless/static:latest
-LABEL maintainer="Krzysztof Grygiel <kgrygiel@google.com>"
 
 ARG TARGETARCH
 

--- a/vertical-pod-autoscaler/pkg/updater/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/updater/Dockerfile
@@ -25,7 +25,6 @@ ARG TARGETOS TARGETARCH
 RUN CGO_ENABLED=0 LD_FLAGS=-s GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/updater -mod vendor -o updater-$TARGETARCH
 
 FROM gcr.io/distroless/static:latest
-LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ARG TARGETARCH
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the maintainer label from all our Dockerfiles, these values just get stale and can be misleading. They are [optional labels](https://docs.docker.com/reference/dockerfile/#label) added to the built images.