### PR TITLE
Patches based implementation for DRA snapshot.

### DIFF
--- a/cluster-autoscaler/core/podlistprocessor/filter_out_expendable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_expendable_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
@@ -111,7 +110,7 @@ func TestFilterOutExpendable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			processor := NewFilterOutExpendablePodListProcessor()
 			snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-			err := snapshot.SetClusterState(tc.nodes, nil, drasnapshot.Snapshot{})
+			err := snapshot.SetClusterState(tc.nodes, nil, nil)
 			assert.NoError(t, err)
 
 			pods, err := processor.Process(&context.AutoscalingContext{

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -281,7 +280,7 @@ func BenchmarkFilterOutSchedulable(b *testing.B) {
 				}
 
 				clusterSnapshot := snapshotFactory()
-				if err := clusterSnapshot.SetClusterState(nodes, scheduledPods, drasnapshot.Snapshot{}); err != nil {
+				if err := clusterSnapshot.SetClusterState(nodes, scheduledPods, nil); err != nil {
 					assert.NoError(b, err)
 				}
 

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -406,7 +406,7 @@ func (a *Actuator) createSnapshot(nodes []*apiv1.Node) (clustersnapshot.ClusterS
 	scheduledPods := kube_util.ScheduledPods(pods)
 	nonExpendableScheduledPods := utils.FilterOutExpendablePods(scheduledPods, a.ctx.ExpendablePodsPriorityCutoff)
 
-	var draSnapshot drasnapshot.Snapshot
+	var draSnapshot *drasnapshot.Snapshot
 	if a.ctx.DynamicResourceAllocationEnabled && a.ctx.DraProvider != nil {
 		draSnapshot, err = a.ctx.DraProvider.Snapshot()
 		if err != nil {

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -42,7 +42,7 @@ type testCase struct {
 	desc                        string
 	nodes                       []*apiv1.Node
 	pods                        []*apiv1.Pod
-	draSnapshot                 drasnapshot.Snapshot
+	draSnapshot                 *drasnapshot.Snapshot
 	draEnabled                  bool
 	wantUnneeded                []string
 	wantUnremovable             []*simulator.UnremovableNode

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	processorstest "k8s.io/autoscaler/cluster-autoscaler/processors/test"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -1044,7 +1043,7 @@ func runSimpleScaleUpTest(t *testing.T, config *ScaleUpTestConfig) *ScaleUpTestR
 	// build orchestrator
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
 	assert.NoError(t, err)
-	err = context.ClusterSnapshot.SetClusterState(nodes, kube_util.ScheduledPods(pods), drasnapshot.Snapshot{})
+	err = context.ClusterSnapshot.SetClusterState(nodes, kube_util.ScheduledPods(pods), nil)
 	assert.NoError(t, err)
 	nodeInfos, err := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).
 		Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
@@ -1154,7 +1153,7 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	}
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
 	assert.NoError(t, err)
-	err = context.ClusterSnapshot.SetClusterState(nodes, pods, drasnapshot.Snapshot{})
+	err = context.ClusterSnapshot.SetClusterState(nodes, pods, nil)
 	assert.NoError(t, err)
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker())
@@ -1197,7 +1196,7 @@ func TestBinpackingLimiter(t *testing.T) {
 
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
 	assert.NoError(t, err)
-	err = context.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+	err = context.ClusterSnapshot.SetClusterState(nodes, nil, nil)
 	assert.NoError(t, err)
 	nodeInfos, err := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).
 		Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
@@ -1257,7 +1256,7 @@ func TestScaleUpNoHelp(t *testing.T) {
 	}
 	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
 	assert.NoError(t, err)
-	err = context.ClusterSnapshot.SetClusterState(nodes, pods, drasnapshot.Snapshot{})
+	err = context.ClusterSnapshot.SetClusterState(nodes, pods, nil)
 	assert.NoError(t, err)
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker())
@@ -1412,7 +1411,7 @@ func TestComputeSimilarNodeGroups(t *testing.T) {
 			listers := kube_util.NewListerRegistry(nil, nil, kube_util.NewTestPodLister(nil), nil, nil, nil, nil, nil, nil)
 			ctx, err := NewScaleTestAutoscalingContext(config.AutoscalingOptions{BalanceSimilarNodeGroups: tc.balancingEnabled}, &fake.Clientset{}, listers, provider, nil, nil)
 			assert.NoError(t, err)
-			err = ctx.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+			err = ctx.ClusterSnapshot.SetClusterState(nodes, nil, nil)
 			assert.NoError(t, err)
 			nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&ctx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 			clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, ctx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker())
@@ -1496,7 +1495,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 			}
 			context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil)
 			assert.NoError(t, err)
-			err = context.ClusterSnapshot.SetClusterState(nodes, podList, drasnapshot.Snapshot{})
+			err = context.ClusterSnapshot.SetClusterState(nodes, podList, nil)
 			assert.NoError(t, err)
 			nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 			clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, context.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker())
@@ -1672,7 +1671,7 @@ func TestScaleUpToMeetNodeGroupMinSize(t *testing.T) {
 	assert.NoError(t, err)
 
 	nodes := []*apiv1.Node{n1, n2}
-	err = context.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+	err = context.ClusterSnapshot.SetClusterState(nodes, nil, nil)
 	assert.NoError(t, err)
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 	processors := processorstest.NewTestProcessors(&context)

--- a/cluster-autoscaler/core/scaleup/resource/manager_test.go
+++ b/cluster-autoscaler/core/scaleup/resource/manager_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/test"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
 	processorstest "k8s.io/autoscaler/cluster-autoscaler/processors/test"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	utils_test "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -72,7 +71,7 @@ func TestDeltaForNode(t *testing.T) {
 
 		ng := testCase.nodeGroupConfig
 		group, nodes := newNodeGroup(t, cp, ng.Name, ng.Min, ng.Max, ng.Size, ng.CPU, ng.Mem)
-		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil, nil)
 		assert.NoError(t, err)
 		nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&ctx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 
@@ -115,7 +114,7 @@ func TestResourcesLeft(t *testing.T) {
 
 		ng := testCase.nodeGroupConfig
 		_, nodes := newNodeGroup(t, cp, ng.Name, ng.Min, ng.Max, ng.Size, ng.CPU, ng.Mem)
-		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil, nil)
 		assert.NoError(t, err)
 		nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&ctx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 
