### PR TITLE
Enable forbidigo for VPA

### DIFF
--- a/vertical-pod-autoscaler/.golangci.yaml
+++ b/vertical-pod-autoscaler/.golangci.yaml
@@ -1,7 +1,14 @@
 linters:
   enable:
+    - forbidigo
     - goimports
 
 linters-settings:
+  forbidigo:
+    forbid:
+      # Forbid use of archived package "github.com/pkg/errors". Context: https://github.com/kubernetes/autoscaler/pull/7845
+      - pkg: github.com/pkg/errors
+    analyze-types: true
+
   goimports:
     local-prefixes: "k8s.io/autoscaler/vertical-pod-autoscaler"


### PR DESCRIPTION
And forbid the github.com/pkg/errors package

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Bryan pointed out the use of an archived package in https://github.com/kubernetes/autoscaler/pull/7845

Since humans forget things, I thought it would be useful to codify this rule of "don't use github.com/pkg/errors" anymore so that the package isn't re-introduced by mistake in the future.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
