### PR TITLE
VPA: Poll/PollImmediate PollUntilContextTimeout in v1 e2e tests

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/e2e/v1/actuation.go
@@ -530,9 +530,8 @@ func assertPodsPendingForDuration(c clientset.Interface, deployment *appsv1.Depl
 
 	pendingPods := make(map[string]time.Time)
 
-	err := wait.PollImmediate(pollInterval, pollTimeout+pendingDuration, func() (bool, error) {
-		var err error
-		currentPodList, err := framework_deployment.GetPodsForDeployment(context.TODO(), c, deployment)
+	err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (done bool, err error) {
+		currentPodList, err := framework_deployment.GetPodsForDeployment(ctx, c, deployment)
 		if err != nil {
 			return false, err
 		}
@@ -708,7 +707,7 @@ func setupHamsterReplicationController(f *framework.Framework, cpu, memory strin
 }
 
 func waitForRCPodsRunning(f *framework.Framework, rc *apiv1.ReplicationController) error {
-	return wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (done bool, err error) {
 		podList, err := GetHamsterPods(f)
 		if err != nil {
 			framework.Logf("Error listing pods, retrying: %v", err)

--- a/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
@@ -245,7 +245,7 @@ func (rc *ResourceConsumer) sendConsumeCPURequest(millicores int) {
 	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
 	defer cancel()
 
-	err := wait.PollImmediate(serviceInitializationInterval, serviceInitializationTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (done bool, err error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -271,7 +271,7 @@ func (rc *ResourceConsumer) sendConsumeMemRequest(megabytes int) {
 	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
 	defer cancel()
 
-	err := wait.PollImmediate(serviceInitializationInterval, serviceInitializationTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (done bool, err error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -297,7 +297,7 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(delta int) {
 	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
 	defer cancel()
 
-	err := wait.PollImmediate(serviceInitializationInterval, serviceInitializationTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (done bool, err error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -241,7 +241,7 @@ func NewTestCronJob(name, schedule string, replicas int32) *batchv1.CronJob {
 }
 
 func waitForActiveJobs(c clientset.Interface, ns, cronJobName string, active int) error {
-	return wait.Poll(framework.Poll, cronJobsWaitTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), framework.Poll, cronJobsWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		curr, err := getCronJob(c, ns, cronJobName)
 		if err != nil {
 			return false, err
@@ -391,7 +391,7 @@ func MakePodSet(pods *apiv1.PodList) PodSet {
 func WaitForPodsRestarted(f *framework.Framework, podList *apiv1.PodList) error {
 	initialPodSet := MakePodSet(podList)
 
-	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (done bool, err error) {
 		currentPodList, err := GetHamsterPods(f)
 		if err != nil {
 			return false, err
@@ -399,18 +399,13 @@ func WaitForPodsRestarted(f *framework.Framework, podList *apiv1.PodList) error 
 		currentPodSet := MakePodSet(currentPodList)
 		return WerePodsSuccessfullyRestarted(currentPodSet, initialPodSet), nil
 	})
-
-	if err != nil {
-		return fmt.Errorf("waiting for set of pods changed: %v", err)
-	}
-	return nil
 }
 
 // WaitForPodsEvicted waits until some pods from the list are evicted.
 func WaitForPodsEvicted(f *framework.Framework, podList *apiv1.PodList) error {
 	initialPodSet := MakePodSet(podList)
 
-	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (done bool, err error) {
 		currentPodList, err := GetHamsterPods(f)
 		if err != nil {
 			return false, err
@@ -418,11 +413,6 @@ func WaitForPodsEvicted(f *framework.Framework, podList *apiv1.PodList) error {
 		currentPodSet := MakePodSet(currentPodList)
 		return GetEvictedPodsCount(currentPodSet, initialPodSet) > 0, nil
 	})
-
-	if err != nil {
-		return fmt.Errorf("waiting for set of pods changed: %v", err)
-	}
-	return nil
 }
 
 // WerePodsSuccessfullyRestarted returns true if some pods from initialPodSet have been
@@ -469,8 +459,7 @@ func CheckNoPodsEvicted(f *framework.Framework, initialPodSet PodSet) {
 // polled vpa object. On timeout returns error.
 func WaitForVPAMatch(c vpa_clientset.Interface, vpa *vpa_types.VerticalPodAutoscaler, match func(vpa *vpa_types.VerticalPodAutoscaler) bool) (*vpa_types.VerticalPodAutoscaler, error) {
 	var polledVpa *vpa_types.VerticalPodAutoscaler
-	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		var err error
+	err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (done bool, err error) {
 		polledVpa, err = c.AutoscalingV1().VerticalPodAutoscalers(vpa.Namespace).Get(context.TODO(), vpa.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/vertical-pod-autoscaler/e2e/v1/e2e.go
+++ b/vertical-pod-autoscaler/e2e/v1/e2e.go
@@ -156,8 +156,8 @@ func waitForDaemonSets(c clientset.Interface, ns string, allowedNotReadyNodes in
 	framework.Logf("Waiting up to %v for all daemonsets in namespace '%s' to start",
 		timeout, ns)
 
-	return wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
-		dsList, err := c.AppsV1().DaemonSets(ns).List(context.TODO(), metav1.ListOptions{})
+	return wait.PollUntilContextTimeout(context.Background(), framework.Poll, timeout, true, func(ctx context.Context) (done bool, err error) {
+		dsList, err := c.AppsV1().DaemonSets(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			framework.Logf("Error getting daemonsets in namespace: '%s': %v", ns, err)
 			return false, err

--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -316,12 +316,11 @@ var _ = FullVpaE2eDescribe("OOMing pods under VPA", func() {
 })
 
 func waitForPodsMatch(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, matcher func(pod apiv1.Pod) bool) error {
-	return wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
-
+	return wait.PollUntilContextTimeout(context.Background(), pollInterval, timeout, true, func(ctx context.Context) (done bool, err error) {
 		ns := f.Namespace.Name
 		c := f.ClientSet
 
-		podList, err := c.CoreV1().Pods(ns).List(context.TODO(), listOptions)
+		podList, err := c.CoreV1().Pods(ns).List(ctx, listOptions)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Deprecates `wait.Poll` and `wait.PollImmediate` in favor of `wait.PollUntilContextTimeout`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
