### PR TITLE
Improve frequent loops when only one of activities is productive

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -670,10 +670,13 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 
 	// Autoscale ad infinitum.
 	if *frequentLoopsEnabled {
+		// We need to have two timestamps because the scaleUp activity alternates between processing ProvisioningRequests,
+		// so we need to pass the older timestamp (previousRun) to trigger.Wait to run immediately if only one of the activities is productive.
 		lastRun := time.Now()
+		previousRun := time.Now()
 		for {
-			trigger.Wait(lastRun)
-			lastRun = time.Now()
+			trigger.Wait(previousRun)
+			previousRun, lastRun = lastRun, time.Now()
 			loop.RunAutoscalerOnce(autoscaler, healthCheck, lastRun)
 		}
 	} else {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

In a single iteration of the autoscaler, only one of the activities can occur alternately: scaling up or processing ProvisioningRequests. If the activity is productive (scale up attempt was successful or ProvisioningRequest was processed), the next iteration is started immediately. Unfortunately, if there is only successful processing of ProvisioningRequests without scaling up activity (so if there are only unschedulable pods that CA scale up won't help), the autoscaler will be put to sleep unnecessarily. This PR changes the logic slightly to compare not with the start of the last iteration, but with the previous to the last, to support alternate activities well.

For example, before this PR:
successful provreq processing -> immediate next loop (because provreq was processed) -> scale up attempt with non-successful result -> sleep for scanInterval duration (because scale up attempt was not successful)-> next provreq processing

After:
successful provreq processing -> immediate next loop (because provreq was processed)  -> scale up attempt with non-successful result -> immediate next loop (because before the scale up attempt provreq was processed)-> next provreq processing

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improved frequent loops when there is only one of scale up activity or ProvisioningRequest processing is productive.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
