### PR TITLE
VPA: Replace stress image with agnhost

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
@@ -63,7 +63,7 @@ const (
 	customMetricName                = "QPS"
 	serviceInitializationTimeout    = 2 * time.Minute
 	serviceInitializationInterval   = 15 * time.Second
-	stressImage                     = "gcr.io/google-containers/stress:v1"
+	stressImage                     = "registry.k8s.io/e2e-test-images/agnhost:2.53"
 )
 
 var (
@@ -439,7 +439,7 @@ func runOomingReplicationController(c clientset.Interface, ns, name string, repl
 		Client: c,
 		Image:  stressImage,
 		// request exactly 1025 MiB, in a single chunk (1 MiB above the limit)
-		Command:     []string{"/stress", "--mem-total", "1074790400", "--logtostderr", "--mem-alloc-size", "1074790400"},
+		Command:     []string{"/agnhost", "stress", "--mem-total", "1074790400", "--mem-alloc-size", "1074790400"},
 		Name:        name,
 		Namespace:   ns,
 		Timeout:     timeoutRC,

--- a/vertical-pod-autoscaler/e2e/v1beta2/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/autoscaling_utils.go
@@ -62,12 +62,12 @@ const (
 	customMetricName                = "QPS"
 	serviceInitializationTimeout    = 2 * time.Minute
 	serviceInitializationInterval   = 15 * time.Second
-	stressImage                     = "gcr.io/google-containers/stress:v1"
+	stressImage                     = "registry.k8s.io/e2e-test-images/agnhost:2.53"
 )
 
 var (
 	resourceConsumerImage = imageutils.GetE2EImage(imageutils.ResourceConsumer)
-	stressCommand         = []string{"/stress", "--mem-total", "10000000000", "--logtostderr", "--mem-alloc-size", "8000"}
+	stressCommand         = []string{"/agnhost", "stress", "--mem-total", "10000000000", "--mem-alloc-size", "8000"}
 )
 
 var (


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces the old stress image with [agnhost](https://github.com/kubernetes/kubernetes/tree/master/test/images/agnhost).

The arnhost image is maintained and supports arm64 and amd64

#### Which issue(s) this PR fixes:
Fixes #4750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
