### PR TITLE
Fix typo in custom memory bump-up documentation

### DIFF
--- a/vertical-pod-autoscaler/docs/examples.md
+++ b/vertical-pod-autoscaler/docs/examples.md
@@ -52,7 +52,7 @@ You can then choose which recommender to use by setting `recommenders` inside th
 
 ## Custom memory bump-up after OOMKill
 
-After an OOMKill event was observed, VPA increases the memory recommendation based on the observed memory usage in the event according to this formula: `recommendation = memory-usage-in-oomkill-event + max(oom-min-bump-up-bytes, memory-usage-in-oomkill-event * oom-bump-up-ratio)`.
+After an OOMKill event was observed, VPA increases the memory recommendation based on the observed memory usage in the event according to this formula: `recommendation = max(memory-usage-in-oomkill-event + oom-min-bump-up-bytes, memory-usage-in-oomkill-event * oom-bump-up-ratio)`.
 You can configure the minimum bump-up as well as the multiplier by specifying startup arguments for the recommender:
 `oom-bump-up-ratio` specifies the memory bump up ratio when OOM occurred, default is `1.2`. This means, memory will be increased by 20% after an OOMKill event.
 `oom-min-bump-up-bytes` specifies minimal increase of memory after observing OOM. Defaults to `100 * 1024 * 1024` (=100MiB)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR modifies the expression in the examples for how the recommender computes an increased memory recommendation after an OOM event to match the behavior of the code and the following documentation. The expression is written as `used + max(minimum bump, used * bump up ratio)`, when it should be `max(used + minimum bump, used * bump up ratio)`: https://github.com/kubernetes/autoscaler/blob/c44d4f00334f2d76410c237d4675eba7c49bd3df/vertical-pod-autoscaler/pkg/recommender/model/container.go#L194-L196

I proofread the remaining examples and did not find any other obvious errors, grammar issues, broken links, etc. 

#### Which issue(s) this PR fixes:

None, will file tracking issue if necessary :shrug: 

#### Special notes for your reviewer:

This is a trivial typo fix, should be a quick review

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A