### PR TITLE
Make VPA and Checkpoint updates concurrent

### DIFF
--- a/vertical-pod-autoscaler/common/flags.go
+++ b/vertical-pod-autoscaler/common/flags.go
@@ -39,8 +39,8 @@ type CommonFlags struct {
 func InitCommonFlags() *CommonFlags {
 	cf := &CommonFlags{}
 	flag.StringVar(&cf.KubeConfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	flag.Float64Var(&cf.KubeApiQps, "kube-api-qps", 5.0, "QPS limit when making requests to Kubernetes apiserver")
-	flag.Float64Var(&cf.KubeApiBurst, "kube-api-burst", 10.0, "QPS burst limit when making requests to Kubernetes apiserver")
+	flag.Float64Var(&cf.KubeApiQps, "kube-api-qps", 50.0, "QPS limit when making requests to Kubernetes apiserver")
+	flag.Float64Var(&cf.KubeApiBurst, "kube-api-burst", 100.0, "QPS burst limit when making requests to Kubernetes apiserver")
 	flag.BoolVar(&cf.EnableProfiling, "profiling", false, "Is debug/pprof endpoint enabled")
 	flag.StringVar(&cf.VpaObjectNamespace, "vpa-object-namespace", apiv1.NamespaceAll, "Specifies the namespace to search for VPA objects. Leave empty to include all namespaces. If provided, the garbage collector will only clean this namespace.")
 	flag.StringVar(&cf.IgnoredVpaObjectNamespaces, "ignored-vpa-object-namespaces", "", "A comma-separated list of namespaces to ignore when searching for VPA objects. Leave empty to avoid ignoring any namespaces. These namespaces will not be cleaned by the garbage collector.")

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -15,8 +15,8 @@ This document is auto-generated from the flag definitions in the VPA admission-c
 | `--alsologtostderr` |  |                        log to standard error as well as files (no effect when -logtostderr=true) |
 | `--client-ca-file` | "/etc/tls-certs/caCert.pem" |                  Path to CA PEM file. |
 | `--ignored-vpa-object-namespaces` |  |   A comma-separated list of namespaces to ignore when searching for VPA objects. Leave empty to avoid ignoring any namespaces. These namespaces will not be cleaned by the garbage collector. |
-| `--kube-api-burst` | 10 |                   QPS burst limit when making requests to Kubernetes apiserver |
-| `--kube-api-qps` | 5 |                     QPS limit when making requests to Kubernetes apiserver |
+| `--kube-api-burst` | 100 |                   QPS burst limit when making requests to Kubernetes apiserver |
+| `--kube-api-qps` | 50 |                     QPS limit when making requests to Kubernetes apiserver |
 | `--kubeconfig` |  |                      Path to a kubeconfig. Only required if out-of-cluster. |
 | `--log-backtrace-at` | :0 |         when logging hits line file:N, emit a stack trace |
 | `--log-dir` |  |                         If non-empty, write log files in this directory (no effect when -logtostderr=true) |
@@ -71,8 +71,8 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `--history-resolution` | "1h" |                              Resolution at which Prometheus is queried for historical metrics |
 | `--humanize-memory` |  |                                        Convert memory values in recommendations to the highest appropriate SI unit with up to 2 decimal places for better readability. |
 | `--ignored-vpa-object-namespaces` |  |                   A comma-separated list of namespaces to ignore when searching for VPA objects. Leave empty to avoid ignoring any namespaces. These namespaces will not be cleaned by the garbage collector. |
-| `--kube-api-burst` | 10 |                                   QPS burst limit when making requests to Kubernetes apiserver |
-| `--kube-api-qps` | 5 |                                     QPS limit when making requests to Kubernetes apiserver |
+| `--kube-api-burst` | 100 |                                   QPS burst limit when making requests to Kubernetes apiserver |
+| `--kube-api-qps` | 50 |                                     QPS limit when making requests to Kubernetes apiserver |
 | `--kubeconfig` |  |                                      Path to a kubeconfig. Only required if out-of-cluster. |
 | `--leader-elect` |  |                                           Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. |
 | `--leader-elect-lease-duration` | 15s |                   The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. |
@@ -119,6 +119,7 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `--storage` |  |                                         Specifies storage mode. Supported values: prometheus, checkpoint |
 | `--target-cpu-percentile` | 0.9 |                            CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations. |
 | `--target-memory-percentile` | 0.9 |                         Memory usage percentile that will be used as a base for memory target recommendation. Doesn't affect memory lower bound nor memory upper bound. |
+| `--update-worker-count` | 10 |                       Number of concurrent workers to update VPA recommendations and checkpoints. When increasing this setting, make sure the client-side rate limits (kube-api-qps and `kube-api-burst`) are either increased or turned off as well. |
 | `--use-external-metrics` |  |                                   ALPHA.  Use an external metrics provider instead of metrics_server. |
 | `--username` |  |                                        The username used in the prometheus server basic auth |
 | `--v` | 4 | Set the log level verbosity |
@@ -139,8 +140,8 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `--eviction-tolerance` | 0.5 |                                        Fraction of replica count that can be evicted for update, if more than one pod can be evicted. |
 | `--ignored-vpa-object-namespaces` |  |                            A comma-separated list of namespaces to ignore when searching for VPA objects. Leave empty to avoid ignoring any namespaces. These namespaces will not be cleaned by the garbage collector. |
 | `--in-recommendation-bounds-eviction-lifetime-threshold` | 12h0m0s |   Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range |
-| `--kube-api-burst` | 10 |                                            QPS burst limit when making requests to Kubernetes apiserver |
-| `--kube-api-qps` | 5 |                                              QPS limit when making requests to Kubernetes apiserver |
+| `--kube-api-burst` | 100 |                                            QPS burst limit when making requests to Kubernetes apiserver |
+| `--kube-api-qps` | 50 |                                              QPS limit when making requests to Kubernetes apiserver |
 | `--kubeconfig` |  |                                               Path to a kubeconfig. Only required if out-of-cluster. |
 | `--leader-elect` |  |                                                    Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. |
 | `--leader-elect-lease-duration` | 15s |                            The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. |

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -91,7 +91,7 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `--memory-histogram-decay-half-life` | 24h0m0s |              The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period. |
 | `--memory-saver` |  |                                           If true, only track pods which have an associated VPA |
 | `--metric-for-pod-labels` | "up{job=\"kubernetes-pods\"}" |                           Which metric to look for pod labels in metrics |
-| `--min-checkpoints` | 10 |                                    Minimum number of checkpoints to write per recommender's main loop |
+| `--min-checkpoints` | 10 |                                    Minimum number of checkpoints to write per recommender's main loop. WARNING: this flag is deprecated and doesn't have any effect. It will be removed in a future release. Refer to update-worker-count to influence the minimum number of checkpoints written per loop. |
 | `--one-output` |  |                                             If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true) |
 | `--oom-bump-up-ratio` | 1.2 |                                The memory bump up ratio when OOM occurred, default is 1.2. |
 | `--oom-min-bump-up-bytes` | 1.048576e+08 |                            The minimal increase of memory when OOM occurred in bytes, default is 100 * 1024 * 1024 |
@@ -119,7 +119,7 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `--storage` |  |                                         Specifies storage mode. Supported values: prometheus, checkpoint |
 | `--target-cpu-percentile` | 0.9 |                            CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations. |
 | `--target-memory-percentile` | 0.9 |                         Memory usage percentile that will be used as a base for memory target recommendation. Doesn't affect memory lower bound nor memory upper bound. |
-| `--update-worker-count` | 10 |                       Number of concurrent workers to update VPA recommendations and checkpoints. When increasing this setting, make sure the client-side rate limits (kube-api-qps and `kube-api-burst`) are either increased or turned off as well. |
+| `--update-worker-count` | 10 |                       Number of concurrent workers to update VPA recommendations and checkpoints. When increasing this setting, make sure the client-side rate limits (kube-api-qps and `kube-api-burst`) are either increased or turned off as well. Determines the minimum number of VPA checkpoints written per recommender loop. |
 | `--use-external-metrics` |  |                                   ALPHA.  Use an external metrics provider instead of metrics_server. |
 | `--username` |  |                                        The username used in the prometheus server basic auth |
 | `--v` | 4 | Set the log level verbosity |

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -36,9 +36,9 @@ import (
 // CheckpointWriter persistently stores aggregated historical usage of containers
 // controlled by VPA objects. This state can be restored to initialize the model after restart.
 type CheckpointWriter interface {
-	// StoreCheckpoints writes at least minCheckpoints if there are more checkpoints to write.
+	// StoreCheckpoints writes checkpoints for at least `concurrentWorkers` number of VPAs.
 	// Checkpoints are written until ctx permits or all checkpoints are written.
-	StoreCheckpoints(ctx context.Context, minCheckpoints int, concurrentWorkers int)
+	StoreCheckpoints(ctx context.Context, concurrentWorkers int)
 }
 
 type checkpointWriter struct {
@@ -77,8 +77,7 @@ func getVpasToCheckpoint(clusterVpas map[model.VpaID]*model.Vpa) []*model.Vpa {
 	return vpas
 }
 
-func processCheckpointUpdateForVPA(vpa *model.Vpa, writer *checkpointWriter) int {
-	checkpointsWritten := 0
+func processCheckpointUpdateForVPA(vpa *model.Vpa, writer *checkpointWriter) {
 	now := time.Now()
 	aggregateContainerStateMap := buildAggregateContainerStateMap(vpa, writer.cluster, now)
 	for container, aggregatedContainerState := range aggregateContainerStateMap {
@@ -103,54 +102,29 @@ func processCheckpointUpdateForVPA(vpa *model.Vpa, writer *checkpointWriter) int
 			klog.V(3).InfoS("Saved checkpoint for VPA", "vpa", klog.KRef(vpa.ID.Namespace, vpaCheckpoint.Spec.VPAObjectName), "container", vpaCheckpoint.Spec.ContainerName)
 			vpa.CheckpointWritten = now
 		}
-		checkpointsWritten++
 	}
-	return checkpointsWritten
 }
 
-func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, minCheckpoints int, concurrentWorkers int) {
+func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, concurrentWorkers int) {
 	vpas := getVpasToCheckpoint(writer.cluster.VPAs())
 
 	// Create a channel to send VPA updates to workers
 	vpaCheckpointUpdates := make(chan *model.Vpa, len(vpas))
 
-	// Create a channel to receive the number of checkpoints written
-	checkpointCounterChannel := make(chan int, len(vpas))
-	defer close(checkpointCounterChannel)
-
-	// Create a separate context for the workers. We don't simply pass the outside context,
-	// but want to only cancel the workerCtx if minCheckpoints has been reached already.
-	workerCtx, cancelWorkers := context.WithCancel(context.Background())
-
-	go func() {
-		for updatedCheckpointsCounter := range checkpointCounterChannel {
-			minCheckpoints -= updatedCheckpointsCounter
-			select {
-			case <-ctx.Done():
-				if minCheckpoints <= 0 {
-					klog.V(0).InfoS("Failed to store all checkpoints within the configured `checkpoints-timeout`", "err", ctx.Err())
-					cancelWorkers()
-					return
-				}
-			default:
-			}
-		}
-	}()
-
 	// Create a wait group to wait for all workers to finish
 	var wg sync.WaitGroup
-	// Start workers
+	// Start workers. Each worker processes at least one checkpoint before checking for a cancelled context.
 	for i := 0; i < concurrentWorkers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for vpaToCheckpoint := range vpaCheckpointUpdates {
+				processCheckpointUpdateForVPA(vpaToCheckpoint, writer)
 				select {
-				case <-workerCtx.Done():
+				case <-ctx.Done():
 					return
 				default:
 				}
-				checkpointCounterChannel <- processCheckpointUpdateForVPA(vpaToCheckpoint, writer)
 			}
 		}()
 	}
@@ -165,6 +139,10 @@ func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, minCheckpo
 
 	// Wait for all workers to finish
 	wg.Wait()
+
+	if ctx.Err() != nil {
+		klog.V(0).InfoS("Failed to store all checkpoints within the configured `checkpoints-timeout`", "err", ctx.Err())
+	}
 }
 
 // Build the AggregateContainerState for the purpose of the checkpoint. This is an aggregation of state of all

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -120,7 +120,7 @@ func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, minCheckpo
 
 	// Create a separate context for the workers. We don't simply pass the outside context,
 	// but want to only cancel the workerCtx if minCheckpoints has been reached already.
-	workerCtx, cancelWorkers := context.WithCancel(ctx)
+	workerCtx, cancelWorkers := context.WithCancel(context.Background())
 
 	go func() {
 		for updatedCheckpointsCounter := range checkpointCounterChannel {

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -128,7 +128,7 @@ func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, minCheckpo
 			select {
 			case <-ctx.Done():
 				if minCheckpoints <= 0 {
-					klog.V(0).InfoS("Failed to store checkpoints", "err", ctx.Err())
+					klog.V(0).InfoS("Failed to store all checkpoints within the configured `checkpoints-timeout`", "err", ctx.Err())
 					cancelWorkers()
 					return
 				}

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -140,7 +140,7 @@ func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, minCheckpo
 	// Create a wait group to wait for all workers to finish
 	var wg sync.WaitGroup
 	// Start workers
-	for i := 0; i < 10; i++ {
+	for i := 0; i < concurrentWorkers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -37,7 +37,7 @@ import (
 type CheckpointWriter interface {
 	// StoreCheckpoints writes at least minCheckpoints if there are more checkpoints to write.
 	// Checkpoints are written until ctx permits or all checkpoints are written.
-	StoreCheckpoints(ctx context.Context, now time.Time, minCheckpoints int) error
+	StoreCheckpoints(ctx context.Context, minCheckpoints int) error
 }
 
 type checkpointWriter struct {
@@ -76,7 +76,7 @@ func getVpasToCheckpoint(clusterVpas map[model.VpaID]*model.Vpa) []*model.Vpa {
 	return vpas
 }
 
-func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, now time.Time, minCheckpoints int) error {
+func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, minCheckpoints int) error {
 	vpas := getVpasToCheckpoint(writer.cluster.VPAs())
 	for _, vpa := range vpas {
 
@@ -91,13 +91,14 @@ func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, now time.T
 			return ctx.Err()
 		}
 
-		processCheckpointUpdateForVPA(vpa, writer, now)
+		processCheckpointUpdateForVPA(vpa, writer)
 		minCheckpoints--
 	}
 	return nil
 }
 
-func processCheckpointUpdateForVPA(vpa *model.Vpa, writer *checkpointWriter, now time.Time) {
+func processCheckpointUpdateForVPA(vpa *model.Vpa, writer *checkpointWriter) {
+	now := time.Now()
 	aggregateContainerStateMap := buildAggregateContainerStateMap(vpa, writer.cluster, now)
 	for container, aggregatedContainerState := range aggregateContainerStateMap {
 		containerCheckpoint, err := aggregatedContainerState.SaveToCheckpoint()

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
@@ -29,13 +29,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
+	klogtest "k8s.io/klog/v2/test"
+
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	fakeautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/fake"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
-	core "k8s.io/client-go/testing"
-	"k8s.io/klog/v2"
-	klogtest "k8s.io/klog/v2/test"
 )
 
 // TODO: Extract these constants to a common test module.

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -63,7 +63,7 @@ var (
 	address                = flag.String("address", ":8942", "The address to expose Prometheus metrics.")
 	storage                = flag.String("storage", "", `Specifies storage mode. Supported values: prometheus, checkpoint (default)`)
 	memorySaver            = flag.Bool("memory-saver", false, `If true, only track pods which have an associated VPA`)
-	updateWorkerCount      = flag.Int("update-worker-count", 10, "Number of concurrent workers to update VPA recommendations and checkpoints. When increasing this setting, make sure the client-side rate limits (`kube-api-qps` and `kube-api-burst`) are either increased or turned off as well.")
+	updateWorkerCount      = flag.Int("update-worker-count", 10, "Number of concurrent workers to update VPA recommendations and checkpoints. When increasing this setting, make sure the client-side rate limits (`kube-api-qps` and `kube-api-burst`) are either increased or turned off as well. Determines the minimum number of VPA checkpoints written per recommender loop.")
 )
 
 // Prometheus history provider flags
@@ -139,6 +139,11 @@ func main() {
 		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
 		os.Exit(255)
 	}
+
+	if *routines.MinCheckpointsPerRun != 10 { // Default value is 10
+		klog.InfoS("DEPRECATION WARNING: The 'min-checkpoints' flag is deprecated and has no effect. It will be removed in a future release.")
+	}
+
 	ctx := context.Background()
 
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval * 5)

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -63,7 +63,7 @@ var (
 	address                = flag.String("address", ":8942", "The address to expose Prometheus metrics.")
 	storage                = flag.String("storage", "", `Specifies storage mode. Supported values: prometheus, checkpoint (default)`)
 	memorySaver            = flag.Bool("memory-saver", false, `If true, only track pods which have an associated VPA`)
-	updateWorkerCount      = flag.Int("update-worker-count", 10, "Number of concurrent workers to update VPA recommendations and checkpoints")
+	updateWorkerCount      = flag.Int("update-worker-count", 10, "Number of concurrent workers to update VPA recommendations and checkpoints. When increasing this setting, make sure the client-side rate limits (`kube-api-qps` and `kube-api-burst`) are either increased or turned off as well.")
 )
 
 // Prometheus history provider flags

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -63,6 +63,7 @@ var (
 	address                = flag.String("address", ":8942", "The address to expose Prometheus metrics.")
 	storage                = flag.String("storage", "", `Specifies storage mode. Supported values: prometheus, checkpoint (default)`)
 	memorySaver            = flag.Bool("memory-saver", false, `If true, only track pods which have an associated VPA`)
+	updateWorkerCount      = flag.Int("update-worker-count", 10, "Number of concurrent workers to update VPA recommendations and checkpoints")
 )
 
 // Prometheus history provider flags
@@ -279,6 +280,7 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 		RecommendationPostProcessors: postProcessors,
 		CheckpointsGCInterval:        *checkpointsGCInterval,
 		UseCheckpoints:               useCheckpoints,
+		UpdateWorkerCount:            *updateWorkerCount,
 	}.Make()
 
 	promQueryTimeout, err := time.ParseDuration(*queryTimeout)

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -161,13 +161,12 @@ func (r *recommender) UpdateVPAs() {
 }
 
 func (r *recommender) MaintainCheckpoints(ctx context.Context, minCheckpointsPerRun int) {
-	now := time.Now()
 	if r.useCheckpoints {
-		if err := r.checkpointWriter.StoreCheckpoints(ctx, now, minCheckpointsPerRun); err != nil {
+		if err := r.checkpointWriter.StoreCheckpoints(ctx, minCheckpointsPerRun); err != nil {
 			klog.V(0).InfoS("Failed to store checkpoints", "err", err)
 		}
 		if time.Since(r.lastCheckpointGC) > r.checkpointsGCInterval {
-			r.lastCheckpointGC = now
+			r.lastCheckpointGC = time.Now()
 			r.clusterStateFeeder.GarbageCollectCheckpoints(ctx)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Introduce a worker pool for updates to VPA status and VPACheckpoints, such that vpa-recommender can deal with large-scale systems. In the current implementation updates are executed sequentially, which means that at some point the latency from vpa-recommender to kubernetes-apiserver will become the limiting factor for updates per second.

This PR introduces a new parameter, `--update-worker-count`, defaulting to `10`, which determines the size of the worker pool. This can be used to control the load on the kubernetes-apiserver.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Closes #7951
Inspired by https://github.com/kubernetes/autoscaler/compare/master...tkukushkin:autoscaler:parallel-updates
Thanks @tkukushkin!


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
BREAKING: deprecated recommender flag `min-checkpoints`, progress is now ensured by the new `update-worker-count` flag. This flag will be removed in a later release.
FEATURE: Make updates to VPA status and VPACheckpoints concurrent to perform better in clusters with a large amount of VPAs.
Added new flag `update-worker-count` to the recommender to control the amount of concurrent workers for VPA and VPACheckpoint updates.
Increased defaults for client-side rate limits to `kube-api-qps=50.0` and `kube-api-burst=100.0` such that the settings make sense together with the default `update-worker-count=10`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
