### PR TITLE
CA: prepare for DRA integration

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -309,6 +309,8 @@ type AutoscalingOptions struct {
 	CheckCapacityProvisioningRequestBatchTimebox time.Duration
 	// ForceDeleteLongUnregisteredNodes is used to enable/disable ignoring min size constraints during removal of long unregistered nodes
 	ForceDeleteLongUnregisteredNodes bool
+	// DynamicResourceAllocationEnabled configures whether logic for handling DRA objects is enabled.
+	DynamicResourceAllocationEnabled bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -117,7 +117,7 @@ func initializeDefaultOptions(opts *AutoscalerOptions, informerFactory informers
 		opts.AutoscalingKubeClients = context.NewAutoscalingKubeClients(opts.AutoscalingOptions, opts.KubeClient, opts.InformerFactory)
 	}
 	if opts.FrameworkHandle == nil {
-		fwHandle, err := framework.NewHandle(opts.InformerFactory, opts.SchedulerConfig)
+		fwHandle, err := framework.NewHandle(opts.InformerFactory, opts.SchedulerConfig, opts.DynamicResourceAllocationEnabled)
 		if err != nil {
 			return err
 		}

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -124,7 +124,7 @@ func initializeDefaultOptions(opts *AutoscalerOptions, informerFactory informers
 		opts.FrameworkHandle = fwHandle
 	}
 	if opts.ClusterSnapshot == nil {
-		opts.ClusterSnapshot = predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), opts.FrameworkHandle)
+		opts.ClusterSnapshot = predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), opts.FrameworkHandle, opts.DynamicResourceAllocationEnabled)
 	}
 	if opts.RemainingPdbTracker == nil {
 		opts.RemainingPdbTracker = pdb.NewBasicRemainingPdbTracker()

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_expendable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_expendable_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
@@ -110,7 +111,7 @@ func TestFilterOutExpendable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			processor := NewFilterOutExpendablePodListProcessor()
 			snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-			err := snapshot.SetClusterState(tc.nodes, nil)
+			err := snapshot.SetClusterState(tc.nodes, nil, drasnapshot.Snapshot{})
 			assert.NoError(t, err)
 
 			pods, err := processor.Process(&context.AutoscalingContext{

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -280,7 +281,7 @@ func BenchmarkFilterOutSchedulable(b *testing.B) {
 				}
 
 				clusterSnapshot := snapshotFactory()
-				if err := clusterSnapshot.SetClusterState(nodes, scheduledPods); err != nil {
+				if err := clusterSnapshot.SetClusterState(nodes, scheduledPods, drasnapshot.Snapshot{}); err != nil {
 					assert.NoError(b, err)
 				}
 

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -358,7 +358,7 @@ func (a *Actuator) taintNode(node *apiv1.Node) error {
 }
 
 func (a *Actuator) createSnapshot(nodes []*apiv1.Node) (clustersnapshot.ClusterSnapshot, error) {
-	snapshot := predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), a.ctx.FrameworkHandle)
+	snapshot := predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), a.ctx.FrameworkHandle, a.ctx.DynamicResourceAllocationEnabled)
 	pods, err := a.ctx.AllPodLister().List()
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/predicate"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/utilization"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -367,7 +368,7 @@ func (a *Actuator) createSnapshot(nodes []*apiv1.Node) (clustersnapshot.ClusterS
 	scheduledPods := kube_util.ScheduledPods(pods)
 	nonExpendableScheduledPods := utils.FilterOutExpendablePods(scheduledPods, a.ctx.ExpendablePodsPriorityCutoff)
 
-	err = snapshot.SetClusterState(nodes, nonExpendableScheduledPods)
+	err = snapshot.SetClusterState(nodes, nonExpendableScheduledPods, drasnapshot.Snapshot{})
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -31,7 +31,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 )
 
 const (

--- a/cluster-autoscaler/core/scaleup/resource/manager_test.go
+++ b/cluster-autoscaler/core/scaleup/resource/manager_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/test"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
 	processorstest "k8s.io/autoscaler/cluster-autoscaler/processors/test"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	utils_test "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -71,7 +72,7 @@ func TestDeltaForNode(t *testing.T) {
 
 		ng := testCase.nodeGroupConfig
 		group, nodes := newNodeGroup(t, cp, ng.Name, ng.Min, ng.Max, ng.Size, ng.CPU, ng.Mem)
-		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil)
+		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 		assert.NoError(t, err)
 		nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&ctx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 
@@ -114,7 +115,7 @@ func TestResourcesLeft(t *testing.T) {
 
 		ng := testCase.nodeGroupConfig
 		_, nodes := newNodeGroup(t, cp, ng.Name, ng.Min, ng.Max, ng.Size, ng.CPU, ng.Mem)
-		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil)
+		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 		assert.NoError(t, err)
 		nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&ctx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 
@@ -167,7 +168,7 @@ func TestApplyLimits(t *testing.T) {
 
 		ng := testCase.nodeGroupConfig
 		group, nodes := newNodeGroup(t, cp, ng.Name, ng.Min, ng.Max, ng.Size, ng.CPU, ng.Mem)
-		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil)
+		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 		assert.NoError(t, err)
 		nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&ctx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 
@@ -234,7 +235,7 @@ func TestResourceManagerWithGpuResource(t *testing.T) {
 	assert.NoError(t, err)
 
 	nodes := []*corev1.Node{n1}
-	err = context.ClusterSnapshot.SetClusterState(nodes, nil)
+	err = context.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 	assert.NoError(t, err)
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
@@ -337,7 +338,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 	nonExpendableScheduledPods := core_utils.FilterOutExpendablePods(originalScheduledPods, a.ExpendablePodsPriorityCutoff)
 	// Initialize cluster state to ClusterSnapshot
-	if err := a.ClusterSnapshot.SetClusterState(allNodes, nonExpendableScheduledPods); err != nil {
+	if err := a.ClusterSnapshot.SetClusterState(allNodes, nonExpendableScheduledPods, drasnapshot.Snapshot{}); err != nil {
 		return caerrors.ToAutoscalerError(caerrors.InternalError, err).AddPrefix("failed to initialize ClusterSnapshot: ")
 	}
 	// Initialize Pod Disruption Budget tracking

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -496,7 +496,7 @@ func buildAutoscaler(context ctx.Context, debuggingSnapshotter debuggingsnapshot
 	}
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, 0, informers.WithTransform(trim))
 
-	fwHandle, err := framework.NewHandle(informerFactory, autoscalingOptions.SchedulerConfig)
+	fwHandle, err := framework.NewHandle(informerFactory, autoscalingOptions.SchedulerConfig, autoscalingOptions.DynamicResourceAllocationEnabled)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -506,7 +506,7 @@ func buildAutoscaler(context ctx.Context, debuggingSnapshotter debuggingsnapshot
 	opts := core.AutoscalerOptions{
 		AutoscalingOptions:   autoscalingOptions,
 		FrameworkHandle:      fwHandle,
-		ClusterSnapshot:      predicate.NewPredicateSnapshot(store.NewDeltaSnapshotStore(), fwHandle),
+		ClusterSnapshot:      predicate.NewPredicateSnapshot(store.NewDeltaSnapshotStore(), fwHandle, autoscalingOptions.DynamicResourceAllocationEnabled),
 		KubeClient:           kubeClient,
 		InformerFactory:      informerFactory,
 		DebuggingSnapshotter: debuggingSnapshotter,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -280,6 +280,7 @@ var (
 	checkCapacityProvisioningRequestMaxBatchSize = flag.Int("check-capacity-provisioning-request-max-batch-size", 10, "Maximum number of provisioning requests to process in a single batch.")
 	checkCapacityProvisioningRequestBatchTimebox = flag.Duration("check-capacity-provisioning-request-batch-timebox", 10*time.Second, "Maximum time to process a batch of provisioning requests.")
 	forceDeleteLongUnregisteredNodes             = flag.Bool("force-delete-unregistered-nodes", false, "Whether to enable force deletion of long unregistered nodes, regardless of the min size of the node group the belong to.")
+	enableDynamicResourceAllocation              = flag.Bool("enable-dynamic-resource-allocation", false, "Whether logic for handling DRA (Dynamic Resource Allocation) objects is enabled.")
 )
 
 func isFlagPassed(name string) bool {
@@ -459,6 +460,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		CheckCapacityProvisioningRequestMaxBatchSize: *checkCapacityProvisioningRequestMaxBatchSize,
 		CheckCapacityProvisioningRequestBatchTimebox: *checkCapacityProvisioningRequestBatchTimebox,
 		ForceDeleteLongUnregisteredNodes:             *forceDeleteLongUnregisteredNodes,
+		DynamicResourceAllocationEnabled:             *enableDynamicResourceAllocation,
 	}
 }
 

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
@@ -27,6 +27,7 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -77,7 +78,7 @@ func TestGetNodeInfosForGroups(t *testing.T) {
 
 	nodes := []*apiv1.Node{justReady5, unready4, unready3, ready2, ready1}
 	snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-	err := snapshot.SetClusterState(nodes, nil)
+	err := snapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 	assert.NoError(t, err)
 
 	ctx := context.AutoscalingContext{
@@ -163,7 +164,7 @@ func TestGetNodeInfosForGroupsCache(t *testing.T) {
 
 	nodes := []*apiv1.Node{unready4, unready3, ready2, ready1}
 	snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-	err := snapshot.SetClusterState(nodes, nil)
+	err := snapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 	assert.NoError(t, err)
 
 	// Fill cache
@@ -254,7 +255,7 @@ func TestGetNodeInfosCacheExpired(t *testing.T) {
 
 	nodes := []*apiv1.Node{ready1}
 	snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-	err := snapshot.SetClusterState(nodes, nil)
+	err := snapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 	assert.NoError(t, err)
 
 	ctx := context.AutoscalingContext{

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	apiv1 "k8s.io/api/core/v1"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
 )
@@ -60,7 +61,7 @@ type ClusterSnapshotStore interface {
 
 	// SetClusterState resets the snapshot to an unforked state and replaces the contents of the snapshot
 	// with the provided data. scheduledPods are correlated to their Nodes based on spec.NodeName.
-	SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod) error
+	SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod, draSnapshot drasnapshot.Snapshot) error
 
 	// ForceAddPod adds the given Pod to the Node with the given nodeName inside the snapshot without checking scheduler predicates.
 	ForceAddPod(pod *apiv1.Pod, nodeName string) error
@@ -79,6 +80,9 @@ type ClusterSnapshotStore interface {
 	GetNodeInfo(nodeName string) (*framework.NodeInfo, error)
 	// ListNodeInfos returns internal NodeInfos for all Nodes tracked in the snapshot. See the comment on GetNodeInfo.
 	ListNodeInfos() ([]*framework.NodeInfo, error)
+
+	// DraSnapshot returns an interface that allows accessing and modifying the DRA objects in the snapshot.
+	DraSnapshot() drasnapshot.Snapshot
 
 	// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert().
 	// Use WithForkedSnapshot() helper function instead if possible.

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -23,12 +23,26 @@ import (
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 // ClusterSnapshot is abstraction of cluster state used for predicate simulations.
 // It exposes mutation methods and can be viewed as scheduler's SharedLister.
 type ClusterSnapshot interface {
 	ClusterSnapshotStore
+
+	// AddNodeInfo adds the given NodeInfo to the snapshot without checking scheduler predicates. The Node and the Pods are added,
+	// as well as any DRA objects passed along them.
+	AddNodeInfo(nodeInfo *framework.NodeInfo) error
+	// RemoveNodeInfo removes the given NodeInfo from the snapshot The Node and the Pods are removed, as well as
+	// any DRA objects owned by them.
+	RemoveNodeInfo(nodeName string) error
+	// GetNodeInfo returns an internal NodeInfo for a given Node - all information about the Node tracked in the snapshot.
+	// This means the Node itself, its scheduled Pods, as well as all relevant DRA objects. The internal NodeInfos
+	// obtained via this method should always be used in CA code instead of directly using *schedulerframework.NodeInfo.
+	GetNodeInfo(nodeName string) (*framework.NodeInfo, error)
+	// ListNodeInfos returns internal NodeInfos for all Nodes tracked in the snapshot. See the comment on GetNodeInfo.
+	ListNodeInfos() ([]*framework.NodeInfo, error)
 
 	// SchedulePod tries to schedule the given Pod on the Node with the given name inside the snapshot,
 	// checking scheduling predicates. The pod is only scheduled if the predicates pass. If the pod is scheduled,
@@ -68,18 +82,13 @@ type ClusterSnapshotStore interface {
 	// ForceRemovePod removes the given Pod (and all DRA objects it owns) from the snapshot.
 	ForceRemovePod(namespace string, podName string, nodeName string) error
 
-	// AddNodeInfo adds the given NodeInfo to the snapshot without checking scheduler predicates. The Node and the Pods are added,
-	// as well as any DRA objects passed along them.
-	AddNodeInfo(nodeInfo *framework.NodeInfo) error
-	// RemoveNodeInfo removes the given NodeInfo from the snapshot The Node and the Pods are removed, as well as
-	// any DRA objects owned by them.
-	RemoveNodeInfo(nodeName string) error
-	// GetNodeInfo returns an internal NodeInfo for a given Node - all information about the Node tracked in the snapshot.
-	// This means the Node itself, its scheduled Pods, as well as all relevant DRA objects. The internal NodeInfos
-	// obtained via this method should always be used in CA code instead of directly using *schedulerframework.NodeInfo.
-	GetNodeInfo(nodeName string) (*framework.NodeInfo, error)
-	// ListNodeInfos returns internal NodeInfos for all Nodes tracked in the snapshot. See the comment on GetNodeInfo.
-	ListNodeInfos() ([]*framework.NodeInfo, error)
+	// AddSchedulerNodeInfo adds the given schedulerframework.NodeInfo to the snapshot without checking scheduler predicates, and
+	// without taking DRA objects into account. This shouldn't be used outside the clustersnapshot pkg, use ClusterSnapshot.AddNodeInfo()
+	// instead.
+	AddSchedulerNodeInfo(nodeInfo *schedulerframework.NodeInfo) error
+	// RemoveSchedulerNodeInfo removes the given schedulerframework.NodeInfo from the snapshot without taking DRA objects into account. This shouldn't
+	// be used outside the clustersnapshot pkg, use ClusterSnapshot.RemoveNodeInfo() instead.
+	RemoveSchedulerNodeInfo(nodeName string) error
 
 	// DraSnapshot returns an interface that allows accessing and modifying the DRA objects in the snapshot.
 	DraSnapshot() drasnapshot.Snapshot

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -22,7 +22,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 // ClusterSnapshot is abstraction of cluster state used for predicate simulations.
@@ -57,7 +56,7 @@ type ClusterSnapshot interface {
 // without going through scheduler predicates. ClusterSnapshotStore shouldn't be directly used outside the clustersnapshot pkg, its methods
 // should be accessed via ClusterSnapshot.
 type ClusterSnapshotStore interface {
-	schedulerframework.SharedLister
+	framework.SharedLister
 
 	// SetClusterState resets the snapshot to an unforked state and replaces the contents of the snapshot
 	// with the provided data. scheduledPods are correlated to their Nodes based on spec.NodeName.

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
@@ -44,10 +44,10 @@ func NewSchedulerPluginRunner(fwHandle *framework.Handle, snapshot clustersnapsh
 // function - until a Node where the Filters pass is found. Filters are only run for matching Nodes. If no matching Node with passing Filters is found, an error is returned.
 //
 // The node iteration always starts from the next Node from the last Node that was found by this method. TODO: Extract the iteration strategy out of SchedulerPluginRunner.
-func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, nodeMatches func(*framework.NodeInfo) bool) (string, clustersnapshot.SchedulingError) {
+func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, nodeMatches func(*framework.NodeInfo) bool) (*apiv1.Node, *schedulerframework.CycleState, clustersnapshot.SchedulingError) {
 	nodeInfosList, err := p.snapshot.ListNodeInfos()
 	if err != nil {
-		return "", clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("error listing NodeInfos: %v", err))
+		return nil, nil, clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("error listing NodeInfos: %v", err))
 	}
 
 	p.fwHandle.DelegatingLister.UpdateDelegate(p.snapshot)
@@ -61,7 +61,7 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, nodeM
 	if !preFilterStatus.IsSuccess() {
 		// If any of the plugin PreFilter methods isn't successful, the corresponding Filter method can't be run, so the whole scheduling cycle is aborted.
 		// Match that behavior here.
-		return "", clustersnapshot.NewFailingPredicateError(pod, preFilterStatus.Plugin(), preFilterStatus.Reasons(), "PreFilter failed", "")
+		return nil, nil, clustersnapshot.NewFailingPredicateError(pod, preFilterStatus.Plugin(), preFilterStatus.Reasons(), "PreFilter failed", "")
 	}
 
 	for i := range nodeInfosList {
@@ -92,18 +92,18 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, nodeM
 		if filterStatus.IsSuccess() {
 			// Filter passed for all plugins, so this pod can be scheduled on this Node.
 			p.lastIndex = (p.lastIndex + i + 1) % len(nodeInfosList)
-			return nodeInfo.Node().Name, nil
+			return nodeInfo.Node(), state, nil
 		}
 		// Filter didn't pass for some plugin, so this Node won't work - move on to the next one.
 	}
-	return "", clustersnapshot.NewNoNodesPassingPredicatesFoundError(pod)
+	return nil, nil, clustersnapshot.NewNoNodesPassingPredicatesFoundError(pod)
 }
 
 // RunFiltersOnNode runs the scheduler framework PreFilter and Filter phases to check if the given pod can be scheduled on the given node.
-func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string) clustersnapshot.SchedulingError {
+func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string) (*apiv1.Node, *schedulerframework.CycleState, clustersnapshot.SchedulingError) {
 	nodeInfo, err := p.snapshot.GetNodeInfo(nodeName)
 	if err != nil {
-		return clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("error obtaining NodeInfo for name %q: %v", nodeName, err))
+		return nil, nil, clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("error obtaining NodeInfo for name %q: %v", nodeName, err))
 	}
 
 	p.fwHandle.DelegatingLister.UpdateDelegate(p.snapshot)
@@ -113,10 +113,10 @@ func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string
 	// Run the PreFilter phase of the framework for the Pod and check the results. See the corresponding comments in RunFiltersUntilPassingNode() for more info.
 	preFilterResult, preFilterStatus, _ := p.fwHandle.Framework.RunPreFilterPlugins(context.TODO(), state, pod)
 	if !preFilterStatus.IsSuccess() {
-		return clustersnapshot.NewFailingPredicateError(pod, preFilterStatus.Plugin(), preFilterStatus.Reasons(), "PreFilter failed", "")
+		return nil, nil, clustersnapshot.NewFailingPredicateError(pod, preFilterStatus.Plugin(), preFilterStatus.Reasons(), "PreFilter failed", "")
 	}
 	if !preFilterResult.AllNodes() && !preFilterResult.NodeNames.Has(nodeInfo.Node().Name) {
-		return clustersnapshot.NewFailingPredicateError(pod, preFilterStatus.Plugin(), preFilterStatus.Reasons(), "PreFilter filtered the Node out", "")
+		return nil, nil, clustersnapshot.NewFailingPredicateError(pod, preFilterStatus.Plugin(), preFilterStatus.Reasons(), "PreFilter filtered the Node out", "")
 	}
 
 	// Run the Filter phase of the framework for the Pod and the Node and check the results. See the corresponding comments in RunFiltersUntilPassingNode() for more info.
@@ -128,10 +128,22 @@ func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string
 		if !filterStatus.IsRejected() {
 			unexpectedErrMsg = fmt.Sprintf("unexpected filter status %q", filterStatus.Code().String())
 		}
-		return clustersnapshot.NewFailingPredicateError(pod, filterName, filterReasons, unexpectedErrMsg, p.failingFilterDebugInfo(filterName, nodeInfo))
+		return nil, nil, clustersnapshot.NewFailingPredicateError(pod, filterName, filterReasons, unexpectedErrMsg, p.failingFilterDebugInfo(filterName, nodeInfo))
 	}
 
 	// PreFilter and Filter phases checked, this Pod can be scheduled on this Node.
+	return nodeInfo.Node(), state, nil
+}
+
+// RunReserveOnNode runs the scheduler framework Reserve phase to update the scheduler plugins state to reflect the Pod being scheduled on the Node.
+func (p *SchedulerPluginRunner) RunReserveOnNode(pod *apiv1.Pod, nodeName string, postFilterState *schedulerframework.CycleState) error {
+	p.fwHandle.DelegatingLister.UpdateDelegate(p.snapshot)
+	defer p.fwHandle.DelegatingLister.ResetDelegate()
+
+	status := p.fwHandle.Framework.RunReservePluginsReserve(context.Background(), postFilterState, pod, nodeName)
+	if !status.IsSuccess() {
+		return fmt.Errorf("couldn't reserve node %s for pod %s/%s: %v", nodeName, pod.Namespace, pod.Name, status.Message())
+	}
 	return nil
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
@@ -321,7 +321,7 @@ func newTestPluginRunner(snapshotStore clustersnapshot.ClusterSnapshotStore, sch
 		schedConfig = defaultConfig
 	}
 
-	fwHandle, err := framework.NewHandle(informers.NewSharedInformerFactory(clientsetfake.NewSimpleClientset(), 0), schedConfig)
+	fwHandle, err := framework.NewHandle(informers.NewSharedInformerFactory(clientsetfake.NewSimpleClientset(), 0), schedConfig, true)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
@@ -27,13 +27,15 @@ import (
 type PredicateSnapshot struct {
 	clustersnapshot.ClusterSnapshotStore
 	pluginRunner *SchedulerPluginRunner
+	draEnabled   bool
 }
 
 // NewPredicateSnapshot builds a PredicateSnapshot.
-func NewPredicateSnapshot(snapshotStore clustersnapshot.ClusterSnapshotStore, fwHandle *framework.Handle) *PredicateSnapshot {
+func NewPredicateSnapshot(snapshotStore clustersnapshot.ClusterSnapshotStore, fwHandle *framework.Handle, draEnabled bool) *PredicateSnapshot {
 	return &PredicateSnapshot{
 		ClusterSnapshotStore: snapshotStore,
 		pluginRunner:         NewSchedulerPluginRunner(fwHandle, snapshotStore),
+		draEnabled:           draEnabled,
 	}
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_benchmark_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
@@ -39,7 +40,7 @@ func BenchmarkAddNodeInfo(b *testing.B) {
 			b.Run(fmt.Sprintf("%s: AddNodeInfo() %d", snapshotName, tc), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
-					assert.NoError(b, clusterSnapshot.SetClusterState(nil, nil))
+					assert.NoError(b, clusterSnapshot.SetClusterState(nil, nil, drasnapshot.Snapshot{}))
 					b.StartTimer()
 					for _, node := range nodes {
 						err := clusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node))
@@ -61,7 +62,7 @@ func BenchmarkListNodeInfos(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc)
 			clusterSnapshot, err := snapshotFactory()
 			assert.NoError(b, err)
-			err = clusterSnapshot.SetClusterState(nodes, nil)
+			err = clusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 			if err != nil {
 				assert.NoError(b, err)
 			}
@@ -91,14 +92,14 @@ func BenchmarkAddPods(b *testing.B) {
 			clustersnapshot.AssignTestPodsToNodes(pods, nodes)
 			clusterSnapshot, err := snapshotFactory()
 			assert.NoError(b, err)
-			err = clusterSnapshot.SetClusterState(nodes, nil)
+			err = clusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 			assert.NoError(b, err)
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s: ForceAddPod() 30*%d", snapshotName, tc), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
-					err = clusterSnapshot.SetClusterState(nodes, nil)
+					err = clusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
 					if err != nil {
 						assert.NoError(b, err)
 					}
@@ -127,7 +128,7 @@ func BenchmarkForkAddRevert(b *testing.B) {
 				clustersnapshot.AssignTestPodsToNodes(pods, nodes)
 				clusterSnapshot, err := snapshotFactory()
 				assert.NoError(b, err)
-				err = clusterSnapshot.SetClusterState(nodes, pods)
+				err = clusterSnapshot.SetClusterState(nodes, pods, drasnapshot.Snapshot{})
 				assert.NoError(b, err)
 				tmpNode1 := BuildTestNode("tmp-1", 2000, 2000000)
 				tmpNode2 := BuildTestNode("tmp-2", 2000, 2000000)

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -25,6 +25,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -90,7 +91,7 @@ func getSnapshotState(t *testing.T, snapshot clustersnapshot.ClusterSnapshot) sn
 func startSnapshot(t *testing.T, snapshotFactory func() (clustersnapshot.ClusterSnapshot, error), state snapshotState) clustersnapshot.ClusterSnapshot {
 	snapshot, err := snapshotFactory()
 	assert.NoError(t, err)
-	err = snapshot.SetClusterState(state.nodes, state.pods)
+	err = snapshot.SetClusterState(state.nodes, state.pods, drasnapshot.Snapshot{})
 	assert.NoError(t, err)
 	return snapshot
 }
@@ -324,7 +325,7 @@ func TestSetClusterState(t *testing.T) {
 				snapshot := startSnapshot(t, snapshotFactory, state)
 				compareStates(t, state, getSnapshotState(t, snapshot))
 
-				assert.NoError(t, snapshot.SetClusterState(nil, nil))
+				assert.NoError(t, snapshot.SetClusterState(nil, nil, drasnapshot.Snapshot{}))
 
 				compareStates(t, snapshotState{}, getSnapshotState(t, snapshot))
 			})
@@ -335,7 +336,7 @@ func TestSetClusterState(t *testing.T) {
 
 				newNodes, newPods := clustersnapshot.CreateTestNodes(13), clustersnapshot.CreateTestPods(37)
 				clustersnapshot.AssignTestPodsToNodes(newPods, newNodes)
-				assert.NoError(t, snapshot.SetClusterState(newNodes, newPods))
+				assert.NoError(t, snapshot.SetClusterState(newNodes, newPods, drasnapshot.Snapshot{}))
 
 				compareStates(t, snapshotState{nodes: newNodes, pods: newPods}, getSnapshotState(t, snapshot))
 			})
@@ -358,7 +359,7 @@ func TestSetClusterState(t *testing.T) {
 
 				compareStates(t, snapshotState{allNodes, allPods}, getSnapshotState(t, snapshot))
 
-				assert.NoError(t, snapshot.SetClusterState(nil, nil))
+				assert.NoError(t, snapshot.SetClusterState(nil, nil, drasnapshot.Snapshot{}))
 
 				compareStates(t, snapshotState{}, getSnapshotState(t, snapshot))
 
@@ -754,7 +755,7 @@ func TestPVCClearAndFork(t *testing.T) {
 			volumeExists := snapshot.StorageInfos().IsPVCUsedByPods(schedulerframework.GetNamespacedName("default", "claim1"))
 			assert.Equal(t, true, volumeExists)
 
-			assert.NoError(t, snapshot.SetClusterState(nil, nil))
+			assert.NoError(t, snapshot.SetClusterState(nil, nil, drasnapshot.Snapshot{}))
 			volumeExists = snapshot.StorageInfos().IsPVCUsedByPods(schedulerframework.GetNamespacedName("default", "claim1"))
 			assert.Equal(t, false, volumeExists)
 

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -38,14 +38,14 @@ var snapshots = map[string]func() (clustersnapshot.ClusterSnapshot, error){
 		if err != nil {
 			return nil, err
 		}
-		return NewPredicateSnapshot(store.NewBasicSnapshotStore(), fwHandle), nil
+		return NewPredicateSnapshot(store.NewBasicSnapshotStore(), fwHandle, true), nil
 	},
 	"delta": func() (clustersnapshot.ClusterSnapshot, error) {
 		fwHandle, err := framework.NewTestFrameworkHandle()
 		if err != nil {
 			return nil, err
 		}
-		return NewPredicateSnapshot(store.NewDeltaSnapshotStore(), fwHandle), nil
+		return NewPredicateSnapshot(store.NewDeltaSnapshotStore(), fwHandle, true), nil
 	},
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -211,13 +211,17 @@ func (snapshot *BasicSnapshotStore) GetNodeInfo(nodeName string) (*framework.Nod
 	if err != nil {
 		return nil, err
 	}
-	return framework.WrapSchedulerNodeInfo(schedNodeInfo), nil
+	return framework.WrapSchedulerNodeInfo(schedNodeInfo, nil, nil), nil
 }
 
 // ListNodeInfos lists NodeInfos.
 func (snapshot *BasicSnapshotStore) ListNodeInfos() ([]*framework.NodeInfo, error) {
 	schedNodeInfos := snapshot.getInternalData().listNodeInfos()
-	return framework.WrapSchedulerNodeInfos(schedNodeInfos), nil
+	var result []*framework.NodeInfo
+	for _, schedNodeInfo := range schedNodeInfos {
+		result = append(result, framework.WrapSchedulerNodeInfo(schedNodeInfo, nil, nil))
+	}
+	return result, nil
 }
 
 // AddNodeInfo adds a NodeInfo.

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -319,6 +319,21 @@ func (snapshot *BasicSnapshotStore) StorageInfos() schedulerframework.StorageInf
 	return (*basicSnapshotStoreStorageLister)(snapshot)
 }
 
+// ResourceClaims exposes snapshot as ResourceClaimTracker
+func (snapshot *BasicSnapshotStore) ResourceClaims() schedulerframework.ResourceClaimTracker {
+	return nil
+}
+
+// ResourceSlices exposes snapshot as ResourceSliceLister.
+func (snapshot *BasicSnapshotStore) ResourceSlices() schedulerframework.ResourceSliceLister {
+	return nil
+}
+
+// DeviceClasses exposes the snapshot as DeviceClassLister.
+func (snapshot *BasicSnapshotStore) DeviceClasses() schedulerframework.DeviceClassLister {
+	return nil
+}
+
 // List returns the list of nodes in the snapshot.
 func (snapshot *basicSnapshotStoreNodeLister) List() ([]*schedulerframework.NodeInfo, error) {
 	return (*BasicSnapshotStore)(snapshot).getInternalData().listNodeInfos(), nil

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -36,6 +36,7 @@ type BasicSnapshotStore struct {
 type internalBasicSnapshotData struct {
 	nodeInfoMap        map[string]*schedulerframework.NodeInfo
 	pvcNamespacePodMap map[string]map[string]bool
+	draSnapshot        drasnapshot.Snapshot
 }
 
 func (data *internalBasicSnapshotData) listNodeInfos() []*schedulerframework.NodeInfo {
@@ -142,6 +143,7 @@ func (data *internalBasicSnapshotData) clone() *internalBasicSnapshotData {
 	return &internalBasicSnapshotData{
 		nodeInfoMap:        clonedNodeInfoMap,
 		pvcNamespacePodMap: clonedPvcNamespaceNodeMap,
+		draSnapshot:        data.draSnapshot.Clone(),
 	}
 }
 
@@ -208,8 +210,7 @@ func (snapshot *BasicSnapshotStore) getInternalData() *internalBasicSnapshotData
 
 // DraSnapshot returns the DRA snapshot.
 func (snapshot *BasicSnapshotStore) DraSnapshot() drasnapshot.Snapshot {
-	// TODO(DRA): Return DRA snapshot.
-	return drasnapshot.Snapshot{}
+	return snapshot.getInternalData().draSnapshot
 }
 
 // GetNodeInfo gets a NodeInfo.
@@ -262,7 +263,7 @@ func (snapshot *BasicSnapshotStore) SetClusterState(nodes []*apiv1.Node, schedul
 			}
 		}
 	}
-	// TODO(DRA): Save DRA snapshot.
+	snapshot.getInternalData().draSnapshot = draSnapshot
 	return nil
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -21,6 +21,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -205,6 +206,12 @@ func (snapshot *BasicSnapshotStore) getInternalData() *internalBasicSnapshotData
 	return snapshot.data[len(snapshot.data)-1]
 }
 
+// DraSnapshot returns the DRA snapshot.
+func (snapshot *BasicSnapshotStore) DraSnapshot() drasnapshot.Snapshot {
+	// TODO(DRA): Return DRA snapshot.
+	return drasnapshot.Snapshot{}
+}
+
 // GetNodeInfo gets a NodeInfo.
 func (snapshot *BasicSnapshotStore) GetNodeInfo(nodeName string) (*framework.NodeInfo, error) {
 	schedNodeInfo, err := snapshot.getInternalData().getNodeInfo(nodeName)
@@ -238,7 +245,7 @@ func (snapshot *BasicSnapshotStore) AddNodeInfo(nodeInfo *framework.NodeInfo) er
 }
 
 // SetClusterState sets the cluster state.
-func (snapshot *BasicSnapshotStore) SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod) error {
+func (snapshot *BasicSnapshotStore) SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod, draSnapshot drasnapshot.Snapshot) error {
 	snapshot.clear()
 
 	knownNodes := make(map[string]bool)
@@ -255,6 +262,7 @@ func (snapshot *BasicSnapshotStore) SetClusterState(nodes []*apiv1.Node, schedul
 			}
 		}
 	}
+	// TODO(DRA): Save DRA snapshot.
 	return nil
 }
 
@@ -325,17 +333,17 @@ func (snapshot *BasicSnapshotStore) StorageInfos() schedulerframework.StorageInf
 
 // ResourceClaims exposes snapshot as ResourceClaimTracker
 func (snapshot *BasicSnapshotStore) ResourceClaims() schedulerframework.ResourceClaimTracker {
-	return nil
+	return snapshot.DraSnapshot().ResourceClaims()
 }
 
 // ResourceSlices exposes snapshot as ResourceSliceLister.
 func (snapshot *BasicSnapshotStore) ResourceSlices() schedulerframework.ResourceSliceLister {
-	return nil
+	return snapshot.DraSnapshot().ResourceSlices()
 }
 
 // DeviceClasses exposes the snapshot as DeviceClassLister.
 func (snapshot *BasicSnapshotStore) DeviceClasses() schedulerframework.DeviceClassLister {
-	return nil
+	return snapshot.DraSnapshot().DeviceClasses()
 }
 
 // List returns the list of nodes in the snapshot.

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -22,7 +22,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -213,31 +212,12 @@ func (snapshot *BasicSnapshotStore) DraSnapshot() drasnapshot.Snapshot {
 	return snapshot.getInternalData().draSnapshot
 }
 
-// GetNodeInfo gets a NodeInfo.
-func (snapshot *BasicSnapshotStore) GetNodeInfo(nodeName string) (*framework.NodeInfo, error) {
-	schedNodeInfo, err := snapshot.getInternalData().getNodeInfo(nodeName)
-	if err != nil {
-		return nil, err
-	}
-	return framework.WrapSchedulerNodeInfo(schedNodeInfo, nil, nil), nil
-}
-
-// ListNodeInfos lists NodeInfos.
-func (snapshot *BasicSnapshotStore) ListNodeInfos() ([]*framework.NodeInfo, error) {
-	schedNodeInfos := snapshot.getInternalData().listNodeInfos()
-	var result []*framework.NodeInfo
-	for _, schedNodeInfo := range schedNodeInfos {
-		result = append(result, framework.WrapSchedulerNodeInfo(schedNodeInfo, nil, nil))
-	}
-	return result, nil
-}
-
-// AddNodeInfo adds a NodeInfo.
-func (snapshot *BasicSnapshotStore) AddNodeInfo(nodeInfo *framework.NodeInfo) error {
+// AddSchedulerNodeInfo adds a NodeInfo.
+func (snapshot *BasicSnapshotStore) AddSchedulerNodeInfo(nodeInfo *schedulerframework.NodeInfo) error {
 	if err := snapshot.getInternalData().addNode(nodeInfo.Node()); err != nil {
 		return err
 	}
-	for _, podInfo := range nodeInfo.Pods() {
+	for _, podInfo := range nodeInfo.Pods {
 		if err := snapshot.getInternalData().addPod(podInfo.Pod, nodeInfo.Node().Name); err != nil {
 			return err
 		}
@@ -267,8 +247,8 @@ func (snapshot *BasicSnapshotStore) SetClusterState(nodes []*apiv1.Node, schedul
 	return nil
 }
 
-// RemoveNodeInfo removes nodes (and pods scheduled to it) from the snapshot.
-func (snapshot *BasicSnapshotStore) RemoveNodeInfo(nodeName string) error {
+// RemoveSchedulerNodeInfo removes nodes (and pods scheduled to it) from the snapshot.
+func (snapshot *BasicSnapshotStore) RemoveSchedulerNodeInfo(nodeName string) error {
 	return snapshot.getInternalData().removeNodeInfo(nodeName)
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -387,6 +387,21 @@ func (snapshot *DeltaSnapshotStore) StorageInfos() schedulerframework.StorageInf
 	return (*deltaSnapshotStoreStorageLister)(snapshot)
 }
 
+// ResourceClaims exposes snapshot as ResourceClaimTracker
+func (snapshot *DeltaSnapshotStore) ResourceClaims() schedulerframework.ResourceClaimTracker {
+	return nil
+}
+
+// ResourceSlices exposes snapshot as ResourceSliceLister.
+func (snapshot *DeltaSnapshotStore) ResourceSlices() schedulerframework.ResourceSliceLister {
+	return nil
+}
+
+// DeviceClasses exposes the snapshot as DeviceClassLister.
+func (snapshot *DeltaSnapshotStore) DeviceClasses() schedulerframework.DeviceClassLister {
+	return nil
+}
+
 // NewDeltaSnapshotStore creates instances of DeltaSnapshotStore.
 func NewDeltaSnapshotStore() *DeltaSnapshotStore {
 	snapshot := &DeltaSnapshotStore{}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -415,13 +415,17 @@ func (snapshot *DeltaSnapshotStore) GetNodeInfo(nodeName string) (*framework.Nod
 	if err != nil {
 		return nil, err
 	}
-	return framework.WrapSchedulerNodeInfo(schedNodeInfo), nil
+	return framework.WrapSchedulerNodeInfo(schedNodeInfo, nil, nil), nil
 }
 
 // ListNodeInfos lists NodeInfos.
 func (snapshot *DeltaSnapshotStore) ListNodeInfos() ([]*framework.NodeInfo, error) {
 	schedNodeInfos := snapshot.data.getNodeInfoList()
-	return framework.WrapSchedulerNodeInfos(schedNodeInfos), nil
+	var result []*framework.NodeInfo
+	for _, schedNodeInfo := range schedNodeInfos {
+		result = append(result, framework.WrapSchedulerNodeInfo(schedNodeInfo, nil, nil))
+	}
+	return result, nil
 }
 
 // AddNodeInfo adds a NodeInfo.

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -21,6 +21,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -389,17 +390,17 @@ func (snapshot *DeltaSnapshotStore) StorageInfos() schedulerframework.StorageInf
 
 // ResourceClaims exposes snapshot as ResourceClaimTracker
 func (snapshot *DeltaSnapshotStore) ResourceClaims() schedulerframework.ResourceClaimTracker {
-	return nil
+	return snapshot.DraSnapshot().ResourceClaims()
 }
 
 // ResourceSlices exposes snapshot as ResourceSliceLister.
 func (snapshot *DeltaSnapshotStore) ResourceSlices() schedulerframework.ResourceSliceLister {
-	return nil
+	return snapshot.DraSnapshot().ResourceSlices()
 }
 
 // DeviceClasses exposes the snapshot as DeviceClassLister.
 func (snapshot *DeltaSnapshotStore) DeviceClasses() schedulerframework.DeviceClassLister {
-	return nil
+	return snapshot.DraSnapshot().DeviceClasses()
 }
 
 // NewDeltaSnapshotStore creates instances of DeltaSnapshotStore.
@@ -407,6 +408,12 @@ func NewDeltaSnapshotStore() *DeltaSnapshotStore {
 	snapshot := &DeltaSnapshotStore{}
 	snapshot.clear()
 	return snapshot
+}
+
+// DraSnapshot returns the DRA snapshot.
+func (snapshot *DeltaSnapshotStore) DraSnapshot() drasnapshot.Snapshot {
+	// TODO(DRA): Return DRA snapshot.
+	return drasnapshot.Snapshot{}
 }
 
 // GetNodeInfo gets a NodeInfo.
@@ -442,7 +449,7 @@ func (snapshot *DeltaSnapshotStore) AddNodeInfo(nodeInfo *framework.NodeInfo) er
 }
 
 // SetClusterState sets the cluster state.
-func (snapshot *DeltaSnapshotStore) SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod) error {
+func (snapshot *DeltaSnapshotStore) SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod, draSnapshot drasnapshot.Snapshot) error {
 	snapshot.clear()
 
 	knownNodes := make(map[string]bool)
@@ -459,6 +466,7 @@ func (snapshot *DeltaSnapshotStore) SetClusterState(nodes []*apiv1.Node, schedul
 			}
 		}
 	}
+	// TODO(DRA): Save DRA snapshot.
 	return nil
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -22,7 +22,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -416,31 +415,12 @@ func (snapshot *DeltaSnapshotStore) DraSnapshot() drasnapshot.Snapshot {
 	return drasnapshot.Snapshot{}
 }
 
-// GetNodeInfo gets a NodeInfo.
-func (snapshot *DeltaSnapshotStore) GetNodeInfo(nodeName string) (*framework.NodeInfo, error) {
-	schedNodeInfo, err := snapshot.getNodeInfo(nodeName)
-	if err != nil {
-		return nil, err
-	}
-	return framework.WrapSchedulerNodeInfo(schedNodeInfo, nil, nil), nil
-}
-
-// ListNodeInfos lists NodeInfos.
-func (snapshot *DeltaSnapshotStore) ListNodeInfos() ([]*framework.NodeInfo, error) {
-	schedNodeInfos := snapshot.data.getNodeInfoList()
-	var result []*framework.NodeInfo
-	for _, schedNodeInfo := range schedNodeInfos {
-		result = append(result, framework.WrapSchedulerNodeInfo(schedNodeInfo, nil, nil))
-	}
-	return result, nil
-}
-
-// AddNodeInfo adds a NodeInfo.
-func (snapshot *DeltaSnapshotStore) AddNodeInfo(nodeInfo *framework.NodeInfo) error {
+// AddSchedulerNodeInfo adds a NodeInfo.
+func (snapshot *DeltaSnapshotStore) AddSchedulerNodeInfo(nodeInfo *schedulerframework.NodeInfo) error {
 	if err := snapshot.data.addNode(nodeInfo.Node()); err != nil {
 		return err
 	}
-	for _, podInfo := range nodeInfo.Pods() {
+	for _, podInfo := range nodeInfo.Pods {
 		if err := snapshot.data.addPod(podInfo.Pod, nodeInfo.Node().Name); err != nil {
 			return err
 		}
@@ -470,8 +450,8 @@ func (snapshot *DeltaSnapshotStore) SetClusterState(nodes []*apiv1.Node, schedul
 	return nil
 }
 
-// RemoveNodeInfo removes nodes (and pods scheduled to it) from the snapshot.
-func (snapshot *DeltaSnapshotStore) RemoveNodeInfo(nodeName string) error {
+// RemoveSchedulerNodeInfo removes nodes (and pods scheduled to it) from the snapshot.
+func (snapshot *DeltaSnapshotStore) RemoveSchedulerNodeInfo(nodeName string) error {
 	return snapshot.data.removeNodeInfo(nodeName)
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 )
 
@@ -48,7 +49,7 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 		b.Run(fmt.Sprintf("fork add 1000 to %d", tc.nodeCount), func(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc.nodeCount + 1000)
 			deltaStore := NewDeltaSnapshotStore()
-			if err := deltaStore.SetClusterState(nodes[:tc.nodeCount], nil); err != nil {
+			if err := deltaStore.SetClusterState(nodes[:tc.nodeCount], nil, drasnapshot.Snapshot{}); err != nil {
 				assert.NoError(b, err)
 			}
 			deltaStore.Fork()
@@ -68,7 +69,7 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 		b.Run(fmt.Sprintf("base %d", tc.nodeCount), func(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc.nodeCount)
 			deltaStore := NewDeltaSnapshotStore()
-			if err := deltaStore.SetClusterState(nodes, nil); err != nil {
+			if err := deltaStore.SetClusterState(nodes, nil, drasnapshot.Snapshot{}); err != nil {
 				assert.NoError(b, err)
 			}
 			b.ResetTimer()

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 func BenchmarkBuildNodeInfoList(b *testing.B) {
@@ -54,7 +54,9 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 			}
 			deltaStore.Fork()
 			for _, node := range nodes[tc.nodeCount:] {
-				if err := deltaStore.AddNodeInfo(framework.NewTestNodeInfo(node)); err != nil {
+				schedNodeInfo := schedulerframework.NewNodeInfo()
+				schedNodeInfo.SetNode(node)
+				if err := deltaStore.AddSchedulerNodeInfo(schedNodeInfo); err != nil {
 					assert.NoError(b, err)
 				}
 			}

--- a/cluster-autoscaler/simulator/clustersnapshot/test_utils.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/test_utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "k8s.io/api/core/v1"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
@@ -38,7 +39,7 @@ func InitializeClusterSnapshotOrDie(
 	pods []*apiv1.Pod) {
 	var err error
 
-	assert.NoError(t, snapshot.SetClusterState(nil, nil))
+	assert.NoError(t, snapshot.SetClusterState(nil, nil, drasnapshot.Snapshot{}))
 
 	for _, node := range nodes {
 		err = snapshot.AddNodeInfo(framework.NewTestNodeInfo(node))

--- a/cluster-autoscaler/simulator/clustersnapshot/testsnapshot/test_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/testsnapshot/test_snapshot.go
@@ -34,7 +34,7 @@ func NewTestSnapshot() (clustersnapshot.ClusterSnapshot, error) {
 	if err != nil {
 		return nil, err
 	}
-	return predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), testFwHandle), nil
+	return predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), testFwHandle, true), nil
 }
 
 // NewTestSnapshotOrDie returns an instance of ClusterSnapshot that can be used in tests.
@@ -52,7 +52,7 @@ func NewCustomTestSnapshot(snapshotStore clustersnapshot.ClusterSnapshotStore) (
 	if err != nil {
 		return nil, err
 	}
-	return predicate.NewPredicateSnapshot(snapshotStore, testFwHandle), nil
+	return predicate.NewPredicateSnapshot(snapshotStore, testFwHandle, true), nil
 }
 
 // NewCustomTestSnapshotOrDie returns an instance of ClusterSnapshot with a specific ClusterSnapshotStore that can be used in tests.

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// Snapshot contains a snapshot of all DRA objects taken at a ~single point in time.
+type Snapshot struct {
+}
+
+// ResourceClaims exposes the Snapshot as schedulerframework.ResourceClaimTracker, in order to interact with
+// the scheduler framework.
+func (s Snapshot) ResourceClaims() schedulerframework.ResourceClaimTracker {
+	return nil
+}
+
+// ResourceSlices exposes the Snapshot as schedulerframework.ResourceSliceLister, in order to interact with
+// the scheduler framework.
+func (s Snapshot) ResourceSlices() schedulerframework.ResourceSliceLister {
+	return nil
+}
+
+// DeviceClasses exposes the Snapshot as schedulerframework.DeviceClassLister, in order to interact with
+// the scheduler framework.
+func (s Snapshot) DeviceClasses() schedulerframework.DeviceClassLister {
+	return nil
+}
+
+// Clone returns a copy of this Snapshot that can be independently modified without affecting this Snapshot.
+func (s Snapshot) Clone() Snapshot {
+	return Snapshot{}
+}

--- a/cluster-autoscaler/simulator/framework/delegating_shared_lister.go
+++ b/cluster-autoscaler/simulator/framework/delegating_shared_lister.go
@@ -19,13 +19,23 @@ package framework
 import (
 	"fmt"
 
+	resourceapi "k8s.io/api/resource/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/dynamic-resource-allocation/structured"
+	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
-// DelegatingSchedulerSharedLister is an implementation of scheduler.SharedLister which
-// passes logic to delegate. Delegate can be updated.
+// SharedLister groups all interfaces that Cluster Autoscaler needs to implement for integrating with kube-scheduler.
+type SharedLister interface {
+	schedulerframework.SharedLister
+	schedulerframework.SharedDRAManager
+}
+
+// DelegatingSchedulerSharedLister implements schedulerframework interfaces by passing the logic to a delegate. Delegate can be updated.
 type DelegatingSchedulerSharedLister struct {
-	delegate schedulerframework.SharedLister
+	delegate SharedLister
 }
 
 // NewDelegatingSchedulerSharedLister creates new NewDelegatingSchedulerSharedLister
@@ -45,8 +55,23 @@ func (lister *DelegatingSchedulerSharedLister) StorageInfos() schedulerframework
 	return lister.delegate.StorageInfos()
 }
 
+// ResourceClaims returns a ResourceClaimTracker.
+func (lister *DelegatingSchedulerSharedLister) ResourceClaims() schedulerframework.ResourceClaimTracker {
+	return lister.delegate.ResourceClaims()
+}
+
+// ResourceSlices returns a ResourceSliceLister.
+func (lister *DelegatingSchedulerSharedLister) ResourceSlices() schedulerframework.ResourceSliceLister {
+	return lister.delegate.ResourceSlices()
+}
+
+// DeviceClasses returns a DeviceClassLister.
+func (lister *DelegatingSchedulerSharedLister) DeviceClasses() schedulerframework.DeviceClassLister {
+	return lister.delegate.DeviceClasses()
+}
+
 // UpdateDelegate updates the delegate
-func (lister *DelegatingSchedulerSharedLister) UpdateDelegate(delegate schedulerframework.SharedLister) {
+func (lister *DelegatingSchedulerSharedLister) UpdateDelegate(delegate SharedLister) {
 	lister.delegate = delegate
 }
 
@@ -58,6 +83,9 @@ func (lister *DelegatingSchedulerSharedLister) ResetDelegate() {
 type unsetSharedLister struct{}
 type unsetNodeInfoLister unsetSharedLister
 type unsetStorageInfoLister unsetSharedLister
+type unsetResourceClaimTracker unsetSharedLister
+type unsetResourceSliceLister unsetSharedLister
+type unsetDeviceClassLister unsetSharedLister
 
 // List always returns an error
 func (lister *unsetNodeInfoLister) List() ([]*schedulerframework.NodeInfo, error) {
@@ -83,14 +111,72 @@ func (lister *unsetStorageInfoLister) IsPVCUsedByPods(key string) bool {
 	return false
 }
 
-// NodeInfos: Pods returns a fake NodeInfoLister which always returns an error
+func (u unsetResourceClaimTracker) List() ([]*resourceapi.ResourceClaim, error) {
+	return nil, fmt.Errorf("lister not set in delegate")
+}
+
+func (u unsetResourceClaimTracker) Get(namespace, claimName string) (*resourceapi.ResourceClaim, error) {
+	return nil, fmt.Errorf("lister not set in delegate")
+}
+
+func (u unsetResourceClaimTracker) ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error) {
+	return nil, fmt.Errorf("lister not set in delegate")
+}
+
+func (u unsetResourceClaimTracker) SignalClaimPendingAllocation(claimUID types.UID, allocatedClaim *resourceapi.ResourceClaim) error {
+	return fmt.Errorf("lister not set in delegate")
+}
+
+func (u unsetResourceClaimTracker) ClaimHasPendingAllocation(claimUID types.UID) bool {
+	klog.Errorf("lister not set in delegate")
+	return false
+}
+
+func (u unsetResourceClaimTracker) RemoveClaimPendingAllocation(claimUID types.UID) (deleted bool) {
+	klog.Errorf("lister not set in delegate")
+	return false
+}
+
+func (u unsetResourceClaimTracker) AssumeClaimAfterAPICall(claim *resourceapi.ResourceClaim) error {
+	return fmt.Errorf("lister not set in delegate")
+}
+
+func (u unsetResourceClaimTracker) AssumedClaimRestore(namespace, claimName string) {
+	klog.Errorf("lister not set in delegate")
+}
+
+func (u unsetResourceSliceLister) List() ([]*resourceapi.ResourceSlice, error) {
+	return nil, fmt.Errorf("lister not set in delegate")
+}
+
+func (u unsetDeviceClassLister) List() ([]*resourceapi.DeviceClass, error) {
+	return nil, fmt.Errorf("lister not set in delegate")
+}
+
+func (u unsetDeviceClassLister) Get(className string) (*resourceapi.DeviceClass, error) {
+	return nil, fmt.Errorf("lister not set in delegate")
+}
+
+// NodeInfos returns a fake NodeInfoLister which always returns an error
 func (lister *unsetSharedLister) NodeInfos() schedulerframework.NodeInfoLister {
 	return (*unsetNodeInfoLister)(lister)
 }
 
-// StorageInfos: Pods returns a fake StorageInfoLister which always returns an error
+// StorageInfos returns a fake StorageInfoLister which always returns an error
 func (lister *unsetSharedLister) StorageInfos() schedulerframework.StorageInfoLister {
 	return (*unsetStorageInfoLister)(lister)
+}
+
+func (lister *unsetSharedLister) ResourceClaims() schedulerframework.ResourceClaimTracker {
+	return (*unsetResourceClaimTracker)(lister)
+}
+
+func (lister *unsetSharedLister) ResourceSlices() schedulerframework.ResourceSliceLister {
+	return (*unsetResourceSliceLister)(lister)
+}
+
+func (lister *unsetSharedLister) DeviceClasses() schedulerframework.DeviceClassLister {
+	return (*unsetDeviceClassLister)(lister)
 }
 
 var unsetSharedListerSingleton *unsetSharedLister

--- a/cluster-autoscaler/simulator/framework/infos.go
+++ b/cluster-autoscaler/simulator/framework/infos.go
@@ -18,7 +18,7 @@ package framework
 
 import (
 	apiv1 "k8s.io/api/core/v1"
-	resourceapi "k8s.io/api/resource/v1alpha3"
+	resourceapi "k8s.io/api/resource/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"

--- a/cluster-autoscaler/simulator/framework/infos.go
+++ b/cluster-autoscaler/simulator/framework/infos.go
@@ -28,13 +28,15 @@ import (
 type PodInfo struct {
 	// This type embeds *apiv1.Pod to make the accesses easier - most of the code just needs to access the Pod.
 	*apiv1.Pod
-
-	// NeededResourceClaims contains ResourceClaim objects needed by the Pod.
-	NeededResourceClaims []*resourceapi.ResourceClaim
+	// PodExtraInfo is an embedded struct containing all additional information that CA needs to track about a Pod.
+	PodExtraInfo
 }
 
-type podExtraInfo struct {
-	neededResourceClaims []*resourceapi.ResourceClaim
+// PodExtraInfo contains all necessary information about a Pod that Cluster Autoscaler needs to track, apart from the Pod itself.
+// This is extracted from PodInfo so that it can be stored separately from the Pod.
+type PodExtraInfo struct {
+	// NeededResourceClaims contains ResourceClaim objects needed by the Pod.
+	NeededResourceClaims []*resourceapi.ResourceClaim
 }
 
 // NodeInfo contains all necessary information about a Node that Cluster Autoscaler needs to track.
@@ -43,7 +45,7 @@ type NodeInfo struct {
 	// schedNodeInfo is the part of information needed by the scheduler.
 	schedNodeInfo *schedulerframework.NodeInfo
 	// podsExtraInfo contains extra pod-level data needed only by CA.
-	podsExtraInfo map[types.UID]podExtraInfo
+	podsExtraInfo map[types.UID]PodExtraInfo
 
 	// Extra node-level data needed only by CA below.
 
@@ -66,7 +68,7 @@ func (n *NodeInfo) Pods() []*PodInfo {
 	var result []*PodInfo
 	for _, pod := range n.schedNodeInfo.Pods {
 		extraInfo := n.podsExtraInfo[pod.Pod.UID]
-		podInfo := &PodInfo{Pod: pod.Pod, NeededResourceClaims: extraInfo.neededResourceClaims}
+		podInfo := &PodInfo{Pod: pod.Pod, PodExtraInfo: extraInfo}
 		result = append(result, podInfo)
 	}
 	return result
@@ -75,7 +77,7 @@ func (n *NodeInfo) Pods() []*PodInfo {
 // AddPod adds the given Pod and associated data to the NodeInfo.
 func (n *NodeInfo) AddPod(pod *PodInfo) {
 	n.schedNodeInfo.AddPod(pod.Pod)
-	n.podsExtraInfo[pod.UID] = podExtraInfo{neededResourceClaims: pod.NeededResourceClaims}
+	n.podsExtraInfo[pod.UID] = pod.PodExtraInfo
 }
 
 // RemovePod removes the given pod and its associated data from the NodeInfo.
@@ -101,7 +103,7 @@ func (n *NodeInfo) DeepCopy() *NodeInfo {
 		for _, claim := range podInfo.NeededResourceClaims {
 			newClaims = append(newClaims, claim.DeepCopy())
 		}
-		newPods = append(newPods, &PodInfo{Pod: podInfo.Pod.DeepCopy(), NeededResourceClaims: newClaims})
+		newPods = append(newPods, &PodInfo{Pod: podInfo.Pod.DeepCopy(), PodExtraInfo: PodExtraInfo{NeededResourceClaims: newClaims}})
 	}
 	var newSlices []*resourceapi.ResourceSlice
 	for _, slice := range n.LocalResourceSlices {
@@ -115,7 +117,7 @@ func (n *NodeInfo) DeepCopy() *NodeInfo {
 func NewNodeInfo(node *apiv1.Node, slices []*resourceapi.ResourceSlice, pods ...*PodInfo) *NodeInfo {
 	result := &NodeInfo{
 		schedNodeInfo:       schedulerframework.NewNodeInfo(),
-		podsExtraInfo:       map[types.UID]podExtraInfo{},
+		podsExtraInfo:       map[types.UID]PodExtraInfo{},
 		LocalResourceSlices: slices,
 	}
 	if node != nil {
@@ -128,18 +130,15 @@ func NewNodeInfo(node *apiv1.Node, slices []*resourceapi.ResourceSlice, pods ...
 }
 
 // WrapSchedulerNodeInfo wraps a *schedulerframework.NodeInfo into an internal *NodeInfo.
-func WrapSchedulerNodeInfo(schedNodeInfo *schedulerframework.NodeInfo) *NodeInfo {
+func WrapSchedulerNodeInfo(schedNodeInfo *schedulerframework.NodeInfo, slices []*resourceapi.ResourceSlice, podExtraInfos map[types.UID]PodExtraInfo) *NodeInfo {
 	return &NodeInfo{
-		schedNodeInfo: schedNodeInfo,
-		podsExtraInfo: map[types.UID]podExtraInfo{},
+		schedNodeInfo:       schedNodeInfo,
+		podsExtraInfo:       podExtraInfos,
+		LocalResourceSlices: slices,
 	}
 }
 
-// WrapSchedulerNodeInfos wraps a list of *schedulerframework.NodeInfos into internal *NodeInfos.
-func WrapSchedulerNodeInfos(schedNodeInfos []*schedulerframework.NodeInfo) []*NodeInfo {
-	var result []*NodeInfo
-	for _, schedNodeInfo := range schedNodeInfos {
-		result = append(result, WrapSchedulerNodeInfo(schedNodeInfo))
-	}
-	return result
+// NewPodInfo is a convenience function for creating new PodInfos without typing out the "PodExtraInfo" part.
+func NewPodInfo(pod *apiv1.Pod, claims []*resourceapi.ResourceClaim) *PodInfo {
+	return &PodInfo{Pod: pod, PodExtraInfo: PodExtraInfo{NeededResourceClaims: claims}}
 }

--- a/cluster-autoscaler/simulator/framework/infos_test.go
+++ b/cluster-autoscaler/simulator/framework/infos_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	apiv1 "k8s.io/api/core/v1"
-	resourceapi "k8s.io/api/resource/v1alpha3"
+	resourceapi "k8s.io/api/resource/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"

--- a/cluster-autoscaler/simulator/framework/test_utils.go
+++ b/cluster-autoscaler/simulator/framework/test_utils.go
@@ -33,7 +33,7 @@ type testFailer interface {
 func NewTestNodeInfo(node *apiv1.Node, pods ...*apiv1.Pod) *NodeInfo {
 	nodeInfo := NewNodeInfo(node, nil)
 	for _, pod := range pods {
-		nodeInfo.AddPod(&PodInfo{Pod: pod, NeededResourceClaims: nil})
+		nodeInfo.AddPod(NewPodInfo(pod, nil))
 	}
 	return nodeInfo
 }

--- a/cluster-autoscaler/simulator/framework/test_utils.go
+++ b/cluster-autoscaler/simulator/framework/test_utils.go
@@ -44,7 +44,7 @@ func NewTestFrameworkHandle() (*Handle, error) {
 	if err != nil {
 		return nil, err
 	}
-	fwHandle, err := NewHandle(informers.NewSharedInformerFactory(clientsetfake.NewSimpleClientset(), 0), defaultConfig)
+	fwHandle, err := NewHandle(informers.NewSharedInformerFactory(clientsetfake.NewSimpleClientset(), 0), defaultConfig, true)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/simulator/node_info_utils.go
+++ b/cluster-autoscaler/simulator/node_info_utils.go
@@ -82,7 +82,7 @@ func sanitizeNodeInfo(nodeInfo *framework.NodeInfo, newNodeNameBase string, name
 
 	for _, podInfo := range nodeInfo.Pods() {
 		freshPod := sanitizePod(podInfo.Pod, freshNode.Name, namesSuffix)
-		result.AddPod(&framework.PodInfo{Pod: freshPod})
+		result.AddPod(framework.NewPodInfo(freshPod, nil))
 	}
 	return result
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is a part of Dynamic Resource Allocation (DRA) support in Cluster Autoscaler.

This PR implements the first bits of the DRA integration in CA:

* A DRA flag guard is added to help with preserving old behavior until we're confident in the new logic.
* The scheduler framework integration is extended to cover the new `SharedDRAManager` interface introduced in https://github.com/kubernetes/kubernetes/pull/127904.
* The `ClusterSnapshot` interface is extended to cover DRA objects.
* `SchedulerPluginRunner` is extended so that it can run the `Reserve` phase of the framework.

#### Which issue(s) this PR fixes:

The CA/DRA integration is tracked in https://github.com/kubernetes/kubernetes/issues/118612, this is just part of the implementation.

#### Special notes for your reviewer:

This is mostly a refactor and some preparations for the actual DRA logic in the next PR. All new logic is behind a DRA flag guard, the intention is to have no change in behavior if the flag is disabled.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
https://github.com/kubernetes/enhancements/blob/9de7f62e16fc5c1ea3bd40689487c9edc7fa5057/keps/sig-node/4381-dra-structured-parameters/README.md
```
