### PR TITLE
Update ubuntu-slim with Docker Schema 2 image

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -144,7 +144,7 @@ func NewNHamstersDeployment(f *framework.Framework, n int) *appsv1.Deployment {
 		defaultHamsterReplicas,                     /*replicas*/
 		hamsterLabels,                              /*podLabels*/
 		GetHamsterContainerNameByIndex(0),          /*imageName*/
-		"registry.k8s.io/ubuntu-slim:0.1",          /*image*/
+		"registry.k8s.io/ubuntu-slim:0.14",         /*image*/
 		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name
@@ -278,7 +278,7 @@ func SetupHamsterContainer(cpu, memory string) apiv1.Container {
 
 	return apiv1.Container{
 		Name:  "hamster",
-		Image: "registry.k8s.io/ubuntu-slim:0.1",
+		Image: "registry.k8s.io/ubuntu-slim:0.14",
 		Resources: apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
 				apiv1.ResourceCPU:    cpuQuantity,

--- a/vertical-pod-autoscaler/e2e/v1beta2/common.go
+++ b/vertical-pod-autoscaler/e2e/v1beta2/common.go
@@ -144,7 +144,7 @@ func NewNHamstersDeployment(f *framework.Framework, n int) *appsv1.Deployment {
 		defaultHamsterReplicas,                     /*replicas*/
 		hamsterLabels,                              /*podLabels*/
 		GetHamsterContainerNameByIndex(0),          /*imageName*/
-		"registry.k8s.io/ubuntu-slim:0.1",          /*image*/
+		"registry.k8s.io/ubuntu-slim:0.14",         /*image*/
 		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name
@@ -279,7 +279,7 @@ func SetupHamsterContainer(cpu, memory string) apiv1.Container {
 
 	return apiv1.Container{
 		Name:  "hamster",
-		Image: "registry.k8s.io/ubuntu-slim:0.1",
+		Image: "registry.k8s.io/ubuntu-slim:0.14",
 		Resources: apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
 				apiv1.ResourceCPU:    cpuQuantity,

--- a/vertical-pod-autoscaler/examples/hamster-deprecated.yaml
+++ b/vertical-pod-autoscaler/examples/hamster-deprecated.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: hamster
-          image: registry.k8s.io/ubuntu-slim:0.1
+          image: registry.k8s.io/ubuntu-slim:0.14
           resources:
             requests:
               cpu: 100m

--- a/vertical-pod-autoscaler/examples/hamster.yaml
+++ b/vertical-pod-autoscaler/examples/hamster.yaml
@@ -49,7 +49,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: hamster
-          image: registry.k8s.io/ubuntu-slim:0.1
+          image: registry.k8s.io/ubuntu-slim:0.14
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
Docker Schema 1 images are deprecated and support is [removed in containerd 2.0](https://containerd.io/releases/#deprecated-features). These workloads need updating in order to continue working.

Verified image schemas via:
```sh
$ crane manifest registry.k8s.io/ubuntu-slim:0.1 | jq .schemaVersion
1

$ crane manifest registry.k8s.io/ubuntu-slim:0.14 | jq .schemaVersion
2
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```