### PR TITLE
chore: improve logging for missing limit assignments

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
@@ -61,11 +61,11 @@ func getProportionalResourceLimit(resourceName core.ResourceName, originalLimit,
 	}
 	// originalLimit not set, don't set limit.
 	if originalLimit == nil || originalLimit.Value() == 0 {
-		return nil, ""
+		return nil, fmt.Sprintf("%v: limit NOT set since originalLimit is nil or 0", resourceName)
 	}
 	// recommendedRequest not set, don't set limit.
 	if recommendedRequest == nil || recommendedRequest.Value() == 0 {
-		return nil, ""
+		return nil, fmt.Sprintf("%v: limit NOT set since recommendedRequest is nil or 0", resourceName)
 	}
 	// originalLimit set but originalRequest not set - K8s will treat the pod as if they were equal,
 	// recommend limit equal to request

--- a/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling_test.go
@@ -60,6 +60,7 @@ func TestGetProportionalResourceLimitCPU(t *testing.T) {
 			originalRequest:    mustParseToPointer("1"),
 			recommendedRequest: mustParseToPointer("10"),
 			expectLimit:        nil,
+			expectAnnotation:   true,
 		},
 		{
 			name:               "no original request",
@@ -73,6 +74,7 @@ func TestGetProportionalResourceLimitCPU(t *testing.T) {
 			recommendedRequest: mustParseToPointer("0"),
 			defaultLimit:       mustParseToPointer("2"),
 			expectLimit:        nil,
+			expectAnnotation:   true,
 		},
 		{
 			name:               "limit equal to request",
@@ -141,6 +143,7 @@ func TestGetProportionalResourceLimitMem(t *testing.T) {
 			originalRequest:    mustParseToPointer("1"),
 			recommendedRequest: mustParseToPointer("10"),
 			expectLimit:        nil,
+			expectAnnotation:   true,
 		},
 		{
 			name:               "no original request",
@@ -154,6 +157,7 @@ func TestGetProportionalResourceLimitMem(t *testing.T) {
 			recommendedRequest: mustParseToPointer("0"),
 			defaultLimit:       mustParseToPointer("2"),
 			expectLimit:        nil,
+			expectAnnotation:   true,
 		},
 		{
 			name:               "limit equal to request",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Improves visibility when limit is not set by vertical pod autoscaler returning the reason why the limit is not set.

Fixes #7884
