### PR TITLE
[CheckCapacity] Update Conditions in Parallel

### DIFF
--- a/cluster-autoscaler/processors/provreq/injector.go
+++ b/cluster-autoscaler/processors/provreq/injector.go
@@ -49,6 +49,7 @@ type ProvisioningRequestPodsInjector struct {
 func (p *ProvisioningRequestPodsInjector) IsAvailableForProvisioning(pr *provreqwrapper.ProvisioningRequest) bool {
 	conditions := pr.Status.Conditions
 	if apimeta.IsStatusConditionTrue(conditions, v1.Failed) || apimeta.IsStatusConditionTrue(conditions, v1.Provisioned) {
+		p.backoffDuration.Remove(key(pr))
 		return false
 	}
 	provisioned := apimeta.FindStatusCondition(conditions, v1.Provisioned)
@@ -78,7 +79,7 @@ func (p *ProvisioningRequestPodsInjector) MarkAsAccepted(pr *provreqwrapper.Prov
 		klog.Errorf("failed add Accepted condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, err)
 		return err
 	}
-	p.lastProvisioningRequestProcessTime = p.clock.Now()
+	p.UpdateLastProcessTime()
 	return nil
 }
 
@@ -88,7 +89,7 @@ func (p *ProvisioningRequestPodsInjector) MarkAsFailed(pr *provreqwrapper.Provis
 	if _, err := p.client.UpdateProvisioningRequest(pr.ProvisioningRequest); err != nil {
 		klog.Errorf("failed add Failed condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, err)
 	}
-	p.lastProvisioningRequestProcessTime = p.clock.Now()
+	p.UpdateLastProcessTime()
 }
 
 // GetPodsFromNextRequest picks one ProvisioningRequest meeting the condition passed using isSupportedClass function, marks it as accepted and returns pods from it.
@@ -101,11 +102,6 @@ func (p *ProvisioningRequestPodsInjector) GetPodsFromNextRequest(
 	}
 	for _, pr := range provReqs {
 		if !isSupportedClass(pr) {
-			continue
-		}
-		conditions := pr.Status.Conditions
-		if apimeta.IsStatusConditionTrue(conditions, v1.Failed) || apimeta.IsStatusConditionTrue(conditions, v1.Provisioned) {
-			p.backoffDuration.Remove(key(pr))
 			continue
 		}
 
@@ -127,6 +123,44 @@ func (p *ProvisioningRequestPodsInjector) GetPodsFromNextRequest(
 		return podsFromProvReq, nil
 	}
 	return nil, nil
+}
+
+// ProvisioningRequestWithPods contains a ProvisioningRequest Wrapper
+// and its associated pods.
+type ProvisioningRequestWithPods struct {
+	PrWrapper *provreqwrapper.ProvisioningRequest
+	Pods      []*apiv1.Pod
+}
+
+// GetCheckCapacityBatch returns up to the requested number of ProvisioningRequestWithPods.
+// We do not mark the PRs as accepted here.
+// If we fail to get the pods for a PR, we mark the PR as failed and issue an update.
+func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(maxPrs int) ([]ProvisioningRequestWithPods, error) {
+	provReqs, err := p.client.ProvisioningRequests()
+	if err != nil {
+		return nil, err
+	}
+	prsWithPods := make([]ProvisioningRequestWithPods, 0, min(maxPrs, len(provReqs)))
+	for _, pr := range provReqs {
+		if len(prsWithPods) >= maxPrs {
+			break
+		}
+		if pr.Spec.ProvisioningClassName != v1.ProvisioningClassCheckCapacity {
+			continue
+		}
+		if !p.IsAvailableForProvisioning(pr) {
+			continue
+		}
+
+		pods, err := provreqpods.PodsForProvisioningRequest(pr)
+		if err != nil {
+			klog.Errorf("Failed to get pods for ProvisioningRequest %v", pr.Name)
+			p.MarkAsFailed(pr, provreqconditions.FailedToCreatePodsReason, err.Error())
+			continue
+		}
+		prsWithPods = append(prsWithPods, ProvisioningRequestWithPods{pr, pods})
+	}
+	return prsWithPods, nil
 }
 
 // Process pick one ProvisioningRequest, update Accepted condition and inject pods to unscheduled pods list.
@@ -169,4 +203,11 @@ func key(pr *provreqwrapper.ProvisioningRequest) string {
 // LastProvisioningRequestProcessTime returns the time when the last provisioning request was processed.
 func (p *ProvisioningRequestPodsInjector) LastProvisioningRequestProcessTime() time.Time {
 	return p.lastProvisioningRequestProcessTime
+}
+
+// UpdateLastProcessTime updates the time we last processed a ProvisioningRequest
+// to now. This time is used to skip waiting between loops if a request
+// was processed in the last loop.
+func (p *ProvisioningRequestPodsInjector) UpdateLastProcessTime() {
+	p.lastProvisioningRequestProcessTime = p.clock.Now()
 }

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
@@ -34,7 +35,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/conditions"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqclient"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqwrapper"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -95,130 +95,133 @@ func (o *checkCapacityProvClass) Provision(
 	nodeInfos map[string]*framework.NodeInfo,
 ) (*status.ScaleUpStatus, errors.AutoscalerError) {
 	combinedStatus := NewCombinedStatusSet()
-	provisioningRequestsProcessed := make(map[string]bool)
 	startTime := time.Now()
 
 	o.context.ClusterSnapshot.Fork()
 	defer o.context.ClusterSnapshot.Revert()
 
-	prPods := unschedulablePods
-
-	for len(prPods) > 0 {
-		prs := provreqclient.ProvisioningRequestsForPods(o.client, prPods)
-		prs = provreqclient.FilterOutProvisioningClass(prs, v1.ProvisioningClassCheckCapacity)
-		if len(prs) == 0 {
-			break
-		}
-
-		// Pick 1 ProvisioningRequest.
-		pr := prs[0]
-
-		scaleUpIsSuccessful, err := o.checkcapacity(prPods, pr)
-		if err != nil {
-			scaleUpStatus, _ := status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
-			combinedStatus.Add(scaleUpStatus)
-		} else if scaleUpIsSuccessful {
-			combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
-		} else {
-			combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable})
-		}
-
-		provisioningRequestsProcessed[pr.Name] = true
-		if stopBatch := o.shouldStopBatchProcessing(len(provisioningRequestsProcessed), startTime); stopBatch {
-			break
-		}
-
-		// For batch processing, the next ProvisioningRequest's pods are fetched using the provisioningRequest pods injector.
-		// TODO: Refactor such that injector injects pods for multiple ProvisioningRequests at once. Pods should be segregated by ProvisioningRequest before being processed.
-		prPods, err = o.getNextPrPods(provisioningRequestsProcessed)
-		// Error might be returned here if the pod-template for current ProvisioningRequest is not found in cluster. We continue with the next ProvisioningRequest as it might have a valid pod-template and may be processed successfully.
-		if err != nil {
-			st, _ := status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
-			combinedStatus.Add(st)
-		}
+	// Gather ProvisioningRequests.
+	prs, err := o.getProvisioningRequestsAndPods(unschedulablePods)
+	if err != nil {
+		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "Error fetching provisioning requests and associated pods: %s", err.Error()))
+	} else if len(prs) == 0 {
+		return &status.ScaleUpStatus{Result: status.ScaleUpNotTried}, nil
 	}
+
+	if o.provreqInjector != nil {
+		// for more frequent iterations.
+		// See https://github.com/kubernetes/autoscaler/pull/7271
+		o.provreqInjector.UpdateLastProcessTime()
+	}
+
+	// Add accepted condition to ProvisioningRequests.
+	for _, pr := range prs {
+		conditions.AddOrUpdateCondition(pr.PrWrapper, v1.Accepted, metav1.ConditionTrue, conditions.AcceptedReason, conditions.AcceptedMsg, metav1.Now())
+	}
+
+	// Check Capacity. Add Provisioned or Failed conditions.
+	processedPrs := o.checkCapacityBatch(prs, &combinedStatus, startTime)
+
+	// Use client to update ProvisioningRequests conditions.
+	updateRequests(o.client, processedPrs, &combinedStatus)
 
 	return combinedStatus.Export()
 }
 
