### PR TITLE
feat: Support DRA Admin Access

### DIFF
--- a/cluster-autoscaler/simulator/dynamicresources/utils/utilization.go
+++ b/cluster-autoscaler/simulator/dynamicresources/utils/utilization.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/utils/ptr"
 )
 
 // CalculateDynamicResourceUtilization calculates a map of ResourceSlice pool utilization grouped by the driver and pool. Returns
@@ -29,7 +30,7 @@ import (
 func CalculateDynamicResourceUtilization(nodeInfo *framework.NodeInfo) (map[string]map[string]float64, error) {
 	result := map[string]map[string]float64{}
 	claims := nodeInfo.ResourceClaims()
-	allocatedDevices, err := groupAllocatedDevices(claims)
+	allocatedDevices, err := groupAllocatedReservedDevices(claims)
 	if err != nil {
 		return nil, err
 	}
@@ -99,9 +100,10 @@ func getAllDevices(slices []*resourceapi.ResourceSlice) []resourceapi.Device {
 	return devices
 }
 
-// groupAllocatedDevices groups the devices from claim allocations by their driver and pool. Returns an error
-// if any of the claims isn't allocated.
-func groupAllocatedDevices(claims []*resourceapi.ResourceClaim) (map[string]map[string][]string, error) {
+// groupAllocatedReservedDevices groups reserved devices from claim allocations by their driver and pool.
+// If a deviced will not exclusively reserved (i.e. AdminAccess), it will not be included in the result.
+// Returns an error if any of the claims isn't allocated.
+func groupAllocatedReservedDevices(claims []*resourceapi.ResourceClaim) (map[string]map[string][]string, error) {
 	result := map[string]map[string][]string{}
 	for _, claim := range claims {
 		alloc := claim.Status.Allocation
@@ -110,6 +112,11 @@ func groupAllocatedDevices(claims []*resourceapi.ResourceClaim) (map[string]map[
 		}
 
 		for _, deviceAlloc := range alloc.Devices.Results {
+			if ptr.Deref(deviceAlloc.AdminAccess, false) {
+				// Admin access Device allocations don't actually reserve the Device, so they shouldn't be counted towards utilization.
+				continue
+			}
+
 			if result[deviceAlloc.Driver] == nil {
 				result[deviceAlloc.Driver] = map[string][]string{}
 			}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This is a part of Dynamic Resource Allocation (DRA) support in Cluster Autoscaler.  ResourceClaims support the AdminAccess field which is used to allow cluster administrators to access devices already in use. This changes the CA's business logic by introducing the idea that "some resourceclaims don't reserve their allocated devices". 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/7685

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ResourceClaims with AdminAccess will now be ignored when calculating node utilization for scaledown
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: https://github.com/kubernetes/enhancements/blob/a55eefc6051d6684d8cc7521e1f4de6319625e23/keps/sig-auth/5018-dra-adminaccess/README.md
```

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
