### PR TITLE
[cluster-autoscaler-release-1.28] test: clean up environments properly before/after each unit test in azure_manager_test.go

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -214,6 +214,9 @@ func loadEnv(originalEnv []string) {
 
 func TestCreateAzureManagerValidConfig(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -293,12 +296,13 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
-
-	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerLegacyConfig(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -376,12 +380,13 @@ func TestCreateAzureManagerLegacyConfig(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
-
-	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerValidConfigForStandardVMType(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -483,22 +488,24 @@ func TestCreateAzureManagerValidConfigForStandardVMType(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
-
-	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerValidConfigForStandardVMTypeWithoutDeploymentParameters(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForStandardVMTypeWithoutDeploymentParameters), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{})
 	expectedErr := "open /var/lib/azure/azuredeploy.parameters.json: no such file or directory"
 	assert.Nil(t, manager)
 	assert.Equal(t, expectedErr, err.Error(), "return error does not match, expected: %v, actual: %v", expectedErr, err.Error())
-
-	loadEnv(originalEnv)
 }
 func TestCreateAzureManagerValidConfigForVMsPool(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -580,12 +587,13 @@ func TestCreateAzureManagerValidConfigForVMsPool(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
-
-	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -827,12 +835,13 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
 	})
-
-	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerWithEnvOverridingConfig(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -958,21 +967,23 @@ func TestCreateAzureManagerWithEnvOverridingConfig(t *testing.T) {
 		assert.NoError(t, err)
 		assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
 	})
-
-	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerInvalidConfig(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	_, err := createAzureManagerInternal(strings.NewReader(invalidAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{})
 	assert.Error(t, err, "failed to unmarshal config body")
-
-	loadEnv(originalEnv)
 }
 
 func TestFetchExplicitNodeGroups(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1046,12 +1057,13 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 	err = manager.fetchExplicitNodeGroups(ngdo.NodeGroupSpecs)
 	expectedErr = fmt.Errorf("failed to parse node group spec: vmtype invalidVMType not supported")
 	assert.Equal(t, expectedErr, err, "manager.fetchExplicitNodeGroups return error does not match, expected: %v, actual: %v", expectedErr, err)
-
-	loadEnv(originalEnv)
 }
 
 func TestGetFilteredAutoscalingGroupsVmss(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1095,12 +1107,13 @@ func TestGetFilteredAutoscalingGroupsVmss(t *testing.T) {
 		InstanceCache:            InstanceCache{instancesRefreshPeriod: defaultVmssInstancesRefreshPeriod},
 	}}
 	assert.True(t, assert.ObjectsAreEqualValues(expectedAsgs, asgs), "expected %#v, but found: %#v", expectedAsgs, asgs)
-
-	loadEnv(originalEnv)
 }
 
 func TestGetFilteredAutoscalingGroupsWithInvalidVMType(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1129,12 +1142,13 @@ func TestGetFilteredAutoscalingGroupsWithInvalidVMType(t *testing.T) {
 	asgs, err2 = manager.getFilteredNodeGroups(specs)
 	assert.Nil(t, asgs)
 	assert.Equal(t, expectedErr, err2, "Not match, expected: %v, actual: %v", expectedErr, err2)
-
-	loadEnv(originalEnv)
 }
 
 func TestFetchAutoAsgsVmss(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1187,12 +1201,13 @@ func TestFetchAutoAsgsVmss(t *testing.T) {
 	manager.fetchAutoNodeGroups()
 	asgs = manager.azureCache.getRegisteredNodeGroups()
 	assert.Equal(t, 1, len(asgs))
-
-	loadEnv(originalEnv)
 }
 
 func TestManagerRefreshAndCleanup(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1201,12 +1216,13 @@ func TestManagerRefreshAndCleanup(t *testing.T) {
 	err := manager.Refresh()
 	assert.NoError(t, err)
 	manager.Cleanup()
-
-	loadEnv(originalEnv)
 }
 
 func TestGetScaleSetOptions(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	manager := &AzureManager{
 		azureCache: &azureCache{
@@ -1249,8 +1265,6 @@ func TestGetScaleSetOptions(t *testing.T) {
 	manager.azureCache.autoscalingOptions[azureRef{Name: "test3"}] = map[string]string{}
 	opts = manager.GetScaleSetOptions("test3", defaultOptions)
 	assert.Equal(t, *opts, defaultOptions)
-
-	loadEnv(originalEnv)
 }
 
 // TestVMSSNotFound ensures that AzureManager is still able to be built
@@ -1259,6 +1273,9 @@ func TestGetScaleSetOptions(t *testing.T) {
 // BuildAzure returns log.Fatalf() which caused CAS to crash.
 func TestVMSSNotFound(t *testing.T) {
 	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
 
 	// client setup
 	ctrl := gomock.NewController(t)
@@ -1296,8 +1313,6 @@ func TestVMSSNotFound(t *testing.T) {
 		scaleSets := manager.azureCache.getScaleSets()
 		assert.Len(t, scaleSets, 0)
 	})
-
-	loadEnv(originalEnv)
 }
 
 func assertStructsMinimallyEqual(t *testing.T, struct1, struct2 interface{}) bool {

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -197,7 +198,23 @@ const (
 	testASG         = "test-asg"
 )
 
+func saveAndClearEnv() []string {
+	originalEnv := os.Environ()
+	os.Clearenv()
+	return originalEnv
+}
+
+func loadEnv(originalEnv []string) {
+	os.Clearenv()
+	for _, e := range originalEnv {
+		parts := strings.SplitN(e, "=", 2)
+		os.Setenv(parts[0], parts[1])
+	}
+}
+
 func TestCreateAzureManagerValidConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -276,9 +293,13 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
+
+	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerLegacyConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -355,9 +376,13 @@ func TestCreateAzureManagerLegacyConfig(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
+
+	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerValidConfigForStandardVMType(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -458,15 +483,23 @@ func TestCreateAzureManagerValidConfigForStandardVMType(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
+
+	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerValidConfigForStandardVMTypeWithoutDeploymentParameters(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForStandardVMTypeWithoutDeploymentParameters), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{})
 	expectedErr := "open /var/lib/azure/azuredeploy.parameters.json: no such file or directory"
 	assert.Nil(t, manager)
 	assert.Equal(t, expectedErr, err.Error(), "return error does not match, expected: %v, actual: %v", expectedErr, err.Error())
+
+	loadEnv(originalEnv)
 }
 func TestCreateAzureManagerValidConfigForVMsPool(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -547,9 +580,13 @@ func TestCreateAzureManagerValidConfigForVMsPool(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
+
+	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerWithNilConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -790,9 +827,13 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
 	})
+
+	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerWithEnvOverridingConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -917,14 +958,22 @@ func TestCreateAzureManagerWithEnvOverridingConfig(t *testing.T) {
 		assert.NoError(t, err)
 		assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
 	})
+
+	loadEnv(originalEnv)
 }
 
 func TestCreateAzureManagerInvalidConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	_, err := createAzureManagerInternal(strings.NewReader(invalidAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{})
 	assert.Error(t, err, "failed to unmarshal config body")
+
+	loadEnv(originalEnv)
 }
 
 func TestFetchExplicitNodeGroups(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -997,9 +1046,13 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 	err = manager.fetchExplicitNodeGroups(ngdo.NodeGroupSpecs)
 	expectedErr = fmt.Errorf("failed to parse node group spec: vmtype invalidVMType not supported")
 	assert.Equal(t, expectedErr, err, "manager.fetchExplicitNodeGroups return error does not match, expected: %v, actual: %v", expectedErr, err)
+
+	loadEnv(originalEnv)
 }
 
 func TestGetFilteredAutoscalingGroupsVmss(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1042,9 +1095,13 @@ func TestGetFilteredAutoscalingGroupsVmss(t *testing.T) {
 		InstanceCache:            InstanceCache{instancesRefreshPeriod: defaultVmssInstancesRefreshPeriod},
 	}}
 	assert.True(t, assert.ObjectsAreEqualValues(expectedAsgs, asgs), "expected %#v, but found: %#v", expectedAsgs, asgs)
+
+	loadEnv(originalEnv)
 }
 
 func TestGetFilteredAutoscalingGroupsWithInvalidVMType(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1072,9 +1129,13 @@ func TestGetFilteredAutoscalingGroupsWithInvalidVMType(t *testing.T) {
 	asgs, err2 = manager.getFilteredNodeGroups(specs)
 	assert.Nil(t, asgs)
 	assert.Equal(t, expectedErr, err2, "Not match, expected: %v, actual: %v", expectedErr, err2)
+
+	loadEnv(originalEnv)
 }
 
 func TestFetchAutoAsgsVmss(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1126,9 +1187,13 @@ func TestFetchAutoAsgsVmss(t *testing.T) {
 	manager.fetchAutoNodeGroups()
 	asgs = manager.azureCache.getRegisteredNodeGroups()
 	assert.Equal(t, 1, len(asgs))
+
+	loadEnv(originalEnv)
 }
 
 func TestManagerRefreshAndCleanup(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1136,9 +1201,13 @@ func TestManagerRefreshAndCleanup(t *testing.T) {
 	err := manager.Refresh()
 	assert.NoError(t, err)
 	manager.Cleanup()
+
+	loadEnv(originalEnv)
 }
 
 func TestGetScaleSetOptions(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	manager := &AzureManager{
 		azureCache: &azureCache{
 			autoscalingOptions: make(map[azureRef]map[string]string),
@@ -1180,6 +1249,8 @@ func TestGetScaleSetOptions(t *testing.T) {
 	manager.azureCache.autoscalingOptions[azureRef{Name: "test3"}] = map[string]string{}
 	opts = manager.GetScaleSetOptions("test3", defaultOptions)
 	assert.Equal(t, *opts, defaultOptions)
+
+	loadEnv(originalEnv)
 }
 
 // TestVMSSNotFound ensures that AzureManager is still able to be built
@@ -1187,6 +1258,8 @@ func TestGetScaleSetOptions(t *testing.T) {
 // if even one expected nodeGroup was not found. When manager creation errored out,
 // BuildAzure returns log.Fatalf() which caused CAS to crash.
 func TestVMSSNotFound(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+
 	// client setup
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1223,6 +1296,8 @@ func TestVMSSNotFound(t *testing.T) {
 		scaleSets := manager.azureCache.getScaleSets()
 		assert.Len(t, scaleSets, 0)
 	})
+
+	loadEnv(originalEnv)
 }
 
 func assertStructsMinimallyEqual(t *testing.T, struct1, struct2 interface{}) bool {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Cherry-pick of https://github.com/kubernetes/autoscaler/pull/7735.
Automated one doesn't work due to new functions in 1.31 and beyond.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
