### PR TITLE
Removes stale owners from DO cluster autoscaler owners file and updates to current DO employee

### DIFF
--- a/cluster-autoscaler/cloudprovider/digitalocean/OWNERS
+++ b/cluster-autoscaler/cloudprovider/digitalocean/OWNERS
@@ -1,9 +1,7 @@
 approvers:
-- andrewsykim
-- MorrisLaw
+- gottwald
 reviewers:
-- andrewsykim
-- MorrisLaw
+- gottwald
 
 labels:
 - area/provider/digitalocean

--- a/cluster-autoscaler/cloudprovider/digitalocean/OWNERS
+++ b/cluster-autoscaler/cloudprovider/digitalocean/OWNERS
@@ -2,6 +2,9 @@ approvers:
 - gottwald
 reviewers:
 - gottwald
+emeritus_approvers:
+- andrewsykim
+- MorrisLaw
 
 labels:
 - area/provider/digitalocean


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
We have an outdated owners file here. This PR updates the owners file to reflect the current DO employee who owns this area of cluster autoscaler.

#### Special notes for your reviewer:
@gottwald is the current DO employee who needs to have approver/reviewer rights for the DO cluster autoscaler.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
