### PR TITLE
VPA - Cleanup OWNERS

### DIFF
--- a/vertical-pod-autoscaler/OWNERS
+++ b/vertical-pod-autoscaler/OWNERS
@@ -1,20 +1,18 @@
 approvers:
 - kwiesmueller
-- kgolab
 - jbartosik
-- krzysied
 - voelzmo
 - raywainman
 reviewers:
 - kwiesmueller
-- kgolab
 - jbartosik
-- krzysied
 - voelzmo
 - raywainman
 - adrianmoisey
 - omerap12
 emeritus_approvers:
 - schylek # 2022-09-30
+- kgolab # 2025-02-21
+- krzysied # 2025-02-21
 labels:
 - area/vertical-pod-autoscaler


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Cleans up 2 inactive approvers/reviewers from VPA Owners and moves to emeritus status - highlighted via the [maintainers](https://github.com/kubernetes-sigs/maintainers) tool:

```bash
maintainers prune --repository-devstats kubernetes/autoscaler --repository-github kubernetes/autoscaler
```

cc: @kgolab and @krzysied 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
