### PR TITLE
VPA: Fix nil ptr when loading metrics and `memory-saver=true`

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -499,6 +499,7 @@ func (feeder *clusterStateFeeder) LoadRealTimeMetrics(ctx context.Context) {
 	sampleCount := 0
 	droppedSampleCount := 0
 	for _, containerMetrics := range containersMetrics {
+		// Container metrics are fetched for all pods, however, not all pod states are tracked in memory saver mode.
 		if pod, exists := feeder.clusterState.Pods()[containerMetrics.ID.PodID]; exists && pod != nil {
 			if slices.Contains(pod.InitContainers, containerMetrics.ID.ContainerName) {
 				klog.V(3).InfoS("Skipping metric samples for init container", "pod", klog.KRef(containerMetrics.ID.PodID.Namespace, containerMetrics.ID.PodID.PodName), "container", containerMetrics.ID.ContainerName)
@@ -508,7 +509,7 @@ func (feeder *clusterStateFeeder) LoadRealTimeMetrics(ctx context.Context) {
 		}
 		for _, sample := range newContainerUsageSamplesWithKey(containerMetrics) {
 			if err := feeder.clusterState.AddSample(sample); err != nil {
-				// Not all pod states are tracked in memory saver mode
+				// Not all pod states are tracked in memory saver mode.
 				if _, isKeyError := err.(model.KeyError); isKeyError && feeder.memorySaveMode {
 					continue
 				}

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -499,11 +499,12 @@ func (feeder *clusterStateFeeder) LoadRealTimeMetrics(ctx context.Context) {
 	sampleCount := 0
 	droppedSampleCount := 0
 	for _, containerMetrics := range containersMetrics {
-		podInitContainers := feeder.clusterState.Pods()[containerMetrics.ID.PodID].InitContainers
-		if slices.Contains(podInitContainers, containerMetrics.ID.ContainerName) {
-			klog.V(3).InfoS("Skipping metric samples for init container", "pod", klog.KRef(containerMetrics.ID.PodID.Namespace, containerMetrics.ID.PodID.PodName), "container", containerMetrics.ID.ContainerName)
-			droppedSampleCount += len(containerMetrics.Usage)
-			continue
+		if pod, exists := feeder.clusterState.Pods()[containerMetrics.ID.PodID]; exists && pod != nil {
+			if slices.Contains(pod.InitContainers, containerMetrics.ID.ContainerName) {
+				klog.V(3).InfoS("Skipping metric samples for init container", "pod", klog.KRef(containerMetrics.ID.PodID.Namespace, containerMetrics.ID.PodID.PodName), "container", containerMetrics.ID.ContainerName)
+				droppedSampleCount += len(containerMetrics.Usage)
+				continue
+			}
 		}
 		for _, sample := range newContainerUsageSamplesWithKey(containerMetrics) {
 			if err := feeder.clusterState.AddSample(sample); err != nil {

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -97,6 +97,10 @@ type fakeClusterState struct {
 }
 
 func (cs *fakeClusterState) AddSample(sample *model.ContainerUsageSampleWithKey) error {
+	_, podExists := cs.stubbedPods[sample.Container.PodID]
+	if !podExists {
+		return model.NewKeyError(sample.Container.PodID)
+	}
 	samplesForContainer := cs.addedSamples[sample.Container]
 	cs.addedSamples[sample.Container] = append(samplesForContainer, sample)
 	return nil
@@ -651,6 +655,27 @@ func TestClusterStateFeeder_LoadRealTimeMetrics(t *testing.T) {
 	samplesForContainer2 := clusterState.addedSamples[regularContainer2]
 	assert.Contains(t, samplesForContainer2, regularContainer2UsageSamples[0])
 	assert.Contains(t, samplesForContainer2, regularContainer2UsageSamples[1])
+
+	// Add extra container metrics for which there are no added pods to the state to simulate memory-saver=true
+	extraPodID := model.PodID{Namespace: namespaceName, PodName: "ExtraPod"}
+	extraContainer := model.ContainerID{PodID: extraPodID, ContainerName: "ExtraContainer"}
+	extraContainerMetricsSnapshot, _ := newContainerMetricsSnapshot(extraContainer, 200, 2048)
+	containerMetricsSnapshots = append(containerMetricsSnapshots, extraContainerMetricsSnapshot)
+
+	clusterState = NewFakeClusterState(nil, pods)
+
+	feeder = clusterStateFeeder{
+		memorySaveMode: true,
+		clusterState:   clusterState,
+		metricsClient:  fakeMetricsClient{snapshots: containerMetricsSnapshots},
+	}
+
+	feeder.LoadRealTimeMetrics(tctx)
+
+	assert.Equal(t, 2, len(clusterState.addedSamples))
+
+	_, samplesForExtraContainerExist := clusterState.addedSamples[extraContainer]
+	assert.False(t, samplesForExtraContainerExist)
 }
 
 type fakeHistoryProvider struct {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
This PR fixes a nil pointer exception that was introduced with https://github.com/kubernetes/autoscaler/pull/7891 that can happen if `memory-saver=true`. 

The reason this happens is that `feeder.metricsClient.GetContainersMetrics` loads metrics for all pods in the cluster whereas when `memory-saver=true` only pods for which there are VPAs are added to the `feeder.clusterState.Pods()` map

I also added a test that breaks without this change.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I have left `NONE` in the release not as I think there isn't a release yet that contains the nil pointer exception.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
