### PR TITLE
Parametrize pod resize timeouts in AEP-4016 beta

### DIFF
--- a/vertical-pod-autoscaler/enhancements/4016-in-place-updates-support/README.md
+++ b/vertical-pod-autoscaler/enhancements/4016-in-place-updates-support/README.md
@@ -168,10 +168,16 @@ be prevented anyway.
 
 VPA updater will consider that the update failed if:
 * The pod has condition `PodResizePending` with reason `Infeasible` or
-* The pod has condition `PodResizePending` with reason `Deferred` and more than 5 minutes elapsed
-  since the update or
-* The pod has condition `PodResizeInProgress` and more than 1 hour elapsed since
-  the update or
+* The pod has condition `PodResizePending` with reason `Deferred` and:
+  * **In the initial alpha implementation:** more than 5 minutes elapsed since
+    the update or
+  * **Eventually in the alpha stage:** more than
+    `--in-place-deferred-resize-timeout` elapsed since the update or
+* The pod has condition `PodResizeInProgress` and:
+  * **In the initial alpha implementation:** more than 1 hour elapsed since the
+    update or
+  * **Eventually in the alpha stage:** more than `--in-place-resize-timeout`
+    elapsed since the update or
 * Patch attempt returns an error.
 
 Note that in the initial version of In-Place updates, memory limit downscaling will always fail
@@ -314,3 +320,4 @@ Needs more research on how to scale down on memory safely.
 - 2025-02-19: Updates to align with latest changes to [KEP-1287](https://github.com/kubernetes/enhancements/issues/1287).
 - 2025-03-06: Scope changes to "partial updates" feature
 - 2025-03-08: Add "Upgrade / Downgrade Strategy" and "Kubernetes version compatibility" sections
+- 2025-03-27: Add flags to control the in-place resize timeouts


### PR DESCRIPTION
#### What type of PR is this?


/kind documentation

#### What this PR does / why we need it:

Introduce two new flags, `--in-place-deferred-resize-timeout` and `--in-place-resize-timeout`, to replace the hardcoded 5-minute and 1-hour timeouts used in in-place pod resizing operations.

The hardcoded values were picked arbitrarily, but VPA users should have the option to configure them. 

For example, in place resizes can[ have a ](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources#container-resize-policy)Deferred[ condition](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources#container-resize-policy) when "the proposed resize is feasible in theory (it fits on this node) but is not possible right now; it will be regularly reevaluated."

VPA users should have the option to not wait for the hardcoded 5 minutes if they are not expecting to evict other pods to make space for the new resized pod or also wait longer if they have cluster autoscaler on and want to wait longer than 5 minutes until a new node is brought up and some of the pods get rescheduled onto a different node to make space for the pod being resized.
