### PR TITLE
Fix memory leak while fetching GCE instance templates.

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -306,7 +306,14 @@ func (m *gceManagerImpl) Refresh() error {
 	if m.lastRefresh.Add(refreshInterval).After(time.Now()) {
 		return nil
 	}
-	return m.forceRefresh()
+
+	if err := m.forceRefresh(); err != nil {
+		return err
+	}
+
+	migs := m.migLister.GetMigs()
+	m.cache.DropInstanceTemplatesForMissingMigs(migs)
+	return nil
 }
 
 func (m *gceManagerImpl) CreateInstances(mig Mig, delta int64) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR prevents instance templates and instance template names cache from leaking. Currently those caches aren't cleaned at all which causes issues for clusters with MIGs churn. This change is are adding cleaning for those caches to `RegenerateMigInstancesCache` which is called each hour worst case and cleans up caches only for the MIGs which are untracked.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed memory leak for GCE instance templates fetching
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
