### PR TITLE
VPA: Remove obsolete comment and a few lines of code from addCPUSample

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -37,7 +37,6 @@ package model
 
 import (
 	"fmt"
-	"math"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -207,12 +206,8 @@ func (a *AggregateContainerState) SubtractSample(sample *ContainerUsageSample) {
 
 func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 	cpuUsageCores := CoresFromCPUAmount(sample.Usage)
-	cpuRequestCores := CoresFromCPUAmount(sample.Request)
-	// Samples are added with the weight equal to the current request. This means that
-	// whenever the request is increased, the history accumulated so far effectively decays,
-	// which helps react quickly to CPU starvation.
 	a.AggregateCPUUsage.AddSample(
-		cpuUsageCores, math.Max(cpuRequestCores, minSampleWeight), sample.MeasureStart)
+		cpuUsageCores, minSampleWeight, sample.MeasureStart)
 	if sample.MeasureStart.After(a.LastSampleStart) {
 		a.LastSampleStart = sample.MeasureStart
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
@@ -86,9 +86,9 @@ func TestAggregateContainerUsageSamples(t *testing.T) {
 	// Verify that CPU measures are added to the CPU histogram.
 	// The weight should be equal to the current request.
 	timeStep := memoryAggregationInterval / 2
-	test.mockCPUHistogram.On("AddSample", 3.14, 2.3, testTimestamp)
-	test.mockCPUHistogram.On("AddSample", 6.28, 2.3, testTimestamp.Add(timeStep))
-	test.mockCPUHistogram.On("AddSample", 1.57, 2.3, testTimestamp.Add(2*timeStep))
+	test.mockCPUHistogram.On("AddSample", 3.14, minSampleWeight, testTimestamp)
+	test.mockCPUHistogram.On("AddSample", 6.28, minSampleWeight, testTimestamp.Add(timeStep))
+	test.mockCPUHistogram.On("AddSample", 1.57, minSampleWeight, testTimestamp.Add(2*timeStep))
 	// Verify that memory peaks are added to the memory peaks histogram.
 	memoryAggregationWindowEnd := testTimestamp.Add(memoryAggregationInterval)
 	test.mockMemoryHistogram.On("AddSample", 5.0, 1.0, memoryAggregationWindowEnd)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR deletes an obsolete comment and a few lines of code that were possibly not removed after [this change](https://github.com/kubernetes/autoscaler/pull/815).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7818

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

n/a