### PR TITLE
chore(vpa): run codegen

### DIFF
--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/clientset.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/clientset.go
@@ -19,8 +19,8 @@ limitations under the License.
 package versioned
 
 import (
-	"fmt"
-	"net/http"
+	fmt "fmt"
+	http "net/http"
 
 	autoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1"
 	autoscalingv1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1"

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/autoscaling.k8s.io_client.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/autoscaling.k8s.io_client.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1
 
 import (
-	"net/http"
+	http "net/http"
 
-	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
+	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -90,10 +90,10 @@ func New(c rest.Interface) *AutoscalingV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
+	gv := autoscalingk8siov1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = rest.CodecFactoryForGeneratedClient(scheme.Scheme, scheme.Codecs).WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/fake/fake_autoscaling.k8s.io_client.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/fake/fake_autoscaling.k8s.io_client.go
@@ -29,11 +29,11 @@ type FakeAutoscalingV1 struct {
 }
 
 func (c *FakeAutoscalingV1) VerticalPodAutoscalers(namespace string) v1.VerticalPodAutoscalerInterface {
-	return &FakeVerticalPodAutoscalers{c, namespace}
+	return newFakeVerticalPodAutoscalers(c, namespace)
 }
 
 func (c *FakeAutoscalingV1) VerticalPodAutoscalerCheckpoints(namespace string) v1.VerticalPodAutoscalerCheckpointInterface {
-	return &FakeVerticalPodAutoscalerCheckpoints{c, namespace}
+	return newFakeVerticalPodAutoscalerCheckpoints(c, namespace)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/fake/fake_verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/fake/fake_verticalpodautoscaler.go
@@ -19,129 +19,34 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
 	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	testing "k8s.io/client-go/testing"
+	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeVerticalPodAutoscalers implements VerticalPodAutoscalerInterface
-type FakeVerticalPodAutoscalers struct {
+// fakeVerticalPodAutoscalers implements VerticalPodAutoscalerInterface
+type fakeVerticalPodAutoscalers struct {
+	*gentype.FakeClientWithList[*v1.VerticalPodAutoscaler, *v1.VerticalPodAutoscalerList]
 	Fake *FakeAutoscalingV1
-	ns   string
 }
 
-var verticalpodautoscalersResource = v1.SchemeGroupVersion.WithResource("verticalpodautoscalers")
-
-var verticalpodautoscalersKind = v1.SchemeGroupVersion.WithKind("VerticalPodAutoscaler")
-
-// Get takes name of the verticalPodAutoscaler, and returns the corresponding verticalPodAutoscaler object, and an error if there is any.
-func (c *FakeVerticalPodAutoscalers) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewGetActionWithOptions(verticalpodautoscalersResource, c.ns, name, options), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
+func newFakeVerticalPodAutoscalers(fake *FakeAutoscalingV1, namespace string) autoscalingk8siov1.VerticalPodAutoscalerInterface {
+	return &fakeVerticalPodAutoscalers{
+		gentype.NewFakeClientWithList[*v1.VerticalPodAutoscaler, *v1.VerticalPodAutoscalerList](
+			fake.Fake,
+			namespace,
+			v1.SchemeGroupVersion.WithResource("verticalpodautoscalers"),
+			v1.SchemeGroupVersion.WithKind("VerticalPodAutoscaler"),
+			func() *v1.VerticalPodAutoscaler { return &v1.VerticalPodAutoscaler{} },
+			func() *v1.VerticalPodAutoscalerList { return &v1.VerticalPodAutoscalerList{} },
+			func(dst, src *v1.VerticalPodAutoscalerList) { dst.ListMeta = src.ListMeta },
+			func(list *v1.VerticalPodAutoscalerList) []*v1.VerticalPodAutoscaler {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1.VerticalPodAutoscalerList, items []*v1.VerticalPodAutoscaler) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1.VerticalPodAutoscaler), err
-}
-
-// List takes label and field selectors, and returns the list of VerticalPodAutoscalers that match those selectors.
-func (c *FakeVerticalPodAutoscalers) List(ctx context.Context, opts metav1.ListOptions) (result *v1.VerticalPodAutoscalerList, err error) {
-	emptyResult := &v1.VerticalPodAutoscalerList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewListActionWithOptions(verticalpodautoscalersResource, verticalpodautoscalersKind, c.ns, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1.VerticalPodAutoscalerList{ListMeta: obj.(*v1.VerticalPodAutoscalerList).ListMeta}
-	for _, item := range obj.(*v1.VerticalPodAutoscalerList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested verticalPodAutoscalers.
-func (c *FakeVerticalPodAutoscalers) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchActionWithOptions(verticalpodautoscalersResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a verticalPodAutoscaler and creates it.  Returns the server's representation of the verticalPodAutoscaler, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalers) Create(ctx context.Context, verticalPodAutoscaler *v1.VerticalPodAutoscaler, opts metav1.CreateOptions) (result *v1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateActionWithOptions(verticalpodautoscalersResource, c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.VerticalPodAutoscaler), err
-}
-
-// Update takes the representation of a verticalPodAutoscaler and updates it. Returns the server's representation of the verticalPodAutoscaler, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalers) Update(ctx context.Context, verticalPodAutoscaler *v1.VerticalPodAutoscaler, opts metav1.UpdateOptions) (result *v1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateActionWithOptions(verticalpodautoscalersResource, c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.VerticalPodAutoscaler), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeVerticalPodAutoscalers) UpdateStatus(ctx context.Context, verticalPodAutoscaler *v1.VerticalPodAutoscaler, opts metav1.UpdateOptions) (result *v1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceActionWithOptions(verticalpodautoscalersResource, "status", c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.VerticalPodAutoscaler), err
-}
-
-// Delete takes name of the verticalPodAutoscaler and deletes it. Returns an error if one occurs.
-func (c *FakeVerticalPodAutoscalers) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(verticalpodautoscalersResource, c.ns, name, opts), &v1.VerticalPodAutoscaler{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeVerticalPodAutoscalers) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
-	action := testing.NewDeleteCollectionActionWithOptions(verticalpodautoscalersResource, c.ns, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1.VerticalPodAutoscalerList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched verticalPodAutoscaler.
-func (c *FakeVerticalPodAutoscalers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceActionWithOptions(verticalpodautoscalersResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.VerticalPodAutoscaler), err
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/fake/fake_verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/fake/fake_verticalpodautoscalercheckpoint.go
@@ -19,116 +19,34 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
 	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	testing "k8s.io/client-go/testing"
+	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeVerticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
-type FakeVerticalPodAutoscalerCheckpoints struct {
+// fakeVerticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
+type fakeVerticalPodAutoscalerCheckpoints struct {
+	*gentype.FakeClientWithList[*v1.VerticalPodAutoscalerCheckpoint, *v1.VerticalPodAutoscalerCheckpointList]
 	Fake *FakeAutoscalingV1
-	ns   string
 }
 
-var verticalpodautoscalercheckpointsResource = v1.SchemeGroupVersion.WithResource("verticalpodautoscalercheckpoints")
-
-var verticalpodautoscalercheckpointsKind = v1.SchemeGroupVersion.WithKind("VerticalPodAutoscalerCheckpoint")
-
-// Get takes name of the verticalPodAutoscalerCheckpoint, and returns the corresponding verticalPodAutoscalerCheckpoint object, and an error if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewGetActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, options), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
+func newFakeVerticalPodAutoscalerCheckpoints(fake *FakeAutoscalingV1, namespace string) autoscalingk8siov1.VerticalPodAutoscalerCheckpointInterface {
+	return &fakeVerticalPodAutoscalerCheckpoints{
+		gentype.NewFakeClientWithList[*v1.VerticalPodAutoscalerCheckpoint, *v1.VerticalPodAutoscalerCheckpointList](
+			fake.Fake,
+			namespace,
+			v1.SchemeGroupVersion.WithResource("verticalpodautoscalercheckpoints"),
+			v1.SchemeGroupVersion.WithKind("VerticalPodAutoscalerCheckpoint"),
+			func() *v1.VerticalPodAutoscalerCheckpoint { return &v1.VerticalPodAutoscalerCheckpoint{} },
+			func() *v1.VerticalPodAutoscalerCheckpointList { return &v1.VerticalPodAutoscalerCheckpointList{} },
+			func(dst, src *v1.VerticalPodAutoscalerCheckpointList) { dst.ListMeta = src.ListMeta },
+			func(list *v1.VerticalPodAutoscalerCheckpointList) []*v1.VerticalPodAutoscalerCheckpoint {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1.VerticalPodAutoscalerCheckpointList, items []*v1.VerticalPodAutoscalerCheckpoint) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1.VerticalPodAutoscalerCheckpoint), err
-}
-
-// List takes label and field selectors, and returns the list of VerticalPodAutoscalerCheckpoints that match those selectors.
-func (c *FakeVerticalPodAutoscalerCheckpoints) List(ctx context.Context, opts metav1.ListOptions) (result *v1.VerticalPodAutoscalerCheckpointList, err error) {
-	emptyResult := &v1.VerticalPodAutoscalerCheckpointList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewListActionWithOptions(verticalpodautoscalercheckpointsResource, verticalpodautoscalercheckpointsKind, c.ns, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1.VerticalPodAutoscalerCheckpointList{ListMeta: obj.(*v1.VerticalPodAutoscalerCheckpointList).ListMeta}
-	for _, item := range obj.(*v1.VerticalPodAutoscalerCheckpointList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested verticalPodAutoscalerCheckpoints.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a verticalPodAutoscalerCheckpoint and creates it.  Returns the server's representation of the verticalPodAutoscalerCheckpoint, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Create(ctx context.Context, verticalPodAutoscalerCheckpoint *v1.VerticalPodAutoscalerCheckpoint, opts metav1.CreateOptions) (result *v1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, verticalPodAutoscalerCheckpoint, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.VerticalPodAutoscalerCheckpoint), err
-}
-
-// Update takes the representation of a verticalPodAutoscalerCheckpoint and updates it. Returns the server's representation of the verticalPodAutoscalerCheckpoint, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Update(ctx context.Context, verticalPodAutoscalerCheckpoint *v1.VerticalPodAutoscalerCheckpoint, opts metav1.UpdateOptions) (result *v1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, verticalPodAutoscalerCheckpoint, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.VerticalPodAutoscalerCheckpoint), err
-}
-
-// Delete takes name of the verticalPodAutoscalerCheckpoint and deletes it. Returns an error if one occurs.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, opts), &v1.VerticalPodAutoscalerCheckpoint{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeVerticalPodAutoscalerCheckpoints) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
-	action := testing.NewDeleteCollectionActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1.VerticalPodAutoscalerCheckpointList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched verticalPodAutoscalerCheckpoint.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.VerticalPodAutoscalerCheckpoint), err
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/verticalpodautoscaler.go
@@ -19,12 +19,12 @@ limitations under the License.
 package v1
 
 import (
-	"context"
+	context "context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	gentype "k8s.io/client-go/gentype"
 )
@@ -37,33 +37,36 @@ type VerticalPodAutoscalersGetter interface {
 
 // VerticalPodAutoscalerInterface has methods to work with VerticalPodAutoscaler resources.
 type VerticalPodAutoscalerInterface interface {
-	Create(ctx context.Context, verticalPodAutoscaler *v1.VerticalPodAutoscaler, opts metav1.CreateOptions) (*v1.VerticalPodAutoscaler, error)
-	Update(ctx context.Context, verticalPodAutoscaler *v1.VerticalPodAutoscaler, opts metav1.UpdateOptions) (*v1.VerticalPodAutoscaler, error)
+	Create(ctx context.Context, verticalPodAutoscaler *autoscalingk8siov1.VerticalPodAutoscaler, opts metav1.CreateOptions) (*autoscalingk8siov1.VerticalPodAutoscaler, error)
+	Update(ctx context.Context, verticalPodAutoscaler *autoscalingk8siov1.VerticalPodAutoscaler, opts metav1.UpdateOptions) (*autoscalingk8siov1.VerticalPodAutoscaler, error)
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-	UpdateStatus(ctx context.Context, verticalPodAutoscaler *v1.VerticalPodAutoscaler, opts metav1.UpdateOptions) (*v1.VerticalPodAutoscaler, error)
+	UpdateStatus(ctx context.Context, verticalPodAutoscaler *autoscalingk8siov1.VerticalPodAutoscaler, opts metav1.UpdateOptions) (*autoscalingk8siov1.VerticalPodAutoscaler, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.VerticalPodAutoscaler, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.VerticalPodAutoscalerList, error)
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*autoscalingk8siov1.VerticalPodAutoscaler, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*autoscalingk8siov1.VerticalPodAutoscalerList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VerticalPodAutoscaler, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *autoscalingk8siov1.VerticalPodAutoscaler, err error)
 	VerticalPodAutoscalerExpansion
 }
 
 // verticalPodAutoscalers implements VerticalPodAutoscalerInterface
 type verticalPodAutoscalers struct {
-	*gentype.ClientWithList[*v1.VerticalPodAutoscaler, *v1.VerticalPodAutoscalerList]
+	*gentype.ClientWithList[*autoscalingk8siov1.VerticalPodAutoscaler, *autoscalingk8siov1.VerticalPodAutoscalerList]
 }
 
 // newVerticalPodAutoscalers returns a VerticalPodAutoscalers
 func newVerticalPodAutoscalers(c *AutoscalingV1Client, namespace string) *verticalPodAutoscalers {
 	return &verticalPodAutoscalers{
-		gentype.NewClientWithList[*v1.VerticalPodAutoscaler, *v1.VerticalPodAutoscalerList](
+		gentype.NewClientWithList[*autoscalingk8siov1.VerticalPodAutoscaler, *autoscalingk8siov1.VerticalPodAutoscalerList](
 			"verticalpodautoscalers",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1.VerticalPodAutoscaler { return &v1.VerticalPodAutoscaler{} },
-			func() *v1.VerticalPodAutoscalerList { return &v1.VerticalPodAutoscalerList{} }),
+			func() *autoscalingk8siov1.VerticalPodAutoscaler { return &autoscalingk8siov1.VerticalPodAutoscaler{} },
+			func() *autoscalingk8siov1.VerticalPodAutoscalerList {
+				return &autoscalingk8siov1.VerticalPodAutoscalerList{}
+			},
+		),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoint.go
@@ -19,12 +19,12 @@ limitations under the License.
 package v1
 
 import (
-	"context"
+	context "context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	gentype "k8s.io/client-go/gentype"
 )
@@ -37,31 +37,36 @@ type VerticalPodAutoscalerCheckpointsGetter interface {
 
 // VerticalPodAutoscalerCheckpointInterface has methods to work with VerticalPodAutoscalerCheckpoint resources.
 type VerticalPodAutoscalerCheckpointInterface interface {
-	Create(ctx context.Context, verticalPodAutoscalerCheckpoint *v1.VerticalPodAutoscalerCheckpoint, opts metav1.CreateOptions) (*v1.VerticalPodAutoscalerCheckpoint, error)
-	Update(ctx context.Context, verticalPodAutoscalerCheckpoint *v1.VerticalPodAutoscalerCheckpoint, opts metav1.UpdateOptions) (*v1.VerticalPodAutoscalerCheckpoint, error)
+	Create(ctx context.Context, verticalPodAutoscalerCheckpoint *autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, opts metav1.CreateOptions) (*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, error)
+	Update(ctx context.Context, verticalPodAutoscalerCheckpoint *autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, opts metav1.UpdateOptions) (*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.VerticalPodAutoscalerCheckpoint, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.VerticalPodAutoscalerCheckpointList, error)
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*autoscalingk8siov1.VerticalPodAutoscalerCheckpointList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VerticalPodAutoscalerCheckpoint, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, err error)
 	VerticalPodAutoscalerCheckpointExpansion
 }
 
 // verticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
 type verticalPodAutoscalerCheckpoints struct {
-	*gentype.ClientWithList[*v1.VerticalPodAutoscalerCheckpoint, *v1.VerticalPodAutoscalerCheckpointList]
+	*gentype.ClientWithList[*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, *autoscalingk8siov1.VerticalPodAutoscalerCheckpointList]
 }
 
 // newVerticalPodAutoscalerCheckpoints returns a VerticalPodAutoscalerCheckpoints
 func newVerticalPodAutoscalerCheckpoints(c *AutoscalingV1Client, namespace string) *verticalPodAutoscalerCheckpoints {
 	return &verticalPodAutoscalerCheckpoints{
-		gentype.NewClientWithList[*v1.VerticalPodAutoscalerCheckpoint, *v1.VerticalPodAutoscalerCheckpointList](
+		gentype.NewClientWithList[*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, *autoscalingk8siov1.VerticalPodAutoscalerCheckpointList](
 			"verticalpodautoscalercheckpoints",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1.VerticalPodAutoscalerCheckpoint { return &v1.VerticalPodAutoscalerCheckpoint{} },
-			func() *v1.VerticalPodAutoscalerCheckpointList { return &v1.VerticalPodAutoscalerCheckpointList{} }),
+			func() *autoscalingk8siov1.VerticalPodAutoscalerCheckpoint {
+				return &autoscalingk8siov1.VerticalPodAutoscalerCheckpoint{}
+			},
+			func() *autoscalingk8siov1.VerticalPodAutoscalerCheckpointList {
+				return &autoscalingk8siov1.VerticalPodAutoscalerCheckpointList{}
+			},
+		),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/autoscaling.k8s.io_client.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/autoscaling.k8s.io_client.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	"net/http"
+	http "net/http"
 
-	v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
+	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
+	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -90,10 +90,10 @@ func New(c rest.Interface) *AutoscalingV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
+	gv := autoscalingk8siov1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = rest.CodecFactoryForGeneratedClient(scheme.Scheme, scheme.Codecs).WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/fake/fake_autoscaling.k8s.io_client.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/fake/fake_autoscaling.k8s.io_client.go
@@ -29,11 +29,11 @@ type FakeAutoscalingV1beta1 struct {
 }
 
 func (c *FakeAutoscalingV1beta1) VerticalPodAutoscalers(namespace string) v1beta1.VerticalPodAutoscalerInterface {
-	return &FakeVerticalPodAutoscalers{c, namespace}
+	return newFakeVerticalPodAutoscalers(c, namespace)
 }
 
 func (c *FakeAutoscalingV1beta1) VerticalPodAutoscalerCheckpoints(namespace string) v1beta1.VerticalPodAutoscalerCheckpointInterface {
-	return &FakeVerticalPodAutoscalerCheckpoints{c, namespace}
+	return newFakeVerticalPodAutoscalerCheckpoints(c, namespace)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/fake/fake_verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/fake/fake_verticalpodautoscaler.go
@@ -19,129 +19,34 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
 	v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
-	testing "k8s.io/client-go/testing"
+	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeVerticalPodAutoscalers implements VerticalPodAutoscalerInterface
-type FakeVerticalPodAutoscalers struct {
+// fakeVerticalPodAutoscalers implements VerticalPodAutoscalerInterface
+type fakeVerticalPodAutoscalers struct {
+	*gentype.FakeClientWithList[*v1beta1.VerticalPodAutoscaler, *v1beta1.VerticalPodAutoscalerList]
 	Fake *FakeAutoscalingV1beta1
-	ns   string
 }
 
-var verticalpodautoscalersResource = v1beta1.SchemeGroupVersion.WithResource("verticalpodautoscalers")
-
-var verticalpodautoscalersKind = v1beta1.SchemeGroupVersion.WithKind("VerticalPodAutoscaler")
-
-// Get takes name of the verticalPodAutoscaler, and returns the corresponding verticalPodAutoscaler object, and an error if there is any.
-func (c *FakeVerticalPodAutoscalers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewGetActionWithOptions(verticalpodautoscalersResource, c.ns, name, options), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
+func newFakeVerticalPodAutoscalers(fake *FakeAutoscalingV1beta1, namespace string) autoscalingk8siov1beta1.VerticalPodAutoscalerInterface {
+	return &fakeVerticalPodAutoscalers{
+		gentype.NewFakeClientWithList[*v1beta1.VerticalPodAutoscaler, *v1beta1.VerticalPodAutoscalerList](
+			fake.Fake,
+			namespace,
+			v1beta1.SchemeGroupVersion.WithResource("verticalpodautoscalers"),
+			v1beta1.SchemeGroupVersion.WithKind("VerticalPodAutoscaler"),
+			func() *v1beta1.VerticalPodAutoscaler { return &v1beta1.VerticalPodAutoscaler{} },
+			func() *v1beta1.VerticalPodAutoscalerList { return &v1beta1.VerticalPodAutoscalerList{} },
+			func(dst, src *v1beta1.VerticalPodAutoscalerList) { dst.ListMeta = src.ListMeta },
+			func(list *v1beta1.VerticalPodAutoscalerList) []*v1beta1.VerticalPodAutoscaler {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1beta1.VerticalPodAutoscalerList, items []*v1beta1.VerticalPodAutoscaler) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1beta1.VerticalPodAutoscaler), err
-}
-
-// List takes label and field selectors, and returns the list of VerticalPodAutoscalers that match those selectors.
-func (c *FakeVerticalPodAutoscalers) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.VerticalPodAutoscalerList, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscalerList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewListActionWithOptions(verticalpodautoscalersResource, verticalpodautoscalersKind, c.ns, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.VerticalPodAutoscalerList{ListMeta: obj.(*v1beta1.VerticalPodAutoscalerList).ListMeta}
-	for _, item := range obj.(*v1beta1.VerticalPodAutoscalerList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested verticalPodAutoscalers.
-func (c *FakeVerticalPodAutoscalers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchActionWithOptions(verticalpodautoscalersResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a verticalPodAutoscaler and creates it.  Returns the server's representation of the verticalPodAutoscaler, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalers) Create(ctx context.Context, verticalPodAutoscaler *v1beta1.VerticalPodAutoscaler, opts v1.CreateOptions) (result *v1beta1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateActionWithOptions(verticalpodautoscalersResource, c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta1.VerticalPodAutoscaler), err
-}
-
-// Update takes the representation of a verticalPodAutoscaler and updates it. Returns the server's representation of the verticalPodAutoscaler, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalers) Update(ctx context.Context, verticalPodAutoscaler *v1beta1.VerticalPodAutoscaler, opts v1.UpdateOptions) (result *v1beta1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateActionWithOptions(verticalpodautoscalersResource, c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta1.VerticalPodAutoscaler), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeVerticalPodAutoscalers) UpdateStatus(ctx context.Context, verticalPodAutoscaler *v1beta1.VerticalPodAutoscaler, opts v1.UpdateOptions) (result *v1beta1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceActionWithOptions(verticalpodautoscalersResource, "status", c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta1.VerticalPodAutoscaler), err
-}
-
-// Delete takes name of the verticalPodAutoscaler and deletes it. Returns an error if one occurs.
-func (c *FakeVerticalPodAutoscalers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(verticalpodautoscalersResource, c.ns, name, opts), &v1beta1.VerticalPodAutoscaler{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeVerticalPodAutoscalers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionActionWithOptions(verticalpodautoscalersResource, c.ns, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.VerticalPodAutoscalerList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched verticalPodAutoscaler.
-func (c *FakeVerticalPodAutoscalers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceActionWithOptions(verticalpodautoscalersResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta1.VerticalPodAutoscaler), err
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/fake/fake_verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/fake/fake_verticalpodautoscalercheckpoint.go
@@ -19,116 +19,36 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
 	v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
-	testing "k8s.io/client-go/testing"
+	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeVerticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
-type FakeVerticalPodAutoscalerCheckpoints struct {
+// fakeVerticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
+type fakeVerticalPodAutoscalerCheckpoints struct {
+	*gentype.FakeClientWithList[*v1beta1.VerticalPodAutoscalerCheckpoint, *v1beta1.VerticalPodAutoscalerCheckpointList]
 	Fake *FakeAutoscalingV1beta1
-	ns   string
 }
 
-var verticalpodautoscalercheckpointsResource = v1beta1.SchemeGroupVersion.WithResource("verticalpodautoscalercheckpoints")
-
-var verticalpodautoscalercheckpointsKind = v1beta1.SchemeGroupVersion.WithKind("VerticalPodAutoscalerCheckpoint")
-
-// Get takes name of the verticalPodAutoscalerCheckpoint, and returns the corresponding verticalPodAutoscalerCheckpoint object, and an error if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewGetActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, options), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
+func newFakeVerticalPodAutoscalerCheckpoints(fake *FakeAutoscalingV1beta1, namespace string) autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpointInterface {
+	return &fakeVerticalPodAutoscalerCheckpoints{
+		gentype.NewFakeClientWithList[*v1beta1.VerticalPodAutoscalerCheckpoint, *v1beta1.VerticalPodAutoscalerCheckpointList](
+			fake.Fake,
+			namespace,
+			v1beta1.SchemeGroupVersion.WithResource("verticalpodautoscalercheckpoints"),
+			v1beta1.SchemeGroupVersion.WithKind("VerticalPodAutoscalerCheckpoint"),
+			func() *v1beta1.VerticalPodAutoscalerCheckpoint { return &v1beta1.VerticalPodAutoscalerCheckpoint{} },
+			func() *v1beta1.VerticalPodAutoscalerCheckpointList {
+				return &v1beta1.VerticalPodAutoscalerCheckpointList{}
+			},
+			func(dst, src *v1beta1.VerticalPodAutoscalerCheckpointList) { dst.ListMeta = src.ListMeta },
+			func(list *v1beta1.VerticalPodAutoscalerCheckpointList) []*v1beta1.VerticalPodAutoscalerCheckpoint {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1beta1.VerticalPodAutoscalerCheckpointList, items []*v1beta1.VerticalPodAutoscalerCheckpoint) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1beta1.VerticalPodAutoscalerCheckpoint), err
-}
-
-// List takes label and field selectors, and returns the list of VerticalPodAutoscalerCheckpoints that match those selectors.
-func (c *FakeVerticalPodAutoscalerCheckpoints) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.VerticalPodAutoscalerCheckpointList, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscalerCheckpointList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewListActionWithOptions(verticalpodautoscalercheckpointsResource, verticalpodautoscalercheckpointsKind, c.ns, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.VerticalPodAutoscalerCheckpointList{ListMeta: obj.(*v1beta1.VerticalPodAutoscalerCheckpointList).ListMeta}
-	for _, item := range obj.(*v1beta1.VerticalPodAutoscalerCheckpointList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested verticalPodAutoscalerCheckpoints.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a verticalPodAutoscalerCheckpoint and creates it.  Returns the server's representation of the verticalPodAutoscalerCheckpoint, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Create(ctx context.Context, verticalPodAutoscalerCheckpoint *v1beta1.VerticalPodAutoscalerCheckpoint, opts v1.CreateOptions) (result *v1beta1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, verticalPodAutoscalerCheckpoint, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta1.VerticalPodAutoscalerCheckpoint), err
-}
-
-// Update takes the representation of a verticalPodAutoscalerCheckpoint and updates it. Returns the server's representation of the verticalPodAutoscalerCheckpoint, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Update(ctx context.Context, verticalPodAutoscalerCheckpoint *v1beta1.VerticalPodAutoscalerCheckpoint, opts v1.UpdateOptions) (result *v1beta1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, verticalPodAutoscalerCheckpoint, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta1.VerticalPodAutoscalerCheckpoint), err
-}
-
-// Delete takes name of the verticalPodAutoscalerCheckpoint and deletes it. Returns an error if one occurs.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, opts), &v1beta1.VerticalPodAutoscalerCheckpoint{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeVerticalPodAutoscalerCheckpoints) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.VerticalPodAutoscalerCheckpointList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched verticalPodAutoscalerCheckpoint.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1beta1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta1.VerticalPodAutoscalerCheckpoint), err
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/verticalpodautoscaler.go
@@ -19,12 +19,12 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
+	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
 	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	gentype "k8s.io/client-go/gentype"
 )
@@ -37,33 +37,38 @@ type VerticalPodAutoscalersGetter interface {
 
 // VerticalPodAutoscalerInterface has methods to work with VerticalPodAutoscaler resources.
 type VerticalPodAutoscalerInterface interface {
-	Create(ctx context.Context, verticalPodAutoscaler *v1beta1.VerticalPodAutoscaler, opts v1.CreateOptions) (*v1beta1.VerticalPodAutoscaler, error)
-	Update(ctx context.Context, verticalPodAutoscaler *v1beta1.VerticalPodAutoscaler, opts v1.UpdateOptions) (*v1beta1.VerticalPodAutoscaler, error)
+	Create(ctx context.Context, verticalPodAutoscaler *autoscalingk8siov1beta1.VerticalPodAutoscaler, opts v1.CreateOptions) (*autoscalingk8siov1beta1.VerticalPodAutoscaler, error)
+	Update(ctx context.Context, verticalPodAutoscaler *autoscalingk8siov1beta1.VerticalPodAutoscaler, opts v1.UpdateOptions) (*autoscalingk8siov1beta1.VerticalPodAutoscaler, error)
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-	UpdateStatus(ctx context.Context, verticalPodAutoscaler *v1beta1.VerticalPodAutoscaler, opts v1.UpdateOptions) (*v1beta1.VerticalPodAutoscaler, error)
+	UpdateStatus(ctx context.Context, verticalPodAutoscaler *autoscalingk8siov1beta1.VerticalPodAutoscaler, opts v1.UpdateOptions) (*autoscalingk8siov1beta1.VerticalPodAutoscaler, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta1.VerticalPodAutoscaler, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1beta1.VerticalPodAutoscalerList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*autoscalingk8siov1beta1.VerticalPodAutoscaler, error)
+	List(ctx context.Context, opts v1.ListOptions) (*autoscalingk8siov1beta1.VerticalPodAutoscalerList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.VerticalPodAutoscaler, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *autoscalingk8siov1beta1.VerticalPodAutoscaler, err error)
 	VerticalPodAutoscalerExpansion
 }
 
 // verticalPodAutoscalers implements VerticalPodAutoscalerInterface
 type verticalPodAutoscalers struct {
-	*gentype.ClientWithList[*v1beta1.VerticalPodAutoscaler, *v1beta1.VerticalPodAutoscalerList]
+	*gentype.ClientWithList[*autoscalingk8siov1beta1.VerticalPodAutoscaler, *autoscalingk8siov1beta1.VerticalPodAutoscalerList]
 }
 
 // newVerticalPodAutoscalers returns a VerticalPodAutoscalers
 func newVerticalPodAutoscalers(c *AutoscalingV1beta1Client, namespace string) *verticalPodAutoscalers {
 	return &verticalPodAutoscalers{
-		gentype.NewClientWithList[*v1beta1.VerticalPodAutoscaler, *v1beta1.VerticalPodAutoscalerList](
+		gentype.NewClientWithList[*autoscalingk8siov1beta1.VerticalPodAutoscaler, *autoscalingk8siov1beta1.VerticalPodAutoscalerList](
 			"verticalpodautoscalers",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1beta1.VerticalPodAutoscaler { return &v1beta1.VerticalPodAutoscaler{} },
-			func() *v1beta1.VerticalPodAutoscalerList { return &v1beta1.VerticalPodAutoscalerList{} }),
+			func() *autoscalingk8siov1beta1.VerticalPodAutoscaler {
+				return &autoscalingk8siov1beta1.VerticalPodAutoscaler{}
+			},
+			func() *autoscalingk8siov1beta1.VerticalPodAutoscalerList {
+				return &autoscalingk8siov1beta1.VerticalPodAutoscalerList{}
+			},
+		),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta1/verticalpodautoscalercheckpoint.go
@@ -19,12 +19,12 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
+	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
 	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	gentype "k8s.io/client-go/gentype"
 )
@@ -37,33 +37,36 @@ type VerticalPodAutoscalerCheckpointsGetter interface {
 
 // VerticalPodAutoscalerCheckpointInterface has methods to work with VerticalPodAutoscalerCheckpoint resources.
 type VerticalPodAutoscalerCheckpointInterface interface {
-	Create(ctx context.Context, verticalPodAutoscalerCheckpoint *v1beta1.VerticalPodAutoscalerCheckpoint, opts v1.CreateOptions) (*v1beta1.VerticalPodAutoscalerCheckpoint, error)
-	Update(ctx context.Context, verticalPodAutoscalerCheckpoint *v1beta1.VerticalPodAutoscalerCheckpoint, opts v1.UpdateOptions) (*v1beta1.VerticalPodAutoscalerCheckpoint, error)
+	Create(ctx context.Context, verticalPodAutoscalerCheckpoint *autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, opts v1.CreateOptions) (*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, error)
+	Update(ctx context.Context, verticalPodAutoscalerCheckpoint *autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, opts v1.UpdateOptions) (*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta1.VerticalPodAutoscalerCheckpoint, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1beta1.VerticalPodAutoscalerCheckpointList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, error)
+	List(ctx context.Context, opts v1.ListOptions) (*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpointList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.VerticalPodAutoscalerCheckpoint, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, err error)
 	VerticalPodAutoscalerCheckpointExpansion
 }
 
 // verticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
 type verticalPodAutoscalerCheckpoints struct {
-	*gentype.ClientWithList[*v1beta1.VerticalPodAutoscalerCheckpoint, *v1beta1.VerticalPodAutoscalerCheckpointList]
+	*gentype.ClientWithList[*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, *autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpointList]
 }
 
 // newVerticalPodAutoscalerCheckpoints returns a VerticalPodAutoscalerCheckpoints
 func newVerticalPodAutoscalerCheckpoints(c *AutoscalingV1beta1Client, namespace string) *verticalPodAutoscalerCheckpoints {
 	return &verticalPodAutoscalerCheckpoints{
-		gentype.NewClientWithList[*v1beta1.VerticalPodAutoscalerCheckpoint, *v1beta1.VerticalPodAutoscalerCheckpointList](
+		gentype.NewClientWithList[*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, *autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpointList](
 			"verticalpodautoscalercheckpoints",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1beta1.VerticalPodAutoscalerCheckpoint { return &v1beta1.VerticalPodAutoscalerCheckpoint{} },
-			func() *v1beta1.VerticalPodAutoscalerCheckpointList {
-				return &v1beta1.VerticalPodAutoscalerCheckpointList{}
-			}),
+			func() *autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint {
+				return &autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint{}
+			},
+			func() *autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpointList {
+				return &autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpointList{}
+			},
+		),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/autoscaling.k8s.io_client.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/autoscaling.k8s.io_client.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1beta2
 
 import (
-	"net/http"
+	http "net/http"
 
-	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
+	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -90,10 +90,10 @@ func New(c rest.Interface) *AutoscalingV1beta2Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta2.SchemeGroupVersion
+	gv := autoscalingk8siov1beta2.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = rest.CodecFactoryForGeneratedClient(scheme.Scheme, scheme.Codecs).WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/fake/fake_autoscaling.k8s.io_client.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/fake/fake_autoscaling.k8s.io_client.go
@@ -29,11 +29,11 @@ type FakeAutoscalingV1beta2 struct {
 }
 
 func (c *FakeAutoscalingV1beta2) VerticalPodAutoscalers(namespace string) v1beta2.VerticalPodAutoscalerInterface {
-	return &FakeVerticalPodAutoscalers{c, namespace}
+	return newFakeVerticalPodAutoscalers(c, namespace)
 }
 
 func (c *FakeAutoscalingV1beta2) VerticalPodAutoscalerCheckpoints(namespace string) v1beta2.VerticalPodAutoscalerCheckpointInterface {
-	return &FakeVerticalPodAutoscalerCheckpoints{c, namespace}
+	return newFakeVerticalPodAutoscalerCheckpoints(c, namespace)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/fake/fake_verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/fake/fake_verticalpodautoscaler.go
@@ -19,129 +19,34 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
 	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
-	testing "k8s.io/client-go/testing"
+	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeVerticalPodAutoscalers implements VerticalPodAutoscalerInterface
-type FakeVerticalPodAutoscalers struct {
+// fakeVerticalPodAutoscalers implements VerticalPodAutoscalerInterface
+type fakeVerticalPodAutoscalers struct {
+	*gentype.FakeClientWithList[*v1beta2.VerticalPodAutoscaler, *v1beta2.VerticalPodAutoscalerList]
 	Fake *FakeAutoscalingV1beta2
-	ns   string
 }
 
-var verticalpodautoscalersResource = v1beta2.SchemeGroupVersion.WithResource("verticalpodautoscalers")
-
-var verticalpodautoscalersKind = v1beta2.SchemeGroupVersion.WithKind("VerticalPodAutoscaler")
-
-// Get takes name of the verticalPodAutoscaler, and returns the corresponding verticalPodAutoscaler object, and an error if there is any.
-func (c *FakeVerticalPodAutoscalers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewGetActionWithOptions(verticalpodautoscalersResource, c.ns, name, options), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
+func newFakeVerticalPodAutoscalers(fake *FakeAutoscalingV1beta2, namespace string) autoscalingk8siov1beta2.VerticalPodAutoscalerInterface {
+	return &fakeVerticalPodAutoscalers{
+		gentype.NewFakeClientWithList[*v1beta2.VerticalPodAutoscaler, *v1beta2.VerticalPodAutoscalerList](
+			fake.Fake,
+			namespace,
+			v1beta2.SchemeGroupVersion.WithResource("verticalpodautoscalers"),
+			v1beta2.SchemeGroupVersion.WithKind("VerticalPodAutoscaler"),
+			func() *v1beta2.VerticalPodAutoscaler { return &v1beta2.VerticalPodAutoscaler{} },
+			func() *v1beta2.VerticalPodAutoscalerList { return &v1beta2.VerticalPodAutoscalerList{} },
+			func(dst, src *v1beta2.VerticalPodAutoscalerList) { dst.ListMeta = src.ListMeta },
+			func(list *v1beta2.VerticalPodAutoscalerList) []*v1beta2.VerticalPodAutoscaler {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1beta2.VerticalPodAutoscalerList, items []*v1beta2.VerticalPodAutoscaler) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1beta2.VerticalPodAutoscaler), err
-}
-
-// List takes label and field selectors, and returns the list of VerticalPodAutoscalers that match those selectors.
-func (c *FakeVerticalPodAutoscalers) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.VerticalPodAutoscalerList, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscalerList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewListActionWithOptions(verticalpodautoscalersResource, verticalpodautoscalersKind, c.ns, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta2.VerticalPodAutoscalerList{ListMeta: obj.(*v1beta2.VerticalPodAutoscalerList).ListMeta}
-	for _, item := range obj.(*v1beta2.VerticalPodAutoscalerList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested verticalPodAutoscalers.
-func (c *FakeVerticalPodAutoscalers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchActionWithOptions(verticalpodautoscalersResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a verticalPodAutoscaler and creates it.  Returns the server's representation of the verticalPodAutoscaler, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalers) Create(ctx context.Context, verticalPodAutoscaler *v1beta2.VerticalPodAutoscaler, opts v1.CreateOptions) (result *v1beta2.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateActionWithOptions(verticalpodautoscalersResource, c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta2.VerticalPodAutoscaler), err
-}
-
-// Update takes the representation of a verticalPodAutoscaler and updates it. Returns the server's representation of the verticalPodAutoscaler, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalers) Update(ctx context.Context, verticalPodAutoscaler *v1beta2.VerticalPodAutoscaler, opts v1.UpdateOptions) (result *v1beta2.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateActionWithOptions(verticalpodautoscalersResource, c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta2.VerticalPodAutoscaler), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeVerticalPodAutoscalers) UpdateStatus(ctx context.Context, verticalPodAutoscaler *v1beta2.VerticalPodAutoscaler, opts v1.UpdateOptions) (result *v1beta2.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceActionWithOptions(verticalpodautoscalersResource, "status", c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta2.VerticalPodAutoscaler), err
-}
-
-// Delete takes name of the verticalPodAutoscaler and deletes it. Returns an error if one occurs.
-func (c *FakeVerticalPodAutoscalers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(verticalpodautoscalersResource, c.ns, name, opts), &v1beta2.VerticalPodAutoscaler{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeVerticalPodAutoscalers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionActionWithOptions(verticalpodautoscalersResource, c.ns, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1beta2.VerticalPodAutoscalerList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched verticalPodAutoscaler.
-func (c *FakeVerticalPodAutoscalers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceActionWithOptions(verticalpodautoscalersResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta2.VerticalPodAutoscaler), err
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/fake/fake_verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/fake/fake_verticalpodautoscalercheckpoint.go
@@ -19,116 +19,36 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
 	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
-	testing "k8s.io/client-go/testing"
+	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeVerticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
-type FakeVerticalPodAutoscalerCheckpoints struct {
+// fakeVerticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
+type fakeVerticalPodAutoscalerCheckpoints struct {
+	*gentype.FakeClientWithList[*v1beta2.VerticalPodAutoscalerCheckpoint, *v1beta2.VerticalPodAutoscalerCheckpointList]
 	Fake *FakeAutoscalingV1beta2
-	ns   string
 }
 
-var verticalpodautoscalercheckpointsResource = v1beta2.SchemeGroupVersion.WithResource("verticalpodautoscalercheckpoints")
-
-var verticalpodautoscalercheckpointsKind = v1beta2.SchemeGroupVersion.WithKind("VerticalPodAutoscalerCheckpoint")
-
-// Get takes name of the verticalPodAutoscalerCheckpoint, and returns the corresponding verticalPodAutoscalerCheckpoint object, and an error if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta2.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewGetActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, options), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
+func newFakeVerticalPodAutoscalerCheckpoints(fake *FakeAutoscalingV1beta2, namespace string) autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpointInterface {
+	return &fakeVerticalPodAutoscalerCheckpoints{
+		gentype.NewFakeClientWithList[*v1beta2.VerticalPodAutoscalerCheckpoint, *v1beta2.VerticalPodAutoscalerCheckpointList](
+			fake.Fake,
+			namespace,
+			v1beta2.SchemeGroupVersion.WithResource("verticalpodautoscalercheckpoints"),
+			v1beta2.SchemeGroupVersion.WithKind("VerticalPodAutoscalerCheckpoint"),
+			func() *v1beta2.VerticalPodAutoscalerCheckpoint { return &v1beta2.VerticalPodAutoscalerCheckpoint{} },
+			func() *v1beta2.VerticalPodAutoscalerCheckpointList {
+				return &v1beta2.VerticalPodAutoscalerCheckpointList{}
+			},
+			func(dst, src *v1beta2.VerticalPodAutoscalerCheckpointList) { dst.ListMeta = src.ListMeta },
+			func(list *v1beta2.VerticalPodAutoscalerCheckpointList) []*v1beta2.VerticalPodAutoscalerCheckpoint {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1beta2.VerticalPodAutoscalerCheckpointList, items []*v1beta2.VerticalPodAutoscalerCheckpoint) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1beta2.VerticalPodAutoscalerCheckpoint), err
-}
-
-// List takes label and field selectors, and returns the list of VerticalPodAutoscalerCheckpoints that match those selectors.
-func (c *FakeVerticalPodAutoscalerCheckpoints) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.VerticalPodAutoscalerCheckpointList, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscalerCheckpointList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewListActionWithOptions(verticalpodautoscalercheckpointsResource, verticalpodautoscalercheckpointsKind, c.ns, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta2.VerticalPodAutoscalerCheckpointList{ListMeta: obj.(*v1beta2.VerticalPodAutoscalerCheckpointList).ListMeta}
-	for _, item := range obj.(*v1beta2.VerticalPodAutoscalerCheckpointList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested verticalPodAutoscalerCheckpoints.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a verticalPodAutoscalerCheckpoint and creates it.  Returns the server's representation of the verticalPodAutoscalerCheckpoint, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Create(ctx context.Context, verticalPodAutoscalerCheckpoint *v1beta2.VerticalPodAutoscalerCheckpoint, opts v1.CreateOptions) (result *v1beta2.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, verticalPodAutoscalerCheckpoint, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta2.VerticalPodAutoscalerCheckpoint), err
-}
-
-// Update takes the representation of a verticalPodAutoscalerCheckpoint and updates it. Returns the server's representation of the verticalPodAutoscalerCheckpoint, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Update(ctx context.Context, verticalPodAutoscalerCheckpoint *v1beta2.VerticalPodAutoscalerCheckpoint, opts v1.UpdateOptions) (result *v1beta2.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, verticalPodAutoscalerCheckpoint, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta2.VerticalPodAutoscalerCheckpoint), err
-}
-
-// Delete takes name of the verticalPodAutoscalerCheckpoint and deletes it. Returns an error if one occurs.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, opts), &v1beta2.VerticalPodAutoscalerCheckpoint{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeVerticalPodAutoscalerCheckpoints) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1beta2.VerticalPodAutoscalerCheckpointList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched verticalPodAutoscalerCheckpoint.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1beta2.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1beta2.VerticalPodAutoscalerCheckpoint), err
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/verticalpodautoscaler.go
@@ -19,12 +19,12 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	gentype "k8s.io/client-go/gentype"
 )
@@ -37,33 +37,38 @@ type VerticalPodAutoscalersGetter interface {
 
 // VerticalPodAutoscalerInterface has methods to work with VerticalPodAutoscaler resources.
 type VerticalPodAutoscalerInterface interface {
-	Create(ctx context.Context, verticalPodAutoscaler *v1beta2.VerticalPodAutoscaler, opts v1.CreateOptions) (*v1beta2.VerticalPodAutoscaler, error)
-	Update(ctx context.Context, verticalPodAutoscaler *v1beta2.VerticalPodAutoscaler, opts v1.UpdateOptions) (*v1beta2.VerticalPodAutoscaler, error)
+	Create(ctx context.Context, verticalPodAutoscaler *autoscalingk8siov1beta2.VerticalPodAutoscaler, opts v1.CreateOptions) (*autoscalingk8siov1beta2.VerticalPodAutoscaler, error)
+	Update(ctx context.Context, verticalPodAutoscaler *autoscalingk8siov1beta2.VerticalPodAutoscaler, opts v1.UpdateOptions) (*autoscalingk8siov1beta2.VerticalPodAutoscaler, error)
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-	UpdateStatus(ctx context.Context, verticalPodAutoscaler *v1beta2.VerticalPodAutoscaler, opts v1.UpdateOptions) (*v1beta2.VerticalPodAutoscaler, error)
+	UpdateStatus(ctx context.Context, verticalPodAutoscaler *autoscalingk8siov1beta2.VerticalPodAutoscaler, opts v1.UpdateOptions) (*autoscalingk8siov1beta2.VerticalPodAutoscaler, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta2.VerticalPodAutoscaler, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1beta2.VerticalPodAutoscalerList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*autoscalingk8siov1beta2.VerticalPodAutoscaler, error)
+	List(ctx context.Context, opts v1.ListOptions) (*autoscalingk8siov1beta2.VerticalPodAutoscalerList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.VerticalPodAutoscaler, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *autoscalingk8siov1beta2.VerticalPodAutoscaler, err error)
 	VerticalPodAutoscalerExpansion
 }
 
 // verticalPodAutoscalers implements VerticalPodAutoscalerInterface
 type verticalPodAutoscalers struct {
-	*gentype.ClientWithList[*v1beta2.VerticalPodAutoscaler, *v1beta2.VerticalPodAutoscalerList]
+	*gentype.ClientWithList[*autoscalingk8siov1beta2.VerticalPodAutoscaler, *autoscalingk8siov1beta2.VerticalPodAutoscalerList]
 }
 
 // newVerticalPodAutoscalers returns a VerticalPodAutoscalers
 func newVerticalPodAutoscalers(c *AutoscalingV1beta2Client, namespace string) *verticalPodAutoscalers {
 	return &verticalPodAutoscalers{
-		gentype.NewClientWithList[*v1beta2.VerticalPodAutoscaler, *v1beta2.VerticalPodAutoscalerList](
+		gentype.NewClientWithList[*autoscalingk8siov1beta2.VerticalPodAutoscaler, *autoscalingk8siov1beta2.VerticalPodAutoscalerList](
 			"verticalpodautoscalers",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1beta2.VerticalPodAutoscaler { return &v1beta2.VerticalPodAutoscaler{} },
-			func() *v1beta2.VerticalPodAutoscalerList { return &v1beta2.VerticalPodAutoscalerList{} }),
+			func() *autoscalingk8siov1beta2.VerticalPodAutoscaler {
+				return &autoscalingk8siov1beta2.VerticalPodAutoscaler{}
+			},
+			func() *autoscalingk8siov1beta2.VerticalPodAutoscalerList {
+				return &autoscalingk8siov1beta2.VerticalPodAutoscalerList{}
+			},
+		),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1beta2/verticalpodautoscalercheckpoint.go
@@ -19,12 +19,12 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	gentype "k8s.io/client-go/gentype"
 )
@@ -37,33 +37,36 @@ type VerticalPodAutoscalerCheckpointsGetter interface {
 
 // VerticalPodAutoscalerCheckpointInterface has methods to work with VerticalPodAutoscalerCheckpoint resources.
 type VerticalPodAutoscalerCheckpointInterface interface {
-	Create(ctx context.Context, verticalPodAutoscalerCheckpoint *v1beta2.VerticalPodAutoscalerCheckpoint, opts v1.CreateOptions) (*v1beta2.VerticalPodAutoscalerCheckpoint, error)
-	Update(ctx context.Context, verticalPodAutoscalerCheckpoint *v1beta2.VerticalPodAutoscalerCheckpoint, opts v1.UpdateOptions) (*v1beta2.VerticalPodAutoscalerCheckpoint, error)
+	Create(ctx context.Context, verticalPodAutoscalerCheckpoint *autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, opts v1.CreateOptions) (*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, error)
+	Update(ctx context.Context, verticalPodAutoscalerCheckpoint *autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, opts v1.UpdateOptions) (*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta2.VerticalPodAutoscalerCheckpoint, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1beta2.VerticalPodAutoscalerCheckpointList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, error)
+	List(ctx context.Context, opts v1.ListOptions) (*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpointList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta2.VerticalPodAutoscalerCheckpoint, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, err error)
 	VerticalPodAutoscalerCheckpointExpansion
 }
 
 // verticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
 type verticalPodAutoscalerCheckpoints struct {
-	*gentype.ClientWithList[*v1beta2.VerticalPodAutoscalerCheckpoint, *v1beta2.VerticalPodAutoscalerCheckpointList]
+	*gentype.ClientWithList[*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, *autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpointList]
 }
 
 // newVerticalPodAutoscalerCheckpoints returns a VerticalPodAutoscalerCheckpoints
 func newVerticalPodAutoscalerCheckpoints(c *AutoscalingV1beta2Client, namespace string) *verticalPodAutoscalerCheckpoints {
 	return &verticalPodAutoscalerCheckpoints{
-		gentype.NewClientWithList[*v1beta2.VerticalPodAutoscalerCheckpoint, *v1beta2.VerticalPodAutoscalerCheckpointList](
+		gentype.NewClientWithList[*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, *autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpointList](
 			"verticalpodautoscalercheckpoints",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1beta2.VerticalPodAutoscalerCheckpoint { return &v1beta2.VerticalPodAutoscalerCheckpoint{} },
-			func() *v1beta2.VerticalPodAutoscalerCheckpointList {
-				return &v1beta2.VerticalPodAutoscalerCheckpointList{}
-			}),
+			func() *autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint {
+				return &autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint{}
+			},
+			func() *autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpointList {
+				return &autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpointList{}
+			},
+		),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/fake/fake_poc.autoscaling.k8s.io_client.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/fake/fake_poc.autoscaling.k8s.io_client.go
@@ -29,11 +29,11 @@ type FakePocV1alpha1 struct {
 }
 
 func (c *FakePocV1alpha1) VerticalPodAutoscalers(namespace string) v1alpha1.VerticalPodAutoscalerInterface {
-	return &FakeVerticalPodAutoscalers{c, namespace}
+	return newFakeVerticalPodAutoscalers(c, namespace)
 }
 
 func (c *FakePocV1alpha1) VerticalPodAutoscalerCheckpoints(namespace string) v1alpha1.VerticalPodAutoscalerCheckpointInterface {
-	return &FakeVerticalPodAutoscalerCheckpoints{c, namespace}
+	return newFakeVerticalPodAutoscalerCheckpoints(c, namespace)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/fake/fake_verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/fake/fake_verticalpodautoscaler.go
@@ -19,129 +19,34 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
 	v1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
-	testing "k8s.io/client-go/testing"
+	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeVerticalPodAutoscalers implements VerticalPodAutoscalerInterface
-type FakeVerticalPodAutoscalers struct {
+// fakeVerticalPodAutoscalers implements VerticalPodAutoscalerInterface
+type fakeVerticalPodAutoscalers struct {
+	*gentype.FakeClientWithList[*v1alpha1.VerticalPodAutoscaler, *v1alpha1.VerticalPodAutoscalerList]
 	Fake *FakePocV1alpha1
-	ns   string
 }
 
-var verticalpodautoscalersResource = v1alpha1.SchemeGroupVersion.WithResource("verticalpodautoscalers")
-
-var verticalpodautoscalersKind = v1alpha1.SchemeGroupVersion.WithKind("VerticalPodAutoscaler")
-
-// Get takes name of the verticalPodAutoscaler, and returns the corresponding verticalPodAutoscaler object, and an error if there is any.
-func (c *FakeVerticalPodAutoscalers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewGetActionWithOptions(verticalpodautoscalersResource, c.ns, name, options), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
+func newFakeVerticalPodAutoscalers(fake *FakePocV1alpha1, namespace string) pocautoscalingk8siov1alpha1.VerticalPodAutoscalerInterface {
+	return &fakeVerticalPodAutoscalers{
+		gentype.NewFakeClientWithList[*v1alpha1.VerticalPodAutoscaler, *v1alpha1.VerticalPodAutoscalerList](
+			fake.Fake,
+			namespace,
+			v1alpha1.SchemeGroupVersion.WithResource("verticalpodautoscalers"),
+			v1alpha1.SchemeGroupVersion.WithKind("VerticalPodAutoscaler"),
+			func() *v1alpha1.VerticalPodAutoscaler { return &v1alpha1.VerticalPodAutoscaler{} },
+			func() *v1alpha1.VerticalPodAutoscalerList { return &v1alpha1.VerticalPodAutoscalerList{} },
+			func(dst, src *v1alpha1.VerticalPodAutoscalerList) { dst.ListMeta = src.ListMeta },
+			func(list *v1alpha1.VerticalPodAutoscalerList) []*v1alpha1.VerticalPodAutoscaler {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1alpha1.VerticalPodAutoscalerList, items []*v1alpha1.VerticalPodAutoscaler) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1alpha1.VerticalPodAutoscaler), err
-}
-
-// List takes label and field selectors, and returns the list of VerticalPodAutoscalers that match those selectors.
-func (c *FakeVerticalPodAutoscalers) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.VerticalPodAutoscalerList, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscalerList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewListActionWithOptions(verticalpodautoscalersResource, verticalpodautoscalersKind, c.ns, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1alpha1.VerticalPodAutoscalerList{ListMeta: obj.(*v1alpha1.VerticalPodAutoscalerList).ListMeta}
-	for _, item := range obj.(*v1alpha1.VerticalPodAutoscalerList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested verticalPodAutoscalers.
-func (c *FakeVerticalPodAutoscalers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchActionWithOptions(verticalpodautoscalersResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a verticalPodAutoscaler and creates it.  Returns the server's representation of the verticalPodAutoscaler, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalers) Create(ctx context.Context, verticalPodAutoscaler *v1alpha1.VerticalPodAutoscaler, opts v1.CreateOptions) (result *v1alpha1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateActionWithOptions(verticalpodautoscalersResource, c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.VerticalPodAutoscaler), err
-}
-
-// Update takes the representation of a verticalPodAutoscaler and updates it. Returns the server's representation of the verticalPodAutoscaler, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalers) Update(ctx context.Context, verticalPodAutoscaler *v1alpha1.VerticalPodAutoscaler, opts v1.UpdateOptions) (result *v1alpha1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateActionWithOptions(verticalpodautoscalersResource, c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.VerticalPodAutoscaler), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeVerticalPodAutoscalers) UpdateStatus(ctx context.Context, verticalPodAutoscaler *v1alpha1.VerticalPodAutoscaler, opts v1.UpdateOptions) (result *v1alpha1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceActionWithOptions(verticalpodautoscalersResource, "status", c.ns, verticalPodAutoscaler, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.VerticalPodAutoscaler), err
-}
-
-// Delete takes name of the verticalPodAutoscaler and deletes it. Returns an error if one occurs.
-func (c *FakeVerticalPodAutoscalers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(verticalpodautoscalersResource, c.ns, name, opts), &v1alpha1.VerticalPodAutoscaler{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeVerticalPodAutoscalers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionActionWithOptions(verticalpodautoscalersResource, c.ns, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.VerticalPodAutoscalerList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched verticalPodAutoscaler.
-func (c *FakeVerticalPodAutoscalers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.VerticalPodAutoscaler, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscaler{}
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceActionWithOptions(verticalpodautoscalersResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.VerticalPodAutoscaler), err
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/fake/fake_verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/fake/fake_verticalpodautoscalercheckpoint.go
@@ -19,116 +19,36 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
 	v1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
-	testing "k8s.io/client-go/testing"
+	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeVerticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
-type FakeVerticalPodAutoscalerCheckpoints struct {
+// fakeVerticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
+type fakeVerticalPodAutoscalerCheckpoints struct {
+	*gentype.FakeClientWithList[*v1alpha1.VerticalPodAutoscalerCheckpoint, *v1alpha1.VerticalPodAutoscalerCheckpointList]
 	Fake *FakePocV1alpha1
-	ns   string
 }
 
-var verticalpodautoscalercheckpointsResource = v1alpha1.SchemeGroupVersion.WithResource("verticalpodautoscalercheckpoints")
-
-var verticalpodautoscalercheckpointsKind = v1alpha1.SchemeGroupVersion.WithKind("VerticalPodAutoscalerCheckpoint")
-
-// Get takes name of the verticalPodAutoscalerCheckpoint, and returns the corresponding verticalPodAutoscalerCheckpoint object, and an error if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewGetActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, options), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
+func newFakeVerticalPodAutoscalerCheckpoints(fake *FakePocV1alpha1, namespace string) pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpointInterface {
+	return &fakeVerticalPodAutoscalerCheckpoints{
+		gentype.NewFakeClientWithList[*v1alpha1.VerticalPodAutoscalerCheckpoint, *v1alpha1.VerticalPodAutoscalerCheckpointList](
+			fake.Fake,
+			namespace,
+			v1alpha1.SchemeGroupVersion.WithResource("verticalpodautoscalercheckpoints"),
+			v1alpha1.SchemeGroupVersion.WithKind("VerticalPodAutoscalerCheckpoint"),
+			func() *v1alpha1.VerticalPodAutoscalerCheckpoint { return &v1alpha1.VerticalPodAutoscalerCheckpoint{} },
+			func() *v1alpha1.VerticalPodAutoscalerCheckpointList {
+				return &v1alpha1.VerticalPodAutoscalerCheckpointList{}
+			},
+			func(dst, src *v1alpha1.VerticalPodAutoscalerCheckpointList) { dst.ListMeta = src.ListMeta },
+			func(list *v1alpha1.VerticalPodAutoscalerCheckpointList) []*v1alpha1.VerticalPodAutoscalerCheckpoint {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1alpha1.VerticalPodAutoscalerCheckpointList, items []*v1alpha1.VerticalPodAutoscalerCheckpoint) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1alpha1.VerticalPodAutoscalerCheckpoint), err
-}
-
-// List takes label and field selectors, and returns the list of VerticalPodAutoscalerCheckpoints that match those selectors.
-func (c *FakeVerticalPodAutoscalerCheckpoints) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.VerticalPodAutoscalerCheckpointList, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscalerCheckpointList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewListActionWithOptions(verticalpodautoscalercheckpointsResource, verticalpodautoscalercheckpointsKind, c.ns, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1alpha1.VerticalPodAutoscalerCheckpointList{ListMeta: obj.(*v1alpha1.VerticalPodAutoscalerCheckpointList).ListMeta}
-	for _, item := range obj.(*v1alpha1.VerticalPodAutoscalerCheckpointList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested verticalPodAutoscalerCheckpoints.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a verticalPodAutoscalerCheckpoint and creates it.  Returns the server's representation of the verticalPodAutoscalerCheckpoint, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Create(ctx context.Context, verticalPodAutoscalerCheckpoint *v1alpha1.VerticalPodAutoscalerCheckpoint, opts v1.CreateOptions) (result *v1alpha1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, verticalPodAutoscalerCheckpoint, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.VerticalPodAutoscalerCheckpoint), err
-}
-
-// Update takes the representation of a verticalPodAutoscalerCheckpoint and updates it. Returns the server's representation of the verticalPodAutoscalerCheckpoint, and an error, if there is any.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Update(ctx context.Context, verticalPodAutoscalerCheckpoint *v1alpha1.VerticalPodAutoscalerCheckpoint, opts v1.UpdateOptions) (result *v1alpha1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, verticalPodAutoscalerCheckpoint, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.VerticalPodAutoscalerCheckpoint), err
-}
-
-// Delete takes name of the verticalPodAutoscalerCheckpoint and deletes it. Returns an error if one occurs.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, opts), &v1alpha1.VerticalPodAutoscalerCheckpoint{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeVerticalPodAutoscalerCheckpoints) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.VerticalPodAutoscalerCheckpointList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched verticalPodAutoscalerCheckpoint.
-func (c *FakeVerticalPodAutoscalerCheckpoints) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.VerticalPodAutoscalerCheckpoint, err error) {
-	emptyResult := &v1alpha1.VerticalPodAutoscalerCheckpoint{}
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceActionWithOptions(verticalpodautoscalercheckpointsResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1alpha1.VerticalPodAutoscalerCheckpoint), err
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/poc.autoscaling.k8s.io_client.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/poc.autoscaling.k8s.io_client.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"net/http"
+	http "net/http"
 
-	v1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
+	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
+	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -90,10 +90,10 @@ func New(c rest.Interface) *PocV1alpha1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1alpha1.SchemeGroupVersion
+	gv := pocautoscalingk8siov1alpha1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = rest.CodecFactoryForGeneratedClient(scheme.Scheme, scheme.Codecs).WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscaler.go
@@ -19,12 +19,12 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	v1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
+	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
 	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	gentype "k8s.io/client-go/gentype"
 )
@@ -37,33 +37,38 @@ type VerticalPodAutoscalersGetter interface {
 
 // VerticalPodAutoscalerInterface has methods to work with VerticalPodAutoscaler resources.
 type VerticalPodAutoscalerInterface interface {
-	Create(ctx context.Context, verticalPodAutoscaler *v1alpha1.VerticalPodAutoscaler, opts v1.CreateOptions) (*v1alpha1.VerticalPodAutoscaler, error)
-	Update(ctx context.Context, verticalPodAutoscaler *v1alpha1.VerticalPodAutoscaler, opts v1.UpdateOptions) (*v1alpha1.VerticalPodAutoscaler, error)
+	Create(ctx context.Context, verticalPodAutoscaler *pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, opts v1.CreateOptions) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, error)
+	Update(ctx context.Context, verticalPodAutoscaler *pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, opts v1.UpdateOptions) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, error)
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-	UpdateStatus(ctx context.Context, verticalPodAutoscaler *v1alpha1.VerticalPodAutoscaler, opts v1.UpdateOptions) (*v1alpha1.VerticalPodAutoscaler, error)
+	UpdateStatus(ctx context.Context, verticalPodAutoscaler *pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, opts v1.UpdateOptions) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1alpha1.VerticalPodAutoscaler, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1alpha1.VerticalPodAutoscalerList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, error)
+	List(ctx context.Context, opts v1.ListOptions) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.VerticalPodAutoscaler, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, err error)
 	VerticalPodAutoscalerExpansion
 }
 
 // verticalPodAutoscalers implements VerticalPodAutoscalerInterface
 type verticalPodAutoscalers struct {
-	*gentype.ClientWithList[*v1alpha1.VerticalPodAutoscaler, *v1alpha1.VerticalPodAutoscalerList]
+	*gentype.ClientWithList[*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerList]
 }
 
 // newVerticalPodAutoscalers returns a VerticalPodAutoscalers
 func newVerticalPodAutoscalers(c *PocV1alpha1Client, namespace string) *verticalPodAutoscalers {
 	return &verticalPodAutoscalers{
-		gentype.NewClientWithList[*v1alpha1.VerticalPodAutoscaler, *v1alpha1.VerticalPodAutoscalerList](
+		gentype.NewClientWithList[*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerList](
 			"verticalpodautoscalers",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1alpha1.VerticalPodAutoscaler { return &v1alpha1.VerticalPodAutoscaler{} },
-			func() *v1alpha1.VerticalPodAutoscalerList { return &v1alpha1.VerticalPodAutoscalerList{} }),
+			func() *pocautoscalingk8siov1alpha1.VerticalPodAutoscaler {
+				return &pocautoscalingk8siov1alpha1.VerticalPodAutoscaler{}
+			},
+			func() *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerList {
+				return &pocautoscalingk8siov1alpha1.VerticalPodAutoscalerList{}
+			},
+		),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscalercheckpoint.go
@@ -19,12 +19,12 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	v1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
+	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
 	scheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/scheme"
 	gentype "k8s.io/client-go/gentype"
 )
@@ -37,33 +37,36 @@ type VerticalPodAutoscalerCheckpointsGetter interface {
 
 // VerticalPodAutoscalerCheckpointInterface has methods to work with VerticalPodAutoscalerCheckpoint resources.
 type VerticalPodAutoscalerCheckpointInterface interface {
-	Create(ctx context.Context, verticalPodAutoscalerCheckpoint *v1alpha1.VerticalPodAutoscalerCheckpoint, opts v1.CreateOptions) (*v1alpha1.VerticalPodAutoscalerCheckpoint, error)
-	Update(ctx context.Context, verticalPodAutoscalerCheckpoint *v1alpha1.VerticalPodAutoscalerCheckpoint, opts v1.UpdateOptions) (*v1alpha1.VerticalPodAutoscalerCheckpoint, error)
+	Create(ctx context.Context, verticalPodAutoscalerCheckpoint *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, opts v1.CreateOptions) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, error)
+	Update(ctx context.Context, verticalPodAutoscalerCheckpoint *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, opts v1.UpdateOptions) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1alpha1.VerticalPodAutoscalerCheckpoint, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1alpha1.VerticalPodAutoscalerCheckpointList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, error)
+	List(ctx context.Context, opts v1.ListOptions) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpointList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.VerticalPodAutoscalerCheckpoint, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, err error)
 	VerticalPodAutoscalerCheckpointExpansion
 }
 
 // verticalPodAutoscalerCheckpoints implements VerticalPodAutoscalerCheckpointInterface
 type verticalPodAutoscalerCheckpoints struct {
-	*gentype.ClientWithList[*v1alpha1.VerticalPodAutoscalerCheckpoint, *v1alpha1.VerticalPodAutoscalerCheckpointList]
+	*gentype.ClientWithList[*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpointList]
 }
 
 // newVerticalPodAutoscalerCheckpoints returns a VerticalPodAutoscalerCheckpoints
 func newVerticalPodAutoscalerCheckpoints(c *PocV1alpha1Client, namespace string) *verticalPodAutoscalerCheckpoints {
 	return &verticalPodAutoscalerCheckpoints{
-		gentype.NewClientWithList[*v1alpha1.VerticalPodAutoscalerCheckpoint, *v1alpha1.VerticalPodAutoscalerCheckpointList](
+		gentype.NewClientWithList[*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpointList](
 			"verticalpodautoscalercheckpoints",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1alpha1.VerticalPodAutoscalerCheckpoint { return &v1alpha1.VerticalPodAutoscalerCheckpoint{} },
-			func() *v1alpha1.VerticalPodAutoscalerCheckpointList {
-				return &v1alpha1.VerticalPodAutoscalerCheckpointList{}
-			}),
+			func() *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint {
+				return &pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint{}
+			},
+			func() *pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpointList {
+				return &pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpointList{}
+			},
+		),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1/verticalpodautoscaler.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
-	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	apisautoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	versioned "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	internalinterfaces "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions/internalinterfaces"
-	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
+	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -36,7 +36,7 @@ import (
 // VerticalPodAutoscalers.
 type VerticalPodAutoscalerInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1.VerticalPodAutoscalerLister
+	Lister() autoscalingk8siov1.VerticalPodAutoscalerLister
 }
 
 type verticalPodAutoscalerInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredVerticalPodAutoscalerInformer(client versioned.Interface, namesp
 				return client.AutoscalingV1().VerticalPodAutoscalers(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&autoscalingk8siov1.VerticalPodAutoscaler{},
+		&apisautoscalingk8siov1.VerticalPodAutoscaler{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *verticalPodAutoscalerInformer) defaultInformer(client versioned.Interfa
 }
 
 func (f *verticalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&autoscalingk8siov1.VerticalPodAutoscaler{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisautoscalingk8siov1.VerticalPodAutoscaler{}, f.defaultInformer)
 }
 
-func (f *verticalPodAutoscalerInformer) Lister() v1.VerticalPodAutoscalerLister {
-	return v1.NewVerticalPodAutoscalerLister(f.Informer().GetIndexer())
+func (f *verticalPodAutoscalerInformer) Lister() autoscalingk8siov1.VerticalPodAutoscalerLister {
+	return autoscalingk8siov1.NewVerticalPodAutoscalerLister(f.Informer().GetIndexer())
 }

--- a/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoint.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
-	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	apisautoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	versioned "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	internalinterfaces "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions/internalinterfaces"
-	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
+	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -36,7 +36,7 @@ import (
 // VerticalPodAutoscalerCheckpoints.
 type VerticalPodAutoscalerCheckpointInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1.VerticalPodAutoscalerCheckpointLister
+	Lister() autoscalingk8siov1.VerticalPodAutoscalerCheckpointLister
 }
 
 type verticalPodAutoscalerCheckpointInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredVerticalPodAutoscalerCheckpointInformer(client versioned.Interfa
 				return client.AutoscalingV1().VerticalPodAutoscalerCheckpoints(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&autoscalingk8siov1.VerticalPodAutoscalerCheckpoint{},
+		&apisautoscalingk8siov1.VerticalPodAutoscalerCheckpoint{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *verticalPodAutoscalerCheckpointInformer) defaultInformer(client version
 }
 
 func (f *verticalPodAutoscalerCheckpointInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&autoscalingk8siov1.VerticalPodAutoscalerCheckpoint{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisautoscalingk8siov1.VerticalPodAutoscalerCheckpoint{}, f.defaultInformer)
 }
 
-func (f *verticalPodAutoscalerCheckpointInformer) Lister() v1.VerticalPodAutoscalerCheckpointLister {
-	return v1.NewVerticalPodAutoscalerCheckpointLister(f.Informer().GetIndexer())
+func (f *verticalPodAutoscalerCheckpointInformer) Lister() autoscalingk8siov1.VerticalPodAutoscalerCheckpointLister {
+	return autoscalingk8siov1.NewVerticalPodAutoscalerCheckpointLister(f.Informer().GetIndexer())
 }

--- a/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1beta1/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1beta1/verticalpodautoscaler.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
-	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
+	apisautoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
 	versioned "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	internalinterfaces "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions/internalinterfaces"
-	v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1"
+	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -36,7 +36,7 @@ import (
 // VerticalPodAutoscalers.
 type VerticalPodAutoscalerInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1beta1.VerticalPodAutoscalerLister
+	Lister() autoscalingk8siov1beta1.VerticalPodAutoscalerLister
 }
 
 type verticalPodAutoscalerInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredVerticalPodAutoscalerInformer(client versioned.Interface, namesp
 				return client.AutoscalingV1beta1().VerticalPodAutoscalers(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&autoscalingk8siov1beta1.VerticalPodAutoscaler{},
+		&apisautoscalingk8siov1beta1.VerticalPodAutoscaler{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *verticalPodAutoscalerInformer) defaultInformer(client versioned.Interfa
 }
 
 func (f *verticalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&autoscalingk8siov1beta1.VerticalPodAutoscaler{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisautoscalingk8siov1beta1.VerticalPodAutoscaler{}, f.defaultInformer)
 }
 
-func (f *verticalPodAutoscalerInformer) Lister() v1beta1.VerticalPodAutoscalerLister {
-	return v1beta1.NewVerticalPodAutoscalerLister(f.Informer().GetIndexer())
+func (f *verticalPodAutoscalerInformer) Lister() autoscalingk8siov1beta1.VerticalPodAutoscalerLister {
+	return autoscalingk8siov1beta1.NewVerticalPodAutoscalerLister(f.Informer().GetIndexer())
 }

--- a/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1beta1/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1beta1/verticalpodautoscalercheckpoint.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
-	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
+	apisautoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
 	versioned "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	internalinterfaces "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions/internalinterfaces"
-	v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1"
+	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -36,7 +36,7 @@ import (
 // VerticalPodAutoscalerCheckpoints.
 type VerticalPodAutoscalerCheckpointInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1beta1.VerticalPodAutoscalerCheckpointLister
+	Lister() autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpointLister
 }
 
 type verticalPodAutoscalerCheckpointInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredVerticalPodAutoscalerCheckpointInformer(client versioned.Interfa
 				return client.AutoscalingV1beta1().VerticalPodAutoscalerCheckpoints(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint{},
+		&apisautoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *verticalPodAutoscalerCheckpointInformer) defaultInformer(client version
 }
 
 func (f *verticalPodAutoscalerCheckpointInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisautoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint{}, f.defaultInformer)
 }
 
-func (f *verticalPodAutoscalerCheckpointInformer) Lister() v1beta1.VerticalPodAutoscalerCheckpointLister {
-	return v1beta1.NewVerticalPodAutoscalerCheckpointLister(f.Informer().GetIndexer())
+func (f *verticalPodAutoscalerCheckpointInformer) Lister() autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpointLister {
+	return autoscalingk8siov1beta1.NewVerticalPodAutoscalerCheckpointLister(f.Informer().GetIndexer())
 }

--- a/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1beta2/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1beta2/verticalpodautoscaler.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
+	context "context"
 	time "time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
-	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	apisautoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	versioned "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	internalinterfaces "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions/internalinterfaces"
-	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta2"
+	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta2"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -36,7 +36,7 @@ import (
 // VerticalPodAutoscalers.
 type VerticalPodAutoscalerInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1beta2.VerticalPodAutoscalerLister
+	Lister() autoscalingk8siov1beta2.VerticalPodAutoscalerLister
 }
 
 type verticalPodAutoscalerInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredVerticalPodAutoscalerInformer(client versioned.Interface, namesp
 				return client.AutoscalingV1beta2().VerticalPodAutoscalers(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&autoscalingk8siov1beta2.VerticalPodAutoscaler{},
+		&apisautoscalingk8siov1beta2.VerticalPodAutoscaler{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *verticalPodAutoscalerInformer) defaultInformer(client versioned.Interfa
 }
 
 func (f *verticalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&autoscalingk8siov1beta2.VerticalPodAutoscaler{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisautoscalingk8siov1beta2.VerticalPodAutoscaler{}, f.defaultInformer)
 }
 
-func (f *verticalPodAutoscalerInformer) Lister() v1beta2.VerticalPodAutoscalerLister {
-	return v1beta2.NewVerticalPodAutoscalerLister(f.Informer().GetIndexer())
+func (f *verticalPodAutoscalerInformer) Lister() autoscalingk8siov1beta2.VerticalPodAutoscalerLister {
+	return autoscalingk8siov1beta2.NewVerticalPodAutoscalerLister(f.Informer().GetIndexer())
 }

--- a/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1beta2/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/informers/externalversions/autoscaling.k8s.io/v1beta2/verticalpodautoscalercheckpoint.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1beta2
 
 import (
-	"context"
+	context "context"
 	time "time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
-	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	apisautoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	versioned "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	internalinterfaces "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions/internalinterfaces"
-	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta2"
+	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta2"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -36,7 +36,7 @@ import (
 // VerticalPodAutoscalerCheckpoints.
 type VerticalPodAutoscalerCheckpointInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1beta2.VerticalPodAutoscalerCheckpointLister
+	Lister() autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpointLister
 }
 
 type verticalPodAutoscalerCheckpointInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredVerticalPodAutoscalerCheckpointInformer(client versioned.Interfa
 				return client.AutoscalingV1beta2().VerticalPodAutoscalerCheckpoints(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint{},
+		&apisautoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *verticalPodAutoscalerCheckpointInformer) defaultInformer(client version
 }
 
 func (f *verticalPodAutoscalerCheckpointInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisautoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint{}, f.defaultInformer)
 }
 
-func (f *verticalPodAutoscalerCheckpointInformer) Lister() v1beta2.VerticalPodAutoscalerCheckpointLister {
-	return v1beta2.NewVerticalPodAutoscalerCheckpointLister(f.Informer().GetIndexer())
+func (f *verticalPodAutoscalerCheckpointInformer) Lister() autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpointLister {
+	return autoscalingk8siov1beta2.NewVerticalPodAutoscalerCheckpointLister(f.Informer().GetIndexer())
 }

--- a/vertical-pod-autoscaler/pkg/client/informers/externalversions/generic.go
+++ b/vertical-pod-autoscaler/pkg/client/informers/externalversions/generic.go
@@ -19,7 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
-	"fmt"
+	fmt "fmt"
 
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"

--- a/vertical-pod-autoscaler/pkg/client/informers/externalversions/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/informers/externalversions/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscaler.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
-	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
+	apispocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
 	versioned "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	internalinterfaces "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/poc.autoscaling.k8s.io/v1alpha1"
+	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/poc.autoscaling.k8s.io/v1alpha1"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -36,7 +36,7 @@ import (
 // VerticalPodAutoscalers.
 type VerticalPodAutoscalerInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1alpha1.VerticalPodAutoscalerLister
+	Lister() pocautoscalingk8siov1alpha1.VerticalPodAutoscalerLister
 }
 
 type verticalPodAutoscalerInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredVerticalPodAutoscalerInformer(client versioned.Interface, namesp
 				return client.PocV1alpha1().VerticalPodAutoscalers(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&pocautoscalingk8siov1alpha1.VerticalPodAutoscaler{},
+		&apispocautoscalingk8siov1alpha1.VerticalPodAutoscaler{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *verticalPodAutoscalerInformer) defaultInformer(client versioned.Interfa
 }
 
 func (f *verticalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&pocautoscalingk8siov1alpha1.VerticalPodAutoscaler{}, f.defaultInformer)
+	return f.factory.InformerFor(&apispocautoscalingk8siov1alpha1.VerticalPodAutoscaler{}, f.defaultInformer)
 }
 
-func (f *verticalPodAutoscalerInformer) Lister() v1alpha1.VerticalPodAutoscalerLister {
-	return v1alpha1.NewVerticalPodAutoscalerLister(f.Informer().GetIndexer())
+func (f *verticalPodAutoscalerInformer) Lister() pocautoscalingk8siov1alpha1.VerticalPodAutoscalerLister {
+	return pocautoscalingk8siov1alpha1.NewVerticalPodAutoscalerLister(f.Informer().GetIndexer())
 }

--- a/vertical-pod-autoscaler/pkg/client/informers/externalversions/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/informers/externalversions/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscalercheckpoint.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
-	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
+	apispocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
 	versioned "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	internalinterfaces "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/poc.autoscaling.k8s.io/v1alpha1"
+	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/poc.autoscaling.k8s.io/v1alpha1"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -36,7 +36,7 @@ import (
 // VerticalPodAutoscalerCheckpoints.
 type VerticalPodAutoscalerCheckpointInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1alpha1.VerticalPodAutoscalerCheckpointLister
+	Lister() pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpointLister
 }
 
 type verticalPodAutoscalerCheckpointInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredVerticalPodAutoscalerCheckpointInformer(client versioned.Interfa
 				return client.PocV1alpha1().VerticalPodAutoscalerCheckpoints(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint{},
+		&apispocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *verticalPodAutoscalerCheckpointInformer) defaultInformer(client version
 }
 
 func (f *verticalPodAutoscalerCheckpointInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint{}, f.defaultInformer)
+	return f.factory.InformerFor(&apispocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint{}, f.defaultInformer)
 }
 
-func (f *verticalPodAutoscalerCheckpointInformer) Lister() v1alpha1.VerticalPodAutoscalerCheckpointLister {
-	return v1alpha1.NewVerticalPodAutoscalerCheckpointLister(f.Informer().GetIndexer())
+func (f *verticalPodAutoscalerCheckpointInformer) Lister() pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpointLister {
+	return pocautoscalingk8siov1alpha1.NewVerticalPodAutoscalerCheckpointLister(f.Informer().GetIndexer())
 }

--- a/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1/verticalpodautoscaler.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
-	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	labels "k8s.io/apimachinery/pkg/labels"
+	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // VerticalPodAutoscalerLister helps list VerticalPodAutoscalers.
@@ -30,7 +30,7 @@ import (
 type VerticalPodAutoscalerLister interface {
 	// List lists all VerticalPodAutoscalers in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.VerticalPodAutoscaler, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1.VerticalPodAutoscaler, err error)
 	// VerticalPodAutoscalers returns an object that can list and get VerticalPodAutoscalers.
 	VerticalPodAutoscalers(namespace string) VerticalPodAutoscalerNamespaceLister
 	VerticalPodAutoscalerListerExpansion
@@ -38,17 +38,17 @@ type VerticalPodAutoscalerLister interface {
 
 // verticalPodAutoscalerLister implements the VerticalPodAutoscalerLister interface.
 type verticalPodAutoscalerLister struct {
-	listers.ResourceIndexer[*v1.VerticalPodAutoscaler]
+	listers.ResourceIndexer[*autoscalingk8siov1.VerticalPodAutoscaler]
 }
 
 // NewVerticalPodAutoscalerLister returns a new VerticalPodAutoscalerLister.
 func NewVerticalPodAutoscalerLister(indexer cache.Indexer) VerticalPodAutoscalerLister {
-	return &verticalPodAutoscalerLister{listers.New[*v1.VerticalPodAutoscaler](indexer, v1.Resource("verticalpodautoscaler"))}
+	return &verticalPodAutoscalerLister{listers.New[*autoscalingk8siov1.VerticalPodAutoscaler](indexer, autoscalingk8siov1.Resource("verticalpodautoscaler"))}
 }
 
 // VerticalPodAutoscalers returns an object that can list and get VerticalPodAutoscalers.
 func (s *verticalPodAutoscalerLister) VerticalPodAutoscalers(namespace string) VerticalPodAutoscalerNamespaceLister {
-	return verticalPodAutoscalerNamespaceLister{listers.NewNamespaced[*v1.VerticalPodAutoscaler](s.ResourceIndexer, namespace)}
+	return verticalPodAutoscalerNamespaceLister{listers.NewNamespaced[*autoscalingk8siov1.VerticalPodAutoscaler](s.ResourceIndexer, namespace)}
 }
 
 // VerticalPodAutoscalerNamespaceLister helps list and get VerticalPodAutoscalers.
@@ -56,15 +56,15 @@ func (s *verticalPodAutoscalerLister) VerticalPodAutoscalers(namespace string) V
 type VerticalPodAutoscalerNamespaceLister interface {
 	// List lists all VerticalPodAutoscalers in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.VerticalPodAutoscaler, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1.VerticalPodAutoscaler, err error)
 	// Get retrieves the VerticalPodAutoscaler from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.VerticalPodAutoscaler, error)
+	Get(name string) (*autoscalingk8siov1.VerticalPodAutoscaler, error)
 	VerticalPodAutoscalerNamespaceListerExpansion
 }
 
 // verticalPodAutoscalerNamespaceLister implements the VerticalPodAutoscalerNamespaceLister
 // interface.
 type verticalPodAutoscalerNamespaceLister struct {
-	listers.ResourceIndexer[*v1.VerticalPodAutoscaler]
+	listers.ResourceIndexer[*autoscalingk8siov1.VerticalPodAutoscaler]
 }

--- a/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoint.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
-	v1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	labels "k8s.io/apimachinery/pkg/labels"
+	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // VerticalPodAutoscalerCheckpointLister helps list VerticalPodAutoscalerCheckpoints.
@@ -30,7 +30,7 @@ import (
 type VerticalPodAutoscalerCheckpointLister interface {
 	// List lists all VerticalPodAutoscalerCheckpoints in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.VerticalPodAutoscalerCheckpoint, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, err error)
 	// VerticalPodAutoscalerCheckpoints returns an object that can list and get VerticalPodAutoscalerCheckpoints.
 	VerticalPodAutoscalerCheckpoints(namespace string) VerticalPodAutoscalerCheckpointNamespaceLister
 	VerticalPodAutoscalerCheckpointListerExpansion
@@ -38,17 +38,17 @@ type VerticalPodAutoscalerCheckpointLister interface {
 
 // verticalPodAutoscalerCheckpointLister implements the VerticalPodAutoscalerCheckpointLister interface.
 type verticalPodAutoscalerCheckpointLister struct {
-	listers.ResourceIndexer[*v1.VerticalPodAutoscalerCheckpoint]
+	listers.ResourceIndexer[*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint]
 }
 
 // NewVerticalPodAutoscalerCheckpointLister returns a new VerticalPodAutoscalerCheckpointLister.
 func NewVerticalPodAutoscalerCheckpointLister(indexer cache.Indexer) VerticalPodAutoscalerCheckpointLister {
-	return &verticalPodAutoscalerCheckpointLister{listers.New[*v1.VerticalPodAutoscalerCheckpoint](indexer, v1.Resource("verticalpodautoscalercheckpoint"))}
+	return &verticalPodAutoscalerCheckpointLister{listers.New[*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint](indexer, autoscalingk8siov1.Resource("verticalpodautoscalercheckpoint"))}
 }
 
 // VerticalPodAutoscalerCheckpoints returns an object that can list and get VerticalPodAutoscalerCheckpoints.
 func (s *verticalPodAutoscalerCheckpointLister) VerticalPodAutoscalerCheckpoints(namespace string) VerticalPodAutoscalerCheckpointNamespaceLister {
-	return verticalPodAutoscalerCheckpointNamespaceLister{listers.NewNamespaced[*v1.VerticalPodAutoscalerCheckpoint](s.ResourceIndexer, namespace)}
+	return verticalPodAutoscalerCheckpointNamespaceLister{listers.NewNamespaced[*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint](s.ResourceIndexer, namespace)}
 }
 
 // VerticalPodAutoscalerCheckpointNamespaceLister helps list and get VerticalPodAutoscalerCheckpoints.
@@ -56,15 +56,15 @@ func (s *verticalPodAutoscalerCheckpointLister) VerticalPodAutoscalerCheckpoints
 type VerticalPodAutoscalerCheckpointNamespaceLister interface {
 	// List lists all VerticalPodAutoscalerCheckpoints in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.VerticalPodAutoscalerCheckpoint, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, err error)
 	// Get retrieves the VerticalPodAutoscalerCheckpoint from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.VerticalPodAutoscalerCheckpoint, error)
+	Get(name string) (*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint, error)
 	VerticalPodAutoscalerCheckpointNamespaceListerExpansion
 }
 
 // verticalPodAutoscalerCheckpointNamespaceLister implements the VerticalPodAutoscalerCheckpointNamespaceLister
 // interface.
 type verticalPodAutoscalerCheckpointNamespaceLister struct {
-	listers.ResourceIndexer[*v1.VerticalPodAutoscalerCheckpoint]
+	listers.ResourceIndexer[*autoscalingk8siov1.VerticalPodAutoscalerCheckpoint]
 }

--- a/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1/verticalpodautoscaler.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
-	v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	labels "k8s.io/apimachinery/pkg/labels"
+	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // VerticalPodAutoscalerLister helps list VerticalPodAutoscalers.
@@ -30,7 +30,7 @@ import (
 type VerticalPodAutoscalerLister interface {
 	// List lists all VerticalPodAutoscalers in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.VerticalPodAutoscaler, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1beta1.VerticalPodAutoscaler, err error)
 	// VerticalPodAutoscalers returns an object that can list and get VerticalPodAutoscalers.
 	VerticalPodAutoscalers(namespace string) VerticalPodAutoscalerNamespaceLister
 	VerticalPodAutoscalerListerExpansion
@@ -38,17 +38,17 @@ type VerticalPodAutoscalerLister interface {
 
 // verticalPodAutoscalerLister implements the VerticalPodAutoscalerLister interface.
 type verticalPodAutoscalerLister struct {
-	listers.ResourceIndexer[*v1beta1.VerticalPodAutoscaler]
+	listers.ResourceIndexer[*autoscalingk8siov1beta1.VerticalPodAutoscaler]
 }
 
 // NewVerticalPodAutoscalerLister returns a new VerticalPodAutoscalerLister.
 func NewVerticalPodAutoscalerLister(indexer cache.Indexer) VerticalPodAutoscalerLister {
-	return &verticalPodAutoscalerLister{listers.New[*v1beta1.VerticalPodAutoscaler](indexer, v1beta1.Resource("verticalpodautoscaler"))}
+	return &verticalPodAutoscalerLister{listers.New[*autoscalingk8siov1beta1.VerticalPodAutoscaler](indexer, autoscalingk8siov1beta1.Resource("verticalpodautoscaler"))}
 }
 
 // VerticalPodAutoscalers returns an object that can list and get VerticalPodAutoscalers.
 func (s *verticalPodAutoscalerLister) VerticalPodAutoscalers(namespace string) VerticalPodAutoscalerNamespaceLister {
-	return verticalPodAutoscalerNamespaceLister{listers.NewNamespaced[*v1beta1.VerticalPodAutoscaler](s.ResourceIndexer, namespace)}
+	return verticalPodAutoscalerNamespaceLister{listers.NewNamespaced[*autoscalingk8siov1beta1.VerticalPodAutoscaler](s.ResourceIndexer, namespace)}
 }
 
 // VerticalPodAutoscalerNamespaceLister helps list and get VerticalPodAutoscalers.
@@ -56,15 +56,15 @@ func (s *verticalPodAutoscalerLister) VerticalPodAutoscalers(namespace string) V
 type VerticalPodAutoscalerNamespaceLister interface {
 	// List lists all VerticalPodAutoscalers in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.VerticalPodAutoscaler, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1beta1.VerticalPodAutoscaler, err error)
 	// Get retrieves the VerticalPodAutoscaler from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta1.VerticalPodAutoscaler, error)
+	Get(name string) (*autoscalingk8siov1beta1.VerticalPodAutoscaler, error)
 	VerticalPodAutoscalerNamespaceListerExpansion
 }
 
 // verticalPodAutoscalerNamespaceLister implements the VerticalPodAutoscalerNamespaceLister
 // interface.
 type verticalPodAutoscalerNamespaceLister struct {
-	listers.ResourceIndexer[*v1beta1.VerticalPodAutoscaler]
+	listers.ResourceIndexer[*autoscalingk8siov1beta1.VerticalPodAutoscaler]
 }

--- a/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta1/verticalpodautoscalercheckpoint.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
-	v1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	labels "k8s.io/apimachinery/pkg/labels"
+	autoscalingk8siov1beta1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta1"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // VerticalPodAutoscalerCheckpointLister helps list VerticalPodAutoscalerCheckpoints.
@@ -30,7 +30,7 @@ import (
 type VerticalPodAutoscalerCheckpointLister interface {
 	// List lists all VerticalPodAutoscalerCheckpoints in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.VerticalPodAutoscalerCheckpoint, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, err error)
 	// VerticalPodAutoscalerCheckpoints returns an object that can list and get VerticalPodAutoscalerCheckpoints.
 	VerticalPodAutoscalerCheckpoints(namespace string) VerticalPodAutoscalerCheckpointNamespaceLister
 	VerticalPodAutoscalerCheckpointListerExpansion
@@ -38,17 +38,17 @@ type VerticalPodAutoscalerCheckpointLister interface {
 
 // verticalPodAutoscalerCheckpointLister implements the VerticalPodAutoscalerCheckpointLister interface.
 type verticalPodAutoscalerCheckpointLister struct {
-	listers.ResourceIndexer[*v1beta1.VerticalPodAutoscalerCheckpoint]
+	listers.ResourceIndexer[*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint]
 }
 
 // NewVerticalPodAutoscalerCheckpointLister returns a new VerticalPodAutoscalerCheckpointLister.
 func NewVerticalPodAutoscalerCheckpointLister(indexer cache.Indexer) VerticalPodAutoscalerCheckpointLister {
-	return &verticalPodAutoscalerCheckpointLister{listers.New[*v1beta1.VerticalPodAutoscalerCheckpoint](indexer, v1beta1.Resource("verticalpodautoscalercheckpoint"))}
+	return &verticalPodAutoscalerCheckpointLister{listers.New[*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint](indexer, autoscalingk8siov1beta1.Resource("verticalpodautoscalercheckpoint"))}
 }
 
 // VerticalPodAutoscalerCheckpoints returns an object that can list and get VerticalPodAutoscalerCheckpoints.
 func (s *verticalPodAutoscalerCheckpointLister) VerticalPodAutoscalerCheckpoints(namespace string) VerticalPodAutoscalerCheckpointNamespaceLister {
-	return verticalPodAutoscalerCheckpointNamespaceLister{listers.NewNamespaced[*v1beta1.VerticalPodAutoscalerCheckpoint](s.ResourceIndexer, namespace)}
+	return verticalPodAutoscalerCheckpointNamespaceLister{listers.NewNamespaced[*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint](s.ResourceIndexer, namespace)}
 }
 
 // VerticalPodAutoscalerCheckpointNamespaceLister helps list and get VerticalPodAutoscalerCheckpoints.
@@ -56,15 +56,15 @@ func (s *verticalPodAutoscalerCheckpointLister) VerticalPodAutoscalerCheckpoints
 type VerticalPodAutoscalerCheckpointNamespaceLister interface {
 	// List lists all VerticalPodAutoscalerCheckpoints in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.VerticalPodAutoscalerCheckpoint, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, err error)
 	// Get retrieves the VerticalPodAutoscalerCheckpoint from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta1.VerticalPodAutoscalerCheckpoint, error)
+	Get(name string) (*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint, error)
 	VerticalPodAutoscalerCheckpointNamespaceListerExpansion
 }
 
 // verticalPodAutoscalerCheckpointNamespaceLister implements the VerticalPodAutoscalerCheckpointNamespaceLister
 // interface.
 type verticalPodAutoscalerCheckpointNamespaceLister struct {
-	listers.ResourceIndexer[*v1beta1.VerticalPodAutoscalerCheckpoint]
+	listers.ResourceIndexer[*autoscalingk8siov1beta1.VerticalPodAutoscalerCheckpoint]
 }

--- a/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta2/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta2/verticalpodautoscaler.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1beta2
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
-	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	labels "k8s.io/apimachinery/pkg/labels"
+	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // VerticalPodAutoscalerLister helps list VerticalPodAutoscalers.
@@ -30,7 +30,7 @@ import (
 type VerticalPodAutoscalerLister interface {
 	// List lists all VerticalPodAutoscalers in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta2.VerticalPodAutoscaler, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1beta2.VerticalPodAutoscaler, err error)
 	// VerticalPodAutoscalers returns an object that can list and get VerticalPodAutoscalers.
 	VerticalPodAutoscalers(namespace string) VerticalPodAutoscalerNamespaceLister
 	VerticalPodAutoscalerListerExpansion
@@ -38,17 +38,17 @@ type VerticalPodAutoscalerLister interface {
 
 // verticalPodAutoscalerLister implements the VerticalPodAutoscalerLister interface.
 type verticalPodAutoscalerLister struct {
-	listers.ResourceIndexer[*v1beta2.VerticalPodAutoscaler]
+	listers.ResourceIndexer[*autoscalingk8siov1beta2.VerticalPodAutoscaler]
 }
 
 // NewVerticalPodAutoscalerLister returns a new VerticalPodAutoscalerLister.
 func NewVerticalPodAutoscalerLister(indexer cache.Indexer) VerticalPodAutoscalerLister {
-	return &verticalPodAutoscalerLister{listers.New[*v1beta2.VerticalPodAutoscaler](indexer, v1beta2.Resource("verticalpodautoscaler"))}
+	return &verticalPodAutoscalerLister{listers.New[*autoscalingk8siov1beta2.VerticalPodAutoscaler](indexer, autoscalingk8siov1beta2.Resource("verticalpodautoscaler"))}
 }
 
 // VerticalPodAutoscalers returns an object that can list and get VerticalPodAutoscalers.
 func (s *verticalPodAutoscalerLister) VerticalPodAutoscalers(namespace string) VerticalPodAutoscalerNamespaceLister {
-	return verticalPodAutoscalerNamespaceLister{listers.NewNamespaced[*v1beta2.VerticalPodAutoscaler](s.ResourceIndexer, namespace)}
+	return verticalPodAutoscalerNamespaceLister{listers.NewNamespaced[*autoscalingk8siov1beta2.VerticalPodAutoscaler](s.ResourceIndexer, namespace)}
 }
 
 // VerticalPodAutoscalerNamespaceLister helps list and get VerticalPodAutoscalers.
@@ -56,15 +56,15 @@ func (s *verticalPodAutoscalerLister) VerticalPodAutoscalers(namespace string) V
 type VerticalPodAutoscalerNamespaceLister interface {
 	// List lists all VerticalPodAutoscalers in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta2.VerticalPodAutoscaler, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1beta2.VerticalPodAutoscaler, err error)
 	// Get retrieves the VerticalPodAutoscaler from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta2.VerticalPodAutoscaler, error)
+	Get(name string) (*autoscalingk8siov1beta2.VerticalPodAutoscaler, error)
 	VerticalPodAutoscalerNamespaceListerExpansion
 }
 
 // verticalPodAutoscalerNamespaceLister implements the VerticalPodAutoscalerNamespaceLister
 // interface.
 type verticalPodAutoscalerNamespaceLister struct {
-	listers.ResourceIndexer[*v1beta2.VerticalPodAutoscaler]
+	listers.ResourceIndexer[*autoscalingk8siov1beta2.VerticalPodAutoscaler]
 }

--- a/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta2/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1beta2/verticalpodautoscalercheckpoint.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1beta2
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
-	v1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	labels "k8s.io/apimachinery/pkg/labels"
+	autoscalingk8siov1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // VerticalPodAutoscalerCheckpointLister helps list VerticalPodAutoscalerCheckpoints.
@@ -30,7 +30,7 @@ import (
 type VerticalPodAutoscalerCheckpointLister interface {
 	// List lists all VerticalPodAutoscalerCheckpoints in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta2.VerticalPodAutoscalerCheckpoint, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, err error)
 	// VerticalPodAutoscalerCheckpoints returns an object that can list and get VerticalPodAutoscalerCheckpoints.
 	VerticalPodAutoscalerCheckpoints(namespace string) VerticalPodAutoscalerCheckpointNamespaceLister
 	VerticalPodAutoscalerCheckpointListerExpansion
@@ -38,17 +38,17 @@ type VerticalPodAutoscalerCheckpointLister interface {
 
 // verticalPodAutoscalerCheckpointLister implements the VerticalPodAutoscalerCheckpointLister interface.
 type verticalPodAutoscalerCheckpointLister struct {
-	listers.ResourceIndexer[*v1beta2.VerticalPodAutoscalerCheckpoint]
+	listers.ResourceIndexer[*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint]
 }
 
 // NewVerticalPodAutoscalerCheckpointLister returns a new VerticalPodAutoscalerCheckpointLister.
 func NewVerticalPodAutoscalerCheckpointLister(indexer cache.Indexer) VerticalPodAutoscalerCheckpointLister {
-	return &verticalPodAutoscalerCheckpointLister{listers.New[*v1beta2.VerticalPodAutoscalerCheckpoint](indexer, v1beta2.Resource("verticalpodautoscalercheckpoint"))}
+	return &verticalPodAutoscalerCheckpointLister{listers.New[*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint](indexer, autoscalingk8siov1beta2.Resource("verticalpodautoscalercheckpoint"))}
 }
 
 // VerticalPodAutoscalerCheckpoints returns an object that can list and get VerticalPodAutoscalerCheckpoints.
 func (s *verticalPodAutoscalerCheckpointLister) VerticalPodAutoscalerCheckpoints(namespace string) VerticalPodAutoscalerCheckpointNamespaceLister {
-	return verticalPodAutoscalerCheckpointNamespaceLister{listers.NewNamespaced[*v1beta2.VerticalPodAutoscalerCheckpoint](s.ResourceIndexer, namespace)}
+	return verticalPodAutoscalerCheckpointNamespaceLister{listers.NewNamespaced[*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint](s.ResourceIndexer, namespace)}
 }
 
 // VerticalPodAutoscalerCheckpointNamespaceLister helps list and get VerticalPodAutoscalerCheckpoints.
@@ -56,15 +56,15 @@ func (s *verticalPodAutoscalerCheckpointLister) VerticalPodAutoscalerCheckpoints
 type VerticalPodAutoscalerCheckpointNamespaceLister interface {
 	// List lists all VerticalPodAutoscalerCheckpoints in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta2.VerticalPodAutoscalerCheckpoint, err error)
+	List(selector labels.Selector) (ret []*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, err error)
 	// Get retrieves the VerticalPodAutoscalerCheckpoint from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta2.VerticalPodAutoscalerCheckpoint, error)
+	Get(name string) (*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint, error)
 	VerticalPodAutoscalerCheckpointNamespaceListerExpansion
 }
 
 // verticalPodAutoscalerCheckpointNamespaceLister implements the VerticalPodAutoscalerCheckpointNamespaceLister
 // interface.
 type verticalPodAutoscalerCheckpointNamespaceLister struct {
-	listers.ResourceIndexer[*v1beta2.VerticalPodAutoscalerCheckpoint]
+	listers.ResourceIndexer[*autoscalingk8siov1beta2.VerticalPodAutoscalerCheckpoint]
 }

--- a/vertical-pod-autoscaler/pkg/client/listers/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscaler.go
+++ b/vertical-pod-autoscaler/pkg/client/listers/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscaler.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
-	v1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	labels "k8s.io/apimachinery/pkg/labels"
+	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // VerticalPodAutoscalerLister helps list VerticalPodAutoscalers.
@@ -30,7 +30,7 @@ import (
 type VerticalPodAutoscalerLister interface {
 	// List lists all VerticalPodAutoscalers in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.VerticalPodAutoscaler, err error)
+	List(selector labels.Selector) (ret []*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, err error)
 	// VerticalPodAutoscalers returns an object that can list and get VerticalPodAutoscalers.
 	VerticalPodAutoscalers(namespace string) VerticalPodAutoscalerNamespaceLister
 	VerticalPodAutoscalerListerExpansion
@@ -38,17 +38,17 @@ type VerticalPodAutoscalerLister interface {
 
 // verticalPodAutoscalerLister implements the VerticalPodAutoscalerLister interface.
 type verticalPodAutoscalerLister struct {
-	listers.ResourceIndexer[*v1alpha1.VerticalPodAutoscaler]
+	listers.ResourceIndexer[*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler]
 }
 
 // NewVerticalPodAutoscalerLister returns a new VerticalPodAutoscalerLister.
 func NewVerticalPodAutoscalerLister(indexer cache.Indexer) VerticalPodAutoscalerLister {
-	return &verticalPodAutoscalerLister{listers.New[*v1alpha1.VerticalPodAutoscaler](indexer, v1alpha1.Resource("verticalpodautoscaler"))}
+	return &verticalPodAutoscalerLister{listers.New[*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler](indexer, pocautoscalingk8siov1alpha1.Resource("verticalpodautoscaler"))}
 }
 
 // VerticalPodAutoscalers returns an object that can list and get VerticalPodAutoscalers.
 func (s *verticalPodAutoscalerLister) VerticalPodAutoscalers(namespace string) VerticalPodAutoscalerNamespaceLister {
-	return verticalPodAutoscalerNamespaceLister{listers.NewNamespaced[*v1alpha1.VerticalPodAutoscaler](s.ResourceIndexer, namespace)}
+	return verticalPodAutoscalerNamespaceLister{listers.NewNamespaced[*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler](s.ResourceIndexer, namespace)}
 }
 
 // VerticalPodAutoscalerNamespaceLister helps list and get VerticalPodAutoscalers.
@@ -56,15 +56,15 @@ func (s *verticalPodAutoscalerLister) VerticalPodAutoscalers(namespace string) V
 type VerticalPodAutoscalerNamespaceLister interface {
 	// List lists all VerticalPodAutoscalers in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.VerticalPodAutoscaler, err error)
+	List(selector labels.Selector) (ret []*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, err error)
 	// Get retrieves the VerticalPodAutoscaler from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.VerticalPodAutoscaler, error)
+	Get(name string) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler, error)
 	VerticalPodAutoscalerNamespaceListerExpansion
 }
 
 // verticalPodAutoscalerNamespaceLister implements the VerticalPodAutoscalerNamespaceLister
 // interface.
 type verticalPodAutoscalerNamespaceLister struct {
-	listers.ResourceIndexer[*v1alpha1.VerticalPodAutoscaler]
+	listers.ResourceIndexer[*pocautoscalingk8siov1alpha1.VerticalPodAutoscaler]
 }

--- a/vertical-pod-autoscaler/pkg/client/listers/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscalercheckpoint.go
+++ b/vertical-pod-autoscaler/pkg/client/listers/poc.autoscaling.k8s.io/v1alpha1/verticalpodautoscalercheckpoint.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
-	v1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	labels "k8s.io/apimachinery/pkg/labels"
+	pocautoscalingk8siov1alpha1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/poc.autoscaling.k8s.io/v1alpha1"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // VerticalPodAutoscalerCheckpointLister helps list VerticalPodAutoscalerCheckpoints.
@@ -30,7 +30,7 @@ import (
 type VerticalPodAutoscalerCheckpointLister interface {
 	// List lists all VerticalPodAutoscalerCheckpoints in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.VerticalPodAutoscalerCheckpoint, err error)
+	List(selector labels.Selector) (ret []*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, err error)
 	// VerticalPodAutoscalerCheckpoints returns an object that can list and get VerticalPodAutoscalerCheckpoints.
 	VerticalPodAutoscalerCheckpoints(namespace string) VerticalPodAutoscalerCheckpointNamespaceLister
 	VerticalPodAutoscalerCheckpointListerExpansion
@@ -38,17 +38,17 @@ type VerticalPodAutoscalerCheckpointLister interface {
 
 // verticalPodAutoscalerCheckpointLister implements the VerticalPodAutoscalerCheckpointLister interface.
 type verticalPodAutoscalerCheckpointLister struct {
-	listers.ResourceIndexer[*v1alpha1.VerticalPodAutoscalerCheckpoint]
+	listers.ResourceIndexer[*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint]
 }
 
 // NewVerticalPodAutoscalerCheckpointLister returns a new VerticalPodAutoscalerCheckpointLister.
 func NewVerticalPodAutoscalerCheckpointLister(indexer cache.Indexer) VerticalPodAutoscalerCheckpointLister {
-	return &verticalPodAutoscalerCheckpointLister{listers.New[*v1alpha1.VerticalPodAutoscalerCheckpoint](indexer, v1alpha1.Resource("verticalpodautoscalercheckpoint"))}
+	return &verticalPodAutoscalerCheckpointLister{listers.New[*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint](indexer, pocautoscalingk8siov1alpha1.Resource("verticalpodautoscalercheckpoint"))}
 }
 
 // VerticalPodAutoscalerCheckpoints returns an object that can list and get VerticalPodAutoscalerCheckpoints.
 func (s *verticalPodAutoscalerCheckpointLister) VerticalPodAutoscalerCheckpoints(namespace string) VerticalPodAutoscalerCheckpointNamespaceLister {
-	return verticalPodAutoscalerCheckpointNamespaceLister{listers.NewNamespaced[*v1alpha1.VerticalPodAutoscalerCheckpoint](s.ResourceIndexer, namespace)}
+	return verticalPodAutoscalerCheckpointNamespaceLister{listers.NewNamespaced[*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint](s.ResourceIndexer, namespace)}
 }
 
 // VerticalPodAutoscalerCheckpointNamespaceLister helps list and get VerticalPodAutoscalerCheckpoints.
@@ -56,15 +56,15 @@ func (s *verticalPodAutoscalerCheckpointLister) VerticalPodAutoscalerCheckpoints
 type VerticalPodAutoscalerCheckpointNamespaceLister interface {
 	// List lists all VerticalPodAutoscalerCheckpoints in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.VerticalPodAutoscalerCheckpoint, err error)
+	List(selector labels.Selector) (ret []*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, err error)
 	// Get retrieves the VerticalPodAutoscalerCheckpoint from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.VerticalPodAutoscalerCheckpoint, error)
+	Get(name string) (*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint, error)
 	VerticalPodAutoscalerCheckpointNamespaceListerExpansion
 }
 
 // verticalPodAutoscalerCheckpointNamespaceLister implements the VerticalPodAutoscalerCheckpointNamespaceLister
 // interface.
 type verticalPodAutoscalerCheckpointNamespaceLister struct {
-	listers.ResourceIndexer[*v1alpha1.VerticalPodAutoscalerCheckpoint]
+	listers.ResourceIndexer[*pocautoscalingk8siov1alpha1.VerticalPodAutoscalerCheckpoint]
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR runs the `hack/update-codegen.sh` to include any changes that might have come in after the dependency update.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
