### PR TITLE
Force system-node-critical daemon-sets in node group templates

### DIFF
--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
@@ -184,5 +184,12 @@ func isNodeGoodTemplateCandidate(node *apiv1.Node, now time.Time) bool {
 	ready, lastTransitionTime, _ := kube_util.GetReadinessState(node)
 	stable := lastTransitionTime.Add(stabilizationDelay).Before(now)
 	schedulable := !node.Spec.Unschedulable
-	return ready && stable && schedulable
+	toBeDeleted := false
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == taints.ToBeDeletedTaint {
+			toBeDeleted = true
+			break
+		}
+	}
+	return ready && stable && schedulable && !toBeDeleted
 }

--- a/cluster-autoscaler/simulator/node_info_utils_test.go
+++ b/cluster-autoscaler/simulator/node_info_utils_test.go
@@ -31,13 +31,15 @@ import (
 	resourceapi "k8s.io/api/resource/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/controller/daemon"
+
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/labels"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
-	"k8s.io/kubernetes/pkg/controller/daemon"
 )
 
 var (
@@ -69,7 +71,21 @@ var (
 			},
 		},
 	}
-	testDaemonSets = []*appsv1.DaemonSet{ds1, ds2, ds3}
+	ds4 = &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ds4",
+			Namespace: "ds4-namespace",
+			UID:       types.UID("ds4"),
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					PriorityClassName: labels.SystemNodeCriticalLabel,
+				},
+			},
+		},
+	}
+	testDaemonSets = []*appsv1.DaemonSet{ds1, ds2, ds3, ds4}
 )
 
 func TestSanitizedTemplateNodeInfoFromNodeGroup(t *testing.T) {
@@ -98,6 +114,7 @@ func TestSanitizedTemplateNodeInfoFromNodeGroup(t *testing.T) {
 			wantPods: []*apiv1.Pod{
 				buildDSPod(ds1, "n"),
 				buildDSPod(ds2, "n"),
+				buildDSPod(ds4, "n"),
 			},
 		},
 		{
@@ -116,6 +133,7 @@ func TestSanitizedTemplateNodeInfoFromNodeGroup(t *testing.T) {
 				SetMirrorPodSpec(BuildScheduledTestPod("p3", 100, 1, "n")),
 				buildDSPod(ds1, "n"),
 				buildDSPod(ds2, "n"),
+				buildDSPod(ds4, "n"),
 			},
 		},
 	} {
@@ -208,6 +226,7 @@ func TestSanitizedTemplateNodeInfoFromNodeInfo(t *testing.T) {
 			daemonSets: testDaemonSets,
 			wantPods: []*apiv1.Pod{
 				buildDSPod(ds1, "n"),
+				buildDSPod(ds4, "n"),
 			},
 		},
 		{
@@ -232,6 +251,7 @@ func TestSanitizedTemplateNodeInfoFromNodeInfo(t *testing.T) {
 			wantPods: []*apiv1.Pod{
 				buildDSPod(ds1, "n"),
 				buildDSPod(ds2, "n"),
+				buildDSPod(ds4, "n"),
 			},
 		},
 		{
@@ -248,6 +268,7 @@ func TestSanitizedTemplateNodeInfoFromNodeInfo(t *testing.T) {
 			wantPods: []*apiv1.Pod{
 				SetMirrorPodSpec(BuildScheduledTestPod("p3", 100, 1, "n")),
 				buildDSPod(ds1, "n"),
+				buildDSPod(ds4, "n"),
 			},
 		},
 		{
@@ -266,6 +287,7 @@ func TestSanitizedTemplateNodeInfoFromNodeInfo(t *testing.T) {
 				SetMirrorPodSpec(BuildScheduledTestPod("p3", 100, 1, "n")),
 				buildDSPod(ds1, "n"),
 				buildDSPod(ds2, "n"),
+				buildDSPod(ds4, "n"),
 			},
 		},
 	}

--- a/cluster-autoscaler/utils/labels/labels.go
+++ b/cluster-autoscaler/utils/labels/labels.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+const (
+	// SystemNodeCriticalLabel is a label that marks critical pods with the highest priority.
+	SystemNodeCriticalLabel = "system-node-critical"
+)
+
 var (
 	// cpu amount used for account pods that don't specify cpu requests
 	defaultMinCPU        = *resource.NewMilliQuantity(50, resource.DecimalSI)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

For `--force-ds=false` flag, cluster-autoscaler does not account for pending daemon-sets when creating node group templates. It sometimes leads to a cycle of node group recreations:
- User pod consuming most resources of a selected node triggers a scale-up
- System daemon-sets are started on the node
- User pod triggering the scale-up does not fit the node anymore
- Node is removed
- Back to step 1

To fix this scenario (without flipping `--force-ds` flag) two changes were implemented:
- Always account for preempting `system-node-critical` daemon-sets - those DSes will preempt other pods so it's safe to account for them in scale-up simulations. This should solve most of the problems seen in practice
- Do not pick half drained nodes as node group templates - it looks like a bug. Sometimes a half drained node is picked as a node group template leading to a situation where node is assumed to have more available resources than really assignable. This should just stabilize node count state for non system-node-critical daemon-sets.
 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
