### PR TITLE
Add test for recomputing similar nodegroups

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -1060,7 +1060,7 @@ func runSimpleScaleUpTest(t *testing.T, config *ScaleUpTestConfig) *ScaleUpTestR
 	}
 	orchestrator := New()
 	orchestrator.Initialize(&context, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{})
-	expander := NewMockRepotingStrategy(t, config.ExpansionOptionToChoose)
+	expander := NewMockReportingStrategy(t, config.ExpansionOptionToChoose, nil)
 	context.ExpanderStrategy = expander
 
 	// scale up
@@ -1217,7 +1217,7 @@ func TestBinpackingLimiter(t *testing.T) {
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&context, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{})
 
-	expander := NewMockRepotingStrategy(t, nil)
+	expander := NewMockReportingStrategy(t, nil, nil)
 	context.ExpanderStrategy = expander
 
 	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{extraPod}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
@@ -1433,80 +1433,104 @@ func TestComputeSimilarNodeGroups(t *testing.T) {
 }
 
 func TestScaleUpBalanceGroups(t *testing.T) {
-	provider := testprovider.NewTestCloudProvider(func(string, int) error {
-		return nil
-	}, nil)
+	// this will set the similar node groups to empty, it should be recomputed during scaleup
+	emptySimilarNodeGroups := []string{}
+	noSimilarNodeGroupsExpander := NewMockReportingStrategy(t, &GroupSizeChange{GroupName: "ng2", SizeChange: 2}, &emptySimilarNodeGroups)
 
-	type ngInfo struct {
-		min, max, size int
-	}
-	testCfg := map[string]ngInfo{
-		"ng1": {min: 1, max: 1, size: 1},
-		"ng2": {min: 1, max: 2, size: 1},
-		"ng3": {min: 1, max: 5, size: 1},
-		"ng4": {min: 1, max: 5, size: 3},
-	}
-	podList := make([]*apiv1.Pod, 0, len(testCfg))
-	nodes := make([]*apiv1.Node, 0)
-
-	now := time.Now()
-
-	for gid, gconf := range testCfg {
-		provider.AddNodeGroup(gid, gconf.min, gconf.max, gconf.size)
-		for i := 0; i < gconf.size; i++ {
-			nodeName := fmt.Sprintf("%v-node-%v", gid, i)
-			node := BuildTestNode(nodeName, 100, 1000)
-			SetNodeReadyState(node, true, now.Add(-2*time.Minute))
-			nodes = append(nodes, node)
-
-			pod := BuildTestPod(fmt.Sprintf("%v-pod-%v", gid, i), 80, 0)
-			pod.Spec.NodeName = nodeName
-			podList = append(podList, pod)
-
-			provider.AddNode(gid, node)
-		}
+	testCases := []struct {
+		name             string
+		expanderStrategy *MockReportingStrategy
+	}{
+		{
+			name: "balance groups",
+		},
+		{
+			name:             "balance groups recomputes similar nodegroups",
+			expanderStrategy: noSimilarNodeGroupsExpander,
+		},
 	}
 
-	podLister := kube_util.NewTestPodLister(podList)
-	listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := testprovider.NewTestCloudProvider(func(string, int) error {
+				return nil
+			}, nil)
 
-	options := config.AutoscalingOptions{
-		EstimatorName:            estimator.BinpackingEstimatorName,
-		BalanceSimilarNodeGroups: true,
-		MaxCoresTotal:            config.DefaultMaxClusterCores,
-		MaxMemoryTotal:           config.DefaultMaxClusterMemory,
+			type ngInfo struct {
+				min, max, size int
+			}
+			testCfg := map[string]ngInfo{
+				"ng1": {min: 1, max: 1, size: 1},
+				"ng2": {min: 1, max: 2, size: 1},
+				"ng3": {min: 1, max: 5, size: 1},
+				"ng4": {min: 1, max: 5, size: 3},
+			}
+			podList := make([]*apiv1.Pod, 0, len(testCfg))
+			nodes := make([]*apiv1.Node, 0)
+
+			now := time.Now()
+
+			for gid, gconf := range testCfg {
+				provider.AddNodeGroup(gid, gconf.min, gconf.max, gconf.size)
+				for i := 0; i < gconf.size; i++ {
+					nodeName := fmt.Sprintf("%v-node-%v", gid, i)
+					node := BuildTestNode(nodeName, 100, 1000)
+					SetNodeReadyState(node, true, now.Add(-2*time.Minute))
+					nodes = append(nodes, node)
+
+					pod := BuildTestPod(fmt.Sprintf("%v-pod-%v", gid, i), 80, 0)
+					pod.Spec.NodeName = nodeName
+					podList = append(podList, pod)
+
+					provider.AddNode(gid, node)
+				}
+			}
+
+			podLister := kube_util.NewTestPodLister(podList)
+			listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
+
+			options := config.AutoscalingOptions{
+				EstimatorName:            estimator.BinpackingEstimatorName,
+				BalanceSimilarNodeGroups: true,
+				MaxCoresTotal:            config.DefaultMaxClusterCores,
+				MaxMemoryTotal:           config.DefaultMaxClusterMemory,
+			}
+			context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
+			assert.NoError(t, err)
+			err = context.ClusterSnapshot.SetClusterState(nodes, podList, drasnapshot.Snapshot{})
+			assert.NoError(t, err)
+			nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+			clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker())
+			clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+
+			pods := make([]*apiv1.Pod, 0)
+			for i := 0; i < 2; i++ {
+				pods = append(pods, BuildTestPod(fmt.Sprintf("test-pod-%v", i), 80, 0))
+			}
+
+			if tc.expanderStrategy != nil {
+				context.ExpanderStrategy = tc.expanderStrategy
+			}
+			processors := processorstest.NewTestProcessors(&context)
+			suOrchestrator := New()
+			suOrchestrator.Initialize(&context, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{})
+			scaleUpStatus, typedErr := suOrchestrator.ScaleUp(pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+
+			assert.NoError(t, typedErr)
+			assert.True(t, scaleUpStatus.WasSuccessful())
+			groupMap := make(map[string]cloudprovider.NodeGroup, 3)
+			for _, group := range provider.NodeGroups() {
+				groupMap[group.Id()] = group
+			}
+
+			ng2size, err := groupMap["ng2"].TargetSize()
+			assert.NoError(t, err)
+			ng3size, err := groupMap["ng3"].TargetSize()
+			assert.NoError(t, err)
+			assert.Equal(t, 2, ng2size)
+			assert.Equal(t, 2, ng3size)
+		})
 	}
