### PR TITLE
VPA: Small documentation changes to supplement removal of v1beta2

### DIFF
--- a/vertical-pod-autoscaler/MIGRATE.md
+++ b/vertical-pod-autoscaler/MIGRATE.md
@@ -1,5 +1,12 @@
 # Vertical Pod Autoscaler Migration
 
+### Notice on switching to v1 version (0.4.X-1.2.X to >=1.3.X)
+
+The `v1beta2` API was removed in 1.3.0.
+
+Since `v1beta2` is strictly a subset of `v1`, migrating to `v1` is as simple as
+changing the `apiVersion` to `autoscaling.k8s.io/v1`.
+
 ### Notice on switching to v1beta2 version (0.3.X to >=0.4.0)
 
 In 0.4.0 we introduced a new version of the API - `autoscaling.k8s.io/v1beta2`.

--- a/vertical-pod-autoscaler/examples/redis.yaml
+++ b/vertical-pod-autoscaler/examples/redis.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: redis-vpa


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Catching up on some extra documentation after the removal of v1beta2 in https://github.com/kubernetes/autoscaler/pull/7629.

#### Which issue(s) this PR fixes:

Supplement to https://github.com/kubernetes/autoscaler/issues/5922.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```