### PR TITLE
docs(autoscaler): add details about flags

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -79,6 +79,12 @@ in the staging namespace, belonging to the purple cluster, with the label owner=
 
 ## Connecting cluster-autoscaler to Cluster API management and workload Clusters
 
+> [!IMPORTANT]
+> `--cloud-config` is the flag to configure the cloud provider. Here the cloud provider is "Cluster API".
+
+> [!IMPORTANT]
+> `--kubeconfig` is the flag to configure the cluster to watch for the need of autoscaling.
+
 You will also need to provide the path to the kubeconfig(s) for the management
 and workload cluster you wish cluster-autoscaler to run against. To specify the
 kubeconfig path for the workload cluster to monitor, use the `--kubeconfig`

--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -83,7 +83,7 @@ in the staging namespace, belonging to the purple cluster, with the label owner=
 > `--cloud-config` is the flag for specifying a mount volume path to the kubernetes configuration (ie KUBECONFIG) to the cluster-autoscaler for communicating with the cluster-api management cluster for the purpose of scaling machines.
 
 > [!IMPORTANT]
-> `--kubeconfig` is the flag to configure the cluster to watch for the need of autoscaling.
+> ``--kubeconfig` is the flag for specifying a mount volume  path to the kubernetes configuration (ie KUBECONFIG) to the cluster-autoscaler for communicating with the cluster-api workload cluster for the purpose of watching Nodes and Pods. This flag can be affected by the desired topology for deploying the cluster-autoscaler, please see the diagrams below for more information.
 
 You will also need to provide the path to the kubeconfig(s) for the management
 and workload cluster you wish cluster-autoscaler to run against. To specify the

--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -80,7 +80,7 @@ in the staging namespace, belonging to the purple cluster, with the label owner=
 ## Connecting cluster-autoscaler to Cluster API management and workload Clusters
 
 > [!IMPORTANT]
-> `--cloud-config` is the flag to configure the cloud provider. Here the cloud provider is "Cluster API".
+> `--cloud-config` is the flag for specifying a mount volume path to the kubernetes configuration (ie KUBECONFIG) to the cluster-autoscaler for communicating with the cluster-api management cluster for the purpose of scaling machines.
 
 > [!IMPORTANT]
 > `--kubeconfig` is the flag to configure the cluster to watch for the need of autoscaling.


### PR DESCRIPTION
It is currently slightly confusing if you skim through the documentation.

For instance, see the discussion here:
https://github.com/kubernetes/autoscaler/pull/7974

I hope that by adding these 2 Important section the reader would be warned about the key difference, and need for these 2 options.

#### What type of PR is this?

/kind documentation
