### PR TITLE
VPA: Clean up unused `cd` invocation in the `generate-crd-yaml.sh` script

### DIFF
--- a/vertical-pod-autoscaler/hack/generate-crd-yaml.sh
+++ b/vertical-pod-autoscaler/hack/generate-crd-yaml.sh
@@ -44,6 +44,5 @@ ${CONTROLLER_GEN} ${CRD_OPTS} paths="${APIS_PATH}/..." output:crd:dir="\"${WORKS
 grep -v -e 'map keys must be strings, not int' -e 'not all generators ran successfully' -e 'usage' ${WORKSPACE}/errors.log \
     && { echo "Failed to generate CRD YAMLs."; exit 1; }
 
-cd ${WORKSPACE}
 cat "${WORKSPACE}/autoscaling.k8s.io_verticalpodautoscalercheckpoints.yaml" > ${OUTPUT}
 cat "${WORKSPACE}/autoscaling.k8s.io_verticalpodautoscalers.yaml" >> ${OUTPUT}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
While inspecting my changes in https://github.com/kubernetes/autoscaler/pull/7605, I noticed that the `cd ${WORKSPACE}` invocation in https://github.com/kubernetes/autoscaler/pull/7605/files#diff-bff56f4f4c6437e70a970d361f1b5aa99bb218b03adda6f3c5226e029a716c22R47 can be removed.
Previously, `cd ${WORKSPACE}` was required because `kubectl kustomize` was used and the generated files were referenced by relative path.
After https://github.com/kubernetes/autoscaler/pull/7605, we no longer reference using relative path.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow-up after https://github.com/kubernetes/autoscaler/pull/7605

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
