### PR TITLE
Introduce noRetry Parameter for checkcapacity ProvisioningRequest

### DIFF
--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -45,7 +45,11 @@ import (
 )
 
 const (
-	NoRetryParameter = "noRetry"
+	// NoRetryParameterKey is a a key for ProvReq's Parameters that describes
+	// if ProvisioningRequest should be retried in case CA cannot provision it.
+	// Supported values are "true" and "false" - by default ProvisioningRequests are always retried.
+	// Currently supported only for checkcapacity class.
+	NoRetryParameterKey = "noRetry"
 )
 
 type checkCapacityProvClass struct {
@@ -143,11 +147,14 @@ func (o *checkCapacityProvClass) checkcapacity(unschedulablePods []*apiv1.Pod, p
 	err, cleanupErr := clustersnapshot.WithForkedSnapshot(o.context.ClusterSnapshot, func() (bool, error) {
 		st, _, err := o.schedulingSimulator.TrySchedulePods(o.context.ClusterSnapshot, unschedulablePods, scheduling.ScheduleAnywhere, true)
 		if len(st) < len(unschedulablePods) || err != nil {
-			if noRetry, ok := provReq.Spec.Parameters[NoRetryParameter]; ok && noRetry == "true" {
+			if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry == "true" {
 				// Failed=true condition triggers retry in Kueue. Otherwise ProvisioningRequest with Provisioned=Failed
 				// condition block capacity in Kueue even it's in the middle of backoff waiting time.
 				conditions.AddOrUpdateCondition(provReq, v1.Failed, metav1.ConditionTrue, conditions.CapacityIsNotFoundReason, "CA could not find requested capacity", metav1.Now())
 			} else {
+				if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry != "false" {
+					klog.Errorf("Invalid value: %v for %v Parameter in %v ProvisioningRequest. Supported values are: \"true\", \"false\"", noRetry, NoRetryParameterKey, provReq.Name)
+				}
 				conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
 			}
 			capacityAvailable = false

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -149,11 +149,11 @@ func (o *checkCapacityProvClass) checkcapacity(unschedulablePods []*apiv1.Pod, p
 		if len(st) < len(unschedulablePods) || err != nil {
 			if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry == "true" {
 				// Failed=true condition triggers retry in Kueue. Otherwise ProvisioningRequest with Provisioned=Failed
-				// condition block capacity in Kueue even it's in the middle of backoff waiting time.
+				// condition block capacity in Kueue even if it's in the middle of backoff waiting time.
 				conditions.AddOrUpdateCondition(provReq, v1.Failed, metav1.ConditionTrue, conditions.CapacityIsNotFoundReason, "CA could not find requested capacity", metav1.Now())
 			} else {
 				if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry != "false" {
-					klog.Errorf("Invalid value: %v for %v Parameter in %v ProvisioningRequest. Supported values are: \"true\", \"false\"", noRetry, NoRetryParameterKey, provReq.Name)
+					klog.Errorf("Ignoring Parameter %v with invalid value: %v in ProvisioningRequest: %v. Supported values are: \"true\", \"false\"", NoRetryParameterKey, noRetry, provReq.Name)
 				}
 				conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
 			}

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -246,7 +246,7 @@ func TestScaleUp(t *testing.T) {
 		{
 			name: "impossible check-capacity, with noRetry parameter",
 			provReqs: []*provreqwrapper.ProvisioningRequest{
-				impossibleCheckCapacityReq.Parameters(map[string]v1.Parameter{"noRetry": "true"}),
+				impossibleCheckCapacityReq.CopyWithParameters(map[string]v1.Parameter{"noRetry": "true"}),
 			},
 			provReqToScaleUp: impossibleCheckCapacityReq,
 			scaleUpResult:    status.ScaleUpNoOptionsAvailable,

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -206,6 +206,7 @@ func TestScaleUp(t *testing.T) {
 		batchTimebox        time.Duration
 		numProvisionedTrue  int
 		numProvisionedFalse int
+		numFailedTrue       int
 	}{
 		{
 			name:          "no ProvisioningRequests",
@@ -241,6 +242,15 @@ func TestScaleUp(t *testing.T) {
 			provReqs:         []*provreqwrapper.ProvisioningRequest{newCheckCapacityCpuProvReq, bookedCapacityProvReq, atomicScaleUpProvReq},
 			provReqToScaleUp: newCheckCapacityCpuProvReq,
 			scaleUpResult:    status.ScaleUpSuccessful,
+		},
+		{
+			name: "impossible check-capacity, with noRetry parameter",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				impossibleCheckCapacityReq.Parameters(map[string]v1.Parameter{"noRetry": "true"}),
+			},
+			provReqToScaleUp: impossibleCheckCapacityReq,
+			scaleUpResult:    status.ScaleUpNoOptionsAvailable,
+			numFailedTrue:    1,
 		},
 		{
 			name:             "some capacity is pre-booked, atomic scale-up not needed",
@@ -438,6 +448,7 @@ func TestScaleUp(t *testing.T) {
 				provReqsAfterScaleUp, err := client.ProvisioningRequestsNoCache()
 				assert.NoError(t, err)
 				assert.Equal(t, len(tc.provReqs), len(provReqsAfterScaleUp))
+				assert.Equal(t, tc.numFailedTrue, NumProvisioningRequestsWithCondition(provReqsAfterScaleUp, v1.Failed, metav1.ConditionTrue))
 
 				if tc.batchProcessing {
 					// Since batch processing returns aggregated result, we need to check the number of provisioned requests which have the provisioned condition.

--- a/cluster-autoscaler/provisioningrequest/provreqwrapper/testutils.go
+++ b/cluster-autoscaler/provisioningrequest/provreqwrapper/testutils.go
@@ -160,8 +160,8 @@ func BuildTestPods(namespace, name string, podCount int) []*apiv1.Pod {
 	return pods
 }
 
-// Parameters makes a deep copy of embedded ProvReq and sets its Parameters
-func (pr *ProvisioningRequest) Parameters(params map[string]v1.Parameter) *ProvisioningRequest {
+// CopyWithParameters makes a deep copy of embedded ProvReq and sets its CopyWithParameters
+func (pr *ProvisioningRequest) CopyWithParameters(params map[string]v1.Parameter) *ProvisioningRequest {
 	prCopy := pr.DeepCopy()
 	if prCopy.Spec.Parameters == nil {
 		prCopy.Spec.Parameters = make(map[string]v1.Parameter, len(params))

--- a/cluster-autoscaler/provisioningrequest/provreqwrapper/testutils.go
+++ b/cluster-autoscaler/provisioningrequest/provreqwrapper/testutils.go
@@ -159,3 +159,15 @@ func BuildTestPods(namespace, name string, podCount int) []*apiv1.Pod {
 	}
 	return pods
 }
+
+// Parameters makes a deep copy of embedded ProvReq and sets its Parameters
+func (pr *ProvisioningRequest) Parameters(params map[string]v1.Parameter) *ProvisioningRequest {
+	prCopy := pr.DeepCopy()
+	if prCopy.Spec.Parameters == nil {
+		prCopy.Spec.Parameters = make(map[string]v1.Parameter, len(params))
+	}
+	for key, val := range params {
+		prCopy.Spec.Parameters[key] = val
+	}
+	return &ProvisioningRequest{prCopy, pr.PodTemplates}
+}

--- a/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
+++ b/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
@@ -81,3 +81,15 @@ func errMissingPodTemplates(podSets []v1.PodSet, podTemplates []*apiv1.PodTempla
 	}
 	return fmt.Errorf("missing pod templates, %d pod templates were referenced, %d templates were missing: %s", len(podSets), len(missingTemplates), strings.Join(missingTemplates, ","))
 }
+
+// Parameters makes a deep copy of embedded ProvReq and sets its Parameters
+func (pr *ProvisioningRequest) Parameters(params map[string]v1.Parameter) *ProvisioningRequest {
+	prCopy := pr.DeepCopy()
+	if prCopy.Spec.Parameters == nil {
+		prCopy.Spec.Parameters = make(map[string]v1.Parameter, len(params))
+	}
+	for key, val := range params {
+		prCopy.Spec.Parameters[key] = val
+	}
+	return &ProvisioningRequest{prCopy, pr.PodTemplates}
+}

--- a/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
+++ b/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
@@ -81,15 +81,3 @@ func errMissingPodTemplates(podSets []v1.PodSet, podTemplates []*apiv1.PodTempla
 	}
 	return fmt.Errorf("missing pod templates, %d pod templates were referenced, %d templates were missing: %s", len(podSets), len(missingTemplates), strings.Join(missingTemplates, ","))
 }
-
-// Parameters makes a deep copy of embedded ProvReq and sets its Parameters
-func (pr *ProvisioningRequest) Parameters(params map[string]v1.Parameter) *ProvisioningRequest {
-	prCopy := pr.DeepCopy()
-	if prCopy.Spec.Parameters == nil {
-		prCopy.Spec.Parameters = make(map[string]v1.Parameter, len(params))
-	}
-	for key, val := range params {
-		prCopy.Spec.Parameters[key] = val
-	}
-	return &ProvisioningRequest{prCopy, pr.PodTemplates}
-}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Introduces a new Parameter for checkcapacity ProvisioningRequests that limits retry mechanism in ClusterAutoscaler.
If the capacity can't be found then the ProvisioningRequest is marked as `Failed=True` instead of `Provisioned=False`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7495 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New Parameter for checkcapacity ProvisioningRequests that limits retry mechanism
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
