### PR TITLE
Add adrianmoisey to VPA approvers

### DIFF
--- a/vertical-pod-autoscaler/OWNERS
+++ b/vertical-pod-autoscaler/OWNERS
@@ -3,6 +3,7 @@ approvers:
 - jbartosik
 - voelzmo
 - raywainman
+- adrianmoisey
 reviewers:
 - kwiesmueller
 - jbartosik


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I would like to propose joining the list of folks who can approve PRs in the vertical-pod-autoscaler subdirectory. I meet [all requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#approver):

Added as reviewer on December 8th, 2024 (https://github.com/kubernetes/autoscaler/pull/7585).
[36 PRs authored](https://github.com/kubernetes/autoscaler/pulls?q=is%3Apr+author%3Aadrianmoisey+label%3Aarea%2Fvertical-pod-autoscaler)
[70 PRs reviewed](https://github.com/kubernetes/autoscaler/pulls?q=is%3Apr+assignee%3Aadrianmoisey+label%3Aarea%2Fvertical-pod-autoscaler)
Familiar with codebase as I interact with it on a daily basis.
Also active on Slack answering questions and in SIG meetings.

/assign @gjtempleton @raywainman 