### PR TITLE
fix: remove newlines from VPA recommendations

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -188,7 +188,6 @@ func (calc *UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_t
 				sb.WriteString(fmt.Sprintf("%vm;", cr.UncappedTarget.Cpu().MilliValue()))
 			}
 		}
-		sb.WriteString("\n")
 	}
 	return sb.String()
 }

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -602,18 +602,18 @@ func TestAddPodLogs(t *testing.T) {
 			givenRec: &vpa_types.RecommendedPodResources{
 				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
 					{
-						ContainerName: "container-1",
-						Target:        test.Resources("4", "10M"),
+						ContainerName:  "container-1",
+						Target:         test.Resources("4", "10M"),
 						UncappedTarget: test.Resources("4", "10M"),
 					},
 					{
-						ContainerName: "container-2",
-						Target:        test.Resources("8", ""),
+						ContainerName:  "container-2",
+						Target:         test.Resources("8", ""),
 						UncappedTarget: test.Resources("8", ""),
 					},
 					{
-						ContainerName: "container-3",
-						Target:        test.Resources("", "10m"),
+						ContainerName:  "container-3",
+						Target:         test.Resources("", "10m"),
 						UncappedTarget: test.Resources("", "10m"),
 					},
 				},

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -565,17 +565,60 @@ func TestAddPodLogs(t *testing.T) {
 		{
 			name:        "container with target and uncappedTarget",
 			givenRec:    test.Recommendation().WithContainer(containerName).WithTarget("4", "10M").Get(),
-			expectedLog: "container1: target: 10000k 4000m; uncappedTarget: 10000k 4000m;\n",
+			expectedLog: "container1: target: 10000k 4000m; uncappedTarget: 10000k 4000m;",
 		},
 		{
 			name:        "container with cpu only",
 			givenRec:    test.Recommendation().WithContainer(containerName).WithTarget("8", "").Get(),
-			expectedLog: "container1: target: 8000m; uncappedTarget: 8000m;\n",
+			expectedLog: "container1: target: 8000m; uncappedTarget: 8000m;",
 		},
 		{
 			name:        "container with memory only",
 			givenRec:    test.Recommendation().WithContainer(containerName).WithTarget("", "10M").Get(),
-			expectedLog: "container1: target: 10000k uncappedTarget: 10000k \n",
+			expectedLog: "container1: target: 10000k uncappedTarget: 10000k ",
+		},
+		{
+			name: "multi-container with different resources",
+			givenRec: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container-1",
+						Target:        test.Resources("4", "10M"),
+					},
+					{
+						ContainerName: "container-2",
+						Target:        test.Resources("8", ""),
+					},
+					{
+						ContainerName: "container-3",
+						Target:        test.Resources("", "10m"),
+					},
+				},
+			},
+			expectedLog: "container-1: target: 10000k 4000m; container-2: target: 8000m; container-3: target: 1k ",
+		},
+		{
+			name: "multi-containers with uncappedTarget",
+			givenRec: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "container-1",
+						Target:        test.Resources("4", "10M"),
+						UncappedTarget: test.Resources("4", "10M"),
+					},
+					{
+						ContainerName: "container-2",
+						Target:        test.Resources("8", ""),
+						UncappedTarget: test.Resources("8", ""),
+					},
+					{
+						ContainerName: "container-3",
+						Target:        test.Resources("", "10m"),
+						UncappedTarget: test.Resources("", "10m"),
+					},
+				},
+			},
+			expectedLog: "container-1: target: 10000k 4000m; uncappedTarget: 10000k 4000m;container-2: target: 8000m; uncappedTarget: 8000m;container-3: target: 1k uncappedTarget: 1k ",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Originally reported by @adrianmoisey, this PR fixes a logging issue in the VPA updater where multi-line log entries were causing structured log output to be split and harder to read. When logging pod recommendations, newline characters were causing the output to span multiple lines:
```
"Pod accepted for update" pod="vertical-pod-autoscaling-7847/hamster-795f8c8794-7p52p" updatePriority=1.3449756180899484 processedRecommendations=
hamster: target: 587805k 247m; uncappedTarget: 587805k 247m;
>
```
The fix modifies the recommendation formatting to keep everything on a single line for better readability:
```
"Pod accepted for update" pod="vertical-pod-autoscaling-7847/hamster-795f8c8794-7p52p" updatePriority=1.3449756180899484 processedRecommendations="hamster: target: 587805k 247m; uncappedTarget: 587805k 247m;"
```
Additional tests were added to verify the logging format for single and multiple container scenarios.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
