### PR TITLE
refactor: use GroupVersionKind for controller type validation

### DIFF
--- a/cluster-autoscaler/core/scaledown/planner/controller_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/controller_test.go
@@ -193,6 +193,26 @@ func TestReplicasCounter(t *testing.T) {
 			ownerRef:  ownerRef("Job", "j"),
 			expectErr: true,
 		},
+		{
+			name:      "statefulset with wrong api version",
+			ownerRef:  ownerRefWithVersion("StatefulSet", sS.Name, "apps/v1beta1"),
+			expectErr: true,
+		},
+		{
+			name:      "replicaset with wrong api version",
+			ownerRef:  ownerRefWithVersion("ReplicaSet", rs.Name, "apps/v1beta1"),
+			expectErr: true,
+		},
+		{
+			name:      "replicationcontroller with wrong api version",
+			ownerRef:  ownerRefWithVersion("ReplicationController", rC.Name, "apps/v1"),
+			expectErr: true,
+		},
+		{
+			name:      "job with wrong api version",
+			ownerRef:  ownerRefWithVersion("Job", job.Name, "batch/v1beta1"),
+			expectErr: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -220,11 +240,26 @@ func ownerRef(ownerType, ownerName string) metav1.OwnerReference {
 		api = "apps/v1"
 		strType = "statefulsets"
 	case "ReplicationController":
-		api = "core/v1"
+		api = "v1"
 		strType = "replicationcontrollers"
 	case "Job":
 		api = "batch/v1"
 		strType = "jobs"
 	}
 	return test.GenerateOwnerReferences(ownerName, ownerType, api, types.UID(fmt.Sprintf("%s/namespaces/default/%s/%s", api, strType, ownerName)))[0]
+}
+
+func ownerRefWithVersion(ownerType, ownerName, apiVersion string) metav1.OwnerReference {
+	strType := ""
+	switch ownerType {
+	case "ReplicaSet":
+		strType = "replicasets"
+	case "StatefulSet":
+		strType = "statefulsets"
+	case "ReplicationController":
+		strType = "replicationcontrollers"
+	case "Job":
+		strType = "jobs"
+	}
+	return test.GenerateOwnerReferences(ownerName, ownerType, apiVersion, types.UID(fmt.Sprintf("%s/namespaces/default/%s/%s", apiVersion, strType, ownerName)))[0]
 }


### PR DESCRIPTION
Replace string-based API version and kind validation with schema.GroupVersionKind for more robust and idiomatic Kubernetes API handling. This change:
- Uses `schema.ParseGroupVersion` to properly parse API versions
- Uses` GroupVersionKind` for type-safe comparison
- Fixes test to use correct `v1` API version for ReplicationController

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a bug where the controller replicas calculator could incorrectly handle controllers that reuse the same kind name with different API versions. For example, [OpenKruise's Advanced StatefulSet](https://openkruise.io/docs/user-manuals/advancedstatefulset) uses `apps.kruise.io/v1beta1` while reusing the StatefulSet kind name. The fix uses `schema.GroupVersionKind` for proper API version and kind validation.

Without this fix, with a kruise statefulset deployed, you'd end up getting these sorts of errors:
```
statefulset for my-namespace/my-app-0 is not available: err: statefulset.apps "my-app" not found
```

When it's more expected to fall down into the default case of "unhandled controller type".


#### Special notes for your reviewer:

The main change is in `core/scaledown/planner/controller.go` where we've replaced string-based API version and kind validation with `schema.GroupVersionKind`. The test fix in `controller_test.go` ensures we're using the correct API version for `ReplicationController`, as ironically the test case used the wrong version!

#### Does this PR introduce a user-facing change?
In my opinion, not a large enough one to warrant a release note. CAS was still error-ing out, just with an incorrect error message, so behavior does not change here, just a more descriptive error message when an invalid type is found.
