### PR TITLE
logging: Start from a capital letter

### DIFF
--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -156,7 +156,7 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 
 	podsToRemove, daemonSetPods, blockingPod, err := GetPodsToMove(nodeInfo, r.deleteOptions, r.drainabilityRules, r.listers, remainingPdbTracker, timestamp)
 	if err != nil {
-		klog.V(2).Infof("node %s cannot be removed: %v", nodeName, err)
+		klog.V(2).Infof("Node %s cannot be removed: %v", nodeName, err)
 		if blockingPod != nil {
 			return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: BlockedByPod, BlockingPod: blockingPod}
 		}
@@ -167,10 +167,10 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 		return r.findPlaceFor(nodeName, podsToRemove, destinationMap, timestamp)
 	})
 	if err != nil {
-		klog.V(2).Infof("node %s is not suitable for removal: %v", nodeName, err)
+		klog.V(2).Infof("Node %s is not suitable for removal: %v", nodeName, err)
 		return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: NoPlaceToMovePods}
 	}
-	klog.V(2).Infof("node %s may be removed", nodeName)
+	klog.V(2).Infof("Node %s may be removed", nodeName)
 	return &NodeToBeRemoved{
 		Node:             nodeInfo.Node(),
 		PodsToReschedule: podsToRemove,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
From [sig-instrumentation's Logging guide](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md): "Start from a capital letter."

Right now some log entries start with a capital letter, other don't:
```
2025-01-07 14:12:37	{"log":"Simulating node foo removal","pid":"1","severity":"INFO","source":"cluster.go:156"}
2025-01-07 14:12:37	{"log":"Node foo - cpu requested is 6.1809% of allocatable","pid":"1","severity":"INFO","source":"klogx.go:87"}
2025-01-07 14:12:37	{"log":"Node foo is underutilized: cpu requested (6.1809% of allocatable) is below the scale-down utilization threshold","pid":"1","severity":"INFO","source":"eligibility.go:167"}
2025-01-07 14:12:27	{"log":"node foo may be removed","pid":"1","severity":"INFO","source":"cluster.go:174"}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
