### PR TITLE
[Addon Resizer] Increase build timeout

### DIFF
--- a/addon-resizer/cloudbuild.yaml
+++ b/addon-resizer/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 7200s
+timeout: 43200s # 12 hours - builds for each arch take time
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:

--- a/addon-resizer/cloudbuild.yaml
+++ b/addon-resizer/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 43200s # 12 hours - builds for each arch take time
+timeout: 21600s # 6 hours - builds for each arch take time and is slower on Cloud Build
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

See #7615.

The build process runs very slowly on Cloud Build and we build addon-resizer for every architecture.

The [most recent run](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-autoscaler-push-addon-resizer-images/1891948922289524736) timed out after 2 hours and managed to build 4 out of the 5 images.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
