### PR TITLE
Use k8s.io/component-helpers/resource for pod request calculations

### DIFF
--- a/cluster-autoscaler/cloudprovider/equinixmetal/price_model.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/price_model.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
+	podutils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 )
 
@@ -73,11 +74,8 @@ func getHours(startTime time.Time, endTime time.Time) float64 {
 // PodPrice returns a theoretical minimum price of running a pod for a given
 // period of time on a perfectly matching machine.
 func (model *Price) PodPrice(pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
-	price := 0.0
-	for _, container := range pod.Spec.Containers {
-		price += getBasePrice(container.Resources.Requests, startTime, endTime)
-	}
-	return price, nil
+	podRequests := podutils.PodRequests(pod)
+	return getBasePrice(podRequests, startTime, endTime), nil
 }
 
 func getBasePrice(resources apiv1.ResourceList, startTime time.Time, endTime time.Time) float64 {

--- a/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_price_model.go
@@ -24,6 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce/localssdsize"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+	podutils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 
 	klog "k8s.io/klog/v2"
@@ -155,11 +156,8 @@ func (model *GcePriceModel) getPreemptibleDiscount(node *apiv1.Node) float64 {
 // PodPrice returns a theoretical minimum price of running a pod for a given
 // period of time on a perfectly matching machine.
 func (model *GcePriceModel) PodPrice(pod *apiv1.Pod, startTime time.Time, endTime time.Time) (float64, error) {
-	price := 0.0
-	for _, container := range pod.Spec.Containers {
-		price += model.getBasePrice(container.Resources.Requests, "", startTime, endTime)
-		price += model.getAdditionalPrice(container.Resources.Requests, startTime, endTime)
-	}
+	podRequests := podutils.PodRequests(pod)
+	price := model.getBasePrice(podRequests, "", startTime, endTime) + model.getAdditionalPrice(podRequests, startTime, endTime)
 	return price, nil
 }
 

--- a/cluster-autoscaler/expander/waste/waste.go
+++ b/cluster-autoscaler/expander/waste/waste.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	podutils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 	klog "k8s.io/klog/v2"
 )
 
@@ -73,14 +74,9 @@ func (l *leastwaste) BestOptions(expansionOptions []expander.Option, nodeInfo ma
 
 func resourcesForPods(pods []*apiv1.Pod) (cpu resource.Quantity, memory resource.Quantity) {
 	for _, pod := range pods {
-		for _, container := range pod.Spec.Containers {
-			if request, ok := container.Resources.Requests[apiv1.ResourceCPU]; ok {
-				cpu.Add(request)
-			}
-			if request, ok := container.Resources.Requests[apiv1.ResourceMemory]; ok {
-				memory.Add(request)
-			}
-		}
+		podRequests := podutils.PodRequests(pod)
+		cpu.Add(podRequests[apiv1.ResourceCPU])
+		memory.Add(podRequests[apiv1.ResourceMemory])
 	}
 
 	return cpu, memory

--- a/cluster-autoscaler/simulator/utilization/info.go
+++ b/cluster-autoscaler/simulator/utilization/info.go
@@ -29,7 +29,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
-	resourcehelper "k8s.io/kubernetes/pkg/api/v1/resource"
 )
 
 // Info contains utilization information for a node.
@@ -108,7 +107,8 @@ func CalculateUtilizationOfResource(nodeInfo *framework.NodeInfo, resourceName a
 	podsRequest := resource.MustParse("0")
 	daemonSetAndMirrorPodsUtilization := resource.MustParse("0")
 	for _, podInfo := range nodeInfo.Pods() {
-		resourceValue := resourcehelper.GetResourceRequestQuantity(podInfo.Pod, resourceName)
+		podRequests := podutils.PodRequests(podInfo.Pod)
+		resourceValue := podRequests[resourceName]
 
 		// factor daemonset pods out of the utilization calculations
 		if skipDaemonSetPods && podutils.IsDaemonSetPod(podInfo.Pod) {

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -19,6 +19,7 @@ package gpu
 import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	podutils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 	"k8s.io/klog/v2"
 )
 
@@ -105,15 +106,9 @@ func NodeHasGpu(GPULabel string, node *apiv1.Node) bool {
 
 // PodRequestsGpu returns true if a given pod has GPU request.
 func PodRequestsGpu(pod *apiv1.Pod) bool {
-	for _, container := range pod.Spec.Containers {
-		if container.Resources.Requests != nil {
-			_, gpuFound := container.Resources.Requests[ResourceNvidiaGPU]
-			if gpuFound {
-				return true
-			}
-		}
-	}
-	return false
+	podRequests := podutils.PodRequests(pod)
+	_, gpuFound := podRequests[ResourceNvidiaGPU]
+	return gpuFound
 }
 
 // GetNodeGPUFromCloudProvider returns the GPU the node has. Returned GPU has the GPU label of the

--- a/cluster-autoscaler/utils/labels/labels.go
+++ b/cluster-autoscaler/utils/labels/labels.go
@@ -23,6 +23,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	podutils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 )
 
 const (
@@ -88,12 +89,9 @@ func calculateNodeSelectorStats(pods []*apiv1.Pod) []nodeSelectorStats {
 	stats := make([]nodeSelectorStats, 0)
 	for _, pod := range pods {
 		var podCpu resource.Quantity
-		for _, container := range pod.Spec.Containers {
-			if container.Resources.Requests != nil {
-				containerCpu := container.Resources.Requests[apiv1.ResourceCPU]
-				podCpu.Add(containerCpu)
-			}
-		}
+		podRequests := podutils.PodRequests(pod)
+		podCpu.Add(podRequests[apiv1.ResourceCPU])
+
 		if podCpu.MilliValue() == 0 {
 			podCpu = defaultMinCPU
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:

Replaces all (hopefully) Pod resource calculations with `k8s.io/component-helpers/resource.PodRequests`. This helper is the source of truth how to calculate resource requests. It's used by the scheduler among others and captures developments like e.g. [KEP-1287: In-place Update of Pod Resources](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources) (beta in 1.33) and [KEP-2837: Pod Level Resource Specifications](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2837-pod-level-resource-spec/README.md) (beta in 1.34).

**Important note**: as a side-effect it means Cluster Autoscaler will start considering init containers as well for it's resource calculations. Init containers with restart policy of `ContainerRestartPolicyAlways` are counted in the container sum of requests, init containers with other restart policies are counted in init container sum of requests. The sum that is higher is what ends up returned by `PodRequests`. This seems to me to be the desired behavior.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```