### PR TITLE
VPA: Silence error when pod controller is Node

### DIFF
--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -290,7 +290,7 @@ func (f *controllerFetcher) getOwnerForScaleResource(ctx context.Context, groupK
 		// Some pods specify nodes as their owners. This causes performance problems
 		// in big clusters when VPA tries to get all nodes. We know nodes aren't
 		// valid controllers so we can skip trying to fetch them.
-		return nil, fmt.Errorf("node is not a valid owner")
+		return nil, nil
 	}
 	mappings, err := f.mapper.RESTMappings(groupKind)
 	if err != nil {

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
@@ -389,8 +389,9 @@ func TestControllerFetcher(t *testing.T) {
 					},
 				},
 			}},
-			expectedKey:   nil,
-			expectedError: fmt.Errorf("Unhandled targetRef v1 / Node / node, last error node is not a valid owner"),
+			expectedKey: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
+				Name: testDeployment, Kind: "Deployment", Namespace: testNamespace}}, // Parent does not support scale subresource so should return itself"
+			expectedError: nil,
 		},
 		{
 			name: "custom resource with no scale subresource",


### PR DESCRIPTION
I noticed this in our logs too, the admission-controller logs fill up with this error, which is just noisy and hides other sorts of logs

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Avoid logging unnecessary errors 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/7378

#### Special notes for your reviewer:

I'm not too sure if this is the right way to handle this, but figured I'd put up a PR and see what others think

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
