### PR TITLE
Add admission controller service to kustomization

### DIFF
--- a/vertical-pod-autoscaler/deploy/kustomization.yaml
+++ b/vertical-pod-autoscaler/deploy/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - admission-controller-deployment.yaml
+- admission-controller-service.yaml
 - recommender-deployment.yaml
 - updater-deployment.yaml
 - vpa-rbac.yaml


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Adds the Admission Controller service to the Kustomization file. The VPA webhook is broken today, see #8173

#### Which issue(s) this PR fixes:
Fixes #8173

#### Does this PR introduce a user-facing change?
```release-note
Includes the Admission Controller service to the Kustomization file.
```

