### PR TITLE
VPA: add error checking to pods eviction test

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction_test.go
@@ -591,6 +591,7 @@ func TestEvictEmitEvent(t *testing.T) {
 		evictionTolerance float64
 		vpa               *vpa_types.VerticalPodAutoscaler
 		pods              []podWithExpectations
+		errorExpected     bool
 	}{
 		{
 			name:              "Pods that can be evicted",
@@ -609,6 +610,7 @@ func TestEvictEmitEvent(t *testing.T) {
 					evictionSuccess: true,
 				},
 			},
+			errorExpected: false,
 		},
 		{
 			name:              "Pod that can not be evicted",
@@ -623,6 +625,7 @@ func TestEvictEmitEvent(t *testing.T) {
 					evictionSuccess: false,
 				},
 			},
+			errorExpected: true,
 		},
 	}
 
@@ -642,7 +645,12 @@ func TestEvictEmitEvent(t *testing.T) {
 			mockRecorder.On("Event", mock.Anything, apiv1.EventTypeNormal, "EvictedByVPA", mock.Anything).Return()
 			mockRecorder.On("Event", mock.Anything, apiv1.EventTypeNormal, "EvictedPod", mock.Anything).Return()
 
-			_ = eviction.Evict(p.pod, testCase.vpa, mockRecorder)
+			errGot := eviction.Evict(p.pod, testCase.vpa, mockRecorder)
+			if testCase.errorExpected {
+				assert.Error(t, errGot)
+			} else {
+				assert.NoError(t, errGot)
+			}
 
 			if p.canEvict {
 				mockRecorder.AssertNumberOfCalls(t, "Event", 2)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds error checking to pod eviction tests in VPA, makes sure we detect when pod eviction fails properly.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7544

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
