### PR TITLE
Add raywainman to vpa approvers

### DIFF
--- a/vertical-pod-autoscaler/OWNERS
+++ b/vertical-pod-autoscaler/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - jbartosik
 - krzysied
 - voelzmo
+- raywainman
 reviewers:
 - kwiesmueller
 - kgolab


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I would like to propose joining the list of folks who can approve PRs in the vertical-pod-autoscaler subdirectory. I meet [all requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#approver):

- Added as reviewer on August 19th (https://github.com/kubernetes/autoscaler/pull/7183).
- [25 PRs authored](https://github.com/kubernetes/autoscaler/pulls?q=is%3Apr+author%3Araywainman+label%3Aarea%2Fvertical-pod-autoscaler)
- [30 PRs reviewed](https://github.com/kubernetes/autoscaler/pulls?q=is%3Apr+assignee%3Araywainman+label%3Aarea%2Fvertical-pod-autoscaler)
- Familiar with codebase as I interact with it on a daily basis.
- Also active on Slack answering questions and in SIG meetings.