### PR TITLE
[ovhcloud] openstack application credentials, gpu flavors update, stressed downscale fix

### DIFF
--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager_test.go
@@ -290,3 +290,99 @@ func TestOvhCloudManager_cacheConcurrency(t *testing.T) {
 		manager.getNodeGroupPerProviderID("")
 	})
 }
+
+func TestOvhCloudManager_setNodePoolsState(t *testing.T) {
+	manager := newTestManager(t)
+	np1 := sdk.NodePool{ID: "np1", DesiredNodes: 1}
+	np2 := sdk.NodePool{ID: "np2", DesiredNodes: 2}
+	np3 := sdk.NodePool{ID: "np3", DesiredNodes: 3}
+
+	type fields struct {
+		NodePoolsPerID         map[string]*sdk.NodePool
+		NodeGroupPerProviderID map[string]*NodeGroup
+	}
+	type args struct {
+		poolsList []sdk.NodePool
+
+		nodePoolsPerID         map[string]*sdk.NodePool
+		nodeGroupPerProviderID map[string]*NodeGroup
+	}
+	tests := []struct {
+		name                       string
+		fields                     fields
+		args                       args
+		wantNodePoolsPerID         map[string]uint32 // ID => desired nodes
+		wantNodeGroupPerProviderID map[string]uint32 // ID => desired nodes
+	}{
+		{
+			name: "NodePoolsPerID and NodeGroupPerProviderID empty",
+			fields: fields{
+				NodePoolsPerID:         map[string]*sdk.NodePool{},
+				NodeGroupPerProviderID: map[string]*NodeGroup{},
+			},
+			args: args{
+				poolsList: []sdk.NodePool{
+					np1,
+				},
+				nodePoolsPerID:         map[string]*sdk.NodePool{},
+				nodeGroupPerProviderID: map[string]*NodeGroup{},
+			},
+			wantNodePoolsPerID:         map[string]uint32{"np1": 1},
+			wantNodeGroupPerProviderID: map[string]uint32{},
+		},
+		{
+			name: "NodePoolsPerID and NodeGroupPerProviderID empty",
+			fields: fields{
+				NodePoolsPerID: map[string]*sdk.NodePool{
+					"np2": &np2,
+					"np3": &np3,
+				},
+				NodeGroupPerProviderID: map[string]*NodeGroup{
+					"np2-node-id": {NodePool: &np2},
+					"np3-node-id": {NodePool: &np3},
+				},
+			},
+			args: args{
+				poolsList: []sdk.NodePool{
+					{
+						ID:           "np1",
+						DesiredNodes: 1,
+					},
+					{
+						ID:           "np2",
+						DesiredNodes: 20,
+					},
+				},
+				nodePoolsPerID:         map[string]*sdk.NodePool{},
+				nodeGroupPerProviderID: map[string]*NodeGroup{},
+			},
+			wantNodePoolsPerID: map[string]uint32{
+				"np1": 1,  // np1 added
+				"np2": 20, // np2 updated
+				// np3 removed
+			},
+			wantNodeGroupPerProviderID: map[string]uint32{
+				"np2-node-id": 20,
+				"np3-node-id": 3, // Node reference that eventually stays in cache must not crash
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager.NodePoolsPerID = tt.fields.NodePoolsPerID
+			manager.NodeGroupPerProviderID = tt.fields.NodeGroupPerProviderID
+
+			manager.setNodePoolsState(tt.args.poolsList)
+
+			assert.Len(t, manager.NodePoolsPerID, len(tt.wantNodePoolsPerID))
+			for id, desiredNodes := range tt.wantNodePoolsPerID {
+				assert.Equal(t, desiredNodes, manager.NodePoolsPerID[id].DesiredNodes)
+			}
+
+			assert.Len(t, manager.NodeGroupPerProviderID, len(tt.wantNodeGroupPerProviderID))
+			for nodeID, desiredNodes := range tt.wantNodeGroupPerProviderID {
+				assert.Equal(t, desiredNodes, manager.NodeGroupPerProviderID[nodeID].DesiredNodes)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager_test.go
@@ -78,6 +78,26 @@ func newTestManager(t *testing.T) *OvhCloudManager {
 	return manager
 }
 
+func TestOvhCloudManager_validateConfig(t *testing.T) {
+	tests := []struct {
+		name                 string
+		configContent        string
+		expectedErrorMessage string
+	}{
+		{
+			name:                 "New entry",
+			configContent:        "{}",
+			expectedErrorMessage: "config content validation failed: `cluster_id` not found in config file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewManager(bytes.NewBufferString(tt.configContent))
+			assert.ErrorContains(t, err, tt.expectedErrorMessage)
+		})
+	}
+}
+
 func TestOvhCloudManager_getFlavorsByName(t *testing.T) {
 	expectedFlavorsByNameFromAPICall := map[string]sdk.Flavor{
 		"b2-7": {

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_manager_test.go
@@ -192,14 +192,14 @@ func TestOvhCloudManager_getFlavorByName(t *testing.T) {
 	})
 }
 
-func TestOvhCloudManager_setNodeGroupPerProviderID(t *testing.T) {
+func TestOvhCloudManager_setNodeGroupPerName(t *testing.T) {
 	manager := newTestManager(t)
 	ng1 := NodeGroup{
 		CurrentSize: 1,
 	}
 
 	type fields struct {
-		NodeGroupPerProviderID map[string]*NodeGroup
+		NodeGroupPerName map[string]*NodeGroup
 	}
 	type args struct {
 		providerID string
@@ -214,7 +214,7 @@ func TestOvhCloudManager_setNodeGroupPerProviderID(t *testing.T) {
 		{
 			name: "New entry",
 			fields: fields{
-				NodeGroupPerProviderID: map[string]*NodeGroup{},
+				NodeGroupPerName: map[string]*NodeGroup{},
 			},
 			args: args{
 				providerID: "providerID1",
@@ -226,7 +226,7 @@ func TestOvhCloudManager_setNodeGroupPerProviderID(t *testing.T) {
 		}, {
 			name: "Replace entry",
 			fields: fields{
-				NodeGroupPerProviderID: map[string]*NodeGroup{
+				NodeGroupPerName: map[string]*NodeGroup{
 					"providerID1": {},
 				},
 			},
@@ -241,23 +241,23 @@ func TestOvhCloudManager_setNodeGroupPerProviderID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager.NodeGroupPerProviderID = tt.fields.NodeGroupPerProviderID
+			manager.NodeGroupPerName = tt.fields.NodeGroupPerName
 
-			manager.setNodeGroupPerProviderID(tt.args.providerID, tt.args.nodeGroup)
+			manager.setNodeGroupPerName(tt.args.providerID, tt.args.nodeGroup)
 
-			assert.Equal(t, tt.wantCache, manager.NodeGroupPerProviderID)
+			assert.Equal(t, tt.wantCache, manager.NodeGroupPerName)
 		})
 	}
 }
 
-func TestOvhCloudManager_getNodeGroupPerProviderID(t *testing.T) {
+func TestOvhCloudManager_GetNodeGroupPerName(t *testing.T) {
 	manager := newTestManager(t)
 	ng1 := NodeGroup{
 		CurrentSize: 1,
 	}
 
 	type fields struct {
-		NodeGroupPerProviderID map[string]*NodeGroup
+		NodeGroupPerName map[string]*NodeGroup
 	}
 	type args struct {
 		providerID string
@@ -271,7 +271,7 @@ func TestOvhCloudManager_getNodeGroupPerProviderID(t *testing.T) {
 		{
 			name: "Node group found",
 			fields: fields{
-				NodeGroupPerProviderID: map[string]*NodeGroup{
+				NodeGroupPerName: map[string]*NodeGroup{
 					"providerID1": &ng1,
 				},
 			},
@@ -283,7 +283,7 @@ func TestOvhCloudManager_getNodeGroupPerProviderID(t *testing.T) {
 		{
 			name: "Node group not found",
 			fields: fields{
-				NodeGroupPerProviderID: map[string]*NodeGroup{},
+				NodeGroupPerName: map[string]*NodeGroup{},
 			},
 			args: args{
 				providerID: "providerID1",
@@ -293,9 +293,9 @@ func TestOvhCloudManager_getNodeGroupPerProviderID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager.NodeGroupPerProviderID = tt.fields.NodeGroupPerProviderID
+			manager.NodeGroupPerName = tt.fields.NodeGroupPerName
 
-			assert.Equalf(t, tt.want, manager.getNodeGroupPerProviderID(tt.args.providerID), "getNodeGroupPerProviderID(%v)", tt.args.providerID)
+			assert.Equalf(t, tt.want, manager.GetNodeGroupPerName(tt.args.providerID), "GetNodeGroupPerName(%v)", tt.args.providerID)
 		})
 	}
 }
@@ -303,61 +303,60 @@ func TestOvhCloudManager_getNodeGroupPerProviderID(t *testing.T) {
 func TestOvhCloudManager_cacheConcurrency(t *testing.T) {
 	manager := newTestManager(t)
 
-	t.Run("Check NodeGroupPerProviderID cache is safe for concurrency (needs to be run with -race)", func(t *testing.T) {
+	t.Run("Check NodeGroupPerName cache is safe for concurrency (needs to be run with -race)", func(t *testing.T) {
 		go func() {
-			manager.setNodeGroupPerProviderID("", &NodeGroup{})
+			manager.setNodeGroupPerName("", &NodeGroup{})
 		}()
-		manager.getNodeGroupPerProviderID("")
+		manager.GetNodeGroupPerName("")
 	})
 }
 
 func TestOvhCloudManager_setNodePoolsState(t *testing.T) {
 	manager := newTestManager(t)
-	np1 := sdk.NodePool{ID: "np1", DesiredNodes: 1}
-	np2 := sdk.NodePool{ID: "np2", DesiredNodes: 2}
-	np3 := sdk.NodePool{ID: "np3", DesiredNodes: 3}
+	np1 := sdk.NodePool{Name: "np1", DesiredNodes: 1}
+	np2 := sdk.NodePool{Name: "np2", DesiredNodes: 2}
+	np3 := sdk.NodePool{Name: "np3", DesiredNodes: 3}
 
 	type fields struct {
-		NodePoolsPerID         map[string]*sdk.NodePool
-		NodeGroupPerProviderID map[string]*NodeGroup
+		NodePoolsPerName map[string]*sdk.NodePool
+		NodeGroupPerName map[string]*NodeGroup
 	}
 	type args struct {
 		poolsList []sdk.NodePool
 
-		nodePoolsPerID         map[string]*sdk.NodePool
-		nodeGroupPerProviderID map[string]*NodeGroup
+		NodePoolsPerName map[string]*sdk.NodePool
+		NodeGroupPerName map[string]*NodeGroup
 	}
 	tests := []struct {
-		name                       string
-		fields                     fields
-		args                       args
-		wantNodePoolsPerID         map[string]uint32 // ID => desired nodes
-		wantNodeGroupPerProviderID map[string]uint32 // ID => desired nodes
+		name                 string
+		fields               fields
+		args                 args
+		wantNodePoolsPerName map[string]uint32 // ID => desired nodes
+		wantNodeGroupPerName map[string]uint32 // ID => desired nodes
 	}{
 		{
-			name: "NodePoolsPerID and NodeGroupPerProviderID empty",
+			name: "NodePoolsPerName and NodeGroupPerName empty",
 			fields: fields{
-				NodePoolsPerID:         map[string]*sdk.NodePool{},
-				NodeGroupPerProviderID: map[string]*NodeGroup{},
+				NodePoolsPerName: map[string]*sdk.NodePool{},
+				NodeGroupPerName: map[string]*NodeGroup{},
 			},
 			args: args{
 				poolsList: []sdk.NodePool{
 					np1,
 				},
-				nodePoolsPerID:         map[string]*sdk.NodePool{},
-				nodeGroupPerProviderID: map[string]*NodeGroup{},
+				NodePoolsPerName: map[string]*sdk.NodePool{},
 			},
-			wantNodePoolsPerID:         map[string]uint32{"np1": 1},
-			wantNodeGroupPerProviderID: map[string]uint32{},
+			wantNodePoolsPerName: map[string]uint32{"np1": 1},
+			wantNodeGroupPerName: map[string]uint32{},
 		},
 		{
-			name: "NodePoolsPerID and NodeGroupPerProviderID empty",
+			name: "NodePoolsPerName and NodeGroupPerName empty",
 			fields: fields{
-				NodePoolsPerID: map[string]*sdk.NodePool{
+				NodePoolsPerName: map[string]*sdk.NodePool{
 					"np2": &np2,
 					"np3": &np3,
 				},
-				NodeGroupPerProviderID: map[string]*NodeGroup{
+				NodeGroupPerName: map[string]*NodeGroup{
 					"np2-node-id": {NodePool: &np2},
 					"np3-node-id": {NodePool: &np3},
 				},
@@ -365,23 +364,22 @@ func TestOvhCloudManager_setNodePoolsState(t *testing.T) {
 			args: args{
 				poolsList: []sdk.NodePool{
 					{
-						ID:           "np1",
+						Name:         "np1",
 						DesiredNodes: 1,
 					},
 					{
-						ID:           "np2",
+						Name:         "np2",
 						DesiredNodes: 20,
 					},
 				},
-				nodePoolsPerID:         map[string]*sdk.NodePool{},
-				nodeGroupPerProviderID: map[string]*NodeGroup{},
+				NodeGroupPerName: map[string]*NodeGroup{},
 			},
-			wantNodePoolsPerID: map[string]uint32{
+			wantNodePoolsPerName: map[string]uint32{
 				"np1": 1,  // np1 added
 				"np2": 20, // np2 updated
 				// np3 removed
 			},
-			wantNodeGroupPerProviderID: map[string]uint32{
+			wantNodeGroupPerName: map[string]uint32{
 				"np2-node-id": 20,
 				"np3-node-id": 3, // Node reference that eventually stays in cache must not crash
 			},
@@ -389,19 +387,19 @@ func TestOvhCloudManager_setNodePoolsState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager.NodePoolsPerID = tt.fields.NodePoolsPerID
-			manager.NodeGroupPerProviderID = tt.fields.NodeGroupPerProviderID
+			manager.NodePoolsPerName = tt.fields.NodePoolsPerName
+			manager.NodeGroupPerName = tt.fields.NodeGroupPerName
 
 			manager.setNodePoolsState(tt.args.poolsList)
 
-			assert.Len(t, manager.NodePoolsPerID, len(tt.wantNodePoolsPerID))
-			for id, desiredNodes := range tt.wantNodePoolsPerID {
-				assert.Equal(t, desiredNodes, manager.NodePoolsPerID[id].DesiredNodes)
+			assert.Len(t, manager.NodePoolsPerName, len(tt.wantNodePoolsPerName))
+			for name, desiredNodes := range tt.wantNodePoolsPerName {
+				assert.Equal(t, desiredNodes, manager.NodePoolsPerName[name].DesiredNodes)
 			}
 
-			assert.Len(t, manager.NodeGroupPerProviderID, len(tt.wantNodeGroupPerProviderID))
-			for nodeID, desiredNodes := range tt.wantNodeGroupPerProviderID {
-				assert.Equal(t, desiredNodes, manager.NodeGroupPerProviderID[nodeID].DesiredNodes)
+			assert.Len(t, manager.NodeGroupPerName, len(tt.wantNodeGroupPerName))
+			for nodeID, desiredNodes := range tt.wantNodeGroupPerName {
+				assert.Equal(t, desiredNodes, manager.NodeGroupPerName[nodeID].DesiredNodes)
 			}
 		})
 	}

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -41,7 +41,7 @@ const providerIDPrefix = "openstack:///"
 
 // NodeGroup implements cloudprovider.NodeGroup interface.
 type NodeGroup struct {
-	sdk.NodePool
+	*sdk.NodePool
 
 	Manager     *OvhCloudManager
 	CurrentSize int
@@ -294,7 +294,7 @@ func (ng *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
 
 	// Forge a node group interface given the API response
 	return &NodeGroup{
-		NodePool:    *np,
+		NodePool:    np,
 		Manager:     ng.Manager,
 		CurrentSize: int(ng.DesiredNodes),
 	}, nil

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -213,7 +213,7 @@ func (ng *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 		instances = append(instances, instance)
 
 		// Store the associated node group in cache for future reference
-		ng.Manager.setNodeGroupPerProviderID(instance.Id, ng)
+		ng.Manager.setNodeGroupPerName(ng.Name, ng)
 	}
 
 	return instances, nil
@@ -238,7 +238,7 @@ func (ng *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 		},
 	}
 
-	// Add the nodepool label
+	// Add the nodepool name label
 	if node.ObjectMeta.Labels == nil {
 		node.ObjectMeta.Labels = make(map[string]string)
 	}

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -242,7 +242,7 @@ func (ng *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 	if node.ObjectMeta.Labels == nil {
 		node.ObjectMeta.Labels = make(map[string]string)
 	}
-	node.ObjectMeta.Labels[NodePoolLabel] = ng.Id()
+	node.ObjectMeta.Labels[NodePoolLabel] = ng.Name
 
 	flavor, err := ng.Manager.getFlavorByName(ng.Flavor)
 	if err != nil {
@@ -328,11 +328,12 @@ func (ng *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*c
 		return nil, nil
 	}
 
+	// Initialize configuration from defaults
+	cfg := defaults
+
 	// Forge autoscaling configuration from node pool
-	cfg := &config.NodeGroupAutoscalingOptions{
-		ScaleDownUnneededTime: time.Duration(ng.Autoscaling.ScaleDownUnneededTimeSeconds) * time.Second,
-		ScaleDownUnreadyTime:  time.Duration(ng.Autoscaling.ScaleDownUnreadyTimeSeconds) * time.Second,
-	}
+	cfg.ScaleDownUnneededTime = time.Duration(ng.Autoscaling.ScaleDownUnneededTimeSeconds) * time.Second
+	cfg.ScaleDownUnreadyTime = time.Duration(ng.Autoscaling.ScaleDownUnreadyTimeSeconds) * time.Second
 
 	// Switch utilization threshold from defaults given flavor type
 	if ng.isGpu() {
@@ -343,7 +344,7 @@ func (ng *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*c
 		cfg.ScaleDownGpuUtilizationThreshold = defaults.ScaleDownGpuUtilizationThreshold
 	}
 
-	return cfg, nil
+	return &cfg, nil
 }
 
 // isGpu checks if a node group is using GPU machines

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -352,7 +352,11 @@ func (ng *NodeGroup) isGpu() bool {
 	if err != nil {
 		// Fallback when we are unable to get the flavor: refer to the only category
 		// known to be a GPU flavor category
-		return strings.HasPrefix(ng.Flavor, GPUMachineCategory)
+		for _, gpuCategoryPrefix := range GPUMachineCategoryPrefixes {
+			if strings.HasPrefix(ng.Flavor, gpuCategoryPrefix) {
+				return true
+			}
+		}
 	}
 
 	return flavor.GPUs > 0

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
@@ -85,7 +85,7 @@ func newTestNodeGroup(t *testing.T, flavor string) *NodeGroup {
 
 	ng := &NodeGroup{
 		Manager: manager,
-		NodePool: sdk.NodePool{
+		NodePool: &sdk.NodePool{
 			ID:           "id",
 			Name:         fmt.Sprintf("pool-%s", flavor),
 			Flavor:       flavor,

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
@@ -261,7 +261,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-1",
 					Labels: map[string]string{
-						"nodepool": ng.Id(),
+						"nodepool": ng.Name,
 					},
 				},
 				Spec: v1.NodeSpec{
@@ -295,7 +295,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-1",
 					Labels: map[string]string{
-						"nodepool": ng.Id(),
+						"nodepool": ng.Name,
 					},
 				},
 			},
@@ -303,7 +303,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-2",
 					Labels: map[string]string{
-						"nodepool": ng.Id(),
+						"nodepool": ng.Name,
 					},
 				},
 			},
@@ -311,7 +311,7 @@ func TestOVHCloudNodeGroup_DeleteNodes(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-3",
 					Labels: map[string]string{
-						"nodepool": ng.Id(),
+						"nodepool": ng.Name,
 					},
 				},
 			},
@@ -329,10 +329,8 @@ func TestOVHCloudNodeGroup_DecreaseTargetSize(t *testing.T) {
 func TestOVHCloudNodeGroup_Id(t *testing.T) {
 	ng := newTestNodeGroup(t, "b2-7")
 
-	t.Run("check node group id fetch", func(t *testing.T) {
-		name := ng.Id()
-
-		assert.Equal(t, "pool-b2-7", name)
+	t.Run("check node group name fetch", func(t *testing.T) {
+		assert.Equal(t, "pool-b2-7", ng.Name)
 	})
 }
 
@@ -379,7 +377,7 @@ func TestOVHCloudNodeGroup_TemplateNodeInfo(t *testing.T) {
 		assert.NotNil(t, node)
 
 		assert.Contains(t, node.ObjectMeta.Name, fmt.Sprintf("%s-node-", ng.Id()))
-		assert.Equal(t, map[string]string{"nodepool": ng.Id()}, node.Labels)
+		assert.Equal(t, map[string]string{"nodepool": ng.Name}, node.Labels)
 		assert.Equal(t, map[string]string(nil), node.Annotations)
 		assert.Equal(t, []string(nil), node.Finalizers)
 		assert.Equal(t, []v1.Taint(nil), node.Spec.Taints)
@@ -399,7 +397,7 @@ func TestOVHCloudNodeGroup_TemplateNodeInfo(t *testing.T) {
 		assert.NotNil(t, node)
 
 		assert.Contains(t, node.ObjectMeta.Name, fmt.Sprintf("%s-node-", ng.Id()))
-		assert.Equal(t, map[string]string{"nodepool": ng.Id()}, node.Labels)
+		assert.Equal(t, map[string]string{"nodepool": ng.Name}, node.Labels)
 		assert.Equal(t, map[string]string(nil), node.Annotations)
 		assert.Equal(t, []string(nil), node.Finalizers)
 		assert.Equal(t, []v1.Taint(nil), node.Spec.Taints)
@@ -438,7 +436,7 @@ func TestOVHCloudNodeGroup_TemplateNodeInfo(t *testing.T) {
 		assert.NotNil(t, node)
 
 		assert.Contains(t, node.ObjectMeta.Name, fmt.Sprintf("%s-node-", ng.Id()))
-		assert.Equal(t, map[string]string{"nodepool": ng.Id(), "label1": "labelValue1"}, node.Labels)
+		assert.Equal(t, map[string]string{"nodepool": ng.Name, "label1": "labelValue1"}, node.Labels)
 		assert.Equal(t, ng.Template.Metadata.Annotations, node.Annotations)
 		assert.Equal(t, ng.Template.Metadata.Finalizers, node.Finalizers)
 		assert.Equal(t, ng.Template.Spec.Taints, node.Spec.Taints)
@@ -538,6 +536,16 @@ func TestOVHCloudNodeGroup_IsGpu(t *testing.T) {
 }
 
 func TestOVHCloudNodeGroup_GetOptions(t *testing.T) {
+	t.Run("check default autoscaling options", func(t *testing.T) {
+		ng := newTestNodeGroup(t, "b2-7")
+		opts, err := ng.GetOptions(config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, true, opts.ZeroOrMaxNodeScaling)
+		assert.Equal(t, false, opts.IgnoreDaemonSetsUtilization)
+	})
 	t.Run("check get autoscaling options", func(t *testing.T) {
 		ng := newTestNodeGroup(t, "b2-7")
 		opts, err := ng.GetOptions(config.NodeGroupAutoscalingOptions{})

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group_test.go
@@ -522,8 +522,18 @@ func TestOVHCloudNodeGroup_IsGpu(t *testing.T) {
 	})
 
 	t.Run("not found but belong to GPU category", func(t *testing.T) {
-		ng := newTestNodeGroup(t, GPUMachineCategory+"1-123")
+		ng := newTestNodeGroup(t, "t1-123")
 		assert.True(t, ng.isGpu())
+	})
+
+	t.Run("not found but belong to GPU category", func(t *testing.T) {
+		ng := newTestNodeGroup(t, "h1-123")
+		assert.True(t, ng.isGpu())
+	})
+
+	t.Run("not found and does not belong to GPU category", func(t *testing.T) {
+		ng := newTestNodeGroup(t, "n1-123")
+		assert.False(t, ng.isGpu())
 	})
 }
 

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
@@ -100,7 +100,7 @@ func (provider *OVHCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	groups := make([]cloudprovider.NodeGroup, 0)
 
 	// Cast API node pools into CA node groups
-	for _, pool := range provider.manager.NodePools {
+	for _, pool := range provider.manager.NodePoolsPerID {
 		// Node pools without autoscaling are equivalent to node pools with autoscaling but no scale possible
 		if !pool.Autoscale {
 			pool.MaxNodes = pool.DesiredNodes
@@ -238,7 +238,7 @@ func (provider *OVHCloudProvider) GetAvailableMachineTypes() ([]string, error) {
 // Implementation optional.
 func (provider *OVHCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
 	ng := &NodeGroup{
-		NodePool: sdk.NodePool{
+		NodePool: &sdk.NodePool{
 			Name:     fmt.Sprintf("%s-%d", machineType, rand.Int63()),
 			Flavor:   machineType,
 			MinNodes: 0,
@@ -314,7 +314,7 @@ func (provider *OVHCloudProvider) Refresh() error {
 	}
 
 	// Update the node pools cache
-	provider.manager.NodePools = pools
+	provider.manager.setNodePoolsState(pools)
 
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
@@ -44,10 +44,10 @@ const (
 
 	// MachineAvailableState defines the state for available flavors for node resources.
 	MachineAvailableState = "available"
-
-	// GPUMachineCategory defines the default instance category for GPU resources.
-	GPUMachineCategory = "t"
 )
+
+// GPUMachineCategoryPrefixes defines the flavors prefixes for GPU resources.
+var GPUMachineCategoryPrefixes = [4]string{"t", "h", "a", "l"}
 
 // OVHCloudProvider implements CloudProvider interface.
 type OVHCloudProvider struct {

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider_test.go
@@ -141,7 +141,7 @@ func TestOVHCloudProvider_NodeGroups(t *testing.T) {
 	})
 
 	t.Run("check empty node groups length after reset", func(t *testing.T) {
-		provider.manager.NodePools = []sdk.NodePool{}
+		provider.manager.NodePoolsPerID = map[string]*sdk.NodePool{}
 		groups := provider.NodeGroups()
 
 		assert.Equal(t, 0, len(groups))
@@ -403,7 +403,7 @@ func TestOVHCloudProvider_Refresh(t *testing.T) {
 	provider := newTestProvider(t)
 
 	t.Run("check refresh reset node groups correctly", func(t *testing.T) {
-		provider.manager.NodePools = []sdk.NodePool{}
+		provider.manager.NodePoolsPerID = map[string]*sdk.NodePool{}
 		groups := provider.NodeGroups()
 
 		assert.Equal(t, 0, len(groups))

--- a/cluster-autoscaler/cloudprovider/ovhcloud/sdk/ovh.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/sdk/ovh.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -469,7 +469,7 @@ func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, re
 func (c *Client) UnmarshalResponse(response *http.Response, result interface{}) error {
 	// Read all the response body
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR edits the ovhcloud provider with the following latest updates:

* Refactor ovh sdk.NodePool state cache to avoid store out-of-date copy of TargetSize, etc... that was leading to inconsistencies in few downscale cases. A pointer is used instead of copy when refreshing objects.

* Add another authentication method for the ovhcloud api, using Openstack application credentials.

* Update the GPU flavor prefix to match the current flavors on ovhcloud
* Removes logic involving spec.providerID after https://github.com/kubernetes/autoscaler/issues/8342 was reported

#### Special notes for your reviewer:

This PR doesn't include any breaking change

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
