### PR TITLE
Adds volumeattachments resource permissions to the Cluster Autoscaler…

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.46.2
+version: 9.46.3

--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -111,6 +111,7 @@ rules:
     - csinodes
     - csidrivers
     - csistoragecapacities
+    - volumeattachments
     verbs:
     - watch
     - list


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Adds `volumeattachments` resource permissions to the Cluster Autoscaler Helm chart to resolve authorization issues.

#### Which issue(s) this PR fixes:
Fixes #7663

related to #7674