### PR TITLE
Allow using scheduled pods as samples in proactive scale up

### DIFF
--- a/cluster-autoscaler/processors/podinjection/pod_group.go
+++ b/cluster-autoscaler/processors/podinjection/pod_group.go
@@ -57,7 +57,7 @@ func updatePodGroups(pod *apiv1.Pod, ownerRef metav1.OwnerReference, podGroups m
 	if !found {
 		return podGroups
 	}
-	if group.sample == nil && pod.Spec.NodeName == "" {
+	if group.sample == nil || pod.CreationTimestamp.After(group.sample.CreationTimestamp.Time) {
 		group.sample = pod
 		group.ownerUid = ownerRef.UID
 	}

--- a/cluster-autoscaler/processors/podinjection/pod_injection_processor.go
+++ b/cluster-autoscaler/processors/podinjection/pod_injection_processor.go
@@ -93,6 +93,7 @@ func makeFakePods(ownerUid types.UID, samplePod *apiv1.Pod, podCount int) []*api
 		newPod := withFakePodAnnotation(samplePod.DeepCopy())
 		newPod.Name = fmt.Sprintf("%s-copy-%d", samplePod.Name, i)
 		newPod.UID = types.UID(fmt.Sprintf("%s-%d", string(ownerUid), i))
+		newPod.Spec.NodeName = ""
 		fakePods = append(fakePods, newPod)
 	}
 	return fakePods

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/mock"
-
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -113,6 +112,13 @@ func WithResourceClaim(refName, claimName, templateName string) func(*apiv1.Pod)
 	}
 }
 
+// WithControllerOwnerRef sets an owner reference to the pod.
+func WithControllerOwnerRef(name, kind string, uid types.UID) func(*apiv1.Pod) {
+	return func(pod *apiv1.Pod) {
+		pod.OwnerReferences = GenerateOwnerReferences(name, kind, "apps/v1", uid)
+	}
+}
+
 // WithDSController creates a daemonSet owner ref for the pod.
 func WithDSController() func(*apiv1.Pod) {
 	return func(pod *apiv1.Pod) {
@@ -171,6 +177,13 @@ func WithMaxSkew(maxSkew int32, topologySpreadingKey string) func(*apiv1.Pod) {
 				},
 			}
 		}
+	}
+}
+
+// WithCreationTimestamp sets creation timestamp to the pod.
+func WithCreationTimestamp(timestamp time.Time) func(*apiv1.Pod) {
+	return func(pod *apiv1.Pod) {
+		pod.CreationTimestamp = metav1.Time{Time: timestamp}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Proactive scale up does not take scheduled pods as samples for fake pods, which limits proactive scale up to a short time window in which there are newly created, not yet scheduled pods. This PR allows taking scheduled pods as well, ensuring that the node name is removed from the generated fake pods, and also ensuring that the newest existing pod is taken as a sample. That maximizes the probability that fake pods will have configuration up to date.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
