### PR TITLE
Revert "Parallelize creating cluster snapshot"

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -311,8 +311,6 @@ type AutoscalingOptions struct {
 	ForceDeleteLongUnregisteredNodes bool
 	// DynamicResourceAllocationEnabled configures whether logic for handling DRA objects is enabled.
 	DynamicResourceAllocationEnabled bool
-	// ClusterSnapshotParallelism is the maximum parallelism of cluster snapshot creation.
-	ClusterSnapshotParallelism int
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
@@ -254,7 +254,7 @@ func BenchmarkFilterOutSchedulable(b *testing.B) {
 			return testsnapshot.NewCustomTestSnapshotOrDie(b, store.NewBasicSnapshotStore())
 		},
 		"delta": func() clustersnapshot.ClusterSnapshot {
-			return testsnapshot.NewCustomTestSnapshotOrDie(b, store.NewDeltaSnapshotStore(16))
+			return testsnapshot.NewCustomTestSnapshotOrDie(b, store.NewDeltaSnapshotStore())
 		},
 	}
 	for snapshotName, snapshotFactory := range snapshots {

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -283,7 +283,6 @@ var (
 	checkCapacityProvisioningRequestBatchTimebox = flag.Duration("check-capacity-provisioning-request-batch-timebox", 10*time.Second, "Maximum time to process a batch of provisioning requests.")
 	forceDeleteLongUnregisteredNodes             = flag.Bool("force-delete-unregistered-nodes", false, "Whether to enable force deletion of long unregistered nodes, regardless of the min size of the node group the belong to.")
 	enableDynamicResourceAllocation              = flag.Bool("enable-dynamic-resource-allocation", false, "Whether logic for handling DRA (Dynamic Resource Allocation) objects is enabled.")
-	clusterSnapshotParallelism                   = flag.Int("cluster-snapshot-parallelism", 16, "Maximum parallelism of cluster snapshot creation.")
 )
 
 func isFlagPassed(name string) bool {
@@ -464,7 +463,6 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		CheckCapacityProvisioningRequestBatchTimebox: *checkCapacityProvisioningRequestBatchTimebox,
 		ForceDeleteLongUnregisteredNodes:             *forceDeleteLongUnregisteredNodes,
 		DynamicResourceAllocationEnabled:             *enableDynamicResourceAllocation,
-		ClusterSnapshotParallelism:                   *clusterSnapshotParallelism,
 	}
 }
 
@@ -507,7 +505,7 @@ func buildAutoscaler(context ctx.Context, debuggingSnapshotter debuggingsnapshot
 	deleteOptions := options.NewNodeDeleteOptions(autoscalingOptions)
 	drainabilityRules := rules.Default(deleteOptions)
 
-	var snapshotStore clustersnapshot.ClusterSnapshotStore = store.NewDeltaSnapshotStore(autoscalingOptions.ClusterSnapshotParallelism)
+	var snapshotStore clustersnapshot.ClusterSnapshotStore = store.NewDeltaSnapshotStore()
 	if autoscalingOptions.DynamicResourceAllocationEnabled {
 		// TODO(DRA): Remove this once DeltaSnapshotStore is integrated with DRA.
 		klog.Warningf("Using BasicSnapshotStore instead of DeltaSnapshotStore because DRA is enabled. Autoscaling performance/scalability might be decreased.")

--- a/cluster-autoscaler/processors/podinjection/pod_injection_processor_test.go
+++ b/cluster-autoscaler/processors/podinjection/pod_injection_processor_test.go
@@ -114,7 +114,7 @@ func TestTargetCountInjectionPodListProcessor(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			p := NewPodInjectionPodListProcessor(podinjectionbackoff.NewFakePodControllerRegistry())
-			clusterSnapshot := testsnapshot.NewCustomTestSnapshotOrDie(t, store.NewDeltaSnapshotStore(16))
+			clusterSnapshot := testsnapshot.NewCustomTestSnapshotOrDie(t, store.NewDeltaSnapshotStore())
 			err := clusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node, tc.scheduledPods...))
 			assert.NoError(t, err)
 			ctx := context.AutoscalingContext{

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -56,7 +56,7 @@ var snapshots = map[string]func() (clustersnapshot.ClusterSnapshot, error){
 		if err != nil {
 			return nil, err
 		}
-		return NewPredicateSnapshot(store.NewDeltaSnapshotStore(16), fwHandle, true), nil
+		return NewPredicateSnapshot(store.NewDeltaSnapshotStore(), fwHandle, true), nil
 	},
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
@@ -48,7 +48,7 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(fmt.Sprintf("fork add 1000 to %d", tc.nodeCount), func(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc.nodeCount + 1000)
-			deltaStore := NewDeltaSnapshotStore(16)
+			deltaStore := NewDeltaSnapshotStore()
 			if err := deltaStore.SetClusterState(nodes[:tc.nodeCount], nil, drasnapshot.Snapshot{}); err != nil {
 				assert.NoError(b, err)
 			}
@@ -70,7 +70,7 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(fmt.Sprintf("base %d", tc.nodeCount), func(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc.nodeCount)
-			deltaStore := NewDeltaSnapshotStore(16)
+			deltaStore := NewDeltaSnapshotStore()
 			if err := deltaStore.SetClusterState(nodes, nil, drasnapshot.Snapshot{}); err != nil {
 				assert.NoError(b, err)
 			}


### PR DESCRIPTION
Reverts kubernetes/autoscaler#7630

There's a race condition when clearing the cache, which sometimes breaks unit tests:

```
WARNING: DATA RACE
Write at 0x00c001446ae8 by goroutine 49556:
  k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store.(*internalDeltaSnapshotData).clearPodCaches()
      /cluster-autoscaler/simulator/clustersnapshot/store/delta.go:185 +0x124
  k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store.(*internalDeltaSnapshotData).clearCaches()
      /cluster-autoscaler/simulator/clustersnapshot/store/delta.go:178 +0xb6
  k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store.(*internalDeltaSnapshotData).addPodsToNode()
      /cluster-autoscaler/simulator/clustersnapshot/store/delta.go:265 +0x82
  k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store.(*DeltaSnapshotStore).setClusterStatePodsParallelized.func1()
      /cluster-autoscaler/simulator/clustersnapshot/store/delta.go:485 +0x11b
  k8s.io/client-go/util/workqueue.ParallelizeUntil.func1()
      /gopath/pkg/mod/k8s.io/client-go@v0.33.0-alpha.0/util/workqueue/parallelizer.go:90 +0x1c1

Previous write at 0x00c001446ae8 by goroutine 49567:
  k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store.(*internalDeltaSnapshotData).clearPodCaches()
      /cluster-autoscaler/simulator/clustersnapshot/store/delta.go:185 +0x124
  k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store.(*internalDeltaSnapshotData).clearCaches()
      /cluster-autoscaler/simulator/clustersnapshot/store/delta.go:178 +0xb6
  k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store.(*internalDeltaSnapshotData).addPodsToNode()
      /cluster-autoscaler/simulator/clustersnapshot/store/delta.go:265 +0x82
  k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store.(*DeltaSnapshotStore).setClusterStatePodsParallelized.func1()
      /cluster-autoscaler/simulator/clustersnapshot/store/delta.go:485 +0x11b
  k8s.io/client-go/util/workqueue.ParallelizeUntil.func1()
      /gopath/pkg/mod/k8s.io/client-go@v0.33.0-alpha.0/util/workqueue/parallelizer.go:90 +0x1c1
```