### PR TITLE
[addon-resizer] Cross compile addon-resizer for efficiency

### DIFF
--- a/addon-resizer/Dockerfile
+++ b/addon-resizer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Currently the addon-resizer build uses emulation which is very slow and leads to issues with the automatic builds (see https://github.com/kubernetes/test-infra/pull/34380).

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/autoscaler/issues/7615

#### Special notes for your reviewer:

- See notes from https://github.com/kubernetes/test-infra/pull/34380.
- Tested locally with no issues.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```