### PR TITLE
feat: implement force delete for the azure provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -446,34 +446,11 @@ func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
-	refs := make([]*azureRef, 0, len(nodes))
-	for _, node := range nodes {
-		belongs, err := as.Belongs(node)
-		if err != nil {
-			return err
-		}
-
-		if belongs != true {
-			return fmt.Errorf("%s belongs to a different asg than %s", node.Name, as.Name)
-		}
-
-		ref := &azureRef{
-			Name: node.Spec.ProviderID,
-		}
-		refs = append(refs, ref)
-	}
-
-	err = as.deleteOutdatedDeployments()
-	if err != nil {
-		klog.Warningf("DeleteNodes: failed to cleanup outdated deployments with err: %v.", err)
-	}
-
-	return as.DeleteInstances(refs)
+	return as.ForceDeleteNodes(nodes)
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
 func (as *AgentPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
-	klog.V(6).Infof("Delete nodes requested: %v\n", nodes)
 	refs := make([]*azureRef, 0, len(nodes))
 	for _, node := range nodes {
 		belongs, err := as.Belongs(node)

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -473,7 +473,30 @@ func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
 func (as *AgentPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
-	return cloudprovider.ErrNotImplemented
+	klog.V(6).Infof("Delete nodes requested: %v\n", nodes)
+	refs := make([]*azureRef, 0, len(nodes))
+	for _, node := range nodes {
+		belongs, err := as.Belongs(node)
+		if err != nil {
+			return err
+		}
+
+		if belongs != true {
+			return fmt.Errorf("%s belongs to a different asg than %s", node.Name, as.Name)
+		}
+
+		ref := &azureRef{
+			Name: node.Spec.ProviderID,
+		}
+		refs = append(refs, ref)
+	}
+
+	err := as.deleteOutdatedDeployments()
+	if err != nil {
+		klog.Warningf("ForceDeleteNodes: failed to cleanup outdated deployments with err: %v.", err)
+	}
+
+	return as.DeleteInstances(refs)
 }
 
 // Debug returns a debug string for the agent pool.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Introduces the force delete implementation for azure to help clean up long unregistered nodes. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
