### PR TITLE
Replace PodResizing with PodResizeInProgress pod condition in AEP-4016

### DIFF
--- a/vertical-pod-autoscaler/enhancements/4016-in-place-updates-support/README.md
+++ b/vertical-pod-autoscaler/enhancements/4016-in-place-updates-support/README.md
@@ -170,7 +170,8 @@ VPA updater will consider that the update failed if:
 * The pod has condition `PodResizePending` with reason `Infeasible` or
 * The pod has condition `PodResizePending` with reason `Deferred` and more than 5 minutes elapsed
   since the update or
-* The pod has condition `PodResizing` and more than 1 hour elapsed since the update or
+* The pod has condition `PodResizeInProgress` and more than 1 hour elapsed since
+  the update or
 * Patch attempt returns an error.
 
 Note that in the initial version of In-Place updates, memory limit downscaling will always fail
@@ -228,7 +229,7 @@ Today, VPA updater considers the following conditions when deciding if it should
    * Outside recommended range,
    * Long-lived pod with significant change.
    * `EvictionRequirements` are all true.
- 
+
 `InPlaceOrRecreate` will attempt to apply an update in place if it meets at least one
 of the following conditions:
 * Quick OOM,
@@ -251,7 +252,7 @@ of the following conditions:
 The following test scenarios will be added to e2e tests. The `InPlaceOrRecreate` mode will be
 tested in the following scenarios:
 
-* Admission controller applies recommendation to pod controlled by VPA. 
+* Admission controller applies recommendation to pod controlled by VPA.
 * In-place update applied to all containers of a pod.
 * In-place update will fail. Pod should be evicted and the recommendation applied.
 * In-place update will fail but `CanEvict` is false, pod should not be evicted.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation


`PodResizing` pod condition has recently been renamed to `PodResizeInProgress:` https://github.com/kubernetes/kubernetes/blob/62555cadc741a8aef31acab05e9ed60f897edb1b/pkg/apis/core/types.go#L2954-L2964
