### PR TITLE
Fix cert generation for VPA 1.2.2 when running vpa-up.sh

### DIFF
--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -63,7 +63,7 @@ fi
 
 for i in $COMPONENTS; do
   if [ $i == admission-controller-deployment ] ; then
-    if [ ${ACTION} == create ] ; then
+    if [ ${ACTION} == create || ${ACTION} == apply ] ; then
       (bash ${SCRIPT_ROOT}/pkg/admission-controller/gencerts.sh || true)
     elif [ ${ACTION} == delete ] ; then
       (bash ${SCRIPT_ROOT}/pkg/admission-controller/rmcerts.sh || true)

--- a/vertical-pod-autoscaler/hack/vpa-up.sh
+++ b/vertical-pod-autoscaler/hack/vpa-up.sh
@@ -26,4 +26,4 @@ if [ "${TAG_TO_APPLY}" == "${DEFAULT_TAG}" ]; then
   git switch --detach vertical-pod-autoscaler-${DEFAULT_TAG}
 fi
 
-$SCRIPT_ROOT/hack/vpa-process-yamls.sh create $*
+$SCRIPT_ROOT/hack/vpa-process-yamls.sh apply $*


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes the problem people currently experience when running `hack/vpa-up.sh` from `master`, as seen in https://github.com/kubernetes/autoscaler/issues/7270 and very recently again in https://github.com/kubernetes/autoscaler/issues/4775#issuecomment-2579663219

This is necessary, because we did https://github.com/kubernetes/autoscaler/pull/7365 only on `master`, but `hack/vpa-up.sh` checks out the release branch before running `hack/vpa-process-yamls.sh`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4775 
Fixes #7270

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed cert generation issues when installing VPA with `hack/vpa-up.sh`. No need to run `pkg/admission-controller/gencerts.sh` manually anymore.
```

