### PR TITLE
doc(gce): Update manual MIG specification URL

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.46.0
+version: 9.46.1

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -187,7 +187,7 @@ In the event you want to explicitly specify MIGs instead of using auto-discovery
 
 ```
 # where 'n' is the index, starting at 0
---set autoscalingGroups[n].name=https://content.googleapis.com/compute/v1/projects/$PROJECTID/zones/$ZONENAME/instanceGroupManagers/$FULL-MIG-NAME,autoscalingGroups[n].maxSize=$MAXSIZE,autoscalingGroups[n].minSize=$MINSIZE
+--set autoscalingGroups[n].name=https://content.googleapis.com/compute/v1/projects/$PROJECTID/zones/$ZONENAME/instanceGroups/$FULL-MIG-NAME,autoscalingGroups[n].maxSize=$MAXSIZE,autoscalingGroups[n].minSize=$MINSIZE
 ```
 
 ### Azure

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -187,7 +187,7 @@ In the event you want to explicitly specify MIGs instead of using auto-discovery
 
 ```
 # where 'n' is the index, starting at 0
---set autoscalingGroups[n].name=https://content.googleapis.com/compute/v1/projects/$PROJECTID/zones/$ZONENAME/instanceGroupManagers/$FULL-MIG-NAME,autoscalingGroups[n].maxSize=$MAXSIZE,autoscalingGroups[n].minSize=$MINSIZE
+--set autoscalingGroups[n].name=https://content.googleapis.com/compute/v1/projects/$PROJECTID/zones/$ZONENAME/instanceGroups/$FULL-MIG-NAME,autoscalingGroups[n].maxSize=$MAXSIZE,autoscalingGroups[n].minSize=$MINSIZE
 ```
 
 ### Azure


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The documentation can not be applied cleanly and results in errors, the code claims to expect `…/instanceGroups/` in the URL but the documentation specifies `…/instanceGroupManagers/`:

```
I1211 11:40:11.612854       1 gce_manager.go:176] GCE projectId=foobar-... location=europe-...
F1211 11:40:11.613108       1 gce_cloud_provider.go:388] Failed to create GCE Manager:
  failed to fetch MIGs:
  failed to parse mig URL:
    https://content.googleapis.com/compute/v1/projects/foobar-.../zones/europe-.../instanceGroupManagers/kubernetes-...
  got error: wrong URL:
    expected format https://.*/projects/<project-id>/zones/<zone>/instanceGroups/<name>,
    got https://content.googleapis.com/compute/v1/projects/foobar-.../zones/europe-.../instanceGroupManagers/kubernetes-...
```

#### Which issue(s) this PR fixes:
No corresponding issue.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
