### PR TITLE
fix: don't crash when vmss not present or has no nodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -170,7 +170,7 @@ func (m *azureCache) regenerate() error {
 		if err != nil {
 			return err
 		}
-		klog.V(4).Infof("regenerate: found nodes for node group %s: %+v", ng.Id(), instances)
+		klog.V(4).Infof("regenerate: found %d nodes for node group %s: %+v", len(instances), ng.Id(), instances)
 
 		for _, instance := range instances {
 			ref := azureRef{Name: instance.Id}

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -1249,6 +1249,49 @@ func TestGetScaleSetOptions(t *testing.T) {
 	assert.Equal(t, *opts, defaultOptions)
 }
 
+// TestVMSSNotFound ensures that AzureManager is still able to be built
+// if one nodeGroup (VMSS) is not found. Previously, we would fail on manager creation
+// if even one expected nodeGroup was not found. When manager creation errored out,
+// BuildAzure returns log.Fatalf() which caused CAS to crash.
+func TestVMSSNotFound(t *testing.T) {
+	// client setup
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	client := azClient{}
+	client.virtualMachineScaleSetsClient = mockVMSSClient
+	client.virtualMachinesClient = mockVMClient
+	client.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	// Expect that no vmss are present in the vmss client
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), "fakeId", testASG, gomock.Any()).Return([]compute.VirtualMachineScaleSetVM{}, nil).AnyTimes()
+	mockVMClient.EXPECT().List(gomock.Any(), "fakeId").Return([]compute.VirtualMachine{}, nil).AnyTimes()
+	mockVMSSClient.EXPECT().List(gomock.Any(), "fakeId").Return([]compute.VirtualMachineScaleSet{}, nil).AnyTimes()
+
+	// Add explicit node group to look for during init
+	ngdo := cloudprovider.NodeGroupDiscoveryOptions{
+		NodeGroupSpecs: []string{
+			fmt.Sprintf("%d:%d:%s", 1, 3, testASG),
+		},
+	}
+
+	// We expect the initial BuildAzure flow to pass when a NodeGroup is detected
+	// that doesn't have a corresponding VMSS in the cache.
+	t.Run("should not error when VMSS not found in cache", func(t *testing.T) {
+		manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfg), ngdo, &client)
+		assert.NoError(t, err)
+		// expect one nodegroup to be present
+		nodeGroups := manager.getNodeGroups()
+		assert.Len(t, nodeGroups, 1)
+		assert.Equal(t, nodeGroups[0].Id(), testASG)
+		// expect no scale sets to be present
+		scaleSets := manager.azureCache.getScaleSets()
+		assert.Len(t, scaleSets, 0)
+	})
+}
+
 func assertStructsMinimallyEqual(t *testing.T, struct1, struct2 interface{}) bool {
 	return compareStructFields(t, reflect.ValueOf(struct1), reflect.ValueOf(struct2))
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Clone of https://github.com/kubernetes/autoscaler/pull/6672 with an additional fix on printing format.

> #### Testing
> * One unit test in `azure_manager_test.go` that acts as an acceptance test.
> * One e2e test (in-progress)
> 
> #### What this PR does / why we need it:
> We currently crash CAS if there are no nodes or if VMSS (Azure `NodeGroup` implementation) is not present. Ideally, we'd like to avoid crashing in most situations and instead log.
> 
> **Main problem was in BuildAzure (call path shown below)**:
> 
> * [cloudprovider.BuildAzure](https://github.com/kubernetes/autoscaler/blob/9b41b9dc5bf431a4ad657c044e809b15cc28a7e2/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go#L206) --> `klog.Fatalf("Failed to create Azure Manager: %v", err`
> * [CreateAzureManager](https://github.com/kubernetes/autoscaler/blob/9b41b9dc5bf431a4ad657c044e809b15cc28a7e2/cluster-autoscaler/cloudprovider/azure/azure_manager.go#L138) --> returns forceRefresh err
> * [azureManager.forceRefresh](https://github.com/kubernetes/autoscaler/blob/9b41b9dc5bf431a4ad657c044e809b15cc28a7e2/cluster-autoscaler/cloudprovider/azure/azure_manager.go#L208) --> `klog.Errorf("Failed to regenerate Azure cache: %v", err), return err`
> * [azureCache.regenerate](https://github.com/kubernetes/autoscaler/blob/9b41b9dc5bf431a4ad657c044e809b15cc28a7e2/cluster-autoscaler/cloudprovider/azure/azure_cache.go#L169-L171) --> return ng.Nodes() error
> * [scaleSet.Nodes](https://github.com/kubernetes/autoscaler/blob/9b41b9dc5bf431a4ad657c044e809b15cc28a7e2/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go#L651-L655) --> `klog.Errorf("Failed to get current size for vmss %q: %v", scaleSet.Name, err), return err`
> * [scaleSet.getCurSize](https://github.com/kubernetes/autoscaler/blob/9b41b9dc5bf431a4ad657c044e809b15cc28a7e2/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go#L189-L194) --> `klog.Errorf("failed to get information for VMSS: %s, error: %v", scaleSet.Name, err), return err`
> * [getVMSSFromCache](https://github.com/kubernetes/autoscaler/blob/9b41b9dc5bf431a4ad657c044e809b15cc28a7e2/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go#L179-L181) --> `return compute.VirtualMachineScaleSet{}, fmt.Errorf("could not find vmss: %s", scaleSet.Name)`
> 
> **Main updates include:**
> 
> * updating `Nodes()` to not error if there are zero nodes, but rather log and return an empty list of instances
> * updated `GetOptions()` to not error
> * updated `regenerate` to handle `instances == nil`
> 
> **Key exceptions found**:
> 
> * `TemplateNodeInfo()` errors are handled by the core code. Typically, if the node group is not found, core logs a warning and skips the node group. The only exception is for `GetNodeFromTemplate()`. If `TemplateNodeInfo()` returns an error, this case is not handled since it's required to spin up a new node.
> * `GetOptions()` should not error, because if options are nil, we just use default options. GCE + AWS both return nil error here.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Should be identical to https://github.com/kubernetes/autoscaler/pull/6672 but with https://github.com/kubernetes/autoscaler/pull/6672#discussion_r1848944063

#### Does this PR introduce a user-facing change?
Yes

```release-note
- Azure: fixed an issue where CAS crashes when VMSS is not present or has no nodes
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
