### PR TITLE
chore(vpa): update api-docs script

### DIFF
--- a/vertical-pod-autoscaler/hack/generate-api-docs.sh
+++ b/vertical-pod-autoscaler/hack/generate-api-docs.sh
@@ -31,15 +31,15 @@ trap cleanup EXIT
 if [[ -z $(which crd-ref-docs) ]]; then
     (
         cd $WORKSPACE
-	      go install github.com/elastic/crd-ref-docs@latest
+        go install github.com/elastic/crd-ref-docs@latest
     )
-    CONTROLLER_GEN=${GOBIN:-$(go env GOPATH)/bin}/crd-ref-docs
+    export CONTROLLER_GEN=${GOBIN:-$(go env GOPATH)/bin}/crd-ref-docs
 else
-    CONTROLLER_GEN=$(which crd-ref-docs)
+    export CONTROLLER_GEN=$(which crd-ref-docs)
 fi
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
-crd-ref-docs \
+$CONTROLLER_GEN \
     --source-path=pkg/apis/ \
     --config=./hack/api-docs/config.yaml \
     --renderer=markdown \


### PR DESCRIPTION
PR updates the generate-api-docs script for VPA.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Executing the generate scripts locally fails as the reference to crd-ref-docs is not provided in the script

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
