### PR TITLE
VPA: Enforce flag documentation check in CI

### DIFF
--- a/hack/verify-vpa-flags.sh
+++ b/hack/verify-vpa-flags.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+VPA_FLAGS_SCRIPT="${KUBE_ROOT}/vertical-pod-autoscaler/hack/verify-vpa-flags.sh"
+
+echo "Running VPA flags verification..."
+"$VPA_FLAGS_SCRIPT"

--- a/vertical-pod-autoscaler/hack/verify-vpa-flags.sh
+++ b/vertical-pod-autoscaler/hack/verify-vpa-flags.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(realpath $(dirname "${BASH_SOURCE[0]}"))/..
+FLAG_FILE="${SCRIPT_ROOT}/docs/flags.md"
+GENERATE_FLAGS_SCRIPT="${SCRIPT_ROOT}/hack/generate-flags.sh"
+
+existing_flags=$(<"$FLAG_FILE")
+"$GENERATE_FLAGS_SCRIPT"
+updated_flags=$(<"$FLAG_FILE")
+
+if [[ "$existing_flags" != "$updated_flags" ]]; then
+    echo "VPA flags are not up to date. Please run ${GENERATE_FLAGS_SCRIPT}"
+    exit 1
+fi


### PR DESCRIPTION
#### What type of PR is this?
/area vertical-pod-autoscaler
/kind cleanup

#### What this PR does / why we need it: 
Adds a CI check to enforce that VPA flag documentation remains up-to-date by failing if modifications are detected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7844 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
