### PR TITLE
feat(cluster-autoscaler/exoscale): add `volumeattachments` to ClusterRole

### DIFF
--- a/cluster-autoscaler/cloudprovider/exoscale/examples/cluster-autoscaler-run-on-control-plane.yaml
+++ b/cluster-autoscaler/cloudprovider/exoscale/examples/cluster-autoscaler-run-on-control-plane.yaml
@@ -54,7 +54,12 @@ rules:
     resources: ["statefulsets", "replicasets", "daemonsets"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes", "csistoragecapacities", "csidrivers"]
+    resources:
+      - "storageclasses"
+      - "csinodes"
+      - "csistoragecapacities"
+      - "csidrivers"
+      - "volumeattachments"
     verbs: ["watch", "list", "get"]
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]

--- a/cluster-autoscaler/cloudprovider/exoscale/examples/cluster-autoscaler.yaml
+++ b/cluster-autoscaler/cloudprovider/exoscale/examples/cluster-autoscaler.yaml
@@ -54,7 +54,12 @@ rules:
     resources: ["statefulsets", "replicasets", "daemonsets"]
     verbs: ["watch", "list", "get"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes", "csistoragecapacities", "csidrivers"]
+    resources:
+      - "storageclasses"
+      - "csinodes"
+      - "csistoragecapacities"
+      - "csidrivers"
+      - "volumeattachments"
     verbs: ["watch", "list", "get"]
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Grant access to resource `storage.k8s.io/volumeattachments` in the resource example for Cluster Autoscaler using the Exoscale Cloud Provider.

This aligns the example with the chart in `charts/cluster-autoscaler`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Related: https://github.com/kubernetes/autoscaler/issues/7663

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
