### PR TITLE
Build VPA components in parallel

### DIFF
--- a/vertical-pod-autoscaler/cloudbuild.yaml
+++ b/vertical-pod-autoscaler/cloudbuild.yaml
@@ -19,6 +19,7 @@ steps:
       - TAG=$_GIT_TAG
     args:
       - release
+    waitFor: ['-']  # The '-' indicates that this step begins immediately.
   - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest"
     dir: pkg/updater
     entrypoint: make
@@ -26,5 +27,6 @@ steps:
       - TAG=$_GIT_TAG
     args:
       - release
+    waitFor: ['-']  # The '-' indicates that this step begins immediately.
 substitutions:
   _GIT_TAG: "0.0.0" # default value, this is substituted at build time


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The current automated VPA build fails because it takes longer than 2 hours (Cloud Build is slow). Attempt to speed things up by running the separate binary builds in parallel. See https://cloud.google.com/build/docs/configuring-builds/configure-build-step-order.

#### Which issue(s) this PR fixes:

Part of #7902.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
