### PR TITLE
fix bug 8168 GetEndpoint resolving fail

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/endpoints/location_resolver.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/endpoints/location_resolver.go
@@ -89,9 +89,10 @@ func (resolver *LocationResolver) TryResolve(param *ResolveParam) (endpoint stri
 		return
 	}
 
-	err = json.Unmarshal([]byte(response.GetHttpContentString()), &getEndpointResponse)
+	content := response.GetHttpContentString()
+	err = json.Unmarshal([]byte(content), &getEndpointResponse)
 	if err != nil {
-		klog.Errorf("failed to unmarshal endpoint response, error: %v", err)
+		klog.Errorf("failed to resolve endpoint, error: %v, response: %s", err, content)
 		support = false
 		return
 	}
@@ -153,7 +154,7 @@ type EndpointsObj struct {
 
 // EndpointObj wrapper endpoint
 type EndpointObj struct {
-	Protocols   map[string]string
+	Protocols   json.RawMessage
 	Type        string
 	Namespace   string
 	Id          string


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #8168

#### Special notes for your reviewer:
There is an endpoint resolution failure due to a changed JSON schema, causing scaling groups not to be discovered. Because of this, the autoscaler doesn't work at all.
`failed to unmarshal endpoint response, error: json: cannot unmarshal array into Go struct field EndpointObj.Endpoints.Endpoint.Protocols of type string`
The Protocols is not at use at all.

#### Does this PR introduce a user-facing change?
no
```release-note
NONE
```
