### PR TITLE
Fix auto_scaling_group asg failed multi line warn log

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -548,7 +548,7 @@ func (m *asgCache) isNodeGroupAvailable(group *autoscaling.Group) (bool, error) 
 			if activity.StartTime.Before(lut) {
 				break
 			} else if *activity.StatusCode == "Failed" {
-				klog.Warningf("ASG %s scaling failed with %s", asgRef.Name, *activity)
+				klog.Warningf("ASG %s scaling failed with %s", asgRef.Name, *activity.StatusMessage)
 				return false, nil
 			}
 		} else {

--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups_test.go
@@ -81,8 +81,9 @@ func TestCreatePlaceholders(t *testing.T) {
 			desiredCapacity: aws.Int64(1),
 			activities: []*autoscaling.Activity{
 				{
-					StatusCode: aws.String("Failed"),
-					StartTime:  aws.Time(time.Unix(10, 0)),
+					StatusCode:    aws.String("Failed"),
+					StartTime:     aws.Time(time.Unix(10, 0)),
+					StatusMessage: aws.String("Something failed"),
 				},
 			},
 			groupLastUpdateTime: time.Unix(9, 0),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Change multiline warn log into single log using required information not to output multi line output.

See also https://github.com/kubernetes/autoscaler/issues/7702

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7702

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
