### PR TITLE
Fixes histograms becoming empty after loaded from checkpoints

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
@@ -277,6 +277,14 @@ func (h *histogram) LoadFromCheckpoint(checkpoint *vpa_types.HistogramCheckpoint
 		h.bucketWeight[bucket] += float64(weight) * ratio
 	}
 	h.totalWeight += checkpoint.TotalWeight
+
+	// In some cases where the weight of the max bucket is close (equal or less) to `MaxCheckpointWeight` times epsilon
+	// and there are buckets with weights slightly higher or equal to epsilon, saving the histogram to a checkpoint and
+	// then loading it will cause the weights that are close to epsilon to become smaller than epsilon due to rounding errors
+	// and differences between the load and save algorithm. If one of those weights is the min weight, this will cause the
+	// histogram to incorrectly become "empty" and the `Percentile(...)` function to always return 0.
+	// To cover for such cases, the min and max buckets are updated here, so that those less than epsilon are dropped.
+	// For more information check https://github.com/kubernetes/autoscaler/issues/7726
 	h.updateMinAndMaxBucket()
 
 	return nil

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
@@ -277,6 +277,7 @@ func (h *histogram) LoadFromCheckpoint(checkpoint *vpa_types.HistogramCheckpoint
 		h.bucketWeight[bucket] += float64(weight) * ratio
 	}
 	h.totalWeight += checkpoint.TotalWeight
