### PR TITLE
vpa-updater: Allow patch and update for events

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
@@ -29,13 +29,16 @@ rules:
       - watch
   - apiGroups:
       - ""
+      - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - watch
-      - create
+      - patch
+      - update
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After updating to VPA 1.3.0, our vpa-updater logs are full with:
```
E0505 11:18:10.361238       1 event.go:359] "Server rejected event (will not retry!)" err="events \"bar.183c9d4d7cff8f87\" is forbidden: User \"system:serviceaccount:kube-system:vpa-updater\" cannot patch resource \"events\" in API group \"\" in the namespace \"foo\"" event="&Event{ObjectMeta:{bar.183c9d4d7cff8f87  foo   242426133 0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},InvolvedObject:ObjectReference{Kind:VerticalPodAutoscaler,Namespace:foo,Name:bar,UID:8dd98ac4-0aa7-463b-8a13-547ae29c0d5c,APIVersion:autoscaling.k8s.io/v1,ResourceVersion:9896005394,FieldPath:,},Reason:EvictedPod,Message:VPA Updater evicted Pod bar-0 to apply resource recommendation.,Source:EventSource{Component:vpa-updater,Host:,},FirstTimestamp:2025-05-05 11:15:11 +0000 UTC,LastTimestamp:2025-05-05 11:18:10.348031113 +0000 UTC m=+167331.471400160,Count:2,Type:Normal,EventTime:0001-01-01 00:00:00 +0000 UTC,Series:nil,Action:,Related:nil,ReportingController:vpa-updater,ReportingInstance:,}"
```

The issue is introduced with https://github.com/kubernetes/autoscaler/pull/7413. The corresponding PR does not adapt the RBAC for events as needed.

Looks like after we introduce events for VPAs as well, then underlying `k8s.io/client-go/tools/record.EventRecorder` needs to `patch` the event. See https://github.com/kubernetes/kubernetes/blob/893486dfd16ff8c628c6f33bb2bea869ad86115f/staging/src/k8s.io/client-go/tools/record/event.go#L49-L53 and https://github.com/kubernetes/kubernetes/blob/893486dfd16ff8c628c6f33bb2bea869ad86115f/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go#L212-L226.

This PR also allows events from the `events.k8s.io` API group to be managed.

Depending on the underlying `EventRecorder` implementation,  `k8s.io/api/core/v1.Event` or `k8s.io/api/events/v1.Event` will be used:
- `k8s.io/client-go/tools/record.EventRecorder` uses `k8s.io/api/core/v1.Event`: [ref](https://github.com/kubernetes/kubernetes/blob/893486dfd16ff8c628c6f33bb2bea869ad86115f/staging/src/k8s.io/client-go/tools/record/doc.go#L17-L19)
- `k8s.io/client-go/tools/events.EventRecorder` uses `k8s.io/api/events/v1.Event`: [ref](https://github.com/kubernetes/kubernetes/blob/893486dfd16ff8c628c6f33bb2bea869ad86115f/staging/src/k8s.io/client-go/tools/events/doc.go#L17-L19)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
vpa-updater: An issue preventing events to be patched when recording eviction event on VerticalPodAutoscaler resource is now fixed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
