### PR TITLE
Read container resources from containerStatus in the spec client

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test.go
@@ -47,6 +47,6 @@ func TestGetPodSpecsReturnsSpecs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(tc.podSpecs), len(podSpecs), "SpecClient returned different number of results then expected")
 	for _, podSpec := range podSpecs {
-		assert.Contains(t, tc.podSpecs, podSpec, "One of returned BasicPodSpcec is different than expected")
+		assert.Contains(t, tc.podSpecs, podSpec, "One of returned BasicPodSpec is different than expected")
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test_util.go
@@ -68,6 +68,19 @@ metadata:
   name: Pod2
   labels:
     Pod2LabelKey: Pod2LabelValue
+status:
+  containerStatuses:
+  - name: Name23
+    resources:
+      requests:
+        memory: "250Mi"
+        cpu: "30m"
+  initContainerStatuses:
+  - name: Name22-init
+    resources:
+      requests:
+        memory: "350Mi"
+        cpu: "40m"
 spec:
   containers:
   - name: Name21
@@ -82,6 +95,14 @@ spec:
       requests:
         memory: "4096Mi"
         cpu: "4000m"
+  - name: Name23
+    image: Name23Image
+    resources:
+      # Requests below will be ignored because
+      # requests are also defined in containerStatus.
+      requests:
+        memory: "1Mi"
+        cpu: "1m"
   initContainers:
   - name: Name21-init
     image: Name21-initImage
@@ -89,6 +110,14 @@ spec:
       requests:
         memory: "128Mi"
         cpu: "40m"
+  - name: Name22-init
+    image: Name22-initImage
+    resources:
+      requests:
+        # Requests below will be ignored because
+        # requests are also defined in initContainerStatus.
+        memory: "1Mi"
+        cpu: "1m"
 `
 
 type podListerMock struct {
@@ -122,11 +151,13 @@ func newSpecClientTestCase() *specClientTestCase {
 	containerSpec12 := newTestContainerSpec(podID1, "Name12", 1000, 1024*1024*1024)
 	containerSpec21 := newTestContainerSpec(podID2, "Name21", 2000, 2048*1024*1024)
 	containerSpec22 := newTestContainerSpec(podID2, "Name22", 4000, 4096*1024*1024)
+	containerSpec23 := newTestContainerSpec(podID2, "Name23", 30, 250*1024*1024)
 
 	initContainerSpec21 := newTestContainerSpec(podID2, "Name21-init", 40, 128*1024*1024)
+	initContainerSpec22 := newTestContainerSpec(podID2, "Name22-init", 40, 350*1024*1024)
 
 	podSpec1 := newTestPodSpec(podID1, []BasicContainerSpec{containerSpec11, containerSpec12}, nil)
-	podSpec2 := newTestPodSpec(podID2, []BasicContainerSpec{containerSpec21, containerSpec22}, []BasicContainerSpec{initContainerSpec21})
+	podSpec2 := newTestPodSpec(podID2, []BasicContainerSpec{containerSpec21, containerSpec22, containerSpec23}, []BasicContainerSpec{initContainerSpec21, initContainerSpec22})
 
 	return &specClientTestCase{
 		podSpecs: []*BasicPodSpec{podSpec1, podSpec2},

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
@@ -22,15 +22,15 @@ import (
 )
 
 // ContainerRequestsAndLimits returns a copy of the actual resource requests and
-// limits of a given container or initContainer:
+// limits of a given container:
 //
 //   - If in-place pod updates feature [1] is enabled, the actual resource requests
-//     are stored in the container/initContainer status field.
+//     are stored in the container status field.
 //   - Otherwise, fallback to the resource requests defined in the pod spec.
 //
 // [1] https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
 func ContainerRequestsAndLimits(containerName string, pod *v1.Pod) (v1.ResourceList, v1.ResourceList) {
-	cs := containerStatusForContainer(containerName, pod)
+	cs := containerStatusFor(containerName, pod)
 	if cs != nil && cs.Resources != nil {
 		return cs.Resources.Requests.DeepCopy(), cs.Resources.Limits.DeepCopy()
 	}
@@ -44,30 +44,59 @@ func ContainerRequestsAndLimits(containerName string, pod *v1.Pod) (v1.ResourceL
 	return nil, nil
 }
 
+// InitContainerRequestsAndLimits returns a copy of the actual resource requests
+// and limits of a given initContainer:
+//
+//   - If in-place pod updates feature [1] is enabled, the actual resource requests
+//     are stored in the initContainer status field.
+//   - Otherwise, fallback to the resource requests defined in the pod spec.
+//
+// [1] https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
+func InitContainerRequestsAndLimits(initContainerName string, pod *v1.Pod) (v1.ResourceList, v1.ResourceList) {
+	cs := initContainerStatusFor(initContainerName, pod)
+	if cs != nil && cs.Resources != nil {
+		return cs.Resources.Requests.DeepCopy(), cs.Resources.Limits.DeepCopy()
+	}
+
+	klog.V(6).InfoS("initContainer resources not found in initContainerStatus for initContainer. Falling back to resources defined in the pod spec. This is expected for clusters with in-place pod updates feature disabled.", "initContainer", initContainerName, "initContainerStatus", cs)
+	initContainer := findInitContainer(initContainerName, pod)
+	if initContainer != nil {
+		return initContainer.Resources.Requests.DeepCopy(), initContainer.Resources.Limits.DeepCopy()
+	}
+
+	return nil, nil
+}
+
 func findContainer(containerName string, pod *v1.Pod) *v1.Container {
 	for i, container := range pod.Spec.Containers {
 		if container.Name == containerName {
 			return &pod.Spec.Containers[i]
 		}
 	}
+	return nil
+}
 
+func findInitContainer(initContainerName string, pod *v1.Pod) *v1.Container {
 	for i, initContainer := range pod.Spec.InitContainers {
-		if initContainer.Name == containerName {
+		if initContainer.Name == initContainerName {
 			return &pod.Spec.InitContainers[i]
 		}
 	}
 	return nil
 }
 
-func containerStatusForContainer(containerName string, pod *v1.Pod) *v1.ContainerStatus {
+func containerStatusFor(containerName string, pod *v1.Pod) *v1.ContainerStatus {
 	for i, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.Name == containerName {
 			return &pod.Status.ContainerStatuses[i]
 		}
 	}
+	return nil
+}
 
+func initContainerStatusFor(initContainerName string, pod *v1.Pod) *v1.ContainerStatus {
 	for i, initContainerStatus := range pod.Status.InitContainerStatuses {
-		if initContainerStatus.Name == containerName {
+		if initContainerStatus.Name == initContainerName {
 			return &pod.Status.InitContainerStatuses[i]
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
@@ -22,10 +22,10 @@ import (
 )
 
 // ContainerRequestsAndLimits returns a copy of the actual resource requests and
-// limits of a given container:
+// limits of a given container or initContainer:
 //
 //   - If in-place pod updates feature [1] is enabled, the actual resource requests
-//     are stored in the container status field.
+//     are stored in the container/initContainer status field.
 //   - Otherwise, fallback to the resource requests defined in the pod spec.
 //
 // [1] https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
@@ -50,6 +50,12 @@ func findContainer(containerName string, pod *v1.Pod) *v1.Container {
 			return &pod.Spec.Containers[i]
 		}
 	}
+
+	for i, initContainer := range pod.Spec.InitContainers {
+		if initContainer.Name == containerName {
+			return &pod.Spec.InitContainers[i]
+		}
+	}
 	return nil
 }
 
@@ -57,6 +63,12 @@ func containerStatusForContainer(containerName string, pod *v1.Pod) *v1.Containe
 	for i, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.Name == containerName {
 			return &pod.Status.ContainerStatuses[i]
+		}
+	}
+
+	for i, initContainerStatus := range pod.Status.InitContainerStatuses {
+		if initContainerStatus.Name == containerName {
+			return &pod.Status.InitContainerStatuses[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Read container resources from `containerStatus` and `initContainerStatus` in the spec client in VPA, if available. If not, VPA will fallback to the container resources defined in `Pod.Spec.Containers[i].Resources` or the equivalent for `initContainers`.  

This is needed because with [In-Place Update of Pod Resources feature](https://github.com/kubernetes/enhancements/issues/1287) (see [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources) for details), `Pod.Spec.Containers[i].Resources` may not contain the actual resources held by the pod and its containers (see https://github.com/kubernetes/autoscaler/issues/7971 for details).

#### Does this PR introduce a user-facing change?
Yes 

```release-note

Also consider (init)containerStatus.resources when handling container resources in VPA's spec client:  first try to read the resource requests and limits from the (init)container status field (`Pod.Status.(init)ContainerStatuses[i].Resources`). Otherwise, fallback to the resource requests defined in the pod spec (`Pod.Spec.(init)Containers[i].Resources`). 

```

