### PR TITLE
Add cloudbuild.yaml for addon-resizer

### DIFF
--- a/addon-resizer/cloudbuild.yaml
+++ b/addon-resizer/cloudbuild.yaml
@@ -1,0 +1,15 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest'
+    entrypoint: make
+    env:
+    - TAG=$_GIT_TAG
+    args:
+    - all-push
+substitutions:
+  _GIT_TAG: '0.0.0' # default value, this is substituted at build time


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is the first step from the [onboarding process](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md) to integrate automatic continuous builds.

I am using addon-resizer as a first candidate for the process to become familiar with it so that I can also apply it to VPA and CA.

The next step will be to setup the prow job in the https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing directory to kick off this process automatically.

#### Which issue(s) this PR fixes:

Ref #7615

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```