### PR TITLE
Handle Error for Pods with `ownerRef: Node`

### DIFF
--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -18,6 +18,7 @@ package controllerfetcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -58,6 +59,8 @@ const (
 const (
 	discoveryResetPeriod time.Duration = 5 * time.Minute
 )
+
+var NodeInvalidOwnerError = errors.New("node is not a valid owner")
 
 // ControllerKey identifies a controller.
 type ControllerKey struct {
@@ -290,7 +293,7 @@ func (f *controllerFetcher) getOwnerForScaleResource(ctx context.Context, groupK
 		// Some pods specify nodes as their owners. This causes performance problems
 		// in big clusters when VPA tries to get all nodes. We know nodes aren't
 		// valid controllers so we can skip trying to fetch them.
-		return nil, fmt.Errorf("node is not a valid owner")
+		return nil, NodeInvalidOwnerError
 	}
 	mappings, err := f.mapper.RESTMappings(groupKind)
 	if err != nil {

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -60,6 +60,7 @@ const (
 	discoveryResetPeriod time.Duration = 5 * time.Minute
 )
 
+// ErrNodeInvalidOwner is thrown when a Pod is owned by a Node.
 var ErrNodeInvalidOwner = errors.New("node is not a valid owner")
 
 // ControllerKey identifies a controller.

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -60,7 +60,7 @@ const (
 	discoveryResetPeriod time.Duration = 5 * time.Minute
 )
 
-var NodeInvalidOwnerError = errors.New("node is not a valid owner")
+var ErrNodeInvalidOwner = errors.New("node is not a valid owner")
 
 // ControllerKey identifies a controller.
 type ControllerKey struct {
@@ -293,7 +293,7 @@ func (f *controllerFetcher) getOwnerForScaleResource(ctx context.Context, groupK
 		// Some pods specify nodes as their owners. This causes performance problems
 		// in big clusters when VPA tries to get all nodes. We know nodes aren't
 		// valid controllers so we can skip trying to fetch them.
-		return nil, NodeInvalidOwnerError
+		return nil, ErrNodeInvalidOwner
 	}
 	mappings, err := f.mapper.RESTMappings(groupKind)
 	if err != nil {

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package controllerfetcher
 
-import (
-	"context"
-	"fmt"
-)
+import "context"
 
 // FakeControllerFetcher should be used in test only. It returns exactly the same controllerKey
 type FakeControllerFetcher struct{}
@@ -28,7 +25,7 @@ type FakeControllerFetcher struct{}
 // See pkg/target/controller_fetcher/controller_fetcher.go:296 where the original implementation does the same.
 func (f FakeControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context, controller *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
 	if controller.Kind == "Node" {
-		return nil, fmt.Errorf("node is not a valid owner")
+		return nil, NodeInvalidOwnerError
 	}
 	return controller, nil
 }

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
@@ -16,13 +16,20 @@ limitations under the License.
 
 package controllerfetcher
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // FakeControllerFetcher should be used in test only. It returns exactly the same controllerKey
 type FakeControllerFetcher struct{}
 
-// FindTopMostWellKnownOrScalable returns the same key for that fake implementation
+// FindTopMostWellKnownOrScalable returns the same key for that fake implementation and returns and error when the kind is Node
+// See pkg/target/controller_fetcher/controller_fetcher.go:296 where the original implementation does the same.
 func (f FakeControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context, controller *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+	if controller.Kind == "Node" {
+		return nil, fmt.Errorf("node is not a valid owner")
+	}
 	return controller, nil
 }
 

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
@@ -26,4 +26,12 @@ func (f FakeControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context,
 	return controller, nil
 }
 
+// NilControllerFetcher is a fake ControllerFetcher which always returns 'nil'
+type NilControllerFetcher struct{}
+
+// FindTopMostWellKnownOrScalable always returns nil
+func (f NilControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context, _ *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+	return nil, nil
+}
+
 var _ ControllerFetcher = &FakeControllerFetcher{}

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
@@ -25,7 +25,7 @@ type FakeControllerFetcher struct{}
 // See pkg/target/controller_fetcher/controller_fetcher.go:296 where the original implementation does the same.
 func (f FakeControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context, controller *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
 	if controller.Kind == "Node" {
-		return nil, NodeInvalidOwnerError
+		return nil, ErrNodeInvalidOwner
 	}
 	return controller, nil
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -187,7 +187,7 @@ func FindParentControllerForPod(ctx context.Context, pod *core.Pod, ctrlFetcher 
 	// validating the targetRef of a VPA, this is a valid scenario when iterating over all Pods and finding their owner.
 	// vpa updater and admission-controller don't care about these Pods, because they cannot have a valid VPA point to
 	// them, so it is safe to ignore this here.
-	if err != nil && !errors.Is(err, controllerfetcher.NodeInvalidOwnerError) {
+	if err != nil && !errors.Is(err, controllerfetcher.ErrNodeInvalidOwner) {
 		return nil, err
 	}
 	return controller, nil

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -19,6 +19,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -180,7 +181,16 @@ func FindParentControllerForPod(ctx context.Context, pod *core.Pod, ctrlFetcher 
 		},
 		ApiVersion: ownerRefrence.APIVersion,
 	}
-	return ctrlFetcher.FindTopMostWellKnownOrScalable(ctx, k)
+	controller, err := ctrlFetcher.FindTopMostWellKnownOrScalable(ctx, k)
+
+	// ignore NodeInvalidOwner error when looking for the parent controller for a Pod. While this _is_ an error when
+	// validating the targetRef of a VPA, this is a valid scenario when iterating over all Pods and finding their owner.
+	// vpa updater and admission-controller don't care about these Pods, because they cannot have a valid VPA point to
+	// them, so it is safe to ignore this here.
+	if err != nil && !errors.Is(err, controllerfetcher.NodeInvalidOwnerError) {
+		return nil, err
+	}
+	return controller, nil
 }
 
 // GetUpdateMode returns the updatePolicy.updateMode for a given VPA.

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -373,6 +373,24 @@ func TestFindParentControllerForPod(t *testing.T) {
 				ApiVersion: "apps/v1",
 			},
 		},
+		{
+			name: "should not return an error for Node owner reference",
+			pod: &core.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Namespace: "bar",
+					OwnerReferences: []meta.OwnerReference{
+						{
+							APIVersion: "v1",
+							Controller: ptr.To(true),
+							Kind:       "Node",
+							Name:       "foo",
+						},
+					},
+				},
+			},
+			ctrlFetcher: &controllerfetcher.FakeControllerFetcher{},
+			expected:    nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := FindParentControllerForPod(context.Background(), tc.pod, tc.ctrlFetcher)

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -144,7 +144,6 @@ func TestPodMatchesVPA(t *testing.T) {
 func TestGetControllingVPAForPod(t *testing.T) {
 	ctx := context.Background()
 
-	isController := true
 	pod := test.Pod().WithName("test-pod").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).WithMemRequest(resource.MustParse("100M")).Get()).Get()
 	pod.Labels = map[string]string{"app": "testingApp"}
 	pod.OwnerReferences = []meta.OwnerReference{
@@ -152,7 +151,7 @@ func TestGetControllingVPAForPod(t *testing.T) {
 			APIVersion: "apps/v1",
 			Kind:       "StatefulSet",
 			Name:       "test-sts",
-			Controller: &isController,
+			Controller: ptr.To(true),
 		},
 	}
 

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -141,15 +141,6 @@ func TestPodMatchesVPA(t *testing.T) {
 	}
 }
 
-type NilControllerFetcher struct{}
-
-// FindTopMostWellKnownOrScalable returns the same key for that fake implementation
-func (f NilControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context, _ *controllerfetcher.ControllerKeyWithAPIVersion) (*controllerfetcher.ControllerKeyWithAPIVersion, error) {
-	return nil, nil
-}
-
-var _ controllerfetcher.ControllerFetcher = &NilControllerFetcher{}
-
 func TestGetControllingVPAForPod(t *testing.T) {
 	ctx := context.Background()
 
@@ -188,7 +179,7 @@ func TestGetControllingVPAForPod(t *testing.T) {
 	// For some Pods (which are *not* under VPA), controllerFetcher.FindTopMostWellKnownOrScalable will return `nil`, e.g. when the Pod owner is a custom resource, which doesn't implement the /scale subresource
 	// See pkg/target/controller_fetcher/controller_fetcher_test.go:393 for testing this behavior
 	// This test case makes sure that GetControllingVPAForPod will just return `nil` in that case as well
-	chosen = GetControllingVPAForPod(ctx, pod, []*VpaWithSelector{{vpaA, parseLabelSelector("app = testingApp")}}, &NilControllerFetcher{})
+	chosen = GetControllingVPAForPod(ctx, pod, []*VpaWithSelector{{vpaA, parseLabelSelector("app = testingApp")}}, &controllerfetcher.NilControllerFetcher{})
 	assert.Nil(t, chosen)
 }
 
@@ -321,7 +312,7 @@ func TestFindParentControllerForPod(t *testing.T) {
 					OwnerReferences: nil,
 				},
 			},
-			ctrlFetcher: &NilControllerFetcher{},
+			ctrlFetcher: &controllerfetcher.NilControllerFetcher{},
 			expected:    nil,
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
With https://github.com/kubernetes/autoscaler/pull/6460/files#diff-51c34291d2c70f6960e18f955f2a33928e8f5ac58d2d94fe0b7a8f4735f3eca3R151 we introduced as a side-effect a high amount of error logs into the vpa-updater and vpa-admission-controller. Those two components are fetching all Pods and try to find out if they are controlled via a VPA object. As part of this process, they go up the chain of `ownerRef`s.

The method `controllerFetcher#getOwnerForScaleResource` is also used during validating if a `targetRef` defined in an VPA object is valid. It correctly throws an error if a Pod `ownerRef` is of `Kind: Node`, because static Pods cannot be managed under VPA.

This PR handles the error thrown by `controllerFetcher#getOwnerForScaleResource` such that vpa-updater and vpa-admission-controller don't log an error and the original validation still remains.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7378

#### Special notes for your reviewer:
Supersedes #7609 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
vpa-updater and vpa-admission-controller no longer excessively log fail to get pod controller: (...) last error node is not a valid owner
```