### PR TITLE
Fix incorrect usage of klog .*f functions

### DIFF
--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -111,13 +111,13 @@ func (e *BinpackingNodeEstimator) Estimate(
 
 		remainingPods, err = e.tryToScheduleOnExistingNodes(estimationState, podsEquivalenceGroup.Pods)
 		if err != nil {
-			klog.Errorf(err.Error())
+			klog.Error(err.Error())
 			return 0, nil
 		}
 
 		err = e.tryToScheduleOnNewNodes(estimationState, nodeTemplate, remainingPods)
 		if err != nil {
-			klog.Errorf(err.Error())
+			klog.Error(err.Error())
 			return 0, nil
 		}
 	}

--- a/cluster-autoscaler/loop/trigger.go
+++ b/cluster-autoscaler/loop/trigger.go
@@ -139,7 +139,7 @@ func (t *LoopTrigger) logTriggerReason(message string) {
 	case <-t.podObserver.unschedulablePodChan:
 		klog.Info("Autoscaler loop triggered by unschedulable pod appearing")
 	default:
-		klog.Infof(message)
+		klog.Info(message)
 	}
 }
 


### PR DESCRIPTION
The .*f variants should only ever be called with arguments to format.

#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Cleanup the code to properly use logging functions without formatting.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
