### PR TITLE
Improve logging when the cluster reaches max nodes total.

### DIFF
--- a/cluster-autoscaler/processors/status/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_up_status_processor.go
@@ -66,6 +66,8 @@ const (
 	ScaleUpNotTried
 	// ScaleUpInCooldown - the scale up wasn't even attempted, because it's in a cooldown state (it's suspended for a scheduled period of time).
 	ScaleUpInCooldown
+	// ScaleUpLimitedByMaxNodesTotal - the scale up wasn't attempted, because the cluster reached max nodes total
+	ScaleUpLimitedByMaxNodesTotal
 )
 
 // WasSuccessful returns true if the scale-up was successful.


### PR DESCRIPTION
- add autoscaling status to reflect that
- change the log severity to warning as this means that autoscaler will not be fully functional (in praticular scaling up will not work)

Note: the newly introduced status will be set only if there are no prov requests (and therefore there is no forced scale up). Otherwise the forced scaleup will override it. 

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Expose more descriptive scale up status and log with higher severity when cluster reaches max total nodes.


#### Does this PR introduce a user-facing change?
```release-note
Introduce new scale up status when cluster reaches max nodes total limit.
```