### PR TITLE
Bumps golang from 1.23.6 to 1.24.0.

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/updater/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.23.6 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.0 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Re raise this PR: https://github.com/kubernetes/autoscaler/pull/7834 due to flake test