### PR TITLE
VPA - Add golangci-lint to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ env:
 permissions:
   contents: read
   checks: write
-  pull-requests: read
 
 jobs:
   test-and-verify:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ env:
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: read
 
 jobs:
   test-and-verify:
@@ -37,6 +39,12 @@ jobs:
         run: hack/verify-all.sh -v
         env:
           GO111MODULE: auto
+
+      - name: golangci-lint - vertical-pod-autoscaler
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --timeout=30m
+          working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler/vertical-pod-autoscaler
 
       - name: Test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

golangci-lint was added in https://github.com/kubernetes/autoscaler/pull/7797, this adds it to GitHub Actions to allow for PRs to be listed before needing a human to get manually run the lint

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