-	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
-	assert.NoError(t, err)
-	err = context.ClusterSnapshot.SetClusterState(nodes, podList, drasnapshot.Snapshot{})
-	assert.NoError(t, err)
-	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker())
-	clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
-
-	pods := make([]*apiv1.Pod, 0)
-	for i := 0; i < 2; i++ {
-		pods = append(pods, BuildTestPod(fmt.Sprintf("test-pod-%v", i), 80, 0))
-	}
-
-	processors := processorstest.NewTestProcessors(&context)
-	suOrchestrator := New()
-	suOrchestrator.Initialize(&context, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{})
-	scaleUpStatus, typedErr := suOrchestrator.ScaleUp(pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
-
-	assert.NoError(t, typedErr)
-	assert.True(t, scaleUpStatus.WasSuccessful())
-	groupMap := make(map[string]cloudprovider.NodeGroup, 3)
-	for _, group := range provider.NodeGroups() {
-		groupMap[group.Id()] = group
-	}
-
-	ng2size, err := groupMap["ng2"].TargetSize()
-	assert.NoError(t, err)
-	ng3size, err := groupMap["ng3"].TargetSize()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, ng2size)
-	assert.Equal(t, 2, ng3size)
 }
 
 func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -19,6 +19,7 @@ package test
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -341,19 +342,21 @@ type expanderResults struct {
 
 // MockReportingStrategy implements expander.Strategy
 type MockReportingStrategy struct {
-	defaultStrategy expander.Strategy
-	optionToChoose  *GroupSizeChange
-	t               *testing.T
-	results         *expanderResults
+	defaultStrategy           expander.Strategy
+	optionToChoose            *GroupSizeChange
+	similarNodeGroupsToChoose *[]string
+	t                         *testing.T
+	results                   *expanderResults
 }
 
-// NewMockRepotingStrategy creates an expander strategy with reporting and mocking capabilities.
-func NewMockRepotingStrategy(t *testing.T, optionToChoose *GroupSizeChange) *MockReportingStrategy {
+// NewMockReportingStrategy creates an expander strategy with reporting and mocking capabilities.
+func NewMockReportingStrategy(t *testing.T, optionToChoose *GroupSizeChange, similarNodeGroupsToChoose *[]string) *MockReportingStrategy {
 	return &MockReportingStrategy{
-		defaultStrategy: random.NewStrategy(),
-		results:         &expanderResults{},
-		optionToChoose:  optionToChoose,
-		t:               t,
+		defaultStrategy:           random.NewStrategy(),
+		results:                   &expanderResults{},
+		optionToChoose:            optionToChoose,
+		similarNodeGroupsToChoose: similarNodeGroupsToChoose,
+		t:                         t,
 	}
 }
 
@@ -373,7 +376,16 @@ func (r *MockReportingStrategy) BestOption(options []expander.Option, nodeInfo m
 	for _, option := range options {
 		groupSizeChange := expanderOptionToGroupSizeChange(option)
 		if groupSizeChange == *r.optionToChoose {
-			return &option
+			bestOption := option
+			if r.similarNodeGroupsToChoose != nil {
+				bestOption.SimilarNodeGroups = []cloudprovider.NodeGroup{}
+				for _, nodeGroup := range options {
+					if slices.Contains(*r.similarNodeGroupsToChoose, nodeGroup.NodeGroup.Id()) {
+						bestOption.SimilarNodeGroups = append(bestOption.SimilarNodeGroups, nodeGroup.NodeGroup)
+					}
+				}
+			}
+			return &bestOption
 		}
 	}
 	assert.Fail(r.t, "did not find expansionOptionToChoose %+v", r.optionToChoose)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Related to https://github.com/kubernetes/autoscaler/pull/6926

It was suggested that first I add a test that will ensure that by default the similar nodegroup recomputation works. And then in my other PR I can add a test to ensure that if the `SkipSimilarNodeGroupRecomputation` field is true, then we will not recompute similar nodegroups

This adds no new functionality, just a test. It is almost identical to the existing test [here](https://github.com/kubernetes/autoscaler/blob/4896bd81877ef4a171ca56cc7fc954a06b2a1dd9/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go#L1429-L1503). My new test just changes the expander strategy so that it returns a best option with no similar nodegroups. This will test to make sure [this line](https://github.com/kubernetes/autoscaler/blob/4896bd81877ef4a171ca56cc7fc954a06b2a1dd9/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go#L688-L689) correctly recomputes the similar nodegroups

#### Special notes for your reviewer:

You can hide whitespace changes to make it easier to review

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
