### PR TITLE
Add support for SageMaker HyperPod nodes by skipping them in cluster autoscaler

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -725,8 +725,21 @@ func TestHasInstance(t *testing.T) {
 	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
 	assert.True(t, present)
 
-	// Case 3: correct node - not present in AWS
+	// Case 3: incorrect node - sagemaker hyperpod is unsupported
 	node3 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hyperpod-node-1",
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: "aws:///use1-az2/sagemaker/cluster/hyperpod-abc123-i-abc123",
+		},
+	}
+	present, err = provider.HasInstance(node3)
+	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+	assert.True(t, present)
+
+	// Case 4: correct node - not present in AWS
+	node4 := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node-2",
 		},
@@ -734,12 +747,12 @@ func TestHasInstance(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id-2",
 		},
 	}
-	present, err = provider.HasInstance(node3)
+	present, err = provider.HasInstance(node4)
 	assert.ErrorContains(t, err, nodeNotPresentErr)
 	assert.False(t, present)
 
-	// Case 4: correct node - not autoscaled -> not present in AWS -> no warning
-	node4 := &apiv1.Node{
+	// Case 5: correct node - not autoscaled -> not present in AWS -> no warning
+	node5 := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node-2",
 			Annotations: map[string]string{
@@ -750,7 +763,7 @@ func TestHasInstance(t *testing.T) {
 			ProviderID: "aws:///us-east-1a/test-instance-id-2",
 		},
 	}
-	present, err = provider.HasInstance(node4)
+	present, err = provider.HasInstance(node5)
 	assert.NoError(t, err)
 	assert.False(t, present)
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
/kind bug

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/7540

#### Special notes for your reviewer:
SageMaker HyperPod provides managed Kubernetes nodes, but these nodes break the cluster autoscaler because:

- Provider ID parsing fails: HyperPod nodes use a different provider ID format `aws:///region/sagemaker/cluster/instance-id` that doesn't match the standard EC2 format expected by `AwsRefFromProviderId()`
- Cluster autoscaler crashes: When the autoscaler encounters HyperPod nodes, it fails to parse their provider IDs and returns errors, preventing proper operation for the autoscaler for the entire EKS cluster.
- HyperPod nodes shouldn't be autoscaled: These are managed nodes that should not be scaled by the cluster autoscaler anyway

Following the same pattern used for Fargate nodes, this PR adds support for SageMaker HyperPod nodes by:

- Detecting SageMaker nodes: Check for `/sagemaker` in the provider ID string
- Skipping autoscaling operations: Return early from methods that would otherwise try to manage these nodes
- Graceful handling: Return appropriate responses (nil, ErrNotImplemented) instead of errors


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
"NONE"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
