### PR TITLE
CA: Fix a data race in framework.NewHandle

### DIFF
--- a/cluster-autoscaler/simulator/framework/handle.go
+++ b/cluster-autoscaler/simulator/framework/handle.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"k8s.io/client-go/informers"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -27,6 +28,10 @@ import (
 	schedulerplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	schedulerframeworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	schedulermetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
+)
+
+var (
+	initMetricsOnce sync.Once
 )
 
 // Handle is meant for interacting with the scheduler framework.
@@ -50,7 +55,9 @@ func NewHandle(informerFactory informers.SharedInformerFactory, schedConfig *sch
 	}
 	sharedLister := NewDelegatingSchedulerSharedLister()
 
-	schedulermetrics.InitMetrics()
+	initMetricsOnce.Do(func() {
+		schedulermetrics.InitMetrics()
+	})
 	framework, err := schedulerframeworkruntime.NewFramework(
 		context.TODO(),
 		schedulerplugins.NewInTreeRegistry(),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Multiple tests can call `NewHandle()` concurrently, because of `t.Parallel()`. `NewHandle` calls `schedulermetrics.InitMetrics()` which modifies global variables, so there's a race.

Wrapped the `schedulermetrics.InitMetrics()` call in a` sync.Once.Do()` so that it's only done once, in a thread-safe manner.


#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/assign @jackfrancis