### PR TITLE
fix lint: update tests with context

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -600,11 +600,12 @@ type fakeMetricsClient struct {
 	snapshots []*metrics.ContainerMetricsSnapshot
 }
 
-func (m fakeMetricsClient) GetContainersMetrics() ([]*metrics.ContainerMetricsSnapshot, error) {
+func (m fakeMetricsClient) GetContainersMetrics(_ context.Context) ([]*metrics.ContainerMetricsSnapshot, error) {
 	return m.snapshots, nil
 }
 
 func TestClusterStateFeeder_LoadRealTimeMetrics(t *testing.T) {
+	_, tctx := ktesting.NewTestContext(t)
 	namespaceName := "test-namespace"
 	podID := model.PodID{Namespace: namespaceName, PodName: "Pod"}
 	regularContainer1 := model.ContainerID{PodID: podID, ContainerName: "Container1"}
@@ -639,7 +640,7 @@ func TestClusterStateFeeder_LoadRealTimeMetrics(t *testing.T) {
 		metricsClient:  fakeMetricsClient{snapshots: containerMetricsSnapshots},
 	}
 
-	feeder.LoadRealTimeMetrics()
+	feeder.LoadRealTimeMetrics(tctx)
 
 	assert.Equal(t, 2, len(clusterState.addedSamples))
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes:
```bash
pkg/recommender/input/cluster_feeder.go:1: : # k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input [k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input.test]
pkg/recommender/input/cluster_feeder_test.go:639:19: cannot use fakeMetricsClient{…} (value of struct type fakeMetricsClient) as "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/metrics".MetricsClient value in struct literal: fakeMetricsClient does not implement "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/metrics".MetricsClient (wrong type for method GetContainersMetrics)
		have GetContainersMetrics() ([]*"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/metrics".ContainerMetricsSnapshot, error)
		want GetContainersMetrics(context.Context) ([]*"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/metrics".ContainerMetricsSnapshot, error)
pkg/recommender/input/cluster_feeder_test.go:642:2: not enough arguments in call to feeder.LoadRealTimeMetrics
	have ()
	want (context.Context) (typecheck)
/*
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
