### PR TITLE
Actuator force delete

### DIFF
--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
@@ -289,6 +289,10 @@ func (m *mockActuator) StartDeletion(_, _ []*apiv1.Node) (status.ScaleDownResult
 	return status.ScaleDownError, []*status.ScaleDownNode{}, nil
 }
 
+func (m *mockActuator) StartForceDeletion(_, _ []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
+	return status.ScaleDownError, []*status.ScaleDownNode{}, nil
+}
+
 func (m *mockActuator) CheckStatus() scaledown.ActuationStatus {
 	return m.status
 }

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -621,7 +621,7 @@ func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, suffix string) 
 					},
 				},
 			},
-			wantDeletedNodes: []string{"test-node-1", "test-node-3"},
+			wantDeletedNodes: []string{"test-node-0", "test-node-1", "test-node-2", "test-node-3"},
 			wantDeletedPods: []string{
 				"test-node-0-pod-2",
 				"test-node-1-pod-0", "test-node-1-pod-1", "test-node-1-pod-2",
@@ -631,39 +631,21 @@ func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, suffix string) 
 			wantTaintUpdates: map[string][][]apiv1.Taint{
 				"test-node-0": {
 					{toBeDeletedTaint},
-					{},
 				},
 				"test-node-1": {
 					{toBeDeletedTaint},
 				},
 				"test-node-2": {
 					{toBeDeletedTaint},
-					{},
 				},
 				"test-node-3": {
 					{toBeDeletedTaint},
 				},
 			},
 			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
-				"test-node-0": {
-					ResultType: status.NodeDeleteErrorFailedToEvictPods,
-					Err:        cmpopts.AnyError,
-					PodEvictionResults: map[string]status.PodEvictionResult{
-						"test-node-0-pod-0": {Pod: removablePod("test-node-0-pod-0", "test-node-0"), Err: cmpopts.AnyError, TimedOut: true},
-						"test-node-0-pod-1": {Pod: removablePod("test-node-0-pod-1", "test-node-0"), Err: cmpopts.AnyError, TimedOut: true},
-						"test-node-0-pod-2": {Pod: removablePod("test-node-0-pod-2", "test-node-0")},
-					},
-				},
+				"test-node-0": {ResultType: status.NodeDeleteOk},
 				"test-node-1": {ResultType: status.NodeDeleteOk},
-				"test-node-2": {
-					ResultType: status.NodeDeleteErrorFailedToEvictPods,
-					Err:        cmpopts.AnyError,
-					PodEvictionResults: map[string]status.PodEvictionResult{
-						"test-node-2-pod-0": {Pod: removablePod("test-node-2-pod-0", "test-node-2")},
-						"test-node-2-pod-1": {Pod: removablePod("test-node-2-pod-1", "test-node-2"), Err: cmpopts.AnyError, TimedOut: true},
-						"test-node-2-pod-2": {Pod: removablePod("test-node-2-pod-2", "test-node-2")},
-					},
-				},
+				"test-node-2": {ResultType: status.NodeDeleteOk},
 				"test-node-3": {ResultType: status.NodeDeleteOk},
 			},
 		},

--- a/cluster-autoscaler/core/scaledown/actuation/drain.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain.go
@@ -261,6 +261,9 @@ func (e Evictor) evictPod(ctx *acontext.AutoscalingContext, podToEvict *apiv1.Po
 		if err := forceDeletePod(ctx, podToEvict); err != nil {
 			return status.PodEvictionResult{Pod: podToEvict, TimedOut: false, Err: err}
 		}
+		if e.evictionRegister != nil {
+			e.evictionRegister.RegisterEviction(podToEvict)
+		}
 		return status.PodEvictionResult{Pod: podToEvict, TimedOut: false, Err: nil}
 	}
 	if fullEvictionPod {

--- a/cluster-autoscaler/core/scaledown/actuation/drain.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain.go
@@ -77,12 +77,23 @@ func NewEvictor(evictionRegister evictionRegister, shutdownGracePeriodByPodPrior
 // DrainNode groups pods in the node in to priority groups and, evicts pods in the ascending order of priorities.
 // If priority evictor is not enable, eviction of daemonSet pods is the best effort.
 func (e Evictor) DrainNode(ctx *acontext.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
+	return e.drainNode(ctx, nodeInfo, false)
+}
+
+// drainNodeForce performs similar logic to DrainNode, but forcefully deletes pods on drain failure.
+func (e Evictor) drainNodeForce(ctx *acontext.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
+	return e.drainNode(ctx, nodeInfo, true)
+}
+
+// drainNode implements the shared logic for draining a node, with the 'force' parameter
+// determining whether to forcefully delete pods upon eviction failure.
+func (e Evictor) drainNode(ctx *acontext.AutoscalingContext, nodeInfo *framework.NodeInfo, force bool) (map[string]status.PodEvictionResult, error) {
 	node := nodeInfo.Node()
 	dsPods, pods := podsToEvict(nodeInfo, ctx.DaemonSetEvictionForOccupiedNodes)
 	if e.fullDsEviction {
-		return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, append(pods, dsPods...), nil)
+		return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, append(pods, dsPods...), nil, force)
 	}
-	return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, pods, dsPods)
+	return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, pods, dsPods, false)
 }
 
 // EvictDaemonSetPods creates eviction objects for all DaemonSet pods on the node.
