### PR TITLE
Use klog.FlushAndExit() instead of os.Exit(255) for fatal exits

### DIFF
--- a/addon-resizer/vendor/github.com/golang/glog/glog.go
+++ b/addon-resizer/vendor/github.com/golang/glog/glog.go
@@ -86,6 +86,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	klog "k8s.io/klog/v2"
 )
 
 // severity identifies the sort of log: info, warning etc. It also implements
@@ -726,7 +727,7 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 		}
 		l.mu.Unlock()
 		timeoutFlush(10 * time.Second)
-		os.Exit(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
+		klog.FlushAndExit(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
 	}
 	l.putBuffer(buf)
 	l.mu.Unlock()

--- a/addon-resizer/vendor/github.com/golang/glog/glog.go
+++ b/addon-resizer/vendor/github.com/golang/glog/glog.go
@@ -86,7 +86,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 )
 
 // severity identifies the sort of log: info, warning etc. It also implements
@@ -726,8 +726,7 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 			}
 		}
 		l.mu.Unlock()
-		timeoutFlush(10 * time.Second)
-		klog.FlushAndExit(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
+		klog.FlushAndExit(10 * time.Second, 255) // C++ uses -1, which is silly because it's anded with 255 anyway.
 	}
 	l.putBuffer(buf)
 	l.mu.Unlock()

--- a/cluster-autoscaler/cloudprovider/exoscale/internal/k8s.io/klog/klog.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/internal/k8s.io/klog/klog.go
@@ -869,7 +869,7 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 		}
 		l.mu.Unlock()
 		timeoutFlush(10 * time.Second)
-		os.Exit(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
+		klog.FlushAndExit(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
 	}
 	l.putBuffer(buf)
 	l.mu.Unlock()

--- a/cluster-autoscaler/cloudprovider/exoscale/internal/k8s.io/klog/klog.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/internal/k8s.io/klog/klog.go
@@ -118,6 +118,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 // severity identifies the sort of log: info, warning etc. It also implements
@@ -868,8 +870,7 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 			}
 		}
 		l.mu.Unlock()
-		timeoutFlush(10 * time.Second)
-		klog.FlushAndExit(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
+		klog.FlushAndExit(10 * time.Second, 255) // C++ uses -1, which is silly because it's anded with 255 anyway.
 	}
 	l.putBuffer(buf)
 	l.mu.Unlock()

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -89,7 +89,7 @@ func main() {
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
 		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10 * time.Second, 255)
 
 	}
 
@@ -119,7 +119,7 @@ func main() {
 	hostname, err := os.Hostname()
 	if err != nil {
 		klog.ErrorS(err, "Unable to get hostname")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10 * time.Second, 255)
 	}
 
 	statusNamespace := status.AdmissionControllerStatusNamespace
@@ -158,6 +158,6 @@ func main() {
 
 	if err = server.ListenAndServeTLS("", ""); err != nil {
 		klog.ErrorS(err, "Failed to start HTTPS server")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10 * time.Second, 255)
 	}
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -89,7 +89,8 @@ func main() {
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
 		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
-		os.Exit(255)
+		klog.FlushAndExit(255)
+
 	}
 
 	healthCheck := metrics.NewHealthCheck(time.Minute)
