### PR TITLE
Configure e2e local scripts for the actuation suite

### DIFF
--- a/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
@@ -31,6 +31,7 @@ function print_help {
   echo " - recommender-externalmetrics"
   echo " - updater"
   echo " - admission-controller"
+  echo " - actuation"
   echo " - full-vpa"
 }
 
@@ -52,6 +53,9 @@ case ${SUITE} in
     ;;
   full-vpa)
     COMPONENTS="recommender updater admission-controller"
+    ;;
+  actuation)
+    COMPONENTS="updater admission-controller"
     ;;
   *)
     print_help

--- a/vertical-pod-autoscaler/hack/run-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-locally.sh
@@ -27,8 +27,8 @@ function print_help {
   echo " - recommender-externalmetrics"
   echo " - updater"
   echo " - admission-controller"
+  echo " - actuation"
   echo " - full-vpa"
-
 }
 
 if [ $# -eq 0 ]; then
@@ -84,7 +84,7 @@ kind load docker-image localhost:5001/write-metrics:dev
 
 
 case ${SUITE} in
-  recommender|recommender-externalmetrics|updater|admission-controller|full-vpa)
+  recommender|recommender-externalmetrics|updater|admission-controller|actuation|full-vpa)
     ${SCRIPT_ROOT}/hack/vpa-down.sh
     echo " ** Deploying for suite ${SUITE}"
     ${SCRIPT_ROOT}/hack/deploy-for-e2e-locally.sh ${SUITE}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When looking at the e2e tests that run on every PR, I noticed that actuation was run, and it isn't available for local e2e testing


#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
