### PR TITLE
e2e(recommender): Restrict the internal `VPA` controller scope to test namespace

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1/recommender.go
@@ -102,8 +102,8 @@ func (o *observer) OnUpdate(oldObj, newObj interface{}) {
 	go func() { o.channel <- result }()
 }
 
-func getVpaObserver(vpaClientSet vpa_clientset.Interface) *observer {
-	vpaListWatch := cache.NewListWatchFromClient(vpaClientSet.AutoscalingV1().RESTClient(), "verticalpodautoscalers", apiv1.NamespaceAll, fields.Everything())
+func getVpaObserver(vpaClientSet vpa_clientset.Interface, namespace string) *observer {
+	vpaListWatch := cache.NewListWatchFromClient(vpaClientSet.AutoscalingV1().RESTClient(), "verticalpodautoscalers", namespace, fields.Everything())
 	vpaObserver := observer{channel: make(chan recommendationChange)}
 	_, controller := cache.NewIndexerInformer(vpaListWatch,
 		&vpa_types.VerticalPodAutoscaler{},
@@ -232,7 +232,7 @@ var _ = RecommenderE2eDescribe("VPA CRD object", func() {
 
 	ginkgo.It("doesn't drop lower/upper after recommender's restart", func() {
 
-		o := getVpaObserver(vpaClientSet)
+		o := getVpaObserver(vpaClientSet, f.Namespace.Name)
 
 		ginkgo.By("Waiting for recommendation to be filled")
 		_, err := WaitForRecommendationPresent(vpaClientSet, vpaCRD)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Running `recommender`'s `doesn't drop lower/upper after recommender's restart` e2e tests against an existing cluster, that has `VPA` resources created in advance, causes a failure as it's internal observer `controller` considers all namespaces when watching for resource events.

https://github.com/kubernetes/autoscaler/blob/25ad4c2c26f10451a1a6d2047884e9a31913c5da/vertical-pod-autoscaler/e2e/v1/recommender.go#L106-L112

As the primary goal of the test is to validate the `hamster` deployment that it creates, validating recommendations for resources outside of its scope introduces nondeterministic behaviour with failing `Expect` assertions.

With the change introduced in this PR, we are limiting the internal observer `controller` scope to `VPA` resources within the `namespace` created by the test, thus prohibiting the processing of non-related resources.

<!--
#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
- 
-->

<!--
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
```release-note

```
-->


<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
```docs

```
-->