-// checkcapacity checks if there is capacity in the cluster for pods from a ProvisioningRequest. It persists the scheduling in cluster snapshot whenever all pods can be scheduled, and doesn't change the snapshot otherwise.
-func (o *checkCapacityProvClass) checkcapacity(unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest) (bool, error) {
-	var capacityAvailable bool
-	err, cleanupErr := clustersnapshot.WithForkedSnapshot(o.context.ClusterSnapshot, func() (bool, error) {
-		st, _, err := o.schedulingSimulator.TrySchedulePods(o.context.ClusterSnapshot, unschedulablePods, scheduling.ScheduleAnywhere, true)
-		if len(st) < len(unschedulablePods) || err != nil {
-			if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry == "true" {
-				// Failed=true condition triggers retry in Kueue. Otherwise ProvisioningRequest with Provisioned=Failed
-				// condition block capacity in Kueue even if it's in the middle of backoff waiting time.
-				conditions.AddOrUpdateCondition(provReq, v1.Failed, metav1.ConditionTrue, conditions.CapacityIsNotFoundReason, "CA could not find requested capacity", metav1.Now())
-			} else {
-				if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry != "false" {
-					klog.Errorf("Ignoring Parameter %v with invalid value: %v in ProvisioningRequest: %v. Supported values are: \"true\", \"false\"", NoRetryParameterKey, noRetry, provReq.Name)
-				}
-				conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
-			}
-			capacityAvailable = false
-		} else {
-			conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
-			capacityAvailable = true
+func (o *checkCapacityProvClass) getProvisioningRequestsAndPods(unschedulablePods []*apiv1.Pod) ([]provreq.ProvisioningRequestWithPods, error) {
+	if !o.isBatchEnabled() {
+		klog.Info("Processing single provisioning request (non-batch)")
+		prs := provreqclient.ProvisioningRequestsForPods(o.client, unschedulablePods)
+		prs = provreqclient.FilterOutProvisioningClass(prs, v1.ProvisioningClassCheckCapacity)
+		if len(prs) == 0 {
+			return nil, nil
 		}
-
-		_, updErr := o.client.UpdateProvisioningRequest(provReq.ProvisioningRequest)
-		if updErr != nil {
-			return false, fmt.Errorf("failed to update Provisioned condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, updErr)
-		}
-
-		return capacityAvailable, nil
-	})
-
-	if cleanupErr != nil {
-		return false, cleanupErr
+		return []provreq.ProvisioningRequestWithPods{{PrWrapper: prs[0], Pods: unschedulablePods}}, nil
 	}
 
+	batch, err := o.provreqInjector.GetCheckCapacityBatch(o.checkCapacityProvisioningRequestMaxBatchSize)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-
-	return capacityAvailable, nil
+	klog.Infof("Processing provisioning requests as batch of size %d", len(batch))
+	return batch, nil
 }
 
-// shouldStopBatchProcessing returns true if the batch processing should be stopped when:
-// - Batch processing is misconfigured
-// - Upper limits of batch processing parameters are reached
-func (o *checkCapacityProvClass) shouldStopBatchProcessing(prsProcessed int, startTime time.Time) bool {
-	if prsProcessed >= o.checkCapacityProvisioningRequestMaxBatchSize {
-		return true
-	}
-
-	if o.provreqInjector == nil {
-		klog.Errorf("ProvisioningRequestPodsInjector is not set, falling back to non-batch processing")
-		return true
-	}
-
-	if o.checkCapacityProvisioningRequestMaxBatchSize <= 1 {
-		klog.Errorf("MaxBatchSize is set to %d, falling back to non-batch processing", o.checkCapacityProvisioningRequestMaxBatchSize)
-		return true
-	}
-
-	if time.Since(startTime) > o.checkCapacityProvisioningRequestBatchTimebox {
-		klog.Infof("Batch timebox exceeded, processed %d check capacity provisioning requests this iteration", prsProcessed)
-		return true
-	}
-
-	return false
+func (o *checkCapacityProvClass) isBatchEnabled() bool {
+	return o.provreqInjector != nil && o.checkCapacityProvisioningRequestMaxBatchSize > 1
 }
 
-// getNextPrPods retreives pods from the next CheckCapacity ProvisioningRequest.
-func (o *checkCapacityProvClass) getNextPrPods(provisioningRequestsProcessed map[string]bool) ([]*apiv1.Pod, error) {
-	return o.provreqInjector.GetPodsFromNextRequest(func(pr *provreqwrapper.ProvisioningRequest) bool {
-		if pr.Spec.ProvisioningClassName != v1.ProvisioningClassCheckCapacity {
-			return false
+func (o *checkCapacityProvClass) checkCapacityBatch(reqs []provreq.ProvisioningRequestWithPods, combinedStatus *combinedStatusSet, startTime time.Time) []*provreqwrapper.ProvisioningRequest {
+	updates := make([]*provreqwrapper.ProvisioningRequest, 0, len(reqs))
+	for _, req := range reqs {
+		if err := o.checkCapacity(req.Pods, req.PrWrapper, combinedStatus); err != nil {
+			klog.Errorf("error checking capacity %v", err)
+			continue
 		}
-		if _, found := provisioningRequestsProcessed[pr.Name]; found {
-			return false
+
+		updates = append(updates, req.PrWrapper)
+
+		// timebox checkCapacity when batch processing.
+		if o.isBatchEnabled() && time.Since(startTime) > o.checkCapacityProvisioningRequestBatchTimebox {
+			klog.Infof("Batch timebox exceeded, processed %d check capacity provisioning requests this iteration", len(updates))
+			break
 		}
-		return true
-	})
+	}
+	return updates
+}
+
+// checkCapacity checks if there is capacity, updates combinedStatus and Conditions. If capacity is found, it commits to the clusterSnapshot.
+func (o *checkCapacityProvClass) checkCapacity(unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) error {
+	o.context.ClusterSnapshot.Fork()
+
+	// Case 1: Capacity fits.
+	scheduled, _, err := o.schedulingSimulator.TrySchedulePods(o.context.ClusterSnapshot, unschedulablePods, scheduling.ScheduleAnywhere, true)
+	if err == nil && len(scheduled) == len(unschedulablePods) {
+		commitError := o.context.ClusterSnapshot.Commit()
+		if commitError != nil {
+			o.context.ClusterSnapshot.Revert()
+			return commitError
+		}
+		combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
+		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+		return nil
+	}
+	// Case 2: Capacity doesn't fit.
+	o.context.ClusterSnapshot.Revert()
+	combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable})
+	if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry == "true" {
+		// Failed=true condition triggers retry in Kueue. Otherwise ProvisioningRequest with Provisioned=Failed
+		// condition block capacity in Kueue even if it's in the middle of backoff waiting time.
+		conditions.AddOrUpdateCondition(provReq, v1.Failed, metav1.ConditionTrue, conditions.CapacityIsNotFoundReason, "CA could not find requested capacity", metav1.Now())
+	} else {
+		if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry != "false" {
+			klog.Errorf("Ignoring Parameter %v with invalid value: %v in ProvisioningRequest: %v. Supported values are: \"true\", \"false\"", NoRetryParameterKey, noRetry, provReq.Name)
+		}
+		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
+	}
+	return err
+}
+
+// updateRequests calls the client to update ProvisioningRequests, in parallel.
+func updateRequests(client *provreqclient.ProvisioningRequestClient, prWrappers []*provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) {
+	wg := sync.WaitGroup{}
+	wg.Add(len(prWrappers))
+	lock := sync.Mutex{}
+	for _, wrapper := range prWrappers {
+		go func() {
+			provReq := wrapper.ProvisioningRequest
+			_, updErr := client.UpdateProvisioningRequest(provReq)
+			if updErr != nil {
+				err := fmt.Errorf("failed to update ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, updErr)
+				scaleUpStatus, _ := status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+				lock.Lock()
+				combinedStatus.Add(scaleUpStatus)
+				lock.Unlock()
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 // combinedStatusSet is a helper struct to combine multiple ScaleUpStatuses into one. It keeps track of the best result and all errors that occurred during the ScaleUp process.

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -378,11 +378,11 @@ func TestScaleUp(t *testing.T) {
 			name:               "process atomic scale-up requests where batch processing of check capacity requests is enabled and check capacity requests are present in cluster",
 			provReqs:           []*provreqwrapper.ProvisioningRequest{newCheckCapacityMemProvReq, newCheckCapacityCpuProvReq, atomicScaleUpProvReq},
 			provReqToScaleUp:   atomicScaleUpProvReq,
-			scaleUpResult:      status.ScaleUpNotNeeded,
+			scaleUpResult:      status.ScaleUpSuccessful,
 			batchProcessing:    true,
 			maxBatchSize:       3,
 			batchTimebox:       5 * time.Minute,
-			numProvisionedTrue: 1,
+			numProvisionedTrue: 2,
 		},
 		{
 			name:                "batch processing of check capacity requests where some requests' capacity is not available",


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind feature


#### What this PR does / why we need it:
We mark accepted condition the same time we mark failed/provisioned. Additionally, we issue these requests in parallel. This increases CheckCapacity throughput


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Mark ProvisioningRequest CheckCapacity conditions in parallel to increase throughput
```
