### PR TITLE
VPA: fixed flags script to include constants values

### DIFF
--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -1,6 +1,6 @@
 # What are the parameters to VPA admission controller?
 This document is auto-generated from the flag definitions in the VPA admission controller code.
-Last updated: 2024-12-17 13:09:20 UTC
+Last updated: 2024-12-21 10:48:13 UTC
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
@@ -23,31 +23,31 @@ Last updated: 2024-12-17 13:09:20 UTC
 
 # What are the parameters to VPA recommender?
 This document is auto-generated from the flag definitions in the VPA recommender code.
-Last updated: 2024-12-17 13:09:18 UTC
+Last updated: 2024-12-21 10:48:12 UTC
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | --address | String | :8942 | The address to expose Prometheus metrics. |
 | --checkpoints-gc-interval | Duration | 10Minute | `How often orphaned checkpoints should be garbage collected` |
-| --checkpoints-timeout | Duration | 0 | `Timeout for writing checkpoints since the start of the recommender's main loop` |
+| --checkpoints-timeout | Duration | time.Minute | `Timeout for writing checkpoints since the start of the recommender's main loop` |
 | --container-name-label | String | name | `Label name to look for container names` |
 | --container-namespace-label | String | namespace | `Label name to look for container namespaces` |
 | --container-pod-name-label | String | pod_name | `Label name to look for container pod names` |
-| --cpu-histogram-decay-half-life | Duration | 0 | `The amount of time it takes a historical CPU usage sample to lose half of its weight.` |
+| --cpu-histogram-decay-half-life | Duration | model.DefaultCPUHistogramDecayHalfLife | `The amount of time it takes a historical CPU usage sample to lose half of its weight.` |
 | --cpu-integer-post-processor-enabled | Bool | false | Enable the cpu-integer recommendation post processor. The post processor will round up CPU recommendations to a whole CPU for pods which were opted in by setting an appropriate label on VPA object (experimental) |
 | --external-metrics-cpu-metric | String |  | ALPHA.  Metric to use with external metrics provider for CPU usage. |
 | --external-metrics-memory-metric | String |  | ALPHA.  Metric to use with external metrics provider for memory usage. |
 | --history-length | String | 8d | `How much time back prometheus have to be queried to get historical metrics` |
 | --history-resolution | String | 1h | `Resolution at which Prometheus is queried for historical metrics` |
 | --humanize-memory | Bool | false | Convert memory values in recommendations to the highest appropriate SI unit with up to 2 decimal places for better readability. |
