### PR TITLE
Converting klog.Fatalf to structured logging equivalent

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -153,7 +153,7 @@ func main() {
 	}()
 
 	if err = server.ListenAndServeTLS("", ""); err != nil {
-		klog.ErrorS(err, "Failed to start server")
+		klog.ErrorS(err, "Failed to start HTTPS server")
 		os.Exit(255)
 	}
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -85,7 +85,8 @@ func main() {
 	klog.V(1).InfoS("Starting Vertical Pod Autoscaler Admission Controller", "version", common.VerticalPodAutoscalerVersion)
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
-		klog.Fatalf("--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
+		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
+		os.Exit(255)
 	}
 
 	healthCheck := metrics.NewHealthCheck(time.Minute)
@@ -113,7 +114,8 @@ func main() {
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		klog.Fatalf("Unable to get hostname: %v", err)
+		klog.ErrorS(err, "Unable to get hostname")
+		os.Exit(255)
 	}
 
 	statusNamespace := status.AdmissionControllerStatusNamespace
@@ -151,6 +153,7 @@ func main() {
 	}()
 
 	if err = server.ListenAndServeTLS("", ""); err != nil {
-		klog.Fatalf("HTTPS Error: %s", err)
+		klog.ErrorS(err, "Failed to start server")
+		os.Exit(255)
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"os"
 	"time"
 
 	k8sapiv1 "k8s.io/api/core/v1"
@@ -70,7 +71,8 @@ type ExternalClientOptions struct {
 func NewExternalClient(c *rest.Config, clusterState *model.ClusterState, options ExternalClientOptions) PodMetricsLister {
 	extClient, err := external_metrics.NewForConfig(c)
 	if err != nil {
-		klog.Fatalf("Failed initializing external metrics client: %v", err)
+		klog.ErrorS(err, "Failed initializing external metrics client")
+		os.Exit(255)
 	}
 	return &externalMetricsClient{
 		externalClient: extClient,

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -127,7 +127,8 @@ func main() {
 	klog.V(1).InfoS("Vertical Pod Autoscaler Recommender", "version", common.VerticalPodAutoscalerVersion, "recommenderName", *recommenderName)
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
-		klog.Fatalf("--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
+		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
+		os.Exit(255)
 	}
 
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval * 5)
@@ -140,7 +141,8 @@ func main() {
 	} else {
 		id, err := os.Hostname()
 		if err != nil {
-			klog.Fatalf("Unable to get hostname: %v", err)
+			klog.ErrorS(err, "Unable to get hostname")
+			os.Exit(255)
 		}
 		id = id + "_" + string(uuid.NewUUID())
 
@@ -158,7 +160,8 @@ func main() {
 			},
 		)
 		if err != nil {
-			klog.Fatalf("Unable to create leader election lock: %v", err)
+			klog.ErrorS(err, "Unable to create leader election lock")
+			os.Exit(255)
 		}
 
 		leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
@@ -266,7 +269,8 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 
 	promQueryTimeout, err := time.ParseDuration(*queryTimeout)
 	if err != nil {
-		klog.Fatalf("Could not parse --prometheus-query-timeout as a time.Duration: %v", err)
+		klog.ErrorS(err, "Could not parse --prometheus-query-timeout as a time.Duration")
+		os.Exit(255)
 	}
 
 	if useCheckpoints {
@@ -293,7 +297,8 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		}
 		provider, err := history.NewPrometheusHistoryProvider(config)
 		if err != nil {
-			klog.Fatalf("Could not initialize history provider: %v", err)
+			klog.ErrorS(err, "Could not initialize history provider")
+			os.Exit(255)
 		}
 		recommender.GetClusterStateFeeder().InitFromHistoryProvider(provider)
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -19,6 +19,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -354,7 +355,8 @@ func addVpaObject(cluster *ClusterState, id VpaID, vpa *vpa_types.VerticalPodAut
 	parsedSelector, _ := metav1.LabelSelectorAsSelector(labelSelector)
 	err := cluster.AddOrUpdateVpa(vpa, parsedSelector)
 	if err != nil {
-		klog.Fatalf("AddOrUpdateVpa() failed: %v", err)
+		klog.ErrorS(err, "AddOrUpdateVpa() failed")
+		os.Exit(255)
 	}
 	return cluster.Vpas[id]
 }

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -115,7 +116,8 @@ func (f *controllerFetcher) Start(ctx context.Context, loopPeriod time.Duration)
 func NewControllerFetcher(config *rest.Config, kubeClient kube_client.Interface, factory informers.SharedInformerFactory, betweenRefreshes, lifeTime time.Duration, jitterFactor float64) *controllerFetcher {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
-		klog.Fatalf("Could not create discoveryClient: %v", err)
+		klog.ErrorS(err, "Could not create discoveryClient")
+		os.Exit(255)
 	}
 	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
 	restClient := kubeClient.CoreV1().RESTClient()

--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -19,6 +19,7 @@ package target
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -69,7 +70,8 @@ const (
 func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Interface, factory informers.SharedInformerFactory) VpaTargetSelectorFetcher {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
-		klog.Fatalf("Could not create discoveryClient: %v", err)
+		klog.ErrorS(err, "Could not create discoveryClient")
+		os.Exit(255)
 	}
 	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
 	restClient := kubeClient.CoreV1().RESTClient()
@@ -94,7 +96,8 @@ func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Int
 		go informer.Run(stopCh)
 		synced := cache.WaitForCacheSync(stopCh, informer.HasSynced)
 		if !synced {
-			klog.Fatalf("Could not sync cache for %s: %v", kind, err)
+			klog.ErrorS(nil, "Could not sync cache for "+string(kind))
+			os.Exit(255)
 		} else {
 			klog.InfoS("Initial sync completed", "kind", kind)
 		}

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -19,6 +19,7 @@ package logic
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"time"
 
@@ -135,7 +136,8 @@ func (u *updater) RunOnce(ctx context.Context) {
 
 	vpaList, err := u.vpaLister.List(labels.Everything())
 	if err != nil {
-		klog.Fatalf("failed get VPA list: %v", err)
+		klog.ErrorS(err, "Failed to get VPA list")
+		os.Exit(255)
 	}
 	timer.ObserveStep("ListVPAs")
 
@@ -318,7 +320,8 @@ func newEventRecorder(kubeClient kube_client.Interface) record.EventRecorder {
 
 	vpascheme := scheme.Scheme
 	if err := corescheme.AddToScheme(vpascheme); err != nil {
-		klog.Fatalf("Error adding core scheme: %v", err)
+		klog.ErrorS(err, "Error adding core scheme")
+		os.Exit(255)
 	}
 
 	return eventBroadcaster.NewRecorder(vpascheme, apiv1.EventSource{Component: "vpa-updater"})

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -92,7 +92,8 @@ func main() {
 	klog.V(1).InfoS("Vertical Pod Autoscaler Updater", "version", common.VerticalPodAutoscalerVersion)
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
-		klog.Fatalf("--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
+		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
+		os.Exit(255)
 	}
 
 	healthCheck := metrics.NewHealthCheck(*updaterInterval * 5)
@@ -105,7 +106,8 @@ func main() {
 	} else {
 		id, err := os.Hostname()
 		if err != nil {
-			klog.Fatalf("Unable to get hostname: %v", err)
+			klog.ErrorS(err, "Unable to get hostname")
+			os.Exit(255)
 		}
 		id = id + "_" + string(uuid.NewUUID())
 
@@ -123,7 +125,8 @@ func main() {
 			},
 		)
 		if err != nil {
-			klog.Fatalf("Unable to create leader election lock: %v", err)
+			klog.ErrorS(err, "Unable to create leader election lock")
+			os.Exit(255)
 		}
 
 		leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
@@ -201,7 +204,8 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		ignoredNamespaces,
 	)
 	if err != nil {
-		klog.Fatalf("Failed to create updater: %v", err)
+		klog.ErrorS(err, "Failed to create updater")
+		os.Exit(255)
 	}
 
 	// Start updating health check endpoint.

--- a/vertical-pod-autoscaler/pkg/utils/metrics/healthcheck.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/healthcheck.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -75,7 +76,8 @@ func (hc *HealthCheck) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
-			klog.Fatalf("Failed to write response message: %v", err)
+			klog.ErrorS(err, "Failed to write response message")
+			os.Exit(255)
 		}
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/server/server.go
+++ b/vertical-pod-autoscaler/pkg/utils/server/server.go
@@ -20,6 +20,7 @@ package server
 import (
 	"net/http"
 	"net/http/pprof"
+	"os"
 
 	"k8s.io/klog/v2"
 
@@ -46,6 +47,7 @@ func Initialize(enableProfiling *bool, healthCheck *metrics.HealthCheck, address
 		}
 
 		err := http.ListenAndServe(*address, mux)
-		klog.Fatalf("Failed to start metrics: %v", err)
+		klog.ErrorS(err, "Failed to start metrics")
+		os.Exit(255)
 	}()
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As part of migrating to structured logging this is the right replacement for `klog.Fatalf`.
Ref: https://github.com/kubernetes/klog/issues/416#issuecomment-2564462438 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
