### PR TITLE
Allow draining when StatefulSet kind has custom API Group

### DIFF
--- a/cluster-autoscaler/simulator/drainability/rules/replicacount/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/replicacount/rule.go
@@ -111,6 +111,11 @@ func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod, _ 
 			return drainability.NewBlockedStatus(drain.ControllerNotFound, fmt.Errorf("replication controller for %s/%s is not available, err: %v", pod.Namespace, pod.Name, err))
 		}
 	} else if refKind == "StatefulSet" {
+		if refGroup.Group != "apps" {
+			// We don't have a listener for the other StatefulSet group.
+			return drainability.NewUndefinedStatus()
+		}
+
 		ss, err := drainCtx.Listers.StatefulSetLister().StatefulSets(controllerNamespace).Get(controllerRef.Name)
 
 		if err != nil && ss == nil {

--- a/cluster-autoscaler/simulator/drainability/rules/replicacount/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/replicacount/rule_test.go
@@ -243,6 +243,30 @@ func TestDrainable(t *testing.T) {
 			wantReason: drain.ControllerNotFound,
 			wantError:  true,
 		},
+		"SS-managed pod by a custom API Group": {
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "default",
+					OwnerReferences: test.GenerateOwnerReferences(statefulset.Name, "StatefulSet", "kruise/v1", ""),
+				},
+				Spec: apiv1.PodSpec{
+					NodeName: "node",
+				},
+			},
+		},
+		"SS-managed pod by a custom API Group with missing reference": {
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "default",
+					OwnerReferences: test.GenerateOwnerReferences("missing", "StatefulSet", "kruise/v1", ""),
+				},
+				Spec: apiv1.PodSpec{
+					NodeName: "node",
+				},
+			},
+		},
 		"RS-managed pod": {
 			pod: &apiv1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Related to 
https://github.com/kubernetes/autoscaler/issues/5977
https://github.com/kubernetes/autoscaler/pull/6412
https://github.com/kubernetes/autoscaler/pull/8006

Our fleet running on AKS uses lots of [OpenKruise's Advanced StatefulSet](https://openkruise.io/docs/user-manuals/advancedstatefulset). The check here was blocking thousands of nodes being scaled down, with the following error message:
```
statefulset for my-namespace/my-app-0 is not available: err: statefulset.apps "my-app" not found
```
This PR added an additional check to unblock third party statefulset being drained


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

Fixed a bug that prevents third party statefulset from being drained by cluster auto scaler

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
