### PR TITLE
fix missing rbac for cluster autoscaler

### DIFF
--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -111,6 +111,7 @@ rules:
     - csinodes
     - csidrivers
     - csistoragecapacities
+    - volumeattachments
     verbs:
     - watch
     - list


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

while installing cluster autoscaler in aws cloud and on inspecting the logs we kept getting error wrt to rbac 
```
W0130 04:21:47.608718       1 reflector.go:569] pkg/mod/k8s.io/client-go@v0.32.0/tools/cache/reflector.go:251: failed to list *v1.VolumeAttachment: volumeattachments.storage.k8s.io is forbidden: User "system:serviceaccount:cluster-autoscaler:cluster-autoscaler" cannot list resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope
```

. After further investigation it turn to be the cluster role doesnt seems to have priviledge added in the chart repo

#### What this PR does / why we need it:
This PR fixes an rbac issue for cluster autoscaler helm chart

#### Special notes for your reviewer:

This is a cluster autoscaler helm chart change which adds new rbac to existing rules 
