### PR TITLE
allow `tpl` on common metadata to DRY

### DIFF
--- a/charts/cluster-autoscaler/Chart.yaml
+++ b/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.46.5
+version: 9.46.6

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -183,7 +183,7 @@ $ helm install my-release autoscaler/cluster-autoscaler \
 
 Note that `your-ig-prefix` should be a _prefix_ matching one or more MIGs, and _not_ the full name of the MIG. For example, to match multiple instance groups - `k8s-node-group-a-standard`, `k8s-node-group-b-gpu`, you would use a prefix of `k8s-node-group-`.
 
-Prefixes will be rendered using `tpl` function so you can use any value of your choice if that's a valid prefix. For instance (ignore escaping characters): `gke-\{\{ .Values.autoDiscovery.clusterName }}`
+Prefixes will be rendered using `tpl` function so you can use any value of your choice if that's a valid prefix. For instance (ignore escaping characters): `gke-{{ .Values.autoDiscovery.clusterName }}`
 
 In the event you want to explicitly specify MIGs instead of using auto-discovery, set members of the `autoscalingGroups` array directly - e.g.
 
@@ -334,7 +334,7 @@ Once you have the IAM role configured, you would then need to `--set rbac.servic
 rbac:
   serviceAccount:
     annotations:
-      eks.amazonaws.com/role-arn: "\{\{ .Values.aws.myroleARN }}"
+      eks.amazonaws.com/role-arn: "{{ .Values.aws.myroleARN }}"
 ```
 
 ### Azure - Using azure workload identity

--- a/charts/cluster-autoscaler/README.md
+++ b/charts/cluster-autoscaler/README.md
@@ -183,6 +183,8 @@ $ helm install my-release autoscaler/cluster-autoscaler \
 
 Note that `your-ig-prefix` should be a _prefix_ matching one or more MIGs, and _not_ the full name of the MIG. For example, to match multiple instance groups - `k8s-node-group-a-standard`, `k8s-node-group-b-gpu`, you would use a prefix of `k8s-node-group-`.
 
+Prefixes will be rendered using `tpl` function so you can use any value of your choice if that's a valid prefix. For instance (ignore escaping characters): `gke-\{\{ .Values.autoDiscovery.clusterName }}`
+
 In the event you want to explicitly specify MIGs instead of using auto-discovery, set members of the `autoscalingGroups` array directly - e.g.
 
 ```
@@ -326,7 +328,14 @@ For Kubernetes clusters that use Amazon EKS, the service account can be configur
 
 In order to accomplish this, you will first need to create a new IAM role with the above mentions policies.  Take care in [configuring the trust relationship](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#iam-role-configuration) to restrict access just to the service account used by cluster autoscaler.
 
-Once you have the IAM role configured, you would then need to `--set rbac.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/MyRoleName` when installing.
+Once you have the IAM role configured, you would then need to `--set rbac.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/MyRoleName` when installing. Alternatively, you can embed templates in values (ignore escaping characters):
+
+```yaml
+rbac:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: "\{\{ .Values.aws.myroleARN }}"
+```
 
 ### Azure - Using azure workload identity
 

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -183,7 +183,7 @@ $ helm install my-release autoscaler/cluster-autoscaler \
 
 Note that `your-ig-prefix` should be a _prefix_ matching one or more MIGs, and _not_ the full name of the MIG. For example, to match multiple instance groups - `k8s-node-group-a-standard`, `k8s-node-group-b-gpu`, you would use a prefix of `k8s-node-group-`.
 
-Prefixes will be rendered using `tpl` function so you can use any value of your choice if that's a valid prefix. For instance (ignore escaping characters): `gke-\{\{ .Values.autoDiscovery.clusterName }}`
+Prefixes will be rendered using `tpl` function so you can use any value of your choice if that's a valid prefix. For instance (ignore escaping characters): `gke-{{`{{ .Values.autoDiscovery.clusterName }}`}}`
 
 In the event you want to explicitly specify MIGs instead of using auto-discovery, set members of the `autoscalingGroups` array directly - e.g.
 
@@ -335,7 +335,7 @@ Once you have the IAM role configured, you would then need to `--set rbac.servic
 rbac:
   serviceAccount:
     annotations:
-      eks.amazonaws.com/role-arn: "\{\{ .Values.aws.myroleARN }}"
+      eks.amazonaws.com/role-arn: "{{`{{ .Values.aws.myroleARN `}}}}"
 ```
 
 ### Azure - Using azure workload identity

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -183,7 +183,7 @@ $ helm install my-release autoscaler/cluster-autoscaler \
 
 Note that `your-ig-prefix` should be a _prefix_ matching one or more MIGs, and _not_ the full name of the MIG. For example, to match multiple instance groups - `k8s-node-group-a-standard`, `k8s-node-group-b-gpu`, you would use a prefix of `k8s-node-group-`.
 
-Prefixes will be rendered using `tpl` function so you can use any value of your choice if that's a valid prefix. For instance: `gke-{{ .Values.autoDiscovery.clusterName }}`
+Prefixes will be rendered using `tpl` function so you can use any value of your choice if that's a valid prefix. For instance (ignore escaping characters): `gke-\{\{ .Values.autoDiscovery.clusterName }}`
 
 In the event you want to explicitly specify MIGs instead of using auto-discovery, set members of the `autoscalingGroups` array directly - e.g.
 
@@ -329,13 +329,13 @@ For Kubernetes clusters that use Amazon EKS, the service account can be configur
 
 In order to accomplish this, you will first need to create a new IAM role with the above mentions policies.  Take care in [configuring the trust relationship](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#iam-role-configuration) to restrict access just to the service account used by cluster autoscaler.
 
-Once you have the IAM role configured, you would then need to `--set rbac.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/MyRoleName` when installing. Alternatively, you can embed templates in values:
+Once you have the IAM role configured, you would then need to `--set rbac.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/MyRoleName` when installing. Alternatively, you can embed templates in values (ignore escaping characters):
 
 ```yaml
 rbac:
   serviceAccount:
     annotations:
