### PR TITLE
Trigger an explicit scale up error when expander filters out all scale-up options

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -177,9 +177,10 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	// Pick some expansion option.
 	bestOption := o.autoscalingContext.ExpanderStrategy.BestOption(options, nodeInfos)
 	if bestOption == nil || bestOption.NodeCount <= 0 {
+		klog.Errorf("Expander filtered out all options, valid options: %d (this shouldn't happen)", len(options))
 		return &status.ScaleUpStatus{
-			Result:                  status.ScaleUpNoOptionsAvailable,
-			PodsRemainUnschedulable: GetRemainingPods(podEquivalenceGroups, skippedNodeGroups),
+			Result:                  status.ScaleUpError,
+			PodsRemainUnschedulable: getAllPods(podEquivalenceGroups, skippedNodeGroups),
 			ConsideredNodeGroups:    nodeGroups,
 		}, nil
 	}
@@ -812,6 +813,23 @@ func GetRemainingPods(egs []*equivalence.PodGroup, skipped map[string]status.Rea
 		}
 	}
 	return remaining
+}
+
+// ExpandPodGrops flattens all equivalence groups into a list of NoScaleUpInfo
+func getAllPods(egs []*equivalence.PodGroup, skipped map[string]status.Reasons) []status.NoScaleUpInfo {
+	podInfos := []status.NoScaleUpInfo{}
+	for _, eg := range egs {
+		for _, pod := range eg.Pods {
+			noScaleUpInfo := status.NoScaleUpInfo{
+				Pod:                pod,
+				RejectedNodeGroups: eg.SchedulingErrors,
+				SkippedNodeGroups:  skipped,
+			}
+			podInfos = append(podInfos, noScaleUpInfo)
+		}
+	}
+
+	return podInfos
 }
 
 // GetPodsAwaitingEvaluation returns list of pods for which CA was unable to help


### PR DESCRIPTION
…ons.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Cluster autoscaler will silently fail the scale-up in case expander was not able to pick the best option, this change adds logs to capture this behavior as well as changes the status of the scale up from ScaleUpNoOptionsAvailable to ScaleUpError 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Are there any expanders which should intentionally want to filter out options completely and not to come up with some?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
