### PR TITLE
Ignore Containers without recommendations for EvictionRequirements

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission_test.go
@@ -402,4 +402,24 @@ func TestAdmitForMultipleContainer(t *testing.T) {
 
 		assert.Equal(tt, false, sdpea.Admit(pod, recommendation))
 	})
+
+	t.Run("it should not admit the Pod even if there is a container that doesn't have a Recommendation and the other one doesn't fulfill the EvictionRequirements", func(tt *testing.T) {
+		evictionRequirements := map[*corev1.Pod][]*v1.EvictionRequirement{
+			pod: {
+				{
+					Resources:         []corev1.ResourceName{corev1.ResourceCPU},
+					ChangeRequirement: v1.TargetHigherThanRequests,
+				},
+			},
+		}
+		sdpea := NewScalingDirectionPodEvictionAdmission()
+		sdpea.(*scalingDirectionPodEvictionAdmission).EvictionRequirements = evictionRequirements
+		recommendation := &v1.RecommendedPodResources{
+			ContainerRecommendations: []v1.RecommendedContainerResources{
+				test.Recommendation().WithContainer(container2Name).WithTarget("300m", "10Gi").GetContainerResources(),
+			},
+		}
+
+		assert.Equal(tt, false, sdpea.Admit(pod, recommendation))
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR treats Pods which have at least one container without a recommendation correctly when evaluating `EvictionRequirements` in the updater.
Previously, a Pod that had at least one Container without a recommendation was admitted for eviction, which is incorrect.
This occurs, when users set `.containerPolicy.mode: off` for a Container, which means VPA should ignore this Container entirely. The correct behavior for checking `EvictionRequirements` therefore is to ignore this container and evaluate against the other Containers of this Pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug which lead to Pods that had a Container without recommendations to be evicted despite having an EvictionRequirement configured that was evaluated to `false`.
```

