### PR TITLE
Finalize VPA release 1.3.0.

### DIFF
--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
-          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.2.2
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.3.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.2.2
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.3.0
         imagePullPolicy: Always
         args:
           - --recommender-name=performance

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.2.2
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.3.0
         imagePullPolicy: Always
         args:
           - --recommender-name=frugal

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.2.2
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.3.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: updater
-          image: registry.k8s.io/autoscaling/vpa-updater:1.2.2
+          image: registry.k8s.io/autoscaling/vpa-updater:1.3.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/docs/installation.md
+++ b/vertical-pod-autoscaler/docs/installation.md
@@ -10,12 +10,13 @@
   - [Install command](#install-command)
   - [Tear down](#tear-down)
 
-The current default version is Vertical Pod Autoscaler 1.2.2
+The current default version is Vertical Pod Autoscaler 1.3.0
 
 ## Compatibility
 
 | VPA version     | Kubernetes version |
 |-----------------|--------------------|
+| 1.3.0           | 1.28+              |
 | 1.2.x           | 1.27+              |
 | 1.1.x           | 1.25+              |
 | 1.0             | 1.25+              |

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -32,7 +32,7 @@ if [ $# -eq 0 ]; then
 fi
 
 DEFAULT_REGISTRY="registry.k8s.io/autoscaling"
-DEFAULT_TAG="1.2.2"
+DEFAULT_TAG="1.3.0"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}

--- a/vertical-pod-autoscaler/hack/vpa-up.sh
+++ b/vertical-pod-autoscaler/hack/vpa-up.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
-DEFAULT_TAG="1.2.2"
+DEFAULT_TAG="1.3.0"
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}
 
 if [ "${TAG_TO_APPLY}" == "${DEFAULT_TAG}" ]; then


### PR DESCRIPTION
Updates docs, deployments, scripts for the VPA 1.3.0 release.

Marks VPA 1.3.0 as compatible with Kubernetes 1.28+ (verified by running "hack/run-e2e-tests.sh full-vpa" with GKE 1.28.15-gke.1342000).

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Finalizes the VPA release 1.3.0, see
[#7731](https://github.com/kubernetes/autoscaler/issues/7731)