### PR TITLE
Fix OOM detection for pods with restartPolicy: Never

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
@@ -123,15 +123,6 @@ func findStatus(name string, containerStatuses []corev1.ContainerStatus) *corev1
 	return nil
 }
 
-func findSpec(name string, containers []corev1.Container) *corev1.Container {
-	for _, containerSpec := range containers {
-		if containerSpec.Name == name {
-			return &containerSpec
-		}
-	}
-	return nil
-}
-
 // OnAdd is Noop
 func (o *observer) OnAdd(obj any, isInInitialList bool) {}
 
@@ -153,23 +144,25 @@ func (o *observer) OnUpdate(oldObj, newObj any) {
 			continue
 		}
 
+		oldNotTerminated := oldStatus.State.Terminated == nil
+		restartCountIncreased := containerStatus.RestartCount > oldStatus.RestartCount
+
 		// Check if container changes state from non-Terminated to Terminated
 		// with OOMKilled reason. Also if container fails too fast, it may
-		// skip Running state and change state direcly to Terminated
+		// skip Running state and change state directly to Terminated
 		// (from Terminated or Waiting) with increased RestartCount.
 		// We check for this case as well.
 		isNewOOM := containerStatus.State.Terminated != nil &&
 			containerStatus.State.Terminated.Reason == "OOMKilled" &&
-			(oldStatus.State.Terminated == nil ||
-				containerStatus.RestartCount > oldStatus.RestartCount)
+			(oldNotTerminated || restartCountIncreased)
 
 		// If controller restarts container, it may skip
 		// Terminated state and change directly from Running
 		// to Running with increased RestartCount. In this
 		// case we check LastTerminationState.
 		isPreviousOOM := containerStatus.State.Running != nil &&
-			oldStatus.State.Terminated == nil &&
-			containerStatus.RestartCount > oldStatus.RestartCount &&
+			oldNotTerminated &&
+			restartCountIncreased &&
 			containerStatus.LastTerminationState.Terminated != nil &&
 			containerStatus.LastTerminationState.Terminated.Reason == "OOMKilled"
 
@@ -177,21 +170,25 @@ func (o *observer) OnUpdate(oldObj, newObj any) {
 			continue
 		}
 
-		var oomState *apiv1.ContainerStateTerminated
+		var oomState *corev1.ContainerStateTerminated
+		// For isNewOOM the OOM happened during the transition to the current
+		// terminated state, so the resources in effect are those of newPod.
+		// For isPreviousOOM the OOM happened in the previous container instance
+		// (before the restart observed in this update), whose resources are
+		// reflected in oldPod.
+		var oomPod *corev1.Pod
 		if isNewOOM {
 			oomState = containerStatus.State.Terminated
+			oomPod = newPod
 		} else {
 			oomState = containerStatus.LastTerminationState.Terminated
+			oomPod = oldPod
 		}
 
-		oldSpec := findSpec(containerStatus.Name, oldPod.Spec.Containers)
-		if oldSpec == nil {
-			continue
-		}
 		var memory resource.Quantity
-		requests, _ := resourcehelpers.ContainerRequestsAndLimits(containerStatus.Name, oldPod)
+		requests, _ := resourcehelpers.ContainerRequestsAndLimits(containerStatus.Name, oomPod)
 		if requests != nil {
-			memory = requests[apiv1.ResourceMemory]
+			memory = requests[corev1.ResourceMemory]
 		}
 		oomInfo := OomInfo{
 			Timestamp: oomState.FinishedAt.UTC(),

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
@@ -144,7 +144,6 @@ func (o *observer) OnUpdate(oldObj, newObj any) {
 			continue
 		}
 
-		oldNotTerminated := oldStatus.State.Terminated == nil
 		restartCountIncreased := containerStatus.RestartCount > oldStatus.RestartCount
 
 		// Check if container changes state from non-Terminated to Terminated
@@ -154,14 +153,17 @@ func (o *observer) OnUpdate(oldObj, newObj any) {
 		// We check for this case as well.
 		isNewOOM := containerStatus.State.Terminated != nil &&
 			containerStatus.State.Terminated.Reason == "OOMKilled" &&
-			(oldNotTerminated || restartCountIncreased)
+			(oldStatus.State.Terminated == nil || restartCountIncreased)
 
 		// If controller restarts container, it may skip
 		// Terminated state and change directly from Running
 		// to Running with increased RestartCount. In this
-		// case we check LastTerminationState.
+		// case we check LastTerminationState. We require the
+		// old state to be Running, not just non-Terminated,
+		// to avoid double-counting on a Waiting -> Running
+		// transition after CrashLoopBackOff.
 		isPreviousOOM := containerStatus.State.Running != nil &&
-			oldNotTerminated &&
+			oldStatus.State.Running != nil &&
 			restartCountIncreased &&
 			containerStatus.LastTerminationState.Terminated != nil &&
 			containerStatus.LastTerminationState.Terminated.Reason == "OOMKilled"

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
@@ -437,6 +437,105 @@ status:
 	}
 }
 
