### PR TITLE
Also consider containerStatus.resources when handling container resources

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -520,17 +520,17 @@ func TestGetContainersResources(t *testing.T) {
 			addAll:           false,
 		},
 		{
-			name:      "Memory only recommendation, request and limits only set in containerStatus, addAll true",
+			name:      "CPU and memory recommendation, request and limits only set in containerStatus, addAll true",
 			container: test.Container().WithName("container").Get(),
 			containerStatus: test.ContainerStatus().WithName("container").
-				WithCPURequest(resource.MustParse("1m")).
+				WithCPURequest(resource.MustParse("1")).
 				WithMemRequest(resource.MustParse("1M")).
-				WithCPULimit(resource.MustParse("40m")).
+				WithCPULimit(resource.MustParse("10")).
 				WithMemLimit(resource.MustParse("3M")).Get(),
-			vpa:              test.VerticalPodAutoscaler().WithContainer("container").WithTargetResource(apiv1.ResourceMemory, "2M").Get(),
-			expectedCPU:      mustParseResourcePointer("1m"),
+			vpa:              test.VerticalPodAutoscaler().WithContainer("container").WithTarget("3", "2M").Get(),
+			expectedCPU:      mustParseResourcePointer("3"),
 			expectedMem:      mustParseResourcePointer("2M"),
-			expectedCPULimit: mustParseResourcePointer("40m"),
+			expectedCPULimit: mustParseResourcePointer("30"),
 			expectedMemLimit: mustParseResourcePointer("6M"),
 			addAll:           true,
 		},

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -365,6 +365,7 @@ func TestGetContainersResources(t *testing.T) {
 	testCases := []struct {
 		name             string
 		container        apiv1.Container
+		containerStatus  apiv1.ContainerStatus
 		vpa              *vpa_types.VerticalPodAutoscaler
 		expectedCPU      *resource.Quantity
 		expectedMem      *resource.Quantity
@@ -518,11 +519,26 @@ func TestGetContainersResources(t *testing.T) {
 			expectedMemLimit: mustParseResourcePointer("20M"),
 			addAll:           false,
 		},
+		{
+			name:      "Memory only recommendation, request and limits only set in containerStatus, addAll true",
+			container: test.Container().WithName("container").Get(),
+			containerStatus: test.ContainerStatus().WithName("container").
+				WithCPURequest(resource.MustParse("1m")).
+				WithMemRequest(resource.MustParse("1M")).
+				WithCPULimit(resource.MustParse("40m")).
+				WithMemLimit(resource.MustParse("3M")).Get(),
+			vpa:              test.VerticalPodAutoscaler().WithContainer("container").WithTargetResource(apiv1.ResourceMemory, "2M").Get(),
+			expectedCPU:      mustParseResourcePointer("1m"),
+			expectedMem:      mustParseResourcePointer("2M"),
+			expectedCPULimit: mustParseResourcePointer("40m"),
+			expectedMemLimit: mustParseResourcePointer("6M"),
+			addAll:           true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pod := test.Pod().WithName("pod").AddContainer(tc.container).Get()
+			pod := test.Pod().WithName("pod").AddContainer(tc.container).AddContainerStatus(tc.containerStatus).Get()
 			resources := GetContainersResources(pod, tc.vpa.Spec.ResourcePolicy, *tc.vpa.Status.Recommendation, nil, tc.addAll, vpa_api_util.ContainerToAnnotationsMap{})
 
 			cpu, cpuPresent := resources[0].Requests[apiv1.ResourceCPU]

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
@@ -24,6 +24,7 @@ import (
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+	resourcehelpers "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/resources"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
@@ -65,7 +66,8 @@ func (*defaultPriorityProcessor) GetUpdatePriority(pod *apiv1.Pod, vpa *vpa_type
 			totalRecommendedPerResource[resourceName] += recommended.MilliValue()
 			lowerBound, hasLowerBound := recommendedRequest.LowerBound[resourceName]
 			upperBound, hasUpperBound := recommendedRequest.UpperBound[resourceName]
-			if request, hasRequest := podContainer.Resources.Requests[resourceName]; hasRequest {
+			requests, _ := resourcehelpers.ContainerRequestsAndLimits(podContainer.Name, pod)
+			if request, hasRequest := requests[resourceName]; hasRequest {
 				totalRequestPerResource[resourceName] += request.MilliValue()
 				if recommended.MilliValue() > request.MilliValue() {
 					scaleUp = true

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
@@ -47,6 +47,16 @@ func TestGetUpdatePriority(t *testing.T) {
 				ScaleUp:                 true,
 			},
 		}, {
+			name: "simple scale up, resources from containerStatus have higher priority",
+			pod: test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("10000")).Get()).
+				AddContainerStatus(test.ContainerStatus().WithName(containerName).WithCPURequest(resource.MustParse("2")).Get()).Get(),
+			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("10", "").Get(),
+			expectedPrio: PodPriority{
+				OutsideRecommendedRange: false,
+				ResourceDiff:            4.0,
+				ScaleUp:                 true,
+			},
+		}, {
 			name: "simple scale down",
 			pod:  test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("4")).Get()).Get(),
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "").Get(),

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
@@ -18,19 +18,24 @@ package resourcehelpers
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 )
 
 // ContainerRequestsAndLimits returns a copy of the actual resource requests and
 // limits of a given container:
-//   - If in-place pod updates feature is enabled, the actual resource requests
+//
+//   - If in-place pod updates feature [1] is enabled, the actual resource requests
 //     are stored in the container status field.
 //   - Otherwise, fallback to the resource requests defined in the pod spec.
+//
+// [1] https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
 func ContainerRequestsAndLimits(containerName string, pod *v1.Pod) (v1.ResourceList, v1.ResourceList) {
 	cs := containerStatusForContainer(containerName, pod)
 	if cs != nil && cs.Resources != nil {
 		return cs.Resources.Requests.DeepCopy(), cs.Resources.Limits.DeepCopy()
 	}
 
+	klog.V(6).InfoS("Container resources not found in containerStatus for container. Falling back to resources defined in the pod spec. This is expected for clusters with in-place pod updates feature disabled.", "container", containerName, "containerStatus", cs)
 	container := findContainer(containerName, pod)
 	if container != nil {
 		return container.Resources.Requests.DeepCopy(), container.Resources.Limits.DeepCopy()

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcehelpers
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// ContainerRequestsAndLimits returns a copy of the actual resource requests and
+// limits of a given container:
+//   - If in-place pod updates feature is enabled, the actual resource requests
+//     are stored in the container status field.
+//   - Otherwise, fallback to the resource requests defined in the pod spec.
+func ContainerRequestsAndLimits(containerName string, pod *v1.Pod) (v1.ResourceList, v1.ResourceList) {
+	cs := containerStatusForContainer(containerName, pod)
+	if cs != nil && cs.Resources != nil {
+		return cs.Resources.Requests.DeepCopy(), cs.Resources.Limits.DeepCopy()
+	}
+
+	container := findContainer(containerName, pod)
+	if container != nil {
+		return container.Resources.Requests.DeepCopy(), container.Resources.Limits.DeepCopy()
+	}
+
+	return nil, nil
+}
+
+func findContainer(containerName string, pod *v1.Pod) *v1.Container {
+	for i, container := range pod.Spec.Containers {
+		if container.Name == containerName {
+			return &pod.Spec.Containers[i]
+		}
+	}
+	return nil
+}
+
+func containerStatusForContainer(containerName string, pod *v1.Pod) *v1.ContainerStatus {
+	for i, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Name == containerName {
+			return &pod.Status.ContainerStatuses[i]
+		}
+	}
+	return nil
+}

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 )
 

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcehelpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+func TestContainerRequestsAndLimits(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		containerName string
+		pod           *apiv1.Pod
+		wantRequests  apiv1.ResourceList
+		wantLimits    apiv1.ResourceList
+	}{
+		{
+			desc:          "Prefer resource requests from container status",
+			containerName: "container",
+			pod: test.Pod().AddContainer(
+				test.Container().WithName("container").
+					WithCPURequest(resource.MustParse("1")).
+					WithMemRequest(resource.MustParse("10Mi")).
+					WithCPULimit(resource.MustParse("2")).
+					WithMemLimit(resource.MustParse("20Mi")).Get()).
+				AddContainerStatus(
+					test.ContainerStatus().WithName("container").
+						WithCPURequest(resource.MustParse("3")).
+						WithMemRequest(resource.MustParse("30Mi")).
+						WithCPULimit(resource.MustParse("4")).
+						WithMemLimit(resource.MustParse("40Mi")).Get()).Get(),
+			wantRequests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("3"),
+				apiv1.ResourceMemory: resource.MustParse("30Mi"),
+			},
+			wantLimits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("4"),
+				apiv1.ResourceMemory: resource.MustParse("40Mi"),
+			},
+		},
+		{
+			desc:          "No container status, get resources from pod spec",
+			containerName: "container",
+			pod: test.Pod().AddContainer(
+				test.Container().WithName("container").
+					WithCPURequest(resource.MustParse("1")).
+					WithMemRequest(resource.MustParse("10Mi")).
+					WithCPULimit(resource.MustParse("2")).
+					WithMemLimit(resource.MustParse("20Mi")).Get()).Get(),
+			wantRequests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("1"),
+				apiv1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+			wantLimits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("2"),
+				apiv1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+		},
+		{
+			desc:          "Only containerStatus, get resources from containerStatus",
+			containerName: "container",
+			pod: test.Pod().AddContainerStatus(
+				test.ContainerStatus().WithName("container").
+					WithCPURequest(resource.MustParse("0")).
+					WithMemRequest(resource.MustParse("30Mi")).
+					WithCPULimit(resource.MustParse("4")).
+					WithMemLimit(resource.MustParse("40Mi")).Get()).Get(),
+			wantRequests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("0"),
+				apiv1.ResourceMemory: resource.MustParse("30Mi"),
+			},
+			wantLimits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("4"),
+				apiv1.ResourceMemory: resource.MustParse("40Mi"),
+			},
+		},
+		{
+			desc:          "Inexistent container",
+			containerName: "inexistent-container",
+			pod: test.Pod().AddContainer(
+				test.Container().WithName("container").
+					WithCPURequest(resource.MustParse("1")).
+					WithMemRequest(resource.MustParse("10Mi")).
+					WithCPULimit(resource.MustParse("2")).
+					WithMemLimit(resource.MustParse("20Mi")).Get()).Get(),
+			wantRequests: nil,
+			wantLimits:   nil,
+		},
+		{
+			desc:          "Container with no requests or limits",
+			containerName: "inexistent-container",
+			pod:           test.Pod().AddContainer(test.Container().WithName("container").Get()).Get(),
+			wantRequests:  nil,
+			wantLimits:    nil,
+		},
+		{
+			desc:          "2 containers",
+			containerName: "container-1",
+			pod: test.Pod().AddContainer(
+				test.Container().WithName("container-1").
+					WithCPURequest(resource.MustParse("1")).
+					WithMemRequest(resource.MustParse("10Mi")).
+					WithCPULimit(resource.MustParse("2")).
+					WithMemLimit(resource.MustParse("20Mi")).Get()).
+				AddContainerStatus(
+					test.ContainerStatus().WithName("container-1").
+						WithCPURequest(resource.MustParse("3")).
+						WithMemRequest(resource.MustParse("30Mi")).
+						WithCPULimit(resource.MustParse("4")).
+						WithMemLimit(resource.MustParse("40Mi")).Get()).
+				AddContainer(
+					test.Container().WithName("container-2").
+						WithCPURequest(resource.MustParse("5")).
+						WithMemRequest(resource.MustParse("5Mi")).
+						WithCPULimit(resource.MustParse("5")).
+						WithMemLimit(resource.MustParse("5Mi")).Get()).
+				AddContainerStatus(
+					test.ContainerStatus().WithName("container-2").
+						WithCPURequest(resource.MustParse("5")).
+						WithMemRequest(resource.MustParse("5Mi")).
+						WithCPULimit(resource.MustParse("5")).
+						WithMemLimit(resource.MustParse("5Mi")).Get()).
+				Get(),
+			wantRequests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("3"),
+				apiv1.ResourceMemory: resource.MustParse("30Mi"),
+			},
+			wantLimits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("4"),
+				apiv1.ResourceMemory: resource.MustParse("40Mi"),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotRequests, gotLimits := ContainerRequestsAndLimits(tc.containerName, tc.pod)
+			assert.Equal(t, tc.wantRequests, gotRequests, "requests don't match")
+			assert.Equal(t, tc.wantLimits, gotLimits, "limits don't match")
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/test/test_containerstatus.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_containerstatus.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type containerStatusBuilder struct {
+	name       string
+	cpuRequest *resource.Quantity
+	memRequest *resource.Quantity
+	cpuLimit   *resource.Quantity
+	memLimit   *resource.Quantity
+}
+
+// Container returns object that helps build containers for tests.
+func ContainerStatus() *containerStatusBuilder {
+	return &containerStatusBuilder{}
+}
+
+func (cs *containerStatusBuilder) WithName(name string) *containerStatusBuilder {
+	r := *cs
+	r.name = name
+	return &r
+}
+
+func (cs *containerStatusBuilder) WithCPURequest(cpuRequest resource.Quantity) *containerStatusBuilder {
+	r := *cs
+	r.cpuRequest = &cpuRequest
+	return &r
+}
+
+func (cs *containerStatusBuilder) WithMemRequest(memRequest resource.Quantity) *containerStatusBuilder {
+	r := *cs
+	r.memRequest = &memRequest
+	return &r
+}
+
+func (cs *containerStatusBuilder) WithCPULimit(cpuLimit resource.Quantity) *containerStatusBuilder {
+	r := *cs
+	r.cpuLimit = &cpuLimit
+	return &r
+}
+
+func (cs *containerStatusBuilder) WithMemLimit(memLimit resource.Quantity) *containerStatusBuilder {
+	r := *cs
+	r.memLimit = &memLimit
+	return &r
+}
+
+func (cs *containerStatusBuilder) Get() apiv1.ContainerStatus {
+	containerStatus := apiv1.ContainerStatus{
+		Name: cs.name,
+		Resources: &apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{},
+			Limits:   apiv1.ResourceList{},
+		},
+	}
+	if cs.cpuRequest != nil {
+		containerStatus.Resources.Requests[apiv1.ResourceCPU] = *cs.cpuRequest
+	}
+	if cs.memRequest != nil {
+		containerStatus.Resources.Requests[apiv1.ResourceMemory] = *cs.memRequest
+	}
+	if cs.cpuLimit != nil {
+		containerStatus.Resources.Limits[apiv1.ResourceCPU] = *cs.cpuLimit
+	}
+	if cs.memLimit != nil {
+		containerStatus.Resources.Limits[apiv1.ResourceMemory] = *cs.memLimit
+	}
+	return containerStatus
+}

