### PR TITLE
cloudbuild.yaml file for cluster-autoscaler for automated builds

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -7,7 +7,7 @@ LDFLAGS?=-s
 ENVVAR=CGO_ENABLED=0
 GOOS?=linux
 GOARCH?=$(shell go env GOARCH)
-REGISTRY?=staging-k8s.gcr.io
+REGISTRY?=gcr.io/k8s-staging-autoscaling
 DOCKER_NETWORK?=default
 SUPPORTED_BUILD_TAGS=$(shell ls cloudprovider/builder/ | grep -e '^builder_.*\.go' | sed 's/builder_\(.*\)\.go/\1/')
 ifdef BUILD_TAGS
@@ -64,7 +64,8 @@ dev-release-arch-%: build-arch-% make-image-arch-% push-image-arch-%
 make-image: make-image-arch-$(GOARCH)
 
 make-image-arch-%:
-	GOOS=$(GOOS) GOARCH=$* docker buildx build --pull --platform linux/$* \
+	GOOS=$(GOOS) docker buildx build --pull --platform linux/$* \
+		--build-arg "GOARCH=$*" \
 		-t ${IMAGE}-$*:${TAG} \
 		-f Dockerfile .
 	@echo "Image ${TAG}${FOR_PROVIDER}-$* completed"
@@ -74,12 +75,15 @@ push-image: push-image-arch-$(GOARCH)
 push-image-arch-%:
 	./push_image.sh ${IMAGE}-$*:${TAG}
 
+push-release-image-arch-%:
+	docker push ${IMAGE}-$*:${TAG}
+
 push-manifest:
 	docker manifest create ${IMAGE}:${TAG} \
 	    $(addprefix $(REGISTRY)/cluster-autoscaler$(PROVIDER)-, $(addsuffix :$(TAG), $(ALL_ARCH)))
 	docker manifest push --purge ${IMAGE}:${TAG}
 
-execute-release: $(addprefix make-image-arch-,$(ALL_ARCH)) $(addprefix push-image-arch-,$(ALL_ARCH)) push-manifest
+execute-release: $(addprefix make-image-arch-,$(ALL_ARCH)) $(addprefix push-release-image-arch-,$(ALL_ARCH)) push-manifest
 	@echo "Release ${TAG}${FOR_PROVIDER} completed"
 
 clean: clean-arch-$(GOARCH)

--- a/cluster-autoscaler/cloudbuild.yaml
+++ b/cluster-autoscaler/cloudbuild.yaml
@@ -1,60 +1,15 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 3600s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
 options:
-  machineType: E2_HIGHCPU_32
-timeout: 10800s
-
-substitutions:
-  { "_TAG": "dev" }
-
+  substitution_option: ALLOW_LOOSE
 steps:
-- name: gcr.io/cloud-builders/git
-  id: git-clone
-  entrypoint: bash
-  args:
-  - "-c"
-  - |
-    set -ex
-    mkdir -p /workspace/src/k8s.io
-    cd /workspace/src/k8s.io
-    git clone https://github.com/kubernetes/autoscaler.git
-
-- name: gcr.io/cloud-builders/docker
-  id: build-build-container
-  entrypoint: bash
-  dir: "/workspace/src/k8s.io/autoscaler/cluster-autoscaler"
-  args:
-  - "-c"
-  - |
-    set -e
-    docker build -t autoscaling-builder ../builder
-
-- name: autoscaling-builder
-  id: run-tests
-  entrypoint: godep
-  dir: "/workspace/src/k8s.io/autoscaler/cluster-autoscaler"
-  env:
-  - "GOPATH=/workspace/"
-  args: ["go", "test", "./..."]
-
-- name: autoscaling-builder
-  id: run-build
-  entrypoint: godep
-  dir: "/workspace/src/k8s.io/autoscaler/cluster-autoscaler"
-  env:
-  - "GOPATH=/workspace/"
-  - "GOOS=linux"
-  args: ["go", "build", "-o", "cluster-autoscaler"]
-  waitFor: build-build-container
-
-- name: gcr.io/cloud-builders/docker
-  id: build-container
-  entrypoint: bash
-  dir: "/workspace/src/k8s.io/autoscaler/cluster-autoscaler"
-  args:
-  - "-c"
-  - |
-    set -e
-    docker build -t gcr.io/k8s-image-staging/cluster-autoscaler:${_TAG} .
-  waitFor: ["run-tests", "run-build"]
-
-images:
-  - "gcr.io/k8s-image-staging/cluster-autoscaler:${_TAG}"
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest"
+    entrypoint: make
+    env:
+      - TAG=$_GIT_TAG
+    args:
+      - execute-release
+substitutions:
+  _GIT_TAG: "0.0.0" # default value, this is substituted at build time

--- a/cluster-autoscaler/cloudbuild.yaml
+++ b/cluster-autoscaler/cloudbuild.yaml
@@ -1,8 +1,8 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 timeout: 3600s
-# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
-# or any new substitutions added in the future.
 options:
+  # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+  # or any new substitutions added in the future.
   substitution_option: ALLOW_LOOSE
 steps:
   - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Modifies the cloudbuild.yaml file, containing the instructions to build cluster-autoscaler from Cloud Build in automated builds.

The old content here was a previous attempt at doing this but was abandoned, as far as I can tell it is all dead code.

Tested locally by running:

```
$ gcloud builds submit --region=us-central1 --config=cloudbuild.yaml
```

#### Which issue(s) this PR fixes:

Part of #8032.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```