### PR TITLE
VPA: Add docs about AKS and EKS with Cilium

### DIFF
--- a/vertical-pod-autoscaler/docs/faq.md
+++ b/vertical-pod-autoscaler/docs/faq.md
@@ -10,8 +10,8 @@
 - [What are the parameters to VPA recommender?](#what-are-the-parameters-to-vpa-recommender)
 - [What are the parameters to VPA updater?](#what-are-the-parameters-to-vpa-updater)
 - [How can I configure VPA to manage only specific resources?](#how-can-i-configure-vpa-to-manage-only-specific-resources)
-- [Special requirements when running in AKS?](#special-requirements-when-running-in-aks)
-- [Special requirements when running in EKS with Cilium?](#special-requirements-when-running-in-eks-with-cilium)
+- [How can I have Pods in the kube-system namespace under VPA control in AKS?](#how-can-i-have-pods-in-the-kube-system-namespace-under-vpa-control-in-aks)
+- [How can I configure VPA when running in EKS with Cilium?](#how-can-i-configure-vpa-when-running-in-eks-with-cilium)
 
 ### VPA restarts my pods but does not modify CPU or memory settings
 
@@ -298,15 +298,15 @@ Common use cases:
 * Use controlledResources: ["cpu"] when you want to automate CPU resource allocation
 * Useful when memory requirements are stable but CPU usage varies
 
-### Special requirements when running in AKS?
+### How can I have Pods in the kube-system namespace under VPA control in AKS?
 
 When running a webhook in AKS, it blocks webhook requests for the kube-system namespace in order to protect the system.
 See the [AKS FAQ page](https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces-) for more info.
 
-The `--webhook-labels` paramater for the VPA admission-controller can be used to bypass this behaviour, if required by the user.
+The `--webhook-labels` parameter for the VPA admission-controller can be used to bypass this behaviour, if required by the user.
 
-### Special requirements when running in EKS with Cilium?
+### How can I configure VPA when running in EKS with Cilium?
 
-When running in EKS with Cilium, the EKS API server cannot route traffic to the overlap network. The VPA admission-controller
+When running in EKS with Cilium, the EKS API server cannot route traffic to the overlay network. The VPA admission-controller
 Pods either need to use host networking or be exposed through a service or ingress.
 See the [Cilium Helm installation page](https://docs.cilium.io/en/stable/installation/k8s-install-helm/) for more info.

--- a/vertical-pod-autoscaler/docs/faq.md
+++ b/vertical-pod-autoscaler/docs/faq.md
@@ -10,6 +10,8 @@
 - [What are the parameters to VPA recommender?](#what-are-the-parameters-to-vpa-recommender)
 - [What are the parameters to VPA updater?](#what-are-the-parameters-to-vpa-updater)
 - [How can I configure VPA to manage only specific resources?](#how-can-i-configure-vpa-to-manage-only-specific-resources)
+- [Special requirements when running in AKS?](#special-requirements-when-running-in-aks)
+- [Special requirements when running in EKS with Cilium?](#special-requirements-when-running-in-eks-with-cilium)
 
 ### VPA restarts my pods but does not modify CPU or memory settings
 
@@ -295,3 +297,16 @@ Common use cases:
 2. CPU-only VPA:
 * Use controlledResources: ["cpu"] when you want to automate CPU resource allocation
 * Useful when memory requirements are stable but CPU usage varies
+
+### Special requirements when running in AKS?
+
+When running a webhook in AKS, it blocks webhook requests for the kube-system namespace in order to protect the system.
+See the [AKS FAQ page](https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces-) for more info.
+
+The `--webhook-labels` paramater for the VPA admission-controller can be used to bypass this behaviour, if required by the user.
+
+### Special requirements when running in EKS with Cilium?
+
+When running in EKS with Cilium, the EKS API server cannot route traffic to the overlap network. The VPA admission-controller
+Pods either need to use host networking or be exposed through a service or ingress.
+See the [Cilium Helm installation page](https://docs.cilium.io/en/stable/installation/k8s-install-helm/) for more info.


### PR DESCRIPTION
Ref:
- AKS: https://github.com/kubernetes/autoscaler/issues/7392
- EKS: https://github.com/kubernetes/autoscaler/issues/6915

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

More docs to help users

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6915

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
