### PR TITLE
Make AddTaints and CleanTaints thread safe

### DIFF
--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -391,7 +391,7 @@ func (a *Actuator) scaleDownNodeToReport(node *apiv1.Node, drain bool) (*status.
 
 // taintNode taints the node with NoSchedule to prevent new pods scheduling on it.
 func (a *Actuator) taintNode(node *apiv1.Node) error {
-	if err := taints.MarkToBeDeleted(node, a.ctx.ClientSet, a.ctx.CordonNodeBeforeTerminate); err != nil {
+	if _, err := taints.MarkToBeDeleted(node, a.ctx.ClientSet, a.ctx.CordonNodeBeforeTerminate); err != nil {
 		a.ctx.Recorder.Eventf(node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to mark the node as toBeDeleted/unschedulable: %v", err)
 		return errors.ToAutoscalerError(errors.ApiCallError, err)
 	}

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -1302,9 +1302,7 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 	// Verify ScaleDownNodes looks as expected.
 	ignoreSdNodeOrder := cmpopts.SortSlices(func(a, b *status.ScaleDownNode) bool { return a.Node.Name < b.Node.Name })
 	cmpNg := cmp.Comparer(func(a, b *testprovider.TestNodeGroup) bool { return a.Id() == b.Id() })
-	// Nodes will have deletion taints, skipping them here since we check them later
-	ignoreTaints := cmpopts.IgnoreFields(apiv1.NodeSpec{}, "Taints")
-	statusCmpOpts := cmp.Options{ignoreSdNodeOrder, cmpNg, cmpopts.EquateEmpty(), ignoreTaints}
+	statusCmpOpts := cmp.Options{ignoreSdNodeOrder, cmpNg, cmpopts.EquateEmpty()}
 	if diff := cmp.Diff(wantScaleDownNodes, gotScaleDownNodes, statusCmpOpts); diff != "" {
 		t.Errorf("StartDeletion scaled down nodes diff (-want +got):\n%s", diff)
 	}

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
@@ -206,7 +206,7 @@ func CleanUpAndRecordFailedScaleDownEvent(ctx *context.AutoscalingContext, node 
 		klog.Errorf("Scale-down: "+logMsgFormat+", %v, status error: %v", node.Name, errMsg, status.Err)
 	}
 	ctx.Recorder.Eventf(node, apiv1.EventTypeWarning, "ScaleDownFailed", eventMsgFormat+": %v", status.Err)
-	taints.CleanToBeDeleted(node.DeepCopy(), ctx.ClientSet, ctx.CordonNodeBeforeTerminate)
+	taints.CleanToBeDeleted(node, ctx.ClientSet, ctx.CordonNodeBeforeTerminate)
 	nodeDeletionTracker.EndDeletion(nodeGroupId, node.Name, status)
 }
 

--- a/cluster-autoscaler/core/scaledown/actuation/softtaint.go
+++ b/cluster-autoscaler/core/scaledown/actuation/softtaint.go
@@ -60,7 +60,7 @@ func UpdateSoftDeletionTaints(context *context.AutoscalingContext, uneededNodes,
 			continue
 		}
 		b.processWithinBudget(func() {
-			err := taints.MarkDeletionCandidate(node, context.ClientSet)
+			_, err := taints.MarkDeletionCandidate(node, context.ClientSet)
 			if err != nil {
 				errors = append(errors, err)
 				klog.Warningf("Soft taint on %s adding error %v", node.Name, err)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/kind failing-test

#### What this PR does / why we need it:
Changes done in https://github.com/kubernetes/autoscaler/pull/7820 turned out to be thread unsafe, which was detected by the race detector, since `AddTaints` and `CleanTaints` are used in some goroutines. After multiple attempts to fix that (https://github.com/kubernetes/autoscaler/pull/7868, https://github.com/kubernetes/autoscaler/pull/7864) new failed tests were still emerging. Instead it was decided to make those functions not mutating the original node, but return an updated copy instead, so they can be safely executed by multiple goroutines.



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

