### PR TITLE
feat(recommender): add round cpu millicores

### DIFF
--- a/vertical-pod-autoscaler/docs/features.md
+++ b/vertical-pod-autoscaler/docs/features.md
@@ -38,13 +38,13 @@ To enable this feature, set the `--humanize-memory` flag to true when running th
 
 ## CPU Recommendation Rounding
 
-VPA can provide CPU recommendations rounded to user-specified values, making it easier to interpret and configure resources. This feature is controlled by the `--round-cpu-millicores` flag in the recommender component.
+VPA can provide CPU recommendations rounded up to user-specified values, making it easier to interpret and configure resources. This feature is controlled by the `--round-cpu-millicores` flag in the recommender component.
 
 When enabled, CPU recommendations will be:
-- Rounded to the nearest multiple of the specified millicore value
+- Rounded up to the nearest multiple of the specified millicore value
 - Applied to target, lower bound, and upper bound recommendations
 
-For example, with `--round-cpu-millicores=50`, a CPU recommendation of `79m` would be rounded to `100m`, and a recommendation of `34m` would be rounded to `50m`.
+For example, with `--round-cpu-millicores=50`, a CPU recommendation of `79m` would be rounded up to `100m`, and a recommendation of `34m` would be rounded up to `50m`.
 
 To enable this feature, set the --round-cpu-millicores flag when running the VPA recommender:
 

--- a/vertical-pod-autoscaler/docs/features.md
+++ b/vertical-pod-autoscaler/docs/features.md
@@ -38,7 +38,7 @@ To enable this feature, set the `--humanize-memory` flag to true when running th
 
 ## CPU Recommendation Rounding
 
-VPA can now provide CPU recommendations rounded to user-specified values, making it easier to interpret and configure resources. This feature is controlled by the `--round-cpu-millicores` flag in the recommender component.
+VPA can provide CPU recommendations rounded to user-specified values, making it easier to interpret and configure resources. This feature is controlled by the `--round-cpu-millicores` flag in the recommender component.
 
 When enabled, CPU recommendations will be:
 - Rounded to the nearest multiple of the specified millicore value

--- a/vertical-pod-autoscaler/docs/features.md
+++ b/vertical-pod-autoscaler/docs/features.md
@@ -35,3 +35,19 @@ To enable this feature, set the `--humanize-memory` flag to true when running th
 ```bash
 --humanize-memory=true
 ```
+
+## CPU Recommendation Rounding
+
+VPA can now provide CPU recommendations rounded to user-specified values, making it easier to interpret and configure resources. This feature is controlled by the `--round-cpu-millicores` flag in the recommender component.
+
+When enabled, CPU recommendations will be:
+- Rounded to the nearest multiple of the specified millicore value
+- Applied to target, lower bound, and upper bound recommendations
+
+For example, with `--round-cpu-millicores=50`, a CPU recommendation of `79m` would be rounded to `100m`, and a recommendation of `34m` would be rounded to `50m`.
+
+To enable this feature, set the --round-cpu-millicores flag when running the VPA recommender:
+
+```bash
+--round-cpu-millicores=50
+```

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -1,6 +1,6 @@
 # What are the parameters to VPA admission controller?
 This document is auto-generated from the flag definitions in the VPA admission controller code.
-Last updated: 2025-01-13 10:59:57 UTC
+Last updated: 2025-01-31 18:07:15 UTC
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
@@ -23,7 +23,7 @@ Last updated: 2025-01-13 10:59:57 UTC
 
 # What are the parameters to VPA recommender?
 This document is auto-generated from the flag definitions in the VPA recommender code.
