### PR TITLE
Block cluster autoscaler until API resource caches are synced.

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -638,6 +638,14 @@ func buildAutoscaler(context ctx.Context, debuggingSnapshotter debuggingsnapshot
 	stop := make(chan struct{})
 	informerFactory.Start(stop)
 
+	klog.Info("Initializing resource informers, blocking until caches are synced")
+	informersSynced := informerFactory.WaitForCacheSync(stop)
+	for _, synced := range informersSynced {
+		if !synced {
+			return nil, nil, fmt.Errorf("unable to start and sync resource informers")
+		}
+	}
+
 	podObserver := loop.StartPodObserver(context, kube_util.CreateKubeClient(autoscalingOptions.KubeClientOpts))
 
 	// A ProvisioningRequestPodsInjector is used as provisioningRequestProcessingTimesGetter here to obtain the last time a


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This change would prevent cluster autoscaler from starting without having at least stale caches in informer object storages. This helps to avoid situations like following:

1. Kube API server is overloaded or unresponsive
2. New cluster autoscaler replicas were restarted (for whatever reason) and are just coming up
3. While initializing static autoscaler it's not waiting for caches to get populated which gives us no guarantees that resources were EVER fetched
4. When listing pods as part of the loop cluster autoscaler requests list of pods from informer and it outputs an empty array of pods while cluster contains an unknown amount
5. Autoscaler categorizes this as all the nodes being unused which results in scale-down with the biggest steps it can afford based on MaxScaleDownParallelism

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
