### PR TITLE
Feat: DRA Node Readiness

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -994,12 +994,23 @@ func (a *StaticAutoscaler) obtainNodeLists() ([]*apiv1.Node, []*apiv1.Node, caer
 	}
 	a.reportTaintsCount(allNodes)
 
+	resourceClaims, err := a.AutoscalingContext.ClusterSnapshot.ResourceSlices().List()
+	if err != nil {
+		klog.Errorf("Failed to filter out nodes with unready resources: %v", err)
+		return nil, nil, caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
+	}
+
 	// Handle GPU case - allocatable GPU may be equal to 0 up to 15 minutes after
 	// node registers as ready. See https://github.com/kubernetes/kubernetes/issues/54959
 	// Treat those nodes as unready until GPU actually becomes available and let
 	// our normal handling for booting up nodes deal with this.
 	// TODO: Remove this call when we handle dynamically provisioned resources.
 	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
+	allNodes, readyNodes, err = a.processors.DynamicResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes, resourceClaims)
+	if err != nil {
+		klog.Errorf("Failed to filter out nodes with unready resources: %v", err)
+		return nil, nil, caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
+	}
 	allNodes, readyNodes = taints.FilterOutNodesWithStartupTaints(a.taintConfig, allNodes, readyNodes)
 	return allNodes, readyNodes, nil
 }

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -995,6 +995,14 @@ func (a *StaticAutoscaler) obtainNodeLists() ([]*apiv1.Node, []*apiv1.Node, caer
 	}
 	a.reportTaintsCount(allNodes)
 
+	// Handle GPU case - allocatable GPU may be equal to 0 up to 15 minutes after
+	// node registers as ready. See https://github.com/kubernetes/kubernetes/issues/54959
+	// Treat those nodes as unready until GPU actually becomes available and let
+	// our normal handling for booting up nodes deal with this.
+	// TODO: Remove this call when we handle dynamically provisioned resources.
+	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
+	allNodes, readyNodes = taints.FilterOutNodesWithStartupTaints(a.taintConfig, allNodes, readyNodes)
+
 	if a.draProvider != nil {
 		resourceSliceSnapshot, err := a.draProvider.Snapshot()
 		if err != nil {
@@ -1009,19 +1017,12 @@ func (a *StaticAutoscaler) obtainNodeLists() ([]*apiv1.Node, []*apiv1.Node, caer
 			}
 		}
 		allNodes, readyNodes, err = a.processors.DynamicResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes, resourceSlices)
+		if err != nil {
+			klog.Errorf("Failed to filter out nodes with unready resources: %v", err)
+			return nil, nil, caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
+		}
 	}
 
-	// Handle GPU case - allocatable GPU may be equal to 0 up to 15 minutes after
-	// node registers as ready. See https://github.com/kubernetes/kubernetes/issues/54959
-	// Treat those nodes as unready until GPU actually becomes available and let
-	// our normal handling for booting up nodes deal with this.
-	// TODO: Remove this call when we handle dynamically provisioned resources.
-	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
-	if err != nil {
-		klog.Errorf("Failed to filter out nodes with unready resources: %v", err)
-		return nil, nil, caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
-	}
-	allNodes, readyNodes = taints.FilterOutNodesWithStartupTaints(a.taintConfig, allNodes, readyNodes)
 	return allNodes, readyNodes, nil
 }
 

