### PR TITLE
added possibility to retrieve hcloud cluster config from file

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/README.md
+++ b/cluster-autoscaler/cloudprovider/hetzner/README.md
@@ -41,6 +41,12 @@ The cluster autoscaler for Hetzner Cloud scales worker nodes.
 }
 ```
 
+`HCLOUD_CLUSTER_CONFIG_FILE` Can be used as alternative to `HCLOUD_CLUSTER_CONFIG`. This is the path to a file
+containing the JSON structure described above. The file will be read and the contents will be used as the configuration.
+Can be useful when you have many different node pools and run into issues of the env var becoming too long.
+
+**NOTE**: In contrast to `HCLOUD_CLUSTER_CONFIG`, this file will not be base64 encoded.
+
 
 `HCLOUD_NETWORK` Default empty , The id or name of the network that is used in the cluster , @see https://docs.hetzner.cloud/#networks
 

--- a/cluster-autoscaler/cloudprovider/hetzner/README.md
+++ b/cluster-autoscaler/cloudprovider/hetzner/README.md
@@ -45,7 +45,7 @@ The cluster autoscaler for Hetzner Cloud scales worker nodes.
 containing the JSON structure described above. The file will be read and the contents will be used as the configuration.
 Can be useful when you have many different node pools and run into issues of the env var becoming too long.
 
-**NOTE**: In contrast to `HCLOUD_CLUSTER_CONFIG`, this file will not be base64 encoded.
+**NOTE**: In contrast to `HCLOUD_CLUSTER_CONFIG`, this file is not base64 encoded.
 
 
 `HCLOUD_NETWORK` Default empty , The id or name of the network that is used in the cluster , @see https://docs.hetzner.cloud/#networks

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -118,32 +118,30 @@ func newManager() (*hetznerManager, error) {
 	}
 	var clusterConfig = &ClusterConfig{}
 
+	var clusterConfigJsonData []byte
+	var readErr error
 	if clusterConfigBase64 != "" {
-		clusterConfigEnv, err := base64.StdEncoding.DecodeString(clusterConfigBase64)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse cluster config error: %s", err)
+		clusterConfigJsonData, readErr = base64.StdEncoding.DecodeString(clusterConfigBase64)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to parse cluster config error: %s", readErr)
 		}
-		err = json.Unmarshal(clusterConfigEnv, &clusterConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal cluster config JSON: %s", err)
-		}
-		clusterConfig.IsUsingNewFormat = true
-
 	} else if clusterConfigFile != "" {
-		clusterConfigData, err := os.ReadFile(clusterConfigFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read cluster config file: %s", err)
+		clusterConfigJsonData, readErr = os.ReadFile(clusterConfigFile)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read cluster config file: %s", readErr)
 		}
-		err = json.Unmarshal(clusterConfigData, &clusterConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal cluster config JSON: %s", err)
+	}
+
+	if clusterConfigJsonData != nil {
+		unmarshalErr := json.Unmarshal(clusterConfigJsonData, &clusterConfig)
+		if unmarshalErr != nil {
+			return nil, fmt.Errorf("failed to unmarshal cluster config JSON: %s", unmarshalErr)
 		}
 		clusterConfig.IsUsingNewFormat = true
-
 	} else {
-		cloudInit, err := base64.StdEncoding.DecodeString(cloudInitBase64)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse cloud init error: %s", err)
+		cloudInit, decErr := base64.StdEncoding.DecodeString(cloudInitBase64)
+		if decErr != nil {
+			return nil, fmt.Errorf("failed to parse cloud init error: %s", decErr)
 		}
 
 		imageName := os.Getenv("HCLOUD_IMAGE")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Picking up from [this issue](https://github.com/kubernetes/autoscaler/issues/7652) it allows to set the the Hetzer Cloud Cluster Config via a file instead of an environment variable. 
As mentioned in the issue the cluster config can become too long for an env var (happened to me today). 

#### Which issue(s) this PR fixes:
Fixes #7652

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- allow setting Hetzner Cloud Cluster Config by providing a json config file, set via `HCLOUD_CLUSTER_CONFIG_FILE`
```

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
