### PR TITLE
Remove Request property from ContainerUsageSample

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
@@ -77,7 +77,6 @@ func TestMergeContainerStateForCheckpointDropsRecentMemoryPeak(t *testing.T) {
 	container.AddSample(&model.ContainerUsageSample{
 		MeasureStart: timeNow,
 		Usage:        model.MemoryAmountFromBytes(1024 * 1024 * 1024),
-		Request:      testRequest[model.ResourceMemory],
 		Resource:     model.ResourceMemory,
 	})
 	vpa := addVpa(t, cluster, testVpaID1, testSelectorStr)

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -483,7 +483,6 @@ func TestClusterStateFeeder_InitFromHistoryProvider(t *testing.T) {
 				{
 					MeasureStart: t0,
 					Usage:        10,
-					Request:      101,
 					Resource:     model.ResourceCPU,
 				},
 			},
@@ -491,7 +490,6 @@ func TestClusterStateFeeder_InitFromHistoryProvider(t *testing.T) {
 				{
 					MeasureStart: t0,
 					Usage:        memAmount,
-					Request:      1024 * 1024 * 1024,
 					Resource:     model.ResourceMemory,
 				},
 			},

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -44,7 +44,6 @@ func addTestCPUSample(cluster *ClusterState, container ContainerID, cpuCores flo
 		ContainerUsageSample: ContainerUsageSample{
 			MeasureStart: testTimestamp,
 			Usage:        CPUAmountFromCores(cpuCores),
-			Request:      testRequest[ResourceCPU],
 			Resource:     ResourceCPU,
 		},
 	}
@@ -57,7 +56,6 @@ func addTestMemorySample(cluster *ClusterState, container ContainerID, memoryByt
 		ContainerUsageSample: ContainerUsageSample{
 			MeasureStart: testTimestamp,
 			Usage:        MemoryAmountFromBytes(memoryBytes),
-			Request:      testRequest[ResourceMemory],
 			Resource:     ResourceMemory,
 		},
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -79,7 +79,6 @@ func makeTestUsageSample() *ContainerUsageSampleWithKey {
 	return &ContainerUsageSampleWithKey{ContainerUsageSample{
 		MeasureStart: testTimestamp,
 		Usage:        1.0,
-		Request:      testRequest[ResourceCPU],
 		Resource:     ResourceCPU},
 		testContainerID}
 }
@@ -276,7 +275,6 @@ func TestAddSampleAfterAggregateContainerStateGCed(t *testing.T) {
 	newUsageSample := &ContainerUsageSampleWithKey{ContainerUsageSample{
 		MeasureStart: gcTimestamp.Add(1 * time.Hour),
 		Usage:        usageSample.Usage,
-		Request:      usageSample.Request,
 		Resource:     usageSample.Resource},
 		testContainerID}
 	// Add usage sample to the container again.

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -33,8 +33,6 @@ type ContainerUsageSample struct {
 	MeasureStart time.Time
 	// Average CPU usage in cores or memory usage in bytes.
 	Usage ResourceAmount
-	// CPU or memory request at the time of measurement.
-	Request ResourceAmount
 	// Which resource is this sample for.
 	Resource ResourceName
 }
@@ -151,7 +149,6 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 			oldPeak := ContainerUsageSample{
 				MeasureStart: container.WindowEnd,
 				Usage:        oldMaxMem,
-				Request:      sample.Request,
 				Resource:     ResourceMemory,
 			}
 			container.aggregator.SubtractSample(&oldPeak)
@@ -171,7 +168,6 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 		newPeak := ContainerUsageSample{
 			MeasureStart: container.WindowEnd,
 			Usage:        sample.Usage,
-			Request:      sample.Request,
 			Resource:     ResourceMemory,
 		}
 		container.aggregator.AddSample(&newPeak)

--- a/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
@@ -44,7 +44,6 @@ func newUsageSample(timestamp time.Time, usage int64, resource ResourceName) *Co
 	return &ContainerUsageSample{
 		MeasureStart: timestamp,
 		Usage:        ResourceAmount(usage),
-		Request:      TestRequest[resource],
 		Resource:     resource,
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As a follow-up to https://github.com/kubernetes/autoscaler/pull/7819, this PR removes the request property from `ContainerUsageSample`, as it is no longer used.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