--- a/cluster-autoscaler/core/static_autoscaler_dra_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_dra_test.go
@@ -291,6 +291,7 @@ func TestStaticAutoscalerDynamicResources(t *testing.T) {
 		},
 		"scale-up: pods requesting a shared, unallocated claim": {
 			extraResourceClaims: []*resourceapi.ResourceClaim{sharedGpuBClaim},
+			extraResourceSlices: node1GpuB1slice.slicesTemplateFunc(node1GpuB1slice.name + "-template"),
 			nodeGroups:          map[*testNodeGroupDef]int{node1GpuB1slice: 1},
 			pods: append(
 				unscheduledPods(baseSmallPod, "unschedulable", 13, nil, sharedGpuBClaim),

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -56,6 +56,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/observers/loopstart"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/dynamicresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups/asyncnodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/scaledowncandidates"
@@ -2853,6 +2854,7 @@ func TestCleaningSoftTaintsInScaleDown(t *testing.T) {
 			autoscaler := buildStaticAutoscaler(t, provider, test.testNodes, test.testNodes, fakeClient)
 			autoscaler.processorCallbacks.disableScaleDownForLoop = test.scaleDownInCoolDown
 			assert.Equal(t, autoscaler.isScaleDownInCooldown(time.Now()), test.scaleDownInCoolDown)
+			autoscaler.processors.DynamicResourcesProcessor = dynamicresources.NewMockDynamicResourcesProcessor()
 
 			err := autoscaler.RunOnce(time.Now())
 

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -905,8 +905,6 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 	for _, forceDeleteLongUnregisteredNodes := range []bool{false, true} {
 		t.Run(fmt.Sprintf("forceDeleteLongUnregisteredNodes=%v", forceDeleteLongUnregisteredNodes), func(t *testing.T) {
-			readyNodeLister := kubernetes.NewTestNodeLister(nil)
-			allNodeLister := kubernetes.NewTestNodeLister(nil)
 			allPodListerMock := &podListerMock{}
 			podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
 			daemonSetListerMock := &daemonSetListerMock{}
@@ -922,19 +920,29 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 			n2 := BuildTestNode("n2", 1000, 1000)
 			SetNodeReadyState(n2, true, time.Now())
 
+			readyNodeLister := kubernetes.NewTestNodeLister([]*apiv1.Node{n1, n2})
+			allNodeLister := kubernetes.NewTestNodeLister([]*apiv1.Node{n1, n2})
+
 			p1 := BuildTestPod("p1", 600, 100)
 			p1.Spec.NodeName = "n1"
 			p2 := BuildTestPod("p2", 600, 100, MarkUnschedulable())
 
-			provider := testprovider.NewTestCloudProvider(
+			provider := testprovider.NewTestAutoprovisioningCloudProvider(
 				func(id string, delta int) error {
 					return onScaleUpMock.ScaleUp(id, delta)
 				}, func(id string, name string) error {
 					ret := onScaleDownMock.ScaleDown(id, name)
 					deleteFinished <- true
 					return ret
-				})
-			provider.AddNodeGroup("ng1", 2, 10, 2)
+				},
+				func(id string) error {
+					return nil
+				}, func(id string) error {
+					return nil
+				},
+				[]string{"ng1"}, map[string]*framework.NodeInfo{"ng1": framework.NewTestNodeInfo(n1)},
+			)
+			provider.AddAutoprovisionedNodeGroup("ng1", 2, 10, 2, "ng1")
 			provider.AddNode("ng1", n1)
 
 			// broken node, that will be just hanging out there during
@@ -1044,8 +1052,6 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 }
 
 func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
-	readyNodeLister := kubernetes.NewTestNodeLister(nil)
-	allNodeLister := kubernetes.NewTestNodeLister(nil)
 	allPodListerMock := &podListerMock{}
 	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
 	daemonSetListerMock := &daemonSetListerMock{}
@@ -1059,6 +1065,9 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	SetNodeReadyState(n2, true, time.Now())
 	n3 := BuildTestNode("n3", 1000, 1000)
 	SetNodeReadyState(n3, true, time.Now())
+
+	readyNodeLister := kubernetes.NewTestNodeLister([]*apiv1.Node{n1, n2, n3})
+	allNodeLister := kubernetes.NewTestNodeLister([]*apiv1.Node{n1, n2, n3})
 
 	// shared owner reference
 	ownerRef := GenerateOwnerReferences("rs", "ReplicaSet", "extensions/v1beta1", "")
@@ -1093,16 +1102,23 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	p6.OwnerReferences = ownerRef
 	p6.Spec.Priority = &priority100
 
-	provider := testprovider.NewTestCloudProvider(
+	provider := testprovider.NewTestAutoprovisioningCloudProvider(
 		func(id string, delta int) error {
 			return onScaleUpMock.ScaleUp(id, delta)
 		}, func(id string, name string) error {
 			ret := onScaleDownMock.ScaleDown(id, name)
 			deleteFinished <- true
 			return ret
-		})
-	provider.AddNodeGroup("ng1", 0, 10, 1)
-	provider.AddNodeGroup("ng2", 0, 10, 2)
+		},
+		func(id string) error {
+			return nil
+		}, func(id string) error {
+			return nil
+		},
+		[]string{"ng1", "ng2"}, map[string]*framework.NodeInfo{"ng1": framework.NewTestNodeInfo(n1), "ng2": framework.NewTestNodeInfo(n2)},
+	)
+	provider.AddAutoprovisionedNodeGroup("ng1", 0, 10, 1, "ng1")
+	provider.AddAutoprovisionedNodeGroup("ng2", 0, 10, 2, "ng2")
 	provider.AddNode("ng1", n1)
 	provider.AddNode("ng2", n2)
 	provider.AddNode("ng2", n3)
@@ -1206,8 +1222,6 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 }
 
 func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T) {
-	readyNodeLister := kubernetes.NewTestNodeLister(nil)
-	allNodeLister := kubernetes.NewTestNodeLister(nil)
 	allPodListerMock := &podListerMock{}
 	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
 	daemonSetListerMock := &daemonSetListerMock{}
@@ -1218,6 +1232,9 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 	SetNodeReadyState(n1, true, time.Now())
 	n2 := BuildTestNode("n2", 2000, 1000)
 	SetNodeReadyState(n2, true, time.Now())
+
+	readyNodeLister := kubernetes.NewTestNodeLister([]*apiv1.Node{n1, n2})
+	allNodeLister := kubernetes.NewTestNodeLister([]*apiv1.Node{n1, n2})
 
 	// shared owner reference
 	ownerRef := GenerateOwnerReferences("rs", "ReplicaSet", "extensions/v1beta1", "")
@@ -1231,16 +1248,24 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 	p4.Spec.NodeName = "n2"
 	p4.OwnerReferences = ownerRef
 
-	provider := testprovider.NewTestCloudProvider(
+	provider := testprovider.NewTestAutoprovisioningCloudProvider(
 		func(id string, delta int) error {
 			return onScaleUpMock.ScaleUp(id, delta)
 		}, func(id string, name string) error {
 			return onScaleDownMock.ScaleDown(id, name)
-		})
-	provider.AddNodeGroup("ng1", 0, 10, 2)
+		},
+		func(id string) error {
+			return nil
+		}, func(id string) error {
+			return nil
+		},
+		[]string{"ng1", "ng2"}, map[string]*framework.NodeInfo{"ng1": framework.NewTestNodeInfo(n1), "ng2": framework.NewTestNodeInfo(n2)},
+	)
+
+	provider.AddAutoprovisionedNodeGroup("ng1", 0, 10, 2, "ng1")
 	provider.AddNode("ng1", n1)
 
-	provider.AddNodeGroup("ng2", 0, 10, 1)
+	provider.AddAutoprovisionedNodeGroup("ng2", 0, 10, 1, "ng2")
 	provider.AddNode("ng2", n2)
 
 	assert.NotNil(t, provider)
@@ -1305,8 +1330,6 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 }
 
 func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *testing.T) {
-	readyNodeLister := kubernetes.NewTestNodeLister(nil)
-	allNodeLister := kubernetes.NewTestNodeLister(nil)
 	allPodListerMock := &podListerMock{}
 	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
 	daemonSetListerMock := &daemonSetListerMock{}
@@ -1317,6 +1340,9 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 	SetNodeReadyState(n2, true, time.Now())
 	n3 := BuildTestNode("n3", 2000, 1000)
 	SetNodeReadyState(n3, true, time.Now())
+
+	readyNodeLister := kubernetes.NewTestNodeLister([]*apiv1.Node{n2, n3})
+	allNodeLister := kubernetes.NewTestNodeLister([]*apiv1.Node{n2, n3})
 
 	// shared owner reference
 	ownerRef := GenerateOwnerReferences("rs", "ReplicaSet", "extensions/v1beta1", "")
@@ -1330,16 +1356,23 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 	p3.Spec.NodeName = "n3"
 	p3.OwnerReferences = ownerRef
 
-	provider := testprovider.NewTestCloudProvider(
+	provider := testprovider.NewTestAutoprovisioningCloudProvider(
 		func(id string, delta int) error {
 			return onScaleUpMock.ScaleUp(id, delta)
 		}, func(id string, name string) error {
 			return onScaleDownMock.ScaleDown(id, name)
-		})
-	provider.AddNodeGroup("ng1", 0, 10, 2)
+		},
+		func(id string) error {
+			return nil
+		}, func(id string) error {
+			return nil
+		},
+		[]string{"ng1", "ng2"}, map[string]*framework.NodeInfo{"ng1": framework.NewTestNodeInfo(n2), "ng2": framework.NewTestNodeInfo(n3)},
+	)
+	provider.AddAutoprovisionedNodeGroup("ng1", 0, 10, 2, "ng1")
 	provider.AddNode("ng1", n2)
 