-      eks.amazonaws.com/role-arn="{{ .Values.aws.myroleARN }}"
+      eks.amazonaws.com/role-arn: "\{\{ .Values.aws.myroleARN }}"
 ```
 
 ### Azure - Using azure workload identity

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -183,7 +183,10 @@ $ helm install my-release autoscaler/cluster-autoscaler \
 
 Note that `your-ig-prefix` should be a _prefix_ matching one or more MIGs, and _not_ the full name of the MIG. For example, to match multiple instance groups - `k8s-node-group-a-standard`, `k8s-node-group-b-gpu`, you would use a prefix of `k8s-node-group-`.
 
+Prefixes will be rendered using `tpl` function so you can use any value of your choice if that's a valid prefix. For instance: `gke-{{ .Values.autoDiscovery.clusterName }}`
+
 In the event you want to explicitly specify MIGs instead of using auto-discovery, set members of the `autoscalingGroups` array directly - e.g.
+
 
 ```
 # where 'n' is the index, starting at 0
@@ -326,7 +329,14 @@ For Kubernetes clusters that use Amazon EKS, the service account can be configur
 
 In order to accomplish this, you will first need to create a new IAM role with the above mentions policies.  Take care in [configuring the trust relationship](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#iam-role-configuration) to restrict access just to the service account used by cluster autoscaler.
 
-Once you have the IAM role configured, you would then need to `--set rbac.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/MyRoleName` when installing.
+Once you have the IAM role configured, you would then need to `--set rbac.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/MyRoleName` when installing. Alternatively, you can embed templates in values:
+
+```yaml
+rbac:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn="{{ .Values.aws.myroleARN }}"
+```
 
 ### Azure - Using azure workload identity
 

--- a/charts/cluster-autoscaler/README.md.gotmpl
+++ b/charts/cluster-autoscaler/README.md.gotmpl
@@ -187,7 +187,6 @@ Prefixes will be rendered using `tpl` function so you can use any value of your 
 
 In the event you want to explicitly specify MIGs instead of using auto-discovery, set members of the `autoscalingGroups` array directly - e.g.
 
-
 ```
 # where 'n' is the index, starting at 0
 --set autoscalingGroups[n].name=https://content.googleapis.com/compute/v1/projects/$PROJECTID/zones/$ZONENAME/instanceGroups/$FULL-MIG-NAME,autoscalingGroups[n].maxSize=$MAXSIZE,autoscalingGroups[n].minSize=$MINSIZE

--- a/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-autoscaler/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
           {{- else if eq .Values.cloudProvider "gce" }}
           {{- if .Values.autoscalingGroupsnamePrefix }}
             {{- range .Values.autoscalingGroupsnamePrefix }}
-            - --node-group-auto-discovery=mig:namePrefix={{ .name }},min={{ .minSize }},max={{ .maxSize }}
+            - --node-group-auto-discovery=mig:namePrefix={{ tpl .name $ }},min={{ .minSize }},max={{ .maxSize }}
             {{- end }}
           {{- end }}
           {{- if eq .Values.cloudProvider "oci" }}
@@ -144,9 +144,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-          {{- if and (eq .Values.cloudProvider "aws") (ne .Values.awsRegion "") }}
+          {{- if and (eq .Values.cloudProvider "aws") (ne (tpl .Values.awsRegion $) "") }}
             - name: AWS_REGION
-              value: "{{ .Values.awsRegion }}"
+              value: "{{ tpl .Values.awsRegion $ }}"
             {{- if .Values.awsAccessKeyID }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/charts/cluster-autoscaler/templates/serviceaccount.yaml
+++ b/charts/cluster-autoscaler/templates/serviceaccount.yaml
@@ -3,11 +3,16 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    foo: bar
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-{{- if .Values.rbac.serviceAccount.annotations }}
-  annotations: {{ toYaml .Values.rbac.serviceAccount.annotations | nindent 4 }}
+
+{{- with .Values.rbac.serviceAccount.annotations }}
+  annotations:
+  {{- range $k, $v := . }}
+    {{- printf "%s: %s" (tpl $k $) (tpl $v $) | nindent 4 }}
+  {{- end }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.rbac.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/cluster-autoscaler/templates/serviceaccount.yaml
+++ b/charts/cluster-autoscaler/templates/serviceaccount.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    foo: bar
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
#### What this PR does / why we need it:

This PR allows DRY common configuration metadata that pops up in many places like `serviceAccount.annotations` or autoscaling group tags, prefixes, etc. Imagine centralized configuration keys like aws account ids, regions, gcp project ids, cluster names, etc, etc. Without this PR you have to set the same value override files over and over again which when multiple (> 10) clusters and multiple clouds are used becomes a maintaince pain having to repeat the same config allover the place.

I implemented the same feature for ExternalDNS: https://github.com/kubernetes-sigs/external-dns/pull/4958 and Cert-Manager: 

https://github.com/cert-manager/cert-manager/pull/7501

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Feature impairment: currently autodiscovery tags are rendered using `tpl` function and I believe the autoscaling prefixes could be a good use case as well. Also service account annotations to leverage Workload Identity or IRSA need pretty common metadata like project ID or AWS account ID.

By running tpl we're not introducing any breaking change as the chart will behave the same regardless if the user injects a template or just a string.
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
