### PR TITLE
correct documentation on cluster-autoscaler priority expander configmap

### DIFF
--- a/cluster-autoscaler/expander/priority/readme.md
+++ b/cluster-autoscaler/expander/priority/readme.md
@@ -11,7 +11,7 @@ The expander is configured using a single ConfigMap, which is watched by the exp
 
 ## Configuration
 
-Configuration is based on the values stored in a ConfigMap. This ConfigMap has to be created before cluster autoscaler with priority expander can be started. The ConfigMap must be named `cluster-autoscaler-priority-expander` and it must be placed in the same namespace as cluster autoscaler pod. The ConfigMap is watched by the cluster autoscaler and any changes made to it are loaded on the fly, without restarting cluster autoscaler.
+Configuration is based on the values stored in a ConfigMap. The ConfigMap must be named `cluster-autoscaler-priority-expander` and it must be placed in the workload cluster, in the namespace specified by the `--namespace` flag (if cluster autoscaler is running inside the workload cluster, this is the namespace of the autoscaler pod). The ConfigMap is watched by the cluster autoscaler and any changes made to it are loaded on the fly, without restarting cluster autoscaler. If the ConfigMap is missing or malformed, cluster autoscaler will skip the priority expander and proceed with the next expander option.
 
 The format of the ConfigMap ([example](priority-expander-configmap.yaml)) is as follows:
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

#### What this PR does / why we need it:
Corrects 2 things:
- priority expander ConfigMap is no longer required for the autoscaler to startup, since the behavior was changed to fallback to the next expander option in https://github.com/kubernetes/autoscaler/pull/5246
- the statement that the expander ConfigMap must be in the same namespace as the autoscaler pod isn't, strictly speaking, correct: if the autoscaler runs outside the workload cluster and uses the `--kubeconfig` flag to point to the workload cluster, then the autoscaler pod and the expander configmap may even live in different clusters (and different namespaces)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
