### PR TITLE
CA: don't error out in HintingSimulator if a hinted Node is gone

### DIFF
--- a/cluster-autoscaler/simulator/scheduling/hinting_simulator.go
+++ b/cluster-autoscaler/simulator/scheduling/hinting_simulator.go
@@ -91,7 +91,8 @@ func (s *HintingSimulator) tryScheduleUsingHints(clusterSnapshot clustersnapshot
 
 	nodeInfo, err := clusterSnapshot.GetNodeInfo(hintedNode)
 	if err != nil {
-		return "", err
+		// The hinted Node is no longer in the cluster. No need to error out, we can just look for another one.
+		return "", nil
 	}
 	if !isNodeAcceptable(nodeInfo) {
 		return "", nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If a hinted Node is no longer in the cluster snapshot (e.g. it was a fake upcoming Node and the real one appeared).

This was introduced in the recent PredicateChecker->PredicateSnapshot refactor. Previously, PredicateChecker.CheckPredicates() would return an error if the hinted Node was gone, and HintingSimulator treated this error the same as failing predicates - it would move on to the non-hinting logic. After the refactor, HintingSimulator explicitly errors out if it can't retrieve the hinted Node from the snapshot, so the behavior changed.

I checked other CheckPredicates()/SchedulePod() callsites, and this is the only one when ignoring the missing Node makes sense. For the others, the Node is added to the snapshot just before the call, so it being missing should cause an error.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
