### PR TITLE
Rewrite TestCloudProvider to use builder pattern

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -62,7 +62,7 @@ func TestOKWithScaleUp(t *testing.T) {
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
 	SetNodeReadyState(ng2_1, true, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 5)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 
@@ -104,7 +104,7 @@ func TestOKWithScaleUp(t *testing.T) {
 func TestEmptyOK(t *testing.T) {
 	now := time.Now()
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 0, 10, 0)
 	assert.NotNil(t, provider)
 
@@ -148,7 +148,7 @@ func TestHasNodeGroupStartedScaleUp(t *testing.T) {
 	for tn, tc := range tests {
 		t.Run(tn, func(t *testing.T) {
 			now := time.Now()
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			provider.AddNodeGroup("ng1", 0, 5, tc.initialSize)
 			fakeClient := &fake.Clientset{}
 			fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
@@ -225,7 +225,7 @@ func TestRecalculateStateAfterNodeGroupSizeChanged(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			provider.AddNodeGroup(ngName, 0, 1000, tc.newTarget)
 
 			fakeLogRecorder, _ := utils.NewStatusMapRecorder(&fake.Clientset{}, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
@@ -255,7 +255,7 @@ func TestOKOneUnreadyNode(t *testing.T) {
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
 	SetNodeReadyState(ng2_1, false, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNode("ng1", ng1_1)
@@ -294,7 +294,7 @@ func TestNodeWithoutNodeGroupDontCrash(t *testing.T) {
 
 	noNgNode := BuildTestNode("no_ng", 1000, 1000)
 	SetNodeReadyState(noNgNode, true, now.Add(-time.Minute))
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNode("no_ng", noNgNode)
 
 	fakeClient := &fake.Clientset{}
@@ -317,7 +317,7 @@ func TestOKOneUnreadyNodeWithScaleDownCandidate(t *testing.T) {
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
 	SetNodeReadyState(ng2_1, false, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNode("ng1", ng1_1)
@@ -370,7 +370,7 @@ func TestMissingNodes(t *testing.T) {
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
 	SetNodeReadyState(ng2_1, true, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 5)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 
@@ -411,7 +411,7 @@ func TestTooManyUnready(t *testing.T) {
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
 	SetNodeReadyState(ng2_1, false, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNode("ng1", ng1_1)
@@ -440,7 +440,7 @@ func TestUnreadyLongAfterCreation(t *testing.T) {
 	SetNodeReadyState(ng2_1, false, now.Add(-time.Minute))
 	ng2_1.CreationTimestamp = metav1.Time{Time: now.Add(-30 * time.Minute)}
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNode("ng1", ng1_1)
@@ -472,7 +472,7 @@ func TestNotStarted(t *testing.T) {
 	SetNodeNotReadyTaint(ng2_1)
 	ng2_1.CreationTimestamp = metav1.Time{Time: now.Add(-10 * time.Minute)}
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNode("ng1", ng1_1)
@@ -511,7 +511,7 @@ func TestExpiredScaleUp(t *testing.T) {
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
 	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 5)
 	provider.AddNode("ng1", ng1_1)
 	assert.NotNil(t, provider)
@@ -536,7 +536,7 @@ func TestExpiredScaleUp(t *testing.T) {
 
 func TestRegisterScaleDown(t *testing.T) {
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNode("ng1", ng1_1)
 	assert.NotNil(t, provider)
@@ -556,7 +556,7 @@ func TestRegisterScaleDown(t *testing.T) {
 }
 
 func TestUpcomingNodes(t *testing.T) {
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	now := time.Now()
 
 	// 6 nodes are expected to come.
@@ -629,8 +629,7 @@ func TestUpcomingNodes(t *testing.T) {
 func TestTaintBasedNodeDeletion(t *testing.T) {
 	// Create a new Cloud Provider that does not implement the HasInstance check
 	// it will return the ErrNotImplemented error instead.
-	provider := testprovider.NewTestNodeDeletionDetectionCloudProvider(nil, nil,
-		func(string) (bool, error) { return false, cloudprovider.ErrNotImplemented })
+	provider := testprovider.NewTestCloudProviderBuilder().WithHasInstance(func(string) (bool, error) { return false, cloudprovider.ErrNotImplemented }).Build()
 	now := time.Now()
 
 	// One node is already there, for a second nde deletion / draining was already started.
@@ -667,7 +666,7 @@ func TestTaintBasedNodeDeletion(t *testing.T) {
 
 func TestIncorrectSize(t *testing.T) {
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 5)
 	provider.AddNode("ng1", ng1_1)
 	assert.NotNil(t, provider)
@@ -702,7 +701,7 @@ func TestUnregisteredNodes(t *testing.T) {
 	ng1_1.Spec.ProviderID = "ng1-1"
 	ng1_2 := BuildTestNode("ng1-2", 1000, 1000)
 	ng1_2.Spec.ProviderID = "ng1-2"
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 2)
 	provider.AddNode("ng1", ng1_1)
 	provider.AddNode("ng1", ng1_2)
@@ -750,7 +749,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	SetNodeReadyState(noNgNode, true, now.Add(-time.Minute))
 
 	noNgNode.Spec.ProviderID = "no-ng"
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 2)
 	provider.AddNode("ng1", ng1_1)
 	provider.AddNode("ng1", ng1_2)
@@ -844,7 +843,7 @@ func TestScaleUpBackoff(t *testing.T) {
 	ng1_3 := BuildTestNode("ng1-3", 1000, 1000)
 	SetNodeReadyState(ng1_3, true, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 4)
 	ng1 := provider.GetNodeGroup("ng1")
 	provider.AddNode("ng1", ng1_1)
@@ -967,7 +966,7 @@ func TestGetClusterSize(t *testing.T) {
 	notAutoscaledNode := BuildTestNode("notAutoscaledNode", 1000, 1000)
 	SetNodeReadyState(notAutoscaledNode, true, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 5)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 
@@ -1018,7 +1017,7 @@ func TestUpdateScaleUp(t *testing.T) {
 	now := time.Now()
 	later := now.Add(time.Minute)
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 5)
 	provider.AddNodeGroup("ng2", 1, 10, 5)
 	fakeClient := &fake.Clientset{}
@@ -1065,7 +1064,7 @@ func TestUpdateScaleUp(t *testing.T) {
 func TestScaleUpFailures(t *testing.T) {
 	now := time.Now()
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 0, 10, 0)
 	provider.AddNodeGroup("ng2", 0, 10, 0)
 	assert.NotNil(t, provider)
@@ -1213,7 +1212,7 @@ func TestUpdateAcceptableRanges(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			for nodeGroupName, targetSize := range tc.targetSizes {
 				provider.AddNodeGroup(nodeGroupName, 0, 1000, targetSize)
 			}
@@ -1397,7 +1396,7 @@ func TestUpdateIncorrectNodeGroupSizes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			for nodeGroupName, acceptableRange := range tc.acceptableRanges {
 				provider.AddNodeGroup(nodeGroupName, 0, 1000, acceptableRange.CurrentTarget)
 			}
@@ -1458,7 +1457,7 @@ func TestTruncateIfExceedMaxSize(t *testing.T) {
 }
 
 func TestIsNodeGroupRegistered(t *testing.T) {
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	registeredNodeGroupName := "registered-node-group"
 	provider.AddNodeGroup(registeredNodeGroupName, 1, 10, 1)
 	fakeClient := &fake.Clientset{}
@@ -1537,7 +1536,7 @@ func TestUpcomingNodesFromUpcomingNodeGroups(t *testing.T) {
 	for _, tc := range testCases {
 
 		now := time.Now()
-		provider := testprovider.NewTestCloudProvider(nil, nil)
+		provider := testprovider.NewTestCloudProviderBuilder().Build()
 		for groupName, groupSize := range tc.nodeGroups {
 			provider.AddUpcomingNodeGroup(groupName, 1, 10, groupSize)
 		}

--- a/cluster-autoscaler/clusterstate/utils/node_instances_cache_test.go
+++ b/cluster-autoscaler/clusterstate/utils/node_instances_cache_test.go
@@ -44,7 +44,7 @@ func TestCloudProviderNodeInstancesCache(t *testing.T) {
 	nodeNg4_1 := BuildTestNode("ng4-1", 1000, 1000)
 	instanceNg4_1 := buildRunningInstance(nodeNg4_1.Name)
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNodeGroup("ng3", 1, 10, 1)

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestAddNodeToBucket(t *testing.T) {
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	ctx, err := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, nil, nil, provider, nil, nil)
 	if err != nil {
 		t.Fatalf("Couldn't set up autoscaling context: %v", err)
@@ -142,14 +142,14 @@ func TestRemove(t *testing.T) {
 			notDeletedNodes := make(chan string, 10)
 			// Hook node deletion at the level of cloud provider, to gather which nodes were deleted, and to fail the deletion for
 			// certain nodes to simulate errors.
-			provider := testprovider.NewTestCloudProvider(nil, func(nodeGroup string, node string) error {
+			provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleDown(func(nodeGroup string, node string) error {
 				if failedNodeDeletion[node] {
 					notDeletedNodes <- node
 					return fmt.Errorf("SIMULATED ERROR: won't remove node")
 				}
 				deletedNodes <- node
 				return nil
-			})
+			}).Build()
 
 			fakeClient.Fake.AddReactor("update", "nodes",
 				func(action core.Action) (bool, runtime.Object, error) {

--- a/cluster-autoscaler/core/scaledown/actuation/drain_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain_test.go
@@ -135,7 +135,7 @@ func TestDaemonSetEvictionForEmptyNodes(t *testing.T) {
 				deletedPods <- eviction.Name
 				return true, nil, nil
 			})
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			provider.AddNodeGroup("ng1", 1, 10, 1)
 			provider.AddNode("ng1", n1)
 			registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)

--- a/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler_test.go
@@ -132,9 +132,9 @@ func TestScheduleDeletion(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			provider := testprovider.NewTestCloudProvider(nil, func(nodeGroup string, node string) error {
+			provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleDown(func(nodeGroup string, node string) error {
 				return nil
-			})
+			}).Build()
 
 			batcher := &countingBatcher{}
 			tracker := deletiontracker.NewNodeDeletionTracker(0)

--- a/cluster-autoscaler/core/scaledown/actuation/softtaint_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/softtaint_test.go
@@ -54,10 +54,10 @@ func TestSoftTaintUpdate(t *testing.T) {
 	_, err = fakeClient.CoreV1().Nodes().Create(ctx, n2000, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	provider := testprovider.NewTestCloudProvider(nil, func(nodeGroup string, node string) error {
+	provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleDown(func(nodeGroup string, node string) error {
 		t.Fatalf("Unexpected deletion of %s", node)
 		return nil
-	})
+	}).Build()
 	provider.AddNodeGroup("ng1", 1, 10, 2)
 	provider.AddNode("ng1", n1000)
 	provider.AddNode("ng1", n2000)
@@ -141,7 +141,7 @@ func TestSoftTaintTimeLimit(t *testing.T) {
 		return false, nil, nil
 	})
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 2)
 	provider.AddNode("ng1", n1)
 	provider.AddNode("ng1", n2)

--- a/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
@@ -420,9 +420,9 @@ func TestCropNodesToBudgets(t *testing.T) {
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
-			provider := testprovider.NewTestCloudProvider(nil, func(nodeGroup string, node string) error {
+			provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleDown(func(nodeGroup string, node string) error {
 				return nil
-			})
+			}).Build()
 			for _, bucket := range append(tc.empty, tc.drain...) {
 				bucket.Group.(*testprovider.TestNodeGroup).SetCloudProvider(provider)
 				provider.InsertNodeGroup(bucket.Group)

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -223,7 +223,7 @@ func TestFilterOutUnremovable(t *testing.T) {
 			}
 			s := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults)
 			c := NewChecker(s)
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			provider.AddNodeGroup("ng1", 1, 10, 2)
 			for _, n := range tc.nodes {
 				provider.AddNode("ng1", n)

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -485,7 +485,7 @@ func TestUpdateClusterState(t *testing.T) {
 			rsLister, err := kube_util.NewTestReplicaSetLister(tc.replicasSets)
 			assert.NoError(t, err)
 			registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, rsLister, nil)
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			provider.AddNodeGroup("ng1", 0, 0, 0)
 			for _, node := range tc.nodes {
 				provider.AddNode("ng1", node)
@@ -681,7 +681,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			for i := 0; i < tc.previouslyUnneeded; i++ {
 				previouslyUnneeded[i] = simulator.NodeToBeRemoved{Node: nodes[i]}
 			}
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			provider.AddNodeGroupWithCustomOptions("ng1", 0, 0, 0, tc.opts)
 			for _, node := range nodes {
 				provider.AddNode("ng1", node)
@@ -844,7 +844,7 @@ func TestNodesToDelete(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			allNodes := []*apiv1.Node{}
 			allRemovables := []simulator.NodeToBeRemoved{}
 			for ng, nodes := range tc.nodes {

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
@@ -187,7 +187,7 @@ func TestRemovableAt(t *testing.T) {
 			}
 
 			removableNodes := append(empty, drain...)
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			provider.InsertNodeGroup(ng)
 			for _, node := range removableNodes {
 				provider.AddNode("ng", node.Node)

--- a/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
@@ -44,13 +44,12 @@ import (
 func TestNodePoolAsyncInitialization(t *testing.T) {
 	scaleUpSize := 3
 	failingNodeGroupName := "failing-ng"
-	provider := testprovider.NewTestCloudProvider(
-		func(nodeGroup string, increase int) error {
-			if nodeGroup == failingNodeGroupName {
-				return fmt.Errorf("Simulated error")
-			}
-			return nil
-		}, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleUp(func(nodeGroup string, increase int) error {
+		if nodeGroup == failingNodeGroupName {
+			return fmt.Errorf("Simulated error")
+		}
+		return nil
+	}).Build()
 	pod := BuildTestPod("p1", 2, 1000)
 	failingNodeGroup := provider.BuildNodeGroup(failingNodeGroupName, 0, 100, 0, false, true, "T1", nil)
 	successfulNodeGroup := provider.BuildNodeGroup("async-ng", 0, 100, 0, false, true, "T1", nil)

--- a/cluster-autoscaler/core/scaleup/resource/manager_test.go
+++ b/cluster-autoscaler/core/scaleup/resource/manager_test.go
@@ -66,7 +66,7 @@ func TestDeltaForNode(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		cp := testprovider.NewTestCloudProvider(nil, nil)
+		cp := testprovider.NewTestCloudProviderBuilder().Build()
 		ctx := newContext(t, cp)
 		processors := processorstest.NewTestProcessors(&ctx)
 
@@ -162,7 +162,7 @@ func TestApplyLimits(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		cp := testprovider.NewTestCloudProvider(nil, nil)
+		cp := testprovider.NewTestCloudProviderBuilder().Build()
 		ctx := newContext(t, cp)
 		processors := processorstest.NewTestProcessors(&ctx)
 
@@ -216,7 +216,7 @@ func TestCheckDeltaWithinLimits(t *testing.T) {
 }
 
 func TestResourceManagerWithGpuResource(t *testing.T) {
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	resourceLimiter := cloudprovider.NewResourceLimiter(
 		map[string]int64{cloudprovider.ResourceNameCores: 0, cloudprovider.ResourceNameMemory: 0, "gpu": 0},
 		map[string]int64{cloudprovider.ResourceNameCores: 320, cloudprovider.ResourceNameMemory: 640, "gpu": 16},
@@ -259,7 +259,7 @@ func TestResourceManagerWithGpuResource(t *testing.T) {
 }
 
 func newCloudProvider(t *testing.T, cpu, mem int64) *testprovider.TestCloudProvider {
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	assert.NotNil(t, provider)
 
 	resourceLimiter := cloudprovider.NewResourceLimiter(

--- a/cluster-autoscaler/estimator/sng_capacity_threshold_test.go
+++ b/cluster-autoscaler/estimator/sng_capacity_threshold_test.go
@@ -77,7 +77,7 @@ func TestSngCapacityThreshold(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider := testprovider.NewTestCloudProvider(func(string, int) error { return nil }, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleUp(func(string, int) error { return nil }).Build()
 			for _, ng := range tt.nodeGroupsConfig {
 				provider.AddNodeGroup(ng.name, 0, ng.maxNodes, ng.nodesCount)
 			}

--- a/cluster-autoscaler/expander/price/price_test.go
+++ b/cluster-autoscaler/expander/price/price_test.go
@@ -81,7 +81,7 @@ func TestPriceExpander(t *testing.T) {
 	p1 := BuildTestPod("p1", 1000, 0)
 	p2 := BuildTestPod("p2", 500, 0)
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNode("ng1", n1)

--- a/cluster-autoscaler/processors/customresources/gpu_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor_test.go
@@ -171,7 +171,7 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 	}
 
 	processor := NewDefaultCustomResourcesProcessor()
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	ctx := &context.AutoscalingContext{CloudProvider: provider}
 	newAllNodes, newReadyNodes := processor.FilterOutNodesWithUnreadyResources(ctx, initialAllNodes, initialReadyNodes)
 

--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
@@ -104,7 +104,7 @@ func TestFindSimilarNodeGroupsAzureByLabel(t *testing.T) {
 	n1 := BuildTestNode("n1", 1000, 1000)
 	n2 := BuildTestNode("n2", 2000, 2000)
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNode("ng1", n1)

--- a/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
@@ -33,7 +33,7 @@ func buildBasicNodeGroups(context *context.AutoscalingContext) (*framework.NodeI
 	n1 := BuildTestNode("n1", 1000, 1000)
 	n2 := BuildTestNode("n2", 1000, 1000)
 	n3 := BuildTestNode("n3", 2000, 2000)
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNodeGroup("ng3", 1, 10, 1)
@@ -112,7 +112,7 @@ func TestBalanceSingleGroup(t *testing.T) {
 	processor := NewDefaultNodeGroupSetProcessor([]string{}, config.NodeGroupDifferenceRatios{})
 	context := &context.AutoscalingContext{}
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 
 	// just one node
@@ -132,7 +132,7 @@ func TestBalanceUnderMaxSize(t *testing.T) {
 	processor := NewDefaultNodeGroupSetProcessor([]string{}, config.NodeGroupDifferenceRatios{})
 	context := &context.AutoscalingContext{}
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 	provider.AddNodeGroup("ng2", 1, 10, 3)
 	provider.AddNodeGroup("ng3", 1, 10, 5)
@@ -182,7 +182,7 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	processor := NewDefaultNodeGroupSetProcessor([]string{}, config.NodeGroupDifferenceRatios{})
 	context := &context.AutoscalingContext{}
 
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 1, 1)
 	provider.AddNodeGroup("ng2", 1, 3, 1)
 	provider.AddNodeGroup("ng3", 1, 10, 3)

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
@@ -61,9 +61,8 @@ func TestGetNodeInfosForGroups(t *testing.T) {
 	tni := framework.NewTestNodeInfo(tn)
 
 	// Cloud provider with TemplateNodeInfo implemented.
-	provider1 := testprovider.NewTestAutoprovisioningCloudProvider(
-		nil, nil, nil, nil, nil,
-		map[string]*framework.NodeInfo{"ng3": tni, "ng4": tni, "ng5": tni, "ng6": tni})
+	provider1 := testprovider.NewTestCloudProviderBuilder().WithMachineTemplates(
+		map[string]*framework.NodeInfo{"ng3": tni, "ng4": tni, "ng5": tni, "ng6": tni}).Build()
 	provider1.AddNodeGroup("ng1", 1, 10, 1) // Nodegroup with ready node.
 	provider1.AddNode("ng1", ready1)
 	provider1.AddNodeGroup("ng2", 1, 10, 1) // Nodegroup with ready and unready node.
@@ -79,7 +78,7 @@ func TestGetNodeInfosForGroups(t *testing.T) {
 	provider1.AddNode("ng6", ready7)
 
 	// Cloud provider with TemplateNodeInfo not implemented.
-	provider2 := testprovider.NewTestAutoprovisioningCloudProvider(nil, nil, nil, nil, nil, nil)
+	provider2 := testprovider.NewTestCloudProviderBuilder().Build()
 	provider2.AddNodeGroup("ng7", 1, 10, 1) // Nodegroup without nodes.
 
 	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
@@ -157,9 +156,7 @@ func TestGetNodeInfosForGroupsCache(t *testing.T) {
 	}
 
 	// Cloud provider with TemplateNodeInfo implemented.
-	provider1 := testprovider.NewTestAutoprovisioningCloudProvider(
-		nil, nil, nil, onDeleteGroup, nil,
-		map[string]*framework.NodeInfo{"ng3": tni, "ng4": tni})
+	provider1 := testprovider.NewTestCloudProviderBuilder().WithOnNodeGroupDelete(onDeleteGroup).WithMachineTemplates(map[string]*framework.NodeInfo{"ng3": tni, "ng4": tni}).Build()
 	provider1.AddNodeGroup("ng1", 1, 10, 1) // Nodegroup with ready node.
 	provider1.AddNode("ng1", ready1)
 	provider1.AddNodeGroup("ng2", 1, 10, 1) // Nodegroup with ready and unready node.
@@ -261,7 +258,7 @@ func TestGetNodeInfosCacheExpired(t *testing.T) {
 	SetNodeReadyState(ready1, true, now.Add(-2*time.Minute))
 
 	// Cloud provider with TemplateNodeInfo not implemented.
-	provider := testprovider.NewTestAutoprovisioningCloudProvider(nil, nil, nil, nil, nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
 	registry := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
 

--- a/cluster-autoscaler/processors/nodes/pre_filtering_processor_test.go
+++ b/cluster-autoscaler/processors/nodes/pre_filtering_processor_test.go
@@ -45,7 +45,7 @@ func TestPreFilteringScaleDownNodeProcessor_GetScaleDownCandidateNodes(t *testin
 	ng1_2 := BuildTestNode("ng1-2", 1000, 1000)
 	ng2_1 := BuildTestNode("ng2-1", 1000, 1000)
 	noNg := BuildTestNode("no-ng", 1000, 1000)
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup("ng1", 1, 10, 2)
 	provider.AddNodeGroup("ng2", 1, 10, 1)
 	provider.AddNode("ng1", ng1_1)

--- a/cluster-autoscaler/processors/nodes/scale_down_set_processor_test.go
+++ b/cluster-autoscaler/processors/nodes/scale_down_set_processor_test.go
@@ -213,7 +213,7 @@ func TestAtomicResizeFilterUnremovableNodes(t *testing.T) {
 			t.Parallel()
 
 			processor := NewAtomicResizeFilteringProcessor()
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			for _, ng := range tc.nodeGroups {
 				provider.AddNodeGroupWithCustomOptions(ng.nodeGroupName, 0, 100, ng.nodeGroupTargetSize, &config.NodeGroupAutoscalingOptions{
 					ZeroOrMaxNodeScaling: ng.zeroOrMaxNodeScaling,

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor_test.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor_test.go
@@ -125,7 +125,7 @@ func TestGetScaleDownCandidates(t *testing.T) {
 
 	for description, testCase := range testCases {
 		t.Run(description, func(t *testing.T) {
-			provider := testprovider.NewTestCloudProvider(nil, nil)
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
 
 			p := NewScaleDownCandidatesDelayProcessor()
 

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -459,7 +459,7 @@ func TestScaleUp(t *testing.T) {
 }
 
 func setupTest(t *testing.T, client *provreqclient.ProvisioningRequestClient, nodes []*apiv1.Node, onScaleUpFunc func(string, int) error, autoprovisioning bool, batchProcessing bool, maxBatchSize int, batchTimebox time.Duration) (*provReqOrchestrator, map[string]*framework.NodeInfo) {
-	provider := testprovider.NewTestCloudProvider(onScaleUpFunc, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleUp(onScaleUpFunc).Build()
 	clock := clocktesting.NewFakePassiveClock(time.Now())
 	now := clock.Now()
 	if autoprovisioning {
@@ -471,7 +471,7 @@ func setupTest(t *testing.T, client *provreqclient.ProvisioningRequestClient, no
 			"large-machine": nodeInfoTemplate,
 		}
 		onNodeGroupCreateFunc := func(name string) error { return nil }
-		provider = testprovider.NewTestAutoprovisioningCloudProvider(onScaleUpFunc, nil, onNodeGroupCreateFunc, nil, machineTypes, machineTemplates)
+		provider = testprovider.NewTestCloudProviderBuilder().WithOnScaleUp(onScaleUpFunc).WithOnNodeGroupCreate(onNodeGroupCreateFunc).WithMachineTypes(machineTypes).WithMachineTemplates(machineTemplates).Build()
 	}
 
 	provider.AddNodeGroup("test-cpu", 50, 150, 100)

--- a/cluster-autoscaler/utils/backoff/exponential_backoff_test.go
+++ b/cluster-autoscaler/utils/backoff/exponential_backoff_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func nodeGroup(id string) cloudprovider.NodeGroup {
-	provider := testprovider.NewTestCloudProvider(nil, nil)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	provider.AddNodeGroup(id, 1, 10, 1)
 	return provider.GetNodeGroup(id)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The TestCloudProvider is used widely in our codebase, but it is passing all its config via arguments on constuction. I've rewritten it to use builder pattern, to make it both easier to use and to read.