+func TestOOMNotDoubleCountedAcrossCrashLoopBackoff(t *testing.T) {
+	// After a container is OOMKilled and enters CrashLoopBackOff, the
+	// subsequent Waiting -> Running transition keeps lastState.terminated
+	// set to the previous OOMKill. That previous OOM has already been
+	// recorded as isNewOOM on the preceding Running -> Terminated
+	// transition, so this update must NOT emit a second OOM event.
+	oldPod, err := newPod(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Pod1
+  namespace: mockNamespace
+spec:
+  containers:
+  - name: Name11
+    resources:
+      requests:
+        memory: "1024"
+status:
+  containerStatuses:
+  - name: Name11
+    restartCount: 3
+    state:
+      waiting:
+        reason: CrashLoopBackOff
+    lastState:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: OOMKilled
+`)
+	assert.NoError(t, err)
+	newPod, err := newPod(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Pod1
+  namespace: mockNamespace
+spec:
+  containers:
+  - name: Name11
+    resources:
+      requests:
+        memory: "1024"
+status:
+  containerStatuses:
+  - name: Name11
+    restartCount: 4
+    state:
+      running:
+        startedAt: 2018-02-23T13:40:00Z
+    lastState:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: OOMKilled
+`)
+	assert.NoError(t, err)
+	observer := NewObserver()
+	observer.OnUpdate(oldPod, newPod)
+	assert.Empty(t, observer.observedOomsChannel)
+}
+
+func TestOOMNotDoubleCountedOnInformerRelist(t *testing.T) {
+	// An informer relist can deliver an update whose old and new states are
+	// identical — the container is in Running with lastState.terminated set
+	// to an OOMKill that has already been processed. Such an update must NOT
+	// emit a second OOM event.
+	podYaml := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Pod1
+  namespace: mockNamespace
+spec:
+  containers:
+  - name: Name11
+    resources:
+      requests:
+        memory: "1024"
+status:
+  containerStatuses:
+  - name: Name11
+    restartCount: 1
+    state:
+      running:
+        startedAt: 2018-02-23T13:38:50Z
+    lastState:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: OOMKilled
+`
+	oldPod, err := newPod(podYaml)
+	assert.NoError(t, err)
+	newPod, err := newPod(podYaml)
+	assert.NoError(t, err)
+	observer := NewObserver()
+	observer.OnUpdate(oldPod, newPod)
+	assert.Empty(t, observer.observedOomsChannel)
+}
+
 func TestOOMStateAfterTerminatedState(t *testing.T) {
 	p1, err := newPod(`
 apiVersion: v1

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
@@ -37,7 +37,10 @@ func init() {
 	utilruntime.Must(corev1.AddToScheme(scheme))
 }
 
-const runningPodYaml = `
+// podYamlHeader is the common metadata/spec prefix for all pod fixtures in
+// this file. Every YAML below appends only the containerStatus fields that
+// distinguish the scenario.
+const podYamlHeader = `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -54,26 +57,96 @@ status:
   - name: Name11
 `
 
-const oomPodYaml = `
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
+const (
+	runningPodYaml = podYamlHeader
+
+	oomPodYaml = podYamlHeader + `
     state:
       terminated:
         finishedAt: 2018-02-23T13:38:48Z
         reason: OOMKilled
 `
+
+	runningBeforeOOMRestartYaml = podYamlHeader + `
+    restartCount: 0
+    state:
+      running:
+        startedAt: 2018-02-23T13:00:00Z
+`
+
+	runningAfterOOMRestartYaml = podYamlHeader + `
+    restartCount: 1
+    state:
+      running:
+        startedAt: 2018-02-23T13:38:50Z
+    lastState:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: OOMKilled
+`
+
+	runningAfterNonOOMRestartYaml = podYamlHeader + `
+    restartCount: 1
+    state:
+      running:
+        startedAt: 2018-02-23T13:38:50Z
+    lastState:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: Error
+`
+
+	terminatedBeforeFastRestartYaml = podYamlHeader + `
+    restartCount: 0
+    state:
+      terminated:
+        finishedAt: 2018-02-23T13:00:00Z
+        reason: Error
+`
+
+	terminatedAfterFastRestartYaml = podYamlHeader + `
+    restartCount: 1
+    state:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: OOMKilled
+`
+
+	terminatedNonOOMYaml = podYamlHeader + `
+    state:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: Error
+`
+
+	terminatedNoReasonYaml = podYamlHeader + `
+    state:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+`
+
+	waitingCrashLoopOOMYaml = podYamlHeader + `
+    restartCount: 3
+    state:
+      waiting:
+        reason: CrashLoopBackOff
+    lastState:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: OOMKilled
+`
+
+	runningAfterCrashLoopYaml = podYamlHeader + `
+    restartCount: 4
+    state:
+      running:
+        startedAt: 2018-02-23T13:40:00Z
+    lastState:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: OOMKilled
+`
+)
 
 func newPod(yaml string) (*corev1.Pod, error) {
 	decode := codecs.UniversalDeserializer().Decode
@@ -82,6 +155,15 @@ func newPod(yaml string) (*corev1.Pod, error) {
 		return nil, err
 	}
 	return obj.(*corev1.Pod), nil
+}
+
+func mustNewPod(t *testing.T, yaml string) *corev1.Pod {
+	t.Helper()
+	pod, err := newPod(yaml)
+	if err != nil {
+		t.Fatalf("failed to parse pod YAML: %v", err)
+	}
+	return pod
 }
 
 func newEvent(yaml string) (*corev1.Event, error) {
@@ -93,195 +175,115 @@ func newEvent(yaml string) (*corev1.Event, error) {
 	return obj.(*corev1.Event), nil
 }
 
-func TestOOMReceived(t *testing.T) {
-	p1, err := newPod(runningPodYaml)
-	assert.NoError(t, err)
-	p2, err := newPod(oomPodYaml)
-	assert.NoError(t, err)
+func TestOOMObserverOnUpdate(t *testing.T) {
 	timestamp, err := time.Parse(time.RFC3339, "2018-02-23T13:38:48Z")
 	assert.NoError(t, err)
 
-	testCases := []struct {
-		desc        string
-		oldPod      *corev1.Pod
-		newPod      *corev1.Pod
-		wantOOMInfo OomInfo
-	}{
-		{
-			desc:   "OK",
-			oldPod: p1,
-			newPod: p2,
-			wantOOMInfo: OomInfo{
-				ContainerID: model.ContainerID{
-					ContainerName: "Name11",
-					PodID: model.PodID{
-						Namespace: "mockNamespace",
-						PodName:   "Pod1",
-					},
-				},
-				Memory:    model.ResourceAmount(int64(1024)),
-				Timestamp: timestamp,
-			},
-		},
-		{
-			desc:   "New pod does not set memory requests",
-			oldPod: p1,
-			newPod: func() *corev1.Pod {
-				newPod := p2.DeepCopy()
-				newPod.Spec.Containers[0].Resources.Requests = nil
-				newPod.Status.ContainerStatuses[0].Resources = nil
-				return newPod
-			}(),
-			wantOOMInfo: OomInfo{
-				ContainerID: model.ContainerID{
-					ContainerName: "Name11",
-					PodID: model.PodID{
-						Namespace: "mockNamespace",
-						PodName:   "Pod1",
-					},
-				},
-				Memory:    model.ResourceAmount(int64(0)),
-				Timestamp: timestamp,
-			},
-		},
-		{
-			desc:   "New pod also set memory request in containerStatus, prefer info from containerStatus",
-			oldPod: p1,
-			newPod: func() *corev1.Pod {
-				newPod := p2.DeepCopy()
-				newPod.Status.ContainerStatuses[0].Resources = &corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("2048"),
-					},
-				}
-				return newPod
-			}(),
-			wantOOMInfo: OomInfo{
-				ContainerID: model.ContainerID{
-					ContainerName: "Name11",
-					PodID: model.PodID{
-						Namespace: "mockNamespace",
-						PodName:   "Pod1",
-					},
-				},
-				Memory:    model.ResourceAmount(int64(2048)),
-				Timestamp: timestamp,
-			},
+	containerID := model.ContainerID{
+		ContainerName: "Name11",
+		PodID: model.PodID{
+			Namespace: "mockNamespace",
+			PodName:   "Pod1",
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			observer := NewObserver()
-			observer.OnUpdate(tc.oldPod, tc.newPod)
-			info := <-observer.observedOomsChannel
-			assert.Equal(t, tc.wantOOMInfo, info)
-		})
+	wantOOM := func(memory int64) *OomInfo {
+		return &OomInfo{
+			ContainerID: containerID,
+			Memory:      model.ResourceAmount(memory),
+			Timestamp:   timestamp,
+		}
 	}
-}
-
-func TestOOMReceivedPreviousOOM(t *testing.T) {
-	oldPodYaml := `
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    restartCount: 0
-    state:
-      running:
-        startedAt: 2018-02-23T13:00:00Z
-`
-	newPodYaml := `
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    restartCount: 1
-    state:
-      running:
-        startedAt: 2018-02-23T13:38:50Z
-    lastState:
-      terminated:
-        finishedAt: 2018-02-23T13:38:48Z
-        reason: OOMKilled
-`
-	timestamp, err := time.Parse(time.RFC3339, "2018-02-23T13:38:48Z")
-	assert.NoError(t, err)
+	setContainerStatusMemory := func(quantity string) func(*corev1.Pod) {
+		return func(pod *corev1.Pod) {
+			pod.Status.ContainerStatuses[0].Resources = &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse(quantity),
+				},
+			}
+		}
+	}
 
 	testCases := []struct {
 		desc        string
+		oldPodYaml  string
+		newPodYaml  string
 		mutateOld   func(*corev1.Pod)
 		mutateNew   func(*corev1.Pod)
-		wantOOMInfo OomInfo
+		wantOOMInfo *OomInfo // nil => expect no OOM event
 	}{
 		{
-			desc: "OK",
-			wantOOMInfo: OomInfo{
-				ContainerID: model.ContainerID{
-					ContainerName: "Name11",
-					PodID: model.PodID{
-						Namespace: "mockNamespace",
-						PodName:   "Pod1",
-					},
-				},
-				Memory:    model.ResourceAmount(int64(1024)),
-				Timestamp: timestamp,
-			},
+			desc:        "Running -> Terminated OOMKilled records a new OOM",
+			oldPodYaml:  runningPodYaml,
+			newPodYaml:  oomPodYaml,
+			wantOOMInfo: wantOOM(1024),
 		},
 		{
-			desc: "Resources are read from oldPod, not newPod",
-			mutateOld: func(pod *corev1.Pod) {
-				pod.Status.ContainerStatuses[0].Resources = &corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("2048"),
-					},
-				}
-			},
+			desc:       "isNewOOM reads zero memory when new pod has no requests",
+			oldPodYaml: runningPodYaml,
+			newPodYaml: oomPodYaml,
 			mutateNew: func(pod *corev1.Pod) {
-				pod.Status.ContainerStatuses[0].Resources = &corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("4096"),
-					},
-				}
+				pod.Spec.Containers[0].Resources.Requests = nil
+				pod.Status.ContainerStatuses[0].Resources = nil
 			},
