### PR TITLE
Create cloudbuild.yaml for VPA binaries to automate builds

### DIFF
--- a/vertical-pod-autoscaler/cloudbuild.yaml
+++ b/vertical-pod-autoscaler/cloudbuild.yaml
@@ -1,0 +1,30 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 3600s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest"
+    dir: pkg/admission-controller
+    entrypoint: make
+    env:
+      - TAG=$_GIT_TAG
+    args:
+      - release
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest"
+    dir: pkg/recommender
+    entrypoint: make
+    env:
+      - TAG=$_GIT_TAG
+    args:
+      - release
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest"
+    dir: pkg/updater
+    entrypoint: make
+    env:
+      - TAG=$_GIT_TAG
+    args:
+      - release
+substitutions:
+  _GIT_TAG: "0.0.0" # default value, this is substituted at build time

--- a/vertical-pod-autoscaler/pkg/admission-controller/Makefile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Makefile
@@ -76,7 +76,7 @@ remove-buildx-builder:
 	docker buildx rm ${BUILDER}
 
 .PHONY: release
-release: show-git-info create-buildx-builder docker-build remove-buildx-builder docker-push
+release: create-buildx-builder docker-build remove-buildx-builder docker-push
 	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
 
 clean: $(addprefix clean-,$(ALL_ARCHITECTURES))

--- a/vertical-pod-autoscaler/pkg/recommender/Makefile
+++ b/vertical-pod-autoscaler/pkg/recommender/Makefile
@@ -78,7 +78,7 @@ remove-buildx-builder:
 	docker buildx rm ${BUILDER}
 
 .PHONY: release
-release: show-git-info create-buildx-builder docker-build remove-buildx-builder docker-push
+release: create-buildx-builder docker-build remove-buildx-builder docker-push
 	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
 
 clean: $(addprefix clean-,$(ALL_ARCHITECTURES))

--- a/vertical-pod-autoscaler/pkg/updater/Makefile
+++ b/vertical-pod-autoscaler/pkg/updater/Makefile
@@ -76,7 +76,7 @@ remove-buildx-builder:
 	docker buildx rm ${BUILDER}
 
 .PHONY: release
-release: show-git-info create-buildx-builder docker-build remove-buildx-builder docker-push
+release: create-buildx-builder docker-build remove-buildx-builder docker-push
 	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
 
 clean: $(addprefix clean-,$(ALL_ARCHITECTURES))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is the first step in automating builds for VPA. This configures the Cloud Build flow for building all 3 VPA binaries and uploading them to the staging repository.

#### Which issue(s) this PR fixes:

Step 1 in #7902

#### Special notes for your reviewer:

Tested locally (and passed) using the following command in my GCP project from the `vertical-pod-autoscaler` directory. I also modified the registry location in my Makefiles locally to write to my own repository for testing.

```
$ gcloud builds submit --region=us-central1 --config=cloudbuild.yaml
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
