### PR TITLE
Emit event on successful async scale-up

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/async_initializer.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/async_initializer.go
@@ -155,9 +155,17 @@ func (s *AsyncNodeGroupInitializer) InitializeNodeGroup(result nodegroups.AsyncN
 		return
 	}
 	klog.Infof("Initial scale-up succeeded. Scale ups: %v", scaleUpInfos)
+	s.emitScaleUpStatus(&status.ScaleUpStatus{
+		Result:                 status.ScaleUpSuccessful,
+		ScaleUpInfos:           scaleUpInfos,
+		CreateNodeGroupResults: []nodegroups.CreateNodeGroupResult{result.CreationResult},
+		PodsTriggeredScaleUp:   s.triggeringPods,
+	}, nil)
 }
 
 func (s *AsyncNodeGroupInitializer) emitScaleUpStatus(scaleUpStatus *status.ScaleUpStatus, err errors.AutoscalerError) {
-	status.UpdateScaleUpError(scaleUpStatus, err)
+	if err != nil {
+		status.UpdateScaleUpError(scaleUpStatus, err)
+	}
 	s.scaleUpStatusProcessor.Process(s.context, scaleUpStatus)
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups/asyncnodegroups"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	processorstest "k8s.io/autoscaler/cluster-autoscaler/processors/test"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
@@ -41,72 +42,80 @@ import (
 )
 
 func TestNodePoolAsyncInitialization(t *testing.T) {
+	scaleUpSize := 3
+	failingNodeGroupName := "failing-ng"
+	provider := testprovider.NewTestCloudProvider(
+		func(nodeGroup string, increase int) error {
+			if nodeGroup == failingNodeGroupName {
+				return fmt.Errorf("Simulated error")
+			}
+			return nil
+		}, nil)
+	pod := BuildTestPod("p1", 2, 1000)
+	failingNodeGroup := provider.BuildNodeGroup(failingNodeGroupName, 0, 100, 0, false, true, "T1", nil)
+	successfulNodeGroup := provider.BuildNodeGroup("async-ng", 0, 100, 0, false, true, "T1", nil)
+	failedScaleUpErr := errors.ToAutoscalerError(errors.CloudProviderError, fmt.Errorf("Simulated error")).AddPrefix("failed to increase node group size: ")
 	testCases := []struct {
-		name             string
-		failingScaleUps  map[string]bool
-		expectedScaleUps map[string]int
+		name       string
+		nodeGroup  *testprovider.TestNodeGroup
+		wantStatus status.ScaleUpStatus
 	}{
 		{
-			name:             "scale up upcoming node group",
-			expectedScaleUps: map[string]int{"async-ng": 3},
+			name:      "scale up upcoming node group",
+			nodeGroup: successfulNodeGroup,
+			wantStatus: status.ScaleUpStatus{
+				Result: status.ScaleUpSuccessful,
+				ScaleUpInfos: []nodegroupset.ScaleUpInfo{
+					{
+						Group:       successfulNodeGroup,
+						CurrentSize: 0,
+						NewSize:     scaleUpSize,
+						MaxSize:     successfulNodeGroup.MaxSize(),
+					},
+				},
+				CreateNodeGroupResults: []nodegroups.CreateNodeGroupResult{
+					{MainCreatedNodeGroup: successfulNodeGroup},
+				},
+				PodsTriggeredScaleUp: []*apiv1.Pod{pod},
+			},
 		},
 		{
-			name:            "failing initial scale up",
-			failingScaleUps: map[string]bool{"async-ng": true},
+			name:      "failing initial scale up",
+			nodeGroup: failingNodeGroup,
+			wantStatus: status.ScaleUpStatus{
+				Result:       status.ScaleUpError,
+				ScaleUpError: &failedScaleUpErr,
+				CreateNodeGroupResults: []nodegroups.CreateNodeGroupResult{
+					{MainCreatedNodeGroup: failingNodeGroup},
+				},
+				FailedResizeNodeGroups: []cloudprovider.NodeGroup{failingNodeGroup},
+				PodsTriggeredScaleUp:   []*apiv1.Pod{pod},
+			},
 		},
 	}
+	listers := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	upcomingNodeGroup := provider.BuildNodeGroup("upcoming-ng", 0, 100, 0, false, true, "T1", nil)
+	options := config.AutoscalingOptions{AsyncNodeGroupsEnabled: true}
+	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
+	assert.NoError(t, err)
+	option := expander.Option{NodeGroup: upcomingNodeGroup, Pods: []*apiv1.Pod{pod}}
+	processors := processorstest.NewTestProcessors(&context)
+	processors.AsyncNodeGroupStateChecker = &asyncnodegroups.MockAsyncNodeGroupStateChecker{IsUpcomingNodeGroup: map[string]bool{upcomingNodeGroup.Id(): true}}
+	nodeInfo := framework.NewTestNodeInfo(BuildTestNode("t1", 100, 0))
+	executor := newScaleUpExecutor(&context, processors.ScaleStateNotifier, processors.AsyncNodeGroupStateChecker)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			scaledUpGroups := make(map[string]int)
-			provider := testprovider.NewTestCloudProvider(
-				func(nodeGroup string, increase int) error {
-					if tc.failingScaleUps[nodeGroup] {
-						return fmt.Errorf("Simulated error")
-					}
-					scaledUpGroups[nodeGroup] += increase
-					return nil
-				}, nil)
-			options := config.AutoscalingOptions{
-				AsyncNodeGroupsEnabled: true,
-			}
-			listers := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)
-			context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
-			assert.NoError(t, err)
-			p1 := BuildTestPod("p1", 2, 1000)
-			upcomingNodeGroup := provider.BuildNodeGroup("upcoming-ng", 0, 100, 0, false, true, "T1", nil)
-			createdNodeGroup := provider.BuildNodeGroup("async-ng", 0, 100, 0, false, true, "T1", nil)
-			option := expander.Option{
-				NodeGroup: upcomingNodeGroup,
-				Pods:      []*apiv1.Pod{p1},
-			}
-			processors := processorstest.NewTestProcessors(&context)
-			processors.AsyncNodeGroupStateChecker = &asyncnodegroups.MockAsyncNodeGroupStateChecker{IsUpcomingNodeGroup: map[string]bool{upcomingNodeGroup.Id(): true}}
-			nodeInfo := framework.NewTestNodeInfo(BuildTestNode("t1", 100, 0))
-			executor := newScaleUpExecutor(&context, processors.ScaleStateNotifier, processors.AsyncNodeGroupStateChecker)
 			scaleUpStatusProcessor := &fakeScaleUpStatusProcessor{}
 			initializer := NewAsyncNodeGroupInitializer(&option, nodeInfo, executor, taints.TaintConfig{}, nil, scaleUpStatusProcessor, &context, false)
-			initializer.SetTargetSize(upcomingNodeGroup.Id(), 3)
+			initializer.SetTargetSize(upcomingNodeGroup.Id(), int64(scaleUpSize))
 			asyncResult := nodegroups.AsyncNodeGroupCreationResult{
-				CreationResult: nodegroups.CreateNodeGroupResult{MainCreatedNodeGroup: createdNodeGroup},
+				CreationResult: nodegroups.CreateNodeGroupResult{MainCreatedNodeGroup: tc.nodeGroup},
 				CreatedToUpcomingMapping: map[string]string{
-					createdNodeGroup.Id(): upcomingNodeGroup.Id(),
+					tc.nodeGroup.Id(): upcomingNodeGroup.Id(),
 				},
 			}
 			initializer.InitializeNodeGroup(asyncResult)
-			assert.Equal(t, len(scaledUpGroups), len(tc.expectedScaleUps))
-			for groupName, increase := range tc.expectedScaleUps {
-				assert.Equal(t, increase, scaledUpGroups[groupName])
-			}
-			if len(tc.failingScaleUps) > 0 {
-				expectedErr := errors.ToAutoscalerError(errors.CloudProviderError, fmt.Errorf("Simulated error")).AddPrefix("failed to increase node group size: ")
-				assert.Equal(t, scaleUpStatusProcessor.lastStatus, &status.ScaleUpStatus{
-					Result:                 status.ScaleUpError,
-					ScaleUpError:           &expectedErr,
-					CreateNodeGroupResults: []nodegroups.CreateNodeGroupResult{asyncResult.CreationResult},
-					FailedResizeNodeGroups: []cloudprovider.NodeGroup{createdNodeGroup},
-					PodsTriggeredScaleUp:   option.Pods,
-				})
-			}
+			assert.Equal(t, *scaleUpStatusProcessor.lastStatus, tc.wantStatus)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

We need to emit an event about successful asynchronous scale-up during node pool initialization for visibility. It important to notify about the success and it's also used to match pod names to failed asynchronous scale-ups. Without this change it's possible to have a failed scale-up without a pod level `FailedScaleUp` event. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
