### PR TITLE
vpa-updater: Fix logging of events

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -309,7 +309,7 @@ func newPodLister(kubeClient kube_client.Interface, namespace string) v1lister.P
 
 func newEventRecorder(kubeClient kube_client.Interface) record.EventRecorder {
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(klog.V(4).InfoS)
+	eventBroadcaster.StartStructuredLogging(4)
 	if _, isFake := kubeClient.(*fake.Clientset); !isFake {
 		eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: clientv1.New(kubeClient.CoreV1().RESTClient()).Events("")})
 	} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
https://github.com/kubernetes/autoscaler/pull/7294 introduces the following issue logging issue for the vpa-updater:
```
% ks logs vpa-updater-85656ccf77-dwjgx | grep event
I1204 15:16:00.947776       1 event.go:298] "Event(%#v): type: '%v' reason: '%v' %v" {Pod default hamster-7d67d5c79f-lzz5p 0329496d-b2b4-455f-90af-06ce50f75725 v1 43391 }="Normal" EvictedByVPA="Pod was evicted by VPA Updater to apply resource recommendation."
I1204 15:16:00.947812       1 event.go:298] "Event(%#v): type: '%v' reason: '%v' %v" {VerticalPodAutoscaler default hamster-vpa c929ac55-07b8-48c9-8cdb-77a42007ca69 autoscaling.k8s.io/v1 43397 }="Normal" EvictedPod="VPA Updater evicted Pod hamster-7d67d5c79f-lzz5p to apply resource recommendation."
I1204 15:17:00.945908       1 event.go:298] "Event(%#v): type: '%v' reason: '%v' %v" {Pod default hamster-7d67d5c79f-hbhks d1ecd881-3c28-44d2-ace8-4d28793b62cd v1 43389 }="Normal" EvictedByVPA="Pod was evicted by VPA Updater to apply resource recommendation."
I1204 15:17:00.946008       1 event.go:298] "Event(%#v): type: '%v' reason: '%v' %v" {VerticalPodAutoscaler default hamster-vpa c929ac55-07b8-48c9-8cdb-77a42007ca69 autoscaling.k8s.io/v1 43504 }="Normal" EvictedPod="VPA Updater evicted Pod hamster-7d67d5c79f-hbhks to apply resource recommendation."
I1204 15:18:00.941555       1 event.go:298] "Event(%#v): type: '%v' reason: '%v' %v" {Pod default hamster-7d67d5c79f-jgjwz 3a512fd4-d645-4fa6-9b0f-f14a4cb005ee v1 43499 }="Normal" EvictedByVPA="Pod was evicted by VPA Updater to apply resource recommendation."
I1204 15:18:00.941576       1 event.go:298] "Event(%#v): type: '%v' reason: '%v' %v" {VerticalPodAutoscaler default hamster-vpa c929ac55-07b8-48c9-8cdb-77a42007ca69 autoscaling.k8s.io/v1 43613 }="Normal" EvictedPod="VPA Updater evicted Pod hamster-7d67d5c79f-jgjwz to apply resource recommendation."
```

The problematic part is https://github.com/kubernetes/autoscaler/commit/13b6d909ab41711734a6a891d4ae7c9655bb6f17#diff-b864a8cf8e133025f0a68284881b2abfda1a098347250e322b8ed2b61b7590cfL310-R311

After the fix from this PR:
```
% ks logs vpa-updater-5f4cd9684f-b9jsl | grep event
I1204 15:48:21.304284       1 event.go:307] "Event occurred" object="default/hamster-7d67d5c79f-flfzx" fieldPath="" kind="Pod" apiVersion="v1" type="Normal" reason="EvictedByVPA" message="Pod was evicted by VPA Updater to apply resource recommendation."
I1204 15:48:21.304308       1 event.go:307] "Event occurred" object="default/hamster-vpa" fieldPath="" kind="VerticalPodAutoscaler" apiVersion="autoscaling.k8s.io/v1" type="Normal" reason="EvictedPod" message="VPA Updater evicted Pod hamster-7d67d5c79f-flfzx to apply resource recommendation."
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/autoscaler/issues/6905
Follow up of issue introduced with https://github.com/kubernetes/autoscaler/pull/7294

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
