### PR TITLE
Chore: fixed lints errors

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
@@ -642,8 +642,7 @@ func TestEvictEmitEvent(t *testing.T) {
 			mockRecorder.On("Event", mock.Anything, apiv1.EventTypeNormal, "EvictedByVPA", mock.Anything).Return()
 			mockRecorder.On("Event", mock.Anything, apiv1.EventTypeNormal, "EvictedPod", mock.Anything).Return()
 
-			err := eviction.Evict(p.pod, testCase.vpa, mockRecorder)
-			assert.NoError(t, err)
+			_ = eviction.Evict(p.pod, testCase.vpa, mockRecorder)
 
 			if p.canEvict {
 				mockRecorder.AssertNumberOfCalls(t, "Event", 2)

--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
@@ -642,7 +642,8 @@ func TestEvictEmitEvent(t *testing.T) {
 			mockRecorder.On("Event", mock.Anything, apiv1.EventTypeNormal, "EvictedByVPA", mock.Anything).Return()
 			mockRecorder.On("Event", mock.Anything, apiv1.EventTypeNormal, "EvictedPod", mock.Anything).Return()
 
-			eviction.Evict(p.pod, testCase.vpa, mockRecorder)
+			err := eviction.Evict(p.pod, testCase.vpa, mockRecorder)
+			assert.NoError(t, err)
 
 			if p.canEvict {
 				mockRecorder.AssertNumberOfCalls(t, "Event", 2)

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -193,9 +193,9 @@ func (calc *UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_t
 	return sb.String()
 }
 
-func parseVpaObservedContainers(pod *apiv1.Pod) (bool, sets.String) {
+func parseVpaObservedContainers(pod *apiv1.Pod) (bool, sets.Set[string]) {
 	observedContainers, hasObservedContainers := pod.GetAnnotations()[annotations.VpaObservedContainersLabel]
-	vpaContainerSet := sets.NewString()
+	vpaContainerSet := sets.New[string]()
 	if hasObservedContainers {
 		if containers, err := annotations.ParseVpaObservedContainersValue(observedContainers); err != nil {
 			klog.ErrorS(err, "VPA annotation failed to parse", "pod", klog.KObj(pod), "annotation", observedContainers)

--- a/vertical-pod-autoscaler/pkg/utils/status/status_object.go
+++ b/vertical-pod-autoscaler/pkg/utils/status/status_object.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	typedcoordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -97,7 +97,7 @@ func (c *Client) UpdateStatus(ctx context.Context) error {
 			return err
 		}
 		lease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
-		lease.Spec.HolderIdentity = pointer.String(c.holderIdentity)
+		lease.Spec.HolderIdentity = ptr.To(c.holderIdentity)
 		_, err = c.client.Update(ctx, lease, metav1.UpdateOptions{})
 		if apierrors.IsConflict(err) {
 			// Lease was updated by an another replica of the component.
@@ -126,8 +126,9 @@ func (c *Client) newLease() *apicoordinationv1.Lease {
 			Namespace: c.leaseNamespace,
 		},
 		Spec: apicoordinationv1.LeaseSpec{
-			HolderIdentity:       pointer.String(c.holderIdentity),
-			LeaseDurationSeconds: pointer.Int32(c.leaseDurationSeconds),
+			HolderIdentity: ptr.To(c.holderIdentity),
+
+			LeaseDurationSeconds: ptr.To(c.leaseDurationSeconds),
 		},
 	}
 }
@@ -174,7 +175,7 @@ func isRetryableAPIError(err error) bool {
 
 func isRetryableNetError(err error) bool {
 	if netError, ok := err.(net.Error); ok {
-		return netError.Temporary() || netError.Timeout()
+		return netError.Timeout()
 	}
 	return false
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR addresses several linting issues identified in the codebase, as follows:
```
 ~/Desktop/PersonlRepos/autoscaler/vertical-pod-autoscaler/ [master] golangci-lint run          
pkg/updater/eviction/pods_eviction_restriction_test.go:645:18: Error return value of `eviction.Evict` is not checked (errcheck)
                        eviction.Evict(p.pod, testCase.vpa, mockRecorder)
                                      ^
pkg/updater/priority/update_priority_calculator.go:196:56: SA1019: sets.String is deprecated: use generic Set instead. new ways: s1 := Set[string]{} s2 := New[string]() (staticcheck)
func parseVpaObservedContainers(pod *apiv1.Pod) (bool, sets.String) {
                                                       ^
pkg/utils/status/status_object.go:177:10: SA1019: netError.Temporary has been deprecated since Go 1.18 because it shouldn't be used: Temporary errors are not well-defined. Most "temporary" errors are timeouts, and the few exceptions are surprising. Do not use this method. (staticcheck)
                return netError.Temporary() || netError.Timeout()
                       ^
pkg/utils/status/status_object.go:31:2: SA1019: "k8s.io/utils/pointer" is deprecated: Use functions in k8s.io/utils/ptr instead: ptr.To to obtain a pointer, ptr.Deref to dereference a pointer, ptr.Equal to compare dereferenced pointers. (staticcheck)
        "k8s.io/utils/pointer"
        ^
```
This PR fixes those issues.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Should we add `golangci-lint run` to our GitHub Actions pipeline? It seems like a helpful way to catch these issues early.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
