### PR TITLE
Set correct k8s/client-go version in go.mod

### DIFF
--- a/vertical-pod-autoscaler/go.mod
+++ b/vertical-pod-autoscaler/go.mod
@@ -15,7 +15,7 @@ require (
 	golang.org/x/time v0.11.0
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
-	k8s.io/client-go v1.5.2
+	k8s.io/client-go v0.33.0
 	k8s.io/code-generator v0.33.0
 	k8s.io/component-base v0.33.0
 	k8s.io/klog/v2 v2.130.1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

This PR sets correct version of k8s.io/client-go in the go.mod file. The dependecies shall follow the versioning recommendation described in the package documentation: [https://pkg.go.dev/k8s.io/client-go](https://pkg.go.dev/k8s.io/client-go)

The correct version is `v0.33.0` and not `v1.5.2`
Version `v1.5.2` breaks other go modules referencing `vertical-pod-autoscaler` as it is not compatible with the `k8s.io/client-go` version used in the main Kubernetes repository.

```release-note
Set k8s.io/client-go version to v0.33.0.
```
