### PR TITLE
Update golang version to 1.24 for addon-resizer to fix build

### DIFF
--- a/addon-resizer/Dockerfile
+++ b/addon-resizer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 WORKDIR /workspace
 

--- a/addon-resizer/Makefile
+++ b/addon-resizer/Makefile
@@ -22,7 +22,7 @@ ARCH ?= amd64
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 GOARM=7
-GOLANG_VERSION = 1.23
+GOLANG_VERSION = 1.24
 REGISTRY = gcr.io/k8s-staging-autoscaling
 IMGNAME = addon-resizer
 IMAGE = $(REGISTRY)/$(IMGNAME)

--- a/addon-resizer/go.mod
+++ b/addon-resizer/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/autoscaler/addon-resizer
 
-go 1.22.0
+go 1.24.0
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The addon-resizer automated build is broken (https://testgrid.k8s.io/sig-autoscaling-addon-resizer#post-autoscaler-push-addon-resizer-images) with the following error:

```
#11 0.151 go: k8s.io/api in vendor/modules.txt requires go >= 1.24.0 (running go 1.23.8; GOTOOLCHAIN=local)
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```