### PR TITLE
Patch TestCleaningSoftTaintsInScaleDown to be compatible with new isScaleDownInCooldown signature

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -2748,28 +2748,35 @@ func TestCleaningSoftTaintsInScaleDown(t *testing.T) {
 	tests := []struct {
 		name                          string
 		testNodes                     []*apiv1.Node
-		expectedScaleDownCoolDown     bool
+		scaleDownInCoolDown           bool
 		expectedNodesWithSoftTaints   []*apiv1.Node
 		expectedNodesWithNoSoftTaints []*apiv1.Node
 	}{
 		{
-			name:                          "Soft tainted nodes are cleaned in case of scale down is in cool down",
+			name:                          "Soft tainted nodes are cleaned when scale down skipped",
 			testNodes:                     nodesToHaveNoTaints,
-			expectedScaleDownCoolDown:     true,
+			scaleDownInCoolDown:           false,
 			expectedNodesWithSoftTaints:   []*apiv1.Node{},
 			expectedNodesWithNoSoftTaints: nodesToHaveNoTaints,
 		},
 		{
-			name:                          "Soft tainted nodes are not cleaned in case of scale down isn't in cool down",
+			name:                          "Soft tainted nodes are cleaned when scale down in cooldown",
+			testNodes:                     nodesToHaveNoTaints,
+			scaleDownInCoolDown:           true,
+			expectedNodesWithSoftTaints:   []*apiv1.Node{},
+			expectedNodesWithNoSoftTaints: nodesToHaveNoTaints,
+		},
+		{
+			name:                          "Soft tainted nodes are not cleaned when scale down requested",
 			testNodes:                     nodesToHaveTaints,
-			expectedScaleDownCoolDown:     false,
+			scaleDownInCoolDown:           false,
 			expectedNodesWithSoftTaints:   nodesToHaveTaints,
 			expectedNodesWithNoSoftTaints: []*apiv1.Node{},
 		},
 		{
-			name:                          "Soft tainted nodes are cleaned only from min sized node group in case of scale down isn't in cool down",
+			name:                          "Soft tainted nodes are cleaned only from min sized node group when scale down requested",
 			testNodes:                     append(nodesToHaveNoTaints, nodesToHaveTaints...),
-			expectedScaleDownCoolDown:     false,
+			scaleDownInCoolDown:           false,
 			expectedNodesWithSoftTaints:   nodesToHaveTaints,
 			expectedNodesWithNoSoftTaints: nodesToHaveNoTaints,
 		},
@@ -2780,13 +2787,12 @@ func TestCleaningSoftTaintsInScaleDown(t *testing.T) {
 			fakeClient := buildFakeClient(t, test.testNodes...)
 
 			autoscaler := buildStaticAutoscaler(t, provider, test.testNodes, test.testNodes, fakeClient)
+			autoscaler.processorCallbacks.disableScaleDownForLoop = test.scaleDownInCoolDown
+			assert.Equal(t, autoscaler.isScaleDownInCooldown(time.Now()), test.scaleDownInCoolDown)
 
 			err := autoscaler.RunOnce(time.Now())
 
 			assert.NoError(t, err)
-			candidates, _ := autoscaler.processors.ScaleDownNodeProcessor.GetScaleDownCandidates(autoscaler.AutoscalingContext, test.testNodes)
-			assert.Equal(t, test.expectedScaleDownCoolDown, autoscaler.isScaleDownInCooldown(time.Now(), candidates))
-
 			assertNodesSoftTaintsStatus(t, fakeClient, test.expectedNodesWithSoftTaints, true)
 			assertNodesSoftTaintsStatus(t, fakeClient, test.expectedNodesWithNoSoftTaints, false)
 		})


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

When both #7997 and #7995 were merged - this led to isScaleDownInCooldown interface incompatibility which causes tests to fail. This PR patches the test to no longer depend on isScaleDownInCooldown as tainting logic was transferred straight to `RunOnce` method

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
