### PR TITLE
Fix 2 bugs in the OCI integration

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
@@ -118,7 +118,7 @@ func (osf *shapeGetterImpl) GetNodePoolShape(np *oke.NodePool, ephemeralStorage 
 		// Update the cache based on latest results
 		for _, s := range resp.Items {
 			osf.cache[*s.Shape] = &Shape{
-				Name:                    shapeName,
+				Name:                    *s.Shape,
 				CPU:                     getFloat32(s.Ocpus) * 2, // convert ocpu to vcpu
 				GPU:                     getInt(s.Gpus),
 				MemoryInBytes:           getFloat32(s.MemoryInGBs) * 1024 * 1024 * 1024,

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
@@ -76,9 +76,7 @@ func (c *nodePoolCache) removeInstance(nodePoolID, instanceID string, nodeName s
 	if instanceID == "" {
 		klog.Errorf("Node %s doesn't have an instance id so it can't be deleted.", nodeName)
 		klog.Errorf("This could be due to a Compute Instance issue in OCI such as Out Of Host Capacity error. Check the instance status on OCI Console.")
-		// We silently fail here because returning an error will cause the cluster autoscaler to stop its reconciliation loop, preventing other
-		// node pools from autoscaling.
-		return nil
+		return errors.Errorf("Node %s doesn't have an instance id so it can't be deleted.", nodeName)
 	}
 
 	klog.Infof("Deleting instance %q from node pool %q", instanceID, nodePoolID)

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
@@ -76,7 +76,9 @@ func (c *nodePoolCache) removeInstance(nodePoolID, instanceID string, nodeName s
 	if instanceID == "" {
 		klog.Errorf("Node %s doesn't have an instance id so it can't be deleted.", nodeName)
 		klog.Errorf("This could be due to a Compute Instance issue in OCI such as Out Of Host Capacity error. Check the instance status on OCI Console.")
-		return errors.Errorf("Node %s doesn't have an instance id so it can't be deleted.", nodeName)
+		// We silently fail here because returning an error will cause the cluster autoscaler to stop its reconciliation loop, preventing other
+		// node pools from autoscaling.
+		return nil
 	}
 
 	klog.Infof("Deleting instance %q from node pool %q", instanceID, nodePoolID)

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -461,18 +461,19 @@ func (m *ociManagerImpl) GetExistingNodePoolSizeViaCompute(np NodePool) (int, er
 			if !strings.HasPrefix(*item.DisplayName, displayNamePrefix) {
 				continue
 			}
+			if *item.Id == "" {
+				continue
+			}
 			switch item.LifecycleState {
 			case core.InstanceLifecycleStateStopped, core.InstanceLifecycleStateTerminated:
 				klog.V(4).Infof("skipping instance is in stopped/terminated state: %q", *item.Id)
 			case core.InstanceLifecycleStateCreatingImage, core.InstanceLifecycleStateStarting, core.InstanceLifecycleStateProvisioning, core.InstanceLifecycleStateMoving:
-				if *item.Id != "" {
-					instances = append(instances, cloudprovider.Instance{
-						Id: *item.Id,
-						Status: &cloudprovider.InstanceStatus{
-							State: cloudprovider.InstanceCreating,
-						},
-					})
-				}
+				instances = append(instances, cloudprovider.Instance{
+					Id: *item.Id,
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+					},
+				})
 			// in case an instance is running, it could either be installing OKE software or become a Ready node.
 			// we do not know, but as we only need info if a node is stopped / terminated, we do not care
 			case core.InstanceLifecycleStateRunning:
@@ -527,6 +528,12 @@ func (m *ociManagerImpl) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance
 	var instances []cloudprovider.Instance
 	for _, node := range nodePool.Nodes {
 
+		// A node pool can fail to scale up if there's no capacity in the region. In that case, the node pool will be
+		// returned by the API, but it will not actually exist or have an ID, so we don't want to tell the autoscaler about it.
+		if *node.Id == "" {
+			continue
+		}
+
 		if node.NodeError != nil {
 
 			errorClass := cloudprovider.OtherErrorClass
@@ -562,16 +569,12 @@ func (m *ociManagerImpl) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance
 				},
 			})
 		case oke.NodeLifecycleStateCreating, oke.NodeLifecycleStateUpdating:
-			// A node pool can fail to scale up if there's no capacity in the region. In that case, the node pool will be
-			// returned by the API, but it will not actually exist or have an ID, so we don't want to tell the autoscaler about it.
-			if *node.Id != "" {
-				instances = append(instances, cloudprovider.Instance{
-					Id: *node.Id,
-					Status: &cloudprovider.InstanceStatus{
-						State: cloudprovider.InstanceCreating,
-					},
-				})
-			}
+			instances = append(instances, cloudprovider.Instance{
+				Id: *node.Id,
+				Status: &cloudprovider.InstanceStatus{
+					State: cloudprovider.InstanceCreating,
+				},
+			})
 		case oke.NodeLifecycleStateActive:
 			instances = append(instances, cloudprovider.Instance{
 				Id: *node.Id,

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -461,7 +461,10 @@ func (m *ociManagerImpl) GetExistingNodePoolSizeViaCompute(np NodePool) (int, er
 			if !strings.HasPrefix(*item.DisplayName, displayNamePrefix) {
 				continue
 			}
+			// A node pool can fail to scale up if there's no capacity in the region. In that case, the node pool will be
+			// returned by the API, but it will not actually exist or have an ID, so we don't want to tell the autoscaler about it.
 			if *item.Id == "" {
+				klog.V(4).Infof("skipping node as it doesn't have a scaled-up instance")
 				continue
 			}
 			switch item.LifecycleState {
@@ -531,6 +534,7 @@ func (m *ociManagerImpl) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance
 		// A node pool can fail to scale up if there's no capacity in the region. In that case, the node pool will be
 		// returned by the API, but it will not actually exist or have an ID, so we don't want to tell the autoscaler about it.
 		if *node.Id == "" {
+			klog.V(4).Infof("skipping node as it doesn't have a scaled-up instance")
 			continue
 		}
 

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -461,9 +461,6 @@ func (m *ociManagerImpl) GetExistingNodePoolSizeViaCompute(np NodePool) (int, er
 			if !strings.HasPrefix(*item.DisplayName, displayNamePrefix) {
 				continue
 			}
-			if *item.Id == "" {
-				continue
-			}
 			switch item.LifecycleState {
 			case core.InstanceLifecycleStateStopped, core.InstanceLifecycleStateTerminated:
 				klog.V(4).Infof("skipping instance is in stopped/terminated state: %q", *item.Id)
@@ -527,12 +524,6 @@ func (m *ociManagerImpl) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance
 
 	var instances []cloudprovider.Instance
 	for _, node := range nodePool.Nodes {
-
-		// A node pool can fail to scale up if there's no capacity in the region. In that case, the node pool will be
-		// returned by the API, but it will not actually exist or have an ID, so we don't want to tell the autoscaler about it.
-		if *node.Id == "" {
-			continue
-		}
 
 		if node.NodeError != nil {
 

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
@@ -6,10 +6,11 @@ package nodepools
 
 import (
 	"context"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/nodepools/consts"
 	"net/http"
 	"reflect"
 	"testing"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/nodepools/consts"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -122,6 +123,12 @@ func TestGetNodePoolNodes(t *testing.T) {
 					Code:    common.String("InternalServerError"),
 					Message: common.String("blah blah quota exceeded blah blah"),
 				},
+			},
+			{
+				// This case happens if a node fails to scale up due to lack of capacity in the region.
+				// It's not a real node, so we shouldn't return it in the list of nodes.
+				Id:             common.String(""),
+				LifecycleState: oke.NodeLifecycleStateCreating,
 			},
 		},
 	}

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
@@ -124,6 +124,12 @@ func TestGetNodePoolNodes(t *testing.T) {
 					Message: common.String("blah blah quota exceeded blah blah"),
 				},
 			},
+			{
+				// This case happens if a node fails to scale up due to lack of capacity in the region.
+				// It's not a real node, so we shouldn't return it in the list of nodes.
+				Id:             common.String(""),
+				LifecycleState: oke.NodeLifecycleStateCreating,
+			},
 		},
 	}
 
@@ -320,9 +326,7 @@ func TestBuildGenericLabels(t *testing.T) {
 
 }
 
-type mockOKEClient struct {
-	deleteCallCount int
-}
+type mockOKEClient struct{}
 
 func (c mockOKEClient) GetNodePool(context.Context, oke.GetNodePoolRequest) (oke.GetNodePoolResponse, error) {
 	return oke.GetNodePoolResponse{}, nil
@@ -331,7 +335,6 @@ func (c mockOKEClient) UpdateNodePool(context.Context, oke.UpdateNodePoolRequest
 	return oke.UpdateNodePoolResponse{}, nil
 }
 func (c mockOKEClient) DeleteNode(context.Context, oke.DeleteNodeRequest) (oke.DeleteNodeResponse, error) {
-	c.deleteCallCount += 1
 	return oke.DeleteNodeResponse{
 		RawResponse: &http.Response{
 			Status:     "200 OK",
@@ -355,9 +358,8 @@ func TestRemoveInstance(t *testing.T) {
 
 	expectedInstances := map[string]int{instanceId4: 1, instanceId5: 1, instanceId6: 1}
 
-	okeClient := mockOKEClient{}
 	nodePoolCache := newNodePoolCache(nil)
-	nodePoolCache.okeClient = okeClient
+	nodePoolCache.okeClient = mockOKEClient{}
 	nodePoolCache.cache[nodePoolId] = &oke.NodePool{
 		Nodes: []oke.Node{
 			{Id: common.String(instanceId1), LifecycleState: oke.NodeLifecycleStateDeleting},
@@ -381,7 +383,7 @@ func TestRemoveInstance(t *testing.T) {
 		t.Errorf("Fail to remove instance #{instanceId3}")
 	}
 
-	if err := nodePoolCache.removeInstance(nodePoolId, "", "badNode"); err != nil || okeClient.deleteCallCount > 3 {
+	if err := nodePoolCache.removeInstance(nodePoolId, "", "badNode"); err == nil {
 		t.Errorf("Bad node should not have been deleted.")
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes 2 bugs with the Oracle Cloud integration:
* When fetching information about node shapes to determine if a node pool with 0 nodes can be scaled up, it only fetches the first 100 results. The code specifies `Limit: 500`, but the max value of the limit on the backend is 100. This prevents nodes not on the first page of results from scaling up from 0.
* It's possible when attempting to scale up that the request fails due to a lack of capacity in the region. In this case OCI will show a node in the pool, but won't assign an ID to the node. This means that any attempts to scale down the node fail. To fix this, we just don't tell the autoscaler about nodes that have no ID.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