-| --memory-aggregation-interval | Duration | 0 | `The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in multiples of this interval. In other words there is one memory usage sample per interval (the maximum usage over that interval)` |
-| --memory-aggregation-interval-count | Int64 | 0 | `The number of consecutive memory-aggregation-intervals which make up the MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words, MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-interval-count.` |
-| --memory-histogram-decay-half-life | Duration | 0 | `The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period.` |
+| --memory-aggregation-interval | Duration | model.DefaultMemoryAggregationInterval | `The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in multiples of this interval. In other words there is one memory usage sample per interval (the maximum usage over that interval)` |
+| --memory-aggregation-interval-count | Int64 | model.DefaultMemoryAggregationIntervalCount | `The number of consecutive memory-aggregation-intervals which make up the MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words, MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-interval-count.` |
+| --memory-histogram-decay-half-life | Duration | model.DefaultMemoryHistogramDecayHalfLife | `The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period.` |
 | --memory-saver | Bool | false | `If true, only track pods which have an associated VPA` |
 | --metric-for-pod-labels | String | up{job=\"kubernetes-pods\"} | `Which metric to look for pod labels in metrics` |
 | --min-checkpoints | Int | 10 | Minimum number of checkpoints to write per recommender's main loop |
-| --oom-bump-up-ratio | Float64 | 0 | `The memory bump up ratio when OOM occurred, default is 1.2.` |
-| --oom-min-bump-up-bytes | Float64 | 0 | `The minimal increase of memory when OOM occurred in bytes, default is 100 * 1024 * 1024` |
+| --oom-bump-up-ratio | Float64 | model.DefaultOOMBumpUpRatio | `The memory bump up ratio when OOM occurred, default is 1.2.` |
+| --oom-min-bump-up-bytes | Float64 | model.DefaultOOMMinBumpUp | `The minimal increase of memory when OOM occurred in bytes, default is 100 * 1024 * 1024` |
 | --password | String |  | The password used in the prometheus server basic auth |
 | --pod-label-prefix | String | pod_label_ | `Which prefix to look for pod labels in metrics` |
 | --pod-name-label | String | kubernetes_pod_name | `Label name to look for pod names` |
@@ -63,7 +63,7 @@ Last updated: 2024-12-17 13:09:18 UTC
 | --recommendation-upper-bound-cpu-percentile | Float64 | 0.95 | `CPU usage percentile that will be used for the upper bound on CPU recommendation.` |
 | --recommendation-upper-bound-memory-percentile | Float64 | 0.95 | `Memory usage percentile that will be used for the upper bound on memory recommendation.` |
 | --recommender-interval | Duration | 1Minute | `How often metrics should be fetched` |
-| --recommender-name | String | 0 | Set the recommender name. Recommender will generate recommendations for VPAs that configure the same recommender name. If the recommender name is left as default it will also generate recommendations that don't explicitly specify recommender. You shouldn't run two recommenders with the same name in a cluster. |
+| --recommender-name | String | input.DefaultRecommenderName | Set the recommender name. Recommender will generate recommendations for VPAs that configure the same recommender name. If the recommender name is left as default it will also generate recommendations that don't explicitly specify recommender. You shouldn't run two recommenders with the same name in a cluster. |
 | --storage | String |  | `Specifies storage mode. Supported values: prometheus, checkpoint (default)` |
 | --target-cpu-percentile | Float64 | 0.9 | CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations. |
 | --target-memory-percentile | Float64 | 0.9 | Memory usage percentile that will be used as a base for memory target recommendation. Doesn't affect memory lower bound nor memory upper bound. |
@@ -72,7 +72,7 @@ Last updated: 2024-12-17 13:09:18 UTC
 
 # What are the parameters to VPA updater?
 This document is auto-generated from the flag definitions in the VPA updater code.
-Last updated: 2024-12-17 13:09:20 UTC
+Last updated: 2024-12-21 10:48:13 UTC
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|

--- a/vertical-pod-autoscaler/hack/vpa-generate-flags.go
+++ b/vertical-pod-autoscaler/hack/vpa-generate-flags.go
@@ -142,8 +142,14 @@ func extractFlagFromCall(call *ast.CallExpr, sourcePath string) *flagInfo {
 		}
 	case *ast.Ident:
 		defaultValue = v.Name
+	case *ast.SelectorExpr:
+		// Handle references to constants like "model.DefaultMemoryAggregationInterval"
+		if x, ok := v.X.(*ast.Ident); ok {
+			defaultValue = fmt.Sprintf("%s.%s", x.Name, v.Sel.Name)
+		}
 	default:
-		defaultValue = "0"
+		// Instead of defaulting to "0", make it clear this is a reference
+		defaultValue = fmt.Sprintf("${%T}", v)
 	}
 
 	// Extract description


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR improves the VPA flag documentation generator script introduced in #7618. Previously, when flags had default values defined as constants (e.g., DefaultOOMBumpUpRatio), the script would output 0 as the default value in the generated documentation. For example:
```go
DefaultOOMBumpUpRatio float64 = 1.2 // Memory is increased by 20% after an OOMKill.
```
Would result in showing 0 as the default value instead of the actual constant reference.
This PR modifies the script to display the constant reference (e.g., model.DefaultMemoryAggregationInterval) in the documentation rather than 0.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