-Last updated: 2025-01-13 10:59:57 UTC
+Last updated: 2025-01-31 18:07:14 UTC
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
@@ -64,7 +64,7 @@ Last updated: 2025-01-13 10:59:57 UTC
 | --recommendation-upper-bound-memory-percentile | Float64 | 0.95 | `Memory usage percentile that will be used for the upper bound on memory recommendation.` |
 | --recommender-interval | Duration | 1Minute | `How often metrics should be fetched` |
 | --recommender-name | String | 0 | Set the recommender name. Recommender will generate recommendations for VPAs that configure the same recommender name. If the recommender name is left as default it will also generate recommendations that don't explicitly specify recommender. You shouldn't run two recommenders with the same name in a cluster. |
-| --round-cpu-millicores | Int | 1 | `CPU recommendation rounding factor in millicores. The CPU value will be rounded to the nearest multiple of this factor.` |
+| --round-cpu-millicores | Int | 1 | `CPU recommendation rounding factor in millicores. The CPU value will always be rounded up to the nearest multiple of this factor.` |
 | --storage | String |  | `Specifies storage mode. Supported values: prometheus, checkpoint (default)` |
 | --target-cpu-percentile | Float64 | 0.9 | CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations. |
 | --target-memory-percentile | Float64 | 0.9 | Memory usage percentile that will be used as a base for memory target recommendation. Doesn't affect memory lower bound nor memory upper bound. |
@@ -73,7 +73,7 @@ Last updated: 2025-01-13 10:59:57 UTC
 
 # What are the parameters to VPA updater?
 This document is auto-generated from the flag definitions in the VPA updater code.
-Last updated: 2025-01-13 10:59:57 UTC
+Last updated: 2025-01-31 18:07:14 UTC
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -1,6 +1,6 @@
 # What are the parameters to VPA admission controller?
 This document is auto-generated from the flag definitions in the VPA admission controller code.
-Last updated: 2024-12-17 13:09:20 UTC
+Last updated: 2025-01-13 10:59:57 UTC
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
@@ -23,7 +23,7 @@ Last updated: 2024-12-17 13:09:20 UTC
 
 # What are the parameters to VPA recommender?
 This document is auto-generated from the flag definitions in the VPA recommender code.
-Last updated: 2024-12-17 13:09:18 UTC
+Last updated: 2025-01-13 10:59:57 UTC
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
@@ -64,6 +64,7 @@ Last updated: 2024-12-17 13:09:18 UTC
 | --recommendation-upper-bound-memory-percentile | Float64 | 0.95 | `Memory usage percentile that will be used for the upper bound on memory recommendation.` |
 | --recommender-interval | Duration | 1Minute | `How often metrics should be fetched` |
 | --recommender-name | String | 0 | Set the recommender name. Recommender will generate recommendations for VPAs that configure the same recommender name. If the recommender name is left as default it will also generate recommendations that don't explicitly specify recommender. You shouldn't run two recommenders with the same name in a cluster. |
+| --round-cpu-millicores | Int | 1 | `CPU recommendation rounding factor in millicores. The CPU value will be rounded to the nearest multiple of this factor.` |
 | --storage | String |  | `Specifies storage mode. Supported values: prometheus, checkpoint (default)` |
 | --target-cpu-percentile | Float64 | 0.9 | CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations. |
 | --target-memory-percentile | Float64 | 0.9 | Memory usage percentile that will be used as a base for memory target recommendation. Doesn't affect memory lower bound nor memory upper bound. |
@@ -72,7 +73,7 @@ Last updated: 2024-12-17 13:09:18 UTC
 
 # What are the parameters to VPA updater?
 This document is auto-generated from the flag definitions in the VPA updater code.
