### PR TITLE
Reduce error output on "kubectl delete" by adding "--ignore-not-found"

### DIFF
--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -74,6 +74,10 @@ for i in $COMPONENTS; do
   if [[ ${ACTION} == print ]]; then
     ${SCRIPT_ROOT}/hack/vpa-process-yaml.sh $(script_path $i)
   else
-    ${SCRIPT_ROOT}/hack/vpa-process-yaml.sh $(script_path $i) | kubectl ${ACTION} -f - || true
+    EXTRA_FLAGS=""
+    if [[ ${ACTION} == delete ]]; then
+      EXTRA_FLAGS+=" --ignore-not-found"
+    fi
+    ${SCRIPT_ROOT}/hack/vpa-process-yaml.sh $(script_path $i) | kubectl ${ACTION} ${EXTRA_FLAGS} -f - || true
   fi
 done

--- a/vertical-pod-autoscaler/pkg/admission-controller/delete-webhook.sh
+++ b/vertical-pod-autoscaler/pkg/admission-controller/delete-webhook.sh
@@ -19,5 +19,4 @@ set -e
 
 echo "Unregistering VPA admission controller webhook"
 
-kubectl delete -n kube-system mutatingwebhookconfiguration.v1.admissionregistration.k8s.io vpa-webhook-config
-
+kubectl delete -n kube-system mutatingwebhookconfiguration.v1.admissionregistration.k8s.io vpa-webhook-config --ignore-not-found

--- a/vertical-pod-autoscaler/pkg/admission-controller/rmcerts.sh
+++ b/vertical-pod-autoscaler/pkg/admission-controller/rmcerts.sh
@@ -20,5 +20,5 @@
 set -e
 
 echo "Deleting VPA Admission Controller certs."
-kubectl delete secret --namespace=kube-system vpa-tls-certs
-kubectl delete secret --namespace=kube-system --ignore-not-found=true vpa-e2e-certs
+kubectl delete secret --namespace=kube-system vpa-tls-certs --ignore-not-found
+kubectl delete secret --namespace=kube-system vpa-e2e-certs --ignore-not-found


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

While doing `./hack/vpa-down.sh` cleanup before deploy/re-deploy, there would have some error output as there's no resource to delete, by adding `--ignore-not-found` could greatly reduce those unnecessary output.

#### Which issue(s) this PR fixes:

Fixes n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md

```release-note
Reduce error output on "kubectl delete" by adding "--ignore-not-found"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