--- a/vertical-pod-autoscaler/pkg/utils/test/test_containerstatus.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_containerstatus.go
@@ -29,7 +29,7 @@ type containerStatusBuilder struct {
 	memLimit   *resource.Quantity
 }
 
-// Container returns object that helps build containers for tests.
+// ContainerStatus returns object that helps build containerStatus for tests.
 func ContainerStatus() *containerStatusBuilder {
 	return &containerStatusBuilder{}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a new helper package to read container resources in VPA and updates most usages to avoid reading the resources directly from `Pod.Spec.Containers[i].Resources`. 

This is needed because with [In-Place Update of Pod Resources feature](https://github.com/kubernetes/enhancements/issues/1287) (see [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources) for details), `Pod.Spec.Containers[i].Resources` may not contain the actual resources held by the pod and its containers (see https://github.com/kubernetes/autoscaler/issues/7971 for details).

#### Special notes for your reviewer:

There are still some places that need to be updated to use the new utility function. They also need to consider init containers. I'll fix them in a follow up PR.

#### Does this PR introduce a user-facing change?
Yes 

```release-note

Also consider containerStatus.resources when handling container resources in VPA:  first try to read the resource requests and limits from the container status field (`Pod.Status.ContainerStatuses[i].Resources`). Otherwise, fallback to the resource requests defined in the pod spec (`Pod.Spec.Containers[i].Resources`). 

```