@@ -90,12 +101,12 @@ func (e Evictor) DrainNode(ctx *acontext.AutoscalingContext, nodeInfo *framework
 func (e Evictor) EvictDaemonSetPods(ctx *acontext.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
 	node := nodeInfo.Node()
 	dsPods, _ := podsToEvict(nodeInfo, ctx.DaemonSetEvictionForEmptyNodes)
-	return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, nil, dsPods)
+	return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, nil, dsPods, false)
 }
 
 // drainNodeWithPodsBasedOnPodPriority performs drain logic on the node based on pod priorities.
 // Removes all pods, giving each pod group up to ShutdownGracePeriodSeconds to finish. The list of pods to evict has to be provided.
-func (e Evictor) drainNodeWithPodsBasedOnPodPriority(ctx *acontext.AutoscalingContext, node *apiv1.Node, fullEvictionPods, bestEffortEvictionPods []*apiv1.Pod) (map[string]status.PodEvictionResult, error) {
+func (e Evictor) drainNodeWithPodsBasedOnPodPriority(ctx *acontext.AutoscalingContext, node *apiv1.Node, fullEvictionPods, bestEffortEvictionPods []*apiv1.Pod, force bool) (map[string]status.PodEvictionResult, error) {
 	evictionResults := make(map[string]status.PodEvictionResult)
 
 	groups := groupByPriority(e.shutdownGracePeriodByPodPriority, fullEvictionPods, bestEffortEvictionPods)
@@ -114,7 +125,7 @@ func (e Evictor) drainNodeWithPodsBasedOnPodPriority(ctx *acontext.AutoscalingCo
 		}
 
 		var err error
-		evictionResults, err = e.initiateEviction(ctx, node, group.FullEvictionPods, group.BestEffortEvictionPods, evictionResults, group.ShutdownGracePeriodSeconds)
+		evictionResults, err = e.initiateEviction(ctx, node, group.FullEvictionPods, group.BestEffortEvictionPods, evictionResults, group.ShutdownGracePeriodSeconds, force)
 		if err != nil {
 			return evictionResults, err
 		}
@@ -167,7 +178,7 @@ func (e Evictor) waitPodsToDisappear(ctx *acontext.AutoscalingContext, node *api
 }
 
 func (e Evictor) initiateEviction(ctx *acontext.AutoscalingContext, node *apiv1.Node, fullEvictionPods, bestEffortEvictionPods []*apiv1.Pod, evictionResults map[string]status.PodEvictionResult,
-	maxTermination int64) (map[string]status.PodEvictionResult, error) {
+	maxTermination int64, force bool) (map[string]status.PodEvictionResult, error) {
 
 	retryUntil := time.Now().Add(ctx.MaxPodEvictionTime)
 	fullEvictionConfirmations := make(chan status.PodEvictionResult, len(fullEvictionPods))
@@ -176,13 +187,13 @@ func (e Evictor) initiateEviction(ctx *acontext.AutoscalingContext, node *apiv1.
 	for _, pod := range fullEvictionPods {
 		evictionResults[pod.Name] = status.PodEvictionResult{Pod: pod, TimedOut: true, Err: nil}
 		go func(pod *apiv1.Pod) {
-			fullEvictionConfirmations <- e.evictPod(ctx, pod, retryUntil, maxTermination, true)
+			fullEvictionConfirmations <- e.evictPod(ctx, pod, retryUntil, maxTermination, true, force)
 		}(pod)
 	}
 
 	for _, pod := range bestEffortEvictionPods {
 		go func(pod *apiv1.Pod) {
-			bestEffortEvictionConfirmations <- e.evictPod(ctx, pod, retryUntil, maxTermination, false)
+			bestEffortEvictionConfirmations <- e.evictPod(ctx, pod, retryUntil, maxTermination, false, false)
 		}(pod)
 	}
 
@@ -212,7 +223,7 @@ func (e Evictor) initiateEviction(ctx *acontext.AutoscalingContext, node *apiv1.
 	return evictionResults, nil
 }
 
-func (e Evictor) evictPod(ctx *acontext.AutoscalingContext, podToEvict *apiv1.Pod, retryUntil time.Time, maxTermination int64, fullEvictionPod bool) status.PodEvictionResult {
+func (e Evictor) evictPod(ctx *acontext.AutoscalingContext, podToEvict *apiv1.Pod, retryUntil time.Time, maxTermination int64, fullEvictionPod bool, force bool) status.PodEvictionResult {
 	ctx.Recorder.Eventf(podToEvict, apiv1.EventTypeNormal, "ScaleDown", "deleting pod for node scale down")
 
 	termination := int64(apiv1.DefaultTerminationGracePeriodSeconds)
@@ -243,13 +254,17 @@ func (e Evictor) evictPod(ctx *acontext.AutoscalingContext, podToEvict *apiv1.Po
 			return status.PodEvictionResult{Pod: podToEvict, TimedOut: false, Err: nil}
 		}
 	}
-	if fullEvictionPod {
-		klog.Errorf("Failed to evict pod %s, error: %v", podToEvict.Name, lastError)
+
+	klog.Errorf("Failed to evict pod %s, error: %v", podToEvict.Name, lastError)
+	if force {
 		// If eviction failed, forcefully delete the pod
 		if err := forceDeletePod(ctx, podToEvict); err != nil {
 			return status.PodEvictionResult{Pod: podToEvict, TimedOut: false, Err: err}
 		}
 		return status.PodEvictionResult{Pod: podToEvict, TimedOut: false, Err: nil}
+	}
+	if fullEvictionPod {
+		ctx.Recorder.Eventf(podToEvict, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to delete pod for ScaleDown")
 	}
 	return status.PodEvictionResult{Pod: podToEvict, TimedOut: true, Err: fmt.Errorf("failed to evict pod %s/%s within allowed timeout (last error: %v)", podToEvict.Namespace, podToEvict.Name, lastError)}
 }

--- a/cluster-autoscaler/core/scaledown/actuation/drain.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain.go
@@ -93,7 +93,7 @@ func (e Evictor) drainNode(ctx *acontext.AutoscalingContext, nodeInfo *framework
 	if e.fullDsEviction {
 		return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, append(pods, dsPods...), nil, force)
 	}
-	return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, pods, dsPods, false)
+	return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, pods, dsPods, force)
 }
 
 // EvictDaemonSetPods creates eviction objects for all DaemonSet pods on the node.
@@ -101,7 +101,7 @@ func (e Evictor) drainNode(ctx *acontext.AutoscalingContext, nodeInfo *framework
 func (e Evictor) EvictDaemonSetPods(ctx *acontext.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
 	node := nodeInfo.Node()
 	dsPods, _ := podsToEvict(nodeInfo, ctx.DaemonSetEvictionForEmptyNodes)
-	return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, nil, dsPods, false)
+	return e.drainNodeWithPodsBasedOnPodPriority(ctx, node, nil, dsPods, false) // force option applies only to full eviction pods
 }
 
 // drainNodeWithPodsBasedOnPodPriority performs drain logic on the node based on pod priorities.
@@ -193,7 +193,7 @@ func (e Evictor) initiateEviction(ctx *acontext.AutoscalingContext, node *apiv1.
 
 	for _, pod := range bestEffortEvictionPods {
 		go func(pod *apiv1.Pod) {
-			bestEffortEvictionConfirmations <- e.evictPod(ctx, pod, retryUntil, maxTermination, false, false)
+			bestEffortEvictionConfirmations <- e.evictPod(ctx, pod, retryUntil, maxTermination, false, false) // force option applies only to full eviction pods
 		}(pod)
 	}
 

--- a/cluster-autoscaler/core/scaledown/actuation/drain_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain_test.go
@@ -35,6 +35,7 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	acontext "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
@@ -365,6 +366,13 @@ func TestDrainNodeWithPodsWithRetries(t *testing.T) {
 	assert.Equal(t, p3.Name, deleted[3])
 }
 
+type wantPodEvictionResult struct {
+	Pod      *apiv1.Pod
+	Error    error
+	TimedOut bool
+	Evicted  bool
+}
+
 func TestDrainNodeWithPodsDaemonSetEvictionFailure(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 
@@ -376,6 +384,11 @@ func TestDrainNodeWithPodsDaemonSetEvictionFailure(t *testing.T) {
 
 	e1 := fmt.Errorf("eviction_error: d1")
 	e2 := fmt.Errorf("eviction_error: d2")
+
+	wantEvictionResults := map[string]wantPodEvictionResult{
+		"p1": {Pod: p1, Error: nil, TimedOut: false, Evicted: true},
+		"p2": {Pod: p2, Error: nil, TimedOut: false, Evicted: true},
+	}
 
 	fakeClient.Fake.AddReactor("get", "pods", func(action core.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.NewNotFound(apiv1.Resource("pod"), "whatever")
@@ -416,15 +429,8 @@ func TestDrainNodeWithPodsDaemonSetEvictionFailure(t *testing.T) {
 	assert.NoError(t, err)
 	evictionResults, err := evictor.DrainNode(&ctx, nodeInfo)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(evictionResults))
-	assert.Equal(t, p1, evictionResults["p1"].Pod)
-	assert.Equal(t, p2, evictionResults["p2"].Pod)
-	assert.NoError(t, evictionResults["p1"].Err)
-	assert.NoError(t, evictionResults["p2"].Err)
-	assert.False(t, evictionResults["p1"].TimedOut)
-	assert.False(t, evictionResults["p2"].TimedOut)
-	assert.True(t, evictionResults["p1"].WasEvictionSuccessful())
-	assert.True(t, evictionResults["p2"].WasEvictionSuccessful())
+
+	assertPodEvictionResults(t, wantEvictionResults, evictionResults)
 }
 
 func TestDrainNodeWithPodsEvictionFailure(t *testing.T) {
@@ -435,8 +441,17 @@ func TestDrainNodeWithPodsEvictionFailure(t *testing.T) {
 	p2 := BuildTestPod("p2", 100, 0, WithNodeName(n1.Name))
 	p3 := BuildTestPod("p3", 100, 0, WithNodeName(n1.Name))
 	p4 := BuildTestPod("p4", 100, 0, WithNodeName(n1.Name))
+
 	e2 := fmt.Errorf("eviction_error: p2")
 	e4 := fmt.Errorf("eviction_error: p4")
+
+	wantEvictionResults := map[string]wantPodEvictionResult{
+		"p1": {Pod: p1, Error: nil, TimedOut: false, Evicted: true},
+		"p2": {Pod: p2, Error: e2, TimedOut: true, Evicted: false},
+		"p3": {Pod: p3, Error: nil, TimedOut: false, Evicted: true},
+		"p4": {Pod: p4, Error: e4, TimedOut: true, Evicted: false},
+	}
+
 	SetNodeReadyState(n1, true, time.Time{})
 
 	fakeClient.Fake.AddReactor("create", "pods", func(action core.Action) (bool, runtime.Object, error) {
@@ -477,24 +492,9 @@ func TestDrainNodeWithPodsEvictionFailure(t *testing.T) {
 	assert.NoError(t, err)
 	evictionResults, err := evictor.DrainNode(&ctx, nodeInfo)
 	assert.Error(t, err)
-	assert.Equal(t, 4, len(evictionResults))
-	assert.Equal(t, *p1, *evictionResults["p1"].Pod)
-	assert.Equal(t, *p2, *evictionResults["p2"].Pod)
-	assert.Equal(t, *p3, *evictionResults["p3"].Pod)
-	assert.Equal(t, *p4, *evictionResults["p4"].Pod)
-	assert.NoError(t, evictionResults["p1"].Err)
-	assert.Contains(t, evictionResults["p2"].Err.Error(), e2.Error())
-	assert.NoError(t, evictionResults["p3"].Err)
-	assert.Contains(t, evictionResults["p4"].Err.Error(), e4.Error())
-	assert.False(t, evictionResults["p1"].TimedOut)
-	assert.True(t, evictionResults["p2"].TimedOut)
-	assert.False(t, evictionResults["p3"].TimedOut)
-	assert.True(t, evictionResults["p4"].TimedOut)
-	assert.True(t, evictionResults["p1"].WasEvictionSuccessful())
-	assert.False(t, evictionResults["p2"].WasEvictionSuccessful())
-	assert.True(t, evictionResults["p3"].WasEvictionSuccessful())
-	assert.False(t, evictionResults["p4"].WasEvictionSuccessful())
-	assert.Contains(t, r.pods, p1, p3)
+
+	assertPodEvictionResults(t, wantEvictionResults, evictionResults)
+	assertEvictedPods(t, r.pods, evictionResults)
 }
 
 func TestDrainForceNodeWithPodsEvictionFailure(t *testing.T) {
@@ -505,9 +505,17 @@ func TestDrainForceNodeWithPodsEvictionFailure(t *testing.T) {
 	p2 := BuildTestPod("p2", 100, 0, WithNodeName(n1.Name))
 	p3 := BuildTestPod("p3", 100, 0, WithNodeName(n1.Name))
 	p4 := BuildTestPod("p4", 100, 0, WithNodeName(n1.Name))
+
 	e2 := fmt.Errorf("eviction_error: p2")
 	e4 := fmt.Errorf("eviction_error: p4")
 	d4 := fmt.Errorf("deletion_error: p4")
+
+	wantEvictionResults := map[string]wantPodEvictionResult{
+		"p1": {Pod: p1, Error: nil, TimedOut: false, Evicted: true},
+		"p2": {Pod: p2, Error: nil, TimedOut: false, Evicted: true},
+		"p3": {Pod: p3, Error: nil, TimedOut: false, Evicted: true},
+		"p4": {Pod: p4, Error: d4, TimedOut: false, Evicted: false},
+	}
 
 	SetNodeReadyState(n1, true, time.Time{})
 
@@ -566,24 +574,9 @@ func TestDrainForceNodeWithPodsEvictionFailure(t *testing.T) {
 	assert.NoError(t, err)
 	evictionResults, err := evictor.drainNodeForce(&ctx, nodeInfo)
 	assert.Error(t, err)
-	assert.Equal(t, 4, len(evictionResults))
-	assert.Equal(t, *p1, *evictionResults["p1"].Pod)
-	assert.Equal(t, *p2, *evictionResults["p2"].Pod)
-	assert.Equal(t, *p3, *evictionResults["p3"].Pod)
-	assert.Equal(t, *p4, *evictionResults["p4"].Pod)
-	assert.NoError(t, evictionResults["p1"].Err)
-	assert.NoError(t, evictionResults["p2"].Err)
-	assert.NoError(t, evictionResults["p3"].Err)
-	assert.Contains(t, evictionResults["p4"].Err.Error(), d4.Error())
-	assert.False(t, evictionResults["p1"].TimedOut)
-	assert.False(t, evictionResults["p2"].TimedOut)
-	assert.False(t, evictionResults["p3"].TimedOut)
-	assert.False(t, evictionResults["p4"].TimedOut)
-	assert.True(t, evictionResults["p1"].WasEvictionSuccessful())
-	assert.True(t, evictionResults["p2"].WasEvictionSuccessful())
-	assert.True(t, evictionResults["p3"].WasEvictionSuccessful())
-	assert.False(t, evictionResults["p4"].WasEvictionSuccessful())
-	assert.Contains(t, r.pods, p1, p2, p3)
+
+	assertPodEvictionResults(t, wantEvictionResults, evictionResults)
+	assertEvictedPods(t, r.pods, evictionResults)
 }
 
 func TestDrainWithPodsNodeDisappearanceFailure(t *testing.T) {
@@ -594,7 +587,16 @@ func TestDrainWithPodsNodeDisappearanceFailure(t *testing.T) {
 	p2 := BuildTestPod("p2", 100, 0, WithNodeName(n1.Name))
 	p3 := BuildTestPod("p3", 100, 0, WithNodeName(n1.Name))
 	p4 := BuildTestPod("p4", 100, 0, WithNodeName(n1.Name))
+
 	e2 := fmt.Errorf("disappearance_error: p2")
+
+	wantEvictionResults := map[string]wantPodEvictionResult{
+		"p1": {Pod: p1, Error: nil, TimedOut: false, Evicted: true},
+		"p2": {Pod: p2, Error: e2, TimedOut: true, Evicted: false},
+		"p3": {Pod: p3, Error: nil, TimedOut: false, Evicted: true},
+		"p4": {Pod: p4, Error: nil, TimedOut: true, Evicted: false},
+	}
+
 	SetNodeReadyState(n1, true, time.Time{})
 
 	fakeClient.Fake.AddReactor("get", "pods", func(action core.Action) (bool, runtime.Object, error) {
@@ -632,23 +634,35 @@ func TestDrainWithPodsNodeDisappearanceFailure(t *testing.T) {
 	assert.NoError(t, err)
 	evictionResults, err := evictor.DrainNode(&ctx, nodeInfo)
 	assert.Error(t, err)
-	assert.Equal(t, 4, len(evictionResults))
-	assert.Equal(t, *p1, *evictionResults["p1"].Pod)
-	assert.Equal(t, *p2, *evictionResults["p2"].Pod)
-	assert.Equal(t, *p3, *evictionResults["p3"].Pod)
-	assert.Equal(t, *p4, *evictionResults["p4"].Pod)
-	assert.NoError(t, evictionResults["p1"].Err)
-	assert.Contains(t, evictionResults["p2"].Err.Error(), e2.Error())
-	assert.NoError(t, evictionResults["p3"].Err)
-	assert.NoError(t, evictionResults["p4"].Err)
-	assert.False(t, evictionResults["p1"].TimedOut)
-	assert.True(t, evictionResults["p2"].TimedOut)
-	assert.False(t, evictionResults["p3"].TimedOut)
-	assert.True(t, evictionResults["p4"].TimedOut)
-	assert.True(t, evictionResults["p1"].WasEvictionSuccessful())
-	assert.False(t, evictionResults["p2"].WasEvictionSuccessful())
-	assert.True(t, evictionResults["p3"].WasEvictionSuccessful())
-	assert.False(t, evictionResults["p4"].WasEvictionSuccessful())
+
+	assertPodEvictionResults(t, wantEvictionResults, evictionResults)
+}
+
+func assertPodEvictionResults(t *testing.T, wantEvictionResults map[string]wantPodEvictionResult, evictionResults map[string]status.PodEvictionResult) {
+	assert.Equal(t, len(wantEvictionResults), len(evictionResults))
+
+	for podName, want := range wantEvictionResults {
+		result := evictionResults[podName]
+		assert.Equal(t, *want.Pod, *result.Pod)
+		if want.Error == nil {
+			assert.NoError(t, result.Err)
+		} else {
+			assert.ErrorContains(t, result.Err, want.Error.Error())
+
+		}
+		assert.Equal(t, want.TimedOut, result.TimedOut)
+		assert.Equal(t, want.Evicted, result.WasEvictionSuccessful())
+	}
+}
+
+func assertEvictedPods(t *testing.T, wantEvictedPods []*apiv1.Pod, evictionResults map[string]status.PodEvictionResult) {
+	evicted := make([]*apiv1.Pod, 0)
+	for _, r := range evictionResults {
+		if r.WasEvictionSuccessful() {
+			evicted = append(evicted, r.Pod)
+		}
+	}
+	assert.ElementsMatch(t, wantEvictedPods, evicted)
 }
 
 func TestPodsToEvict(t *testing.T) {

--- a/cluster-autoscaler/core/scaledown/scaledown.go
+++ b/cluster-autoscaler/core/scaledown/scaledown.go
@@ -57,6 +57,8 @@ type Actuator interface {
 	// Actuator to ignore some of them e.g. if max configured level of
 	// parallelism is reached.
 	StartDeletion(empty, needDrain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError)
+	// StartForceDeletion triggers a new forced deletion process. It bypasses PDBs and forcefully deletes the pods and the nodes.
+	StartForceDeletion(empty, needDrain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError)
 	// CheckStatus returns an immutable snapshot of ongoing deletions.
 	CheckStatus() ActuationStatus
 	// ClearResultsNotNewerThan removes information about deletions finished


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR enables forceful node deletion, bypassing Pod Disruption Budgets (PDBs) when necessary for critical operations like emergency backups of node machine families.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Since we filter nodes for blocking pods before scaling down, and this change only applies to those filtered nodes that are explicitly allowed to be drained, the operation should be safe.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
