### PR TITLE
VPA: Add UpdateModeInPlaceOrRecreate to types

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -458,6 +458,7 @@ spec:
                     - "Off"
                     - Initial
                     - Recreate
+                    - InPlaceOrRecreate
                     - Auto
                     type: string
                 type: object

--- a/vertical-pod-autoscaler/docs/api.md
+++ b/vertical-pod-autoscaler/docs/api.md
@@ -155,7 +155,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `updateMode` _[UpdateMode](#updatemode)_ | Controls when autoscaler applies changes to the pod resources.<br />The default is 'Auto'. |  | Enum: [Off Initial Recreate Auto] <br /> |
+| `updateMode` _[UpdateMode](#updatemode)_ | Controls when autoscaler applies changes to the pod resources.<br />The default is 'Auto'. |  | Enum: [Off Initial Recreate InPlaceOrRecreate Auto] <br /> |
 | `minReplicas` _integer_ | Minimal number of replicas which need to be alive for Updater to attempt<br />pod eviction (pending other checks like PDB). Only positive values are<br />allowed. Overrides global '--min-replicas' flag. |  |  |
 | `evictionRequirements` _[EvictionRequirement](#evictionrequirement) array_ | EvictionRequirements is a list of EvictionRequirements that need to<br />evaluate to true in order for a Pod to be evicted. If more than one<br />EvictionRequirement is specified, all of them need to be fulfilled to allow eviction. |  |  |
 
@@ -208,7 +208,7 @@ _Underlying type:_ _string_
 UpdateMode controls when autoscaler applies changes to the pod resources.
 
 _Validation:_
-- Enum: [Off Initial Recreate Auto]
+- Enum: [Off Initial Recreate InPlaceOrRecreate Auto]
 
 _Appears in:_
 - [PodUpdatePolicy](#podupdatepolicy)
@@ -218,7 +218,8 @@ _Appears in:_
 | `Off` | UpdateModeOff means that autoscaler never changes Pod resources.<br />The recommender still sets the recommended resources in the<br />VerticalPodAutoscaler object. This can be used for a "dry run".<br /> |
 | `Initial` | UpdateModeInitial means that autoscaler only assigns resources on pod<br />creation and does not change them during the lifetime of the pod.<br /> |
 | `Recreate` | UpdateModeRecreate means that autoscaler assigns resources on pod<br />creation and additionally can update them during the lifetime of the<br />pod by deleting and recreating the pod.<br /> |
-| `Auto` | UpdateModeAuto means that autoscaler assigns resources on pod creation<br />and additionally can update them during the lifetime of the pod,<br />using any available update method. Currently this is equivalent to<br />Recreate, which is the only available update method.<br /> |
+| `Auto` | UpdateModeAuto means that autoscaler assigns resources on pod creation<br />and additionally can update them during the lifetime of the pod,<br />using any available update method. Currently this is equivalent to<br />Recreate.<br /> |
+| `InPlaceOrRecreate` | UpdateModeInPlaceOrRecreate means that autoscaler tries to assign resources in-place.<br />If this is not possible (e.g., resizing takes too long or is infeasible), it falls back to the<br />"Recreate" update mode.<br />Requires VPA level feature gate "InPlaceOrRecreate" to be enabled<br />on the admission and updater pods.<br />Requires cluster feature gate "InPlacePodVerticalScaling" to be enabled.<br /> |
 
 
 #### VerticalPodAutoscaler

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -151,7 +151,7 @@ type PodUpdatePolicy struct {
 }
 
 // UpdateMode controls when autoscaler applies changes to the pod resources.
-// +kubebuilder:validation:Enum=Off;Initial;Recreate;Auto
+// +kubebuilder:validation:Enum=Off;Initial;Recreate;InPlaceOrRecreate;Auto
 type UpdateMode string
 
 const (
@@ -169,8 +169,15 @@ const (
 	// UpdateModeAuto means that autoscaler assigns resources on pod creation
 	// and additionally can update them during the lifetime of the pod,
 	// using any available update method. Currently this is equivalent to
-	// Recreate, which is the only available update method.
+	// Recreate.
 	UpdateModeAuto UpdateMode = "Auto"
+	// UpdateModeInPlaceOrRecreate means that autoscaler tries to assign resources in-place.
+	// If this is not possible (e.g., resizing takes too long or is infeasible), it falls back to the
+	// "Recreate" update mode.
+	// Requires VPA level feature gate "InPlaceOrRecreate" to be enabled
+	// on the admission and updater pods.
+	// Requires cluster feature gate "InPlacePodVerticalScaling" to be enabled.
+	UpdateModeInPlaceOrRecreate UpdateMode = "InPlaceOrRecreate"
 )
 
 // PodResourcePolicy controls how autoscaler computes the recommended resources


### PR DESCRIPTION
This just addes the UpdateModeInPlaceOrRecreate mode to the types so we can use it.

#### What type of PR is this?
/kind api-change

#### What this PR does / why we need it:
We need the new API to allow users to specify the new `InPlaceOrRecreate` mode as part of [AEP-4016](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/4016-in-place-updates-support).

#### Which issue(s) this PR fixes:
This PR is part of the larger feature PR in https://github.com/kubernetes/autoscaler/pull/7673

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
[AEP-4016](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/4016-in-place-updates-support)
```