-			wantOOMInfo: OomInfo{
-				ContainerID: model.ContainerID{
-					ContainerName: "Name11",
-					PodID: model.PodID{
-						Namespace: "mockNamespace",
-						PodName:   "Pod1",
-					},
-				},
-				Memory:    model.ResourceAmount(int64(2048)),
-				Timestamp: timestamp,
-			},
+			wantOOMInfo: wantOOM(0),
+		},
+		{
+			desc:        "isNewOOM prefers containerStatus.resources over spec.resources",
+			oldPodYaml:  runningPodYaml,
+			newPodYaml:  oomPodYaml,
+			mutateNew:   setContainerStatusMemory("2048"),
+			wantOOMInfo: wantOOM(2048),
+		},
+		{
+			desc:        "Running -> Running with OOM lastState records a previous OOM",
+			oldPodYaml:  runningBeforeOOMRestartYaml,
+			newPodYaml:  runningAfterOOMRestartYaml,
+			wantOOMInfo: wantOOM(1024),
+		},
+		{
+			desc:        "isPreviousOOM reads resources from oldPod, not newPod",
+			oldPodYaml:  runningBeforeOOMRestartYaml,
+			newPodYaml:  runningAfterOOMRestartYaml,
+			mutateOld:   setContainerStatusMemory("2048"),
+			mutateNew:   setContainerStatusMemory("4096"),
+			wantOOMInfo: wantOOM(2048),
+		},
+		{
+			desc:        "Terminated non-OOM -> Terminated OOMKilled with restart records a new OOM",
+			oldPodYaml:  terminatedBeforeFastRestartYaml,
+			newPodYaml:  terminatedAfterFastRestartYaml,
+			wantOOMInfo: wantOOM(1024),
+		},
+		{
+			desc:       "Running -> Terminated with non-OOM reason is ignored",
+			oldPodYaml: runningPodYaml,
+			newPodYaml: terminatedNonOOMYaml,
+		},
+		{
+			desc:       "Running -> Running with non-OOM lastState is ignored",
+			oldPodYaml: runningPodYaml,
+			newPodYaml: runningAfterNonOOMRestartYaml,
+		},
+		{
+			desc:       "Waiting(CrashLoopBackOff) -> Running with OOM lastState is not double-counted",
+			oldPodYaml: waitingCrashLoopOOMYaml,
+			newPodYaml: runningAfterCrashLoopYaml,
+		},
+		{
+			desc:       "Informer relist emitting identical Running state is not double-counted",
+			oldPodYaml: runningAfterOOMRestartYaml,
+			newPodYaml: runningAfterOOMRestartYaml,
+		},
+		{
+			desc:       "Terminated -> Terminated OOMKilled without restart is ignored",
+			oldPodYaml: terminatedNoReasonYaml,
+			newPodYaml: oomPodYaml,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			oldPod, err := newPod(oldPodYaml)
-			assert.NoError(t, err)
-			newPod, err := newPod(newPodYaml)
-			assert.NoError(t, err)
+			oldPod := mustNewPod(t, tc.oldPodYaml)
+			newPod := mustNewPod(t, tc.newPodYaml)
 			if tc.mutateOld != nil {
 				tc.mutateOld(oldPod)
 			}
@@ -290,280 +292,14 @@ status:
 			}
 			observer := NewObserver()
 			observer.OnUpdate(oldPod, newPod)
