### PR TITLE
VPA: Per-node recommendations (very early draft)

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -21,7 +21,7 @@ package common
 var gitCommit = ""
 
 // versionCore is the version of VPA.
-const versionCore = "1.4.0"
+const versionCore = "1.4.0+scope"
 
 // VerticalPodAutoscalerVersion returns the version of the VPA.
 func VerticalPodAutoscalerVersion() string {

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -375,6 +375,8 @@ spec:
                       type: object
                     type: array
                 type: object
+              scope:
+                type: string
               targetRef:
                 description: |-
                   TargetRef points to the controller managing the set of pods for the
@@ -532,6 +534,10 @@ spec:
                             This amount is not guaranteed to be sufficient for the application to operate in a stable way, however
                             running with less resources is likely to have significant impact on performance/availability.
                           type: object
+                        scope:
+                          description: When running VPA for finer-grained scope than
+                            a workload, e.g. per-node.
+                          type: string
                         target:
                           additionalProperties:
                             anyOf:

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -107,6 +107,8 @@ type VerticalPodAutoscalerSpec struct {
 	// recommendation) or contain exactly one recommender.
 	// +optional
 	Recommenders []*VerticalPodAutoscalerRecommenderSelector `json:"recommenders,omitempty" protobuf:"bytes,4,opt,name=recommenders"`
+
+	Scope string `json:"scope,omitempty" protobuf:"bytes,5,opt,name=scope"`
 }
 
 // EvictionChangeRequirement refers to the relationship between the new target recommendation for a Pod and its current requests, what kind of change is necessary for the Pod to be evicted
@@ -298,6 +300,9 @@ type RecommendedContainerResources struct {
 	// Used only as status indication, will not affect actual resource assignment.
 	// +optional
 	UncappedTarget v1.ResourceList `json:"uncappedTarget,omitempty" protobuf:"bytes,5,opt,name=uncappedTarget"`
+	// When running VPA for finer-grained scope than a workload, e.g. per-node.
+	// +optional
+	Scope string `json:"scope,omitempty" protobuf:"bytes,5,opt,name=scope"`
 }
 
 // VerticalPodAutoscalerConditionType are the valid conditions of

--- a/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go
@@ -73,6 +73,9 @@ func (client *specClient) GetPodSpecs() ([]*BasicPodSpec, error) {
 	}
 	for _, pod := range pods {
 		basicPodSpec := newBasicPodSpec(pod)
+		if pod.Spec.NodeName != "" {
+			basicPodSpec.PodLabels["__internal_node"] = pod.Spec.NodeName
+		}
 		podSpecs = append(podSpecs, basicPodSpec)
 	}
 	return podSpecs, nil

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -210,6 +210,11 @@ func (vpa *Vpa) AggregateStateByContainerName() ContainerNameToAggregateStateMap
 	return containerNameToAggregateStateMap
 }
 
+func (vpa *Vpa) AggregateStateByNodeAndContainerName() map[string]ContainerNameToAggregateStateMap {
+	result := AggregateStateByNodeAndContainerName(vpa.aggregateContainerStates)
+	return result
+}
+
 // HasRecommendation returns if the VPA object contains any recommendation
 func (vpa *Vpa) HasRecommendation() bool {
 	return (vpa.Recommendation != nil) && len(vpa.Recommendation.ContainerRecommendations) > 0


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

/kind api-change

#### What this PR does / why we need it:

This is a very early draft in pursuit of [AEP-7942](https://github.com/kubernetes/autoscaler/pull/7942).

Adds an optional field `scope` on the VPA object, to let the VPA components generate and update more fine-grained recommendations.

Only one value of `scope` is implemented by this PR: `node`.
If this is set, record the node name as an extra label on each pod, then extract it when writing the recommendation.
Inside the admission-controller we recognize which node the pod will run on by unpacking nodeAffinity.

#### Special notes for your reviewer:

The change to `version.go` is intended as temporary while testing, not intended to be merged.

#### Does this PR introduce a user-facing change?
```release-note
Adds an optional field `scope` on the VPA object, to let the VPA components generate and update more fine-grained recommendations. See AEP-7942.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

[AEP-7942](https://github.com/kubernetes/autoscaler/pull/7942)

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
