### PR TITLE
Update GitHub Issues templates to try prompt author to add area

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,6 +15,13 @@ Please answer these questions before submitting your bug report. Thanks!
 
 <!--
 Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) is the bug in?
+
+Add one of the following areas:
+/area addon-resizer
+/area balancer
+/area cluster-autoscaler
+/area helm-charts
+/area vertical-pod-autoscaler
 -->
 
 **What version of the component are you using?**:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,14 @@ Thanks for taking the time to raise a feature request! Please answer these quest
 **Which component are you using?**:
 
 <!--
-Which component hosted in this repository is this a feature for?
+Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) is the bug in?
+
+Add one of the following areas:
+/area addon-resizer
+/area balancer
+/area cluster-autoscaler
+/area helm-charts
+/area vertical-pod-autoscaler
 -->
 
 **Is your feature request designed to solve a problem? If so describe the problem this feature should solve.**:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I've been manually adding the `/area` label to each issue as they get created. I'm hoping that by updating the template we can get the author to do that for us.
