### PR TITLE
Add raywainman to addon-resizer owners

### DIFF
--- a/addon-resizer/OWNERS
+++ b/addon-resizer/OWNERS
@@ -1,6 +1,7 @@
 approvers:
 - kwiesmueller
 - jbartosik
+- raywainman
 reviewers:
 - kwiesmueller
 - jbartosik


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds me to the list of approvers in addon-resizer.

Addon-resizer is pretty stable and seldomly touched at this point but continues to need maintenance.

I was involved in all the recent work in addon-resizer (https://github.com/kubernetes/autoscaler/commits/addon-resizer-release-1.8/addon-resizer) and was added as a reviewer in September 2024 in https://github.com/kubernetes/autoscaler/pull/7242. I have a good grasp of the codebase and would like to offer my help to ensure there is no single-point of failure for this repository as currently there is only a single active approver.
