### PR TITLE
Allow draining when StatefulSet kind has custom API Group

### DIFF
--- a/cluster-autoscaler/simulator/drainability/rules/replicacount/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/replicacount/rule.go
@@ -110,6 +110,10 @@ func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) dr
 			return drainability.NewBlockedStatus(drain.ControllerNotFound, fmt.Errorf("replication controller for %s/%s is not available, err: %v", pod.Namespace, pod.Name, err))
 		}
 	} else if refKind == "StatefulSet" {
+		if refGroup.Group != "apps" {
+			// We don't have a listener for the other StatefulSet group.
+			return drainability.NewUndefinedStatus()
+		}
 		ss, err := drainCtx.Listers.StatefulSetLister().StatefulSets(controllerNamespace).Get(controllerRef.Name)
 
 		if err != nil && ss == nil {

--- a/cluster-autoscaler/simulator/drainability/rules/replicated/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/replicated/rule_test.go
@@ -143,6 +143,30 @@ func TestDrainable(t *testing.T) {
 			},
 			rcs: []*apiv1.ReplicationController{&rc},
 		},
+		"SS-managed pod by a custom API Group": {
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "default",
+					OwnerReferences: test.GenerateOwnerReferences(statefulset.Name, "StatefulSet", "kruise/v1", ""),
+				},
+				Spec: apiv1.PodSpec{
+					NodeName: "node",
+				},
+			},
+		},
+		"SS-managed pod by a custom API Group with missing reference": {
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "bar",
+					Namespace:       "default",
+					OwnerReferences: test.GenerateOwnerReferences("missing", "StatefulSet", "kruise/v1", ""),
+				},
+				Spec: apiv1.PodSpec{
+					NodeName: "node",
+				},
+			},
+		},
 		"RS-managed pod": {
 			pod: &apiv1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes/autoscaler/pull/8011

/assign jackfrancis

```release-note
Fixed a bug that prevents third party statefulset from being drained by cluster auto scaler
```