### PR TITLE
Change default lease name for vpa-recommender to "vpa-recommender-lease"

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -410,7 +410,9 @@ rules:
   - apiGroups:
       - "coordination.k8s.io"
     resourceNames:
+      # TODO: Clean vpa-recommender up once vpa-recommender-lease is used everywhere. See https://github.com/kubernetes/autoscaler/issues/7461.
       - vpa-recommender
+      - vpa-recommender-lease
     resources:
       - leases
     verbs:

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -187,7 +187,8 @@ func defaultLeaderElectionConfiguration() componentbaseconfig.LeaderElectionConf
 		RenewDeadline:     metav1.Duration{Duration: defaultRenewDeadline},
 		RetryPeriod:       metav1.Duration{Duration: defaultRetryPeriod},
 		ResourceLock:      resourcelock.LeasesResourceLock,
-		ResourceName:      "vpa-recommender",
+		// This was changed from "vpa-recommender" to avoid conflicts with managed VPA deployments.
+		ResourceName:      "vpa-recommender-lease",
 		ResourceNamespace: metav1.NamespaceSystem,
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -182,11 +182,11 @@ const (
 
 func defaultLeaderElectionConfiguration() componentbaseconfig.LeaderElectionConfiguration {
 	return componentbaseconfig.LeaderElectionConfiguration{
-		LeaderElect:       false,
-		LeaseDuration:     metav1.Duration{Duration: defaultLeaseDuration},
-		RenewDeadline:     metav1.Duration{Duration: defaultRenewDeadline},
-		RetryPeriod:       metav1.Duration{Duration: defaultRetryPeriod},
-		ResourceLock:      resourcelock.LeasesResourceLock,
+		LeaderElect:   false,
+		LeaseDuration: metav1.Duration{Duration: defaultLeaseDuration},
+		RenewDeadline: metav1.Duration{Duration: defaultRenewDeadline},
+		RetryPeriod:   metav1.Duration{Duration: defaultRetryPeriod},
+		ResourceLock:  resourcelock.LeasesResourceLock,
 		// This was changed from "vpa-recommender" to avoid conflicts with managed VPA deployments.
 		ResourceName:      "vpa-recommender-lease",
 		ResourceNamespace: metav1.NamespaceSystem,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Changes the default lease name for the vpa-recommender to `vpa-recommender-lease` as this can sometimes conflict with managed deployments of HPA and VPA. See #7461.

Though changing the default here is possibly disruptive during upgrade, we believe it is the right path forward to avoid future outages. See the discussion in #7461 where we also discuss the possible scenarios during upgrade where there could temporarily be two leaders.

#### Which issue(s) this PR fixes:

#7461

#### Does this PR introduce a user-facing change?

```release-note
- Changes the default vpa-recommender leader election lease name to `vpa-recommender-lease`. This CAN result in a situation where VPA would temporarily have two leaders during an upgrade operation. This should be harmless as the two VPA leaders would theoretically be writing the same recommendations. See #7461.
```