-Last updated: 2024-12-17 13:09:20 UTC
+Last updated: 2025-01-13 10:59:57 UTC
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -35,7 +35,7 @@ var (
 	lowerBoundMemoryPercentile = flag.Float64("recommendation-lower-bound-memory-percentile", 0.5, `Memory usage percentile that will be used for the lower bound on memory recommendation.`)
 	upperBoundMemoryPercentile = flag.Float64("recommendation-upper-bound-memory-percentile", 0.95, `Memory usage percentile that will be used for the upper bound on memory recommendation.`)
 	humanizeMemory             = flag.Bool("humanize-memory", false, "Convert memory values in recommendations to the highest appropriate SI unit with up to 2 decimal places for better readability.")
-	roundCPUMillicores         = flag.Int("round-cpu-millicores", 1, `CPU recommendation rounding factor in millicores. The CPU value will be rounded to the nearest multiple of this factor.`)
+	roundCPUMillicores         = flag.Int("round-cpu-millicores", 1, `CPU recommendation rounding factor in millicores. The CPU value will always be rounded up to the nearest multiple of this factor.`)
 )
 
 // PodResourceRecommender computes resource recommendation for a Vpa object.

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -35,6 +35,7 @@ var (
 	lowerBoundMemoryPercentile = flag.Float64("recommendation-lower-bound-memory-percentile", 0.5, `Memory usage percentile that will be used for the lower bound on memory recommendation.`)
 	upperBoundMemoryPercentile = flag.Float64("recommendation-upper-bound-memory-percentile", 0.95, `Memory usage percentile that will be used for the upper bound on memory recommendation.`)
 	humanizeMemory             = flag.Bool("humanize-memory", false, "Convert memory values in recommendations to the highest appropriate SI unit with up to 2 decimal places for better readability.")
+	roundCPUMillicores         = flag.Int("round-cpu-millicores", 1, `CPU recommendation rounding factor in millicores. The CPU value will be rounded to the nearest multiple of this factor.`)
 )
 
 // PodResourceRecommender computes resource recommendation for a Vpa object.
