### PR TITLE
[Addon Resizer] Small fixes for automated builds

### DIFF
--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -27,7 +27,7 @@ REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
-TAG = 1.8.23
+TAG ?= 1.8.23
 # The output type could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
 

--- a/addon-resizer/cloudbuild.yaml
+++ b/addon-resizer/cloudbuild.yaml
@@ -1,15 +1,15 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1200s
+timeout: 7200s
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest'
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest"
     entrypoint: make
     env:
-    - TAG=$_GIT_TAG
+      - TAG=$_GIT_TAG
     args:
-    - all-push
+      - all-push
 substitutions:
-  _GIT_TAG: '0.0.0' # default value, this is substituted at build time
+  _GIT_TAG: "0.0.0" # default value, this is substituted at build time


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Small fixes for automated builds as part of #7615:

- Make sure injected tag makes it all the way through to the Dockerfile.
- Increase timeout.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```