### PR TITLE
CA: fix a nil map write in NodeInfo.AddPod()

### DIFF
--- a/cluster-autoscaler/simulator/framework/infos.go
+++ b/cluster-autoscaler/simulator/framework/infos.go
@@ -131,6 +131,9 @@ func NewNodeInfo(node *apiv1.Node, slices []*resourceapi.ResourceSlice, pods ...
 
 // WrapSchedulerNodeInfo wraps a *schedulerframework.NodeInfo into an internal *NodeInfo.
 func WrapSchedulerNodeInfo(schedNodeInfo *schedulerframework.NodeInfo, slices []*resourceapi.ResourceSlice, podExtraInfos map[types.UID]PodExtraInfo) *NodeInfo {
+	if podExtraInfos == nil {
+		podExtraInfos = map[types.UID]PodExtraInfo{}
+	}
 	return &NodeInfo{
 		schedNodeInfo:       schedNodeInfo,
 		podsExtraInfo:       podExtraInfos,


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If the NodeInfo is created via WrapSchedulerNodeInfo with nil podExtraInfos, subsequent AddPod() calls panic on trying to add extra info for the pod.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```