### PR TITLE
Enable TestUnchangedCAReloader tests

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/certs_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/certs_test.go
@@ -276,120 +276,119 @@ func TestChangedCAReloader(t *testing.T) {
 	assert.NotEqual(t, oldCAEncodedString, newCAEncodedString, "expected CA to change")
 }
 
-// TODO(omerap12): Temporary workaround for flakiness (#7831)
-// func TestUnchangedCAReloader(t *testing.T) {
-// 	tempDir := t.TempDir()
-// 	caCert := &x509.Certificate{
-// 		SerialNumber: big.NewInt(0),
-// 		Subject: pkix.Name{
-// 			Organization: []string{"ca"},
-// 		},
-// 		NotBefore:             time.Now(),
-// 		NotAfter:              time.Now().AddDate(2, 0, 0),
-// 		IsCA:                  true,
-// 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-// 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-// 		BasicConstraintsValid: true,
-// 	}
-// 	caKey, err := rsa.GenerateKey(rand.Reader, 4096)
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
-// 	caBytes, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caKey.PublicKey, caKey)
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
-// 	caPath := path.Join(tempDir, "ca.crt")
-// 	caFile, err := os.Create(caPath)
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
-// 	err = pem.Encode(caFile, &pem.Block{
-// 		Type:  "CERTIFICATE",
-// 		Bytes: caBytes,
-// 	})
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
+func TestUnchangedCAReloader(t *testing.T) {
+	tempDir := t.TempDir()
+	caCert := &x509.Certificate{
+		SerialNumber: big.NewInt(0),
+		Subject: pkix.Name{
+			Organization: []string{"ca"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(2, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		t.Error(err)
+	}
+	caBytes, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Error(err)
+	}
+	caPath := path.Join(tempDir, "ca.crt")
+	caFile, err := os.Create(caPath)
+	if err != nil {
+		t.Error(err)
+	}
+	err = pem.Encode(caFile, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	if err != nil {
+		t.Error(err)
+	}
 
-// 	testClientSet := fake.NewSimpleClientset()
+	testClientSet := fake.NewSimpleClientset()
 
-// 	selfRegistration(
-// 		testClientSet,
-// 		readFile(caPath),
-// 		0*time.Second,
-// 		"default",
-// 		"vpa-service",
-// 		"http://example.com/",
-// 		true,
-// 		int32(32),
-// 		"",
-// 		[]string{},
-// 		false,
-// 		"key1:value1,key2:value2",
-// 	)
+	selfRegistration(
+		testClientSet,
+		readFile(caPath),
+		0*time.Second,
+		"default",
+		"vpa-service",
+		"http://example.com/",
+		true,
+		int32(32),
+		"",
+		[]string{},
+		false,
+		"key1:value1,key2:value2",
+	)
 
-// 	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
-// 	oldWebhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
+	webhookConfigInterface := testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
+	oldWebhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
+	if err != nil {
+		t.Error(err)
+	}
 
-// 	assert.Len(t, oldWebhookConfig.Webhooks, 1, "expected one webhook configuration")
-// 	webhook := oldWebhookConfig.Webhooks[0]
-// 	oldWebhookCABundle := webhook.ClientConfig.CABundle
+	assert.Len(t, oldWebhookConfig.Webhooks, 1, "expected one webhook configuration")
+	webhook := oldWebhookConfig.Webhooks[0]
+	oldWebhookCABundle := webhook.ClientConfig.CABundle
 
-// 	var reloadWebhookCACalled, patchCalled atomic.Bool
-// 	reloadWebhookCACalled.Store(false)
-// 	patchCalled.Store(false)
-// 	testClientSet.PrependReactor("get", "mutatingwebhookconfigurations", func(action k8stesting.Action) (bool, runtime.Object, error) {
-// 		reloadWebhookCACalled.Store(true)
-// 		return false, nil, nil
-// 	})
-// 	testClientSet.PrependReactor("patch", "mutatingwebhookconfigurations", func(action k8stesting.Action) (bool, runtime.Object, error) {
-// 		patchCalled.Store(true)
-// 		return false, nil, nil
-// 	})
+	var reloadWebhookCACalled, patchCalled atomic.Bool
+	reloadWebhookCACalled.Store(false)
+	patchCalled.Store(false)
+	testClientSet.PrependReactor("get", "mutatingwebhookconfigurations", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		reloadWebhookCACalled.Store(true)
+		return false, nil, nil
+	})
+	testClientSet.PrependReactor("patch", "mutatingwebhookconfigurations", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchCalled.Store(true)
+		return false, nil, nil
+	})
 
-// 	reloader := certReloader{
-// 		clientCaPath:          caPath,
-// 		mutatingWebhookClient: testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations(),
-// 	}
-// 	stop := make(chan struct{})
-// 	defer close(stop)
-// 	if err := reloader.start(stop); err != nil {
-// 		t.Error(err)
-// 	}
+	reloader := certReloader{
+		clientCaPath:          caPath,
+		mutatingWebhookClient: testClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations(),
+	}
+	stop := make(chan struct{})
+	defer close(stop)
+	if err := reloader.start(stop); err != nil {
+		t.Error(err)
+	}
 
-// 	originalCaFile, err := os.ReadFile(caPath)
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
-// 	err = os.WriteFile(caPath, originalCaFile, 0666)
-// 	if err != nil {
-// 		t.Error(err)
-// 	}
+	originalCaFile, err := os.ReadFile(caPath)
+	if err != nil {
+		t.Error(err)
+	}
+	err = os.WriteFile(caPath, originalCaFile, 0666)
+	if err != nil {
+		t.Error(err)
+	}
 
-// 	oldCAEncodedString := base64.StdEncoding.EncodeToString(oldWebhookCABundle)
+	oldCAEncodedString := base64.StdEncoding.EncodeToString(oldWebhookCABundle)
 
-// 	for tries := 0; tries < 10; tries++ {
-// 		if reloadWebhookCACalled.Load() {
-// 			break
-// 		}
-// 		time.Sleep(1 * time.Second)
-// 	}
-// 	if !reloadWebhookCACalled.Load() {
-// 		t.Error("expected reloadWebhookCA to be called")
-// 	}
+	for tries := 0; tries < 10; tries++ {
+		if reloadWebhookCACalled.Load() {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if !reloadWebhookCACalled.Load() {
+		t.Error("expected reloadWebhookCA to be called")
+	}
 
-// 	assert.False(t, patchCalled.Load(), "expected patch to not be called")
+	assert.False(t, patchCalled.Load(), "expected patch to not be called")
 
-// 	newWebhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
-// 	assert.Nil(t, err, "expected no error")
-// 	assert.NotNil(t, newWebhookConfig, "expected webhook configuration")
-// 	assert.Len(t, newWebhookConfig.Webhooks, 1, "expected one webhook configuration")
+	newWebhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
+	assert.Nil(t, err, "expected no error")
+	assert.NotNil(t, newWebhookConfig, "expected webhook configuration")
+	assert.Len(t, newWebhookConfig.Webhooks, 1, "expected one webhook configuration")
 
-// 	newWebhookCABundle := newWebhookConfig.Webhooks[0].ClientConfig.CABundle
-// 	newCAEncodedString := base64.StdEncoding.EncodeToString(newWebhookCABundle)
-// 	assert.Equal(t, oldCAEncodedString, newCAEncodedString, "expected CA to not change")
-// }
+	newWebhookCABundle := newWebhookConfig.Webhooks[0].ClientConfig.CABundle
+	newCAEncodedString := base64.StdEncoding.EncodeToString(newWebhookCABundle)
+	assert.Equal(t, oldCAEncodedString, newCAEncodedString, "expected CA to not change")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Uncomment the flakey tests.
Since these tests started flaking we have upgraded to [fsnotify 1.9.0](https://github.com/fsnotify/fsnotify/releases/tag/v1.9.0) which contains some inotify fixes, including some race fixes.
I'm hoping that these fix the issues we have in https://github.com/kubernetes/autoscaler/issues/7831 

#### Which issue(s) this PR fixes:
Fixes #7831 🤞 

#### Special notes for your reviewer:

I want to try re-running these tests a few times before merging this PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
