### PR TITLE
Finalize VPA release 1.3.0.

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.45.1
+version: 9.46.0

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -75,6 +75,7 @@ To create a valid configuration, follow instructions for your cloud provider:
 - [Cluster API](#cluster-api)
 - [Exoscale](#exoscale)
 - [Hetzner Cloud](#hetzner-cloud)
+- [Civo](#civo)
 
 ### Templating the autoDiscovery.clusterName
 
@@ -282,6 +283,23 @@ Each autoscaling group requires an additional `instanceType` and `region` key to
 
 Read [cluster-autoscaler/cloudprovider/hetzner/README.md](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/hetzner/README.md) for further information on the setup without helm.
 
+### Civo
+
+The following parameters are required:
+
+- `cloudProvider=civo`
+- `autoscalingGroups=...`
+
+When installing the helm chart to the namespace `kube-system`, you can set `secretKeyRefNameOverride` to `civo-api-access`.
+Otherwise specify the following parameters:
+
+- `civoApiUrl=https://api.civo.com`
+- `civoApiKey=...`
+- `civoClusterID=...`
+- `civoRegion=...`
+
+Read [cluster-autoscaler/cloudprovider/civo/README.md](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/civo/README.md) for further information on the setup without helm.
+
 ## Uninstalling the Chart
 
 To uninstall `my-release`:
@@ -421,8 +439,12 @@ vpa:
 | azureUseManagedIdentityExtension | bool | `false` | Whether to use Azure's managed identity extension for credentials. If using MSI, ensure subscription ID, resource group, and azure AKS cluster name are set. You can only use one authentication method at a time, either azureUseWorkloadIdentityExtension or azureUseManagedIdentityExtension should be set. |
 | azureUseWorkloadIdentityExtension | bool | `false` | Whether to use Azure's workload identity extension for credentials. See the project here: https://github.com/Azure/azure-workload-identity for more details. You can only use one authentication method at a time, either azureUseWorkloadIdentityExtension or azureUseManagedIdentityExtension should be set. |
 | azureVMType | string | `"vmss"` | Azure VM type. |
+| civoApiKey | string | `""` | API key for the Civo API. Required if `cloudProvider=civo` |
+| civoApiUrl | string | `"https://api.civo.com"` | URL for the Civo API. Required if `cloudProvider=civo` |
+| civoClusterID | string | `""` | Cluster ID for the Civo cluster. Required if `cloudProvider=civo` |
+| civoRegion | string | `""` | Region for the Civo cluster. Required if `cloudProvider=civo` |
 | cloudConfigPath | string | `""` | Configuration file for cloud provider. |
-| cloudProvider | string | `"aws"` | The cloud provider where the autoscaler runs. Currently only `gce`, `aws`, `azure`, `magnum` and `clusterapi` are supported. `aws` supported for AWS. `gce` for GCE. `azure` for Azure AKS. `magnum` for OpenStack Magnum, `clusterapi` for Cluster API. |
+| cloudProvider | string | `"aws"` | The cloud provider where the autoscaler runs. Currently only `gce`, `aws`, `azure`, `magnum`, `clusterapi` and `civo` are supported. `aws` supported for AWS. `gce` for GCE. `azure` for Azure AKS. `magnum` for OpenStack Magnum, `clusterapi` for Cluster API. `civo` for Civo Cloud. |
 | clusterAPICloudConfigPath | string | `"/etc/kubernetes/mgmt-kubeconfig"` | Path to kubeconfig for connecting to Cluster API Management Cluster, only used if `clusterAPIMode=kubeconfig-kubeconfig or incluster-kubeconfig` |
 | clusterAPIConfigMapsNamespace | string | `""` | Namespace on the workload cluster to store Leader election and status configmaps |
 | clusterAPIKubeconfigSecret | string | `""` | Secret containing kubeconfig for connecting to Cluster API managed workloadcluster Required if `cloudProvider=clusterapi` and `clusterAPIMode=kubeconfig-kubeconfig,kubeconfig-incluster or incluster-kubeconfig` |
@@ -476,7 +498,7 @@ vpa:
 | replicaCount | int | `1` | Desired number of pods |
 | resources | object | `{}` | Pod resource requests and limits. |
 | revisionHistoryLimit | int | `10` | The number of revisions to keep. |
-| secretKeyRefNameOverride | string | `""` | Overrides the name of the Secret to use when loading the secretKeyRef for AWS and Azure env variables |
+| secretKeyRefNameOverride | string | `""` | Overrides the name of the Secret to use when loading the secretKeyRef for AWS, Azure and Civo env variables |
 | securityContext | object | `{}` | [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | service.annotations | object | `{}` | Annotations to add to service |
 | service.clusterIP | string | `""` | IP address to assign to service |

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -75,6 +75,7 @@ To create a valid configuration, follow instructions for your cloud provider:
 - [Cluster API](#cluster-api)
 - [Exoscale](#exoscale)
 - [Hetzner Cloud](#hetzner-cloud)
+- [Civo](#civo)
 
 ### Templating the autoDiscovery.clusterName
 
@@ -281,6 +282,23 @@ The following parameters are required:
 Each autoscaling group requires an additional `instanceType` and `region` key to be set.
 
 Read [cluster-autoscaler/cloudprovider/hetzner/README.md](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/hetzner/README.md) for further information on the setup without helm.
+
+### Civo
+
+The following parameters are required:
+
+- `cloudProvider=civo`
+- `autoscalingGroups=...`
+
+When installing the helm chart to the namespace `kube-system`, you can set `secretKeyRefNameOverride` to `civo-api-access`.
+Otherwise specify the following parameters:
+
+- `civoApiUrl=https://api.civo.com`
+- `civoApiKey=...`
+- `civoClusterID=...`
+- `civoRegion=...`
+
+Read [cluster-autoscaler/cloudprovider/civo/README.md](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/civo/README.md) for further information on the setup without helm.
 
 ## Uninstalling the Chart
 

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -221,6 +221,27 @@ spec:
           {{- else if eq .Values.cloudProvider "kwok" }}
             - name: KWOK_PROVIDER_CONFIGMAP
               value: "{{.Values.kwokConfigMapName | default "kwok-provider-config"}}"
+          {{- else if eq .Values.cloudProvider "civo" }}
+            - name: CIVO_API_URL
+              valueFrom:
+                secretKeyRef:
+                  key: api-url
+                  name: {{ default (include "cluster-autoscaler.fullname" .) .Values.secretKeyRefNameOverride }}
+            - name: CIVO_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: {{ default (include "cluster-autoscaler.fullname" .) .Values.secretKeyRefNameOverride }}
+            - name: CIVO_CLUSTER_ID
+              valueFrom:
+                secretKeyRef:
+                  key: cluster-id
+                  name: {{ default (include "cluster-autoscaler.fullname" .) .Values.secretKeyRefNameOverride }}
+            - name: CIVO_REGION
+              valueFrom:
+                secretKeyRef:
+                  key: region
+                  name: {{ default (include "cluster-autoscaler.fullname" .) .Values.secretKeyRefNameOverride }}
           {{- end }}
           {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}

--- a/charts/cluster-autoscaler/templates/secret.yaml
+++ b/charts/cluster-autoscaler/templates/secret.yaml
@@ -2,8 +2,9 @@
 {{- $isAzure := eq .Values.cloudProvider "azure" }}
 {{- $isAws := eq .Values.cloudProvider "aws" }}
 {{- $awsCredentialsProvided := and .Values.awsAccessKeyID .Values.awsSecretAccessKey }}
+{{- $isCivo := eq .Values.cloudProvider "civo" }}
 
-{{- if or $isAzure (and $isAws $awsCredentialsProvided) }}
+{{- if or $isAzure (and $isAws $awsCredentialsProvided) $isCivo }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,6 +21,11 @@ data:
 {{- else if $isAws }}
   AwsAccessKeyId: "{{ .Values.awsAccessKeyID | b64enc }}"
   AwsSecretAccessKey: "{{ .Values.awsSecretAccessKey | b64enc }}"
+{{- else if $isCivo }}
+  api-url: "{{ .Values.civoApiUrl | b64enc }}"
+  api-key: "{{ .Values.civoApiKey | b64enc }}"
+  cluster-id: "{{ .Values.civoClusterID | b64enc }}"
+  region: "{{ .Values.civoRegion | b64enc }}"
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cluster-autoscaler/values.yaml
+++ b/charts/cluster-autoscaler/values.yaml
@@ -110,13 +110,30 @@ azureVMType: "vmss"
 # azureEnableForceDelete -- Whether to force delete VMs or VMSS instances when scaling down.
 azureEnableForceDelete: false
 
+# civoApiUrl -- URL for the Civo API.
+# Required if `cloudProvider=civo`
+civoApiUrl: "https://api.civo.com"
+
+# civoApiKey -- API key for the Civo API.
+# Required if `cloudProvider=civo`
+civoApiKey: ""
+
+# civoClusterID -- Cluster ID for the Civo cluster.
+# Required if `cloudProvider=civo`
+civoClusterID: ""
+
+# civoRegion -- Region for the Civo cluster.
+# Required if `cloudProvider=civo`
+civoRegion: ""
+
 # cloudConfigPath -- Configuration file for cloud provider.
 cloudConfigPath: ""
 
 # cloudProvider -- The cloud provider where the autoscaler runs.
-# Currently only `gce`, `aws`, `azure`, `magnum` and `clusterapi` are supported.
+# Currently only `gce`, `aws`, `azure`, `magnum`, `clusterapi` and `civo` are supported.
 # `aws` supported for AWS. `gce` for GCE. `azure` for Azure AKS.
 # `magnum` for OpenStack Magnum, `clusterapi` for Cluster API.
+# `civo` for Civo Cloud.
 cloudProvider: aws
 
 # clusterAPICloudConfigPath -- Path to kubeconfig for connecting to Cluster API Management Cluster, only used if `clusterAPIMode=kubeconfig-kubeconfig or incluster-kubeconfig`
@@ -446,5 +463,5 @@ vpa:
   # vpa.containerPolicy -- [ContainerResourcePolicy](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L159). The containerName is always et to the deployment's container name. This value is required if VPA is enabled.
   containerPolicy: {}
 
-# secretKeyRefNameOverride -- Overrides the name of the Secret to use when loading the secretKeyRef for AWS and Azure env variables
+# secretKeyRefNameOverride -- Overrides the name of the Secret to use when loading the secretKeyRef for AWS, Azure and Civo env variables
 secretKeyRefNameOverride: ""

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -198,7 +199,26 @@ const (
 	testASG         = "test-asg"
 )
 
+func saveAndClearEnv() []string {
+	originalEnv := os.Environ()
+	os.Clearenv()
+	return originalEnv
+}
+
+func loadEnv(originalEnv []string) {
+	os.Clearenv()
+	for _, e := range originalEnv {
+		parts := strings.SplitN(e, "=", 2)
+		os.Setenv(parts[0], parts[1])
+	}
+}
+
 func TestCreateAzureManagerValidConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -284,6 +304,11 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 }
 
 func TestCreateAzureManagerLegacyConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -367,6 +392,11 @@ func TestCreateAzureManagerLegacyConfig(t *testing.T) {
 }
 
 func TestCreateAzureManagerValidConfigForStandardVMType(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -474,12 +504,22 @@ func TestCreateAzureManagerValidConfigForStandardVMType(t *testing.T) {
 }
 
 func TestCreateAzureManagerValidConfigForStandardVMTypeWithoutDeploymentParameters(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForStandardVMTypeWithoutDeploymentParameters), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{})
 	expectedErr := "open /var/lib/azure/azuredeploy.parameters.json: no such file or directory"
 	assert.Nil(t, manager)
 	assert.Equal(t, expectedErr, err.Error(), "return error does not match, expected: %v, actual: %v", expectedErr, err.Error())
 }
 func TestCreateAzureManagerValidConfigForVMsPool(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -567,6 +607,11 @@ func TestCreateAzureManagerValidConfigForVMsPool(t *testing.T) {
 }
 
 func TestCreateAzureManagerWithNilConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -814,6 +859,11 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 }
 
 func TestCreateAzureManagerWithEnvOverridingConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockVMClient := mockvmclient.NewMockInterface(ctrl)
@@ -945,11 +995,21 @@ func TestCreateAzureManagerWithEnvOverridingConfig(t *testing.T) {
 }
 
 func TestCreateAzureManagerInvalidConfig(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	_, err := createAzureManagerInternal(strings.NewReader(invalidAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{})
 	assert.Error(t, err, "failed to unmarshal config body")
 }
 
 func TestFetchExplicitNodeGroups(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1025,6 +1085,11 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 }
 
 func TestGetFilteredAutoscalingGroupsVmss(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1070,6 +1135,11 @@ func TestGetFilteredAutoscalingGroupsVmss(t *testing.T) {
 }
 
 func TestGetFilteredAutoscalingGroupsVmssWithConfiguredSizes(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1118,6 +1188,11 @@ func TestGetFilteredAutoscalingGroupsVmssWithConfiguredSizes(t *testing.T) {
 }
 
 func TestGetFilteredAutoscalingGroupsWithInvalidVMType(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1142,6 +1217,11 @@ func TestGetFilteredAutoscalingGroupsWithInvalidVMType(t *testing.T) {
 }
 
 func TestFetchAutoAsgsVmss(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1196,6 +1276,11 @@ func TestFetchAutoAsgsVmss(t *testing.T) {
 }
 
 func TestManagerRefreshAndCleanup(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -1206,6 +1291,11 @@ func TestManagerRefreshAndCleanup(t *testing.T) {
 }
 
 func TestGetScaleSetOptions(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	manager := &AzureManager{
 		azureCache: &azureCache{
 			autoscalingOptions: make(map[azureRef]map[string]string),
@@ -1254,6 +1344,11 @@ func TestGetScaleSetOptions(t *testing.T) {
 // if even one expected nodeGroup was not found. When manager creation errored out,
 // BuildAzure returns log.Fatalf() which caused CAS to crash.
 func TestVMSSNotFound(t *testing.T) {
+	originalEnv := saveAndClearEnv()
+	t.Cleanup(func() {
+		loadEnv(originalEnv)
+	})
+
 	// client setup
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -809,6 +809,7 @@ func addVMToCache(instances *[]cloudprovider.Instance, id, provisioningState *st
 
 // instanceStatusFromProvisioningStateAndPowerState converts the VM provisioning state to cloudprovider.InstanceStatus
 // instanceStatusFromProvisioningStateAndPowerState used by orchestrationMode == compute.Flexible
+// Suggestion: reunify this with scaleSet.instanceStatusFromVM()
 func instanceStatusFromProvisioningStateAndPowerState(resourceID string, provisioningState *string, powerState string, enableFastDeleteOnFailedProvisioning bool) *cloudprovider.InstanceStatus {
 	if provisioningState == nil {
 		return nil
@@ -823,6 +824,8 @@ func instanceStatusFromProvisioningStateAndPowerState(resourceID string, provisi
 	case provisioningStateCreating:
 		status.State = cloudprovider.InstanceCreating
 	case provisioningStateFailed:
+		status.State = cloudprovider.InstanceRunning
+
 		if enableFastDeleteOnFailedProvisioning {
 			// Provisioning can fail both during instance creation or after the instance is running.
 			// Per https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing#provisioning-states,

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -43,11 +43,10 @@ func newTestScaleSet(manager *AzureManager, name string) *ScaleSet {
 		azureRef: azureRef{
 			Name: name,
 		},
-		manager:                              manager,
-		minSize:                              1,
-		maxSize:                              5,
-		enableForceDelete:                    manager.config.EnableForceDelete,
-		enableFastDeleteOnFailedProvisioning: true,
+		manager:           manager,
+		minSize:           1,
+		maxSize:           5,
+		enableForceDelete: manager.config.EnableForceDelete,
 	}
 }
 
@@ -56,8 +55,20 @@ func newTestScaleSetMinSizeZero(manager *AzureManager, name string) *ScaleSet {
 		azureRef: azureRef{
 			Name: name,
 		},
+		manager:           manager,
+		minSize:           0,
+		maxSize:           5,
+		enableForceDelete: manager.config.EnableForceDelete,
+	}
+}
+
+func newTestScaleSetWithFastDelete(manager *AzureManager, name string) *ScaleSet {
+	return &ScaleSet{
+		azureRef: azureRef{
+			Name: name,
+		},
 		manager:                              manager,
-		minSize:                              0,
+		minSize:                              1,
 		maxSize:                              5,
 		enableForceDelete:                    manager.config.EnableForceDelete,
 		enableFastDeleteOnFailedProvisioning: true,
@@ -362,6 +373,95 @@ func TestIncreaseSizeOnVMProvisioningFailed(t *testing.T) {
 		expectErrorInfoPopulated bool
 	}{
 		"out of resources when no power state exists": {
+			expectErrorInfoPopulated: false,
+		},
+		"out of resources when VM is stopped": {
+			statuses:                 []compute.InstanceViewStatus{{Code: to.StringPtr(vmPowerStateStopped)}},
+			expectErrorInfoPopulated: false,
+		},
+		"out of resources when VM reports invalid power state": {
+			statuses:                 []compute.InstanceViewStatus{{Code: to.StringPtr("PowerState/invalid")}},
+			expectErrorInfoPopulated: false,
+		},
+		"instance running when power state is running": {
+			expectInstanceRunning:    true,
+			statuses:                 []compute.InstanceViewStatus{{Code: to.StringPtr(vmPowerStateRunning)}},
+			expectErrorInfoPopulated: false,
+		},
+		"instance running if instance view cannot be retrieved": {
+			expectInstanceRunning:    true,
+			isMissingInstanceView:    true,
+			expectErrorInfoPopulated: false,
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			manager := newTestAzureManager(t)
+			vmssName := "vmss-failed-upscale"
+
+			expectedScaleSets := newTestVMSSList(3, "vmss-failed-upscale", "eastus", compute.Uniform)
+			expectedVMSSVMs := newTestVMSSVMList(3)
+			// The failed state is important line of code here
+			expectedVMs := newTestVMList(3)
+			expectedVMSSVMs[2].ProvisioningState = to.StringPtr(provisioningStateFailed)
+			if !testCase.isMissingInstanceView {
+				expectedVMSSVMs[2].InstanceView = &compute.VirtualMachineScaleSetVMInstanceView{Statuses: &testCase.statuses}
+			}
+
+			mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil)
+			mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(nil, nil)
+			mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).Return(&http.Response{StatusCode: http.StatusOK}, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+			mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "vmss-failed-upscale", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+			mockVMClient := mockvmclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedVMs, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
+
+			manager.explicitlyConfigured["vmss-failed-upscale"] = true
+			registered := manager.RegisterNodeGroup(newTestScaleSet(manager, vmssName))
+			assert.True(t, registered)
+			manager.Refresh()
+
+			provider, err := BuildAzureCloudProvider(manager, nil)
+			assert.NoError(t, err)
+
+			scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+			assert.True(t, ok)
+
+			// Increase size by one, but the new node fails provisioning
+			err = scaleSet.IncreaseSize(1)
+			assert.NoError(t, err)
+
+			nodes, err := scaleSet.Nodes()
+			assert.NoError(t, err)
+
+			assert.Equal(t, 3, len(nodes))
+
+			assert.Equal(t, testCase.expectErrorInfoPopulated, nodes[2].Status.ErrorInfo != nil)
+			if testCase.expectErrorInfoPopulated {
+				assert.Equal(t, cloudprovider.InstanceCreating, nodes[2].Status.State)
+			} else {
+				assert.Equal(t, cloudprovider.InstanceRunning, nodes[2].Status.State)
+			}
+		})
+	}
+}
+
+func TestIncreaseSizeOnVMProvisioningFailedWithFastDelete(t *testing.T) {
+	testCases := map[string]struct {
+		expectInstanceRunning    bool
+		isMissingInstanceView    bool
+		statuses                 []compute.InstanceViewStatus
+		expectErrorInfoPopulated bool
+	}{
+		"out of resources when no power state exists": {
 			expectErrorInfoPopulated: true,
 		},
 		"out of resources when VM is stopped": {
@@ -414,7 +514,7 @@ func TestIncreaseSizeOnVMProvisioningFailed(t *testing.T) {
 			manager.azClient.virtualMachinesClient = mockVMClient
 
 			manager.explicitlyConfigured["vmss-failed-upscale"] = true
-			registered := manager.RegisterNodeGroup(newTestScaleSet(manager, vmssName))
+			registered := manager.RegisterNodeGroup(newTestScaleSetWithFastDelete(manager, vmssName))
 			assert.True(t, registered)
 			manager.Refresh()
 
@@ -1116,6 +1216,10 @@ func TestTemplateNodeInfo(t *testing.T) {
 	}
 	asg.Name = "test-asg"
 
+	// The dynamic SKU list ("cache") in the test provider is empty
+	// (initialized with cfg.EnableDynamicInstanceList = false).
+	assert.False(t, provider.azureManager.azureCache.HasVMSKUs())
+
 	t.Run("Checking fallback to static because dynamic list is empty", func(t *testing.T) {
 		asg.enableDynamicInstanceList = true
 
@@ -1259,5 +1363,115 @@ func TestCseErrors(t *testing.T) {
 		actualCSEErrorMessage, actualCSEFailureBool := scaleSet.cseErrors(vmssVMs.InstanceView.Extensions)
 		assert.False(t, actualCSEFailureBool)
 		assert.Equal(t, []string(nil), actualCSEErrorMessage)
+	})
+}
+
+func newVMObjectWithState(provisioningState string, powerState string) *compute.VirtualMachineScaleSetVM {
+	return &compute.VirtualMachineScaleSetVM{
+		ID: to.StringPtr("1"), // Beware; refactor if needed
+		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: to.StringPtr(provisioningState),
+			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{Code: to.StringPtr(powerState)},
+				},
+			},
+		},
+	}
+}
+
+// Suggestion: could populate all combinations, should reunify with TestInstanceStatusFromVM
+func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
+	t.Run("fast delete enablement = false", func(t *testing.T) {
+		t.Run("provisioning state = failed, power state = starting", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateStarting, false)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateRunning, false)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateStopping, false)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
+
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateStopped, false)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateDeallocated, false)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateUnknown, false)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+	})
+
+	t.Run("fast delete enablement = true", func(t *testing.T) {
+		t.Run("provisioning state = failed, power state = starting", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateStarting, true)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateRunning, true)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
+		})
+
+		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateStopping, true)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+		})
+
+		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateStopped, true)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+		})
+
+		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateDeallocated, true)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+		})
+
+		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
+			status := instanceStatusFromProvisioningStateAndPowerState("1", to.StringPtr(string(compute.GalleryProvisioningStateFailed)), vmPowerStateUnknown, true)
+
+			assert.NotNil(t, status)
+			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
+			assert.NotNil(t, status.ErrorInfo)
+		})
 	})
 }

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -114,7 +114,6 @@ func multiStringFlag(name string, usage string) *MultiStringFlag {
 }
 
 var (
-	leaseResourceName       = flag.String("lease-resource-name", "cluster-autoscaler", "The lease resource to use in leader election.")
 	clusterName             = flag.String("cluster-name", "", "Autoscaled cluster name, if available")
 	address                 = flag.String("address", ":8085", "The address to expose prometheus metrics.")
 	kubernetes              = flag.String("kubernetes", "", "Kubernetes master location. Leave blank for default")
@@ -563,6 +562,8 @@ func buildAutoscaler(context ctx.Context, debuggingSnapshotter debuggingsnapshot
 		opts.LoopStartNotifier = loopstart.NewObserversList([]loopstart.Observer{provreqProcesor})
 
 		podListProcessor.AddProcessor(provreqProcesor)
+
+		opts.Processors.ScaleUpEnforcer = provreq.NewProvisioningRequestScaleUpEnforcer()
 	}
 
 	if *proactiveScaleupEnabled {
@@ -670,10 +671,13 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 
 	// Autoscale ad infinitum.
 	if *frequentLoopsEnabled {
+		// We need to have two timestamps because the scaleUp activity alternates between processing ProvisioningRequests,
+		// so we need to pass the older timestamp (previousRun) to trigger.Wait to run immediately if only one of the activities is productive.
 		lastRun := time.Now()
+		previousRun := time.Now()
 		for {
-			trigger.Wait(lastRun)
-			lastRun = time.Now()
+			trigger.Wait(previousRun)
+			previousRun, lastRun = lastRun, time.Now()
 			loop.RunAutoscalerOnce(autoscaler, healthCheck, lastRun)
 		}
 	} else {
@@ -694,6 +698,10 @@ func main() {
 		klog.Fatalf("Failed to add logging feature flags: %v", err)
 	}
 
+	leaderElection := leaderElectionConfiguration()
+	// Must be called before kube_flag.InitFlags() to ensure leader election flags are parsed and available.
+	componentopts.BindLeaderElectionFlags(&leaderElection, pflag.CommandLine)
+
 	logsapi.AddFlags(loggingConfig, pflag.CommandLine)
 	featureGate.AddFlag(pflag.CommandLine)
 	kube_flag.InitFlags()
@@ -706,10 +714,6 @@ func main() {
 			klog.Fatalf("couldn't enable the DRA feature gate: %v", err)
 		}
 	}
-
-	leaderElection := defaultLeaderElectionConfiguration()
-	leaderElection.LeaderElect = true
-	componentopts.BindLeaderElectionFlags(&leaderElection, pflag.CommandLine)
 
 	logs.InitLogs()
 	if err := logsapi.ValidateAndApply(loggingConfig, featureGate); err != nil {
@@ -790,14 +794,14 @@ func main() {
 	}
 }
 
-func defaultLeaderElectionConfiguration() componentbaseconfig.LeaderElectionConfiguration {
+func leaderElectionConfiguration() componentbaseconfig.LeaderElectionConfiguration {
 	return componentbaseconfig.LeaderElectionConfiguration{
-		LeaderElect:   false,
+		LeaderElect:   true,
 		LeaseDuration: metav1.Duration{Duration: defaultLeaseDuration},
 		RenewDeadline: metav1.Duration{Duration: defaultRenewDeadline},
 		RetryPeriod:   metav1.Duration{Duration: defaultRetryPeriod},
 		ResourceLock:  resourcelock.LeasesResourceLock,
-		ResourceName:  *leaseResourceName,
+		ResourceName:  "cluster-autoscaler",
 	}
 }
 

--- a/cluster-autoscaler/processors/pods/scaleup_enforcer.go
+++ b/cluster-autoscaler/processors/pods/scaleup_enforcer.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import apiv1 "k8s.io/api/core/v1"
+
+// ScaleUpEnforcer can force scale up even if all pods are new or MaxNodesTotal was achieved.
+type ScaleUpEnforcer interface {
+	ShouldForceScaleUp(unschedulablePods []*apiv1.Pod) bool
+}
+
+// NoOpScaleUpEnforcer returns false by default in case of ProvisioningRequests disabled.
+type NoOpScaleUpEnforcer struct {
+}
+
+// NewDefaultScaleUpEnforcer creates an instance of ScaleUpEnforcer.
+func NewDefaultScaleUpEnforcer() ScaleUpEnforcer {
+	return &NoOpScaleUpEnforcer{}
+}
+
+// ShouldForceScaleUp returns false by default.
+func (p *NoOpScaleUpEnforcer) ShouldForceScaleUp(unschedulablePods []*apiv1.Pod) bool {
+	return false
+}

--- a/cluster-autoscaler/processors/pods/scaleup_enforcer_test.go
+++ b/cluster-autoscaler/processors/pods/scaleup_enforcer_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	testutils "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestDefaultScaleUpEnforcer(t *testing.T) {
+	p1 := testutils.BuildTestPod("p1", 40, 0)
+	unschedulablePods := []*apiv1.Pod{p1}
+	scaleUpEnforcer := NewDefaultScaleUpEnforcer()
+	forceScaleUp := scaleUpEnforcer.ShouldForceScaleUp(unschedulablePods)
+	if forceScaleUp {
+		t.Errorf("Error: scaleUpEnforcer should not force scale up by default")
+	}
+}

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -74,6 +74,8 @@ type AutoscalingProcessors struct {
 	ScaleStateNotifier *nodegroupchange.NodeGroupChangeObserversList
 	// AsyncNodeGroupChecker checks if node group is upcoming or not
 	AsyncNodeGroupStateChecker asyncnodegroups.AsyncNodeGroupStateChecker
+	// ScaleUpEnforcer can force scale up even if all pods are new or MaxNodesTotal was achieved.
+	ScaleUpEnforcer pods.ScaleUpEnforcer
 }
 
 // DefaultProcessors returns default set of processors.
@@ -100,6 +102,7 @@ func DefaultProcessors(options config.AutoscalingOptions) *AutoscalingProcessors
 		TemplateNodeInfoProvider:    nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false),
 		ScaleDownCandidatesNotifier: scaledowncandidates.NewObserversList(),
 		ScaleStateNotifier:          nodegroupchange.NewNodeGroupChangeObserversList(),
+		ScaleUpEnforcer:             pods.NewDefaultScaleUpEnforcer(),
 	}
 }
 

--- a/cluster-autoscaler/processors/provreq/pods_filter.go
+++ b/cluster-autoscaler/processors/provreq/pods_filter.go
@@ -22,7 +22,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/pods"
 	provreqpods "k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/pods"

--- a/cluster-autoscaler/processors/provreq/scaleup_enforcer.go
+++ b/cluster-autoscaler/processors/provreq/scaleup_enforcer.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provreq
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/pods"
+)
+
+// ProvisioningRequestScaleUpEnforcer forces scale up if there is any unschedulable pod that belongs to ProvisioningRequest.
+type ProvisioningRequestScaleUpEnforcer struct {
+}
+
+// NewProvisioningRequestScaleUpEnforcer creates a ProvisioningRequest scale up enforcer.
+func NewProvisioningRequestScaleUpEnforcer() pods.ScaleUpEnforcer {
+	return &ProvisioningRequestScaleUpEnforcer{}
+}
+
+// ShouldForceScaleUp forces scale up if there is any unschedulable pod that belongs to ProvisioningRequest.
+func (p *ProvisioningRequestScaleUpEnforcer) ShouldForceScaleUp(unschedulablePods []*apiv1.Pod) bool {
+	for _, pod := range unschedulablePods {
+		if _, ok := provisioningRequestName(pod); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/cluster-autoscaler/processors/provreq/scaleup_enforcer_test.go
+++ b/cluster-autoscaler/processors/provreq/scaleup_enforcer_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provreq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/pods"
+	testutils "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestProvisioningRequestScaleUpEnforcer(t *testing.T) {
+	prPod1 := testutils.BuildTestPod("pr-pod-1", 500, 10)
+	prPod1.Annotations[v1.ProvisioningRequestPodAnnotationKey] = "pr-class"
+
+	prPod2 := testutils.BuildTestPod("pr-pod-2", 500, 10)
+	prPod2.Annotations[pods.DeprecatedProvisioningRequestPodAnnotationKey] = "pr-class-2"
+
+	pod1 := testutils.BuildTestPod("pod-1", 500, 10)
+	pod2 := testutils.BuildTestPod("pod-2", 500, 10)
+
+	testCases := map[string]struct {
+		unschedulablePods []*apiv1.Pod
+		want              bool
+	}{
+		"Any pod with ProvisioningRequest annotation key forces scale up": {
+			unschedulablePods: []*corev1.Pod{prPod1, pod1},
+			want:              true,
+		},
+		"Any pod with ProvisioningRequest deprecated annotation key forces scale up": {
+			unschedulablePods: []*corev1.Pod{prPod2, pod1},
+			want:              true,
+		},
+		"Pod without ProvisioningRequest annotation key don't force scale up": {
+			unschedulablePods: []*corev1.Pod{pod1, pod2},
+			want:              false,
+		},
+		"No pods don't force scale up": {
+			unschedulablePods: []*corev1.Pod{},
+			want:              false,
+		},
+	}
+	for _, test := range testCases {
+		scaleUpEnforcer := NewProvisioningRequestScaleUpEnforcer()
+		got := scaleUpEnforcer.ShouldForceScaleUp(test.unschedulablePods)
+		assert.Equal(t, got, test.want)
+	}
+}

--- a/cluster-autoscaler/processors/test/common.go
+++ b/cluster-autoscaler/processors/test/common.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/pods"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/scaledowncandidates"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
@@ -56,5 +57,6 @@ func NewTestProcessors(context *context.AutoscalingContext) *processors.Autoscal
 		ScaleDownCandidatesNotifier: scaledowncandidates.NewObserversList(),
 		ScaleStateNotifier:          nodegroupchange.NewNodeGroupChangeObserversList(),
 		AsyncNodeGroupStateChecker:  asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(),
+		ScaleUpEnforcer:             pods.NewDefaultScaleUpEnforcer(),
 	}
 }

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -47,7 +47,6 @@ You can also read about the [features](./docs/features.md) and [known limitation
 
 ## Related links
 
-- [Design
-  proposal](https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/vertical-pod-autoscaler.md)
-- [API
-  definition](pkg/apis/autoscaling.k8s.io/v1/types.go)
+- [Design proposal](https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/vertical-pod-autoscaler.md)
+- [API definition](pkg/apis/autoscaling.k8s.io/v1/types.go)
+- [API reference](./docs/api.md)

--- a/vertical-pod-autoscaler/RELEASE.md
+++ b/vertical-pod-autoscaler/RELEASE.md
@@ -53,14 +53,14 @@ branch. This makes sure you have no local changes while building the images.
 For example:
 ```sh
 git clone git@github.com:kubernetes/autoscaler.git
-git switch vpa-release-1.0
+git switch vpa-release-1.${minor}
 ```
 
 Once in the freshly cloned repo, build and stage the images.
 
 ```sh
 cd vertical-pod-autoscaler/
-for component in recommender updater admission-controller ; do TAG=`grep 'const VerticalPodAutoscalerVersion = ' common/version.go | cut -d '"' -f 2` REGISTRY=gcr.io/k8s-staging-autoscaling make release --directory=pkg/${component}; done
+for component in recommender updater admission-controller ; do TAG=`grep 'const versionCore = ' common/version.go | cut -d '"' -f 2` REGISTRY=gcr.io/k8s-staging-autoscaling make release --directory=pkg/${component}; done
 ```
 
 ## Test the release
@@ -79,7 +79,7 @@ for component in recommender updater admission-controller ; do TAG=`grep 'const 
 
 1.  [ ] Deploy VPA:
     ```shell
-    REGISTRY=gcr.io/k8s-staging-autoscaling TAG=`grep 'const VerticalPodAutoscalerVersion = ' common/version.go | cut -d '"' -f 2` ./hack/vpa-up.sh
+    REGISTRY=gcr.io/k8s-staging-autoscaling TAG=`grep 'const versionCore = ' common/version.go | cut -d '"' -f 2` ./hack/vpa-up.sh
     ```
 
 1.  [ ] [Run](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/hack/run-e2e-tests.sh)

--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
-          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.2.2
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.3.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.2.2
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.3.0
         imagePullPolicy: Always
         args:
           - --recommender-name=performance

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.2.2
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.3.0
         imagePullPolicy: Always
         args:
           - --recommender-name=frugal

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.2.2
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.3.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: updater
-          image: registry.k8s.io/autoscaling/vpa-updater:1.2.2
+          image: registry.k8s.io/autoscaling/vpa-updater:1.3.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/docs/api.md
+++ b/vertical-pod-autoscaler/docs/api.md
@@ -1,0 +1,397 @@
+# API Reference
+
+## Packages
+- [autoscaling.k8s.io/v1](#autoscalingk8siov1)
+
+
+## autoscaling.k8s.io/v1
+
+Package v1 contains definitions of Vertical Pod Autoscaler related objects.
+
+
+
+#### ContainerControlledValues
+
+_Underlying type:_ _string_
+
+ContainerControlledValues controls which resource value should be autoscaled.
+
+_Validation:_
+- Enum: [RequestsAndLimits RequestsOnly]
+
+_Appears in:_
+- [ContainerResourcePolicy](#containerresourcepolicy)
+
+| Field | Description |
+| --- | --- |
+| `RequestsAndLimits` | ContainerControlledValuesRequestsAndLimits means resource request and limits<br />are scaled automatically. The limit is scaled proportionally to the request.<br /> |
+| `RequestsOnly` | ContainerControlledValuesRequestsOnly means only requested resource is autoscaled.<br /> |
+
+
+#### ContainerResourcePolicy
+
+
+
+ContainerResourcePolicy controls how autoscaler computes the recommended
+resources for a specific container.
+
+
+
+_Appears in:_
+- [PodResourcePolicy](#podresourcepolicy)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `containerName` _string_ | Name of the container or DefaultContainerResourcePolicy, in which<br />case the policy is used by the containers that don't have their own<br />policy specified. |  |  |
+| `mode` _[ContainerScalingMode](#containerscalingmode)_ | Whether autoscaler is enabled for the container. The default is "Auto". |  | Enum: [Auto Off] <br /> |
+| `minAllowed` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcelist-v1-core)_ | Specifies the minimal amount of resources that will be recommended<br />for the container. The default is no minimum. |  |  |
+| `maxAllowed` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcelist-v1-core)_ | Specifies the maximum amount of resources that will be recommended<br />for the container. The default is no maximum. |  |  |
+| `controlledResources` _[ResourceName](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcename-v1-core)_ | Specifies the type of recommendations that will be computed<br />(and possibly applied) by VPA.<br />If not specified, the default of [ResourceCPU, ResourceMemory] will be used. |  |  |
+| `controlledValues` _[ContainerControlledValues](#containercontrolledvalues)_ | Specifies which resource values should be controlled.<br />The default is "RequestsAndLimits". |  | Enum: [RequestsAndLimits RequestsOnly] <br /> |
+
+
+#### ContainerScalingMode
+
+_Underlying type:_ _string_
+
+ContainerScalingMode controls whether autoscaler is enabled for a specific
+container.
+
+_Validation:_
+- Enum: [Auto Off]
+
+_Appears in:_
+- [ContainerResourcePolicy](#containerresourcepolicy)
+
+| Field | Description |
+| --- | --- |
+| `Auto` | ContainerScalingModeAuto means autoscaling is enabled for a container.<br /> |
+| `Off` | ContainerScalingModeOff means autoscaling is disabled for a container.<br /> |
+
+
+#### EvictionChangeRequirement
+
+_Underlying type:_ _string_
+
+EvictionChangeRequirement refers to the relationship between the new target recommendation for a Pod and its current requests, what kind of change is necessary for the Pod to be evicted
+
+_Validation:_
+- Enum: [TargetHigherThanRequests TargetLowerThanRequests]
+
+_Appears in:_
+- [EvictionRequirement](#evictionrequirement)
+
+| Field | Description |
+| --- | --- |
+| `TargetHigherThanRequests` | TargetHigherThanRequests means the new target recommendation for a Pod is higher than its current requests, i.e. the Pod is scaled up<br /> |
+| `TargetLowerThanRequests` | TargetLowerThanRequests means the new target recommendation for a Pod is lower than its current requests, i.e. the Pod is scaled down<br /> |
+
+
+#### EvictionRequirement
+
+
+
+EvictionRequirement defines a single condition which needs to be true in
+order to evict a Pod
+
+
+
+_Appears in:_
+- [PodUpdatePolicy](#podupdatepolicy)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `resources` _[ResourceName](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcename-v1-core) array_ | Resources is a list of one or more resources that the condition applies<br />to. If more than one resource is given, the EvictionRequirement is fulfilled<br />if at least one resource meets `changeRequirement`. |  |  |
+| `changeRequirement` _[EvictionChangeRequirement](#evictionchangerequirement)_ |  |  | Enum: [TargetHigherThanRequests TargetLowerThanRequests] <br /> |
+
+
+#### HistogramCheckpoint
+
+
+
+HistogramCheckpoint contains data needed to reconstruct the histogram.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerCheckpointStatus](#verticalpodautoscalercheckpointstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `referenceTimestamp` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta)_ | Reference timestamp for samples collected within this histogram. |  |  |
+| `bucketWeights` _object (keys:integer, values:integer)_ | Map from bucket index to bucket weight. |  | Type: object <br />XPreserveUnknownFields: \{\} <br /> |
+| `totalWeight` _float_ | Sum of samples to be used as denominator for weights from BucketWeights. |  |  |
+
+
+#### PodResourcePolicy
+
+
+
+PodResourcePolicy controls how autoscaler computes the recommended resources
+for containers belonging to the pod. There can be at most one entry for every
+named container and optionally a single wildcard entry with `containerName` = '*',
+which handles all containers that don't have individual policies.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerSpec](#verticalpodautoscalerspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `containerPolicies` _[ContainerResourcePolicy](#containerresourcepolicy) array_ | Per-container resource policies. |  |  |
+
+
+#### PodUpdatePolicy
+
+
+
+PodUpdatePolicy describes the rules on how changes are applied to the pods.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerSpec](#verticalpodautoscalerspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `updateMode` _[UpdateMode](#updatemode)_ | Controls when autoscaler applies changes to the pod resources.<br />The default is 'Auto'. |  | Enum: [Off Initial Recreate Auto] <br /> |
+| `minReplicas` _integer_ | Minimal number of replicas which need to be alive for Updater to attempt<br />pod eviction (pending other checks like PDB). Only positive values are<br />allowed. Overrides global '--min-replicas' flag. |  |  |
+| `evictionRequirements` _[EvictionRequirement](#evictionrequirement) array_ | EvictionRequirements is a list of EvictionRequirements that need to<br />evaluate to true in order for a Pod to be evicted. If more than one<br />EvictionRequirement is specified, all of them need to be fulfilled to allow eviction. |  |  |
+
+
+#### RecommendedContainerResources
+
+
+
+RecommendedContainerResources is the recommendation of resources computed by
+autoscaler for a specific container. Respects the container resource policy
+if present in the spec. In particular the recommendation is not produced for
+containers with `ContainerScalingMode` set to 'Off'.
+
+
+
+_Appears in:_
+- [RecommendedPodResources](#recommendedpodresources)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `containerName` _string_ | Name of the container. |  |  |
+| `target` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcelist-v1-core)_ | Recommended amount of resources. Observes ContainerResourcePolicy. |  |  |
+| `lowerBound` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcelist-v1-core)_ | Minimum recommended amount of resources. Observes ContainerResourcePolicy.<br />This amount is not guaranteed to be sufficient for the application to operate in a stable way, however<br />running with less resources is likely to have significant impact on performance/availability. |  |  |
+| `upperBound` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcelist-v1-core)_ | Maximum recommended amount of resources. Observes ContainerResourcePolicy.<br />Any resources allocated beyond this value are likely wasted. This value may be larger than the maximum<br />amount of application is actually capable of consuming. |  |  |
+| `uncappedTarget` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcelist-v1-core)_ | The most recent recommended resources target computed by the autoscaler<br />for the controlled pods, based only on actual resource usage, not taking<br />into account the ContainerResourcePolicy.<br />May differ from the Recommendation if the actual resource usage causes<br />the target to violate the ContainerResourcePolicy (lower than MinAllowed<br />or higher that MaxAllowed).<br />Used only as status indication, will not affect actual resource assignment. |  |  |
+
+
+#### RecommendedPodResources
+
+
+
+RecommendedPodResources is the recommendation of resources computed by
+autoscaler. It contains a recommendation for each container in the pod
+(except for those with `ContainerScalingMode` set to 'Off').
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerStatus](#verticalpodautoscalerstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `containerRecommendations` _[RecommendedContainerResources](#recommendedcontainerresources) array_ | Resources recommended by the autoscaler for each container. |  |  |
+
+
+#### UpdateMode
+
+_Underlying type:_ _string_
+
+UpdateMode controls when autoscaler applies changes to the pod resources.
+
+_Validation:_
+- Enum: [Off Initial Recreate Auto]
+
+_Appears in:_
+- [PodUpdatePolicy](#podupdatepolicy)
+
+| Field | Description |
+| --- | --- |
+| `Off` | UpdateModeOff means that autoscaler never changes Pod resources.<br />The recommender still sets the recommended resources in the<br />VerticalPodAutoscaler object. This can be used for a "dry run".<br /> |
+| `Initial` | UpdateModeInitial means that autoscaler only assigns resources on pod<br />creation and does not change them during the lifetime of the pod.<br /> |
+| `Recreate` | UpdateModeRecreate means that autoscaler assigns resources on pod<br />creation and additionally can update them during the lifetime of the<br />pod by deleting and recreating the pod.<br /> |
+| `Auto` | UpdateModeAuto means that autoscaler assigns resources on pod creation<br />and additionally can update them during the lifetime of the pod,<br />using any available update method. Currently this is equivalent to<br />Recreate, which is the only available update method.<br /> |
+
+
+#### VerticalPodAutoscaler
+
+
+
+VerticalPodAutoscaler is the configuration for a vertical pod
+autoscaler, which automatically manages pod resources based on historical and
+real time resource utilization.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerList](#verticalpodautoscalerlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[VerticalPodAutoscalerSpec](#verticalpodautoscalerspec)_ | Specification of the behavior of the autoscaler.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. |  |  |
+| `status` _[VerticalPodAutoscalerStatus](#verticalpodautoscalerstatus)_ | Current information about the autoscaler. |  |  |
+
+
+#### VerticalPodAutoscalerCheckpoint
+
+
+
+VerticalPodAutoscalerCheckpoint is the checkpoint of the internal state of VPA that
+is used for recovery after recommender's restart.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerCheckpointList](#verticalpodautoscalercheckpointlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[VerticalPodAutoscalerCheckpointSpec](#verticalpodautoscalercheckpointspec)_ | Specification of the checkpoint.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. |  |  |
+| `status` _[VerticalPodAutoscalerCheckpointStatus](#verticalpodautoscalercheckpointstatus)_ | Data of the checkpoint. |  |  |
+
+
+
+
+#### VerticalPodAutoscalerCheckpointSpec
+
+
+
+VerticalPodAutoscalerCheckpointSpec is the specification of the checkpoint object.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerCheckpoint](#verticalpodautoscalercheckpoint)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `vpaObjectName` _string_ | Name of the VPA object that stored VerticalPodAutoscalerCheckpoint object. |  |  |
+| `containerName` _string_ | Name of the checkpointed container. |  |  |
+
+
+#### VerticalPodAutoscalerCheckpointStatus
+
+
+
+VerticalPodAutoscalerCheckpointStatus contains data of the checkpoint.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerCheckpoint](#verticalpodautoscalercheckpoint)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `lastUpdateTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta)_ | The time when the status was last refreshed. |  |  |
+| `version` _string_ | Version of the format of the stored data. |  |  |
+| `cpuHistogram` _[HistogramCheckpoint](#histogramcheckpoint)_ | Checkpoint of histogram for consumption of CPU. |  |  |
+| `memoryHistogram` _[HistogramCheckpoint](#histogramcheckpoint)_ | Checkpoint of histogram for consumption of memory. |  |  |
+| `firstSampleStart` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta)_ | Timestamp of the fist sample from the histograms. |  |  |
+| `lastSampleStart` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta)_ | Timestamp of the last sample from the histograms. |  |  |
+| `totalSamplesCount` _integer_ | Total number of samples in the histograms. |  |  |
+
+
+#### VerticalPodAutoscalerCondition
+
+
+
+VerticalPodAutoscalerCondition describes the state of
+a VerticalPodAutoscaler at a certain point.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerStatus](#verticalpodautoscalerstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _[VerticalPodAutoscalerConditionType](#verticalpodautoscalerconditiontype)_ | type describes the current condition |  |  |
+| `status` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#conditionstatus-v1-core)_ | status is the status of the condition (True, False, Unknown) |  |  |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta)_ | lastTransitionTime is the last time the condition transitioned from<br />one status to another |  |  |
+| `reason` _string_ | reason is the reason for the condition's last transition. |  |  |
+| `message` _string_ | message is a human-readable explanation containing details about<br />the transition |  |  |
+
+
+#### VerticalPodAutoscalerConditionType
+
+_Underlying type:_ _string_
+
+VerticalPodAutoscalerConditionType are the valid conditions of
+a VerticalPodAutoscaler.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerCondition](#verticalpodautoscalercondition)
+
+
+
+
+
+#### VerticalPodAutoscalerRecommenderSelector
+
+
+
+VerticalPodAutoscalerRecommenderSelector points to a specific Vertical Pod Autoscaler recommender.
+In the future it might pass parameters to the recommender.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscalerSpec](#verticalpodautoscalerspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the recommender responsible for generating recommendation for this object. |  |  |
+
+
+#### VerticalPodAutoscalerSpec
+
+
+
+VerticalPodAutoscalerSpec is the specification of the behavior of the autoscaler.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscaler](#verticalpodautoscaler)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `targetRef` _[CrossVersionObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#crossversionobjectreference-v1-autoscaling)_ | TargetRef points to the controller managing the set of pods for the<br />autoscaler to control - e.g. Deployment, StatefulSet. VerticalPodAutoscaler<br />can be targeted at controller implementing scale subresource (the pod set is<br />retrieved from the controller's ScaleStatus) or some well known controllers<br />(e.g. for DaemonSet the pod set is read from the controller's spec).<br />If VerticalPodAutoscaler cannot use specified target it will report<br />ConfigUnsupported condition.<br />Note that VerticalPodAutoscaler does not require full implementation<br />of scale subresource - it will not use it to modify the replica count.<br />The only thing retrieved is a label selector matching pods grouped by<br />the target resource. |  |  |
+| `updatePolicy` _[PodUpdatePolicy](#podupdatepolicy)_ | Describes the rules on how changes are applied to the pods.<br />If not specified, all fields in the `PodUpdatePolicy` are set to their<br />default values. |  |  |
+| `resourcePolicy` _[PodResourcePolicy](#podresourcepolicy)_ | Controls how the autoscaler computes recommended resources.<br />The resource policy may be used to set constraints on the recommendations<br />for individual containers.<br />If any individual containers need to be excluded from getting the VPA recommendations, then<br />it must be disabled explicitly by setting mode to "Off" under containerPolicies.<br />If not specified, the autoscaler computes recommended resources for all containers in the pod,<br />without additional constraints. |  |  |
+| `recommenders` _[VerticalPodAutoscalerRecommenderSelector](#verticalpodautoscalerrecommenderselector) array_ | Recommender responsible for generating recommendation for this object.<br />List should be empty (then the default recommender will generate the<br />recommendation) or contain exactly one recommender. |  |  |
+
+
+#### VerticalPodAutoscalerStatus
+
+
+
+VerticalPodAutoscalerStatus describes the runtime state of the autoscaler.
+
+
+
+_Appears in:_
+- [VerticalPodAutoscaler](#verticalpodautoscaler)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `recommendation` _[RecommendedPodResources](#recommendedpodresources)_ | The most recently computed amount of resources recommended by the<br />autoscaler for the controlled pods. |  |  |
+| `conditions` _[VerticalPodAutoscalerCondition](#verticalpodautoscalercondition) array_ | Conditions is the set of conditions required for this autoscaler to scale its target,<br />and indicates whether or not those conditions are met. |  |  |
+
+

--- a/vertical-pod-autoscaler/docs/installation.md
+++ b/vertical-pod-autoscaler/docs/installation.md
@@ -10,12 +10,13 @@
   - [Install command](#install-command)
   - [Tear down](#tear-down)
 
-The current default version is Vertical Pod Autoscaler 1.2.2
+The current default version is Vertical Pod Autoscaler 1.3.0
 
 ## Compatibility
 
 | VPA version     | Kubernetes version |
 |-----------------|--------------------|
+| 1.3.x           | 1.28+              |
 | 1.2.x           | 1.27+              |
 | 1.1.x           | 1.25+              |
 | 1.0             | 1.25+              |

--- a/vertical-pod-autoscaler/hack/api-docs/config.yaml
+++ b/vertical-pod-autoscaler/hack/api-docs/config.yaml
@@ -1,0 +1,8 @@
+processor:
+   ignoreGroupVersions:
+   - "poc.autoscaling.k8s.io/v1alpha1"
+   - "autoscaling.k8s.io/v1beta1"
+   - "autoscaling.k8s.io/v1beta2"
+
+render:
+  kubernetesVersion: 1.32

--- a/vertical-pod-autoscaler/hack/generate-api-docs.sh
+++ b/vertical-pod-autoscaler/hack/generate-api-docs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPOSITORY_ROOT=$(realpath $(dirname ${BASH_SOURCE})/..)
+OUTPUT=${REPOSITORY_ROOT}/docs/api.md
+WORKSPACE=$(mktemp -d)
+
+function cleanup() {
+    rm -r ${WORKSPACE}
+}
+trap cleanup EXIT
+
+if [[ -z $(which crd-ref-docs) ]]; then
+    (
+        cd $WORKSPACE
+	      go install github.com/elastic/crd-ref-docs@latest
+    )
+    CONTROLLER_GEN=${GOBIN:-$(go env GOPATH)/bin}/crd-ref-docs
+else
+    CONTROLLER_GEN=$(which crd-ref-docs)
+fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+crd-ref-docs \
+    --source-path=pkg/apis/ \
+    --config=./hack/api-docs/config.yaml \
+    --renderer=markdown \
+    --output-path=${WORKSPACE}
+
+mv ${WORKSPACE}/out.md ${OUTPUT}

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -32,7 +32,7 @@ if [ $# -eq 0 ]; then
 fi
 
 DEFAULT_REGISTRY="registry.k8s.io/autoscaling"
-DEFAULT_TAG="1.2.2"
+DEFAULT_TAG="1.3.0"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}

--- a/vertical-pod-autoscaler/hack/vpa-up.sh
+++ b/vertical-pod-autoscaler/hack/vpa-up.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
-DEFAULT_TAG="1.2.2"
+DEFAULT_TAG="1.3.0"
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}
 
 if [ "${TAG_TO_APPLY}" == "${DEFAULT_TAG}" ]; then

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains definitions of Vertical Pod Autoscaler related objects.
 package v1
 
 import (


### PR DESCRIPTION
Updates docs, deployments, scripts for the VPA 1.3.0 release.

https://github.com/kubernetes/autoscaler/issues/7731

Marks VPA 1.3.0 as compatible with Kubernetes 1.28+ (verified by running
"hack/run-e2e-tests.sh full-vpa" with GKE 1.28.15-gke.1342000).