### PR TITLE
Ignore new unexported fields in the tests

### DIFF
--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -1119,6 +1119,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 						// We don't care about this field staying the same, and it differs because it's a global counter bumped on every AddPod.
 						cmpopts.IgnoreFields(schedulerframework.NodeInfo{}, "Generation"),
 						cmp.AllowUnexported(framework.NodeInfo{}, schedulerframework.NodeInfo{}),
+						cmpopts.IgnoreUnexported(schedulerframework.PodInfo{}),
 						cmpopts.SortSlices(func(i1, i2 *framework.NodeInfo) bool { return i1.Node().Name < i2.Node().Name }),
 						IgnoreObjectOrder[*resourceapi.ResourceClaim](),
 						IgnoreObjectOrder[*resourceapi.ResourceSlice](),

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_test.go
@@ -572,6 +572,7 @@ func TestSnapshotWrapSchedulerNodeInfo(t *testing.T) {
 				t.Fatalf("Snapshot.WrapSchedulerNodeInfo(): unexpected error (-want +got): %s", diff)
 			}
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmp.AllowUnexported(framework.NodeInfo{}, schedulerframework.NodeInfo{}),
+				cmpopts.IgnoreUnexported(schedulerframework.PodInfo{}),
 				test.IgnoreObjectOrder[*resourceapi.ResourceClaim](), test.IgnoreObjectOrder[*resourceapi.ResourceSlice]()}
 			if diff := cmp.Diff(tc.wantNodeInfo, nodeInfo, cmpOpts...); diff != "" {
 				t.Errorf("Snapshot.WrapSchedulerNodeInfo(): unexpected output (-want +got): %s", diff)

--- a/cluster-autoscaler/simulator/framework/infos_test.go
+++ b/cluster-autoscaler/simulator/framework/infos_test.go
@@ -205,6 +205,7 @@ func TestNodeInfo(t *testing.T) {
 				cmpopts.SortSlices(func(p1, p2 *schedulerframework.PodInfo) bool {
 					return p1.Pod.Name < p2.Pod.Name
 				}),
+				cmpopts.IgnoreUnexported(schedulerframework.PodInfo{}),
 			}
 			if diff := cmp.Diff(tc.wantSchedNodeInfo, wrappedNodeInfo.ToScheduler(), nodeInfoCmpOpts...); diff != "" {
 				t.Errorf("ToScheduler() output differs from expected, diff (-want +got): %s", diff)
@@ -297,6 +298,7 @@ func TestDeepCopyNodeInfo(t *testing.T) {
 				// We don't care about this field staying the same, and it differs because it's a global counter bumped
 				// on every AddPod.
 				cmpopts.IgnoreFields(schedulerframework.NodeInfo{}, "Generation"),
+				cmpopts.IgnoreUnexported(schedulerframework.PodInfo{}),
 			); diff != "" {
 				t.Errorf("nodeInfo differs after DeepCopyNodeInfo, diff (-want +got): %s", diff)
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
New unexported field is added in Scheduler -  https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/types.go#L424. Theses tests would start failing / panic due to this. Added `cmpopts.IgnoreUnexported(schedulerframework.PodInfo{})` to ignore this field in test.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
