### PR TITLE
Add metric to track calls to get container/pod resources

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
+	metrics_resources "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/resources"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/server"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
@@ -143,6 +144,7 @@ func main() {
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval * 5)
 	metrics_recommender.Register()
 	metrics_quality.Register()
+	metrics_resources.Register()
 	server.Initialize(&commonFlags.EnableProfiling, healthCheck, address)
 
 	if !leaderElection.LeaderElect {

--- a/vertical-pod-autoscaler/pkg/utils/metrics/resources/resources.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/resources/resources.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resources contains metrics for the VPA resource helper functions.
+package resources
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
+)
+
+const (
+	metricsNamespace = metrics.TopMetricsNamespace + "resources"
+)
+
+type resourcesSource string
+
+const (
+	ContainerStatus      resourcesSource = "Pod.Status.ContainerStatuses"
+	InitContainerStatus  resourcesSource = "Pod.Status.InitContainerStatuses"
+	PodSpecContainer     resourcesSource = "Pod.Spec.Containers"
+	PodSpecInitContainer resourcesSource = "Pod.Spec.InitContainers"
+)
+
+var (
+	getResourcesCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "get_resources_count",
+			Help:      "Count of calls to get the resources of a pod or container.",
+		}, []string{"source"},
+	)
+)
+
+// Register initializes all metrics for VPA resources
+func Register() {
+	prometheus.MustRegister(getResourcesCount)
+}
+
+// RecordGetResourcesCount records how many times VPA requested the resources (
+// CPU/memory requests and limits) of a pod or container by the data source.
+func RecordGetResourcesCount(source resourcesSource) {
+	getResourcesCount.WithLabelValues(string(source)).Inc()
+}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/resources/resources.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/resources/resources.go
@@ -30,9 +30,17 @@ const (
 type resourcesSource string
 
 const (
-	ContainerStatus      resourcesSource = "Pod.Status.ContainerStatuses"
-	InitContainerStatus  resourcesSource = "Pod.Status.InitContainerStatuses"
-	PodSpecContainer     resourcesSource = "Pod.Spec.Containers"
+	// ContainerStatus indicates that resources were fetched from the
+	// containerStatuses pod field.
+	ContainerStatus resourcesSource = "Pod.Status.ContainerStatuses"
+	// InitContainerStatus indicates that resources were fetched from the
+	// initContainerStatuses pod field.
+	InitContainerStatus resourcesSource = "Pod.Status.InitContainerStatuses"
+	// PodSpecContainer indicates that resources were fetched from the
+	// containers field in the pod spec.
+	PodSpecContainer resourcesSource = "Pod.Spec.Containers"
+	// PodSpecInitContainer indicates that resources were fetched from the
+	// initContainers field in the pod spec.
 	PodSpecInitContainer resourcesSource = "Pod.Spec.InitContainers"
 )
 

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
@@ -18,6 +18,7 @@ package resourcehelpers
 
 import (
 	v1 "k8s.io/api/core/v1"
+	metrics_resources "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/resources"
 	"k8s.io/klog/v2"
 )
 
@@ -32,12 +33,14 @@ import (
 func ContainerRequestsAndLimits(containerName string, pod *v1.Pod) (v1.ResourceList, v1.ResourceList) {
 	cs := containerStatusFor(containerName, pod)
 	if cs != nil && cs.Resources != nil {
+		metrics_resources.RecordGetResourcesCount(metrics_resources.ContainerStatus)
 		return cs.Resources.Requests.DeepCopy(), cs.Resources.Limits.DeepCopy()
 	}
 
 	klog.V(6).InfoS("Container resources not found in containerStatus for container. Falling back to resources defined in the pod spec. This is expected for clusters with in-place pod updates feature disabled.", "container", containerName, "containerStatus", cs)
 	container := findContainer(containerName, pod)
 	if container != nil {
+		metrics_resources.RecordGetResourcesCount(metrics_resources.PodSpecContainer)
 		return container.Resources.Requests.DeepCopy(), container.Resources.Limits.DeepCopy()
 	}
 
@@ -55,12 +58,14 @@ func ContainerRequestsAndLimits(containerName string, pod *v1.Pod) (v1.ResourceL
 func InitContainerRequestsAndLimits(initContainerName string, pod *v1.Pod) (v1.ResourceList, v1.ResourceList) {
 	cs := initContainerStatusFor(initContainerName, pod)
 	if cs != nil && cs.Resources != nil {
+		metrics_resources.RecordGetResourcesCount(metrics_resources.InitContainerStatus)
 		return cs.Resources.Requests.DeepCopy(), cs.Resources.Limits.DeepCopy()
 	}
 
 	klog.V(6).InfoS("initContainer resources not found in initContainerStatus for initContainer. Falling back to resources defined in the pod spec. This is expected for clusters with in-place pod updates feature disabled.", "initContainer", initContainerName, "initContainerStatus", cs)
 	initContainer := findInitContainer(initContainerName, pod)
 	if initContainer != nil {
+		metrics_resources.RecordGetResourcesCount(metrics_resources.PodSpecInitContainer)
 		return initContainer.Resources.Requests.DeepCopy(), initContainer.Resources.Limits.DeepCopy()
 	}
 

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
@@ -18,8 +18,9 @@ package resourcehelpers
 
 import (
 	v1 "k8s.io/api/core/v1"
-	metrics_resources "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/resources"
 	"k8s.io/klog/v2"
+
+	metrics_resources "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/resources"
 )
 
 // ContainerRequestsAndLimits returns a copy of the actual resource requests and


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

VPA may read container resources from either `containerStatus` (if available) or `Pod.Spec.Containers[i].Resources` (fallback). 

In clusters with  [In-Place Update of Pod Resources feature](https://github.com/kubernetes/enhancements/issues/1287) (see [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources), it's expected that `containerStatus` hold the actual value of resources, while `Pod.Spec.Containers[i].Resources` is purely a declaration of the desired state of pod resources. 

We're adding a metric that tracks the data source ((init)containerStatus or pod.Spec.(init)Containers.Resources) that was read by VPA.  This can be useful to track how many times we are falling back to reading resources from the pod spec in clusters with in-place update enabled.



#### Does this PR introduce a user-facing change?
Yes 

```release-note

Add a metric to track calls to get container/pod resources, grouped by the data source: (init)containerStatus or podSpec.

```

#### Which issue(s) this PR fixes:

#7971