+			if tc.wantOOMInfo == nil {
+				assert.Empty(t, observer.observedOomsChannel)
+				return
+			}
 			info := <-observer.observedOomsChannel
-			assert.Equal(t, tc.wantOOMInfo, info)
+			assert.Equal(t, *tc.wantOOMInfo, info)
 		})
 	}
-}
-
-func TestOOMReceivedFastRestart(t *testing.T) {
-	// Container went Terminated -> Terminated (OOMKilled) with RestartCount
-	// bumped, skipping the Running state entirely. This happens when the
-	// container fails very fast after restart.
-	oldPod, err := newPod(`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    restartCount: 0
-    state:
-      terminated:
-        finishedAt: 2018-02-23T13:00:00Z
-        reason: Error
-`)
-	assert.NoError(t, err)
-	newPod, err := newPod(`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    restartCount: 1
-    state:
-      terminated:
-        finishedAt: 2018-02-23T13:38:48Z
-        reason: OOMKilled
-`)
-	assert.NoError(t, err)
-	timestamp, err := time.Parse(time.RFC3339, "2018-02-23T13:38:48Z")
-	assert.NoError(t, err)
-
-	observer := NewObserver()
-	observer.OnUpdate(oldPod, newPod)
-	info := <-observer.observedOomsChannel
-	assert.Equal(t, OomInfo{
-		ContainerID: model.ContainerID{
-			ContainerName: "Name11",
-			PodID: model.PodID{
-				Namespace: "mockNamespace",
-				PodName:   "Pod1",
-			},
-		},
-		Memory:    model.ResourceAmount(int64(1024)),
-		Timestamp: timestamp,
-	}, info)
-}
-
-func TestNonOOMTerminationIgnored(t *testing.T) {
-	runningRestarted := `
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    restartCount: 1
-    state:
-      running:
-        startedAt: 2018-02-23T13:38:50Z
-    lastState:
-      terminated:
-        finishedAt: 2018-02-23T13:38:48Z
-        reason: Error
-`
-	terminatedNonOOM := `
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    state:
-      terminated:
-        finishedAt: 2018-02-23T13:38:48Z
-        reason: Error
-`
-	testCases := []struct {
-		desc       string
-		oldPodYaml string
-		newPodYaml string
-	}{
-		{
-			desc:       "Running -> Terminated with non-OOM reason",
-			oldPodYaml: runningPodYaml,
-			newPodYaml: terminatedNonOOM,
-		},
-		{
-			desc:       "Running -> Running with restart but non-OOM lastState",
-			oldPodYaml: runningPodYaml,
-			newPodYaml: runningRestarted,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			oldPod, err := newPod(tc.oldPodYaml)
-			assert.NoError(t, err)
-			newPod, err := newPod(tc.newPodYaml)
-			assert.NoError(t, err)
-			observer := NewObserver()
-			observer.OnUpdate(oldPod, newPod)
-			assert.Empty(t, observer.observedOomsChannel)
-		})
-	}
-}
-
-func TestOOMNotDoubleCountedAcrossCrashLoopBackoff(t *testing.T) {
-	// After a container is OOMKilled and enters CrashLoopBackOff, the
-	// subsequent Waiting -> Running transition keeps lastState.terminated
-	// set to the previous OOMKill. That previous OOM has already been
-	// recorded as isNewOOM on the preceding Running -> Terminated
-	// transition, so this update must NOT emit a second OOM event.
-	oldPod, err := newPod(`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    restartCount: 3
-    state:
-      waiting:
-        reason: CrashLoopBackOff
-    lastState:
-      terminated:
-        finishedAt: 2018-02-23T13:38:48Z
-        reason: OOMKilled
-`)
-	assert.NoError(t, err)
-	newPod, err := newPod(`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    restartCount: 4
-    state:
-      running:
-        startedAt: 2018-02-23T13:40:00Z
-    lastState:
-      terminated:
-        finishedAt: 2018-02-23T13:38:48Z
-        reason: OOMKilled
-`)
-	assert.NoError(t, err)
-	observer := NewObserver()
-	observer.OnUpdate(oldPod, newPod)
-	assert.Empty(t, observer.observedOomsChannel)
-}
-
-func TestOOMNotDoubleCountedOnInformerRelist(t *testing.T) {
-	// An informer relist can deliver an update whose old and new states are
-	// identical — the container is in Running with lastState.terminated set
-	// to an OOMKill that has already been processed. Such an update must NOT
-	// emit a second OOM event.
-	podYaml := `
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    restartCount: 1
-    state:
-      running:
-        startedAt: 2018-02-23T13:38:50Z
-    lastState:
-      terminated:
-        finishedAt: 2018-02-23T13:38:48Z
-        reason: OOMKilled
-`
-	oldPod, err := newPod(podYaml)
-	assert.NoError(t, err)
-	newPod, err := newPod(podYaml)
-	assert.NoError(t, err)
-	observer := NewObserver()
-	observer.OnUpdate(oldPod, newPod)
-	assert.Empty(t, observer.observedOomsChannel)
-}
-
-func TestOOMStateAfterTerminatedState(t *testing.T) {
-	p1, err := newPod(`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: Pod1
-  namespace: mockNamespace
-spec:
-  containers:
-  - name: Name11
-    resources:
-      requests:
-        memory: "1024"
-status:
-  containerStatuses:
-  - name: Name11
-    state:
-      terminated:
-        finishedAt: 2018-02-23T13:38:48Z
-`)
-	assert.NoError(t, err)
-	p2, err := newPod(oomPodYaml)
-	assert.NoError(t, err)
-	observer := NewObserver()
-	observer.OnUpdate(p1, p2)
-
-	// No OOM event should be sent if previous state was also "terminated".
-	assert.Empty(t, observer.observedOomsChannel)
 }
 
 func TestParseEvictionEvent(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
@@ -124,14 +124,14 @@ func TestOOMReceived(t *testing.T) {
 			},
 		},
 		{
-			desc: "Old pod does not set memory requests",
-			oldPod: func() *corev1.Pod {
-				oldPod := p1.DeepCopy()
-				oldPod.Spec.Containers[0].Resources.Requests = nil
-				oldPod.Status.ContainerStatuses[0].Resources = nil
-				return oldPod
+			desc:   "New pod does not set memory requests",
+			oldPod: p1,
+			newPod: func() *corev1.Pod {
+				newPod := p2.DeepCopy()
+				newPod.Spec.Containers[0].Resources.Requests = nil
+				newPod.Status.ContainerStatuses[0].Resources = nil
+				return newPod
 			}(),
-			newPod: p2,
 			wantOOMInfo: OomInfo{
 				ContainerID: model.ContainerID{
 					ContainerName: "Name11",
@@ -145,17 +145,17 @@ func TestOOMReceived(t *testing.T) {
 			},
 		},
 		{
-			desc: "Old pod also set memory request in containerStatus, prefer info from containerStatus",
-			oldPod: func() *corev1.Pod {
-				oldPod := p1.DeepCopy()
-				oldPod.Status.ContainerStatuses[0].Resources = &corev1.ResourceRequirements{
+			desc:   "New pod also set memory request in containerStatus, prefer info from containerStatus",
+			oldPod: p1,
+			newPod: func() *corev1.Pod {
+				newPod := p2.DeepCopy()
+				newPod.Status.ContainerStatuses[0].Resources = &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("2048"),
 					},
 				}
-				return oldPod
+				return newPod
 			}(),
-			newPod: p2,
 			wantOOMInfo: OomInfo{
 				ContainerID: model.ContainerID{
 					ContainerName: "Name11",

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
@@ -148,22 +148,14 @@ const (
 `
 )
 
-func newPod(yaml string) (*corev1.Pod, error) {
+func mustNewPod(t *testing.T, yaml string) *corev1.Pod {
+	t.Helper()
 	decode := codecs.UniversalDeserializer().Decode
 	obj, _, err := decode([]byte(yaml), nil, nil)
 	if err != nil {
-		return nil, err
-	}
-	return obj.(*corev1.Pod), nil
-}
-
-func mustNewPod(t *testing.T, yaml string) *corev1.Pod {
-	t.Helper()
-	pod, err := newPod(yaml)
-	if err != nil {
 		t.Fatalf("failed to parse pod YAML: %v", err)
 	}
-	return pod
+	return obj.(*corev1.Pod)
 }
 
 func newEvent(yaml string) (*corev1.Event, error) {

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
@@ -179,6 +179,264 @@ func TestOOMReceived(t *testing.T) {
 	}
 }
 
+func TestOOMReceivedPreviousOOM(t *testing.T) {
+	oldPodYaml := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Pod1
+  namespace: mockNamespace
+spec:
+  containers:
+  - name: Name11
+    resources:
+      requests:
+        memory: "1024"
+status:
+  containerStatuses:
+  - name: Name11
+    restartCount: 0
+    state:
+      running:
+        startedAt: 2018-02-23T13:00:00Z
+`
+	newPodYaml := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Pod1
+  namespace: mockNamespace
+spec:
+  containers:
+  - name: Name11
+    resources:
+      requests:
+        memory: "1024"
+status:
+  containerStatuses:
+  - name: Name11
+    restartCount: 1
+    state:
+      running:
+        startedAt: 2018-02-23T13:38:50Z
+    lastState:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: OOMKilled
+`
+	timestamp, err := time.Parse(time.RFC3339, "2018-02-23T13:38:48Z")
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		desc        string
+		mutateOld   func(*corev1.Pod)
+		mutateNew   func(*corev1.Pod)
+		wantOOMInfo OomInfo
+	}{
+		{
+			desc: "OK",
+			wantOOMInfo: OomInfo{
+				ContainerID: model.ContainerID{
+					ContainerName: "Name11",
+					PodID: model.PodID{
+						Namespace: "mockNamespace",
+						PodName:   "Pod1",
+					},
+				},
+				Memory:    model.ResourceAmount(int64(1024)),
+				Timestamp: timestamp,
+			},
+		},
+		{
+			desc: "Resources are read from oldPod, not newPod",
+			mutateOld: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses[0].Resources = &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2048"),
+					},
+				}
+			},
+			mutateNew: func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses[0].Resources = &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("4096"),
+					},
+				}
+			},
+			wantOOMInfo: OomInfo{
+				ContainerID: model.ContainerID{
+					ContainerName: "Name11",
+					PodID: model.PodID{
+						Namespace: "mockNamespace",
+						PodName:   "Pod1",
+					},
+				},
+				Memory:    model.ResourceAmount(int64(2048)),
+				Timestamp: timestamp,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			oldPod, err := newPod(oldPodYaml)
+			assert.NoError(t, err)
+			newPod, err := newPod(newPodYaml)
+			assert.NoError(t, err)
+			if tc.mutateOld != nil {
+				tc.mutateOld(oldPod)
+			}
+			if tc.mutateNew != nil {
+				tc.mutateNew(newPod)
+			}
+			observer := NewObserver()
+			observer.OnUpdate(oldPod, newPod)
+			info := <-observer.observedOomsChannel
+			assert.Equal(t, tc.wantOOMInfo, info)
+		})
+	}
+}
+
+func TestOOMReceivedFastRestart(t *testing.T) {
+	// Container went Terminated -> Terminated (OOMKilled) with RestartCount
+	// bumped, skipping the Running state entirely. This happens when the
+	// container fails very fast after restart.
+	oldPod, err := newPod(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Pod1
+  namespace: mockNamespace
+spec:
+  containers:
+  - name: Name11
+    resources:
+      requests:
+        memory: "1024"
+status:
+  containerStatuses:
+  - name: Name11
+    restartCount: 0
+    state:
+      terminated:
+        finishedAt: 2018-02-23T13:00:00Z
+        reason: Error
+`)
+	assert.NoError(t, err)
+	newPod, err := newPod(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Pod1
+  namespace: mockNamespace
+spec:
+  containers:
+  - name: Name11
+    resources:
+      requests:
+        memory: "1024"
+status:
+  containerStatuses:
+  - name: Name11
+    restartCount: 1
+    state:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: OOMKilled
+`)
+	assert.NoError(t, err)
+	timestamp, err := time.Parse(time.RFC3339, "2018-02-23T13:38:48Z")
+	assert.NoError(t, err)
+
+	observer := NewObserver()
+	observer.OnUpdate(oldPod, newPod)
+	info := <-observer.observedOomsChannel
+	assert.Equal(t, OomInfo{
+		ContainerID: model.ContainerID{
+			ContainerName: "Name11",
+			PodID: model.PodID{
+				Namespace: "mockNamespace",
+				PodName:   "Pod1",
+			},
+		},
+		Memory:    model.ResourceAmount(int64(1024)),
+		Timestamp: timestamp,
+	}, info)
+}
+
+func TestNonOOMTerminationIgnored(t *testing.T) {
+	runningRestarted := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Pod1
+  namespace: mockNamespace
+spec:
+  containers:
+  - name: Name11
+    resources:
+      requests:
+        memory: "1024"
+status:
+  containerStatuses:
+  - name: Name11
+    restartCount: 1
+    state:
+      running:
+        startedAt: 2018-02-23T13:38:50Z
+    lastState:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: Error
+`
+	terminatedNonOOM := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Pod1
+  namespace: mockNamespace
+spec:
+  containers:
+  - name: Name11
+    resources:
+      requests:
+        memory: "1024"
+status:
+  containerStatuses:
+  - name: Name11
+    state:
+      terminated:
+        finishedAt: 2018-02-23T13:38:48Z
+        reason: Error
+`
+	testCases := []struct {
+		desc       string
+		oldPodYaml string
+		newPodYaml string
+	}{
+		{
+			desc:       "Running -> Terminated with non-OOM reason",
+			oldPodYaml: runningPodYaml,
+			newPodYaml: terminatedNonOOM,
+		},
+		{
+			desc:       "Running -> Running with restart but non-OOM lastState",
+			oldPodYaml: runningPodYaml,
+			newPodYaml: runningRestarted,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			oldPod, err := newPod(tc.oldPodYaml)
+			assert.NoError(t, err)
+			newPod, err := newPod(tc.newPodYaml)
+			assert.NoError(t, err)
+			observer := NewObserver()
+			observer.OnUpdate(oldPod, newPod)
+			assert.Empty(t, observer.observedOomsChannel)
+		})
+	}
+}
+
 func TestOOMStateAfterTerminatedState(t *testing.T) {
 	p1, err := newPod(`
 apiVersion: v1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Current approach of detection OOMs is based on `RestartCount` and `status.containerStatuses.lastState` of pod. But if pod doesn't restart (`restartPolicy: Never`), pod doesn't have `lastState` and `RestartCount` isn't increased.

I changed it to check `status.containerStatuses.state.terminated` instead. If container's status changes from running to terminated with `OOMKilled` reason, we record OOM. I believe this approach works for regular pods that can restart and works for not restarting pods as well.

If it is regular pod which restarts:
1. Container is running (`status.containerStatuses.state.terminated == nil`)
2. Container is OOM killed (`status.containerStatuses.state.terminated.reason == "OOMKilled"`)
3. We record OOM
4. Container restarts, it's `state.terminated` resets (`status.containerStatuses.state.terminated == nil`)
6. See 1.

If it is pod which doesn't restart:
1. Container is running (`status.containerStatuses.state.terminated == nil`)
2. Container is OOM killed (`status.containerStatuses.state.terminated.reason == "OOMKilled"`)
3. We record OOM

#### Which issue(s) this PR fixes:

Fixes #6236

#### Does this PR introduce a user-facing change?

```release-note
- Fixed OOM detection for pods with `restartPolicy: Never`
```