### PR TITLE
migrate claimReservedForPod to use upstream IsReservedForPod

### DIFF
--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	resourceclaim "k8s.io/dynamic-resource-allocation/resourceclaim"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -194,7 +195,7 @@ func (s Snapshot) ReservePodClaims(pod *apiv1.Pod) error {
 		return err
 	}
 	for _, claim := range claims {
-		if drautils.ClaimFullyReserved(claim) && !drautils.ClaimReservedForPod(claim, pod) {
+		if drautils.ClaimFullyReserved(claim) && !resourceclaim.IsReservedForPod(pod, claim) {
 			return fmt.Errorf("claim %s/%s already has max number of reservations set, can't add more", claim.Namespace, claim.Name)
 		}
 	}

--- a/cluster-autoscaler/simulator/dynamicresources/utils/resource_claims_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/utils/resource_claims_test.go
@@ -241,67 +241,6 @@ func TestClaimInUse(t *testing.T) {
 	}
 }
 
-func TestClaimReservedForPod(t *testing.T) {
-	pod := &apiv1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "chosenPod", UID: "chosenPodUid"}}
-
-	for _, tc := range []struct {
-		testName     string
-		claim        *resourceapi.ResourceClaim
-		wantReserved bool
-	}{
-		{
-			testName: "claim with no reservations",
-			claim: &resourceapi.ResourceClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim", UID: "claimUid", Namespace: "default"},
-				Status:     resourceapi.ResourceClaimStatus{},
-			},
-			wantReserved: false,
-		},
-		{
-			testName: "claim with some reservations, but none match the pod",
-			claim: &resourceapi.ResourceClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim", UID: "claimUid", Namespace: "default"},
-				Status: resourceapi.ResourceClaimStatus{
-					ReservedFor: []resourceapi.ResourceClaimConsumerReference{
-						{Resource: "pods", Name: "pod1", UID: "pod1Uid"},
-						{Resource: "pods", Name: "pod2", UID: "pod2Uid"},
-						{Resource: "somethingelses", Name: "somethingelse", UID: "somethingelseUid"},
-						{Resource: "pods", Name: "chosenPod", UID: "badUid"},
-						{Resource: "pods", Name: "badName", UID: "chosenPodUid"},
-						{Resource: "badResource", Name: "chosenPod", UID: "chosenPodUid"},
-					},
-				},
-			},
-			wantReserved: false,
-		},
-		{
-			testName: "claim with some reservations, one matches the pod",
-			claim: &resourceapi.ResourceClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim", UID: "claimUid", Namespace: "default"},
-				Status: resourceapi.ResourceClaimStatus{
-					ReservedFor: []resourceapi.ResourceClaimConsumerReference{
-						{Resource: "pods", Name: "pod1", UID: "pod1Uid"},
-						{Resource: "pods", Name: "pod2", UID: "pod2Uid"},
-						{Resource: "somethingelses", Name: "somethingelse", UID: "somethingelseUid"},
-						{Resource: "pods", Name: "chosenPod", UID: "badUid"},
-						{Resource: "pods", Name: "badName", UID: "chosenPodUid"},
-						{Resource: "badResource", Name: "chosenPod", UID: "chosenPodUid"},
-						{Resource: "pods", Name: "chosenPod", UID: "chosenPodUid"},
-					},
-				},
-			},
-			wantReserved: true,
-		},
-	} {
-		t.Run(tc.testName, func(t *testing.T) {
-			reserved := ClaimReservedForPod(tc.claim, pod)
-			if tc.wantReserved != reserved {
-				t.Errorf("ClaimReservedForPod(): unexpected result: want %v, got %v", tc.wantReserved, reserved)
-			}
-		})
-	}
-}
-
 func TestClaimFullyReserved(t *testing.T) {
 	for _, tc := range []struct {
 		testName          string


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
migrate claimReservedForPod to use upstream upstream IsReservedForPod 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
part of #7788

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