+	h.updateMinAndMaxBucket()
 
 	return nil
 }

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
@@ -265,6 +265,21 @@ func TestHistogramLoadFromCheckpointReturnsErrorOnNilInput(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestHistogramIsNotEmptyAfterSavingAndLoadingCheckpointsWithBoundaryValues(t *testing.T) {
+	histogram := NewHistogram(testHistogramOptions)
+	histogram.AddSample(1, weightEpsilon, anyTime)
+	histogram.AddSample(2, (float64(MaxCheckpointWeight)*weightEpsilon - weightEpsilon), anyTime)
+	assert.False(t, histogram.IsEmpty())
+
+	checkpoint, err := histogram.SaveToChekpoint()
+	assert.NoError(t, err)
+
+	newHistogram := NewHistogram(testHistogramOptions)
+	err = newHistogram.LoadFromCheckpoint(checkpoint)
+	assert.NoError(t, err)
+	assert.False(t, newHistogram.IsEmpty())
+}
+
 func areUnique(values ...interface{}) bool {
 	dict := make(map[interface{}]bool)
 	for i, v := range values {

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
@@ -266,6 +266,33 @@ func TestHistogramLoadFromCheckpointReturnsErrorOnNilInput(t *testing.T) {
 }
 
 func TestHistogramIsNotEmptyAfterSavingAndLoadingCheckpointsWithBoundaryValues(t *testing.T) {
+	// There is a specific scenario in which the weights of the minimum and maximum histogram buckets,
+	// when saved to a VPACheckpoint and subsequently loaded, result in diminished weights for the minimum buckets.
+
+	// This issue arises due to rounding errors when converting float weights to integers in the VPACheckpoint.
+	// For instance, consider the weights:
+	// `w1` which approximates but is slightly larger than or equal to `epsilon`,
+	// `w2` which approximates but is slightly smaller than or equal to (`MaxCheckpointWeight` * `epsilon`) - `epsilon`.
+
+	// When these weights are stored in a VPACheckpoint, they are translated to integers:
+	// `w1` rounds to `1` (`wi1`),
+	// `w2` rounds to `MaxCheckpointWeight` (`wi2`).
+
+	// Upon loading from the VPACheckpoint, the histogram reconstructs its weights using a calculated ratio,
+	// aimed at reverting integer weights back to float values. This ratio is derived from:
+	// (`w1` + `w2`) / (`wi1` + `wi2`)
+	// Reference: https://github.com/plkokanov/autoscaler/blob/2aba67154cd4f117da4702b60a10c38c0651e659/vertical-pod-autoscaler/pkg/recommender/util/histogram.go#L256-L269
+
+	// Given the maximum potential values for `w1`, `w2`, `wi1` and `wi2` we arrive at:
+	// (`epsilon` + `MaxCheckpointWeight` * `epsilon` - `epsilon`) / (1 + MaxCheckpointWeight) = epsilon * `MaxCheckpointWeight` / (1 + MaxCheckpointWeight)
+
+	// Consequently, the maximum value for this ratio is less than `epsilon`, implying that when `w1`,
+	// initially scaled to `1`, is adjusted by this ratio, its recalculated weight falls short of `epsilon`.
+	// The same behavior can be observed when there are more than two weights.
+
+	// This test ensures that in such cases the histogram does not become empty.
+	// For more information check https://github.com/kubernetes/autoscaler/issues/7726
+
 	histogram := NewHistogram(testHistogramOptions)
 	histogram.AddSample(1, weightEpsilon, anyTime)
 	histogram.AddSample(2, (float64(MaxCheckpointWeight)*weightEpsilon - weightEpsilon), anyTime)

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
@@ -281,13 +281,17 @@ func TestHistogramIsNotEmptyAfterSavingAndLoadingCheckpointsWithBoundaryValues(t
 	// Upon loading from the VPACheckpoint, the histogram reconstructs its weights using a calculated ratio,
 	// aimed at reverting integer weights back to float values. This ratio is derived from:
 	// (`w1` + `w2`) / (`wi1` + `wi2`)
-	// Reference: https://github.com/plkokanov/autoscaler/blob/2aba67154cd4f117da4702b60a10c38c0651e659/vertical-pod-autoscaler/pkg/recommender/util/histogram.go#L256-L269
+	// Reference:  https://github.com/kubernetes/autoscaler/blob/aa1d413ea3bf319b56c7b2e65ade1a028e149439/vertical-pod-autoscaler//pkg/recommender/util/histogram.go#L256-L269
 
 	// Given the maximum potential values for `w1`, `w2`, `wi1` and `wi2` we arrive at:
 	// (`epsilon` + `MaxCheckpointWeight` * `epsilon` - `epsilon`) / (1 + MaxCheckpointWeight) = epsilon * `MaxCheckpointWeight` / (1 + MaxCheckpointWeight)
 
 	// Consequently, the maximum value for this ratio is less than `epsilon`, implying that when `w1`,
 	// initially scaled to `1`, is adjusted by this ratio, its recalculated weight falls short of `epsilon`.
+	// When the `minBucket`'s weight is less than `epsilon`, the `histogram.IsEmpty()` returns true.
+	// Reference: https://github.com/kubernetes/autoscaler/blob/aa1d413ea3bf319b56c7b2e65ade1a028e149439/vertical-pod-autoscaler/pkg/recommender/util/histogram.go#L181-L183
+	// Consequently, the `histogram.Percentile(...)` function will always return 0.
+	// Reference: https://github.com/kubernetes/autoscaler/blob/aa1d413ea3bf319b56c7b2e65ade1a028e149439/vertical-pod-autoscaler/pkg/recommender/util/histogram.go#L159-L162
 	// The same behavior can be observed when there are more than two weights.
 
 	// This test ensures that in such cases the histogram does not become empty.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
This PR makes it so that the min and max buckets of the histogram are updated after the histogram is loaded from a checkpoint. This is necessary in cases where the weights in the histogram are very close to (equal or a bit above) [`epsilon`](https://github.com/kubernetes/autoscaler/blob/02e3d1944990496497387e1274404242003d1ea3/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go#L65) before being saved to a checkpoint and become less than [`epsilon`](https://github.com/kubernetes/autoscaler/blob/02e3d1944990496497387e1274404242003d1ea3/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go#L65) after being loaded from the checkpoint due to rounding errors.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7726 

#### Special notes for your reviewer:
I tried adding a full e2e test, but couldn't get it to work. This issue only occurs with memory recommendations and the hamster pod used in e2e test only produces CPU usage. Additionally, I tried manually crafting and deploying a checkpoint which we know reproduces the problem in #7726, however the results were very flaky. I am open to any suggestions.

In the end I only added a simple unit test which demonstrates the problem with the histogram save/load algorithm with boundary conditions close to what we observed when we reproduced this issue on our landscapes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a problem that could cause the `vpa-recommender` to issue a memory recommendation with value 0 after it restarts. The weights in histograms are now updated after being loaded from `VerticalPodAutoscalerCheckpoints` so that any weights that have become less than `epsilon` due to rounding errors are removed. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
