### PR TITLE
Fix the setup-go Github action caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,14 +15,18 @@ jobs:
   test-and-verify:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v5.1.0
-        with:
-          go-version: '1.22.2'
-
       - uses: actions/checkout@v4.2.2
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/autoscaler
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: '1.22.2'
+          cache-dependency-path: |
+             ${{ env.GOPATH}}/src/k8s.io/autoscaler/cluster-autoscaler/go.sum
+             ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum
+             ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/e2e/go.sum
 
       - name: Apt-get
         run: sudo apt-get install libseccomp-dev -qq

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: '1.22.2'
+          go-version: '1.24.0'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/cluster-autoscaler/go.sum
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum

--- a/hack/for-go-proj.sh
+++ b/hack/for-go-proj.sh
@@ -52,7 +52,7 @@ for project_name in ${PROJECT_NAMES[*]}; do
         if [[ -n $(find . -name "Godeps.json") ]]; then
           godep go test -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e)
         else
-          go test -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e | grep -v cluster-autoscaler/apis)
+          go test -count=1  -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e | grep -v cluster-autoscaler/apis)
         fi
         ;;
       *)
@@ -71,6 +71,6 @@ if [ "${CMD}" = "build" ] || [ "${CMD}" == "test" ]; then
   # Default analyzers that go test runs according to https://github.com/golang/go/blob/52624e533fe52329da5ba6ebb9c37712048168e0/src/cmd/go/internal/test/test.go#L649
   # This doesn't include the `printf` analyzer until cluster-autoscaler libraries are updated.
   ANALYZERS="atomic,bool,buildtags,directive,errorsas,ifaceassert,nilfunc,slog,stringintconv,tests"
-  go test ./... -vet="${ANALYZERS}"
+  go test -count=1 ./... -vet="${ANALYZERS}"
   popd
 fi


### PR DESCRIPTION
I noticed that the Github Action caching wasn't working, so I added this setting to fix it.

https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs

If the cache is populated the tests now take 5 minutes to run (down from
18 minutes).

The one downside is that caching will also cache the test results (along
with the dependencies) so this change adds a `--count=1` to the `go
test` commands to ensure that the go test doesn't use a cached result.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Hopefully speed up GitHub actions 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