@@ -168,7 +167,7 @@ func TestApplyLimits(t *testing.T) {
 
 		ng := testCase.nodeGroupConfig
 		group, nodes := newNodeGroup(t, cp, ng.Name, ng.Min, ng.Max, ng.Size, ng.CPU, ng.Mem)
-		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+		err := ctx.ClusterSnapshot.SetClusterState(nodes, nil, nil)
 		assert.NoError(t, err)
 		nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&ctx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 
@@ -235,7 +234,7 @@ func TestResourceManagerWithGpuResource(t *testing.T) {
 	assert.NoError(t, err)
 
 	nodes := []*corev1.Node{n1}
-	err = context.ClusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+	err = context.ClusterSnapshot.SetClusterState(nodes, nil, nil)
 	assert.NoError(t, err)
 	nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&context, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -335,7 +335,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 	nonExpendableScheduledPods := core_utils.FilterOutExpendablePods(originalScheduledPods, a.ExpendablePodsPriorityCutoff)
 
-	var draSnapshot drasnapshot.Snapshot
+	var draSnapshot *drasnapshot.Snapshot
 	if a.AutoscalingContext.DynamicResourceAllocationEnabled && a.AutoscalingContext.DraProvider != nil {
 		draSnapshot, err = a.AutoscalingContext.DraProvider.Snapshot()
 		if err != nil {

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
@@ -28,7 +28,6 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -86,7 +85,7 @@ func TestGetNodeInfosForGroups(t *testing.T) {
 
 	nodes := []*apiv1.Node{justReady5, unready4, unready3, ready2, ready1, ready7, readyToBeDeleted6}
 	snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-	err := snapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+	err := snapshot.SetClusterState(nodes, nil, nil)
 	assert.NoError(t, err)
 
 	ctx := context.AutoscalingContext{
@@ -173,7 +172,7 @@ func TestGetNodeInfosForGroupsCache(t *testing.T) {
 
 	nodes := []*apiv1.Node{unready4, unready3, ready2, ready1}
 	snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-	err := snapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+	err := snapshot.SetClusterState(nodes, nil, nil)
 	assert.NoError(t, err)
 
 	// Fill cache
@@ -264,7 +263,7 @@ func TestGetNodeInfosCacheExpired(t *testing.T) {
 
 	nodes := []*apiv1.Node{ready1}
 	snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-	err := snapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+	err := snapshot.SetClusterState(nodes, nil, nil)
 	assert.NoError(t, err)
 
 	ctx := context.AutoscalingContext{

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -77,7 +77,7 @@ type ClusterSnapshotStore interface {
 
 	// SetClusterState resets the snapshot to an unforked state and replaces the contents of the snapshot
 	// with the provided data. scheduledPods are correlated to their Nodes based on spec.NodeName.
-	SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod, draSnapshot drasnapshot.Snapshot) error
+	SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod, draSnapshot *drasnapshot.Snapshot) error
 
 	// ForceAddPod adds the given Pod to the Node with the given nodeName inside the snapshot without checking scheduler predicates.
 	ForceAddPod(pod *apiv1.Pod, nodeName string) error
@@ -93,7 +93,7 @@ type ClusterSnapshotStore interface {
 	RemoveSchedulerNodeInfo(nodeName string) error
 
 	// DraSnapshot returns an interface that allows accessing and modifying the DRA objects in the snapshot.
-	DraSnapshot() drasnapshot.Snapshot
+	DraSnapshot() *drasnapshot.Snapshot
 
 	// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert().
 	// Use WithForkedSnapshot() helper function instead if possible.

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
@@ -56,6 +56,7 @@ func (s *PredicateSnapshot) GetNodeInfo(nodeName string) (*framework.NodeInfo, e
 	if err != nil {
 		return nil, err
 	}
+
 	if s.draEnabled {
 		return s.ClusterSnapshotStore.DraSnapshot().WrapSchedulerNodeInfo(schedNodeInfo)
 	}

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_benchmark_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
@@ -40,7 +39,7 @@ func BenchmarkAddNodeInfo(b *testing.B) {
 			b.Run(fmt.Sprintf("%s: AddNodeInfo() %d", snapshotName, tc), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
-					assert.NoError(b, clusterSnapshot.SetClusterState(nil, nil, drasnapshot.Snapshot{}))
+					assert.NoError(b, clusterSnapshot.SetClusterState(nil, nil, nil))
 					b.StartTimer()
 					for _, node := range nodes {
 						err := clusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node))
@@ -62,7 +61,7 @@ func BenchmarkListNodeInfos(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc)
 			clusterSnapshot, err := snapshotFactory()
 			assert.NoError(b, err)
-			err = clusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+			err = clusterSnapshot.SetClusterState(nodes, nil, nil)
 			if err != nil {
 				assert.NoError(b, err)
 			}
@@ -92,14 +91,14 @@ func BenchmarkAddPods(b *testing.B) {
 			clustersnapshot.AssignTestPodsToNodes(pods, nodes)
 			clusterSnapshot, err := snapshotFactory()
 			assert.NoError(b, err)
-			err = clusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+			err = clusterSnapshot.SetClusterState(nodes, nil, nil)
 			assert.NoError(b, err)
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s: ForceAddPod() 30*%d", snapshotName, tc), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
-					err = clusterSnapshot.SetClusterState(nodes, nil, drasnapshot.Snapshot{})
+					err = clusterSnapshot.SetClusterState(nodes, nil, nil)
 					if err != nil {
 						assert.NoError(b, err)
 					}
@@ -128,7 +127,7 @@ func BenchmarkForkAddRevert(b *testing.B) {
 				clustersnapshot.AssignTestPodsToNodes(pods, nodes)
 				clusterSnapshot, err := snapshotFactory()
 				assert.NoError(b, err)
-				err = clusterSnapshot.SetClusterState(nodes, pods, drasnapshot.Snapshot{})
+				err = clusterSnapshot.SetClusterState(nodes, pods, nil)
 				assert.NoError(b, err)
 				tmpNode1 := BuildTestNode("tmp-1", 2000, 2000000)
 				tmpNode2 := BuildTestNode("tmp-2", 2000, 2000000)

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	apiv1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/util/feature"
+	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
+	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	featuretesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func createTestResourceSlice(nodeName string, devicesPerSlice int, slicesPerNode int, driver string, device resourceapi.BasicDevice) *resourceapi.ResourceSlice {
+	sliceId := uuid.New().String()
+	name := fmt.Sprintf("rs-%s", sliceId)
+	uid := types.UID(fmt.Sprintf("rs-%s-uid", sliceId))
+	devices := make([]resourceapi.Device, devicesPerSlice)
+	for deviceIndex := 0; deviceIndex < devicesPerSlice; deviceIndex++ {
+		deviceName := fmt.Sprintf("rs-dev-%s-%d", sliceId, deviceIndex)
+		deviceCopy := device
+		devices[deviceIndex] = resourceapi.Device{Name: deviceName, Basic: &deviceCopy}
+	}
+
+	return &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
+		Spec: resourceapi.ResourceSliceSpec{
+			NodeName: nodeName,
+			Driver:   driver,
+			Pool: resourceapi.ResourcePool{
+				Name:               nodeName,
+				ResourceSliceCount: int64(slicesPerNode),
+			},
+			Devices: devices,
+		},
+	}
+}
+
+func createTestResourceClaim(requestsPerClaim int, devicesPerRequest int, driver string, deviceClass string) *resourceapi.ResourceClaim {
+	claimId := uuid.New().String()
+	name := fmt.Sprintf("claim-%s", claimId)
+	uid := types.UID(fmt.Sprintf("claim-%s-uid", claimId))
+	expression := fmt.Sprintf(`device.driver == "%s"`, driver)
+
+	requests := make([]resourceapi.DeviceRequest, requestsPerClaim)
+	for requestIndex := 0; requestIndex < requestsPerClaim; requestIndex++ {
+		requests[requestIndex] = resourceapi.DeviceRequest{
+			Name:            fmt.Sprintf("deviceRequest-%d", requestIndex),
+			DeviceClassName: deviceClass,
+			Selectors:       []resourceapi.DeviceSelector{{CEL: &resourceapi.CELDeviceSelector{Expression: expression}}},
+			AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+			Count:           int64(devicesPerRequest),
+		}
+	}
+
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid, Namespace: "default"},
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{Requests: requests},
+		},
+	}
+}
+
+// allocateResourceSlicesForClaim attempts to allocate devices from the provided ResourceSlices
+// to satisfy the requests in the given ResourceClaim. It iterates through the claim's device
+// requests and, for each request, tries to find enough available devices in the provided slices.
+//
+// The function returns a new ResourceClaim object with the allocation result (if successful)
+// and a boolean indicating whether all requests in the claim were satisfied.
+//
+// If not all requests can be satisfied with the given slices, the returned ResourceClaim will
+// have a partial or empty allocation, and the boolean will be false.
+// The original ResourceClaim object is not modified.
+func allocateResourceSlicesForClaim(claim *resourceapi.ResourceClaim, nodeName string, slices ...*resourceapi.ResourceSlice) (*resourceapi.ResourceClaim, bool) {
+	allocatedDevices := make([]resourceapi.DeviceRequestAllocationResult, 0, len(claim.Spec.Devices.Requests))
+	sliceIndex, deviceIndex := 0, 0
+	requestSatisfied := true
+
+allocationLoop:
+	for _, request := range claim.Spec.Devices.Requests {
+		for devicesRequired := request.Count; devicesRequired > 0; devicesRequired-- {
+			// Skipping resource slices until we find one with at least a single device available
+			for sliceIndex < len(slices) && deviceIndex >= len(slices[sliceIndex].Spec.Devices) {
+				sliceIndex++
+				deviceIndex = 0
+			}
+
+			// In case in the previous look we weren't able to find a resource slice containing
+			// at least a single device and there's still device request pending from resource
+			// claim - terminate allocation loop and indicate the request wasn't fully satisfied
+			if sliceIndex >= len(slices) {
+				requestSatisfied = false
+				break allocationLoop
+			}
+
+			slice := slices[sliceIndex]
+			device := slice.Spec.Devices[deviceIndex]
+			deviceAllocation := resourceapi.DeviceRequestAllocationResult{
+				Request: request.Name,
+				Driver:  slice.Spec.Driver,
+				Pool:    slice.Spec.Pool.Name,
+				Device:  device.Name,
+			}
+
+			allocatedDevices = append(allocatedDevices, deviceAllocation)
+			deviceIndex++
+		}
+	}
+
+	allocation := &resourceapi.AllocationResult{
+		NodeSelector: selectorForNode(nodeName),
+		Devices:      resourceapi.DeviceAllocationResult{Results: allocatedDevices},
+	}
+
+	return drautils.TestClaimWithAllocation(claim, allocation), requestSatisfied
+}
+
+func selectorForNode(node string) *apiv1.NodeSelector {
+	return &apiv1.NodeSelector{
+		NodeSelectorTerms: []apiv1.NodeSelectorTerm{
+			{
+				MatchFields: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "metadata.name",
+						Operator: apiv1.NodeSelectorOpIn,
+						Values:   []string{node},
+					},
+				},
+			},
+		},
+	}
+}
+
+// BenchmarkScheduleRevert measures the performance of scheduling pods which interact with Dynamic Resources Allocation
+// API onto nodes within a cluster snapshot, followed by snapshot manipulation operations (fork, commit, revert).
+//
+// The benchmark iterates tests for various configurations, varying:
+// - The number of nodes in the initial snapshot.
+// - The number of pods being scheduled, categorized by whether they use shared or pod-owned ResourceClaims.
+// - The number of snapshot operations (Fork, Commit, Revert) performed before/after scheduling.
+//
+// For each configuration and snapshot type, the benchmark performs the following steps:
+//  1. Initializes a cluster snapshot with a predefined set of nodes, ResourceSlices, DeviceClasses, and pre-allocated ResourceClaims (both shared and potentially pod-owned).
+//  2. Iterates through a subset of the nodes based on the configuration.
+//  3. For each node:
+//     a. Performs the configured number of snapshot Forks.
+//     b. Adds the node's NodeInfo (including its ResourceSlices) to the snapshot.
+//     c. Schedules a configured number of pods that reference a shared ResourceClaim onto the node.
+//     d. Schedules a configured number of pods that reference their own pre-allocated pod-owned ResourceClaims onto the node.
+//     e. Performs the configured number of snapshot Commits.
+//     f. Performs the configured number of snapshot Reverts.
+//
+// This benchmark helps evaluate the efficiency of:
+// - Scheduling pods with different types of DRA claims.
+// - Adding nodes with DRA resources to the snapshot.
+// - The overhead of snapshot Fork, Commit, and Revert operations, especially in scenarios involving DRA objects.
+func BenchmarkScheduleRevert(b *testing.B) {
+	featuretesting.SetFeatureGateDuringTest(b, feature.DefaultFeatureGate, features.DynamicResourceAllocation, true)
+
+	const maxNodesCount = 100
+	const devicesPerSlice = 100
+	const maxPodsCount = 100
+	const deviceClassName = "defaultClass"
+	const driverName = "driver.foo.com"
+
+	configurations := map[string]struct {
+		nodesCount int
+
+		sharedClaimPods int
+		ownedClaimPods  int
+		forks           int
+		commits         int
+		reverts         int
+	}{
+		// SHARED CLAIMS
+		"100x32/SharedClaims/ForkRevert":           {sharedClaimPods: 32, nodesCount: 100, forks: 1, reverts: 1},
+		"100x32/SharedClaims/ForkCommit":           {sharedClaimPods: 32, nodesCount: 100, forks: 1, commits: 1},
+		"100x32/SharedClaims/ForkForkCommitRevert": {sharedClaimPods: 32, nodesCount: 100, forks: 2, reverts: 1, commits: 1},
+		"100x32/SharedClaims/Fork":                 {sharedClaimPods: 32, nodesCount: 100, forks: 1},
+		"100x32/SharedClaims/Fork5Revert5":         {sharedClaimPods: 32, nodesCount: 100, forks: 5, reverts: 5},
+		"100x1/SharedClaims/ForkRevert":            {sharedClaimPods: 1, nodesCount: 100, forks: 1, reverts: 1},
+		"100x1/SharedClaims/ForkCommit":            {sharedClaimPods: 1, nodesCount: 100, forks: 1, commits: 1},
+		"100x1/SharedClaims/ForkForkCommitRevert":  {sharedClaimPods: 1, nodesCount: 100, forks: 2, reverts: 1, commits: 1},
+		"100x1/SharedClaims/Fork":                  {sharedClaimPods: 1, nodesCount: 100, forks: 1},
+		"100x1/SharedClaims/Fork5Revert5":          {sharedClaimPods: 1, nodesCount: 100, forks: 5, reverts: 5},
+		"10x32/SharedClaims/ForkRevert":            {sharedClaimPods: 32, nodesCount: 10, forks: 1, reverts: 1},
+		"10x32/SharedClaims/ForkCommit":            {sharedClaimPods: 32, nodesCount: 10, forks: 1, commits: 1},
+		"10x32/SharedClaims/ForkForkCommitRevert":  {sharedClaimPods: 32, nodesCount: 10, forks: 2, reverts: 1, commits: 1},
+		"10x32/SharedClaims/Fork":                  {sharedClaimPods: 32, nodesCount: 10, forks: 1},
+		"10x32/SharedClaims/Fork5Revert5":          {sharedClaimPods: 32, nodesCount: 10, forks: 5, reverts: 5},
+		"10x1/SharedClaims/ForkRevert":             {sharedClaimPods: 1, nodesCount: 10, forks: 1, reverts: 1},
+		"10x1/SharedClaims/ForkCommit":             {sharedClaimPods: 1, nodesCount: 10, forks: 1, commits: 1},
+		"10x1/SharedClaims/ForkForkCommitRevert":   {sharedClaimPods: 1, nodesCount: 10, forks: 2, reverts: 1, commits: 1},
+		"10x1/SharedClaims/Fork":                   {sharedClaimPods: 1, nodesCount: 10, forks: 1},
+		"10x1/SharedClaims/Fork5Revert5":           {sharedClaimPods: 1, nodesCount: 10, forks: 5, reverts: 5},
+		// POD OWNED CLAIMS
+		"100x100/OwnedClaims/ForkRevert":           {ownedClaimPods: 100, nodesCount: 100, forks: 1, reverts: 1},
+		"100x100/OwnedClaims/ForkCommit":           {ownedClaimPods: 100, nodesCount: 100, forks: 1, commits: 1},
+		"100x100/OwnedClaims/ForkForkCommitRevert": {ownedClaimPods: 100, nodesCount: 100, forks: 2, reverts: 1, commits: 1},
+		"100x100/OwnedClaims/Fork":                 {ownedClaimPods: 100, nodesCount: 100, forks: 1},
+		"100x100/OwnedClaims/Fork5Revert5":         {ownedClaimPods: 100, nodesCount: 100, forks: 5, reverts: 5},
+		"100х1/OwnedClaims/ForkRevert":             {ownedClaimPods: 1, nodesCount: 100, forks: 1, reverts: 1},
+		"100x1/OwnedClaims/ForkCommit":             {ownedClaimPods: 1, nodesCount: 100, forks: 1, commits: 1},
+		"100x1/OwnedClaims/ForkForkCommitRevert":   {ownedClaimPods: 1, nodesCount: 100, forks: 2, reverts: 1, commits: 1},
+		"100x1/OwnedClaims/Fork":                   {ownedClaimPods: 1, nodesCount: 100, forks: 1},
+		"100x1/OwnedClaims/Fork5Revert5":           {ownedClaimPods: 1, nodesCount: 100, forks: 5, reverts: 5},
+		"10x100/OwnedClaims/ForkRevert":            {ownedClaimPods: 100, nodesCount: 10, forks: 1, reverts: 1},
+		"10x100/OwnedClaims/ForkCommit":            {ownedClaimPods: 100, nodesCount: 10, forks: 1, commits: 1},
+		"10x100/OwnedClaims/ForkForkCommitRevert":  {ownedClaimPods: 100, nodesCount: 10, forks: 2, reverts: 1, commits: 1},
+		"10x100/OwnedClaims/Fork":                  {ownedClaimPods: 100, nodesCount: 10, forks: 1},
+		"10x100/OwnedClaims/Fork5Revert5":          {ownedClaimPods: 100, nodesCount: 10, forks: 5, reverts: 5},
+		"10х1/OwnedClaims/ForkRevert":              {ownedClaimPods: 1, nodesCount: 10, forks: 1, reverts: 1},
+		"10x1/OwnedClaims/ForkCommit":              {ownedClaimPods: 1, nodesCount: 10, forks: 1, commits: 1},
+		"10x1/OwnedClaims/ForkForkCommitRevert":    {ownedClaimPods: 1, nodesCount: 10, forks: 2, reverts: 1, commits: 1},
+		"10x1/OwnedClaims/Fork":                    {ownedClaimPods: 1, nodesCount: 10, forks: 1},
+		"10x1/OwnedClaims/Fork5Revert5":            {ownedClaimPods: 1, nodesCount: 10, forks: 5, reverts: 5},
+		// MIXED CLAIMS
+		"100x32x50/MixedClaims/ForkRevert":           {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 100, forks: 1, reverts: 1},
+		"100x32x50/MixedClaims/ForkCommit":           {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 100, forks: 1, commits: 1},
+		"100x32x50/MixedClaims/ForkForkCommitRevert": {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 100, forks: 2, reverts: 1, commits: 1},
+		"100x32x50/MixedClaims/Fork":                 {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 100, forks: 1},
+		"100x32x50/MixedClaims/Fork5Revert5":         {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 100, forks: 5, reverts: 5},
+		"100x1x1/MixedClaims/ForkRevert":             {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 100, forks: 1, reverts: 1},
+		"100x1x1/MixedClaims/ForkCommit":             {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 100, forks: 1, commits: 1},
+		"100x1x1/MixedClaims/ForkForkCommitRevert":   {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 100, forks: 2, reverts: 1, commits: 1},
+		"100x1x1/MixedClaims/Fork":                   {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 100, forks: 1},
+		"100x1x1/MixedClaims/Fork5Revert5":           {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 100, forks: 5, reverts: 5},
+		"10x32x50/MixedClaims/ForkRevert":            {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 10, forks: 1, reverts: 1},
+		"10x32x50/MixedClaims/ForkCommit":            {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 10, forks: 1, commits: 1},
+		"10x32x50/MixedClaims/ForkForkCommitRevert":  {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 10, forks: 2, reverts: 1, commits: 1},
+		"10x32x50/MixedClaims/Fork":                  {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 10, forks: 1},
+		"10x32x50/MixedClaims/Fork5Revert5":          {sharedClaimPods: 32, ownedClaimPods: 50, nodesCount: 10, forks: 5, reverts: 5},
+		"10x1x1/MixedClaims/ForkRevert":              {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 10, forks: 1, reverts: 1},
+		"10x1x1/MixedClaims/ForkCommit":              {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 10, forks: 1, commits: 1},
+		"10x1x1/MixedClaims/ForkForkCommitRevert":    {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 10, forks: 2, reverts: 1, commits: 1},
+		"10x1x1/MixedClaims/Fork":                    {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 10, forks: 1},
+		"10x1x1/MixedClaims/Fork5Revert5":            {sharedClaimPods: 1, ownedClaimPods: 1, nodesCount: 10, forks: 5, reverts: 5},
+	}
+
+	devicesClasses := map[string]*resourceapi.DeviceClass{
+		deviceClassName: {ObjectMeta: metav1.ObjectMeta{Name: deviceClassName, UID: "defaultClassUid"}},
+	}
+
+	nodeInfos := make([]*framework.NodeInfo, maxNodesCount)
+	sharedClaims := make([]*resourceapi.ResourceClaim, maxNodesCount)
+	ownedClaims := make([][]*resourceapi.ResourceClaim, maxNodesCount)
+	owningPods := make([][]*apiv1.Pod, maxNodesCount)
+	for nodeIndex := 0; nodeIndex < maxNodesCount; nodeIndex++ {
+		nodeName := fmt.Sprintf("node-%d", nodeIndex)
+		node := BuildTestNode(nodeName, 10000, 10000)
+		nodeSlice := createTestResourceSlice(node.Name, devicesPerSlice, 1, driverName, resourceapi.BasicDevice{})
+		nodeInfo := framework.NewNodeInfo(node, []*resourceapi.ResourceSlice{nodeSlice})
+
+		sharedClaim := createTestResourceClaim(devicesPerSlice, 1, driverName, deviceClassName)
+		sharedClaim, satisfied := allocateResourceSlicesForClaim(sharedClaim, nodeName, nodeSlice)
+		if !satisfied {
+			b.Errorf("Error during setup, claim allocation cannot be satistied")
+		}
+
+		claimsOnNode := make([]*resourceapi.ResourceClaim, maxPodsCount)
+		podsOnNode := make([]*apiv1.Pod, maxPodsCount)
+		for podIndex := 0; podIndex < maxPodsCount; podIndex++ {
+			podName := fmt.Sprintf("pod-%d-%d", nodeIndex, podIndex)
+			ownedClaim := createTestResourceClaim(1, 1, driverName, deviceClassName)
+			pod := BuildTestPod(
+				podName,
+				1,
+				1,
+				WithResourceClaim(ownedClaim.Name, ownedClaim.Name, ""),
+			)
+
+			ownedClaim = drautils.TestClaimWithPodOwnership(pod, ownedClaim)
+			ownedClaim, satisfied := allocateResourceSlicesForClaim(ownedClaim, nodeName, nodeSlice)
+			if !satisfied {
+				b.Errorf("Error during setup, claim allocation cannot be satistied")
+			}
+
+			podsOnNode[podIndex] = pod
+			claimsOnNode[podIndex] = ownedClaim
+		}
+
+		nodeInfos[nodeIndex] = nodeInfo
+		sharedClaims[nodeIndex] = sharedClaim
+		ownedClaims[nodeIndex] = claimsOnNode
+		owningPods[nodeIndex] = podsOnNode
+	}
+
+	b.ResetTimer()
+	for snapshotName, snapshotFactory := range snapshots {
+		b.Run(snapshotName, func(b *testing.B) {
+			for cfgName, cfg := range configurations {
+				b.Run(cfgName, func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						snapshot, err := snapshotFactory()
+						if err != nil {
+							b.Errorf("Failed to create a snapshot: %v", err)
+						}
+
+						draSnapshot := drasnapshot.NewSnapshot(
+							nil,
+							nil,
+							nil,
+							devicesClasses,
+						)
+
+						draSnapshot.AddClaims(sharedClaims)
+						for nodeIndex := 0; nodeIndex < cfg.nodesCount; nodeIndex++ {
+							draSnapshot.AddClaims(ownedClaims[nodeIndex])
+						}
+
+						err = snapshot.SetClusterState(nil, nil, draSnapshot)
+						if err != nil {
+							b.Errorf("Failed to set cluster state: %v", err)
+						}
+
+						for nodeIndex := 0; nodeIndex < cfg.nodesCount; nodeIndex++ {
+							nodeInfo := nodeInfos[nodeIndex]
+							for i := 0; i < cfg.forks; i++ {
+								snapshot.Fork()
+							}
+
+							err := snapshot.AddNodeInfo(nodeInfo)
+							if err != nil {
+								b.Errorf("Failed to add node info to snapshot: %v", err)
+							}
+
+							sharedClaim := sharedClaims[nodeIndex]
+							for podIndex := 0; podIndex < cfg.sharedClaimPods; podIndex++ {
+								pod := BuildTestPod(
+									fmt.Sprintf("pod-%d", podIndex),
+									1,
+									1,
+									WithResourceClaim(sharedClaim.Name, sharedClaim.Name, ""),
+								)
+
+								err := snapshot.SchedulePod(pod, nodeInfo.Node().Name)
+								if err != nil {
+									b.Errorf(
+										"Failed to schedule a pod %s to node %s: %v",
+										pod.Name,
+										nodeInfo.Node().Name,
+										err,
+									)
+								}
+							}
+
+							for podIndex := 0; podIndex < cfg.ownedClaimPods; podIndex++ {
+								owningPod := owningPods[nodeIndex][podIndex]
+								err := snapshot.SchedulePod(owningPod, nodeInfo.Node().Name)
+								if err != nil {
+									b.Errorf(
+										"Failed to schedule a pod %s to node %s: %v",
+										owningPod.Name,
+										nodeInfo.Node().Name,
+										err,
+									)
+								}
+							}
+
+							for i := 0; i < cfg.commits; i++ {
+								snapshot.Commit()
+							}
+
+							for i := 0; i < cfg.reverts; i++ {
+								snapshot.Revert()
+							}
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -41,12 +41,18 @@ import (
 //
 // Watch out for:
 //
-//	node deletions, pod additions & deletions - invalidates cache of current snapshot
-//		(when forked affects delta, but not base.)
-//	pod affinity - causes scheduler framework to list pods with non-empty selector,
-//		so basic caching doesn't help.
+// * Node deletions, pod additions & deletions - invalidates cache of current snapshot
+// (when forked affects delta, but not base.)
+//
+// * Pod affinity - causes scheduler framework to list pods with non-empty selector,
+// so basic caching doesn't help.
+//
+// * DRA objects are tracked in the separate snapshot and while they don't exactly share
+// memory and time complexities of DeltaSnapshotStore - they are optimized for
+// cluster autoscaler operations
 type DeltaSnapshotStore struct {
 	data        *internalDeltaSnapshotData
+	draSnapshot *drasnapshot.Snapshot
 	parallelism int
 }
 
@@ -64,8 +70,6 @@ type internalDeltaSnapshotData struct {
 	havePodsWithAffinity             []*schedulerframework.NodeInfo
 	havePodsWithRequiredAntiAffinity []*schedulerframework.NodeInfo
 	pvcNamespaceMap                  map[string]int
-
-	draSnapshot drasnapshot.Snapshot
 }
 
 func newInternalDeltaSnapshotData() *internalDeltaSnapshotData {
@@ -296,7 +300,6 @@ func (data *internalDeltaSnapshotData) isPVCUsedByPods(key string) bool {
 
 func (data *internalDeltaSnapshotData) fork() *internalDeltaSnapshotData {
 	forkedData := newInternalDeltaSnapshotData()
-	forkedData.draSnapshot = data.draSnapshot.Clone()
 	forkedData.baseData = data
 	return forkedData
 }
@@ -325,7 +328,6 @@ func (data *internalDeltaSnapshotData) commit() (*internalDeltaSnapshotData, err
 		}
 	}
 
-	data.baseData.draSnapshot = data.draSnapshot
 	return data.baseData, nil
 }
 
@@ -424,8 +426,8 @@ func NewDeltaSnapshotStore(parallelism int) *DeltaSnapshotStore {
 }
 
 // DraSnapshot returns the DRA snapshot.
-func (snapshot *DeltaSnapshotStore) DraSnapshot() drasnapshot.Snapshot {
-	return snapshot.data.draSnapshot
+func (snapshot *DeltaSnapshotStore) DraSnapshot() *drasnapshot.Snapshot {
+	return snapshot.draSnapshot
 }
 
 // AddSchedulerNodeInfo adds a NodeInfo.
@@ -473,7 +475,7 @@ func (snapshot *DeltaSnapshotStore) setClusterStatePodsParallelized(nodeInfos []
 }
 
 // SetClusterState sets the cluster state.
-func (snapshot *DeltaSnapshotStore) SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod, draSnapshot drasnapshot.Snapshot) error {
+func (snapshot *DeltaSnapshotStore) SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod, draSnapshot *drasnapshot.Snapshot) error {
 	snapshot.clear()
 
 	nodeNameToIdx := make(map[string]int, len(nodes))
@@ -498,7 +500,12 @@ func (snapshot *DeltaSnapshotStore) SetClusterState(nodes []*apiv1.Node, schedul
 	// Clear caches after adding pods.
 	snapshot.data.clearCaches()
 
-	// TODO(DRA): Save DRA snapshot.
+	if draSnapshot == nil {
+		snapshot.draSnapshot = drasnapshot.NewEmptySnapshot()
+	} else {
+		snapshot.draSnapshot = draSnapshot
+	}
+
 	return nil
 }
 
@@ -526,6 +533,7 @@ func (snapshot *DeltaSnapshotStore) IsPVCUsedByPods(key string) bool {
 // Time: O(1)
 func (snapshot *DeltaSnapshotStore) Fork() {
 	snapshot.data = snapshot.data.fork()
+	snapshot.draSnapshot.Fork()
 }
 
 // Revert reverts snapshot state to moment of forking.
@@ -534,6 +542,7 @@ func (snapshot *DeltaSnapshotStore) Revert() {
 	if snapshot.data.baseData != nil {
 		snapshot.data = snapshot.data.baseData
 	}
+	snapshot.draSnapshot.Revert()
 }
 
 // Commit commits changes done after forking.
@@ -544,6 +553,7 @@ func (snapshot *DeltaSnapshotStore) Commit() error {
 		return err
 	}
 	snapshot.data = newData
+	snapshot.draSnapshot.Commit()
 	return nil
 }
 
@@ -551,4 +561,5 @@ func (snapshot *DeltaSnapshotStore) Commit() error {
 // Time: O(1)
 func (snapshot *DeltaSnapshotStore) clear() {
 	snapshot.data = newInternalDeltaSnapshotData()
+	snapshot.draSnapshot = drasnapshot.NewEmptySnapshot()
 }

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -64,6 +64,8 @@ type internalDeltaSnapshotData struct {
 	havePodsWithAffinity             []*schedulerframework.NodeInfo
 	havePodsWithRequiredAntiAffinity []*schedulerframework.NodeInfo
 	pvcNamespaceMap                  map[string]int
+
+	draSnapshot drasnapshot.Snapshot
 }
 
 func newInternalDeltaSnapshotData() *internalDeltaSnapshotData {
@@ -294,6 +296,7 @@ func (data *internalDeltaSnapshotData) isPVCUsedByPods(key string) bool {
 
 func (data *internalDeltaSnapshotData) fork() *internalDeltaSnapshotData {
 	forkedData := newInternalDeltaSnapshotData()
+	forkedData.draSnapshot = data.draSnapshot.Clone()
 	forkedData.baseData = data
 	return forkedData
 }
@@ -321,6 +324,8 @@ func (data *internalDeltaSnapshotData) commit() (*internalDeltaSnapshotData, err
 			return nil, err
 		}
 	}
+
+	data.baseData.draSnapshot = data.draSnapshot
 	return data.baseData, nil
 }
 
@@ -420,8 +425,7 @@ func NewDeltaSnapshotStore(parallelism int) *DeltaSnapshotStore {
 
 // DraSnapshot returns the DRA snapshot.
 func (snapshot *DeltaSnapshotStore) DraSnapshot() drasnapshot.Snapshot {
-	// TODO(DRA): Return DRA snapshot.
-	return drasnapshot.Snapshot{}
+	return snapshot.data.draSnapshot
 }
 
 // AddSchedulerNodeInfo adds a NodeInfo.

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -49,7 +48,7 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 		b.Run(fmt.Sprintf("fork add 1000 to %d", tc.nodeCount), func(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc.nodeCount + 1000)
 			deltaStore := NewDeltaSnapshotStore(16)
-			if err := deltaStore.SetClusterState(nodes[:tc.nodeCount], nil, drasnapshot.Snapshot{}); err != nil {
+			if err := deltaStore.SetClusterState(nodes[:tc.nodeCount], nil, nil); err != nil {
 				assert.NoError(b, err)
 			}
 			deltaStore.Fork()
@@ -71,7 +70,7 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 		b.Run(fmt.Sprintf("base %d", tc.nodeCount), func(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc.nodeCount)
 			deltaStore := NewDeltaSnapshotStore(16)
-			if err := deltaStore.SetClusterState(nodes, nil, drasnapshot.Snapshot{}); err != nil {
+			if err := deltaStore.SetClusterState(nodes, nil, nil); err != nil {
 				assert.NoError(b, err)
 			}
 			b.ResetTimer()

--- a/cluster-autoscaler/simulator/clustersnapshot/test_utils.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/test_utils.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "k8s.io/api/core/v1"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
@@ -39,7 +38,7 @@ func InitializeClusterSnapshotOrDie(
 	pods []*apiv1.Pod) {
 	var err error
 
-	assert.NoError(t, snapshot.SetClusterState(nil, nil, drasnapshot.Snapshot{}))
+	assert.NoError(t, snapshot.SetClusterState(nil, nil, nil))
 
 	for _, node := range nodes {
 		err = snapshot.AddNodeInfo(framework.NewTestNodeInfo(node))

--- a/cluster-autoscaler/simulator/common/patch.go
+++ b/cluster-autoscaler/simulator/common/patch.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+// Patch represents a single layer of modifications (additions/updates)
+// and deletions for a set of key-value pairs. It's used as a building
+// block for the patchSet.
+type Patch[K comparable, V any] struct {
+	modified map[K]V
+	deleted  map[K]bool
+}
+
+// Set marks a key-value pair as modified in the current patch.
+// If the key was previously marked as deleted, the deletion mark is removed.
+func (p *Patch[K, V]) Set(key K, value V) {
+	p.modified[key] = value
+	delete(p.deleted, key)
+}
+
+// Delete marks a key as deleted in the current patch.
+// If the key was previously marked as modified, the modification is removed.
+func (p *Patch[K, V]) Delete(key K) {
+	delete(p.modified, key)
+	p.deleted[key] = true
+}
+
+// Get retrieves the modified value for a key within this specific patch.
+// It returns the value and true if the key was found in this patch
+// or zero value and false otherwise.
+func (p *Patch[K, V]) Get(key K) (value V, found bool) {
+	value, found = p.modified[key]
+	return value, found
+}
+
+// IsDeleted checks if the key is marked as deleted within this specific patch.
+func (p *Patch[K, V]) IsDeleted(key K) bool {
+	return p.deleted[key]
+}
+
+// NewPatch creates a new, empty patch with no modifications or deletions.
+func NewPatch[K comparable, V any]() *Patch[K, V] {
+	return &Patch[K, V]{
+		modified: make(map[K]V),
+		deleted:  make(map[K]bool),
+	}
+}
+
+// NewPatchFromMap creates a new patch initialized with the data from the provided map
+// the data supplied is recorded as modified in the patch.
+func NewPatchFromMap[M ~map[K]V, K comparable, V any](source M) *Patch[K, V] {
+	if source == nil {
+		source = make(M)
+	}
+
+	return &Patch[K, V]{
+		modified: source,
+		deleted:  make(map[K]bool),
+	}
+}
+
+// mergePatchesInPlace merges two patches into one, while modifying patch a
+// inplace taking records in b as a priority when overwrites are required
+func mergePatchesInPlace[K comparable, V any](a *Patch[K, V], b *Patch[K, V]) *Patch[K, V] {
+	for key, value := range b.modified {
+		a.Set(key, value)
+	}
+
+	for key := range b.deleted {
+		a.Delete(key)
+	}
+
+	return a
+}

--- a/cluster-autoscaler/simulator/common/patch_test.go
+++ b/cluster-autoscaler/simulator/common/patch_test.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"maps"
+	"testing"
+)
+
+func TestPatchOperations(t *testing.T) {
+	p := NewPatch[string, int]()
+
+	// 1. Get and IsDeleted on non-existent key
+	if _, found := p.Get("a"); found {
+		t.Errorf("Get for 'a' should not find anything")
+	}
+	if p.IsDeleted("a") {
+		t.Errorf("IsDeleted for 'a' should be false")
+	}
+
+	// 2. Set 'a' key
+	p.Set("a", 1)
+	if val, found := p.Get("a"); !found || val != 1 {
+		t.Errorf("Get('a') = %v,%v, expected 1,true", val, found)
+	}
+	if p.IsDeleted("a") {
+		t.Errorf("IsDeleted('a') = true, should be false")
+	}
+
+	// 3. Overwrite 'a' key
+	p.Set("a", 2)
+	if val, found := p.Get("a"); !found || val != 2 {
+		t.Errorf("Get('a') = %v,%v, expected 2,true", val, found)
+	}
+	if p.IsDeleted("a") {
+		t.Errorf("IsDeleted('a') = true, should be false")
+	}
+
+	// 4. Delete 'a' key
+	p.Delete("a")
+	if val, found := p.Get("a"); found {
+		t.Errorf("Get('a') = %v,%v, should not find anything after delete", val, found)
+	}
+	if !p.IsDeleted("a") {
+		t.Errorf("IsDeleted('a') = false, should be true")
+	}
+
+	// 5. Set 'a' key again after deletion
+	p.Set("a", 3)
+	if val, found := p.Get("a"); !found || val != 3 {
+		t.Errorf("Get('a') = %v,%v, expected 3,true", val, found)
+	}
+	if p.IsDeleted("a") {
+		t.Errorf("IsDeleted('a') = true, should be false")
+	}
+
+	// 6. Delete a non-existent key 'c'
+	p.Delete("c")
+	if val, found := p.Get("c"); found {
+		t.Errorf("Get('c') = %v, %v, should not find anything", val, found)
+	}
+	if !p.IsDeleted("c") {
+		t.Errorf("IsDeleted('c') = false, should be true")
+	}
+}
+
+func TestCreatePatch(t *testing.T) {
+	tests := map[string]struct {
+		sourceMap    map[string]int
+		addKeys      map[string]int
+		deleteKeys   []string
+		wantModified map[string]int
+		wantDeleted  map[string]bool
+	}{
+		"SourceMapOnlyNoModifications": {
+			sourceMap:    map[string]int{"k1": 1, "k2": 2},
+			addKeys:      map[string]int{},
+			deleteKeys:   []string{},
+			wantModified: map[string]int{"k1": 1, "k2": 2},
+			wantDeleted:  map[string]bool{},
+		},
+		"NilSourceMapAddAndDelete": {
+			sourceMap:    nil,
+			addKeys:      map[string]int{"a": 1, "b": 2},
+			deleteKeys:   []string{"b"},
+			wantModified: map[string]int{"a": 1},
+			wantDeleted:  map[string]bool{"b": true},
+		},
+		"EmptySourceMapAddAndDelete": {
+			sourceMap:    map[string]int{},
+			addKeys:      map[string]int{"x": 10},
+			deleteKeys:   []string{"y"},
+			wantModified: map[string]int{"x": 10},
+			wantDeleted:  map[string]bool{"y": true},
+		},
+		"NonEmptySourceMapAddOverwriteDelete": {
+			sourceMap:    map[string]int{"orig1": 100, "orig2": 200},
+			addKeys:      map[string]int{"new1": 300, "orig1": 101},
+			deleteKeys:   []string{"orig2", "new1"},
+			wantModified: map[string]int{"orig1": 101},
+			wantDeleted:  map[string]bool{"orig2": true, "new1": true},
+		},
+		"DeleteKeyFromSourceMap": {
+			sourceMap:    map[string]int{"key_to_delete": 70, "key_to_keep": 80},
+			addKeys:      map[string]int{},
+			deleteKeys:   []string{"key_to_delete"},
+			wantModified: map[string]int{"key_to_keep": 80},
+			wantDeleted:  map[string]bool{"key_to_delete": true},
+		},
+		"AddOnlyNoSourceMap": {
+			sourceMap:    nil,
+			addKeys:      map[string]int{"add1": 10, "add2": 20},
+			deleteKeys:   []string{},
+			wantModified: map[string]int{"add1": 10, "add2": 20},
+			wantDeleted:  map[string]bool{},
+		},
+		"DeleteOnlyNoSourceMap": {
+			sourceMap:    nil,
+			addKeys:      map[string]int{},
+			deleteKeys:   []string{"del1", "del2"},
+			wantModified: map[string]int{},
+			wantDeleted:  map[string]bool{"del1": true, "del2": true},
+		},
+		"DeleteKeyNotPresentInSourceOrAdded": {
+			sourceMap:    map[string]int{"a": 1},
+			addKeys:      map[string]int{"b": 2},
+			deleteKeys:   []string{"c"},
+			wantModified: map[string]int{"a": 1, "b": 2},
+			wantDeleted:  map[string]bool{"c": true},
+		},
+		"AddKeyThenDeleteIt": {
+			sourceMap:    map[string]int{"base": 100},
+			addKeys:      map[string]int{"temp": 50},
+			deleteKeys:   []string{"temp"},
+			wantModified: map[string]int{"base": 100},
+			wantDeleted:  map[string]bool{"temp": true},
+		},
+		"AllOperations": {
+			sourceMap:    map[string]int{"s1": 1, "s2": 2, "s3": 3},
+			addKeys:      map[string]int{"a1": 10, "s2": 22, "a2": 20},
+			deleteKeys:   []string{"s1", "a1", "nonexistent"},
+			wantModified: map[string]int{"s2": 22, "s3": 3, "a2": 20},
+			wantDeleted:  map[string]bool{"s1": true, "a1": true, "nonexistent": true},
+		},
+		"NoOperationsEmptySource": {
+			sourceMap:    map[string]int{},
+			addKeys:      map[string]int{},
+			deleteKeys:   []string{},
+			wantModified: map[string]int{},
+			wantDeleted:  map[string]bool{},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			p := NewPatchFromMap(test.sourceMap)
+
+			for k, v := range test.addKeys {
+				p.Set(k, v)
+			}
+			for _, k := range test.deleteKeys {
+				p.Delete(k)
+			}
+
+			if !maps.Equal(p.modified, test.wantModified) {
+				t.Errorf("Modified map mismatch: got %v, want %v", p.modified, test.wantModified)
+			}
+
+			if !maps.Equal(p.deleted, test.wantDeleted) {
+				t.Errorf("Deleted map mismatch: got %v, want %v", p.deleted, test.wantDeleted)
+			}
+		})
+	}
+}
+
+func TestMergePatchesInPlace(t *testing.T) {
+	tests := map[string]struct {
+		modifiedPatchA     map[string]int
+		deletedPatchA      map[string]bool
+		modifiedPatchB     map[string]int
+		deletedPatchB      map[string]bool
+		wantModifiedMerged map[string]int
+		wantDeletedMerged  map[string]bool
+	}{
+		"PatchBOverwritesValueInPatchA": {
+			modifiedPatchA:     map[string]int{"a": 1, "b": 2},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{"b": 22, "c": 3},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"a": 1, "b": 22, "c": 3},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"PatchBDeletesValuePresentInPatchA": {
+			modifiedPatchA:     map[string]int{"a": 1, "b": 2},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{"a": true},
+			wantModifiedMerged: map[string]int{"b": 2},
+			wantDeletedMerged:  map[string]bool{"a": true},
+		},
+		"PatchBDeletesValueAlreadyDeletedInPatchA": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{"x": true},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{"x": true, "y": true},
+			wantModifiedMerged: map[string]int{},
+			wantDeletedMerged:  map[string]bool{"x": true, "y": true},
+		},
+		"PatchBAddsValuePreviouslyDeletedInPatchA": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{"x": true},
+			modifiedPatchB:     map[string]int{"x": 10},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"x": 10},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"MergeEmptyPatchBIntoNonEmptyPatchA": {
+			modifiedPatchA:     map[string]int{"a": 1},
+			deletedPatchA:      map[string]bool{"b": true},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"a": 1},
+			wantDeletedMerged:  map[string]bool{"b": true},
+		},
+		"MergeNonEmptyPatchBIntoEmptyPatchA": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{"a": 1},
+			deletedPatchB:      map[string]bool{"b": true},
+			wantModifiedMerged: map[string]int{"a": 1},
+			wantDeletedMerged:  map[string]bool{"b": true},
+		},
+		"MergeTwoEmptyPatches": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"NoOverlapBetweenPatchAAndPatchBModifications": {
+			modifiedPatchA:     map[string]int{"a1": 1, "a2": 2},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{"b1": 10, "b2": 20},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"a1": 1, "a2": 2, "b1": 10, "b2": 20},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"NoOverlapBetweenPatchAAndPatchBDeletions": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{"a1": true, "a2": true},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{"b1": true, "b2": true},
+			wantModifiedMerged: map[string]int{},
+			wantDeletedMerged:  map[string]bool{"a1": true, "a2": true, "b1": true, "b2": true},
+		},
+		"PatchBOnlyAddsNewKeysPatchAUnchanged": {
+			modifiedPatchA:     map[string]int{"orig": 5},
+			modifiedPatchB:     map[string]int{"new1": 100, "new2": 200},
+			deletedPatchA:      map[string]bool{},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"orig": 5, "new1": 100, "new2": 200},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"PatchBOnlyDeletesNewKeysPatchAUnchanged": {
+			modifiedPatchA:     map[string]int{"orig": 5},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{"del1": true, "del2": true},
+			wantModifiedMerged: map[string]int{"orig": 5},
+			wantDeletedMerged:  map[string]bool{"del1": true, "del2": true},
+		},
+		"AllInOne": {
+			modifiedPatchA:     map[string]int{"k1": 1, "k2": 2, "k3": 3},
+			deletedPatchA:      map[string]bool{"d1": true, "d2": true},
+			modifiedPatchB:     map[string]int{"k2": 22, "k4": 4, "d1": 11},
+			deletedPatchB:      map[string]bool{"k3": true, "d2": true, "d3": true},
+			wantModifiedMerged: map[string]int{"k1": 1, "k2": 22, "k4": 4, "d1": 11},
+			wantDeletedMerged:  map[string]bool{"k3": true, "d2": true, "d3": true},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			patchA := NewPatchFromMap(test.modifiedPatchA)
+			for k := range test.deletedPatchA {
+				patchA.Delete(k)
+			}
+
+			patchB := NewPatchFromMap(test.modifiedPatchB)
+			for k := range test.deletedPatchB {
+				patchB.Delete(k)
+			}
+
+			merged := mergePatchesInPlace(patchA, patchB)
+
+			if merged != patchA {
+				t.Errorf("mergePatchesInPlace did not modify patchA inplace, references are different")
+			}
+
+			if !maps.Equal(merged.modified, test.wantModifiedMerged) {
+				t.Errorf("Modified map mismatch: got %v, want %v", merged.modified, test.wantModifiedMerged)
+			}
+
+			if !maps.Equal(merged.deleted, test.wantDeletedMerged) {
+				t.Errorf("Deleted map mismatch: got %v, want %v", merged.deleted, test.wantDeletedMerged)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/simulator/common/patchset.go
+++ b/cluster-autoscaler/simulator/common/patchset.go
@@ -14,116 +14,46 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package snapshot
+package common
 
-// patch represents a single layer of modifications (additions/updates)
-// and deletions for a set of key-value pairs. It's used as a building
-// block for the patchSet.
-type patch[K comparable, V any] struct {
-	Modified map[K]V
-	Deleted  map[K]bool
-}
-
-// Set marks a key-value pair as modified in the current patch.
-// If the key was previously marked as deleted, the deletion mark is removed.
-func (p *patch[K, V]) Set(key K, value V) {
-	p.Modified[key] = value
-	delete(p.Deleted, key)
-}
-
-// Delete marks a key as deleted in the current patch.
-// If the key was previously marked as modified, the modification is removed.
-func (p *patch[K, V]) Delete(key K) {
-	delete(p.Modified, key)
-	p.Deleted[key] = true
-}
-
-// Get retrieves the modified value for a key within this specific patch.
-// It returns the value and true if the key was found in this patch
-// or zero value and false otherwise.
-func (p *patch[K, V]) Get(key K) (value V, found bool) {
-	value, found = p.Modified[key]
-	return value, found
-}
-
-// IsDeleted checks if the key is marked as deleted within this specific patch.
-func (p *patch[K, V]) IsDeleted(key K) bool {
-	return p.Deleted[key]
-}
-
-// newPatch creates a new, empty patch with no modifications or deletions.
-func newPatch[K comparable, V any]() *patch[K, V] {
-	return &patch[K, V]{
-		Modified: make(map[K]V),
-		Deleted:  make(map[K]bool),
-	}
-}
-
-// newPatchFromMap creates a new patch initialized with the data from the provided map
-// the data supplied is recorded as modified in the patch.
-func newPatchFromMap[M ~map[K]V, K comparable, V any](source M) *patch[K, V] {
-	if source == nil {
-		source = make(M)
-	}
-
-	return &patch[K, V]{
-		Modified: source,
-		Deleted:  make(map[K]bool),
-	}
-}
-
-// mergePatchesInPlace merges two patches into one, while modifying patch a
-// inplace taking records in b as a priority when overwrites are required
-func mergePatchesInPlace[K comparable, V any](a *patch[K, V], b *patch[K, V]) *patch[K, V] {
-	for key, value := range b.Modified {
-		a.Set(key, value)
-	}
-
-	for key := range b.Deleted {
-		a.Delete(key)
-	}
-
-	return a
-}
-
-// patchSet manages a stack of patches, allowing for fork/revert/commit operations.
+// PatchSet manages a stack of patches, allowing for fork/revert/commit operations.
 // It provides a view of the data as if all patches were applied sequentially.
 //
 // Time Complexities:
 //   - Fork(): O(1).
 //   - Commit(): O(P), where P is the number of modified/deleted entries
-//     in the current patch or no-op for patchSet with a single patch.
+//     in the current patch or no-op for PatchSet with a single patch.
 //   - Revert(): O(P), where P is the number of modified/deleted entries
-//     in the topmost patch or no-op for patchSet with a single patch.
+//     in the topmost patch or no-op for PatchSet with a single patch.
 //   - FindValue(key): O(1) for cached keys, O(N * P) - otherwise.
 //   - AsMap(): O(N * P) as it needs to iterate through all the layers
 //     modifications and deletions to get the latest state. Best case -
-//     if the cache is currently in sync with the patchSet data complexity becomes
-//     O(C), where C is the actual number key/value pairs in flattened patchSet.
+//     if the cache is currently in sync with the PatchSet data complexity becomes
+//     O(C), where C is the actual number key/value pairs in flattened PatchSet.
 //   - SetCurrent(key, value): O(1).
 //   - DeleteCurrent(key): O(1).
 //   - InCurrentPatch(key): O(1).
 //
 // Variables used in complexity analysis:
-//   - N: The number of patch layers in the patchSet.
+//   - N: The number of patch layers in the PatchSet.
 //   - P: The number of modified/deleted entries in a single patch layer
 //
 // Caching:
 //
-// The patchSet employs a lazy caching mechanism to speed up access to data. When a specific item is requested,
+// The PatchSet employs a lazy caching mechanism to speed up access to data. When a specific item is requested,
 // the cache is checked first. If the item isn't cached, its effective value is computed by traversing the layers
 // of patches from the most recent to the oldest, and the result is then stored in the cache. For operations that
 // require the entire dataset like AsMap, if a cache is fully up-to-date, the data is served directly from the cache.
 // Otherwise, the entire dataset is rebuilt by applying all patches, and this process fully populates the cache.
 // Direct modifications to the current patch update the specific item in the cache immediately. Reverting the latest
 // patch will clear affected items from the cache and mark the cache as potentially out-of-sync, as underlying values may
-// no longer represent the patchSet as a whole. Committing and forking does not invalidate the cache, as the effective
+// no longer represent the PatchSet as a whole. Committing and forking does not invalidate the cache, as the effective
 // values remain consistent from the perspective of read operations.
-type patchSet[K comparable, V any] struct {
+type PatchSet[K comparable, V any] struct {
 	// patches is a stack of individual modification layers. The base data is
 	// at index 0, and subsequent modifications are layered on top.
 	// PatchSet should always contain at least a single patch.
-	patches []*patch[K, V]
+	patches []*Patch[K, V]
 
 	// cache stores the computed effective value for keys that have been accessed.
 	// A nil pointer indicates the key is effectively deleted or not present.
@@ -136,9 +66,9 @@ type patchSet[K comparable, V any] struct {
 	cacheInSync bool
 }
 
-// newPatchSet creates a new patchSet, initializing it with the provided base patches.
-func newPatchSet[K comparable, V any](patches ...*patch[K, V]) *patchSet[K, V] {
-	return &patchSet[K, V]{
+// NewPatchSet creates a new PatchSet, initializing it with the provided base patches.
+func NewPatchSet[K comparable, V any](patches ...*Patch[K, V]) *PatchSet[K, V] {
+	return &PatchSet[K, V]{
 		patches:     patches,
 		cache:       make(map[K]*V),
 		cacheInSync: false,
@@ -147,13 +77,13 @@ func newPatchSet[K comparable, V any](patches ...*patch[K, V]) *patchSet[K, V] {
 
 // Fork adds a new, empty patch layer to the top of the stack.
 // Subsequent modifications will be recorded in this new layer.
-func (p *patchSet[K, V]) Fork() {
-	p.patches = append(p.patches, newPatch[K, V]())
+func (p *PatchSet[K, V]) Fork() {
+	p.patches = append(p.patches, NewPatch[K, V]())
 }
 
 // Commit merges the topmost patch layer into the one below it.
 // If there's only one layer (or none), it's a no-op.
-func (p *patchSet[K, V]) Commit() {
+func (p *PatchSet[K, V]) Commit() {
 	if len(p.patches) < 2 {
 		return
 	}
@@ -166,7 +96,7 @@ func (p *patchSet[K, V]) Commit() {
 
 // Revert removes the topmost patch layer.
 // Any modifications or deletions recorded in that layer are discarded.
-func (p *patchSet[K, V]) Revert() {
+func (p *PatchSet[K, V]) Revert() {
 	if len(p.patches) <= 1 {
 		return
 	}
@@ -174,11 +104,11 @@ func (p *patchSet[K, V]) Revert() {
 	currentPatch := p.patches[len(p.patches)-1]
 	p.patches = p.patches[:len(p.patches)-1]
 
-	for key := range currentPatch.Modified {
+	for key := range currentPatch.modified {
 		delete(p.cache, key)
 	}
 
-	for key := range currentPatch.Deleted {
+	for key := range currentPatch.deleted {
 		delete(p.cache, key)
 	}
 
@@ -188,7 +118,7 @@ func (p *patchSet[K, V]) Revert() {
 // FindValue searches for the effective value of a key by looking through the patches
 // from top to bottom. It returns the value and true if found, or the zero value and false
 // if the key is deleted or not found in any patch.
-func (p *patchSet[K, V]) FindValue(key K) (value V, found bool) {
+func (p *PatchSet[K, V]) FindValue(key K) (value V, found bool) {
 	var zero V
 
 	if cachedValue, cacheHit := p.cache[key]; cacheHit {
@@ -227,7 +157,7 @@ func (p *patchSet[K, V]) FindValue(key K) (value V, found bool) {
 // AsMap merges all patches into a single map representing the current effective state.
 // It iterates through all patches from bottom to top, applying modifications and deletions.
 // The cache is populated with the results during this process.
-func (p *patchSet[K, V]) AsMap() map[K]V {
+func (p *PatchSet[K, V]) AsMap() map[K]V {
 	if p.cacheInSync {
 		patchSetMap := make(map[K]V, len(p.cache))
 		for key, value := range p.cache {
@@ -242,11 +172,11 @@ func (p *patchSet[K, V]) AsMap() map[K]V {
 	patchSetMap := make(map[K]V, keysCount)
 
 	for _, patch := range p.patches {
-		for key, value := range patch.Modified {
+		for key, value := range patch.modified {
 			patchSetMap[key] = value
 		}
 
-		for key := range patch.Deleted {
+		for key := range patch.deleted {
 			delete(patchSetMap, key)
 		}
 	}
@@ -260,7 +190,7 @@ func (p *patchSet[K, V]) AsMap() map[K]V {
 }
 
 // SetCurrent adds or updates a key-value pair in the topmost patch layer.
-func (p *patchSet[K, V]) SetCurrent(key K, value V) {
+func (p *PatchSet[K, V]) SetCurrent(key K, value V) {
 	if len(p.patches) == 0 {
 		p.Fork()
 	}
@@ -271,7 +201,7 @@ func (p *patchSet[K, V]) SetCurrent(key K, value V) {
 }
 
 // DeleteCurrent marks a key as deleted in the topmost patch layer.
-func (p *patchSet[K, V]) DeleteCurrent(key K) {
+func (p *PatchSet[K, V]) DeleteCurrent(key K) {
 	if len(p.patches) == 0 {
 		p.Fork()
 	}
@@ -282,7 +212,7 @@ func (p *patchSet[K, V]) DeleteCurrent(key K) {
 }
 
 // InCurrentPatch checks if the key is available in the topmost patch layer.
-func (p *patchSet[K, V]) InCurrentPatch(key K) bool {
+func (p *PatchSet[K, V]) InCurrentPatch(key K) bool {
 	if len(p.patches) == 0 {
 		return false
 	}
@@ -296,11 +226,40 @@ func (p *patchSet[K, V]) InCurrentPatch(key K) bool {
 // pairs across all patches taking the highest number of records possible
 // this calculation does not consider deleted records - thus it is likely
 // to be not accurate
-func (p *patchSet[K, V]) totalKeyCount() int {
+func (p *PatchSet[K, V]) totalKeyCount() int {
 	count := 0
 	for _, patch := range p.patches {
-		count += len(patch.Modified)
+		count += len(patch.modified)
 	}
 
 	return count
+}
+
+// ClonePatchSet creates a deep copy of a PatchSet object with the same patch layers
+// structure, while copying keys and values using cloneKey and cloneValue functions
+// provided.
+//
+// This function is intended for testing purposes only.
+func ClonePatchSet[K comparable, V any](ps *PatchSet[K, V], cloneKey func(K) K, cloneValue func(V) V) *PatchSet[K, V] {
+	if ps == nil {
+		return nil
+	}
+
+	cloned := NewPatchSet[K, V]()
+	for _, patch := range ps.patches {
+		clonedPatch := NewPatch[K, V]()
+		for key, value := range patch.modified {
+			clonedKey, clonedValue := cloneKey(key), cloneValue(value)
+			clonedPatch.Set(clonedKey, clonedValue)
+		}
+
+		for key := range patch.deleted {
+			clonedKey := cloneKey(key)
+			clonedPatch.Delete(clonedKey)
+		}
+
+		cloned.patches = append(cloned.patches, clonedPatch)
+	}
+
+	return cloned
 }

--- a/cluster-autoscaler/simulator/common/patchset_test.go
+++ b/cluster-autoscaler/simulator/common/patchset_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package snapshot
+package common
 
 import (
 	"maps"
@@ -22,308 +22,6 @@ import (
 
 	"k8s.io/utils/ptr"
 )
-
-func TestPatchOperations(t *testing.T) {
-	p := newPatch[string, int]()
-
-	// 1. Get and IsDeleted on non-existent key
-	if _, found := p.Get("a"); found {
-		t.Errorf("Get for 'a' should not find anything")
-	}
-	if p.IsDeleted("a") {
-		t.Errorf("IsDeleted for 'a' should be false")
-	}
-
-	// 2. Set 'a' key
-	p.Set("a", 1)
-	if val, found := p.Get("a"); !found || val != 1 {
-		t.Errorf("Get('a') = %v,%v, expected 1,true", val, found)
-	}
-	if p.IsDeleted("a") {
-		t.Errorf("IsDeleted('a') = true, should be false")
-	}
-
-	// 3. Overwrite 'a' key
-	p.Set("a", 2)
-	if val, found := p.Get("a"); !found || val != 2 {
-		t.Errorf("Get('a') = %v,%v, expected 2,true", val, found)
-	}
-	if p.IsDeleted("a") {
-		t.Errorf("IsDeleted('a') = true, should be false")
-	}
-
-	// 4. Delete 'a' key
-	p.Delete("a")
-	if val, found := p.Get("a"); found {
-		t.Errorf("Get('a') = %v,%v, should not find anything after delete", val, found)
-	}
-	if !p.IsDeleted("a") {
-		t.Errorf("IsDeleted('a') = false, should be true")
-	}
-
-	// 5. Set 'a' key again after deletion
-	p.Set("a", 3)
-	if val, found := p.Get("a"); !found || val != 3 {
-		t.Errorf("Get('a') = %v,%v, expected 3,true", val, found)
-	}
-	if p.IsDeleted("a") {
-		t.Errorf("IsDeleted('a') = true, should be false")
-	}
-
-	// 6. Delete a non-existent key 'c'
-	p.Delete("c")
-	if val, found := p.Get("c"); found {
-		t.Errorf("Get('c') = %v, %v, should not find anything", val, found)
-	}
-	if !p.IsDeleted("c") {
-		t.Errorf("IsDeleted('c') = false, should be true")
-	}
-}
-
-func TestCreatePatch(t *testing.T) {
-	tests := map[string]struct {
-		sourceMap    map[string]int
-		addKeys      map[string]int
-		deleteKeys   []string
-		wantModified map[string]int
-		wantDeleted  map[string]bool
-	}{
-		"SourceMapOnlyNoModifications": {
-			sourceMap:    map[string]int{"k1": 1, "k2": 2},
-			addKeys:      map[string]int{},
-			deleteKeys:   []string{},
-			wantModified: map[string]int{"k1": 1, "k2": 2},
-			wantDeleted:  map[string]bool{},
-		},
-		"NilSourceMapAddAndDelete": {
-			sourceMap:    nil,
-			addKeys:      map[string]int{"a": 1, "b": 2},
-			deleteKeys:   []string{"b"},
-			wantModified: map[string]int{"a": 1},
-			wantDeleted:  map[string]bool{"b": true},
-		},
-		"EmptySourceMapAddAndDelete": {
-			sourceMap:    map[string]int{},
-			addKeys:      map[string]int{"x": 10},
-			deleteKeys:   []string{"y"},
-			wantModified: map[string]int{"x": 10},
-			wantDeleted:  map[string]bool{"y": true},
-		},
-		"NonEmptySourceMapAddOverwriteDelete": {
-			sourceMap:    map[string]int{"orig1": 100, "orig2": 200},
-			addKeys:      map[string]int{"new1": 300, "orig1": 101},
-			deleteKeys:   []string{"orig2", "new1"},
-			wantModified: map[string]int{"orig1": 101},
-			wantDeleted:  map[string]bool{"orig2": true, "new1": true},
-		},
-		"DeleteKeyFromSourceMap": {
-			sourceMap:    map[string]int{"key_to_delete": 70, "key_to_keep": 80},
-			addKeys:      map[string]int{},
-			deleteKeys:   []string{"key_to_delete"},
-			wantModified: map[string]int{"key_to_keep": 80},
-			wantDeleted:  map[string]bool{"key_to_delete": true},
-		},
-		"AddOnlyNoSourceMap": {
-			sourceMap:    nil,
-			addKeys:      map[string]int{"add1": 10, "add2": 20},
-			deleteKeys:   []string{},
-			wantModified: map[string]int{"add1": 10, "add2": 20},
-			wantDeleted:  map[string]bool{},
-		},
-		"DeleteOnlyNoSourceMap": {
-			sourceMap:    nil,
-			addKeys:      map[string]int{},
-			deleteKeys:   []string{"del1", "del2"},
-			wantModified: map[string]int{},
-			wantDeleted:  map[string]bool{"del1": true, "del2": true},
-		},
-		"DeleteKeyNotPresentInSourceOrAdded": {
-			sourceMap:    map[string]int{"a": 1},
-			addKeys:      map[string]int{"b": 2},
-			deleteKeys:   []string{"c"},
-			wantModified: map[string]int{"a": 1, "b": 2},
-			wantDeleted:  map[string]bool{"c": true},
-		},
-		"AddKeyThenDeleteIt": {
-			sourceMap:    map[string]int{"base": 100},
-			addKeys:      map[string]int{"temp": 50},
-			deleteKeys:   []string{"temp"},
-			wantModified: map[string]int{"base": 100},
-			wantDeleted:  map[string]bool{"temp": true},
-		},
-		"AllOperations": {
-			sourceMap:    map[string]int{"s1": 1, "s2": 2, "s3": 3},
-			addKeys:      map[string]int{"a1": 10, "s2": 22, "a2": 20},
-			deleteKeys:   []string{"s1", "a1", "nonexistent"},
-			wantModified: map[string]int{"s2": 22, "s3": 3, "a2": 20},
-			wantDeleted:  map[string]bool{"s1": true, "a1": true, "nonexistent": true},
-		},
-		"NoOperationsEmptySource": {
-			sourceMap:    map[string]int{},
-			addKeys:      map[string]int{},
-			deleteKeys:   []string{},
-			wantModified: map[string]int{},
-			wantDeleted:  map[string]bool{},
-		},
-	}
-
-	for testName, test := range tests {
-		t.Run(testName, func(t *testing.T) {
-			p := newPatchFromMap(test.sourceMap)
-
-			for k, v := range test.addKeys {
-				p.Set(k, v)
-			}
-			for _, k := range test.deleteKeys {
-				p.Delete(k)
-			}
-
-			if !maps.Equal(p.Modified, test.wantModified) {
-				t.Errorf("Modified map mismatch: got %v, want %v", p.Modified, test.wantModified)
-			}
-
-			if !maps.Equal(p.Deleted, test.wantDeleted) {
-				t.Errorf("Deleted map mismatch: got %v, want %v", p.Deleted, test.wantDeleted)
-			}
-		})
-	}
-}
-
-func TestMergePatchesInPlace(t *testing.T) {
-	tests := map[string]struct {
-		modifiedPatchA     map[string]int
-		deletedPatchA      map[string]bool
-		modifiedPatchB     map[string]int
-		deletedPatchB      map[string]bool
-		wantModifiedMerged map[string]int
-		wantDeletedMerged  map[string]bool
-	}{
-		"PatchBOverwritesValueInPatchA": {
-			modifiedPatchA:     map[string]int{"a": 1, "b": 2},
-			deletedPatchA:      map[string]bool{},
-			modifiedPatchB:     map[string]int{"b": 22, "c": 3},
-			deletedPatchB:      map[string]bool{},
-			wantModifiedMerged: map[string]int{"a": 1, "b": 22, "c": 3},
-			wantDeletedMerged:  map[string]bool{},
-		},
-		"PatchBDeletesValuePresentInPatchA": {
-			modifiedPatchA:     map[string]int{"a": 1, "b": 2},
-			deletedPatchA:      map[string]bool{},
-			modifiedPatchB:     map[string]int{},
-			deletedPatchB:      map[string]bool{"a": true},
-			wantModifiedMerged: map[string]int{"b": 2},
-			wantDeletedMerged:  map[string]bool{"a": true},
-		},
-		"PatchBDeletesValueAlreadyDeletedInPatchA": {
-			modifiedPatchA:     map[string]int{},
-			deletedPatchA:      map[string]bool{"x": true},
-			modifiedPatchB:     map[string]int{},
-			deletedPatchB:      map[string]bool{"x": true, "y": true},
-			wantModifiedMerged: map[string]int{},
-			wantDeletedMerged:  map[string]bool{"x": true, "y": true},
-		},
-		"PatchBAddsValuePreviouslyDeletedInPatchA": {
-			modifiedPatchA:     map[string]int{},
-			deletedPatchA:      map[string]bool{"x": true},
-			modifiedPatchB:     map[string]int{"x": 10},
-			deletedPatchB:      map[string]bool{},
-			wantModifiedMerged: map[string]int{"x": 10},
-			wantDeletedMerged:  map[string]bool{},
-		},
-		"MergeEmptyPatchBIntoNonEmptyPatchA": {
-			modifiedPatchA:     map[string]int{"a": 1},
-			deletedPatchA:      map[string]bool{"b": true},
-			modifiedPatchB:     map[string]int{},
-			deletedPatchB:      map[string]bool{},
-			wantModifiedMerged: map[string]int{"a": 1},
-			wantDeletedMerged:  map[string]bool{"b": true},
-		},
-		"MergeNonEmptyPatchBIntoEmptyPatchA": {
-			modifiedPatchA:     map[string]int{},
-			deletedPatchA:      map[string]bool{},
-			modifiedPatchB:     map[string]int{"a": 1},
-			deletedPatchB:      map[string]bool{"b": true},
-			wantModifiedMerged: map[string]int{"a": 1},
-			wantDeletedMerged:  map[string]bool{"b": true},
-		},
-		"MergeTwoEmptyPatches": {
-			modifiedPatchA:     map[string]int{},
-			deletedPatchA:      map[string]bool{},
-			modifiedPatchB:     map[string]int{},
-			deletedPatchB:      map[string]bool{},
-			wantModifiedMerged: map[string]int{},
-			wantDeletedMerged:  map[string]bool{},
-		},
-		"NoOverlapBetweenPatchAAndPatchBModifications": {
-			modifiedPatchA:     map[string]int{"a1": 1, "a2": 2},
-			deletedPatchA:      map[string]bool{},
-			modifiedPatchB:     map[string]int{"b1": 10, "b2": 20},
-			deletedPatchB:      map[string]bool{},
-			wantModifiedMerged: map[string]int{"a1": 1, "a2": 2, "b1": 10, "b2": 20},
-			wantDeletedMerged:  map[string]bool{},
-		},
-		"NoOverlapBetweenPatchAAndPatchBDeletions": {
-			modifiedPatchA:     map[string]int{},
-			deletedPatchA:      map[string]bool{"a1": true, "a2": true},
-			modifiedPatchB:     map[string]int{},
-			deletedPatchB:      map[string]bool{"b1": true, "b2": true},
-			wantModifiedMerged: map[string]int{},
-			wantDeletedMerged:  map[string]bool{"a1": true, "a2": true, "b1": true, "b2": true},
-		},
-		"PatchBOnlyAddsNewKeysPatchAUnchanged": {
-			modifiedPatchA:     map[string]int{"orig": 5},
-			modifiedPatchB:     map[string]int{"new1": 100, "new2": 200},
-			deletedPatchA:      map[string]bool{},
-			deletedPatchB:      map[string]bool{},
-			wantModifiedMerged: map[string]int{"orig": 5, "new1": 100, "new2": 200},
-			wantDeletedMerged:  map[string]bool{},
-		},
-		"PatchBOnlyDeletesNewKeysPatchAUnchanged": {
-			modifiedPatchA:     map[string]int{"orig": 5},
-			deletedPatchA:      map[string]bool{},
-			modifiedPatchB:     map[string]int{},
-			deletedPatchB:      map[string]bool{"del1": true, "del2": true},
-			wantModifiedMerged: map[string]int{"orig": 5},
-			wantDeletedMerged:  map[string]bool{"del1": true, "del2": true},
-		},
-		"AllInOne": {
-			modifiedPatchA:     map[string]int{"k1": 1, "k2": 2, "k3": 3},
-			deletedPatchA:      map[string]bool{"d1": true, "d2": true},
-			modifiedPatchB:     map[string]int{"k2": 22, "k4": 4, "d1": 11},
-			deletedPatchB:      map[string]bool{"k3": true, "d2": true, "d3": true},
-			wantModifiedMerged: map[string]int{"k1": 1, "k2": 22, "k4": 4, "d1": 11},
-			wantDeletedMerged:  map[string]bool{"k3": true, "d2": true, "d3": true},
-		},
-	}
-
-	for testName, test := range tests {
-		t.Run(testName, func(t *testing.T) {
-			patchA := newPatchFromMap(test.modifiedPatchA)
-			for k := range test.deletedPatchA {
-				patchA.Delete(k)
-			}
-
-			patchB := newPatchFromMap(test.modifiedPatchB)
-			for k := range test.deletedPatchB {
-				patchB.Delete(k)
-			}
-
-			merged := mergePatchesInPlace(patchA, patchB)
-
-			if merged != patchA {
-				t.Errorf("mergePatchesInPlace did not modify patchA inplace, references are different")
-			}
-
-			if !maps.Equal(merged.Modified, test.wantModifiedMerged) {
-				t.Errorf("Modified map mismatch: got %v, want %v", merged.Modified, test.wantModifiedMerged)
-			}
-
-			if !maps.Equal(merged.Deleted, test.wantDeletedMerged) {
-				t.Errorf("Deleted map mismatch: got %v, want %v", merged.Deleted, test.wantDeletedMerged)
-			}
-		})
-	}
-}
 
 func TestPatchSetAsMap(t *testing.T) {
 	tests := map[string]struct {
@@ -572,7 +270,7 @@ func TestPatchSetRevert(t *testing.T) {
 
 func TestPatchSetForkRevert(t *testing.T) {
 	// 1. Initialize empty patchset
-	ps := newPatchSet[string, int](newPatch[string, int]())
+	ps := NewPatchSet(NewPatch[string, int]())
 	if initialMap := ps.AsMap(); len(initialMap) != 0 {
 		t.Fatalf("Initial AsMap() got %v, want empty", initialMap)
 	}
@@ -602,7 +300,7 @@ func TestPatchSetForkRevert(t *testing.T) {
 
 func TestPatchSetForkCommit(t *testing.T) {
 	// 1. Initialize empty patchset
-	ps := newPatchSet[string, int](newPatch[string, int]())
+	ps := NewPatchSet(NewPatch[string, int]())
 	if initialMap := ps.AsMap(); len(initialMap) != 0 {
 		t.Fatalf("Initial AsMap() got %v, want empty", initialMap)
 	}
@@ -726,13 +424,13 @@ func TestPatchSetFindValue(t *testing.T) {
 func TestPatchSetOperations(t *testing.T) {
 	tests := map[string]struct {
 		patchLayers    []map[string]*int
-		mutatePatchSet func(ps *patchSet[string, int])
+		mutatePatchSet func(ps *PatchSet[string, int])
 		searchKey      string
 		wantInCurrent  bool
 	}{
 		"SetCurrent_NewKey_InitiallyEmptyPatchSet": {
 			patchLayers: []map[string]*int{},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.SetCurrent("a", 1)
 			},
 			searchKey:     "a",
@@ -740,7 +438,7 @@ func TestPatchSetOperations(t *testing.T) {
 		},
 		"SetCurrent_NewKey_OnExistingEmptyLayer": {
 			patchLayers: []map[string]*int{{}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.SetCurrent("a", 1)
 			},
 			searchKey:     "a",
@@ -748,7 +446,7 @@ func TestPatchSetOperations(t *testing.T) {
 		},
 		"SetCurrent_OverwriteKey_InCurrentPatch": {
 			patchLayers: []map[string]*int{{"a": ptr.To(10)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.SetCurrent("a", 1)
 			},
 			searchKey:     "a",
@@ -756,7 +454,7 @@ func TestPatchSetOperations(t *testing.T) {
 		},
 		"SetCurrent_OverwriteKey_InLowerPatch_AfterFork": {
 			patchLayers: []map[string]*int{{"a": ptr.To(10)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.Fork()
 				ps.SetCurrent("a", 1)
 			},
@@ -765,7 +463,7 @@ func TestPatchSetOperations(t *testing.T) {
 		},
 		"DeleteCurrent_ExistingKey_InCurrentPatch": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.DeleteCurrent("a")
 			},
 			searchKey:     "a",
@@ -773,7 +471,7 @@ func TestPatchSetOperations(t *testing.T) {
 		},
 		"DeleteCurrent_ExistingKey_InLowerPatch_AfterFork": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.Fork()
 				ps.DeleteCurrent("a")
 			},
@@ -782,7 +480,7 @@ func TestPatchSetOperations(t *testing.T) {
 		},
 		"DeleteCurrent_NonExistentKey_OnExistingEmptyLayer": {
 			patchLayers: []map[string]*int{{}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.DeleteCurrent("x")
 			},
 			searchKey:     "x",
@@ -790,7 +488,7 @@ func TestPatchSetOperations(t *testing.T) {
 		},
 		"DeleteCurrent_NonExistentKey_InitiallyEmptyPatchSet": {
 			patchLayers: []map[string]*int{}, // Starts with no layers
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.DeleteCurrent("x")
 			},
 			searchKey:     "x",
@@ -798,19 +496,19 @@ func TestPatchSetOperations(t *testing.T) {
 		},
 		"InCurrentPatch_KeySetInCurrent": {
 			patchLayers:    []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {},
+			mutatePatchSet: func(ps *PatchSet[string, int]) {},
 			searchKey:      "a",
 			wantInCurrent:  true,
 		},
 		"InCurrentPatch_KeySetInLower_NotInCurrent_AfterFork": {
 			patchLayers:    []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) { ps.Fork() },
+			mutatePatchSet: func(ps *PatchSet[string, int]) { ps.Fork() },
 			searchKey:      "a",
 			wantInCurrent:  false,
 		},
 		"InCurrentPatch_KeyDeletedInCurrent": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.DeleteCurrent("a")
 			},
 			searchKey:     "a",
@@ -818,7 +516,7 @@ func TestPatchSetOperations(t *testing.T) {
 		},
 		"InCurrentPatch_NonExistentKey_InitiallyEmptyPatchSet": {
 			patchLayers:    []map[string]*int{},
-			mutatePatchSet: func(ps *patchSet[string, int]) {},
+			mutatePatchSet: func(ps *PatchSet[string, int]) {},
 			searchKey:      "a",
 			wantInCurrent:  false,
 		},
@@ -840,25 +538,25 @@ func TestPatchSetOperations(t *testing.T) {
 func TestPatchSetCache(t *testing.T) {
 	tests := map[string]struct {
 		patchLayers     []map[string]*int
-		mutatePatchSet  func(ps *patchSet[string, int])
+		mutatePatchSet  func(ps *PatchSet[string, int])
 		wantCache       map[string]*int
 		wantCacheInSync bool
 	}{
 		"Initial_EmptyPatchSet": {
 			patchLayers:     []map[string]*int{},
-			mutatePatchSet:  func(ps *patchSet[string, int]) {},
+			mutatePatchSet:  func(ps *PatchSet[string, int]) {},
 			wantCache:       map[string]*int{},
 			wantCacheInSync: false,
 		},
 		"Initial_WithData_NoCacheAccess": {
 			patchLayers:     []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet:  func(ps *patchSet[string, int]) {},
+			mutatePatchSet:  func(ps *PatchSet[string, int]) {},
 			wantCache:       map[string]*int{},
 			wantCacheInSync: false,
 		},
 		"FindValue_PopulatesCacheForKey": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": ptr.To(2)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.FindValue("a")
 			},
 			wantCache:       map[string]*int{"a": ptr.To(1)},
@@ -866,7 +564,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"FindValue_DeletedKey_PopulatesCacheWithNil": {
 			patchLayers: []map[string]*int{{"a": nil, "b": ptr.To(2)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.FindValue("a")
 			},
 			wantCache:       map[string]*int{"a": nil},
@@ -874,7 +572,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"AsMap_PopulatesAndSyncsCache": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": nil, "c": ptr.To(3)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.AsMap()
 			},
 			wantCache:       map[string]*int{"a": ptr.To(1), "c": ptr.To(3)}, // Cache does not necessarily track deletions like 'b' key
@@ -882,7 +580,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"SetCurrent_UpdatesCache_NewKey": {
 			patchLayers: []map[string]*int{{}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.SetCurrent("x", 10)
 			},
 			wantCache:       map[string]*int{"x": ptr.To(10)},
@@ -890,7 +588,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"SetCurrent_UpdatesCache_OverwriteKey": {
 			patchLayers: []map[string]*int{{"x": ptr.To(5)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.FindValue("x")
 				ps.SetCurrent("x", 10)
 			},
@@ -899,7 +597,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"DeleteCurrent_UpdatesCache": {
 			patchLayers: []map[string]*int{{"x": ptr.To(5)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.FindValue("x")
 				ps.DeleteCurrent("x")
 			},
@@ -908,7 +606,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"Revert_ClearsAffectedCacheEntries_And_SetsCacheNotInSync": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2), "a": ptr.To(11)}}, // Layer 0: a=1; Layer 1: b=2, a=11
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.FindValue("a")
 				ps.FindValue("b")
 				ps.Revert()
@@ -918,7 +616,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"Revert_OnSyncedCache_SetsCacheNotInSync": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.AsMap()
 				ps.Revert()
 			},
@@ -927,7 +625,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"Commit_DoesNotInvalidateCache_IfValuesConsistent": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.FindValue("a")
 				ps.FindValue("b")
 				ps.Commit()
@@ -937,7 +635,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"Commit_OnSyncedCache_KeepsCacheInSync": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.AsMap()
 				ps.Commit()
 			},
@@ -946,7 +644,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"Fork_DoesNotInvalidateCache": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.FindValue("a")
 				ps.Fork()
 			},
@@ -955,7 +653,7 @@ func TestPatchSetCache(t *testing.T) {
 		},
 		"Fork_OnSyncedCache_KeepsCacheInSync": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet: func(ps *patchSet[string, int]) {
+			mutatePatchSet: func(ps *PatchSet[string, int]) {
 				ps.AsMap()
 				ps.Fork()
 			},
@@ -988,14 +686,14 @@ func TestPatchSetCache(t *testing.T) {
 	}
 }
 
-func buildTestPatchSet[K comparable, V any](t *testing.T, patchLayers []map[K]*V) *patchSet[K, V] {
+func buildTestPatchSet[K comparable, V any](t *testing.T, patchLayers []map[K]*V) *PatchSet[K, V] {
 	t.Helper()
 
 	patchesNumber := len(patchLayers)
-	patches := make([]*patch[K, V], patchesNumber)
+	patches := make([]*Patch[K, V], patchesNumber)
 	for i := 0; i < patchesNumber; i++ {
 		layerMap := patchLayers[i]
-		currentPatch := newPatch[K, V]()
+		currentPatch := NewPatch[K, V]()
 		for k, vPtr := range layerMap {
 			if vPtr != nil {
 				currentPatch.Set(k, *vPtr)
@@ -1006,5 +704,5 @@ func buildTestPatchSet[K comparable, V any](t *testing.T, patchLayers []map[K]*V
 		patches[i] = currentPatch
 	}
 
-	return newPatchSet(patches...)
+	return NewPatchSet(patches...)
 }

--- a/cluster-autoscaler/simulator/dynamicresources/provider/provider.go
+++ b/cluster-autoscaler/simulator/dynamicresources/provider/provider.go
@@ -48,10 +48,10 @@ func NewProvider(claims allObjectsLister[*resourceapi.ResourceClaim], slices all
 }
 
 // Snapshot returns a snapshot of all DRA resources at a ~single point in time.
-func (p *Provider) Snapshot() (drasnapshot.Snapshot, error) {
+func (p *Provider) Snapshot() (*drasnapshot.Snapshot, error) {
 	claims, err := p.resourceClaims.ListAll()
 	if err != nil {
-		return drasnapshot.Snapshot{}, err
+		return nil, err
 	}
 	claimMap := make(map[drasnapshot.ResourceClaimId]*resourceapi.ResourceClaim)
 	for _, claim := range claims {
@@ -60,7 +60,7 @@ func (p *Provider) Snapshot() (drasnapshot.Snapshot, error) {
 
 	slices, err := p.resourceSlices.ListAll()
 	if err != nil {
-		return drasnapshot.Snapshot{}, err
+		return nil, err
 	}
 	slicesMap := make(map[string][]*resourceapi.ResourceSlice)
 	var nonNodeLocalSlices []*resourceapi.ResourceSlice
@@ -74,7 +74,7 @@ func (p *Provider) Snapshot() (drasnapshot.Snapshot, error) {
 
 	classes, err := p.deviceClasses.ListAll()
 	if err != nil {
-		return drasnapshot.Snapshot{}, err
+		return nil, err
 	}
 	classMap := make(map[string]*resourceapi.DeviceClass)
 	for _, class := range classes {

--- a/cluster-autoscaler/simulator/dynamicresources/provider/provider_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/provider/provider_test.go
@@ -61,7 +61,7 @@ func TestProviderSnapshot(t *testing.T) {
 		triggerSlicesError  bool
 		classes             []*resourceapi.DeviceClass
 		triggerClassesError bool
-		wantSnapshot        drasnapshot.Snapshot
+		wantSnapshot        *drasnapshot.Snapshot
 		wantErr             error
 	}{
 		{
@@ -133,7 +133,7 @@ func TestProviderSnapshot(t *testing.T) {
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("Provider.Snapshot(): unexpected error (-want +got): %s", diff)
 			}
-			if diff := cmp.Diff(tc.wantSnapshot, snapshot, cmp.AllowUnexported(drasnapshot.Snapshot{}), cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantSnapshot, snapshot, drasnapshot.SnapshotFlattenedComparer()); diff != "" {
 				t.Fatalf("Provider.Snapshot(): snapshot differs from expected (-want +got): %s", diff)
 			}
 		})

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/patchset.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/patchset.go
@@ -1,0 +1,306 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+// patch represents a single layer of modifications (additions/updates)
+// and deletions for a set of key-value pairs. It's used as a building
+// block for the patchSet.
+type patch[K comparable, V any] struct {
+	Modified map[K]V
+	Deleted  map[K]bool
+}
+
+// Set marks a key-value pair as modified in the current patch.
+// If the key was previously marked as deleted, the deletion mark is removed.
+func (p *patch[K, V]) Set(key K, value V) {
+	p.Modified[key] = value
+	delete(p.Deleted, key)
+}
+
+// Delete marks a key as deleted in the current patch.
+// If the key was previously marked as modified, the modification is removed.
+func (p *patch[K, V]) Delete(key K) {
+	delete(p.Modified, key)
+	p.Deleted[key] = true
+}
+
+// Get retrieves the modified value for a key within this specific patch.
+// It returns the value and true if the key was found in this patch
+// or zero value and false otherwise.
+func (p *patch[K, V]) Get(key K) (value V, found bool) {
+	value, found = p.Modified[key]
+	return value, found
+}
+
+// IsDeleted checks if the key is marked as deleted within this specific patch.
+func (p *patch[K, V]) IsDeleted(key K) bool {
+	return p.Deleted[key]
+}
+
+// newPatch creates a new, empty patch with no modifications or deletions.
+func newPatch[K comparable, V any]() *patch[K, V] {
+	return &patch[K, V]{
+		Modified: make(map[K]V),
+		Deleted:  make(map[K]bool),
+	}
+}
+
+// newPatchFromMap creates a new patch initialized with the data from the provided map
+// the data supplied is recorded as modified in the patch.
+func newPatchFromMap[M ~map[K]V, K comparable, V any](source M) *patch[K, V] {
+	if source == nil {
+		source = make(M)
+	}
+
+	return &patch[K, V]{
+		Modified: source,
+		Deleted:  make(map[K]bool),
+	}
+}
+
+// mergePatchesInPlace merges two patches into one, while modifying patch a
+// inplace taking records in b as a priority when overwrites are required
+func mergePatchesInPlace[K comparable, V any](a *patch[K, V], b *patch[K, V]) *patch[K, V] {
+	for key, value := range b.Modified {
+		a.Set(key, value)
+	}
+
+	for key := range b.Deleted {
+		a.Delete(key)
+	}
+
+	return a
+}
+
+// patchSet manages a stack of patches, allowing for fork/revert/commit operations.
+// It provides a view of the data as if all patches were applied sequentially.
+//
+// Time Complexities:
+//   - Fork(): O(1).
+//   - Commit(): O(P), where P is the number of modified/deleted entries
+//     in the current patch or no-op for patchSet with a single patch.
+//   - Revert(): O(P), where P is the number of modified/deleted entries
+//     in the topmost patch or no-op for patchSet with a single patch.
+//   - FindValue(key): O(1) for cached keys, O(N * P) - otherwise.
+//   - AsMap(): O(N * P) as it needs to iterate through all the layers
+//     modifications and deletions to get the latest state. Best case -
+//     if the cache is currently in sync with the patchSet data complexity becomes
+//     O(C), where C is the actual number key/value pairs in flattened patchSet.
+//   - SetCurrent(key, value): O(1).
+//   - DeleteCurrent(key): O(1).
+//   - InCurrentPatch(key): O(1).
+//
+// Variables used in complexity analysis:
+//   - N: The number of patch layers in the patchSet.
+//   - P: The number of modified/deleted entries in a single patch layer
+//
+// Caching:
+//
+// The patchSet employs a lazy caching mechanism to speed up access to data. When a specific item is requested,
+// the cache is checked first. If the item isn't cached, its effective value is computed by traversing the layers
+// of patches from the most recent to the oldest, and the result is then stored in the cache. For operations that
+// require the entire dataset like AsMap, if a cache is fully up-to-date, the data is served directly from the cache.
+// Otherwise, the entire dataset is rebuilt by applying all patches, and this process fully populates the cache.
+// Direct modifications to the current patch update the specific item in the cache immediately. Reverting the latest
+// patch will clear affected items from the cache and mark the cache as potentially out-of-sync, as underlying values may
+// no longer represent the patchSet as a whole. Committing and forking does not invalidate the cache, as the effective
+// values remain consistent from the perspective of read operations.
+type patchSet[K comparable, V any] struct {
+	// patches is a stack of individual modification layers. The base data is
+	// at index 0, and subsequent modifications are layered on top.
+	// PatchSet should always contain at least a single patch.
+	patches []*patch[K, V]
+
+	// cache stores the computed effective value for keys that have been accessed.
+	// A nil pointer indicates the key is effectively deleted or not present.
+	cache map[K]*V
+
+	// cacheInSync indicates whether the cache map accurately reflects the
+	// current state derived from applying all patches in the 'patches' slice.
+	// When false, the cache may be stale and needs to be rebuilt or validated
+	// before being fully trusted for all keys.
+	cacheInSync bool
+}
+
+// newPatchSet creates a new patchSet, initializing it with the provided base patches.
+func newPatchSet[K comparable, V any](patches ...*patch[K, V]) *patchSet[K, V] {
+	return &patchSet[K, V]{
+		patches:     patches,
+		cache:       make(map[K]*V),
+		cacheInSync: false,
+	}
+}
+
+// Fork adds a new, empty patch layer to the top of the stack.
+// Subsequent modifications will be recorded in this new layer.
+func (p *patchSet[K, V]) Fork() {
+	p.patches = append(p.patches, newPatch[K, V]())
+}
+
+// Commit merges the topmost patch layer into the one below it.
+// If there's only one layer (or none), it's a no-op.
+func (p *patchSet[K, V]) Commit() {
+	if len(p.patches) < 2 {
+		return
+	}
+
+	currentPatch := p.patches[len(p.patches)-1]
+	previousPatch := p.patches[len(p.patches)-2]
+	mergePatchesInPlace(previousPatch, currentPatch)
+	p.patches = p.patches[:len(p.patches)-1]
+}
+
+// Revert removes the topmost patch layer.
+// Any modifications or deletions recorded in that layer are discarded.
+func (p *patchSet[K, V]) Revert() {
+	if len(p.patches) <= 1 {
+		return
+	}
+
+	currentPatch := p.patches[len(p.patches)-1]
+	p.patches = p.patches[:len(p.patches)-1]
+
+	for key := range currentPatch.Modified {
+		delete(p.cache, key)
+	}
+
+	for key := range currentPatch.Deleted {
+		delete(p.cache, key)
+	}
+
+	p.cacheInSync = false
+}
+
+// FindValue searches for the effective value of a key by looking through the patches
+// from top to bottom. It returns the value and true if found, or the zero value and false
+// if the key is deleted or not found in any patch.
+func (p *patchSet[K, V]) FindValue(key K) (value V, found bool) {
+	var zero V
+
+	if cachedValue, cacheHit := p.cache[key]; cacheHit {
+		if cachedValue == nil {
+			return zero, false
+		}
+
+		return *cachedValue, true
+	}
+
+	value = zero
+	found = false
+	for i := len(p.patches) - 1; i >= 0; i-- {
+		patch := p.patches[i]
+		if patch.IsDeleted(key) {
+			break
+		}
+
+		foundValue, ok := patch.Get(key)
+		if ok {
+			value = foundValue
+			found = true
+			break
+		}
+	}
+
+	if found {
+		p.cache[key] = &value
+	} else {
+		p.cache[key] = nil
+	}
+
+	return value, found
+}
+
+// AsMap merges all patches into a single map representing the current effective state.
+// It iterates through all patches from bottom to top, applying modifications and deletions.
+// The cache is populated with the results during this process.
+func (p *patchSet[K, V]) AsMap() map[K]V {
+	if p.cacheInSync {
+		patchSetMap := make(map[K]V, len(p.cache))
+		for key, value := range p.cache {
+			if value != nil {
+				patchSetMap[key] = *value
+			}
+		}
+		return patchSetMap
+	}
+
+	keysCount := p.totalKeyCount()
+	patchSetMap := make(map[K]V, keysCount)
+
+	for _, patch := range p.patches {
+		for key, value := range patch.Modified {
+			patchSetMap[key] = value
+		}
+
+		for key := range patch.Deleted {
+			delete(patchSetMap, key)
+		}
+	}
+
+	for key, value := range patchSetMap {
+		p.cache[key] = &value
+	}
+	p.cacheInSync = true
+
+	return patchSetMap
+}
+
+// SetCurrent adds or updates a key-value pair in the topmost patch layer.
+func (p *patchSet[K, V]) SetCurrent(key K, value V) {
+	if len(p.patches) == 0 {
+		p.Fork()
+	}
+
+	currentPatch := p.patches[len(p.patches)-1]
+	currentPatch.Set(key, value)
+	p.cache[key] = &value
+}
+
+// DeleteCurrent marks a key as deleted in the topmost patch layer.
+func (p *patchSet[K, V]) DeleteCurrent(key K) {
+	if len(p.patches) == 0 {
+		p.Fork()
+	}
+
+	currentPatch := p.patches[len(p.patches)-1]
+	currentPatch.Delete(key)
+	p.cache[key] = nil
+}
+
+// InCurrentPatch checks if the key is available in the topmost patch layer.
+func (p *patchSet[K, V]) InCurrentPatch(key K) bool {
+	if len(p.patches) == 0 {
+		return false
+	}
+
+	currentPatch := p.patches[len(p.patches)-1]
+	_, found := currentPatch.Get(key)
+	return found
+}
+
+// totalKeyCount calculates an approximate total number of key-value
+// pairs across all patches taking the highest number of records possible
+// this calculation does not consider deleted records - thus it is likely
+// to be not accurate
+func (p *patchSet[K, V]) totalKeyCount() int {
+	count := 0
+	for _, patch := range p.patches {
+		count += len(patch.Modified)
+	}
+
+	return count
+}

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/patchset_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/patchset_test.go
@@ -1,0 +1,1010 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"maps"
+	"testing"
+
+	"k8s.io/utils/ptr"
+)
+
+func TestPatchOperations(t *testing.T) {
+	p := newPatch[string, int]()
+
+	// 1. Get and IsDeleted on non-existent key
+	if _, found := p.Get("a"); found {
+		t.Errorf("Get for 'a' should not find anything")
+	}
+	if p.IsDeleted("a") {
+		t.Errorf("IsDeleted for 'a' should be false")
+	}
+
+	// 2. Set 'a' key
+	p.Set("a", 1)
+	if val, found := p.Get("a"); !found || val != 1 {
+		t.Errorf("Get('a') = %v,%v, expected 1,true", val, found)
+	}
+	if p.IsDeleted("a") {
+		t.Errorf("IsDeleted('a') = true, should be false")
+	}
+
+	// 3. Overwrite 'a' key
+	p.Set("a", 2)
+	if val, found := p.Get("a"); !found || val != 2 {
+		t.Errorf("Get('a') = %v,%v, expected 2,true", val, found)
+	}
+	if p.IsDeleted("a") {
+		t.Errorf("IsDeleted('a') = true, should be false")
+	}
+
+	// 4. Delete 'a' key
+	p.Delete("a")
+	if val, found := p.Get("a"); found {
+		t.Errorf("Get('a') = %v,%v, should not find anything after delete", val, found)
+	}
+	if !p.IsDeleted("a") {
+		t.Errorf("IsDeleted('a') = false, should be true")
+	}
+
+	// 5. Set 'a' key again after deletion
+	p.Set("a", 3)
+	if val, found := p.Get("a"); !found || val != 3 {
+		t.Errorf("Get('a') = %v,%v, expected 3,true", val, found)
+	}
+	if p.IsDeleted("a") {
+		t.Errorf("IsDeleted('a') = true, should be false")
+	}
+
+	// 6. Delete a non-existent key 'c'
+	p.Delete("c")
+	if val, found := p.Get("c"); found {
+		t.Errorf("Get('c') = %v, %v, should not find anything", val, found)
+	}
+	if !p.IsDeleted("c") {
+		t.Errorf("IsDeleted('c') = false, should be true")
+	}
+}
+
+func TestCreatePatch(t *testing.T) {
+	tests := map[string]struct {
+		sourceMap    map[string]int
+		addKeys      map[string]int
+		deleteKeys   []string
+		wantModified map[string]int
+		wantDeleted  map[string]bool
+	}{
+		"SourceMapOnlyNoModifications": {
+			sourceMap:    map[string]int{"k1": 1, "k2": 2},
+			addKeys:      map[string]int{},
+			deleteKeys:   []string{},
+			wantModified: map[string]int{"k1": 1, "k2": 2},
+			wantDeleted:  map[string]bool{},
+		},
+		"NilSourceMapAddAndDelete": {
+			sourceMap:    nil,
+			addKeys:      map[string]int{"a": 1, "b": 2},
+			deleteKeys:   []string{"b"},
+			wantModified: map[string]int{"a": 1},
+			wantDeleted:  map[string]bool{"b": true},
+		},
+		"EmptySourceMapAddAndDelete": {
+			sourceMap:    map[string]int{},
+			addKeys:      map[string]int{"x": 10},
+			deleteKeys:   []string{"y"},
+			wantModified: map[string]int{"x": 10},
+			wantDeleted:  map[string]bool{"y": true},
+		},
+		"NonEmptySourceMapAddOverwriteDelete": {
+			sourceMap:    map[string]int{"orig1": 100, "orig2": 200},
+			addKeys:      map[string]int{"new1": 300, "orig1": 101},
+			deleteKeys:   []string{"orig2", "new1"},
+			wantModified: map[string]int{"orig1": 101},
+			wantDeleted:  map[string]bool{"orig2": true, "new1": true},
+		},
+		"DeleteKeyFromSourceMap": {
+			sourceMap:    map[string]int{"key_to_delete": 70, "key_to_keep": 80},
+			addKeys:      map[string]int{},
+			deleteKeys:   []string{"key_to_delete"},
+			wantModified: map[string]int{"key_to_keep": 80},
+			wantDeleted:  map[string]bool{"key_to_delete": true},
+		},
+		"AddOnlyNoSourceMap": {
+			sourceMap:    nil,
+			addKeys:      map[string]int{"add1": 10, "add2": 20},
+			deleteKeys:   []string{},
+			wantModified: map[string]int{"add1": 10, "add2": 20},
+			wantDeleted:  map[string]bool{},
+		},
+		"DeleteOnlyNoSourceMap": {
+			sourceMap:    nil,
+			addKeys:      map[string]int{},
+			deleteKeys:   []string{"del1", "del2"},
+			wantModified: map[string]int{},
+			wantDeleted:  map[string]bool{"del1": true, "del2": true},
+		},
+		"DeleteKeyNotPresentInSourceOrAdded": {
+			sourceMap:    map[string]int{"a": 1},
+			addKeys:      map[string]int{"b": 2},
+			deleteKeys:   []string{"c"},
+			wantModified: map[string]int{"a": 1, "b": 2},
+			wantDeleted:  map[string]bool{"c": true},
+		},
+		"AddKeyThenDeleteIt": {
+			sourceMap:    map[string]int{"base": 100},
+			addKeys:      map[string]int{"temp": 50},
+			deleteKeys:   []string{"temp"},
+			wantModified: map[string]int{"base": 100},
+			wantDeleted:  map[string]bool{"temp": true},
+		},
+		"AllOperations": {
+			sourceMap:    map[string]int{"s1": 1, "s2": 2, "s3": 3},
+			addKeys:      map[string]int{"a1": 10, "s2": 22, "a2": 20},
+			deleteKeys:   []string{"s1", "a1", "nonexistent"},
+			wantModified: map[string]int{"s2": 22, "s3": 3, "a2": 20},
+			wantDeleted:  map[string]bool{"s1": true, "a1": true, "nonexistent": true},
+		},
+		"NoOperationsEmptySource": {
+			sourceMap:    map[string]int{},
+			addKeys:      map[string]int{},
+			deleteKeys:   []string{},
+			wantModified: map[string]int{},
+			wantDeleted:  map[string]bool{},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			p := newPatchFromMap(test.sourceMap)
+
+			for k, v := range test.addKeys {
+				p.Set(k, v)
+			}
+			for _, k := range test.deleteKeys {
+				p.Delete(k)
+			}
+
+			if !maps.Equal(p.Modified, test.wantModified) {
+				t.Errorf("Modified map mismatch: got %v, want %v", p.Modified, test.wantModified)
+			}
+
+			if !maps.Equal(p.Deleted, test.wantDeleted) {
+				t.Errorf("Deleted map mismatch: got %v, want %v", p.Deleted, test.wantDeleted)
+			}
+		})
+	}
+}
+
+func TestMergePatchesInPlace(t *testing.T) {
+	tests := map[string]struct {
+		modifiedPatchA     map[string]int
+		deletedPatchA      map[string]bool
+		modifiedPatchB     map[string]int
+		deletedPatchB      map[string]bool
+		wantModifiedMerged map[string]int
+		wantDeletedMerged  map[string]bool
+	}{
+		"PatchBOverwritesValueInPatchA": {
+			modifiedPatchA:     map[string]int{"a": 1, "b": 2},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{"b": 22, "c": 3},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"a": 1, "b": 22, "c": 3},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"PatchBDeletesValuePresentInPatchA": {
+			modifiedPatchA:     map[string]int{"a": 1, "b": 2},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{"a": true},
+			wantModifiedMerged: map[string]int{"b": 2},
+			wantDeletedMerged:  map[string]bool{"a": true},
+		},
+		"PatchBDeletesValueAlreadyDeletedInPatchA": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{"x": true},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{"x": true, "y": true},
+			wantModifiedMerged: map[string]int{},
+			wantDeletedMerged:  map[string]bool{"x": true, "y": true},
+		},
+		"PatchBAddsValuePreviouslyDeletedInPatchA": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{"x": true},
+			modifiedPatchB:     map[string]int{"x": 10},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"x": 10},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"MergeEmptyPatchBIntoNonEmptyPatchA": {
+			modifiedPatchA:     map[string]int{"a": 1},
+			deletedPatchA:      map[string]bool{"b": true},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"a": 1},
+			wantDeletedMerged:  map[string]bool{"b": true},
+		},
+		"MergeNonEmptyPatchBIntoEmptyPatchA": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{"a": 1},
+			deletedPatchB:      map[string]bool{"b": true},
+			wantModifiedMerged: map[string]int{"a": 1},
+			wantDeletedMerged:  map[string]bool{"b": true},
+		},
+		"MergeTwoEmptyPatches": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"NoOverlapBetweenPatchAAndPatchBModifications": {
+			modifiedPatchA:     map[string]int{"a1": 1, "a2": 2},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{"b1": 10, "b2": 20},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"a1": 1, "a2": 2, "b1": 10, "b2": 20},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"NoOverlapBetweenPatchAAndPatchBDeletions": {
+			modifiedPatchA:     map[string]int{},
+			deletedPatchA:      map[string]bool{"a1": true, "a2": true},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{"b1": true, "b2": true},
+			wantModifiedMerged: map[string]int{},
+			wantDeletedMerged:  map[string]bool{"a1": true, "a2": true, "b1": true, "b2": true},
+		},
+		"PatchBOnlyAddsNewKeysPatchAUnchanged": {
+			modifiedPatchA:     map[string]int{"orig": 5},
+			modifiedPatchB:     map[string]int{"new1": 100, "new2": 200},
+			deletedPatchA:      map[string]bool{},
+			deletedPatchB:      map[string]bool{},
+			wantModifiedMerged: map[string]int{"orig": 5, "new1": 100, "new2": 200},
+			wantDeletedMerged:  map[string]bool{},
+		},
+		"PatchBOnlyDeletesNewKeysPatchAUnchanged": {
+			modifiedPatchA:     map[string]int{"orig": 5},
+			deletedPatchA:      map[string]bool{},
+			modifiedPatchB:     map[string]int{},
+			deletedPatchB:      map[string]bool{"del1": true, "del2": true},
+			wantModifiedMerged: map[string]int{"orig": 5},
+			wantDeletedMerged:  map[string]bool{"del1": true, "del2": true},
+		},
+		"AllInOne": {
+			modifiedPatchA:     map[string]int{"k1": 1, "k2": 2, "k3": 3},
+			deletedPatchA:      map[string]bool{"d1": true, "d2": true},
+			modifiedPatchB:     map[string]int{"k2": 22, "k4": 4, "d1": 11},
+			deletedPatchB:      map[string]bool{"k3": true, "d2": true, "d3": true},
+			wantModifiedMerged: map[string]int{"k1": 1, "k2": 22, "k4": 4, "d1": 11},
+			wantDeletedMerged:  map[string]bool{"k3": true, "d2": true, "d3": true},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			patchA := newPatchFromMap(test.modifiedPatchA)
+			for k := range test.deletedPatchA {
+				patchA.Delete(k)
+			}
+
+			patchB := newPatchFromMap(test.modifiedPatchB)
+			for k := range test.deletedPatchB {
+				patchB.Delete(k)
+			}
+
+			merged := mergePatchesInPlace(patchA, patchB)
+
+			if merged != patchA {
+				t.Errorf("mergePatchesInPlace did not modify patchA inplace, references are different")
+			}
+
+			if !maps.Equal(merged.Modified, test.wantModifiedMerged) {
+				t.Errorf("Modified map mismatch: got %v, want %v", merged.Modified, test.wantModifiedMerged)
+			}
+
+			if !maps.Equal(merged.Deleted, test.wantDeletedMerged) {
+				t.Errorf("Deleted map mismatch: got %v, want %v", merged.Deleted, test.wantDeletedMerged)
+			}
+		})
+	}
+}
+
+func TestPatchSetAsMap(t *testing.T) {
+	tests := map[string]struct {
+		patchLayers []map[string]*int
+		wantMap     map[string]int
+	}{
+		"EmptyPatchSet": {
+			patchLayers: []map[string]*int{},
+			wantMap:     map[string]int{},
+		},
+		"SingleLayerNoDeletions": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": ptr.To(2)}},
+			wantMap:     map[string]int{"a": 1, "b": 2},
+		},
+		"SingleLayerOnlyDeletions": {
+			patchLayers: []map[string]*int{{"a": nil, "b": nil}},
+			wantMap:     map[string]int{},
+		},
+		"SingleLayerModificationsAndDeletions": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": nil, "c": ptr.To(3)}},
+			wantMap: map[string]int{"a": 1, "c": 3},
+		},
+		"MultipleLayersNoDeletionsOverwrite": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": ptr.To(2)},
+				{"b": ptr.To(22), "c": ptr.To(3)}},
+			wantMap: map[string]int{"a": 1, "b": 22, "c": 3},
+		},
+		"MultipleLayersWithDeletions": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": nil, "x": ptr.To(100)},
+				{"c": ptr.To(3), "x": ptr.To(101), "a": nil}},
+			wantMap: map[string]int{"c": 3, "x": 101},
+		},
+		"MultipleLayersDeletionInLowerLayer": {
+			patchLayers: []map[string]*int{
+				{"a": nil, "b": ptr.To(2)},
+				{"c": ptr.To(3)}},
+			wantMap: map[string]int{"b": 2, "c": 3},
+		},
+		"MultipleLayersAddAfterDelete": {
+			patchLayers: []map[string]*int{
+				{"a": nil},
+				{"a": ptr.To(11), "b": ptr.To(2)}},
+			wantMap: map[string]int{"a": 11, "b": 2},
+		},
+		"MultipleLayersDeletePreviouslyAdded": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": ptr.To(2)},
+				{"c": ptr.To(3), "b": nil}},
+			wantMap: map[string]int{"a": 1, "c": 3},
+		},
+		"AllInOne": {
+			patchLayers: []map[string]*int{
+				{"k1": ptr.To(1), "k2": ptr.To(2)},
+				{"k2": ptr.To(22), "k3": ptr.To(3), "k1": nil},
+				{"k1": ptr.To(111), "k3": ptr.To(33), "k4": ptr.To(4), "deleted": nil},
+			},
+			wantMap: map[string]int{"k2": 22, "k3": 33, "k4": 4, "k1": 111},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			patchset := buildTestPatchSet(t, test.patchLayers)
+			mergedMap := patchset.AsMap()
+			if !maps.Equal(mergedMap, test.wantMap) {
+				t.Errorf("AsMap() result mismatch: got %v, want %v", mergedMap, test.wantMap)
+			}
+		})
+	}
+}
+
+func TestPatchSetCommit(t *testing.T) {
+	tests := map[string]struct {
+		patchLayers []map[string]*int
+		wantMap     map[string]int // Expected map after each commit
+	}{
+		"CommitEmptyPatchSet": {
+			patchLayers: []map[string]*int{},
+			wantMap:     map[string]int{},
+		},
+		"CommitSingleLayer": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
+			wantMap:     map[string]int{"a": 1},
+		},
+		"CommitTwoLayersNoOverlap": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
+			wantMap:     map[string]int{"a": 1, "b": 2},
+		},
+		"CommitTwoLayersWithOverwrite": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"a": ptr.To(2)}},
+			wantMap:     map[string]int{"a": 2},
+		},
+		"CommitTwoLayersWithDeleteInTopLayer": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": ptr.To(5)}, {"c": ptr.To(3), "a": nil}},
+			wantMap:     map[string]int{"b": 5, "c": 3},
+		},
+		"CommitTwoLayersWithDeleteInBottomLayer": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": nil}, {"a": ptr.To(11), "c": ptr.To(3)}},
+			wantMap:     map[string]int{"a": 11, "c": 3},
+		},
+		"CommitThreeLayers": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": ptr.To(2), "z": ptr.To(100)},
+				{"b": ptr.To(22), "c": ptr.To(3), "a": nil},
+				{"c": ptr.To(33), "d": ptr.To(4), "a": ptr.To(111), "b": nil, "deleted": nil},
+			},
+			wantMap: map[string]int{"z": 100, "c": 33, "d": 4, "a": 111},
+		},
+		"CommitMultipleLayersDeleteAndAddBack": {
+			patchLayers: []map[string]*int{
+				{"x": ptr.To(10)},
+				{"x": nil},
+				{"x": ptr.To(30)},
+				{"y": ptr.To(40), "x": nil}},
+			wantMap: map[string]int{"y": 40},
+		},
+		"CommitEmptyLayersBetweenDataLayers": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {}, {"b": ptr.To(2)}, {}, {"c": ptr.To(3)}},
+			wantMap:     map[string]int{"a": 1, "b": 2, "c": 3},
+		},
+	}
+
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ps := buildTestPatchSet(t, tc.patchLayers)
+			initialNumPatches := len(ps.patches)
+
+			if currentMap := ps.AsMap(); !maps.Equal(currentMap, tc.wantMap) {
+				t.Errorf("AsMap() before any commits mismatch: got %v, want %v", currentMap, tc.wantMap)
+			}
+
+			for i := 0; i < initialNumPatches-1; i++ {
+				expectedPatchesAfterCommit := len(ps.patches) - 1
+				ps.Commit()
+				if len(ps.patches) != expectedPatchesAfterCommit {
+					t.Errorf("After commit #%d, expected %d patches, got %d", i+1, expectedPatchesAfterCommit, len(ps.patches))
+				}
+				if currentMap := ps.AsMap(); !maps.Equal(currentMap, tc.wantMap) {
+					t.Errorf("AsMap() after commit #%d mismatch: got %v, want %v", i+1, currentMap, tc.wantMap)
+				}
+			}
+
+			if initialNumPatches > 0 && len(ps.patches) != 1 {
+				t.Errorf("Expected 1 patch after all commits, got %d", len(ps.patches))
+			} else if initialNumPatches == 0 && len(ps.patches) != 0 {
+				t.Errorf("Expected 0 patches after all commits, got %d", len(ps.patches))
+			}
+		})
+	}
+}
+
+func TestPatchSetRevert(t *testing.T) {
+	tests := map[string]struct {
+		patchLayers         []map[string]*int
+		wantInitialMap      map[string]int
+		wantMapsAfterRevert []map[string]int
+	}{
+		"RevertEmptyPatchSet": {
+			patchLayers:         []map[string]*int{},
+			wantInitialMap:      map[string]int{},
+			wantMapsAfterRevert: []map[string]int{{}},
+		},
+		"RevertSingleLayer": {
+			patchLayers:         []map[string]*int{{"a": ptr.To(1)}},
+			wantInitialMap:      map[string]int{"a": 1},
+			wantMapsAfterRevert: []map[string]int{{"a": 1}},
+		},
+		"RevertTwoLayersNoOverlap": {
+			patchLayers:         []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
+			wantInitialMap:      map[string]int{"a": 1, "b": 2},
+			wantMapsAfterRevert: []map[string]int{{"a": 1}, {"a": 1}},
+		},
+		"RevertTwoLayersWithOverwrite": {
+			patchLayers:         []map[string]*int{{"a": ptr.To(1)}, {"a": ptr.To(2)}},
+			wantInitialMap:      map[string]int{"a": 2},
+			wantMapsAfterRevert: []map[string]int{{"a": 1}, {"a": 1}},
+		},
+		"RevertTwoLayersWithDeleteInTopLayer": {
+			patchLayers:         []map[string]*int{{"a": ptr.To(1), "b": ptr.To(5)}, {"c": ptr.To(3), "a": nil}},
+			wantInitialMap:      map[string]int{"b": 5, "c": 3},
+			wantMapsAfterRevert: []map[string]int{{"a": 1, "b": 5}, {"a": 1, "b": 5}},
+		},
+		"RevertThreeLayers": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": ptr.To(2), "z": ptr.To(100)},
+				{"b": ptr.To(22), "c": ptr.To(3), "a": nil},
+				{"c": ptr.To(33), "d": ptr.To(4), "a": ptr.To(111), "b": nil, "deleted": nil},
+			},
+			wantInitialMap: map[string]int{"z": 100, "c": 33, "d": 4, "a": 111},
+			wantMapsAfterRevert: []map[string]int{
+				{"a": 1, "b": 2, "z": 100},
+				{"a": 1, "b": 2, "z": 100},
+				{"z": 100, "b": 22, "c": 3},
+			},
+		},
+		"RevertMultipleLayersDeleteAndAddBack": {
+			patchLayers:    []map[string]*int{{"x": ptr.To(10)}, {"x": nil}, {"x": ptr.To(30)}, {"y": ptr.To(40), "x": nil}},
+			wantInitialMap: map[string]int{"y": 40},
+			wantMapsAfterRevert: []map[string]int{
+				{"x": 10},
+				{"x": 10},
+				{},
+				{"x": 30},
+			},
+		},
+	}
+
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ps := buildTestPatchSet(t, tc.patchLayers)
+			patchesNumber := len(ps.patches)
+
+			if currentMap := ps.AsMap(); !maps.Equal(currentMap, tc.wantInitialMap) {
+				t.Errorf("AsMap() before any reverts mismatch: got %v, want %v", currentMap, tc.wantInitialMap)
+			}
+
+			for i := 0; i <= patchesNumber; i++ {
+				wantPatchesAfterRevert := len(ps.patches) - 1
+				ps.Revert()
+				if len(ps.patches) != wantPatchesAfterRevert && len(ps.patches) > 1 {
+					t.Errorf("After revert #%d, expected %d patches, got %d", i+1, wantPatchesAfterRevert, len(ps.patches))
+				}
+
+				currentMap := ps.AsMap()
+				wantMapIndex := patchesNumber - i - 1
+				if wantMapIndex < 0 {
+					wantMapIndex = 0
+				}
+				wantMapAfterRevert := tc.wantMapsAfterRevert[wantMapIndex]
+				if !maps.Equal(currentMap, wantMapAfterRevert) {
+					t.Errorf("AsMap() after revert #%d mismatch: got %v, want %v", i+1, currentMap, wantMapAfterRevert)
+				}
+			}
+
+			if patchesNumber >= 1 && len(ps.patches) != 1 {
+				t.Errorf("Expected 1 patch after all reverts, got %d", len(ps.patches))
+			} else if patchesNumber == 0 && len(ps.patches) != 0 {
+				t.Errorf("Expected 0 patches after all reverts, got %d", len(ps.patches))
+			}
+		})
+	}
+}
+
+func TestPatchSetForkRevert(t *testing.T) {
+	// 1. Initialize empty patchset
+	ps := newPatchSet[string, int](newPatch[string, int]())
+	if initialMap := ps.AsMap(); len(initialMap) != 0 {
+		t.Fatalf("Initial AsMap() got %v, want empty", initialMap)
+	}
+
+	// 2. Call Fork
+	ps.Fork()
+	if len(ps.patches) != 2 {
+		t.Fatalf("Expected 2 patches after Fork(), got %d", len(ps.patches))
+	}
+
+	// 3. Perform some mutation operations on the new layer
+	ps.SetCurrent("a", 1)
+	ps.SetCurrent("b", 2)
+	ps.DeleteCurrent("a")
+
+	// 4. Call Revert
+	ps.Revert()
+	if len(ps.patches) != 1 {
+		t.Fatalf("Expected 1 patch after Revert(), got %d", len(ps.patches))
+	}
+
+	// 5. Compare state to the empty map
+	if finalMap := ps.AsMap(); len(finalMap) != 0 {
+		t.Errorf("AsMap() got %v, want empty", finalMap)
+	}
+}
+
+func TestPatchSetForkCommit(t *testing.T) {
+	// 1. Initialize empty patchset
+	ps := newPatchSet[string, int](newPatch[string, int]())
+	if initialMap := ps.AsMap(); len(initialMap) != 0 {
+		t.Fatalf("Initial AsMap() got %v, want empty", initialMap)
+	}
+
+	// 2. Call Fork two times
+	ps.Fork()
+	ps.Fork()
+	if len(ps.patches) != 3 {
+		t.Fatalf("Expected 3 patches after 2xFork(), got %d", len(ps.patches))
+	}
+
+	// 3. Perform some mutation operations on the current layer
+	ps.SetCurrent("a", 1)
+	ps.SetCurrent("b", 2)
+	ps.DeleteCurrent("a")
+
+	// 4. Call Commit to persist changes
+	ps.Commit()
+	if len(ps.patches) != 2 {
+		t.Fatalf("Expected 1 patch after Commit(), got %d", len(ps.patches))
+	}
+
+	// 5. Call Revert on the empty layer
+	ps.Revert()
+	if len(ps.patches) != 1 {
+		t.Fatalf("Expected 1 patch after Revert(), got %d", len(ps.patches))
+	}
+
+	// 6. Compare state to the empty map
+	wantMap := map[string]int{"b": 2}
+	if finalMap := ps.AsMap(); maps.Equal(wantMap, finalMap) {
+		t.Errorf("AsMap() got %v, want %v", finalMap, wantMap)
+	}
+}
+
+func TestPatchSetFindValue(t *testing.T) {
+	tests := map[string]struct {
+		patchLayers []map[string]*int
+		searchKey   string
+		wantValue   int
+		wantFound   bool
+	}{
+		"EmptyPatchSet_KeyNotFound": {
+			patchLayers: []map[string]*int{},
+			searchKey:   "a",
+			wantFound:   false,
+		},
+		"SingleLayer_KeyFound": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": ptr.To(2)}},
+			searchKey:   "a",
+			wantValue:   1,
+			wantFound:   true,
+		},
+		"SingleLayer_KeyNotFound": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
+			searchKey:   "x",
+			wantFound:   false,
+		},
+		"SingleLayer_KeyDeleted": {
+			patchLayers: []map[string]*int{{"a": nil, "b": ptr.To(2)}},
+			searchKey:   "a",
+			wantFound:   false,
+		},
+		"MultiLayer_KeyInTopLayer": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"a": ptr.To(10), "b": ptr.To(2)}},
+			searchKey:   "a",
+			wantValue:   10,
+			wantFound:   true,
+		},
+		"MultiLayer_KeyInBottomLayer": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": ptr.To(2)}, {"b": ptr.To(22)}},
+			searchKey:   "a",
+			wantValue:   1,
+			wantFound:   true,
+		},
+		"MultiLayer_KeyOverwrittenThenDeleted": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"a": ptr.To(10)}, {"a": nil, "b": ptr.To(2)}},
+			searchKey:   "a",
+			wantFound:   false,
+		},
+		"MultiLayer_KeyDeletedThenAddedBack": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"a": nil}, {"a": ptr.To(100), "b": ptr.To(2)}},
+			searchKey:   "a",
+			wantValue:   100,
+			wantFound:   true,
+		},
+		"MultiLayer_KeyNotFoundInAnyLayer": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
+			searchKey:   "x",
+			wantFound:   false,
+		},
+		"MultiLayer_KeyDeletedInMiddleLayer_NotFound": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"a": nil, "b": ptr.To(2)}, {"c": ptr.To(3)}},
+			searchKey:   "a",
+			wantFound:   false,
+		},
+		"MultiLayer_KeyPresentInBase_DeletedInOverlay_ReAddedInTop": {
+			patchLayers: []map[string]*int{
+				{"k1": ptr.To(1)},
+				{"k1": nil},
+				{"k1": ptr.To(111)},
+			},
+			searchKey: "k1",
+			wantValue: 111,
+			wantFound: true,
+		},
+	}
+
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ps := buildTestPatchSet(t, tc.patchLayers)
+			val, found := ps.FindValue(tc.searchKey)
+
+			if found != tc.wantFound || (found && val != tc.wantValue) {
+				t.Errorf("FindValue(%q) got val=%v, found=%v; want val=%v, found=%v", tc.searchKey, val, found, tc.wantValue, tc.wantFound)
+			}
+		})
+	}
+}
+
+func TestPatchSetOperations(t *testing.T) {
+	tests := map[string]struct {
+		patchLayers    []map[string]*int
+		mutatePatchSet func(ps *patchSet[string, int])
+		searchKey      string
+		wantInCurrent  bool
+	}{
+		"SetCurrent_NewKey_InitiallyEmptyPatchSet": {
+			patchLayers: []map[string]*int{},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.SetCurrent("a", 1)
+			},
+			searchKey:     "a",
+			wantInCurrent: true,
+		},
+		"SetCurrent_NewKey_OnExistingEmptyLayer": {
+			patchLayers: []map[string]*int{{}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.SetCurrent("a", 1)
+			},
+			searchKey:     "a",
+			wantInCurrent: true,
+		},
+		"SetCurrent_OverwriteKey_InCurrentPatch": {
+			patchLayers: []map[string]*int{{"a": ptr.To(10)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.SetCurrent("a", 1)
+			},
+			searchKey:     "a",
+			wantInCurrent: true,
+		},
+		"SetCurrent_OverwriteKey_InLowerPatch_AfterFork": {
+			patchLayers: []map[string]*int{{"a": ptr.To(10)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.Fork()
+				ps.SetCurrent("a", 1)
+			},
+			searchKey:     "a",
+			wantInCurrent: true,
+		},
+		"DeleteCurrent_ExistingKey_InCurrentPatch": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.DeleteCurrent("a")
+			},
+			searchKey:     "a",
+			wantInCurrent: false,
+		},
+		"DeleteCurrent_ExistingKey_InLowerPatch_AfterFork": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.Fork()
+				ps.DeleteCurrent("a")
+			},
+			searchKey:     "a",
+			wantInCurrent: false,
+		},
+		"DeleteCurrent_NonExistentKey_OnExistingEmptyLayer": {
+			patchLayers: []map[string]*int{{}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.DeleteCurrent("x")
+			},
+			searchKey:     "x",
+			wantInCurrent: false,
+		},
+		"DeleteCurrent_NonExistentKey_InitiallyEmptyPatchSet": {
+			patchLayers: []map[string]*int{}, // Starts with no layers
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.DeleteCurrent("x")
+			},
+			searchKey:     "x",
+			wantInCurrent: false,
+		},
+		"InCurrentPatch_KeySetInCurrent": {
+			patchLayers:    []map[string]*int{{"a": ptr.To(1)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {},
+			searchKey:      "a",
+			wantInCurrent:  true,
+		},
+		"InCurrentPatch_KeySetInLower_NotInCurrent_AfterFork": {
+			patchLayers:    []map[string]*int{{"a": ptr.To(1)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) { ps.Fork() },
+			searchKey:      "a",
+			wantInCurrent:  false,
+		},
+		"InCurrentPatch_KeyDeletedInCurrent": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.DeleteCurrent("a")
+			},
+			searchKey:     "a",
+			wantInCurrent: false, // Get in current patch won't find it.
+		},
+		"InCurrentPatch_NonExistentKey_InitiallyEmptyPatchSet": {
+			patchLayers:    []map[string]*int{},
+			mutatePatchSet: func(ps *patchSet[string, int]) {},
+			searchKey:      "a",
+			wantInCurrent:  false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ps := buildTestPatchSet(t, tc.patchLayers)
+			tc.mutatePatchSet(ps)
+
+			inCurrent := ps.InCurrentPatch(tc.searchKey)
+			if inCurrent != tc.wantInCurrent {
+				t.Errorf("InCurrentPatch(%q): got %v, want %v", tc.searchKey, inCurrent, tc.wantInCurrent)
+			}
+		})
+	}
+}
+
+func TestPatchSetCache(t *testing.T) {
+	tests := map[string]struct {
+		patchLayers     []map[string]*int
+		mutatePatchSet  func(ps *patchSet[string, int])
+		wantCache       map[string]*int
+		wantCacheInSync bool
+	}{
+		"Initial_EmptyPatchSet": {
+			patchLayers:     []map[string]*int{},
+			mutatePatchSet:  func(ps *patchSet[string, int]) {},
+			wantCache:       map[string]*int{},
+			wantCacheInSync: false,
+		},
+		"Initial_WithData_NoCacheAccess": {
+			patchLayers:     []map[string]*int{{"a": ptr.To(1)}},
+			mutatePatchSet:  func(ps *patchSet[string, int]) {},
+			wantCache:       map[string]*int{},
+			wantCacheInSync: false,
+		},
+		"FindValue_PopulatesCacheForKey": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": ptr.To(2)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.FindValue("a")
+			},
+			wantCache:       map[string]*int{"a": ptr.To(1)},
+			wantCacheInSync: false,
+		},
+		"FindValue_DeletedKey_PopulatesCacheWithNil": {
+			patchLayers: []map[string]*int{{"a": nil, "b": ptr.To(2)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.FindValue("a")
+			},
+			wantCache:       map[string]*int{"a": nil},
+			wantCacheInSync: false,
+		},
+		"AsMap_PopulatesAndSyncsCache": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": nil, "c": ptr.To(3)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.AsMap()
+			},
+			wantCache:       map[string]*int{"a": ptr.To(1), "c": ptr.To(3)}, // Cache does not necessarily track deletions like 'b' key
+			wantCacheInSync: true,
+		},
+		"SetCurrent_UpdatesCache_NewKey": {
+			patchLayers: []map[string]*int{{}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.SetCurrent("x", 10)
+			},
+			wantCache:       map[string]*int{"x": ptr.To(10)},
+			wantCacheInSync: false,
+		},
+		"SetCurrent_UpdatesCache_OverwriteKey": {
+			patchLayers: []map[string]*int{{"x": ptr.To(5)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.FindValue("x")
+				ps.SetCurrent("x", 10)
+			},
+			wantCache:       map[string]*int{"x": ptr.To(10)},
+			wantCacheInSync: false,
+		},
+		"DeleteCurrent_UpdatesCache": {
+			patchLayers: []map[string]*int{{"x": ptr.To(5)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.FindValue("x")
+				ps.DeleteCurrent("x")
+			},
+			wantCache:       map[string]*int{"x": nil},
+			wantCacheInSync: false,
+		},
+		"Revert_ClearsAffectedCacheEntries_And_SetsCacheNotInSync": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2), "a": ptr.To(11)}}, // Layer 0: a=1; Layer 1: b=2, a=11
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.FindValue("a")
+				ps.FindValue("b")
+				ps.Revert()
+			},
+			wantCache:       map[string]*int{},
+			wantCacheInSync: false,
+		},
+		"Revert_OnSyncedCache_SetsCacheNotInSync": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.AsMap()
+				ps.Revert()
+			},
+			wantCache:       map[string]*int{"a": ptr.To(1)},
+			wantCacheInSync: false,
+		},
+		"Commit_DoesNotInvalidateCache_IfValuesConsistent": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.FindValue("a")
+				ps.FindValue("b")
+				ps.Commit()
+			},
+			wantCache:       map[string]*int{"a": ptr.To(1), "b": ptr.To(2)},
+			wantCacheInSync: false,
+		},
+		"Commit_OnSyncedCache_KeepsCacheInSync": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.AsMap()
+				ps.Commit()
+			},
+			wantCache:       map[string]*int{"a": ptr.To(1), "b": ptr.To(2)},
+			wantCacheInSync: true,
+		},
+		"Fork_DoesNotInvalidateCache": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.FindValue("a")
+				ps.Fork()
+			},
+			wantCache:       map[string]*int{"a": ptr.To(1)},
+			wantCacheInSync: false,
+		},
+		"Fork_OnSyncedCache_KeepsCacheInSync": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
+			mutatePatchSet: func(ps *patchSet[string, int]) {
+				ps.AsMap()
+				ps.Fork()
+			},
+			wantCache:       map[string]*int{"a": ptr.To(1)},
+			wantCacheInSync: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ps := buildTestPatchSet(t, tc.patchLayers)
+			tc.mutatePatchSet(ps)
+
+			if !maps.EqualFunc(ps.cache, tc.wantCache, func(a, b *int) bool {
+				if a == nil && b == nil {
+					return true
+				}
+				if a == nil || b == nil {
+					return false
+				}
+				return *a == *b
+			}) {
+				t.Errorf("Cache content mismatch: got %v, want %v", ps.cache, tc.wantCache)
+			}
+
+			if ps.cacheInSync != tc.wantCacheInSync {
+				t.Errorf("cacheInSync status mismatch: got %v, want %v", ps.cacheInSync, tc.wantCacheInSync)
+			}
+		})
+	}
+}
+
+func buildTestPatchSet[K comparable, V any](t *testing.T, patchLayers []map[K]*V) *patchSet[K, V] {
+	t.Helper()
+
+	patchesNumber := len(patchLayers)
+	patches := make([]*patch[K, V], patchesNumber)
+	for i := 0; i < patchesNumber; i++ {
+		layerMap := patchLayers[i]
+		currentPatch := newPatch[K, V]()
+		for k, vPtr := range layerMap {
+			if vPtr != nil {
+				currentPatch.Set(k, *vPtr)
+			} else {
+				currentPatch.Delete(k)
+			}
+		}
+		patches[i] = currentPatch
+	}
+
+	return newPatchSet(patches...)
+}

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
@@ -23,6 +23,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/common"
 	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	resourceclaim "k8s.io/dynamic-resource-allocation/resourceclaim"
@@ -45,9 +46,9 @@ func GetClaimId(claim *resourceapi.ResourceClaim) ResourceClaimId {
 // obtained via the Provider. Then, it can be modified using the exposed methods, to simulate scheduling actions
 // in the cluster.
 type Snapshot struct {
-	resourceClaims *patchSet[ResourceClaimId, *resourceapi.ResourceClaim]
-	resourceSlices *patchSet[string, []*resourceapi.ResourceSlice]
-	deviceClasses  *patchSet[string, *resourceapi.DeviceClass]
+	resourceClaims *common.PatchSet[ResourceClaimId, *resourceapi.ResourceClaim]
+	resourceSlices *common.PatchSet[string, []*resourceapi.ResourceSlice]
+	deviceClasses  *common.PatchSet[string, *resourceapi.DeviceClass]
 }
 
 // nonNodeLocalResourceSlicesIdentifier is a special key used in the resourceSlices patchSet
@@ -61,25 +62,25 @@ func NewSnapshot(claims map[ResourceClaimId]*resourceapi.ResourceClaim, nodeLoca
 	maps.Copy(slices, nodeLocalSlices)
 	slices[nonNodeLocalResourceSlicesIdentifier] = nonNodeLocalSlices
 
-	claimsPatch := newPatchFromMap(claims)
-	slicesPatch := newPatchFromMap(slices)
-	devicesPatch := newPatchFromMap(deviceClasses)
+	claimsPatch := common.NewPatchFromMap(claims)
+	slicesPatch := common.NewPatchFromMap(slices)
+	devicesPatch := common.NewPatchFromMap(deviceClasses)
 	return &Snapshot{
-		resourceClaims: newPatchSet(claimsPatch),
-		resourceSlices: newPatchSet(slicesPatch),
-		deviceClasses:  newPatchSet(devicesPatch),
+		resourceClaims: common.NewPatchSet(claimsPatch),
+		resourceSlices: common.NewPatchSet(slicesPatch),
+		deviceClasses:  common.NewPatchSet(devicesPatch),
 	}
 }
 
 // NewEmptySnapshot returns a zero initialized Snapshot.
 func NewEmptySnapshot() *Snapshot {
-	claimsPatch := newPatch[ResourceClaimId, *resourceapi.ResourceClaim]()
-	slicesPatch := newPatch[string, []*resourceapi.ResourceSlice]()
-	devicesPatch := newPatch[string, *resourceapi.DeviceClass]()
+	claimsPatch := common.NewPatch[ResourceClaimId, *resourceapi.ResourceClaim]()
+	slicesPatch := common.NewPatch[string, []*resourceapi.ResourceSlice]()
+	devicesPatch := common.NewPatch[string, *resourceapi.DeviceClass]()
 	return &Snapshot{
-		resourceClaims: newPatchSet(claimsPatch),
-		resourceSlices: newPatchSet(slicesPatch),
-		deviceClasses:  newPatchSet(devicesPatch),
+		resourceClaims: common.NewPatchSet(claimsPatch),
+		resourceSlices: common.NewPatchSet(slicesPatch),
+		deviceClasses:  common.NewPatchSet(devicesPatch),
 	}
 }
 

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
@@ -152,7 +152,7 @@ func (s *Snapshot) RemovePodOwnedClaims(pod *apiv1.Pod) {
 
 	for _, claim := range claims {
 		claimId := GetClaimId(claim)
-		if drautils.PodOwnsClaim(pod, claim) {
+		if err := resourceclaim.IsForPod(pod, claim); err == nil {
 			s.resourceClaims.DeleteCurrent(claimId)
 			continue
 		}
@@ -201,7 +201,7 @@ func (s *Snapshot) UnreservePodClaims(pod *apiv1.Pod) error {
 		claimId := GetClaimId(claim)
 		claim := s.ensureClaimWritable(claim)
 		drautils.ClearPodReservationInPlace(claim, pod)
-		if drautils.PodOwnsClaim(pod, claim) || !drautils.ClaimInUse(claim) {
+		if err := resourceclaim.IsForPod(pod, claim); err == nil || !drautils.ClaimInUse(claim) {
 			drautils.DeallocateClaimInPlace(claim)
 		}
 

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
@@ -18,6 +18,7 @@ package snapshot
 
 import (
 	"fmt"
+	"maps"
 
 	apiv1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1beta1"
@@ -25,6 +26,7 @@ import (
 	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	resourceclaim "k8s.io/dynamic-resource-allocation/resourceclaim"
+	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -43,54 +45,67 @@ func GetClaimId(claim *resourceapi.ResourceClaim) ResourceClaimId {
 // obtained via the Provider. Then, it can be modified using the exposed methods, to simulate scheduling actions
 // in the cluster.
 type Snapshot struct {
-	resourceClaimsById         map[ResourceClaimId]*resourceapi.ResourceClaim
-	resourceSlicesByNodeName   map[string][]*resourceapi.ResourceSlice
-	nonNodeLocalResourceSlices []*resourceapi.ResourceSlice
-	deviceClasses              map[string]*resourceapi.DeviceClass
+	resourceClaims *patchSet[ResourceClaimId, *resourceapi.ResourceClaim]
+	resourceSlices *patchSet[string, []*resourceapi.ResourceSlice]
+	deviceClasses  *patchSet[string, *resourceapi.DeviceClass]
 }
 
+// nonNodeLocalResourceSlicesIdentifier is a special key used in the resourceSlices patchSet
+// to store ResourceSlices that apply do not apply to specific nodes. The string itself is
+// using a value which kubernetes node names cannot possibly have to avoid having collisions.
+const nonNodeLocalResourceSlicesIdentifier = "--NON-LOCAL--"
+
 // NewSnapshot returns a Snapshot created from the provided data.
-func NewSnapshot(claims map[ResourceClaimId]*resourceapi.ResourceClaim, nodeLocalSlices map[string][]*resourceapi.ResourceSlice, globalSlices []*resourceapi.ResourceSlice, deviceClasses map[string]*resourceapi.DeviceClass) Snapshot {
-	if claims == nil {
-		claims = map[ResourceClaimId]*resourceapi.ResourceClaim{}
+func NewSnapshot(claims map[ResourceClaimId]*resourceapi.ResourceClaim, nodeLocalSlices map[string][]*resourceapi.ResourceSlice, nonNodeLocalSlices []*resourceapi.ResourceSlice, deviceClasses map[string]*resourceapi.DeviceClass) *Snapshot {
+	slices := make(map[string][]*resourceapi.ResourceSlice, len(nodeLocalSlices)+1)
+	maps.Copy(slices, nodeLocalSlices)
+	slices[nonNodeLocalResourceSlicesIdentifier] = nonNodeLocalSlices
+
+	claimsPatch := newPatchFromMap(claims)
+	slicesPatch := newPatchFromMap(slices)
+	devicesPatch := newPatchFromMap(deviceClasses)
+	return &Snapshot{
+		resourceClaims: newPatchSet(claimsPatch),
+		resourceSlices: newPatchSet(slicesPatch),
+		deviceClasses:  newPatchSet(devicesPatch),
 	}
-	if nodeLocalSlices == nil {
-		nodeLocalSlices = map[string][]*resourceapi.ResourceSlice{}
-	}
-	if deviceClasses == nil {
-		deviceClasses = map[string]*resourceapi.DeviceClass{}
-	}
-	return Snapshot{
-		resourceClaimsById:         claims,
-		resourceSlicesByNodeName:   nodeLocalSlices,
-		nonNodeLocalResourceSlices: globalSlices,
-		deviceClasses:              deviceClasses,
+}
+
+// NewEmptySnapshot returns a zero initialized Snapshot.
+func NewEmptySnapshot() *Snapshot {
+	claimsPatch := newPatch[ResourceClaimId, *resourceapi.ResourceClaim]()
+	slicesPatch := newPatch[string, []*resourceapi.ResourceSlice]()
+	devicesPatch := newPatch[string, *resourceapi.DeviceClass]()
+	return &Snapshot{
+		resourceClaims: newPatchSet(claimsPatch),
+		resourceSlices: newPatchSet(slicesPatch),
+		deviceClasses:  newPatchSet(devicesPatch),
 	}
 }
 
 // ResourceClaims exposes the Snapshot as schedulerframework.ResourceClaimTracker, in order to interact with
 // the scheduler framework.
-func (s Snapshot) ResourceClaims() schedulerframework.ResourceClaimTracker {
-	return snapshotClaimTracker(s)
+func (s *Snapshot) ResourceClaims() schedulerframework.ResourceClaimTracker {
+	return snapshotClaimTracker{snapshot: s}
 }
 
 // ResourceSlices exposes the Snapshot as schedulerframework.ResourceSliceLister, in order to interact with
 // the scheduler framework.
-func (s Snapshot) ResourceSlices() schedulerframework.ResourceSliceLister {
-	return snapshotSliceLister(s)
+func (s *Snapshot) ResourceSlices() schedulerframework.ResourceSliceLister {
+	return snapshotSliceLister{snapshot: s}
 }
 
 // DeviceClasses exposes the Snapshot as schedulerframework.DeviceClassLister, in order to interact with
 // the scheduler framework.
-func (s Snapshot) DeviceClasses() schedulerframework.DeviceClassLister {
-	return snapshotClassLister(s)
+func (s *Snapshot) DeviceClasses() schedulerframework.DeviceClassLister {
+	return snapshotClassLister{snapshot: s}
 }
 
 // WrapSchedulerNodeInfo wraps the provided *schedulerframework.NodeInfo into an internal *framework.NodeInfo, adding
 // dra information. Node-local ResourceSlices are added to the NodeInfo, and all ResourceClaims referenced by each Pod
 // are added to each PodInfo. Returns an error if any of the Pods is missing a ResourceClaim.
-func (s Snapshot) WrapSchedulerNodeInfo(schedNodeInfo *schedulerframework.NodeInfo) (*framework.NodeInfo, error) {
-	podExtraInfos := map[types.UID]framework.PodExtraInfo{}
+func (s *Snapshot) WrapSchedulerNodeInfo(schedNodeInfo *schedulerframework.NodeInfo) (*framework.NodeInfo, error) {
+	podExtraInfos := make(map[types.UID]framework.PodExtraInfo, len(schedNodeInfo.Pods))
 	for _, pod := range schedNodeInfo.Pods {
 		podClaims, err := s.PodClaims(pod.Pod)
 		if err != nil {
@@ -104,161 +119,251 @@ func (s Snapshot) WrapSchedulerNodeInfo(schedNodeInfo *schedulerframework.NodeIn
 	return framework.WrapSchedulerNodeInfo(schedNodeInfo, nodeSlices, podExtraInfos), nil
 }
 
-// Clone returns a copy of this Snapshot that can be independently modified without affecting this Snapshot.
-// The only mutable objects in the Snapshot are ResourceClaims, so they are deep-copied. The rest is only a
-// shallow copy.
-func (s Snapshot) Clone() Snapshot {
-	result := Snapshot{
-		resourceClaimsById:       map[ResourceClaimId]*resourceapi.ResourceClaim{},
-		resourceSlicesByNodeName: map[string][]*resourceapi.ResourceSlice{},
-		deviceClasses:            map[string]*resourceapi.DeviceClass{},
-	}
-	// The claims are mutable, they have to be deep-copied.
-	for id, claim := range s.resourceClaimsById {
-		result.resourceClaimsById[id] = claim.DeepCopy()
-	}
-	// The rest of the objects aren't mutable, so a shallow copy should be enough.
-	for nodeName, slices := range s.resourceSlicesByNodeName {
-		for _, slice := range slices {
-			result.resourceSlicesByNodeName[nodeName] = append(result.resourceSlicesByNodeName[nodeName], slice)
-		}
-	}
-	for _, slice := range s.nonNodeLocalResourceSlices {
-		result.nonNodeLocalResourceSlices = append(result.nonNodeLocalResourceSlices, slice)
-	}
-	for className, class := range s.deviceClasses {
-		result.deviceClasses[className] = class
-	}
-	return result
-}
-
 // AddClaims adds additional ResourceClaims to the Snapshot. It can be used e.g. if we need to duplicate a Pod that
 // owns ResourceClaims. Returns an error if any of the claims is already tracked in the snapshot.
-func (s Snapshot) AddClaims(newClaims []*resourceapi.ResourceClaim) error {
+func (s *Snapshot) AddClaims(newClaims []*resourceapi.ResourceClaim) error {
 	for _, claim := range newClaims {
-		if _, found := s.resourceClaimsById[GetClaimId(claim)]; found {
+		if _, found := s.resourceClaims.FindValue(GetClaimId(claim)); found {
 			return fmt.Errorf("claim %s/%s already tracked in the snapshot", claim.Namespace, claim.Name)
 		}
 	}
+
 	for _, claim := range newClaims {
-		s.resourceClaimsById[GetClaimId(claim)] = claim
+		s.resourceClaims.SetCurrent(GetClaimId(claim), claim)
 	}
+
 	return nil
 }
 
 // PodClaims returns ResourceClaims objects for all claims referenced by the Pod. If any of the referenced claims
 // isn't tracked in the Snapshot, an error is returned.
-func (s Snapshot) PodClaims(pod *apiv1.Pod) ([]*resourceapi.ResourceClaim, error) {
-	var result []*resourceapi.ResourceClaim
-
-	for _, claimRef := range pod.Spec.ResourceClaims {
-		claim, err := s.claimForPod(pod, claimRef)
-		if err != nil {
-			return nil, fmt.Errorf("error while obtaining ResourceClaim %s for pod %s/%s: %v", claimRef.Name, pod.Namespace, pod.Name, err)
-		}
-		result = append(result, claim)
-	}
-
-	return result, nil
+func (s *Snapshot) PodClaims(pod *apiv1.Pod) ([]*resourceapi.ResourceClaim, error) {
+	return s.findPodClaims(pod, false)
 }
 
 // RemovePodOwnedClaims iterates over all the claims referenced by the Pod, and removes the ones owned by the Pod from the Snapshot.
 // Claims referenced by the Pod but not owned by it are not removed, but the Pod's reservation is removed from them.
 // This method removes all relevant claims that are in the snapshot, and doesn't error out if any of the claims are missing.
-func (s Snapshot) RemovePodOwnedClaims(pod *apiv1.Pod) {
-	for _, podClaimRef := range pod.Spec.ResourceClaims {
-		claimName := claimRefToName(pod, podClaimRef)
-		if claimName == "" {
-			// This most likely means that the Claim hasn't actually been created. Nothing to remove/modify, so continue to the next claim.
+func (s *Snapshot) RemovePodOwnedClaims(pod *apiv1.Pod) {
+	claims, err := s.findPodClaims(pod, true)
+	if err != nil {
+		klog.Errorf("Snapshot.RemovePodOwnedClaims ignored an error: %s", err)
+	}
+
+	for _, claim := range claims {
+		claimId := GetClaimId(claim)
+		if drautils.PodOwnsClaim(pod, claim) {
+			s.resourceClaims.DeleteCurrent(claimId)
 			continue
 		}
-		claimId := ResourceClaimId{Name: claimName, Namespace: pod.Namespace}
-		claim, found := s.resourceClaimsById[claimId]
-		if !found {
-			// The claim isn't tracked in the snapshot for some reason. Nothing to remove/modify, so continue to the next claim.
-			continue
-		}
-		if err := resourceclaim.IsForPod(pod, claim); err == nil {
-			delete(s.resourceClaimsById, claimId)
-		} else {
-			drautils.ClearPodReservationInPlace(claim, pod)
-		}
+
+		claim := s.ensureClaimWritable(claim)
+		drautils.ClearPodReservationInPlace(claim, pod)
+		s.resourceClaims.SetCurrent(claimId, claim)
 	}
 }
 
 // ReservePodClaims adds a reservation for the provided Pod to all the claims it references. If any of the referenced
 // claims isn't tracked in the Snapshot, or if any of the claims are already at maximum reservation count, an error is
 // returned.
-func (s Snapshot) ReservePodClaims(pod *apiv1.Pod) error {
-	claims, err := s.PodClaims(pod)
+func (s *Snapshot) ReservePodClaims(pod *apiv1.Pod) error {
+	claims, err := s.findPodClaims(pod, false)
 	if err != nil {
 		return err
 	}
+
 	for _, claim := range claims {
 		if drautils.ClaimFullyReserved(claim) && !resourceclaim.IsReservedForPod(pod, claim) {
 			return fmt.Errorf("claim %s/%s already has max number of reservations set, can't add more", claim.Namespace, claim.Name)
 		}
 	}
+
 	for _, claim := range claims {
+		claimId := GetClaimId(claim)
+		claim := s.ensureClaimWritable(claim)
 		drautils.AddPodReservationInPlace(claim, pod)
+		s.resourceClaims.SetCurrent(claimId, claim)
 	}
+
 	return nil
 }
 
 // UnreservePodClaims removes reservations for the provided Pod from all the claims it references. If any of the referenced
 // claims isn't tracked in the Snapshot, an error is returned. If a claim is owned by the pod, or if the claim has no more reservations,
 // its allocation is cleared.
-func (s Snapshot) UnreservePodClaims(pod *apiv1.Pod) error {
-	claims, err := s.PodClaims(pod)
+func (s *Snapshot) UnreservePodClaims(pod *apiv1.Pod) error {
+	claims, err := s.findPodClaims(pod, false)
 	if err != nil {
 		return err
 	}
+
 	for _, claim := range claims {
-		podOwnedClaim := resourceclaim.IsForPod(pod, claim) == nil
+		claimId := GetClaimId(claim)
+		claim := s.ensureClaimWritable(claim)
 		drautils.ClearPodReservationInPlace(claim, pod)
-		if podOwnedClaim || !drautils.ClaimInUse(claim) {
+		if drautils.PodOwnsClaim(pod, claim) || !drautils.ClaimInUse(claim) {
 			drautils.DeallocateClaimInPlace(claim)
 		}
+
+		s.resourceClaims.SetCurrent(claimId, claim)
 	}
 	return nil
 }
 
 // NodeResourceSlices returns all node-local ResourceSlices for the given Node.
-func (s Snapshot) NodeResourceSlices(nodeName string) ([]*resourceapi.ResourceSlice, bool) {
-	slices, found := s.resourceSlicesByNodeName[nodeName]
+func (s *Snapshot) NodeResourceSlices(nodeName string) ([]*resourceapi.ResourceSlice, bool) {
+	slices, found := s.resourceSlices.FindValue(nodeName)
 	return slices, found
 }
 
 // AddNodeResourceSlices adds additional node-local ResourceSlices to the Snapshot. This should be used whenever a Node with
 // node-local ResourceSlices is duplicated in the cluster snapshot.
-func (s Snapshot) AddNodeResourceSlices(nodeName string, slices []*resourceapi.ResourceSlice) error {
-	if _, alreadyInSnapshot := s.resourceSlicesByNodeName[nodeName]; alreadyInSnapshot {
+func (s *Snapshot) AddNodeResourceSlices(nodeName string, slices []*resourceapi.ResourceSlice) error {
+	if _, alreadyInSnapshot := s.NodeResourceSlices(nodeName); alreadyInSnapshot {
 		return fmt.Errorf("node %q ResourceSlices already present", nodeName)
 	}
-	s.resourceSlicesByNodeName[nodeName] = slices
+
+	s.resourceSlices.SetCurrent(nodeName, slices)
 	return nil
 }
 
-// RemoveNodeResourceSlices removes all node-local ResourceSlices for the Node with the given nodeName.
+// RemoveNodeResourceSlices removes all node-local ResourceSlices for the Node with the given node name.
 // It's a no-op if there aren't any slices to remove.
-func (s Snapshot) RemoveNodeResourceSlices(nodeName string) {
-	delete(s.resourceSlicesByNodeName, nodeName)
+func (s *Snapshot) RemoveNodeResourceSlices(nodeName string) {
+	s.resourceSlices.DeleteCurrent(nodeName)
 }
 
-func (s Snapshot) claimForPod(pod *apiv1.Pod, claimRef apiv1.PodResourceClaim) (*resourceapi.ResourceClaim, error) {
-	claimName := claimRefToName(pod, claimRef)
-	if claimName == "" {
-		return nil, fmt.Errorf("couldn't determine ResourceClaim name")
-	}
-
-	claim, found := s.resourceClaimsById[ResourceClaimId{Name: claimName, Namespace: pod.Namespace}]
-	if !found {
-		return nil, fmt.Errorf("couldn't find ResourceClaim %q", claimName)
-	}
-
-	return claim, nil
+// Commit persists changes done in the topmost layer merging them into the one below it.
+func (s *Snapshot) Commit() {
+	s.deviceClasses.Commit()
+	s.resourceClaims.Commit()
+	s.resourceSlices.Commit()
 }
 
+// Revert removes the topmost patch layer for all resource types, discarding
+// any modifications or deletions recorded there.
+func (s *Snapshot) Revert() {
+	s.deviceClasses.Revert()
+	s.resourceClaims.Revert()
+	s.resourceSlices.Revert()
+}
+
+// Fork adds a new, empty patch layer to the top of the stack for all
+// resource types. Subsequent modifications will be recorded in this
+// new layer until Commit() or Revert() are invoked.
+func (s *Snapshot) Fork() {
+	s.deviceClasses.Fork()
+	s.resourceClaims.Fork()
+	s.resourceSlices.Fork()
+}
+
+// listDeviceClasses retrieves all effective DeviceClasses from the snapshot.
+func (s *Snapshot) listDeviceClasses() []*resourceapi.DeviceClass {
+	deviceClasses := s.deviceClasses.AsMap()
+	deviceClassesList := make([]*resourceapi.DeviceClass, 0, len(deviceClasses))
+	for _, class := range deviceClasses {
+		deviceClassesList = append(deviceClassesList, class)
+	}
+
+	return deviceClassesList
+}
+
+// listResourceClaims retrieves all effective ResourceClaims from the snapshot.
+func (s *Snapshot) listResourceClaims() []*resourceapi.ResourceClaim {
+	claims := s.resourceClaims.AsMap()
+	claimsList := make([]*resourceapi.ResourceClaim, 0, len(claims))
+	for _, claim := range claims {
+		claimsList = append(claimsList, claim)
+	}
+
+	return claimsList
+}
+
+// configureResourceClaim updates or adds a ResourceClaim in the current patch layer.
+// This is typically used internally when a claim's state (like allocation) changes.
+func (s *Snapshot) configureResourceClaim(claim *resourceapi.ResourceClaim) {
+	claimId := ResourceClaimId{Name: claim.Name, Namespace: claim.Namespace}
+	s.resourceClaims.SetCurrent(claimId, claim)
+}
+
+// getResourceClaim retrieves a specific ResourceClaim by its ID from the snapshot.
+func (s *Snapshot) getResourceClaim(claimId ResourceClaimId) (*resourceapi.ResourceClaim, bool) {
+	return s.resourceClaims.FindValue(claimId)
+}
+
+// listResourceSlices retrieves all effective ResourceSlices from the snapshot.
+func (s *Snapshot) listResourceSlices() []*resourceapi.ResourceSlice {
+	resourceSlices := s.resourceSlices.AsMap()
+	resourceSlicesList := make([]*resourceapi.ResourceSlice, 0, len(resourceSlices))
+	for _, nodeSlices := range resourceSlices {
+		resourceSlicesList = append(resourceSlicesList, nodeSlices...)
+	}
+
+	return resourceSlicesList
+}
+
+// getDeviceClass retrieves a specific DeviceClass by its name from the snapshot.
+func (s *Snapshot) getDeviceClass(className string) (*resourceapi.DeviceClass, bool) {
+	return s.deviceClasses.FindValue(className)
+}
+
+// findPodClaims retrieves all ResourceClaim objects referenced by a given pod.
+// If ignoreNotTracked is true, it skips claims not found in the snapshot; otherwise, it returns an error.
+func (s *Snapshot) findPodClaims(pod *apiv1.Pod, ignoreNotTracked bool) ([]*resourceapi.ResourceClaim, error) {
+	result := make([]*resourceapi.ResourceClaim, len(pod.Spec.ResourceClaims))
+	for claimIndex, claimRef := range pod.Spec.ResourceClaims {
+		claimName := claimRefToName(pod, claimRef)
+		if claimName == "" {
+			if !ignoreNotTracked {
+				return nil, fmt.Errorf(
+					"error while obtaining ResourceClaim %s for pod %s/%s: couldn't determine ResourceClaim name",
+					claimRef.Name,
+					pod.Namespace,
+					pod.Name,
+				)
+			}
+
+			continue
+		}
+
+		claimId := ResourceClaimId{Name: claimName, Namespace: pod.Namespace}
+		claim, found := s.resourceClaims.FindValue(claimId)
+		if !found {
+			if !ignoreNotTracked {
+				return nil, fmt.Errorf(
+					"error while obtaining ResourceClaim %s for pod %s/%s: couldn't find ResourceClaim in the snapshot",
+					claimRef.Name,
+					pod.Namespace,
+					pod.Name,
+				)
+			}
+
+			continue
+		}
+
+		result[claimIndex] = claim
+	}
+
+	return result, nil
+}
+
+// ensureClaimWritable returns a resource claim suitable for inplace modifications,
+// in case if requested claim is stored in the current patch - the same object
+// is returned, otherwise a deep-copy is created. This is required for resource claim
+// state changing operations to implement copy-on-write policy for inplace modifications
+// when there's no claim tracked on the current layer of the patchset.
+func (s *Snapshot) ensureClaimWritable(claim *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
+	claimId := GetClaimId(claim)
+	if s.resourceClaims.InCurrentPatch(claimId) {
+		return claim
+	}
+
+	return claim.DeepCopy()
+}
+
+// claimRefToName determines the actual name of a ResourceClaim based on a PodResourceClaim reference.
+// It first checks if the name is directly specified in the reference. If not, it looks up the name
+// in the pod's status. Returns an empty string if the name cannot be determined.
 func claimRefToName(pod *apiv1.Pod, claimRef apiv1.PodResourceClaim) string {
 	if claimRef.ResourceClaimName != nil {
 		return *claimRef.ResourceClaimName

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_claim_tracker.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_claim_tracker.go
@@ -25,51 +25,51 @@ import (
 	"k8s.io/dynamic-resource-allocation/structured"
 )
 
-type snapshotClaimTracker Snapshot
-
-func (s snapshotClaimTracker) List() ([]*resourceapi.ResourceClaim, error) {
-	var result []*resourceapi.ResourceClaim
-	for _, claim := range s.resourceClaimsById {
-		result = append(result, claim)
-	}
-	return result, nil
+type snapshotClaimTracker struct {
+	snapshot *Snapshot
 }
 
-func (s snapshotClaimTracker) Get(namespace, claimName string) (*resourceapi.ResourceClaim, error) {
-	claim, found := s.resourceClaimsById[ResourceClaimId{Name: claimName, Namespace: namespace}]
+func (ct snapshotClaimTracker) List() ([]*resourceapi.ResourceClaim, error) {
+	return ct.snapshot.listResourceClaims(), nil
+}
+
+func (ct snapshotClaimTracker) Get(namespace, claimName string) (*resourceapi.ResourceClaim, error) {
+	claimId := ResourceClaimId{Name: claimName, Namespace: namespace}
+	claim, found := ct.snapshot.getResourceClaim(claimId)
 	if !found {
 		return nil, fmt.Errorf("claim %s/%s not found", namespace, claimName)
 	}
 	return claim, nil
 }
 
-func (s snapshotClaimTracker) ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error) {
+func (ct snapshotClaimTracker) ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error) {
 	result := sets.New[structured.DeviceID]()
-	for _, claim := range s.resourceClaimsById {
+	for _, claim := range ct.snapshot.listResourceClaims() {
 		result = result.Union(claimAllocatedDevices(claim))
 	}
 	return result, nil
 }
 
-func (s snapshotClaimTracker) SignalClaimPendingAllocation(claimUid types.UID, allocatedClaim *resourceapi.ResourceClaim) error {
+func (ct snapshotClaimTracker) SignalClaimPendingAllocation(claimUid types.UID, allocatedClaim *resourceapi.ResourceClaim) error {
 	// The DRA scheduler plugin calls this at the end of the scheduling phase, in Reserve. Then, the allocation is persisted via an API
 	// call during the binding phase.
 	//
 	// In Cluster Autoscaler only the scheduling phase is run, so SignalClaimPendingAllocation() is used to obtain the allocation
 	// and persist it in-memory in the snapshot.
-	ref := ResourceClaimId{Name: allocatedClaim.Name, Namespace: allocatedClaim.Namespace}
-	claim, found := s.resourceClaimsById[ref]
+	claimId := ResourceClaimId{Name: allocatedClaim.Name, Namespace: allocatedClaim.Namespace}
+	claim, found := ct.snapshot.getResourceClaim(claimId)
 	if !found {
 		return fmt.Errorf("claim %s/%s not found", allocatedClaim.Namespace, allocatedClaim.Name)
 	}
 	if claim.UID != claimUid {
 		return fmt.Errorf("claim %s/%s: snapshot has UID %q, allocation came for UID %q - shouldn't happenn", allocatedClaim.Namespace, allocatedClaim.Name, claim.UID, claimUid)
 	}
-	s.resourceClaimsById[ref] = allocatedClaim
+
+	ct.snapshot.configureResourceClaim(allocatedClaim)
 	return nil
 }
 
-func (s snapshotClaimTracker) ClaimHasPendingAllocation(claimUid types.UID) bool {
+func (ct snapshotClaimTracker) ClaimHasPendingAllocation(claimUid types.UID) bool {
 	// The DRA scheduler plugin calls this at the beginning of Filter, and fails the filter if true is returned to handle race conditions.
 	//
 	// In the scheduler implementation, ClaimHasPendingAllocation() starts answering true after SignalClaimPendingAllocation()
@@ -81,19 +81,19 @@ func (s snapshotClaimTracker) ClaimHasPendingAllocation(claimUid types.UID) bool
 	return false
 }
 
-func (s snapshotClaimTracker) RemoveClaimPendingAllocation(claimUid types.UID) (deleted bool) {
+func (ct snapshotClaimTracker) RemoveClaimPendingAllocation(claimUid types.UID) (deleted bool) {
 	// This method is only called during the Bind phase of scheduler framework, which is never run by CA. We need to implement
 	// it to satisfy the interface, but it should never be called.
 	panic("snapshotClaimTracker.RemoveClaimPendingAllocation() was called - this should never happen")
 }
 
-func (s snapshotClaimTracker) AssumeClaimAfterAPICall(claim *resourceapi.ResourceClaim) error {
+func (ct snapshotClaimTracker) AssumeClaimAfterAPICall(claim *resourceapi.ResourceClaim) error {
 	// This method is only called during the Bind phase of scheduler framework, which is never run by CA. We need to implement
 	// it to satisfy the interface, but it should never be called.
 	panic("snapshotClaimTracker.AssumeClaimAfterAPICall() was called - this should never happen")
 }
 
-func (s snapshotClaimTracker) AssumedClaimRestore(namespace, claimName string) {
+func (ct snapshotClaimTracker) AssumedClaimRestore(namespace, claimName string) {
 	// This method is only called during the Bind phase of scheduler framework, which is never run by CA. We need to implement
 	// it to satisfy the interface, but it should never be called.
 	panic("snapshotClaimTracker.AssumedClaimRestore() was called - this should never happen")

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_claim_tracker_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_claim_tracker_test.go
@@ -170,7 +170,7 @@ func TestSnapshotClaimTrackerListAllAllocatedDevices(t *testing.T) {
 				GetClaimId(allocatedClaim2): allocatedClaim2,
 				GetClaimId(claim3):          claim3,
 			},
-			wantDevices: sets.New[structured.DeviceID](
+			wantDevices: sets.New(
 				structured.MakeDeviceID("driver.example.com", "pool-1", "device-1"),
 				structured.MakeDeviceID("driver.example.com", "pool-1", "device-2"),
 				structured.MakeDeviceID("driver.example.com", "pool-1", "device-3"),

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_lister.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_lister.go
@@ -22,18 +22,16 @@ import (
 	resourceapi "k8s.io/api/resource/v1beta1"
 )
 
-type snapshotClassLister Snapshot
+type snapshotClassLister struct {
+	snapshot *Snapshot
+}
 
 func (s snapshotClassLister) List() ([]*resourceapi.DeviceClass, error) {
-	var result []*resourceapi.DeviceClass
-	for _, class := range s.deviceClasses {
-		result = append(result, class)
-	}
-	return result, nil
+	return s.snapshot.listDeviceClasses(), nil
 }
 
 func (s snapshotClassLister) Get(className string) (*resourceapi.DeviceClass, error) {
-	class, found := s.deviceClasses[className]
+	class, found := s.snapshot.getDeviceClass(className)
 	if !found {
 		return nil, fmt.Errorf("DeviceClass %q not found", className)
 	}

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_slice_lister.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_slice_lister.go
@@ -20,15 +20,10 @@ import (
 	resourceapi "k8s.io/api/resource/v1beta1"
 )
 
-type snapshotSliceLister Snapshot
+type snapshotSliceLister struct {
+	snapshot *Snapshot
+}
 
-func (s snapshotSliceLister) List() ([]*resourceapi.ResourceSlice, error) {
-	var result []*resourceapi.ResourceSlice
-	for _, slices := range s.resourceSlicesByNodeName {
-		for _, slice := range slices {
-			result = append(result, slice)
-		}
-	}
-	result = append(result, s.nonNodeLocalResourceSlices...)
-	return result, nil
+func (sl snapshotSliceLister) List() ([]*resourceapi.ResourceSlice, error) {
+	return sl.snapshot.listResourceSlices(), nil
 }

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/test_utils.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/test_utils.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"maps"
+
+	"github.com/google/go-cmp/cmp"
+	resourceapi "k8s.io/api/resource/v1beta1"
+)
+
+// CloneTestSnapshot creates a deep copy of the provided Snapshot.
+// This function is intended for testing purposes only.
+func CloneTestSnapshot(snapshot *Snapshot) *Snapshot {
+	cloned := &Snapshot{
+		deviceClasses:  newPatchSet[string, *resourceapi.DeviceClass](),
+		resourceSlices: newPatchSet[string, []*resourceapi.ResourceSlice](),
+		resourceClaims: newPatchSet[ResourceClaimId, *resourceapi.ResourceClaim](),
+	}
+
+	for i := 0; i < len(snapshot.deviceClasses.patches); i++ {
+		devicesPatch := snapshot.deviceClasses.patches[i]
+		clonedPatch := newPatch[string, *resourceapi.DeviceClass]()
+		for key, deviceClass := range devicesPatch.Modified {
+			clonedPatch.Modified[key] = deviceClass.DeepCopy()
+		}
+		maps.Copy(clonedPatch.Deleted, devicesPatch.Deleted)
+		cloned.deviceClasses.patches = append(cloned.deviceClasses.patches, clonedPatch)
+	}
+
+	for i := 0; i < len(snapshot.resourceSlices.patches); i++ {
+		slicesPatch := snapshot.resourceSlices.patches[i]
+		clonedPatch := newPatch[string, []*resourceapi.ResourceSlice]()
+		for key, slices := range slicesPatch.Modified {
+			deepCopySlices := make([]*resourceapi.ResourceSlice, len(slices))
+			for i, slice := range slices {
+				deepCopySlices[i] = slice.DeepCopy()
+			}
+
+			clonedPatch.Modified[key] = deepCopySlices
+		}
+		maps.Copy(clonedPatch.Deleted, slicesPatch.Deleted)
+		cloned.resourceSlices.patches = append(cloned.resourceSlices.patches, clonedPatch)
+	}
+
+	for i := 0; i < len(snapshot.resourceClaims.patches); i++ {
+		claimsPatch := snapshot.resourceClaims.patches[i]
+		clonedPatch := newPatch[ResourceClaimId, *resourceapi.ResourceClaim]()
+		for claimId, claim := range claimsPatch.Modified {
+			clonedPatch.Modified[claimId] = claim.DeepCopy()
+		}
+		maps.Copy(clonedPatch.Deleted, claimsPatch.Deleted)
+		cloned.resourceClaims.patches = append(cloned.resourceClaims.patches, clonedPatch)
+	}
+
+	return cloned
+}
+
+// SnapshotFlattenedComparer returns a cmp.Option that provides a custom comparer function
+// for comparing two *Snapshot objects based on their underlying data maps, it doesn't
+// compare the underlying patchsets, instead flattened objects are compared.
+// This function is intended for testing purposes only.
+func SnapshotFlattenedComparer() cmp.Option {
+	return cmp.Comparer(func(a, b *Snapshot) bool {
+		if a == nil || b == nil {
+			return a == b
+		}
+
+		devicesEqual := cmp.Equal(a.deviceClasses.AsMap(), b.deviceClasses.AsMap())
+		slicesEqual := cmp.Equal(a.resourceSlices.AsMap(), b.resourceSlices.AsMap())
+		claimsEqual := cmp.Equal(a.resourceClaims.AsMap(), b.resourceClaims.AsMap())
+
+		return devicesEqual && slicesEqual && claimsEqual
+	})
+}

--- a/cluster-autoscaler/simulator/dynamicresources/utils/resource_claims.go
+++ b/cluster-autoscaler/simulator/dynamicresources/utils/resource_claims.go
@@ -22,28 +22,9 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/dynamic-resource-allocation/resourceclaim"
-	"k8s.io/utils/ptr"
 )
-
-// ClaimOwningPod returns the name and UID of the Pod owner of the provided claim. If the claim isn't
-// owned by a Pod, empty strings are returned.
-func ClaimOwningPod(claim *resourceapi.ResourceClaim) (string, types.UID) {
-	for _, owner := range claim.OwnerReferences {
-		if ptr.Deref(owner.Controller, false) && owner.APIVersion == "v1" && owner.Kind == "Pod" {
-			return owner.Name, owner.UID
-		}
-	}
-	return "", ""
-}
-
-// PodOwnsClaim determines if the provided pod is the controller of the given claim.
-func PodOwnsClaim(pod *apiv1.Pod, claim *resourceapi.ResourceClaim) bool {
-	ownerPodName, ownerPodUid := ClaimOwningPod(claim)
-	return ownerPodName == pod.Name && ownerPodUid == pod.UID
-}
 
 // ClaimAllocated returns whether the provided claim is allocated.
 func ClaimAllocated(claim *resourceapi.ResourceClaim) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR enhances the performance of DRA snapshot which directly impacts scheduling simulations speed and cluster-autoscaler decision making process overall. In this PR we are changing the approach for its state management from deep copies based into patches based one.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/7681

#### Special notes for your reviewer:

This PR removes the original implementation for dynamicresources.Snapshot and replaces it with the patches based approach, while we can keep the original implementation for the sake of safety and ability to switch store implementation in the running cluster autoscaler, but it would require maintaining two implementations, I've attempted to use clone-based Snapshot as a baseline for the new changes, but it only resulted in complex code while yielding minimal benefits.

In the change you may find a benchmark test which uses exagerrated scheduling scenario to test the performance of two implementations, what I've found that patches based option is roughly 50x times faster in terms of overall runtime while allocating 40x less memory on the heap primarily because Fork/Commit/Revert operations are used A LOT in the suite

Here's a few profiling insights in differences:

##### CPU Profile / Forking
![CPU Profile / Forking](https://github.com/user-attachments/assets/d9174983-f905-4450-aefa-faadcda55f8f)

##### CPU Profile / GC
![CPU Profile / GC](https://github.com/user-attachments/assets/ee7157bd-7cc8-4f66-a49b-b97fa082918a)

##### Memory Profile / Allocated Space
![Memory Profile](https://github.com/user-attachments/assets/12c22f9e-d1fb-4c3d-a14a-fe428baaff9b)

##### Memory Profile / Allocated Objects
![image](https://github.com/user-attachments/assets/ac01b7e6-4e12-4bd9-8c2c-7d68c14ccd91)

Grab a copy of profiling samples -> [Profiles.zip](https://github.com/user-attachments/files/20035681/Profiles.zip)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
