### PR TITLE
Ignore VPA rbac file generated from local e2e installation

### DIFF
--- a/vertical-pod-autoscaler/.gitignore
+++ b/vertical-pod-autoscaler/.gitignore
@@ -1,3 +1,5 @@
 # vendor directories
 vendor/
 e2e/vendor/
+# created from deploy-for-e2e-locally.sh
+hack/e2e/vpa-rbac.yaml


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Adds a file to `.gitignore` which is a yaml file that's generated by  the script `deploy-for-e2e-locally.sh`. This is generated when trying to run the e2e kind tests locally and is annoying since it shows up in git: https://github.com/maxcao13/autoscaler/blob/ignore-file/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh#L71

Another way to fix this is to either redirect the patch to a tmp file or remove the file after the script ends, but I'm not sure if people may be using that file in any way afterwards.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```