### PR TITLE
Add omerap12 to VPA approvers

### DIFF
--- a/vertical-pod-autoscaler/OWNERS
+++ b/vertical-pod-autoscaler/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - voelzmo
 - raywainman
 - adrianmoisey
+- omerap12
 reviewers:
 - kwiesmueller
 - jbartosik


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I would like to propose joining the list of folks who can approve PRs in the vertical-pod-autoscaler subdirectory. I meet [all requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#approver):
- Added as reviewer on Jan 3th, 2025 (#7643)
- PRs authored: [PRs](https://github.com/kubernetes/autoscaler/pulls?q=is:pr+author:omerap12+label:area/vertical-pod-autoscaler+)
- PRs reviewed: [PRs](https://github.com/kubernetes/autoscaler/pulls?q=is:pr+assignee:omerap12+label:area/vertical-pod-autoscaler+)
- Issues authored: [Issues](https://github.com/kubernetes/autoscaler/issues?q=is:issue%20author:omerap12)

Familiar with codebase as I interact with it on a daily basis.
Also active on Slack answering questions and in SIG meetings.

/assign @gjtempleton @raywainman @adrianmoisey 