-	provider.AddNodeGroup("ng2", 0, 10, 1)
+	provider.AddAutoprovisionedNodeGroup("ng2", 0, 10, 1, "ng2")
 	provider.AddNode("ng2", n3)
 
 	assert.NotNil(t, provider)
@@ -1405,6 +1438,8 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 
 // We should not touch taints from unselected node groups.
 func TestStaticAutoscalerRunOnceWithUnselectedNodeGroups(t *testing.T) {
+	onScaleUpMock := &onScaleUpMock{}
+	onScaleDownMock := &onScaleDownMock{}
 	n1 := BuildTestNode("n1", 1000, 1000)
 	n1.Spec.Taints = append(n1.Spec.Taints, apiv1.Taint{
 		Key:    taints.DeletionCandidateTaint,
@@ -1424,8 +1459,20 @@ func TestStaticAutoscalerRunOnceWithUnselectedNodeGroups(t *testing.T) {
 	p1.Spec.NodeName = n1.Name
 
 	// set minimal cloud provider where only ng1 is defined as selected node group
-	provider := testprovider.NewTestCloudProvider(nil, nil)
-	provider.AddNodeGroup("ng1", 1, 10, 1)
+	provider := testprovider.NewTestAutoprovisioningCloudProvider(
+		func(id string, delta int) error {
+			return onScaleUpMock.ScaleUp(id, delta)
+		}, func(id string, name string) error {
+			return onScaleDownMock.ScaleDown(id, name)
+		},
+		func(id string) error {
+			return nil
+		}, func(id string) error {
+			return nil
+		},
+		[]string{"ng1"}, map[string]*framework.NodeInfo{"ng1": framework.NewTestNodeInfo(n1)},
+	)
+	provider.AddAutoprovisionedNodeGroup("ng1", 1, 10, 1, "ng1")
 	provider.AddNode("ng1", n1)
 	assert.NotNil(t, provider)
 

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -2148,6 +2148,7 @@ func TestStaticAutoscalerUpcomingScaleDownCandidates(t *testing.T) {
 	assert.NoError(t, err)
 
 	processors := processorstest.NewTestProcessors(&ctx)
+	processors.DynamicResourcesProcessor = dynamicresources.NewMockDynamicResourcesProcessor()
 
 	// Create CSR with unhealthy cluster protection effectively disabled, to guarantee we reach the tested logic.
 	csrConfig := clusterstate.ClusterStateRegistryConfig{OkTotalUnreadyCount: nodeGroupCount * unreadyNodesCount}
@@ -2665,6 +2666,7 @@ func TestStaticAutoscalerRunOnceInvokesScaleDownStatusProcessor(t *testing.T) {
 
 			statusProcessor := &scaleDownStatusProcessorMock{}
 			autoscaler.processors.ScaleDownStatusProcessor = statusProcessor
+			autoscaler.processors.DynamicResourcesProcessor = dynamicresources.NewMockDynamicResourcesProcessor()
 
 			setupConfig.mocks.readyNodeLister.SetNodes(test.nodes)
 			setupConfig.mocks.allNodeLister.SetNodes(test.nodes)

--- a/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
+++ b/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
@@ -154,22 +154,23 @@ func compareResourceSlices(
 	devices2 := resourceSlice2.Spec.Devices
 	if len(devices1) != len(devices2) {
 		return false
-	} else {
-		matched2 := make([]bool, len(devices2))
-		for _, d1 := range devices1 {
-			foundMatch := false
-			for j, d2 := range devices2 {
-				if !matched2[j] && compareDevicesIgnoringName(d1, d2) {
-					matched2[j] = true
-					foundMatch = true
-					break
-				}
-			}
-			if !foundMatch {
-				return false
+	}
+
+	matched2 := make([]bool, len(devices2))
+	for _, d1 := range devices1 {
+		foundMatch := false
+		for j, d2 := range devices2 {
+			if !matched2[j] && compareDevicesIgnoringName(d1, d2) {
+				matched2[j] = true
+				foundMatch = true
+				break
 			}
 		}
+		if !foundMatch {
+			return false
+		}
 	}
+
 	if !reflect.DeepEqual(resourceSlice1.Spec.AllNodes, resourceSlice2.Spec.AllNodes) {
 		return false
 	}

--- a/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
+++ b/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 )
 
-// DynamicResourcesProcessor handles dynamic resource. 
+// DynamicResourcesProcessor handles dynamic resource.
 // dynamic resources may not be allocatable immediately after the node creation.
 // It compares the expected resourceslices with the existing resourceslices to assess node readiness.
 type DynamicResourcesProcessor interface {

--- a/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
+++ b/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
@@ -26,7 +26,11 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 )
 
+// DynamicResourcesProcessor handles dynamic resource. 
+// dynamic resources may not be allocatable immediately after the node creation.
+// It compares the expected resourceslices with the existing resourceslices to assess node readiness.
 type DynamicResourcesProcessor interface {
+	// FilterOutNodesWithUnreadyResources removes nodes that should have dynamic resources, but have not published resourceslices yet.
 	FilterOutNodesWithUnreadyResources(
 		context *ca_context.AutoscalingContext,
 		allNodes, readyNodes []*apiv1.Node,
@@ -35,12 +39,14 @@ type DynamicResourcesProcessor interface {
 	CleanUp()
 }
 
+// NewDefaultDynamicResourcesProcessor returns a default instance of DynamicResourcesProcessor.
 func NewDefaultDynamicResourcesProcessor() DynamicResourcesProcessor {
 	return &dynamicResourcesProcessor{}
 }
 
 type dynamicResourcesProcessor struct{}
 
+// FilterOutNodesWithUnreadyResources removes nodes that should have dynamic resources, but have not published resourceslices yet.
 func (p *dynamicResourcesProcessor) FilterOutNodesWithUnreadyResources(
 	context *ca_context.AutoscalingContext,
 	allNodes, readyNodes []*apiv1.Node,

--- a/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
+++ b/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
@@ -24,6 +24,7 @@ import (
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 // DynamicResourcesProcessor handles dynamic resource.
@@ -90,7 +91,9 @@ func (p *dynamicResourcesProcessor) checkNodeReadiness(
 	}
 	nodeTemplate, err := nodegroup.TemplateNodeInfo()
 	if err != nil {
-		return false, err
+		// should not happen, but if it does, we assume the node is ready, because it is probably handled by CA
+		klog.V(4).Infof("nodegroup template is not available for node %s: %v", node.Name, err)
+		return true, nil
 	}
 	templateResourceSlices, _, err := drautils.SanitizedNodeResourceSlices(nodeTemplate.LocalResourceSlices, node.Name, "")
 	if err != nil {

--- a/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
+++ b/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicresources
+
+import (
+	"reflect"
+
+	apiv1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1beta1"
+	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+)
+
+type DynamicResourcesProcessor interface {
+	FilterOutNodesWithUnreadyResources(
+		context *ca_context.AutoscalingContext,
+		allNodes, readyNodes []*apiv1.Node,
+		resourceSlices []*resourceapi.ResourceSlice,
+	) ([]*apiv1.Node, []*apiv1.Node, error)
+	CleanUp()
+}
+
+func NewDefaultDynamicResourcesProcessor() DynamicResourcesProcessor {
+	return &dynamicResourcesProcessor{}
+}
+
+type dynamicResourcesProcessor struct{}
+
+func (p *dynamicResourcesProcessor) FilterOutNodesWithUnreadyResources(
+	context *ca_context.AutoscalingContext,
+	allNodes, readyNodes []*apiv1.Node,
+	resourceSlices []*resourceapi.ResourceSlice,
+) ([]*apiv1.Node, []*apiv1.Node, error) {
+	newAllNodes := make([]*apiv1.Node, 0)
+	newReadyNodes := make([]*apiv1.Node, 0)
+	nodesWithUnreadyResources := make(map[string]*apiv1.Node)
+	for _, node := range readyNodes {
+		isReady, err := p.checkNodeReadiness(context, node, resourceSlices)
+		if err != nil {
+			return nil, nil, err
+		}
+		if isReady {
+			newReadyNodes = append(newReadyNodes, node)
+		} else {
+			nodesWithUnreadyResources[node.Name] = node
+		}
+	}
+	for _, node := range allNodes {
+		if newNode, found := nodesWithUnreadyResources[node.Name]; found {
+			newAllNodes = append(newAllNodes, kubernetes.GetUnreadyNodeCopy(newNode, kubernetes.ResourceUnready))
+		} else {
+			newAllNodes = append(newAllNodes, node)
+		}
+	}
+	return newAllNodes, newReadyNodes, nil
+}
+
+func (p *dynamicResourcesProcessor) checkNodeReadiness(
+	context *ca_context.AutoscalingContext,
+	node *apiv1.Node,
+	resourceSlices []*resourceapi.ResourceSlice,
+) (bool, error) {
+	nodegroup, err := context.CloudProvider.NodeGroupForNode(node)
+	if err != nil {
+		return false, err
+	}
+	if nodegroup == nil { // Node is not by autoscaler
+		return true, nil
+	}
+	nodeTemplate, err := nodegroup.TemplateNodeInfo()
+	if err != nil {
+		return false, err
+	}
+	templateResourceSlices, _, err := drautils.SanitizedNodeResourceSlices(nodeTemplate.LocalResourceSlices, node.Name, "")
+	if err != nil {
+		return false, err
+	}
+	if len(templateResourceSlices) == 0 {
+		return true, nil
+	}
+	clusterResourceSlices := resourceSlices
+	nodeResourceSlices := make([]*resourceapi.ResourceSlice, 0)
+	for _, rs := range clusterResourceSlices {
+		if rs != nil && rs.Spec.NodeName == node.Name {
+			nodeResourceSlices = append(nodeResourceSlices, rs)
+		}
+	}
+
+	nodeResourceSlices, _, err = drautils.SanitizedNodeResourceSlices(nodeResourceSlices, node.Name, "")
+	if err != nil {
+		return false, err
+	}
+
+	if len(templateResourceSlices) != len(nodeResourceSlices) {
+		return false, nil // Different number of slices means not ready/matched yet
+	}
+
+	for _, templateResourceSlice := range templateResourceSlices {
+		var matched bool = false
+		for _, nodeResourceSlice := range nodeResourceSlices {
+			if templateResourceSlice.Name == nodeResourceSlice.Name {
+				if compareResourceSlices(templateResourceSlice, nodeResourceSlice) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false, nil // No match was found for this template slice on the node
+			}
+		}
+	}
+
+	return true, nil // All template slices found a match
+
+}
+
+func compareResourceSlices(
+	resourceSlice1, resourceSlice2 *resourceapi.ResourceSlice,
+) bool {
+	// In order to assess whether the expected resourceslices have been published
+	// we only need to compare the spec
+	if resourceSlice1 == nil && resourceSlice2 == nil {
+		return true
+	}
+	if resourceSlice1 == nil || resourceSlice2 == nil {
+		return false
+	}
+	if !reflect.DeepEqual(resourceSlice1.Spec, resourceSlice2.Spec) {
+		return false
+	}
+	return true
+}
+
+// CleanUp cleans up processor's internal structures.
+func (p *dynamicResourcesProcessor) CleanUp() {
+}

--- a/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
+++ b/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
@@ -155,3 +155,21 @@ func compareResourceSlices(
 // CleanUp cleans up processor's internal structures.
 func (p *dynamicResourcesProcessor) CleanUp() {
 }
+
+type mockDynamicResourcesProcessor struct {
+}
+
+func (m *mockDynamicResourcesProcessor) FilterOutNodesWithUnreadyResources(
+	context *ca_context.AutoscalingContext,
+	allNodes, readyNodes []*apiv1.Node,
+	resourceSlices []*resourceapi.ResourceSlice,
+) ([]*apiv1.Node, []*apiv1.Node, error) {
+	return allNodes, readyNodes, nil
+}
+
+func (m *mockDynamicResourcesProcessor) CleanUp() {
+}
+
+func NewMockDynamicResourcesProcessor() DynamicResourcesProcessor {
+	return &mockDynamicResourcesProcessor{}
+}

--- a/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
+++ b/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor.go
@@ -170,6 +170,7 @@ func (m *mockDynamicResourcesProcessor) FilterOutNodesWithUnreadyResources(
 func (m *mockDynamicResourcesProcessor) CleanUp() {
 }
 
+// NewMockDynamicResourcesProcessor returns a mock instance of DynamicResourcesProcessor.
 func NewMockDynamicResourcesProcessor() DynamicResourcesProcessor {
 	return &mockDynamicResourcesProcessor{}
 }

--- a/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor_test.go
+++ b/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor_test.go
@@ -90,12 +90,25 @@ func TestDynamicResourcesProcessor(t *testing.T) {
 			LastHeartbeatTime: metav1.NewTime(later),
 		},
 	}
+	tn5 := testutils.BuildTestNode(
+		"nodenothandledbyautoscaler",
+		1000,
+		1000,
+	)
+	tn5.Status.Conditions = []apiv1.NodeCondition{
+		{
+			Type:              apiv1.NodeReady,
+			Status:            apiv1.ConditionTrue,
+			LastHeartbeatTime: metav1.NewTime(later),
+		},
+	}
 
 	expectedReadiness := make(map[string]bool)
 	expectedReadiness["readynodewithreadyresources"] = true
 	expectedReadiness["readynodewithunreadyresources"] = false
 	expectedReadiness["readynodewithoutresources"] = true
 	expectedReadiness["unreadynodewithoutresources"] = false
+	expectedReadiness["nodenothandledbyautoscaler"] = true
 
 	testResourceSlices := []*resourceapi.ResourceSlice{
 		{
@@ -144,8 +157,8 @@ func TestDynamicResourcesProcessor(t *testing.T) {
 
 	newAllNodes, newReadyNodes, err := processor.FilterOutNodesWithUnreadyResources(
 		&autoscalingContext,
-		[]*apiv1.Node{tn1, tn2, tn3, tn4},
-		[]*apiv1.Node{tn1, tn2, tn3},
+		[]*apiv1.Node{tn1, tn2, tn3, tn4, tn5},
+		[]*apiv1.Node{tn1, tn2, tn3, tn5},
 		testResourceSlices,
 	)
 

--- a/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor_test.go
+++ b/cluster-autoscaler/processors/dynamicresources/dynamic_resources_processor_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicresources
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	apiv1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	testutils "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	klog "k8s.io/klog/v2"
+)
+
+func TestDynamicResourcesProcessor(t *testing.T) {
+	start := time.Now()
+	later := start.Add(10 * time.Minute)
+	onScaleUpMock := &onScaleUpMock{}
+	onScaleDownMock := &onScaleDownMock{}
+	onNodeGroupCreateMock := &onNodeGroupCreateMock{}
+	onNodeGroupDeleteMock := &onNodeGroupDeleteMock{}
+	deleteFinished := make(chan bool, 1)
+
+	tn1 := testutils.BuildTestNode(
+		"readynodewithreadyresources",
+		1000,
+		1000,
+	)
+	tn1.Status.Conditions = []apiv1.NodeCondition{
+		{
+			Type:              apiv1.NodeReady,
+			Status:            apiv1.ConditionTrue,
+			LastHeartbeatTime: metav1.NewTime(later),
+		},
+	}
+	tn2 := testutils.BuildTestNode(
+		"readynodewithunreadyresources",
+		1000,
+		1000,
+	)
+	tn2.Status.Conditions = []apiv1.NodeCondition{
+		{
+			Type:              apiv1.NodeReady,
+			Status:            apiv1.ConditionTrue,
+			LastHeartbeatTime: metav1.NewTime(later),
+		},
+	}
+	tn3 := testutils.BuildTestNode(
+		"readynodewithoutresources",
+		1000,
+		1000,
+	)
+	tn3.Status.Conditions = []apiv1.NodeCondition{
+		{
+			Type:              apiv1.NodeReady,
+			Status:            apiv1.ConditionTrue,
+			LastHeartbeatTime: metav1.NewTime(later),
+		},
+	}
+	tn4 := testutils.BuildTestNode(
+		"unreadynodewithoutresources",
+		1000,
+		1000,
+	)
+	tn4.Status.Conditions = []apiv1.NodeCondition{
+		{
+			Type:              apiv1.NodeReady,
+			Status:            apiv1.ConditionFalse,
+			LastHeartbeatTime: metav1.NewTime(later),
+		},
+	}
+
+	expectedReadiness := make(map[string]bool)
+	expectedReadiness["readynodewithreadyresources"] = true
+	expectedReadiness["readynodewithunreadyresources"] = false
+	expectedReadiness["readynodewithoutresources"] = true
+	expectedReadiness["unreadynodewithoutresources"] = false
+
+	testResourceSlices := []*resourceapi.ResourceSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "slice1",
+			},
+			Spec: resourceapi.ResourceSliceSpec{
+				NodeName: "readynodewithreadyresources",
+			},
+		},
+	}
+
+	tni1 := framework.NewTestNodeInfo(tn1)
+	tni3 := framework.NewTestNodeInfo(tn3)
+
+	tni1.LocalResourceSlices = testResourceSlices
+
+	provider := testprovider.NewTestAutoprovisioningCloudProvider(
+		func(id string, delta int) error {
+			return onScaleUpMock.ScaleUp(id, delta)
+		}, func(id string, name string) error {
+			ret := onScaleDownMock.ScaleDown(id, name)
+			deleteFinished <- true
+			return ret
+		}, func(id string) error {
+			return onNodeGroupCreateMock.Create(id)
+		}, func(id string) error {
+			return onNodeGroupDeleteMock.Delete(id)
+		},
+		[]string{"tni1", "tni3"},
+		map[string]*framework.NodeInfo{"ng1": tni1, "ng3": tni3},
+	)
+
+	provider.AddAutoprovisionedNodeGroup("ng1", 0, 10, 2, "ng1")
+	provider.AddAutoprovisionedNodeGroup("ng3", 0, 10, 2, "ng3")
+	provider.AddNode("ng1", tn1)
+	provider.AddNode("ng1", tn2)
+	provider.AddNode("ng3", tn3)
+	provider.AddNode("ng3", tn4)
+
+	autoscalingContext := ca_context.AutoscalingContext{
+		CloudProvider: provider,
+	}
+
+	processor := NewDefaultDynamicResourcesProcessor()
+
+	newAllNodes, newReadyNodes, err := processor.FilterOutNodesWithUnreadyResources(
+		&autoscalingContext,
+		[]*apiv1.Node{tn1, tn2, tn3, tn4},
+		[]*apiv1.Node{tn1, tn2, tn3},
+		testResourceSlices,
+	)
+
+	assert.NoError(t, err)
+
+	foundInReady := make(map[string]bool)
+	for _, node := range newReadyNodes {
+		foundInReady[node.Name] = true
+		assert.True(t, expectedReadiness[node.Name], fmt.Sprintf("Node %s found in ready nodes list (it shouldn't be there)", node.Name))
+	}
+	for nodeName, expected := range expectedReadiness {
+		if expected {
+			assert.True(t, foundInReady[nodeName], fmt.Sprintf("Node %s expected ready, but not found in ready nodes list", nodeName))
+		}
+	}
+	for _, node := range newAllNodes {
+		assert.Equal(t, len(node.Status.Conditions), 1)
+		if expectedReadiness[node.Name] {
+			assert.Equal(t, node.Status.Conditions[0].Status, apiv1.ConditionTrue, fmt.Sprintf("Unexpected ready condition value for node %s", node.Name))
+		} else {
+			assert.Equal(t, node.Status.Conditions[0].Status, apiv1.ConditionFalse, fmt.Sprintf("Unexpected ready condition value for node %s", node.Name))
+		}
+	}
+}
+
+type onScaleUpMock struct {
+	mock.Mock
+}
+
+func (m *onScaleUpMock) ScaleUp(id string, delta int) error {
+	klog.Infof("Scale up: %v %v", id, delta)
+	args := m.Called(id, delta)
+	return args.Error(0)
+}
+
+type onScaleDownMock struct {
+	mock.Mock
+}
+
+func (m *onScaleDownMock) ScaleDown(id string, name string) error {
+	klog.Infof("Scale down: %v %v", id, name)
+	args := m.Called(id, name)
+	return args.Error(0)
+}
+
+type onNodeGroupCreateMock struct {
+	mock.Mock
+}
+
+func (m *onNodeGroupCreateMock) Create(id string) error {
+	klog.Infof("Create group: %v", id)
+	args := m.Called(id)
+	return args.Error(0)
+}
+
+type onNodeGroupDeleteMock struct {
+	mock.Mock
+}
+
+func (m *onNodeGroupDeleteMock) Delete(id string) error {
+	klog.Infof("Delete group: %v", id)
+	args := m.Called(id)
+	return args.Error(0)
+}

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/actionablecluster"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/binpacking"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/dynamicresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups/asyncnodegroups"
@@ -62,6 +63,8 @@ type AutoscalingProcessors struct {
 	NodeGroupConfigProcessor nodegroupconfig.NodeGroupConfigProcessor
 	// CustomResourcesProcessor is interface defining handling custom resources
 	CustomResourcesProcessor customresources.CustomResourcesProcessor
+	// DynamicResourcesProcessor is interface defining handling dynamic resources
+	DynamicResourcesProcessor dynamicresources.DynamicResourcesProcessor
 	// ActionableClusterProcessor is interface defining whether the cluster is in an actionable state
 	ActionableClusterProcessor actionablecluster.ActionableClusterProcessor
 	// ScaleDownCandidatesNotifier  is used to Update and Register new scale down candidates observer.
@@ -98,6 +101,7 @@ func DefaultProcessors(options config.AutoscalingOptions) *AutoscalingProcessors
 		AsyncNodeGroupStateChecker:  asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(),
 		NodeGroupConfigProcessor:    nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults),
 		CustomResourcesProcessor:    customresources.NewDefaultCustomResourcesProcessor(),
+		DynamicResourcesProcessor:   dynamicresources.NewDefaultDynamicResourcesProcessor(),
 		ActionableClusterProcessor:  actionablecluster.NewDefaultActionableClusterProcessor(),
 		TemplateNodeInfoProvider:    nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false),
 		ScaleDownCandidatesNotifier: scaledowncandidates.NewObserversList(),
@@ -119,6 +123,7 @@ func (ap *AutoscalingProcessors) CleanUp() {
 	ap.ScaleDownNodeProcessor.CleanUp()
 	ap.NodeGroupConfigProcessor.CleanUp()
 	ap.CustomResourcesProcessor.CleanUp()
+	ap.DynamicResourcesProcessor.CleanUp()
 	ap.TemplateNodeInfoProvider.CleanUp()
 	ap.ActionableClusterProcessor.CleanUp()
 }

--- a/cluster-autoscaler/processors/test/common.go
+++ b/cluster-autoscaler/processors/test/common.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/actionablecluster"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/binpacking"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/dynamicresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups/asyncnodegroups"
@@ -53,6 +54,7 @@ func NewTestProcessors(context *context.AutoscalingContext) *processors.Autoscal
 		TemplateNodeInfoProvider:    nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false),
 		NodeGroupConfigProcessor:    nodegroupconfig.NewDefaultNodeGroupConfigProcessor(context.NodeGroupDefaults),
 		CustomResourcesProcessor:    customresources.NewDefaultCustomResourcesProcessor(),
+		DynamicResourcesProcessor:   dynamicresources.NewDefaultDynamicResourcesProcessor(),
 		ActionableClusterProcessor:  actionablecluster.NewDefaultActionableClusterProcessor(),
 		ScaleDownCandidatesNotifier: scaledowncandidates.NewObserversList(),
 		ScaleStateNotifier:          nodegroupchange.NewNodeGroupChangeObserversList(),


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Nodes with custom resources exposed by device plugins (e.g. GPUs) have condition Ready before they actually expose the resources. Cluster Autoscaler has to hack them to be not-Ready until they do expose the resources, otherwise the unschedulable pods don't pack on the Nodes in filter_out_schedulable and CA does another, unnecessary scale-up.

The same happens for DRA resources - until the driver for a given Node publishes its ResourceSlices, the Node is considered Ready but the Pod can't schedule on it, so CA does another scale-up.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/7780

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
