### PR TITLE
[VPA] Change e2e test registry to Artifact Registry

### DIFF
--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -60,7 +60,8 @@ case ${SUITE} in
 esac
 
 export REGISTRY=us-central1-docker.pkg.dev/`gcloud config get-value core/project`/vpa
-gcloud artifacts repositories create vpa --repository-format=docker --location=us-central1
+# gcloud artifacts repositories create vpa --repository-format=docker --location=us-central1
+gcloud container images list
 export TAG=latest
 
 echo "Configuring registry authentication"

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -59,7 +59,7 @@ case ${SUITE} in
     ;;
 esac
 
-export REGISTRY=gcr.io/`gcloud config get-value core/project`
+export REGISTRY=us-central1-docker.pkg.dev/`gcloud config get-value core/project`
 export TAG=latest
 
 echo "Configuring registry authentication"

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -59,7 +59,8 @@ case ${SUITE} in
     ;;
 esac
 
-export REGISTRY=us-central1-docker.pkg.dev/`gcloud config get-value core/project`
+export REGISTRY=us-central1-docker.pkg.dev/`gcloud config get-value core/project`/vpa
+gcloud artifacts repositories create vpa --repository-format=docker --location=us-central1
 export TAG=latest
 
 echo "Configuring registry authentication"


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

GCR is deprecated and no longer allowing writes which has broken the VPA e2e tests.

Write to Artifact Registry instead.

#### Which issue(s) this PR fixes:

Fixes #7946

#### Does this PR introduce a user-facing change?

```release-note
NONE
```