@@ -118,7 +119,7 @@ func main() {
 	hostname, err := os.Hostname()
 	if err != nil {
 		klog.ErrorS(err, "Unable to get hostname")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 
 	statusNamespace := status.AdmissionControllerStatusNamespace
@@ -157,6 +158,6 @@ func main() {
 
 	if err = server.ListenAndServeTLS("", ""); err != nil {
 		klog.ErrorS(err, "Failed to start HTTPS server")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -19,7 +19,6 @@ package input
 import (
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"time"
 
@@ -183,7 +182,7 @@ func newPodClients(kubeClient kube_client.Interface, resourceEventHandler cache.
 	indexer, ok := store.(cache.Indexer)
 	if !ok {
 		klog.ErrorS(nil, "Expected Indexer, but got a Store that does not implement Indexer")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	}
 	podLister := v1lister.NewPodLister(indexer)
 	go controller.Run(stopCh)

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -183,7 +183,7 @@ func newPodClients(kubeClient kube_client.Interface, resourceEventHandler cache.
 	indexer, ok := store.(cache.Indexer)
 	if !ok {
 		klog.ErrorS(nil, "Expected Indexer, but got a Store that does not implement Indexer")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 	podLister := v1lister.NewPodLister(indexer)
 	go controller.Run(stopCh)

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -73,7 +73,7 @@ func NewExternalClient(c *rest.Config, clusterState model.ClusterState, options 
 	extClient, err := external_metrics.NewForConfig(c)
 	if err != nil {
 		klog.ErrorS(err, "Failed initializing external metrics client")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 	return &externalMetricsClient{
 		externalClient: extClient,

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -18,7 +18,6 @@ package metrics
 
 import (
 	"context"
-	"os"
 	"time"
 
 	k8sapiv1 "k8s.io/api/core/v1"
@@ -73,7 +72,7 @@ func NewExternalClient(c *rest.Config, clusterState model.ClusterState, options 
 	extClient, err := external_metrics.NewForConfig(c)
 	if err != nil {
 		klog.ErrorS(err, "Failed initializing external metrics client")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	}
 	return &externalMetricsClient{
 		externalClient: extClient,

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -140,7 +140,7 @@ func main() {
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
 		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10 * time.Second, 255)
 	}
 	ctx := context.Background()
 
@@ -156,7 +156,7 @@ func main() {
 		id, err := os.Hostname()
 		if err != nil {
 			klog.ErrorS(err, "Unable to get hostname")
-			klog.FlushAndExit(255)
+			klog.FlushAndExit(10 * time.Second, 255)
 		}
 		id = id + "_" + string(uuid.NewUUID())
 
@@ -175,7 +175,7 @@ func main() {
 		)
 		if err != nil {
 			klog.ErrorS(err, "Unable to create leader election lock")
-			klog.FlushAndExit(255)
+			klog.FlushAndExit(10 * time.Second, 255)
 		}
 
 		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
@@ -289,7 +289,7 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 	promQueryTimeout, err := time.ParseDuration(*queryTimeout)
 	if err != nil {
 		klog.ErrorS(err, "Could not parse --prometheus-query-timeout as a time.Duration")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10 * time.Second, 255)
 	}
 
 	if useCheckpoints {
@@ -317,7 +317,7 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 		provider, err := history.NewPrometheusHistoryProvider(config)
 		if err != nil {
 			klog.ErrorS(err, "Could not initialize history provider")
-			klog.FlushAndExit(255)
+			klog.FlushAndExit(10 * time.Second, 255)
 		}
 		recommender.GetClusterStateFeeder().InitFromHistoryProvider(provider)
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -140,7 +140,7 @@ func main() {
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
 		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 	ctx := context.Background()
 
@@ -156,7 +156,7 @@ func main() {
 		id, err := os.Hostname()
 		if err != nil {
 			klog.ErrorS(err, "Unable to get hostname")
-			os.Exit(255)
+			klog.FlushAndExit(255)
 		}
 		id = id + "_" + string(uuid.NewUUID())
 
@@ -175,7 +175,7 @@ func main() {
 		)
 		if err != nil {
 			klog.ErrorS(err, "Unable to create leader election lock")
-			os.Exit(255)
+			klog.FlushAndExit(255)
 		}
 
 		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
@@ -289,7 +289,7 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 	promQueryTimeout, err := time.ParseDuration(*queryTimeout)
 	if err != nil {
 		klog.ErrorS(err, "Could not parse --prometheus-query-timeout as a time.Duration")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 
 	if useCheckpoints {
@@ -317,7 +317,7 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 		provider, err := history.NewPrometheusHistoryProvider(config)
 		if err != nil {
 			klog.ErrorS(err, "Could not initialize history provider")
-			os.Exit(255)
+			klog.FlushAndExit(255)
 		}
 		recommender.GetClusterStateFeeder().InitFromHistoryProvider(provider)
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -354,7 +354,7 @@ func addVpaObject(cluster ClusterState, id VpaID, vpa *vpa_types.VerticalPodAuto
 	err := cluster.AddOrUpdateVpa(vpa, parsedSelector)
 	if err != nil {
 		klog.ErrorS(err, "AddOrUpdateVpa() failed")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 	return cluster.VPAs()[id]
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -19,7 +19,6 @@ package model
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -354,7 +353,7 @@ func addVpaObject(cluster ClusterState, id VpaID, vpa *vpa_types.VerticalPodAuto
 	err := cluster.AddOrUpdateVpa(vpa, parsedSelector)
 	if err != nil {
 		klog.ErrorS(err, "AddOrUpdateVpa() failed")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	}
 	return cluster.VPAs()[id]
 }

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -117,7 +116,7 @@ func NewControllerFetcher(config *rest.Config, kubeClient kube_client.Interface,
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		klog.ErrorS(err, "Could not create discoveryClient")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	}
 	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
 	restClient := kubeClient.CoreV1().RESTClient()

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -117,7 +117,7 @@ func NewControllerFetcher(config *rest.Config, kubeClient kube_client.Interface,
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		klog.ErrorS(err, "Could not create discoveryClient")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
 	restClient := kubeClient.CoreV1().RESTClient()

--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -72,7 +72,7 @@ func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Int
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		klog.ErrorS(err, "Could not create discoveryClient")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
 	restClient := kubeClient.CoreV1().RESTClient()
@@ -98,7 +98,7 @@ func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Int
 		synced := cache.WaitForCacheSync(stopCh, informer.HasSynced)
 		if !synced {
 			klog.ErrorS(nil, "Could not sync cache for "+string(kind))
-			os.Exit(255)
+			klog.FlushAndExit(255)
 		} else {
 			klog.InfoS("Initial sync completed", "kind", kind)
 		}

--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -19,7 +19,6 @@ package target
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -72,7 +71,7 @@ func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Int
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		klog.ErrorS(err, "Could not create discoveryClient")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	}
 	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
 	restClient := kubeClient.CoreV1().RESTClient()
@@ -98,7 +97,7 @@ func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Int
 		synced := cache.WaitForCacheSync(stopCh, informer.HasSynced)
 		if !synced {
 			klog.ErrorS(nil, "Could not sync cache for "+string(kind))
-			klog.FlushAndExit(255)
+			klog.FlushAndExit(10*time.Second, 255)
 		} else {
 			klog.InfoS("Initial sync completed", "kind", kind)
 		}

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -152,7 +152,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 	vpaList, err := u.vpaLister.List(labels.Everything())
 	if err != nil {
 		klog.ErrorS(err, "Failed to get VPA list")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 	timer.ObserveStep("ListVPAs")
 
@@ -406,7 +406,7 @@ func newEventRecorder(kubeClient kube_client.Interface) record.EventRecorder {
 	vpascheme := scheme.Scheme
 	if err := corescheme.AddToScheme(vpascheme); err != nil {
 		klog.ErrorS(err, "Error adding core scheme")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 
 	return eventBroadcaster.NewRecorder(vpascheme, apiv1.EventSource{Component: "vpa-updater"})

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -19,7 +19,6 @@ package logic
 import (
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"time"
 
@@ -152,7 +151,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 	vpaList, err := u.vpaLister.List(labels.Everything())
 	if err != nil {
 		klog.ErrorS(err, "Failed to get VPA list")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	}
 	timer.ObserveStep("ListVPAs")
 
@@ -406,7 +405,7 @@ func newEventRecorder(kubeClient kube_client.Interface) record.EventRecorder {
 	vpascheme := scheme.Scheme
 	if err := corescheme.AddToScheme(vpascheme); err != nil {
 		klog.ErrorS(err, "Error adding core scheme")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	}
 
 	return eventBroadcaster.NewRecorder(vpascheme, apiv1.EventSource{Component: "vpa-updater"})

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -99,7 +99,7 @@ func main() {
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
 		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 
 	healthCheck := metrics.NewHealthCheck(*updaterInterval * 5)
@@ -113,7 +113,7 @@ func main() {
 		id, err := os.Hostname()
 		if err != nil {
 			klog.ErrorS(err, "Unable to get hostname")
-			os.Exit(255)
+			klog.FlushAndExit(255)
 		}
 		id = id + "_" + string(uuid.NewUUID())
 
@@ -132,7 +132,7 @@ func main() {
 		)
 		if err != nil {
 			klog.ErrorS(err, "Unable to create leader election lock")
-			os.Exit(255)
+			klog.FlushAndExit(255)
 		}
 
 		leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
@@ -216,7 +216,7 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 	)
 	if err != nil {
 		klog.ErrorS(err, "Failed to create updater")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 
 	// Start updating health check endpoint.

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -99,7 +99,7 @@ func main() {
 
 	if len(commonFlags.VpaObjectNamespace) > 0 && len(commonFlags.IgnoredVpaObjectNamespaces) > 0 {
 		klog.ErrorS(nil, "--vpa-object-namespace and --ignored-vpa-object-namespaces are mutually exclusive and can't be set together.")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10 * time.Second, 255)
 	}
 
 	healthCheck := metrics.NewHealthCheck(*updaterInterval * 5)
@@ -113,7 +113,7 @@ func main() {
 		id, err := os.Hostname()
 		if err != nil {
 			klog.ErrorS(err, "Unable to get hostname")
-			klog.FlushAndExit(255)
+			klog.FlushAndExit(10 * time.Second, 255)
 		}
 		id = id + "_" + string(uuid.NewUUID())
 
@@ -132,7 +132,7 @@ func main() {
 		)
 		if err != nil {
 			klog.ErrorS(err, "Unable to create leader election lock")
-			klog.FlushAndExit(255)
+			klog.FlushAndExit(10 * time.Second, 255)
 		}
 
 		leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
@@ -216,7 +216,7 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 	)
 	if err != nil {
 		klog.ErrorS(err, "Failed to create updater")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10 * time.Second, 255)
 	}
 
 	// Start updating health check endpoint.

--- a/vertical-pod-autoscaler/pkg/utils/metrics/healthcheck.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/healthcheck.go
@@ -19,7 +19,6 @@ package metrics
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -77,7 +76,7 @@ func (hc *HealthCheck) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
 			klog.ErrorS(err, "Failed to write response message")
-			klog.FlushAndExit(255)
+			klog.FlushAndExit(10*time.Second, 255)
 		}
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/metrics/healthcheck.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/healthcheck.go
@@ -77,7 +77,7 @@ func (hc *HealthCheck) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
 			klog.ErrorS(err, "Failed to write response message")
-			os.Exit(255)
+			klog.FlushAndExit(255)
 		}
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/server/server.go
+++ b/vertical-pod-autoscaler/pkg/utils/server/server.go
@@ -20,7 +20,7 @@ package server
 import (
 	"net/http"
 	"net/http/pprof"
-	"os"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -49,6 +49,6 @@ func Initialize(enableProfiling *bool, healthCheck *metrics.HealthCheck, address
 
 		err := http.ListenAndServe(*address, mux)
 		klog.ErrorS(err, "Failed to start metrics")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	}()
 }

--- a/vertical-pod-autoscaler/pkg/utils/server/server.go
+++ b/vertical-pod-autoscaler/pkg/utils/server/server.go
@@ -49,6 +49,6 @@ func Initialize(enableProfiling *bool, healthCheck *metrics.HealthCheck, address
 
 		err := http.ListenAndServe(*address, mux)
 		klog.ErrorS(err, "Failed to start metrics")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}()
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -95,13 +95,13 @@ func NewVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct
 	indexer, ok := store.(cache.Indexer)
 	if !ok {
 		klog.ErrorS(nil, "Expected Indexer, but got a Store that does not implement Indexer")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	}
 	vpaLister := vpa_lister.NewVerticalPodAutoscalerLister(indexer)
 	go controller.Run(stopChannel)
 	if !cache.WaitForCacheSync(stopChannel, controller.HasSynced) {
 		klog.ErrorS(nil, "Failed to sync VPA cache during initialization")
-		os.Exit(255)
+		klog.FlushAndExit(255)
 	} else {
 		klog.InfoS("Initial VPA synced successfully")
 	}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -95,13 +94,13 @@ func NewVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct
 	indexer, ok := store.(cache.Indexer)
 	if !ok {
 		klog.ErrorS(nil, "Expected Indexer, but got a Store that does not implement Indexer")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	}
 	vpaLister := vpa_lister.NewVerticalPodAutoscalerLister(indexer)
 	go controller.Run(stopChannel)
 	if !cache.WaitForCacheSync(stopChannel, controller.HasSynced) {
 		klog.ErrorS(nil, "Failed to sync VPA cache during initialization")
-		klog.FlushAndExit(255)
+		klog.FlushAndExit(10*time.Second, 255)
 	} else {
 		klog.InfoS("Initial VPA synced successfully")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/help wanted
/good first issue
/area vertical-pod-autoscaler

#### What this PR does / why we need it:

This PR updates the Vertical Pod Autoscaler (VPA) code to replace all instances of `os.Exit(255)` after error logging with the recommended `klog.FlushAndExit()` function.

#### Which issue(s) this PR fixes:

Fixes #8146

#### Special notes for your reviewer:

This is a straightforward cleanup to improve logging consistency and reliability during fatal error conditions.

#### Does this PR introduce a user-facing change?

```release-note
NONE
