### PR TITLE
fix(autoscaler): Fix internal cache issue when downscale is stressed

### DIFF
--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -41,7 +41,7 @@ const providerIDPrefix = "openstack:///"
 
 // NodeGroup implements cloudprovider.NodeGroup interface.
 type NodeGroup struct {
-	sdk.NodePool
+	*sdk.NodePool
 
 	Manager     *OvhCloudManager
 	CurrentSize int
@@ -294,7 +294,7 @@ func (ng *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
 
 	// Forge a node group interface given the API response
 	return &NodeGroup{
-		NodePool:    *np,
+		NodePool:    np,
 		Manager:     ng.Manager,
 		CurrentSize: int(ng.DesiredNodes),
 	}, nil

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
@@ -85,7 +85,7 @@ func newTestNodeGroup(t *testing.T, flavor string) *NodeGroup {
 
 	ng := &NodeGroup{
 		Manager: manager,
-		NodePool: sdk.NodePool{
+		NodePool: &sdk.NodePool{
 			ID:           "id",
 			Name:         fmt.Sprintf("pool-%s", flavor),
 			Flavor:       flavor,

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
@@ -100,7 +100,7 @@ func (provider *OVHCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	groups := make([]cloudprovider.NodeGroup, 0)
 
 	// Cast API node pools into CA node groups
-	for _, pool := range provider.manager.NodePools {
+	for _, pool := range provider.manager.NodePoolsPerID {
 		// Node pools without autoscaling are equivalent to node pools with autoscaling but no scale possible
 		if !pool.Autoscale {
 			pool.MaxNodes = pool.DesiredNodes
@@ -238,7 +238,7 @@ func (provider *OVHCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // Implementation optional.
 func (provider *OVHCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	ng := &NodeGroup{
-		NodePool: sdk.NodePool{
+		NodePool: &sdk.NodePool{
 			Name:     fmt.Sprintf("%s-%d", machineType, rand.Int63()),
 			Flavor:   machineType,
 			MinNodes: 0,
@@ -314,7 +314,7 @@ func (provider *OVHCloudProvider) Refresh() error {
 	}
 
 	// Update the node pools cache
-	provider.manager.NodePools = pools
+	provider.manager.setNodePoolsState(pools)
 
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider_test.go
@@ -141,7 +141,7 @@ func TestOVHCloudProvider_NodeGroups(t *testing.T) {
 	})
 
 	t.Run("check empty node groups length after reset", func(t *testing.T) {
-		provider.manager.NodePools = []sdk.NodePool{}
+		provider.manager.NodePoolsPerID = map[string]*sdk.NodePool{}
 		groups := provider.NodeGroups()
 
 		assert.Equal(t, 0, len(groups))
@@ -403,7 +403,7 @@ func TestOVHCloudProvider_Refresh(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("check refresh reset node groups correctly", func(t *testing.T) {
-		provider.manager.NodePools = []sdk.NodePool{}
+		provider.manager.NodePoolsPerID = map[string]*sdk.NodePool{}
 		groups := provider.NodeGroups()
 
 		assert.Equal(t, 0, len(groups))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

Rebase of the bugfix proposed in
PR 7157

What this PR does / why we need it:

This PR refactor ovh sdk.NodePool state cache to avoid store out-of-date copy of TargetSize, etc... that was leading to inconsistencies in few downscale cases
This PR uses pointer to keep reference instead of copy and creates/updates/deletes referenced objects when refreshing
Special notes for your reviewer:
Does this PR introduce a user-facing change?

NONE
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
