### PR TITLE
Kamatera cluster autoscaler fixes

### DIFF
--- a/cluster-autoscaler/cloudprovider/kamatera/README.md
+++ b/cluster-autoscaler/cloudprovider/kamatera/README.md
@@ -30,18 +30,19 @@ You can see an example of the cloud config file at [examples/deployment.yaml](ex
 
 it is an INI file with the following fields:
 
-| Key | Value | Mandatory | Default |
-|-----|-------|-----------|---------|
-| global/kamatera-api-client-id | Kamatera API Client ID | yes | none |
-| global/kamatera-api-secret | Kamatera API Secret | yes | none |
-| global/cluster-name | **max 15 characters: english letters, numbers, dash, underscore, space, dot**: distinct string used to set the cluster server tag | yes | none |
-| global/default-min-size | default minimum size of a node group (must be > 0) | no | 1 |
-| global/default-max-size | default maximum size of a node group | no | 254 |
-| global/default-<SERVER_CONFIG_KEY> | replace <SERVER_CONFIG_KEY> with the relevant configuration key | see below | see below |
-| nodegroup \"name\" | **max 15 characters: english letters, numbers, dash, underscore, space, dot**: distinct string within the cluster used to set the node group server tag | yes | none |
-| nodegroup \"name\"/min-size | minimum size for a specific node group | no | global/defaut-min-size |
-| nodegroup \"name\"/max-size | maximum size for a specific node group | no | global/defaut-min-size |
-| nodegroup \"name\"/<SERVER_CONFIG_KEY> | replace <SERVER_CONFIG_KEY> with the relevant configuration key | no | global/default-<SERVER_CONFIG_KEY> |
+| Key                                    | Value                                                                                                                                                   | Mandatory | Default                            |
+|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|------------------------------------|
+| global/kamatera-api-client-id          | Kamatera API Client ID                                                                                                                                  | yes       | none                               |
+| global/kamatera-api-secret             | Kamatera API Secret                                                                                                                                     | yes       | none                               |
+| global/cluster-name                    | **max 15 characters: english letters, numbers, dash, underscore, space, dot**: distinct string used to set the cluster server tag                       | yes       | none                               |
+| global/filter-name-prefix              | autoscaler will only handle server names that start with this prefix                                                                                    | no        | none                               |
+| global/default-min-size                | default minimum size of a node group (must be > 0)                                                                                                      | no        | 1                                  |
+| global/default-max-size                | default maximum size of a node group                                                                                                                    | no        | 254                                |
+| global/default-<SERVER_CONFIG_KEY>     | replace <SERVER_CONFIG_KEY> with the relevant configuration key                                                                                         | see below | see below                          |
+| nodegroup \"name\"                     | **max 15 characters: english letters, numbers, dash, underscore, space, dot**: distinct string within the cluster used to set the node group server tag | yes       | none                               |
+| nodegroup \"name\"/min-size            | minimum size for a specific node group                                                                                                                  | no        | global/defaut-min-size             |
+| nodegroup \"name\"/max-size            | maximum size for a specific node group                                                                                                                  | no        | global/defaut-min-size             |
+| nodegroup \"name\"/<SERVER_CONFIG_KEY> | replace <SERVER_CONFIG_KEY> with the relevant configuration key                                                                                         | no        | global/default-<SERVER_CONFIG_KEY> |
 
 ### Server configuration keys
 

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client.go
@@ -22,7 +22,7 @@ import (
 
 // kamateraAPIClient is the interface used to call kamatera API
 type kamateraAPIClient interface {
-	ListServers(ctx context.Context, instances map[string]*Instance) ([]Server, error)
+	ListServers(ctx context.Context, instances map[string]*Instance, namePrefix string) ([]Server, error)
 	DeleteServer(ctx context.Context, name string) error
 	CreateServers(ctx context.Context, count int, config ServerConfig) ([]Server, error)
 }

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client_rest.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client_rest.go
@@ -258,7 +258,7 @@ func (c *KamateraApiClientRest) getServerTags(ctx context.Context, serverName st
 		tags := make([]string, 0)
 		for _, row := range res.([]interface{}) {
 			row := row.(map[string]interface{})
-			tags = append(tags, row["tag name"].(string))
+			tags = append(tags, row["tagName"].(string))
 		}
 		return tags, nil
 	}

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client_rest.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client_rest.go
@@ -267,5 +267,5 @@ func kamateraServerName(namePrefix string) string {
 	if len(namePrefix) > 0 {
 		namePrefix = fmt.Sprintf("%s-", namePrefix)
 	}
-	return fmt.Sprintf("%s%s", namePrefix, strings.ReplaceAll(uuid.New().String(), "-", ""))
+	return fmt.Sprintf("%s%s", namePrefix, strings.ReplaceAll(uuid.New().String()[:12], "-", ""))
 }

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client_rest_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_api_client_rest_test.go
@@ -76,7 +76,7 @@ func TestApiClientRest_ListServers(t *testing.T) {
 ]`, newServerName1, cachedServerName2, cachedServerName3, cachedServerName4),
 	).On("handle", "/server/tags").Return(
 		"application/json",
-		`[{"tag name": "test-tag"}, {"tag name": "other-test-tag"}]`,
+		`[{"tagName": "test-tag"}, {"tagName": "other-test-tag"}]`,
 	)
 	servers, err := client.ListServers(ctx, map[string]*Instance{
 		cachedServerName2: {
@@ -140,7 +140,7 @@ func TestApiClientRest_ListServersNamePrefix(t *testing.T) {
 ]`, newServerName1, newServerName2),
 	).On("handle", "/server/tags").Return(
 		"application/json",
-		`[{"tag name": "test-tag"}, {"tag name": "other-test-tag"}]`,
+		`[{"tagName": "test-tag"}, {"tagName": "other-test-tag"}]`,
 	)
 	servers, err := client.ListServers(ctx, map[string]*Instance{}, "prefixb")
 	assert.NoError(t, err)

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_config.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_config.go
@@ -52,13 +52,14 @@ type nodeGroupConfig struct {
 
 // kamateraConfig holds the configuration for the Kamatera provider.
 type kamateraConfig struct {
-	apiClientId    string
-	apiSecret      string
-	apiUrl         string
-	clusterName    string
-	defaultMinSize int
-	defaultMaxSize int
-	nodeGroupCfg   map[string]*nodeGroupConfig // key is the node group name
+	apiClientId      string
+	apiSecret        string
+	apiUrl           string
+	clusterName      string
+	filterNamePrefix string
+	defaultMinSize   int
+	defaultMaxSize   int
+	nodeGroupCfg     map[string]*nodeGroupConfig // key is the node group name
 }
 
 // GcfgGlobalConfig is the gcfg representation of the global section in the cloud config file for Kamatera.
@@ -67,6 +68,7 @@ type GcfgGlobalConfig struct {
 	KamateraApiSecret     string   `gcfg:"kamatera-api-secret"`
 	KamateraApiUrl        string   `gcfg:"kamatera-api-url"`
 	ClusterName           string   `gcfg:"cluster-name"`
+	FilterNamePrefix      string   `gcfg:"filter-name-prefix"`
 	DefaultMinSize        string   `gcfg:"default-min-size"`
 	DefaultMaxSize        string   `gcfg:"default-max-size"`
 	DefaultNamePrefix     string   `gcfg:"default-name-prefix"`
@@ -142,6 +144,8 @@ func buildCloudConfig(config io.Reader) (*kamateraConfig, error) {
 	if len(clusterName) > 15 {
 		return nil, fmt.Errorf("cluster name must be at most 15 characters long")
 	}
+
+	filterNamePrefix := gcfgCloudConfig.Global.FilterNamePrefix
 
 	// get the default min and max size as defined in the global section of the config file
 	defaultMinSize, defaultMaxSize, err := getSizeLimits(
@@ -242,13 +246,14 @@ func buildCloudConfig(config io.Reader) (*kamateraConfig, error) {
 	}
 
 	return &kamateraConfig{
-		clusterName:    clusterName,
-		apiClientId:    apiClientId,
-		apiSecret:      apiSecret,
-		apiUrl:         apiUrl,
-		defaultMinSize: defaultMinSize,
-		defaultMaxSize: defaultMaxSize,
-		nodeGroupCfg:   nodeGroupCfg,
+		clusterName:      clusterName,
+		apiClientId:      apiClientId,
+		apiSecret:        apiSecret,
+		apiUrl:           apiUrl,
+		filterNamePrefix: filterNamePrefix,
+		defaultMinSize:   defaultMinSize,
+		defaultMaxSize:   defaultMaxSize,
+		nodeGroupCfg:     nodeGroupCfg,
 	}, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_manager.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_manager.go
@@ -63,6 +63,7 @@ func (m *manager) refresh() error {
 	servers, err := m.client.ListServers(
 		context.Background(),
 		m.instances,
+		m.config.filterNamePrefix,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to get list of Kamatera servers from Kamatera API: %v", err)

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_manager_test.go
@@ -49,6 +49,7 @@ func TestManager_refresh(t *testing.T) {
 kamatera-api-client-id=1a222bbb3ccc44d5555e6ff77g88hh9i
 kamatera-api-secret=9ii88h7g6f55555ee4444444dd33eee2
 cluster-name=aaabbb
+filter-name-prefix=myprefix
 default-datacenter=IL
 default-image=ubuntu
 default-cpu=1a
@@ -72,12 +73,12 @@ max-size=5
 	m.client = &client
 	ctx := context.Background()
 
-	serverName1 := mockKamateraServerName()
-	serverName2 := mockKamateraServerName()
-	serverName3 := mockKamateraServerName()
-	serverName4 := mockKamateraServerName()
+	serverName1 := "myprefix" + mockKamateraServerName()
+	serverName2 := "myprefix" + mockKamateraServerName()
+	serverName3 := "myprefix" + mockKamateraServerName()
+	serverName4 := "myprefix" + mockKamateraServerName()
 	client.On(
-		"ListServers", ctx, m.instances,
+		"ListServers", ctx, m.instances, "myprefix",
 	).Return(
 		[]Server{
 			{Name: serverName1, Tags: []string{fmt.Sprintf("%s%s", clusterServerTagPrefix, "aaabbb"), fmt.Sprintf("%s%s", nodeGroupTagPrefix, "ng1")}},
@@ -95,7 +96,7 @@ max-size=5
 
 	// test api error
 	client.On(
-		"ListServers", ctx, m.instances,
+		"ListServers", ctx, m.instances, "myprefix",
 	).Return(
 		[]Server{},
 		fmt.Errorf("error on API call"),
@@ -143,7 +144,7 @@ cluster-name=aaabbb
 	ctx := context.Background()
 	serverName1 := mockKamateraServerName()
 	client.On(
-		"ListServers", ctx, m.instances,
+		"ListServers", ctx, m.instances, "",
 	).Return(
 		[]Server{
 			{Name: serverName1, Tags: []string{fmt.Sprintf("%s%s", clusterServerTagPrefix, "aaabbb"), fmt.Sprintf("%s%s", nodeGroupTagPrefix, "ng1")}},

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group_test.go
@@ -159,7 +159,7 @@ func TestNodeGroup_DeleteNodes(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot find this node in the node group")
 
-	// test error on deleting a node when the linode API call fails
+	// test error on deleting a node when the API call fails
 	client.On(
 		"DeleteServer", ctx, serverName4,
 	).Return(fmt.Errorf("error on API call")).Once()

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_utils_test.go
@@ -56,8 +56,8 @@ func (c *kamateraClientMock) SetBaseURL(baseURL string) {
 	c.Called(baseURL)
 }
 
-func (c *kamateraClientMock) ListServers(ctx context.Context, instances map[string]*Instance) ([]Server, error) {
-	args := c.Called(ctx, instances)
+func (c *kamateraClientMock) ListServers(ctx context.Context, instances map[string]*Instance, namePrefix string) ([]Server, error) {
+	args := c.Called(ctx, instances, namePrefix)
 	return args.Get(0).([]Server), args.Error(1)
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes for Kamatera cluster autoscaler:
* added global/filter-name-prefix - optionally allowing to limit the servers considered by the autoscaler
* added retry mechanism to some of the rest api calls
* fixes for tags handling to match latest kamatera rest api responses
* shorten the server uuid suffix to prevent cases of too long server names

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Bug fixes and improvements for Kamatera cluster autoscaler to align with latest Kamatera platform changes
```