@@ -189,10 +190,10 @@ func MapToListOfRecommendedContainerResources(resources RecommendedPodResources)
 	for _, name := range containerNames {
 		containerResources = append(containerResources, vpa_types.RecommendedContainerResources{
 			ContainerName:  name,
-			Target:         model.ResourcesAsResourceList(resources[name].Target, *humanizeMemory),
-			LowerBound:     model.ResourcesAsResourceList(resources[name].LowerBound, *humanizeMemory),
-			UpperBound:     model.ResourcesAsResourceList(resources[name].UpperBound, *humanizeMemory),
-			UncappedTarget: model.ResourcesAsResourceList(resources[name].Target, *humanizeMemory),
+			Target:         model.ResourcesAsResourceList(resources[name].Target, *humanizeMemory, *roundCPUMillicores),
+			LowerBound:     model.ResourcesAsResourceList(resources[name].LowerBound, *humanizeMemory, *roundCPUMillicores),
+			UpperBound:     model.ResourcesAsResourceList(resources[name].UpperBound, *humanizeMemory, *roundCPUMillicores),
+			UncappedTarget: model.ResourcesAsResourceList(resources[name].Target, *humanizeMemory, *roundCPUMillicores),
 		})
 	}
 	recommendation := &vpa_types.RecommendedPodResources{

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+	"math"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -81,7 +82,7 @@ func ScaleResource(amount ResourceAmount, factor float64) ResourceAmount {
 }
 
 // ResourcesAsResourceList converts internal Resources representation to ResourcesList.
-func ResourcesAsResourceList(resources Resources, humanizeMemory bool) apiv1.ResourceList {
+func ResourcesAsResourceList(resources Resources, humanizeMemory bool, roundCPUMillicores int) apiv1.ResourceList {
 	result := make(apiv1.ResourceList)
 	for key, resourceAmount := range resources {
 		var newKey apiv1.ResourceName
@@ -90,6 +91,14 @@ func ResourcesAsResourceList(resources Resources, humanizeMemory bool) apiv1.Res
 		case ResourceCPU:
 			newKey = apiv1.ResourceCPU
 			quantity = QuantityFromCPUAmount(resourceAmount)
+			if roundCPUMillicores != 1 && !quantity.IsZero() {
+				roundedValues, err := RoundUpToScale(resourceAmount, roundCPUMillicores)
+				if err != nil {
+					klog.V(4).InfoS("Error rounding CPU value; leaving unchanged", "rawValue", resourceAmount, "scale", roundCPUMillicores, "error", err)
+				}
+				klog.V(4).InfoS("Successfully rounded CPU value", "rawValue", resourceAmount, "roundedValue", roundedValues)
+				quantity = QuantityFromCPUAmount(roundedValues)
+			}
 		case ResourceMemory:
 			newKey = apiv1.ResourceMemory
 			quantity = QuantityFromMemoryAmount(resourceAmount)
@@ -164,6 +173,16 @@ func HumanizeMemoryQuantity(bytes int64) string {
 	default:
 		return fmt.Sprintf("%d", bytes)
 	}
+}
+
+// RoundUpToScale rounds the value to the nearest multiple of scale, rounding up
+func RoundUpToScale(value ResourceAmount, scale int) (ResourceAmount, error) {
+	if scale <= 0 {
+		return value, fmt.Errorf("scale must be greater than zero")
+	}
+	scale64 := int64(scale)
+	roundedValue := int64(math.Ceil(float64(value)/float64(scale64))) * scale64
+	return ResourceAmount(roundedValue), nil
 }
 
 // PodID contains information needed to identify a Pod within a cluster.

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -95,8 +95,9 @@ func ResourcesAsResourceList(resources Resources, humanizeMemory bool, roundCPUM
 				roundedValues, err := RoundUpToScale(resourceAmount, roundCPUMillicores)
 				if err != nil {
 					klog.V(4).InfoS("Error rounding CPU value; leaving unchanged", "rawValue", resourceAmount, "scale", roundCPUMillicores, "error", err)
+				} else {
+					klog.V(4).InfoS("Successfully rounded CPU value", "rawValue", resourceAmount, "roundedValue", roundedValues)
 				}
-				klog.V(4).InfoS("Successfully rounded CPU value", "rawValue", resourceAmount, "roundedValue", roundedValues)
 				quantity = QuantityFromCPUAmount(roundedValues)
 			}
 		case ResourceMemory:

--- a/vertical-pod-autoscaler/pkg/recommender/model/types_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types_test.go
@@ -28,75 +28,81 @@ type ResourcesAsResourceListTestCase struct {
 	name         string
 	resources    Resources
 	humanize     bool
+	roundCPU     int
 	resourceList apiv1.ResourceList
 }
 
 func TestResourcesAsResourceList(t *testing.T) {
 	testCases := []ResourcesAsResourceListTestCase{
 		{
-			name: "basic resources without humanize",
+			name: "basic resources without humanize and no cpu rounding",
 			resources: Resources{
 				ResourceCPU:    1000,
 				ResourceMemory: 1000,
 			},
 			humanize: false,
+			roundCPU: 1,
 			resourceList: apiv1.ResourceList{
 				apiv1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
 				apiv1.ResourceMemory: *resource.NewQuantity(1000, resource.DecimalSI),
 			},
 		},
 		{
-			name: "basic resources with humanize",
+			name: "basic resources with humanize and cpu rounding to 1",
 			resources: Resources{
 				ResourceCPU:    1000,
 				ResourceMemory: 262144000, // 250Mi
 			},
 			humanize: true,
+			roundCPU: 1,
 			resourceList: apiv1.ResourceList{
 				apiv1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
 				apiv1.ResourceMemory: resource.MustParse("250.00Mi"),
 			},
 		},
 		{
-			name: "large memory value with humanize",
+			name: "large memory value with humanize and cpu rounding to 3",
 			resources: Resources{
 				ResourceCPU:    1000,
 				ResourceMemory: 839500000, // 800.61Mi
 			},
 			humanize: true,
+			roundCPU: 3,
 			resourceList: apiv1.ResourceList{
-				apiv1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
+				apiv1.ResourceCPU:    *resource.NewMilliQuantity(1002, resource.DecimalSI),
 				apiv1.ResourceMemory: resource.MustParse("800.61Mi"),
 			},
 		},
 		{
-			name: "zero values without humanize",
+			name: "zero values without humanize and cpu rounding to 2",
 			resources: Resources{
 				ResourceCPU:    0,
 				ResourceMemory: 0,
 			},
 			humanize: false,
+			roundCPU: 2,
 			resourceList: apiv1.ResourceList{
 				apiv1.ResourceCPU:    *resource.NewMilliQuantity(0, resource.DecimalSI),
 				apiv1.ResourceMemory: *resource.NewQuantity(0, resource.DecimalSI),
 			},
 		},
 		{
-			name: "large memory value without humanize",
+			name: "large memory value without humanize and cpu rounding to 13",
 			resources: Resources{
-				ResourceCPU:    1000,
+				ResourceCPU:    1231241,
 				ResourceMemory: 839500000,
 			},
 			humanize: false,
+			roundCPU: 13,
 			resourceList: apiv1.ResourceList{
-				apiv1.ResourceCPU:    *resource.NewMilliQuantity(1000, resource.DecimalSI),
+				apiv1.ResourceCPU:    *resource.NewMilliQuantity(1231243, resource.DecimalSI),
 				apiv1.ResourceMemory: *resource.NewQuantity(839500000, resource.DecimalSI),
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := ResourcesAsResourceList(tc.resources, tc.humanize)
+			result := ResourcesAsResourceList(tc.resources, tc.humanize, tc.roundCPU)
 			if !result[apiv1.ResourceCPU].Equal(tc.resourceList[apiv1.ResourceCPU]) {
 				t.Errorf("expected %v, got %v", tc.resourceList[apiv1.ResourceCPU], result[apiv1.ResourceCPU])
 			}
@@ -190,6 +196,63 @@ func TestHumanizeMemoryQuantity(t *testing.T) {
 		t.Run(tc.name, func(*testing.T) {
 			result := HumanizeMemoryQuantity(tc.value)
 			assert.Equal(t, tc.wanted, result)
+		})
+	}
+}
+
+type TestRoundUpToScaleTestCase struct {
+	name        string
+	value       ResourceAmount
+	scale       int
+	expected    ResourceAmount
+	expectedErr string
+}
+
+func TestRoundUpToScale(t *testing.T) {
+	testsCases := []TestRoundUpToScaleTestCase{
+		{
+			name:        "Round up to nearest 7",
+			value:       ResourceAmount(100),
+			scale:       7,
+			expected:    ResourceAmount(105),
+			expectedErr: "",
+		},
+		{
+			name:        "Exact multiple of 10",
+			value:       ResourceAmount(100),
+			scale:       10,
+			expected:    ResourceAmount(100),
+			expectedErr: "",
+		},
+		{
+			name:        "Zero value with scale 5",
+			value:       ResourceAmount(0),
+			scale:       5,
+			expected:    ResourceAmount(0),
+			expectedErr: "",
+		},
+		{
+			name:        "Negative scale value",
+			value:       ResourceAmount(100),
+			scale:       -5,
+			expected:    ResourceAmount(100),
+			expectedErr: "scale must be greater than zero",
+		},
+		{
+			name:        "Scale is zero",
+			value:       ResourceAmount(100),
+			scale:       0,
+			expected:    ResourceAmount(100),
+			expectedErr: "scale must be greater than zero",
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := RoundUpToScale(tc.value, tc.scale)
+			assert.Equal(t, tc.expected, result)
+			if tc.expectedErr != "" {
+				assert.Equal(t, tc.expectedErr, err.Error())
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds the `--round-cpu-millicores` flag to the VPA recommender, enabling user-configurable rounding of CPU recommendations. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7678

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`--round-cpu-millicores` flag to the VPA recommender
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Documentation updated to include the `--round-cpu-millicores` flag in the recommender feature set.  
```
