### PR TITLE
Minor tweaks to addon-resizer Makefile to enable automatic builds

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -22,7 +22,7 @@ ARCH ?= amd64
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 GOARM=7
-GOLANG_VERSION = 1.22
+GOLANG_VERSION = 1.23
 REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)
@@ -55,7 +55,7 @@ container: .container-$(ARCH)
 	cp -r * $(TEMP_DIR)
 	cd $(TEMP_DIR) && sed -i 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 
-	docker run --rm -it -v $(TEMP_DIR):$(TEMP_DIR):Z -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \
+	docker run --rm -v $(TEMP_DIR):$(TEMP_DIR):Z -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \
         golang:${GOLANG_VERSION} \
         /bin/bash -c "\
             cd /go/src/k8s.io/autoscaler/addon-resizer/ && \
@@ -68,7 +68,7 @@ container: .container-$(ARCH)
 		-t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)
 
 test:
-	docker run --rm -it -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \
+	docker run --rm -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \
 	golang:${GOLANG_VERSION} \
         /bin/bash -c "\
             cd /go/src/k8s.io/autoscaler/addon-resizer/ && \


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Automatic builds are broken:

```
docker buildx inspect img-builder > /dev/null || docker buildx create --name img-builder --use
ERROR: no builder "img-builder" found
img-builder
cp -r * /tmp/tmp.LlaJKl
cd /tmp/tmp.LlaJKl && sed -i 's|BASEIMAGE|gcr.io/distroless/static:latest|g' Dockerfile
docker run --rm -it -v /tmp/tmp.LlaJKl:/tmp/tmp.LlaJKl:Z -v `pwd`:/go/src/k8s.io/autoscaler/addon-resizer/:Z \
        golang:1.22 \
        /bin/bash -c "\
            cd /go/src/k8s.io/autoscaler/addon-resizer/ && \
            CGO_ENABLED=0 GOARM=7 GOARCH=amd64 go build -a -installsuffix cgo --ldflags '-w -X k8s.io/autoscaler/addon-resizer/nanny.AddonResizerVersion=1.8.22' -o /tmp/tmp.LlaJKl/pod_nanny nanny/main/pod_nanny.go"
the input device is not a TTY
```

I confirmed that builds still work by running `make container` locally.

#### Which issue(s) this PR fixes:

Ref #7615