### PR TITLE
fix: added node annotation as backup method for cooldown timers

### DIFF
--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -456,3 +456,18 @@ func (p *Planner) MarkNodesAsToBeRemoved(nodes []simulator.NodeToBeRemoved, t ti
 	}
 	return nil
 }
+
+func (p *Planner) MarkNodesAsUnremovable(nodes []simulator.UnremovableNode, t time.Time) error {
+	for _, node := range nodes {
+		existingNode := node.Node
+		annotations := existingNode.GetAnnotations()
+		annotations[utils.AnnotationUnneededKey] = "false"
+		delete(annotations, utils.AnnotationUnneededSinceKey)
+		existingNode.SetAnnotations(annotations)
+		_, err := p.context.ClientSet.CoreV1().Nodes().Update(ctx.TODO(), existingNode, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to mark node %s as unremovable: %v", existingNode.Name, err)
+		}
+	}
+	return nil
+}

--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -28,6 +28,11 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 )
 
+const (
+	AnnotationUnneededKey      = "cluster-autoscaler.kubernetes.io/unneeded"
+	AnnotationUnneededSinceKey = "cluster-autoscaler.kubernetes.io/unneeded-since"
+)
+
 // isVirtualNode determines if the node is created by virtual kubelet
 func isVirtualNode(node *apiv1.Node) bool {
 	return node.ObjectMeta.Labels["type"] == "virtual-kubelet"

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -52,6 +52,7 @@ require (
 	k8s.io/cloud-provider-gcp/providers v0.28.2
 	k8s.io/component-base v0.33.0-alpha.0
 	k8s.io/component-helpers v0.33.0-alpha.0
+	k8s.io/dynamic-resource-allocation v0.0.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubelet v0.33.0-alpha.0
 	k8s.io/kubernetes v1.33.0-alpha.0
@@ -206,7 +207,6 @@ require (
 	k8s.io/cri-api v0.33.0-alpha.0 // indirect
 	k8s.io/cri-client v0.0.0 // indirect
 	k8s.io/csi-translation-lib v0.27.0 // indirect
-	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 	k8s.io/kms v0.33.0-alpha.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

added annotations making node as removable, and timestamp marking since when its removable, in order to improve HA performance.

(Until now if a pod died, the cooldown for downscaling will restart)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes/autoscaler/issues/7873

#### Special notes for your reviewer:

this issue has already affected me, and I'm highly motivated to fix this ASAP. so I should be available during the next few days, in order to resolve this quickly. if you have a better way of fixing this HA issue, please suggest one 😄 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed: Cluster Autoscaler now persists scale-down cooldowns across pods. cooldown timestamps were stored in memory, causing inconsistencies when the original cluster autoscaler pod becomes unavailable. Now, cooldown state is stored as node annotations:

"cluster-autoscaler.kubernetes.io/unneeded" ("true"/"false")
"cluster-autoscaler.kubernetes.io/unneeded-since" (RFC3339 timestamp)

This ensures consistent scale-down behavior even if the original pod becomes unavailable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
