### PR TITLE
balancer: fixed lint issues and add linter to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ env:
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: read
 
 jobs:
   test-and-verify:
@@ -37,6 +39,13 @@ jobs:
         run: hack/verify-all.sh -v
         env:
           GO111MODULE: auto
+      
+      - name: golangci-lint - balancer
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --timeout=30m
+          working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler/balancer
+          version: v1.60
 
       - name: Test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler

--- a/balancer/pkg/controller/conditions.go
+++ b/balancer/pkg/controller/conditions.go
@@ -32,7 +32,7 @@ func setConditionsBasedOnError(balancer *v1alpha1.Balancer, err *BalancerError, 
 	} else {
 		balancer.Status.Conditions = setConditionInList(balancer.Status.Conditions,
 			now, v1alpha1.BalancerConditionRunning, metav1.ConditionFalse,
-			string(err.phase), err.Error())
+			string(err.phase), "%s", err.Error())
 	}
 }
 

--- a/balancer/pkg/controller/controller_test.go
+++ b/balancer/pkg/controller/controller_test.go
@@ -37,10 +37,10 @@ import (
 )
 
 type testContext struct {
-	statusInfo      *BalancerStatusInfo
-	balancerError   *BalancerError
-	input           []balancerapi.Balancer
-	core            *fakeCore
+	statusInfo    *BalancerStatusInfo
+	balancerError *BalancerError
+	input         []balancerapi.Balancer
+	// core            *fakeCore
 	controller      *Controller
 	stop            chan struct{}
 	balancerUpdates chan balancerapi.Balancer
@@ -211,6 +211,7 @@ func TestController(t *testing.T) {
 				tc.err,
 				!tc.updateFailed,
 			)
+			//nolint:errcheck
 			go testContext.controller.Run(1, testContext.stop)
 
 			if !tc.updateFailed {

--- a/balancer/pkg/controller/core.go
+++ b/balancer/pkg/controller/core.go
@@ -49,9 +49,9 @@ type BalancerStatusInfo struct {
 	updated          bool
 }
 
-func newBalancerStatusInfo(replicas int32, updated bool) BalancerStatusInfo {
-	return BalancerStatusInfo{replicasObserved: replicas, updated: updated}
-}
+// func newBalancerStatusInfo(replicas int32, updated bool) BalancerStatusInfo {
+// 	return BalancerStatusInfo{replicasObserved: replicas, updated: updated}
+// }
 
 // core is CoreInferface implementation.
 type core struct {

--- a/balancer/pkg/pods/summary.go
+++ b/balancer/pkg/pods/summary.go
@@ -46,13 +46,11 @@ func CalculateSummary(podList []*v1.Pod, now time.Time, startupTimeout time.Dura
 		case v1.PodRunning:
 			result.Total++
 			result.Running++
-			break
 		case v1.PodPending:
 			result.Total++
 			if p.CreationTimestamp.Add(startupTimeout).Before(now) {
 				result.NotStartedWithinDeadline++
 			}
-			break
 		}
 	}
 	return result


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Ref: https://github.com/kubernetes/autoscaler/pull/7556#issuecomment-2516593571
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
