### PR TITLE
Fix a panic in GetContainersResources()

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -81,6 +81,13 @@ func GetContainersResources(pod *core.Pod, vpaResourcePolicy *vpa_types.PodResou
 		// If the recommendation only contains CPU or Memory (if the VPA was configured this way), we need to make sure we "backfill" the other.
 		// Only do this when the addAll flag is true.
 		if addAll {
+			if resources[i].Requests == nil {
+				resources[i].Requests = core.ResourceList{}
+			}
+			if resources[i].Limits == nil {
+				resources[i].Limits = core.ResourceList{}
+			}
+
 			cpuRequest, hasCpuRequest := container.Resources.Requests[core.ResourceCPU]
 			if _, ok := resources[i].Requests[core.ResourceCPU]; !ok && hasCpuRequest {
 				resources[i].Requests[core.ResourceCPU] = cpuRequest

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -424,6 +424,20 @@ func TestGetContainersResources(t *testing.T) {
 			addAll:           true,
 		},
 		{
+			name: "CPU only recommendation, only CPU request and limit set, ContainerControlledValuesRequestOnly",
+			container: test.Container().WithName("container").
+				WithCPURequest(resource.MustParse("1")).
+				WithCPULimit(resource.MustParse("10")).
+				Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer("container").
+				WithControlledValues("container", vpa_types.ContainerControlledValuesRequestsOnly).
+				WithTargetResource(apiv1.ResourceCPU, "2").
+				Get(),
+			expectedCPU:      mustParseResourcePointer("2"),
+			expectedCPULimit: mustParseResourcePointer("10"),
+			addAll:           true,
+		},
+		{
 			name:             "Memory only recommendation, request and limits set",
 			container:        test.Container().WithName("container").WithCPURequest(resource.MustParse("1")).WithMemRequest(resource.MustParse("1M")).WithCPULimit(resource.MustParse("10")).WithMemLimit(resource.MustParse("10M")).Get(),
 			vpa:              test.VerticalPodAutoscaler().WithContainer("container").WithTargetResource(apiv1.ResourceMemory, "2M").Get(),
@@ -454,6 +468,20 @@ func TestGetContainersResources(t *testing.T) {
 			vpa:              test.VerticalPodAutoscaler().WithContainer("container").WithTargetResource(apiv1.ResourceMemory, "2M").Get(),
 			expectedMem:      mustParseResourcePointer("2M"),
 			expectedMemLimit: mustParseResourcePointer("20M"),
+			addAll:           true,
+		},
+		{
+			name: "Memory only recommendation, only memory request and limit set, ContainerControlledValuesRequestOnly",
+			container: test.Container().WithName("container").
+				WithMemRequest(resource.MustParse("1M")).
+				WithMemLimit(resource.MustParse("10M")).
+				Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer("container").
+				WithControlledValues("container", vpa_types.ContainerControlledValuesRequestsOnly).
+				WithTargetResource(apiv1.ResourceMemory, "2M").
+				Get(),
+			expectedMem:      mustParseResourcePointer("2M"),
+			expectedMemLimit: mustParseResourcePointer("10M"),
 			addAll:           true,
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The panic occurs when VPA is set to control only the resource Requests (rather than the default of both Requests and Limits).

#### Which issue(s) this PR fixes:

No issue filed.

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

n/a
