### PR TITLE
VPA: Create a build and deploy locally script

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -20,9 +20,10 @@ package common
 // It is injected at build time.
 var gitCommit = ""
 
-// VerticalPodAutoscalerVersion is the version of VPA.
+// versionCore is the version of VPA.
 const versionCore = "1.2.0"
 
+// VerticalPodAutoscalerVersion returns the version of the VPA.
 func VerticalPodAutoscalerVersion() string {
 	v := versionCore
 	if gitCommit != "" {

--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -16,5 +16,26 @@ limitations under the License.
 
 package common
 
+// gitCommit is the commit used to build the VPA binaries, if available.
+// It is injected at build time.
+var gitCommit = ""
+
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "1.2.0"
+const versionCore = "1.2.0"
+
+func VerticalPodAutoscalerVersion() string {
+	v := versionCore
+	if gitCommit != "" {
+		// NOTE: use 14 character short hash, like Kubernetes
+		v += "+" + truncate(gitCommit, 14)
+	}
+
+	return v
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) < maxLen {
+		return s
+	}
+	return s[:maxLen]
+}

--- a/vertical-pod-autoscaler/hack/dev-deploy-locally.sh
+++ b/vertical-pod-autoscaler/hack/dev-deploy-locally.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2023 The Kubernetes Authors.
+# Copyright 2025 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/vertical-pod-autoscaler/hack/dev-deploy-locally.sh
+++ b/vertical-pod-autoscaler/hack/dev-deploy-locally.sh
@@ -66,5 +66,5 @@ ${SCRIPT_ROOT}/hack/deploy-for-e2e-locally.sh full-vpa
 
 echo " ** Restarting all VPA components"
 for i in admission-controller updater recommender; do
-  kubectl -n kube-system rollout status deployment/vpa-$i
+  kubectl -n kube-system rollout restart deployment/vpa-$i
 done

--- a/vertical-pod-autoscaler/hack/dev-deploy-locally.sh
+++ b/vertical-pod-autoscaler/hack/dev-deploy-locally.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
+
+SUITE=full-vpa
+REQUIRED_COMMANDS="
+docker
+git
+go
+kubectl
+make
+"
+
+for i in $REQUIRED_COMMANDS; do
+  if ! command -v $i > /dev/null 2>&1
+  then
+    echo "$i could not be found, please ensure it is installed"
+    echo
+    echo "The following commands are required to run these tests:"
+    echo $REQUIRED_COMMANDS
+    exit 1;
+  fi
+done
+
+if ! docker ps >/dev/null 2>&1
+then
+  echo "docker isn't running"
+  echo
+  echo "Please ensure that docker is running"
+  exit 1
+fi
+
+if ! kubectl version >/dev/null 2>&1
+then
+  echo "Kubernetes isn't running"
+  echo
+  echo "Please ensure that Kubernetes is running"
+  exit 1
+fi
+
+COMMIT=$(git rev-parse HEAD 2>/dev/null)
+COMMIT=${COMMIT:0:14}
+export BUILD_LD_FLAGS="-s -X=k8s.io/autoscaler/vertical-pod-autoscaler/common.gitCommit=$COMMIT"
+export TAG=$COMMIT
+
+
+echo " ** Deploying building and deploying all VPA components"
+${SCRIPT_ROOT}/hack/deploy-for-e2e-locally.sh full-vpa
+
+echo " ** Restarting all VPA components"
+for i in admission-controller updater recommender; do
+  kubectl -n kube-system rollout status deployment/vpa-$i
+done

--- a/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
@@ -26,8 +26,9 @@ COPY common common
 COPY pkg pkg
 
 ARG TARGETOS TARGETARCH
+ARG BUILD_LD_FLAGS="-s"
 
-RUN CGO_ENABLED=0 LD_FLAGS=-s GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/admission-controller -o admission-controller-$TARGETARCH
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/admission-controller -ldflags="${BUILD_LD_FLAGS}" -o admission-controller-$TARGETARCH
 
 FROM gcr.io/distroless/static:nonroot
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/Makefile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Makefile
@@ -9,6 +9,7 @@ GOOS?=linux
 COMPONENT=admission-controller
 FULL_COMPONENT=vpa-${COMPONENT}
 
+BUILD_LD_FLAGS?=-s
 ALL_ARCHITECTURES?=amd64 arm arm64 ppc64le s390x
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
@@ -35,7 +36,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} -f ./Dockerfile ../../
+	docker buildx build --pull --load --platform linux/$* --build-arg BUILD_LD_FLAGS="${BUILD_LD_FLAGS}" -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} -f ./Dockerfile ../../
 
 .PHONY: docker-push
 docker-push: $(addprefix do-push-,$(ALL_ARCHITECTURES)) push-multi-arch;

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -82,7 +82,7 @@ func main() {
 	klog.InitFlags(nil)
 	common.InitLoggingFlags()
 	kube_flag.InitFlags()
-	klog.V(1).InfoS("Starting Vertical Pod Autoscaler Admission Controller", "version", common.VerticalPodAutoscalerVersion)
+	klog.V(1).InfoS("Starting Vertical Pod Autoscaler Admission Controller", "version", common.VerticalPodAutoscalerVersion())
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
 		klog.Fatalf("--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")

--- a/vertical-pod-autoscaler/pkg/recommender/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/recommender/Dockerfile
@@ -26,8 +26,9 @@ COPY common common
 COPY pkg pkg
 
 ARG TARGETOS TARGETARCH
+ARG BUILD_LD_FLAGS="-s"
 
-RUN CGO_ENABLED=0 LD_FLAGS=-s GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/recommender -o recommender-$TARGETARCH
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/recommender -ldflags="${BUILD_LD_FLAGS}" -o recommender-$TARGETARCH
 
 FROM gcr.io/distroless/static:nonroot
 

--- a/vertical-pod-autoscaler/pkg/recommender/Makefile
+++ b/vertical-pod-autoscaler/pkg/recommender/Makefile
@@ -11,6 +11,7 @@ FULL_COMPONENT=vpa-${COMPONENT}
 # localhost registries need --insecure for some docker commands.
 INSECURE=$(subst localhost,--insecure,$(findstring localhost,$(REGISTRY)))
 
+BUILD_LD_FLAGS?=-s
 ALL_ARCHITECTURES?=amd64 arm arm64 ppc64le s390x
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
@@ -37,7 +38,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} -f ./Dockerfile ../../
+	docker buildx build --pull --load --platform linux/$* --build-arg BUILD_LD_FLAGS="${BUILD_LD_FLAGS}" -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} -f ./Dockerfile ../../
 
 .PHONY: docker-push
 docker-push: $(addprefix do-push-,$(ALL_ARCHITECTURES)) push-multi-arch;

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -124,7 +124,7 @@ func main() {
 	componentbaseoptions.BindLeaderElectionFlags(&leaderElection, pflag.CommandLine)
 
 	kube_flag.InitFlags()
-	klog.V(1).InfoS("Vertical Pod Autoscaler Recommender", "version", common.VerticalPodAutoscalerVersion, "recommenderName", *recommenderName)
+	klog.V(1).InfoS("Vertical Pod Autoscaler Recommender", "version", common.VerticalPodAutoscalerVersion(), "recommenderName", *recommenderName)
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
 		klog.Fatalf("--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")

--- a/vertical-pod-autoscaler/pkg/updater/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/updater/Dockerfile
@@ -26,8 +26,9 @@ COPY common common
 COPY pkg pkg
 
 ARG TARGETOS TARGETARCH
+ARG BUILD_LD_FLAGS="-s"
 
-RUN CGO_ENABLED=0 LD_FLAGS=-s GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/updater -o updater-$TARGETARCH
+RUN CGO_ENABLED=0 LD_FLAGS=-s GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/updater -ldflags="${BUILD_LD_FLAGS}" -o updater-$TARGETARCH
 
 FROM gcr.io/distroless/static:nonroot
 

--- a/vertical-pod-autoscaler/pkg/updater/Makefile
+++ b/vertical-pod-autoscaler/pkg/updater/Makefile
@@ -9,6 +9,7 @@ GOOS?=linux
 COMPONENT=updater
 FULL_COMPONENT=vpa-${COMPONENT}
 
+BUILD_LD_FLAGS?=-s
 ALL_ARCHITECTURES?=amd64 arm arm64 ppc64le s390x
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
@@ -35,7 +36,7 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} -f ./Dockerfile ../../
+	docker buildx build --pull --load --platform linux/$* --build-arg BUILD_LD_FLAGS="${BUILD_LD_FLAGS}" -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} -f ./Dockerfile ../../
 
 .PHONY: docker-push
 docker-push: $(addprefix do-push-,$(ALL_ARCHITECTURES)) push-multi-arch;

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -89,7 +89,7 @@ func main() {
 	componentbaseoptions.BindLeaderElectionFlags(&leaderElection, pflag.CommandLine)
 
 	kube_flag.InitFlags()
-	klog.V(1).InfoS("Vertical Pod Autoscaler Updater", "version", common.VerticalPodAutoscalerVersion)
+	klog.V(1).InfoS("Vertical Pod Autoscaler Updater", "version", common.VerticalPodAutoscalerVersion())
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
 		klog.Fatalf("--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")


### PR DESCRIPTION
This is for easier setup of local environments to test PRs and the like.

Some notes:
1. I thought it was useful to display the git commit in the version number, for debugging purposes
2. The `LD_FLAGS=-s` env-var that used to be set doesn't actually do anything, so I've moved it to the correct location
3. Most of this re-uses existing scripts
4. It doesn't handle setup of the Kubernetes cluster or teardown of the VPA

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7653

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
