### PR TITLE
deps(hetzner): update vendored hcloud-go to v2.21.1

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/action_watch.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/action_watch.go
@@ -21,7 +21,7 @@ import (
 // timeout, use the [context.Context]. Once the method has stopped watching,
 // both returned channels are closed.
 //
-// WatchOverallProgress uses the [WithPollBackoffFunc] of the [Client] to wait
+// WatchOverallProgress uses the [WithPollOpts] of the [Client] to wait
 // until sending the next request.
 //
 // Deprecated: WatchOverallProgress is deprecated, use [WaitForFunc] instead.
@@ -86,7 +86,7 @@ func (c *ActionClient) WatchOverallProgress(ctx context.Context, actions []*Acti
 // timeout, use the [context.Context]. Once the method has stopped watching,
 // both returned channels are closed.
 //
-// WatchProgress uses the [WithPollBackoffFunc] of the [Client] to wait until
+// WatchProgress uses the [WithPollOpts] of the [Client] to wait until
 // sending the next request.
 //
 // Deprecated: WatchProgress is deprecated, use [WaitForFunc] instead.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/certificate.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/certificate.go
@@ -1,15 +1,12 @@
 package hcloud
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/ctxutil"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema"
 )
 
@@ -98,41 +95,32 @@ type CertificateClient struct {
 
 // GetByID retrieves a Certificate by its ID. If the Certificate does not exist, nil is returned.
 func (c *CertificateClient) GetByID(ctx context.Context, id int64) (*Certificate, *Response, error) {
-	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/certificates/%d", id), nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	const opPath = "/certificates/%d"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	var body schema.CertificateGetResponse
-	resp, err := c.client.Do(req, &body)
+	reqPath := fmt.Sprintf(opPath, id)
+
+	respBody, resp, err := getRequest[schema.CertificateGetResponse](ctx, c.client, reqPath)
 	if err != nil {
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
-	return CertificateFromSchema(body.Certificate), resp, nil
+	return CertificateFromSchema(respBody.Certificate), resp, nil
 }
 
 // GetByName retrieves a Certificate by its name. If the Certificate does not exist, nil is returned.
 func (c *CertificateClient) GetByName(ctx context.Context, name string) (*Certificate, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	Certificate, response, err := c.List(ctx, CertificateListOpts{Name: name})
-	if len(Certificate) == 0 {
-		return nil, response, err
-	}
-	return Certificate[0], response, err
+	return firstByName(name, func() ([]*Certificate, *Response, error) {
+		return c.List(ctx, CertificateListOpts{Name: name})
+	})
 }
 
 // Get retrieves a Certificate by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Certificate by its name. If the Certificate does not exist, nil is returned.
 func (c *CertificateClient) Get(ctx context.Context, idOrName string) (*Certificate, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		return c.GetByID(ctx, id)
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // CertificateListOpts specifies options for listing Certificates.
@@ -158,22 +146,17 @@ func (l CertificateListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *CertificateClient) List(ctx context.Context, opts CertificateListOpts) ([]*Certificate, *Response, error) {
-	path := "/certificates?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
+	const opPath = "/certificates?%s"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+
+	respBody, resp, err := getRequest[schema.CertificateListResponse](ctx, c.client, reqPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 
-	var body schema.CertificateListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-	Certificates := make([]*Certificate, 0, len(body.Certificates))
-	for _, s := range body.Certificates {
-		Certificates = append(Certificates, CertificateFromSchema(s))
-	}
-	return Certificates, resp, nil
+	return allFromSchemaFunc(respBody.Certificates, CertificateFromSchema), resp, nil
 }
 
 // All returns all Certificates.
@@ -183,22 +166,10 @@ func (c *CertificateClient) All(ctx context.Context) ([]*Certificate, error) {
 
 // AllWithOpts returns all Certificates for the given options.
 func (c *CertificateClient) AllWithOpts(ctx context.Context, opts CertificateListOpts) ([]*Certificate, error) {
-	allCertificates := []*Certificate{}
-
-	err := c.client.all(func(page int) (*Response, error) {
+	return iterPages(func(page int) ([]*Certificate, *Response, error) {
 		opts.Page = page
-		Certificates, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allCertificates = append(allCertificates, Certificates...)
-		return resp, nil
+		return c.List(ctx, opts)
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allCertificates, nil
 }
 
 // CertificateCreateOpts specifies options for creating a new Certificate.
@@ -214,7 +185,7 @@ type CertificateCreateOpts struct {
 // Validate checks if options are valid.
 func (o CertificateCreateOpts) Validate() error {
 	if o.Name == "" {
-		return errors.New("missing name")
+		return missingField(o, "Name")
 	}
 	switch o.Type {
 	case "", CertificateTypeUploaded:
@@ -222,23 +193,23 @@ func (o CertificateCreateOpts) Validate() error {
 	case CertificateTypeManaged:
 		return o.validateManaged()
 	default:
-		return fmt.Errorf("invalid type: %s", o.Type)
+		return invalidFieldValue(o, "Type", o.Type)
 	}
 }
 
 func (o CertificateCreateOpts) validateManaged() error {
 	if len(o.DomainNames) == 0 {
-		return errors.New("no domain names")
+		return missingField(o, "DomainNames")
 	}
 	return nil
 }
 
 func (o CertificateCreateOpts) validateUploaded() error {
 	if o.Certificate == "" {
-		return errors.New("missing certificate")
+		return missingField(o, "Certificate")
 	}
 	if o.PrivateKey == "" {
-		return errors.New("missing private key")
+		return missingField(o, "PrivateKey")
 	}
 	return nil
 }
@@ -249,7 +220,7 @@ func (o CertificateCreateOpts) validateUploaded() error {
 // CreateCertificate to create such certificates.
 func (c *CertificateClient) Create(ctx context.Context, opts CertificateCreateOpts) (*Certificate, *Response, error) {
 	if !(opts.Type == "" || opts.Type == CertificateTypeUploaded) {
-		return nil, nil, fmt.Errorf("invalid certificate type: %s", opts.Type)
+		return nil, nil, invalidFieldValue(opts, "Type", opts.Type)
 	}
 	result, resp, err := c.CreateCertificate(ctx, opts)
 	if err != nil {
@@ -262,16 +233,20 @@ func (c *CertificateClient) Create(ctx context.Context, opts CertificateCreateOp
 func (c *CertificateClient) CreateCertificate(
 	ctx context.Context, opts CertificateCreateOpts,
 ) (CertificateCreateResult, *Response, error) {
-	var (
-		action  *Action
-		reqBody schema.CertificateCreateRequest
-	)
+	const opPath = "/certificates"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := opPath
+
+	result := CertificateCreateResult{}
 
 	if err := opts.Validate(); err != nil {
-		return CertificateCreateResult{}, nil, err
+		return result, nil, err
 	}
 
-	reqBody.Name = opts.Name
+	reqBody := schema.CertificateCreateRequest{
+		Name: opts.Name,
+	}
 
 	switch opts.Type {
 	case "", CertificateTypeUploaded:
@@ -282,32 +257,24 @@ func (c *CertificateClient) CreateCertificate(
 		reqBody.Type = string(CertificateTypeManaged)
 		reqBody.DomainNames = opts.DomainNames
 	default:
-		return CertificateCreateResult{}, nil, fmt.Errorf("invalid certificate type: %v", opts.Type)
+		return result, nil, invalidFieldValue(opts, "Type", opts.Type)
 	}
 
 	if opts.Labels != nil {
 		reqBody.Labels = &opts.Labels
 	}
-	reqBodyData, err := json.Marshal(reqBody)
+
+	respBody, resp, err := postRequest[schema.CertificateCreateResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
-		return CertificateCreateResult{}, nil, err
-	}
-	req, err := c.client.NewRequest(ctx, "POST", "/certificates", bytes.NewReader(reqBodyData))
-	if err != nil {
-		return CertificateCreateResult{}, nil, err
+		return result, resp, err
 	}
 
-	respBody := schema.CertificateCreateResponse{}
-	resp, err := c.client.Do(req, &respBody)
-	if err != nil {
-		return CertificateCreateResult{}, resp, err
-	}
-	cert := CertificateFromSchema(respBody.Certificate)
+	result.Certificate = CertificateFromSchema(respBody.Certificate)
 	if respBody.Action != nil {
-		action = ActionFromSchema(*respBody.Action)
+		result.Action = ActionFromSchema(*respBody.Action)
 	}
 
-	return CertificateCreateResult{Certificate: cert, Action: action}, resp, nil
+	return result, resp, nil
 }
 
 // CertificateUpdateOpts specifies options for updating a Certificate.
@@ -318,6 +285,11 @@ type CertificateUpdateOpts struct {
 
 // Update updates a Certificate.
 func (c *CertificateClient) Update(ctx context.Context, certificate *Certificate, opts CertificateUpdateOpts) (*Certificate, *Response, error) {
+	const opPath = "/certificates/%d"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, certificate.ID)
+
 	reqBody := schema.CertificateUpdateRequest{}
 	if opts.Name != "" {
 		reqBody.Name = &opts.Name
@@ -325,46 +297,36 @@ func (c *CertificateClient) Update(ctx context.Context, certificate *Certificate
 	if opts.Labels != nil {
 		reqBody.Labels = &opts.Labels
 	}
-	reqBodyData, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	path := fmt.Sprintf("/certificates/%d", certificate.ID)
-	req, err := c.client.NewRequest(ctx, "PUT", path, bytes.NewReader(reqBodyData))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	respBody := schema.CertificateUpdateResponse{}
-	resp, err := c.client.Do(req, &respBody)
+	respBody, resp, err := putRequest[schema.CertificateUpdateResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return CertificateFromSchema(respBody.Certificate), resp, nil
 }
 
 // Delete deletes a certificate.
 func (c *CertificateClient) Delete(ctx context.Context, certificate *Certificate) (*Response, error) {
-	req, err := c.client.NewRequest(ctx, "DELETE", fmt.Sprintf("/certificates/%d", certificate.ID), nil)
-	if err != nil {
-		return nil, err
-	}
-	return c.client.Do(req, nil)
+	const opPath = "/certificates/%d"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, certificate.ID)
+
+	return deleteRequestNoResult(ctx, c.client, reqPath)
 }
 
 // RetryIssuance retries the issuance of a failed managed certificate.
 func (c *CertificateClient) RetryIssuance(ctx context.Context, certificate *Certificate) (*Action, *Response, error) {
-	var respBody schema.CertificateIssuanceRetryResponse
+	const opPath = "/certificates/%d/actions/retry"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	req, err := c.client.NewRequest(ctx, "POST", fmt.Sprintf("/certificates/%d/actions/retry", certificate.ID), nil)
+	reqPath := fmt.Sprintf(opPath, certificate.ID)
+
+	respBody, resp, err := postRequest[schema.CertificateIssuanceRetryResponse](ctx, c.client, reqPath, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
-	resp, err := c.client.Do(req, &respBody)
-	if err != nil {
-		return nil, nil, err
-	}
-	action := ActionFromSchema(respBody.Action)
-	return action, resp, nil
+
+	return ActionFromSchema(respBody.Action), resp, nil
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client.go
@@ -3,13 +3,12 @@ package hcloud
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math"
+	"math/rand"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strconv"
 	"strings"
@@ -19,7 +18,6 @@ import (
 	"golang.org/x/net/http/httpguts"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/internal/instrumentation"
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema"
 )
 
 // Endpoint is the base URL of the API.
@@ -43,13 +41,43 @@ func ConstantBackoff(d time.Duration) BackoffFunc {
 }
 
 // ExponentialBackoff returns a BackoffFunc which implements an exponential
-// backoff.
-// It uses the formula:
+// backoff, truncated to 60 seconds.
+// See [ExponentialBackoffWithOpts] for more details.
+func ExponentialBackoff(multiplier float64, base time.Duration) BackoffFunc {
+	return ExponentialBackoffWithOpts(ExponentialBackoffOpts{
+		Base:       base,
+		Multiplier: multiplier,
+		Cap:        time.Minute,
+	})
+}
+
+// ExponentialBackoffOpts defines the options used by [ExponentialBackoffWithOpts].
+type ExponentialBackoffOpts struct {
+	Base       time.Duration
+	Multiplier float64
+	Cap        time.Duration
+	Jitter     bool
+}
+
+// ExponentialBackoffWithOpts returns a BackoffFunc which implements an exponential
+// backoff, truncated to a maximum, and an optional full jitter.
 //
-//	b^retries * d
-func ExponentialBackoff(b float64, d time.Duration) BackoffFunc {
+// See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+func ExponentialBackoffWithOpts(opts ExponentialBackoffOpts) BackoffFunc {
+	baseSeconds := opts.Base.Seconds()
+	capSeconds := opts.Cap.Seconds()
+
 	return func(retries int) time.Duration {
-		return time.Duration(math.Pow(b, float64(retries))) * d
+		// Exponential backoff
+		backoff := baseSeconds * math.Pow(opts.Multiplier, float64(retries))
+		// Cap backoff
+		backoff = math.Min(capSeconds, backoff)
+		// Add jitter
+		if opts.Jitter {
+			backoff = ((backoff - baseSeconds) * rand.Float64()) + baseSeconds // #nosec G404
+		}
+
+		return time.Duration(backoff * float64(time.Second))
 	}
 }
 
@@ -58,7 +86,8 @@ type Client struct {
 	endpoint                string
 	token                   string
 	tokenValid              bool
-	backoffFunc             BackoffFunc
+	retryBackoffFunc        BackoffFunc
+	retryMaxRetries         int
 	pollBackoffFunc         BackoffFunc
 	httpClient              *http.Client
 	applicationName         string
@@ -66,6 +95,7 @@ type Client struct {
 	userAgent               string
 	debugWriter             io.Writer
 	instrumentationRegistry prometheus.Registerer
+	handler                 handler
 
 	Action           ActionClient
 	Certificate      CertificateClient
@@ -110,30 +140,73 @@ func WithToken(token string) ClientOption {
 // polling from the API.
 //
 // Deprecated: Setting the poll interval is deprecated, you can now configure
-// [WithPollBackoffFunc] with a [ConstantBackoff] to get the same results. To
+// [WithPollOpts] with a [ConstantBackoff] to get the same results. To
 // migrate your code, replace your usage like this:
 //
 //	// before
 //	hcloud.WithPollInterval(2 * time.Second)
 //	// now
-//	hcloud.WithPollBackoffFunc(hcloud.ConstantBackoff(2 * time.Second))
+//	hcloud.WithPollOpts(hcloud.PollOpts{
+//		BackoffFunc: hcloud.ConstantBackoff(2 * time.Second),
+//	})
 func WithPollInterval(pollInterval time.Duration) ClientOption {
-	return WithPollBackoffFunc(ConstantBackoff(pollInterval))
+	return WithPollOpts(PollOpts{
+		BackoffFunc: ConstantBackoff(pollInterval),
+	})
 }
 
 // WithPollBackoffFunc configures a Client to use the specified backoff
 // function when polling from the API.
+//
+// Deprecated: WithPollBackoffFunc is deprecated, use [WithPollOpts] instead.
 func WithPollBackoffFunc(f BackoffFunc) ClientOption {
+	return WithPollOpts(PollOpts{
+		BackoffFunc: f,
+	})
+}
+
+// PollOpts defines the options used by [WithPollOpts].
+type PollOpts struct {
+	BackoffFunc BackoffFunc
+}
+
+// WithPollOpts configures a Client to use the specified options when polling from the API.
+//
+// If [PollOpts.BackoffFunc] is nil, the existing backoff function will be preserved.
+func WithPollOpts(opts PollOpts) ClientOption {
 	return func(client *Client) {
-		client.pollBackoffFunc = f
+		if opts.BackoffFunc != nil {
+			client.pollBackoffFunc = opts.BackoffFunc
+		}
 	}
 }
 
 // WithBackoffFunc configures a Client to use the specified backoff function.
 // The backoff function is used for retrying HTTP requests.
+//
+// Deprecated: WithBackoffFunc is deprecated, use [WithRetryOpts] instead.
 func WithBackoffFunc(f BackoffFunc) ClientOption {
 	return func(client *Client) {
-		client.backoffFunc = f
+		client.retryBackoffFunc = f
+	}
+}
+
+// RetryOpts defines the options used by [WithRetryOpts].
+type RetryOpts struct {
+	BackoffFunc BackoffFunc
+	MaxRetries  int
+}
+
+// WithRetryOpts configures a Client to use the specified options when retrying API
+// requests.
+//
+// If [RetryOpts.BackoffFunc] is nil, the existing backoff function will be preserved.
+func WithRetryOpts(opts RetryOpts) ClientOption {
+	return func(client *Client) {
+		if opts.BackoffFunc != nil {
+			client.retryBackoffFunc = opts.BackoffFunc
+		}
+		client.retryMaxRetries = opts.MaxRetries
 	}
 }
 
@@ -172,10 +245,18 @@ func WithInstrumentation(registry prometheus.Registerer) ClientOption {
 // NewClient creates a new client.
 func NewClient(options ...ClientOption) *Client {
 	client := &Client{
-		endpoint:        Endpoint,
-		tokenValid:      true,
-		httpClient:      &http.Client{},
-		backoffFunc:     ExponentialBackoff(2, 500*time.Millisecond),
+		endpoint:   Endpoint,
+		tokenValid: true,
+		httpClient: &http.Client{},
+
+		retryBackoffFunc: ExponentialBackoffWithOpts(ExponentialBackoffOpts{
+			Base:       time.Second,
+			Multiplier: 2,
+			Cap:        time.Minute,
+			Jitter:     true,
+		}),
+		retryMaxRetries: 5,
+
 		pollBackoffFunc: ConstantBackoff(500 * time.Millisecond),
 	}
 
@@ -186,8 +267,10 @@ func NewClient(options ...ClientOption) *Client {
 	client.buildUserAgent()
 	if client.instrumentationRegistry != nil {
 		i := instrumentation.New("api", client.instrumentationRegistry)
-		client.httpClient.Transport = i.InstrumentedRoundTripper()
+		client.httpClient.Transport = i.InstrumentedRoundTripper(client.httpClient.Transport)
 	}
+
+	client.handler = assembleHandlerChain(client)
 
 	client.Action = ActionClient{action: &ResourceActionClient{client: client}}
 	client.Datacenter = DatacenterClient{client: client}
@@ -238,97 +321,8 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body io.Re
 // Do performs an HTTP request against the API.
 // v can be nil, an io.Writer to write the response body to or a pointer to
 // a struct to json.Unmarshal the response to.
-func (c *Client) Do(r *http.Request, v interface{}) (*Response, error) {
-	var retries int
-	var body []byte
-	var err error
-	if r.ContentLength > 0 {
-		body, err = io.ReadAll(r.Body)
-		if err != nil {
-			r.Body.Close()
-			return nil, err
-		}
-		r.Body.Close()
-	}
-	for {
-		if r.ContentLength > 0 {
-			r.Body = io.NopCloser(bytes.NewReader(body))
-		}
-
-		if c.debugWriter != nil {
-			dumpReq, err := dumpRequest(r)
-			if err != nil {
-				return nil, err
-			}
-			fmt.Fprintf(c.debugWriter, "--- Request:\n%s\n\n", dumpReq)
-		}
-
-		resp, err := c.httpClient.Do(r)
-		if err != nil {
-			return nil, err
-		}
-		response := &Response{Response: resp}
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			resp.Body.Close()
-			return response, err
-		}
-		resp.Body.Close()
-		resp.Body = io.NopCloser(bytes.NewReader(body))
-
-		if c.debugWriter != nil {
-			dumpResp, err := httputil.DumpResponse(resp, true)
-			if err != nil {
-				return nil, err
-			}
-			fmt.Fprintf(c.debugWriter, "--- Response:\n%s\n\n", dumpResp)
-		}
-
-		if err = response.readMeta(body); err != nil {
-			return response, fmt.Errorf("hcloud: error reading response meta data: %s", err)
-		}
-
-		if response.StatusCode >= 400 && response.StatusCode <= 599 {
-			err = errorFromResponse(response, body)
-			if err == nil {
-				err = fmt.Errorf("hcloud: server responded with status code %d", resp.StatusCode)
-			} else if IsError(err, ErrorCodeConflict) {
-				c.backoff(retries)
-				retries++
-				continue
-			}
-			return response, err
-		}
-		if v != nil {
-			if w, ok := v.(io.Writer); ok {
-				_, err = io.Copy(w, bytes.NewReader(body))
-			} else {
-				err = json.Unmarshal(body, v)
-			}
-		}
-
-		return response, err
-	}
-}
-
-func (c *Client) backoff(retries int) {
-	time.Sleep(c.backoffFunc(retries))
-}
-
-func (c *Client) all(f func(int) (*Response, error)) error {
-	var (
-		page = 1
-	)
-	for {
-		resp, err := f(page)
-		if err != nil {
-			return err
-		}
-		if resp.Meta.Pagination == nil || resp.Meta.Pagination.NextPage == 0 {
-			return nil
-		}
-		page = resp.Meta.Pagination.NextPage
-	}
+func (c *Client) Do(req *http.Request, v any) (*Response, error) {
+	return c.handler.Do(req, v)
 }
 
 func (c *Client) buildUserAgent() {
@@ -342,43 +336,6 @@ func (c *Client) buildUserAgent() {
 	}
 }
 
-func dumpRequest(r *http.Request) ([]byte, error) {
-	// Duplicate the request, so we can redact the auth header
-	rDuplicate := r.Clone(context.Background())
-	rDuplicate.Header.Set("Authorization", "REDACTED")
-
-	// To get the request body we need to read it before the request was actually sent.
-	// See https://github.com/golang/go/issues/29792
-	dumpReq, err := httputil.DumpRequestOut(rDuplicate, true)
-	if err != nil {
-		return nil, err
-	}
-
-	// Set original request body to the duplicate created by DumpRequestOut. The request body is not duplicated
-	// by .Clone() and instead just referenced, so it would be completely read otherwise.
-	r.Body = rDuplicate.Body
-
-	return dumpReq, nil
-}
-
-func errorFromResponse(resp *Response, body []byte) error {
-	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
-		return nil
-	}
-
-	var respBody schema.ErrorResponse
-	if err := json.Unmarshal(body, &respBody); err != nil {
-		return nil
-	}
-	if respBody.Error.Code == "" && respBody.Error.Message == "" {
-		return nil
-	}
-
-	hcErr := ErrorFromSchema(respBody.Error)
-	hcErr.response = resp
-	return hcErr
-}
-
 const (
 	headerCorrelationID = "X-Correlation-Id"
 )
@@ -387,33 +344,32 @@ const (
 type Response struct {
 	*http.Response
 	Meta Meta
+
+	// body holds a copy of the http.Response body that must be used within the handler
+	// chain. The http.Response.Body is reserved for external users.
+	body []byte
 }
 
-func (r *Response) readMeta(body []byte) error {
-	if h := r.Header.Get("RateLimit-Limit"); h != "" {
-		r.Meta.Ratelimit.Limit, _ = strconv.Atoi(h)
+// populateBody copies the original [http.Response] body into the internal [Response] body
+// property, and restore the original [http.Response] body as if it was untouched.
+func (r *Response) populateBody() error {
+	// Read full response body and save it for later use
+	body, err := io.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		return err
 	}
-	if h := r.Header.Get("RateLimit-Remaining"); h != "" {
-		r.Meta.Ratelimit.Remaining, _ = strconv.Atoi(h)
-	}
-	if h := r.Header.Get("RateLimit-Reset"); h != "" {
-		if ts, err := strconv.ParseInt(h, 10, 64); err == nil {
-			r.Meta.Ratelimit.Reset = time.Unix(ts, 0)
-		}
-	}
+	r.body = body
 
-	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
-		var s schema.MetaResponse
-		if err := json.Unmarshal(body, &s); err != nil {
-			return err
-		}
-		if s.Meta.Pagination != nil {
-			p := PaginationFromSchema(*s.Meta.Pagination)
-			r.Meta.Pagination = &p
-		}
-	}
+	// Restore the body as if it was untouched, as it might be read by external users
+	r.Body = io.NopCloser(bytes.NewReader(body))
 
 	return nil
+}
+
+// hasJSONBody returns whether the response has a JSON body.
+func (r *Response) hasJSONBody() bool {
+	return len(r.body) > 0 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/json")
 }
 
 // internalCorrelationID returns the unique ID of the request as set by the API. This ID can help with support requests,

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_generic.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_generic.go
@@ -1,0 +1,101 @@
+package hcloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+)
+
+func getRequest[Schema any](ctx context.Context, client *Client, url string) (Schema, *Response, error) {
+	var respBody Schema
+
+	req, err := client.NewRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return respBody, nil, err
+	}
+
+	resp, err := client.Do(req, &respBody)
+	if err != nil {
+		return respBody, resp, err
+	}
+
+	return respBody, resp, nil
+}
+
+func postRequest[Schema any](ctx context.Context, client *Client, url string, reqBody any) (Schema, *Response, error) {
+	var respBody Schema
+
+	var reqBodyReader io.Reader
+	if reqBody != nil {
+		reqBodyBytes, err := json.Marshal(reqBody)
+		if err != nil {
+			return respBody, nil, err
+		}
+
+		reqBodyReader = bytes.NewReader(reqBodyBytes)
+	}
+
+	req, err := client.NewRequest(ctx, "POST", url, reqBodyReader)
+	if err != nil {
+		return respBody, nil, err
+	}
+
+	resp, err := client.Do(req, &respBody)
+	if err != nil {
+		return respBody, resp, err
+	}
+
+	return respBody, resp, nil
+}
+
+func putRequest[Schema any](ctx context.Context, client *Client, url string, reqBody any) (Schema, *Response, error) {
+	var respBody Schema
+
+	var reqBodyReader io.Reader
+	if reqBody != nil {
+		reqBodyBytes, err := json.Marshal(reqBody)
+		if err != nil {
+			return respBody, nil, err
+		}
+
+		reqBodyReader = bytes.NewReader(reqBodyBytes)
+	}
+
+	req, err := client.NewRequest(ctx, "PUT", url, reqBodyReader)
+	if err != nil {
+		return respBody, nil, err
+	}
+
+	resp, err := client.Do(req, &respBody)
+	if err != nil {
+		return respBody, resp, err
+	}
+
+	return respBody, resp, nil
+}
+
+func deleteRequest[Schema any](ctx context.Context, client *Client, url string) (Schema, *Response, error) {
+	var respBody Schema
+
+	req, err := client.NewRequest(ctx, "DELETE", url, nil)
+	if err != nil {
+		return respBody, nil, err
+	}
+
+	resp, err := client.Do(req, &respBody)
+	if err != nil {
+		return respBody, resp, err
+	}
+
+	return respBody, resp, nil
+}
+
+func deleteRequestNoResult(ctx context.Context, client *Client, url string) (*Response, error) {
+	req, err := client.NewRequest(ctx, "DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.Do(req, nil)
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler.go
@@ -1,0 +1,56 @@
+package hcloud
+
+import (
+	"context"
+	"net/http"
+)
+
+// handler is an interface representing a client request transaction. The handler are
+// meant to be chained, similarly to the [http.RoundTripper] interface.
+//
+// The handler chain is placed between the [Client] API operations and the
+// [http.Client].
+type handler interface {
+	Do(req *http.Request, v any) (resp *Response, err error)
+}
+
+// assembleHandlerChain assembles the chain of handlers used to make API requests.
+//
+// The order of the handlers is important.
+func assembleHandlerChain(client *Client) handler {
+	// Start down the chain: sending the http request
+	h := newHTTPHandler(client.httpClient)
+
+	// Insert debug writer if enabled
+	if client.debugWriter != nil {
+		h = wrapDebugHandler(h, client.debugWriter)
+	}
+
+	// Read rate limit headers
+	h = wrapRateLimitHandler(h)
+
+	// Build error from response
+	h = wrapErrorHandler(h)
+
+	// Retry request if condition are met
+	h = wrapRetryHandler(h, client.retryBackoffFunc, client.retryMaxRetries)
+
+	// Finally parse the response body into the provided schema
+	h = wrapParseHandler(h)
+
+	return h
+}
+
+// cloneRequest clones both the request and the request body.
+func cloneRequest(req *http.Request, ctx context.Context) (cloned *http.Request, err error) { //revive:disable:context-as-argument
+	cloned = req.Clone(ctx)
+
+	if req.ContentLength > 0 {
+		cloned.Body, err = req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return cloned, nil
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_debug.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_debug.go
@@ -1,0 +1,50 @@
+package hcloud
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+)
+
+func wrapDebugHandler(wrapped handler, output io.Writer) handler {
+	return &debugHandler{wrapped, output}
+}
+
+type debugHandler struct {
+	handler handler
+	output  io.Writer
+}
+
+func (h *debugHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	// Clone the request, so we can redact the auth header, read the body
+	// and use a new context.
+	cloned, err := cloneRequest(req, context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	cloned.Header.Set("Authorization", "REDACTED")
+
+	dumpReq, err := httputil.DumpRequestOut(cloned, true)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Fprintf(h.output, "--- Request:\n%s\n\n", dumpReq)
+
+	resp, err = h.handler.Do(req, v)
+	if err != nil {
+		return resp, err
+	}
+
+	dumpResp, err := httputil.DumpResponse(resp.Response, true)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Fprintf(h.output, "--- Response:\n%s\n\n", dumpResp)
+
+	return resp, err
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_error.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_error.go
@@ -1,0 +1,53 @@
+package hcloud
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema"
+)
+
+var ErrStatusCode = errors.New("server responded with status code")
+
+func wrapErrorHandler(wrapped handler) handler {
+	return &errorHandler{wrapped}
+}
+
+type errorHandler struct {
+	handler handler
+}
+
+func (h *errorHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	resp, err = h.handler.Do(req, v)
+	if err != nil {
+		return resp, err
+	}
+
+	if resp.StatusCode >= 400 && resp.StatusCode <= 599 {
+		err = errorFromBody(resp)
+		if err == nil {
+			err = fmt.Errorf("hcloud: %w %d", ErrStatusCode, resp.StatusCode)
+		}
+	}
+	return resp, err
+}
+
+func errorFromBody(resp *Response) error {
+	if !resp.hasJSONBody() {
+		return nil
+	}
+
+	var s schema.ErrorResponse
+	if err := json.Unmarshal(resp.body, &s); err != nil {
+		return nil // nolint: nilerr
+	}
+	if s.Error.Code == "" && s.Error.Message == "" {
+		return nil
+	}
+
+	hcErr := ErrorFromSchema(s.Error)
+	hcErr.response = resp
+	return hcErr
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_http.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_http.go
@@ -1,0 +1,28 @@
+package hcloud
+
+import (
+	"net/http"
+)
+
+func newHTTPHandler(httpClient *http.Client) handler {
+	return &httpHandler{httpClient}
+}
+
+type httpHandler struct {
+	httpClient *http.Client
+}
+
+func (h *httpHandler) Do(req *http.Request, _ interface{}) (*Response, error) {
+	httpResponse, err := h.httpClient.Do(req) //nolint: bodyclose
+	resp := &Response{Response: httpResponse}
+	if err != nil {
+		return resp, err
+	}
+
+	err = resp.populateBody()
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_parse.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_parse.go
@@ -1,0 +1,50 @@
+package hcloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema"
+)
+
+func wrapParseHandler(wrapped handler) handler {
+	return &parseHandler{wrapped}
+}
+
+type parseHandler struct {
+	handler handler
+}
+
+func (h *parseHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	// respBody is not needed down the handler chain
+	resp, err = h.handler.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	if resp.hasJSONBody() {
+		// Parse the response meta
+		var s schema.MetaResponse
+		if err := json.Unmarshal(resp.body, &s); err != nil {
+			return resp, fmt.Errorf("hcloud: error reading response meta data: %w", err)
+		}
+		if s.Meta.Pagination != nil {
+			p := PaginationFromSchema(*s.Meta.Pagination)
+			resp.Meta.Pagination = &p
+		}
+	}
+
+	// Parse the response schema
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			_, err = io.Copy(w, bytes.NewReader(resp.body))
+		} else {
+			err = json.Unmarshal(resp.body, v)
+		}
+	}
+
+	return resp, err
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_rate_limit.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_rate_limit.go
@@ -1,0 +1,36 @@
+package hcloud
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+func wrapRateLimitHandler(wrapped handler) handler {
+	return &rateLimitHandler{wrapped}
+}
+
+type rateLimitHandler struct {
+	handler handler
+}
+
+func (h *rateLimitHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	resp, err = h.handler.Do(req, v)
+
+	// Ensure the embedded [*http.Response] is not nil, e.g. on canceled context
+	if resp != nil && resp.Response != nil && resp.Response.Header != nil {
+		if h := resp.Header.Get("RateLimit-Limit"); h != "" {
+			resp.Meta.Ratelimit.Limit, _ = strconv.Atoi(h)
+		}
+		if h := resp.Header.Get("RateLimit-Remaining"); h != "" {
+			resp.Meta.Ratelimit.Remaining, _ = strconv.Atoi(h)
+		}
+		if h := resp.Header.Get("RateLimit-Reset"); h != "" {
+			if ts, err := strconv.ParseInt(h, 10, 64); err == nil {
+				resp.Meta.Ratelimit.Reset = time.Unix(ts, 0)
+			}
+		}
+	}
+
+	return resp, err
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_retry.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_handler_retry.go
@@ -1,0 +1,84 @@
+package hcloud
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"time"
+)
+
+func wrapRetryHandler(wrapped handler, backoffFunc BackoffFunc, maxRetries int) handler {
+	return &retryHandler{wrapped, backoffFunc, maxRetries}
+}
+
+type retryHandler struct {
+	handler     handler
+	backoffFunc BackoffFunc
+	maxRetries  int
+}
+
+func (h *retryHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	retries := 0
+	ctx := req.Context()
+
+	for {
+		// Clone the request using the original context
+		cloned, err := cloneRequest(req, ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err = h.handler.Do(cloned, v)
+		if err != nil {
+			// Beware the diversity of the errors:
+			// - request preparation
+			// - network connectivity
+			// - http status code (see [errorHandler])
+			if ctx.Err() != nil {
+				// early return if the context was canceled or timed out
+				return resp, err
+			}
+
+			if retries < h.maxRetries && retryPolicy(resp, err) {
+				select {
+				case <-ctx.Done():
+					return resp, err
+				case <-time.After(h.backoffFunc(retries)):
+					retries++
+					continue
+				}
+			}
+		}
+
+		return resp, err
+	}
+}
+
+func retryPolicy(resp *Response, err error) bool {
+	if err != nil {
+		var apiErr Error
+		var netErr net.Error
+
+		switch {
+		case errors.As(err, &apiErr):
+			switch apiErr.Code { //nolint:exhaustive
+			case ErrorCodeConflict:
+				return true
+			case ErrorCodeRateLimitExceeded:
+				return true
+			}
+		case errors.Is(err, ErrStatusCode):
+			switch resp.Response.StatusCode {
+			// 5xx errors
+			case http.StatusBadGateway, http.StatusGatewayTimeout:
+				return true
+			}
+		case errors.As(err, &netErr):
+			if netErr.Timeout() {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_helper.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client_helper.go
@@ -1,0 +1,85 @@
+package hcloud
+
+import (
+	"context"
+	"strconv"
+)
+
+// allFromSchemaFunc transform each item in the list using the FromSchema function, and
+// returns the result.
+func allFromSchemaFunc[T, V any](all []T, fn func(T) V) []V {
+	result := make([]V, len(all))
+	for i, t := range all {
+		result[i] = fn(t)
+	}
+
+	return result
+}
+
+// iterPages fetches each pages using the list function, and returns the result.
+func iterPages[T any](listFn func(int) ([]*T, *Response, error)) ([]*T, error) {
+	page := 1
+	result := []*T{}
+
+	for {
+		pageResult, resp, err := listFn(page)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, pageResult...)
+
+		if resp.Meta.Pagination == nil || resp.Meta.Pagination.NextPage == 0 {
+			return result, nil
+		}
+		page = resp.Meta.Pagination.NextPage
+	}
+}
+
+// firstBy fetches a list of items using the list function, and returns the first item
+// of the list if present otherwise nil.
+func firstBy[T any](listFn func() ([]*T, *Response, error)) (*T, *Response, error) {
+	items, resp, err := listFn()
+	if len(items) == 0 {
+		return nil, resp, err
+	}
+
+	return items[0], resp, err
+}
+
+// firstByName is a wrapper around [firstBy], that checks if the provided name is not
+// empty.
+func firstByName[T any](name string, listFn func() ([]*T, *Response, error)) (*T, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
+
+	return firstBy(listFn)
+}
+
+// getByIDOrName fetches the resource by ID when the identifier is an integer, otherwise
+// by Name. To support resources that have a integer as Name, an additional attempt is
+// made to fetch the resource by Name using the ID.
+//
+// Since API managed resources (locations, server types, ...) do not have integers as
+// names, this function is only meaningful for user managed resources (ssh keys,
+// servers).
+func getByIDOrName[T any](
+	ctx context.Context,
+	getByIDFn func(ctx context.Context, id int64) (*T, *Response, error),
+	getByNameFn func(ctx context.Context, name string) (*T, *Response, error),
+	idOrName string,
+) (*T, *Response, error) {
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		result, resp, err := getByIDFn(ctx, id)
+		if err != nil {
+			return result, resp, err
+		}
+		if result != nil {
+			return result, resp, err
+		}
+		// Fallback to get by Name if the resource was not found
+	}
+
+	return getByNameFn(ctx, idOrName)
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/datacenter.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/datacenter.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/ctxutil"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema"
 )
 
@@ -32,32 +33,27 @@ type DatacenterClient struct {
 
 // GetByID retrieves a datacenter by its ID. If the datacenter does not exist, nil is returned.
 func (c *DatacenterClient) GetByID(ctx context.Context, id int64) (*Datacenter, *Response, error) {
-	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/datacenters/%d", id), nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	const opPath = "/datacenters/%d"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	var body schema.DatacenterGetResponse
-	resp, err := c.client.Do(req, &body)
+	reqPath := fmt.Sprintf(opPath, id)
+
+	respBody, resp, err := getRequest[schema.DatacenterGetResponse](ctx, c.client, reqPath)
 	if err != nil {
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
 		return nil, resp, err
 	}
-	return DatacenterFromSchema(body.Datacenter), resp, nil
+
+	return DatacenterFromSchema(respBody.Datacenter), resp, nil
 }
 
 // GetByName retrieves a datacenter by its name. If the datacenter does not exist, nil is returned.
 func (c *DatacenterClient) GetByName(ctx context.Context, name string) (*Datacenter, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	datacenters, response, err := c.List(ctx, DatacenterListOpts{Name: name})
-	if len(datacenters) == 0 {
-		return nil, response, err
-	}
-	return datacenters[0], response, err
+	return firstByName(name, func() ([]*Datacenter, *Response, error) {
+		return c.List(ctx, DatacenterListOpts{Name: name})
+	})
 }
 
 // Get retrieves a datacenter by its ID if the input can be parsed as an integer, otherwise it
@@ -92,22 +88,17 @@ func (l DatacenterListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *DatacenterClient) List(ctx context.Context, opts DatacenterListOpts) ([]*Datacenter, *Response, error) {
-	path := "/datacenters?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
+	const opPath = "/datacenters?%s"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+
+	respBody, resp, err := getRequest[schema.DatacenterListResponse](ctx, c.client, reqPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 
-	var body schema.DatacenterListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-	datacenters := make([]*Datacenter, 0, len(body.Datacenters))
-	for _, i := range body.Datacenters {
-		datacenters = append(datacenters, DatacenterFromSchema(i))
-	}
-	return datacenters, resp, nil
+	return allFromSchemaFunc(respBody.Datacenters, DatacenterFromSchema), resp, nil
 }
 
 // All returns all datacenters.
@@ -117,20 +108,8 @@ func (c *DatacenterClient) All(ctx context.Context) ([]*Datacenter, error) {
 
 // AllWithOpts returns all datacenters for the given options.
 func (c *DatacenterClient) AllWithOpts(ctx context.Context, opts DatacenterListOpts) ([]*Datacenter, error) {
-	allDatacenters := []*Datacenter{}
-
-	err := c.client.all(func(page int) (*Response, error) {
+	return iterPages(func(page int) ([]*Datacenter, *Response, error) {
 		opts.Page = page
-		datacenters, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allDatacenters = append(allDatacenters, datacenters...)
-		return resp, nil
+		return c.List(ctx, opts)
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allDatacenters, nil
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/actionutil/actions.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/actionutil/actions.go
@@ -1,0 +1,11 @@
+package actionutil
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud"
+
+// AppendNext return the action and the next actions in a new slice.
+func AppendNext(action *hcloud.Action, nextActions []*hcloud.Action) []*hcloud.Action {
+	all := make([]*hcloud.Action, 0, 1+len(nextActions))
+	all = append(all, action)
+	all = append(all, nextActions...)
+	return all
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/ctxutil/ctxutil.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/ctxutil/ctxutil.go
@@ -1,0 +1,30 @@
+package ctxutil
+
+import (
+	"context"
+	"strings"
+)
+
+// key is an unexported type to prevents collisions with keys defined in other packages.
+type key struct{}
+
+// opPathKey is the key for operation path in Contexts.
+var opPathKey = key{}
+
+// SetOpPath processes the operation path and save it in the context before returning it.
+func SetOpPath(ctx context.Context, path string) context.Context {
+	path, _, _ = strings.Cut(path, "?")
+	path = strings.ReplaceAll(path, "%d", "-")
+	path = strings.ReplaceAll(path, "%s", "-")
+
+	return context.WithValue(ctx, opPathKey, path)
+}
+
+// OpPath returns the operation path from the context.
+func OpPath(ctx context.Context) string {
+	result, ok := ctx.Value(opPathKey).(string)
+	if !ok {
+		return ""
+	}
+	return result
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/doc.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/doc.go
@@ -1,0 +1,4 @@
+// Package exp is a namespace that holds experimental features for the `hcloud-go` library.
+//
+// Breaking changes may occur without notice. Do not use in production!
+package exp

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/envutil/env.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/envutil/env.go
@@ -1,0 +1,40 @@
+package envutil
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// LookupEnvWithFile retrieves the value of the environment variable named by the key (e.g.
+// HCLOUD_TOKEN). If the previous environment variable is not set, it retrieves the
+// content of the file located by a second environment variable named by the key +
+// '_FILE' (.e.g HCLOUD_TOKEN_FILE).
+//
+// For both cases, the returned value may be empty.
+//
+// The value from the environment takes precedence over the value from the file.
+func LookupEnvWithFile(key string) (string, error) {
+	// Check if the value is set in the environment (e.g. HCLOUD_TOKEN)
+	value, ok := os.LookupEnv(key)
+	if ok {
+		return value, nil
+	}
+
+	key += "_FILE"
+
+	// Check if the value is set via a file (e.g. HCLOUD_TOKEN_FILE)
+	valueFile, ok := os.LookupEnv(key)
+	if !ok {
+		// Validation of the value happens outside of this function
+		return "", nil
+	}
+
+	// Read the content of the file
+	valueBytes, err := os.ReadFile(valueFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read %s: %w", key, err)
+	}
+
+	return strings.TrimSpace(string(valueBytes)), nil
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/randutil/id.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/randutil/id.go
@@ -1,0 +1,19 @@
+package randutil
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// GenerateID returns a hex encoded random string with a len of 8 chars similar to
+// "2873fce7".
+func GenerateID() string {
+	b := make([]byte, 4)
+	_, err := rand.Read(b)
+	if err != nil {
+		// Should never happen as of go1.24: https://github.com/golang/go/issues/66821
+		panic(fmt.Errorf("failed to generate random string: %w", err))
+	}
+	return hex.EncodeToString(b)
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/sshutil/ssh_key.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/sshutil/ssh_key.go
@@ -1,0 +1,86 @@
+package sshutil
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"encoding/pem"
+	"fmt"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// GenerateKeyPair generates a new ed25519 ssh key pair, and returns the private key and
+// the public key respectively.
+func GenerateKeyPair() ([]byte, []byte, error) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not generate key pair: %w", err)
+	}
+
+	privBytes, err := encodePrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not encode private key: %w", err)
+	}
+
+	pubBytes, err := encodePublicKey(pub)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not encode public key: %w", err)
+	}
+
+	return privBytes, pubBytes, nil
+}
+
+func encodePrivateKey(priv crypto.PrivateKey) ([]byte, error) {
+	privPem, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(privPem), nil
+}
+
+func encodePublicKey(pub crypto.PublicKey) ([]byte, error) {
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+
+	return ssh.MarshalAuthorizedKey(sshPub), nil
+}
+
+type privateKeyWithPublicKey interface {
+	crypto.PrivateKey
+	Public() crypto.PublicKey
+}
+
+// GeneratePublicKey generate a public key from the provided private key.
+func GeneratePublicKey(privBytes []byte) ([]byte, error) {
+	priv, err := ssh.ParseRawPrivateKey(privBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode private key: %w", err)
+	}
+
+	key, ok := priv.(privateKeyWithPublicKey)
+	if !ok {
+		return nil, fmt.Errorf("private key doesn't export Public() crypto.PublicKey")
+	}
+
+	pubBytes, err := encodePublicKey(key.Public())
+	if err != nil {
+		return nil, fmt.Errorf("could not encode public key: %w", err)
+	}
+
+	return pubBytes, nil
+}
+
+// GetPublicKeyFingerprint generate the finger print for the provided public key.
+func GetPublicKeyFingerprint(pubBytes []byte) (string, error) {
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(pubBytes)
+	if err != nil {
+		return "", fmt.Errorf("could not decode public key: %w", err)
+	}
+
+	fingerprint := ssh.FingerprintLegacyMD5(pub)
+
+	return fingerprint, nil
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/labelutil/selector.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/labelutil/selector.go
@@ -1,0 +1,24 @@
+package labelutil
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Selector combines the label set into a [label selector](https://docs.hetzner.cloud/#label-selector) that only selects
+// resources have all specified labels set.
+//
+// The selector string can be used to filter resources when listing, for example with [hcloud.ServerClient.AllWithOpts()].
+func Selector(labels map[string]string) string {
+	selectors := make([]string, 0, len(labels))
+
+	for k, v := range labels {
+		selectors = append(selectors, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	// Reproducible result for tests
+	sort.Strings(selectors)
+
+	return strings.Join(selectors, ",")
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/mockutil/http.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/mockutil/http.go
@@ -1,0 +1,123 @@
+package mockutil
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Request describes a http request that a [httptest.Server] should receive, and the
+// corresponding response to return.
+//
+// Additional checks on the request (e.g. request body) may be added using the
+// [Request.Want] function.
+//
+// The response body is populated from either a JSON struct, or a JSON string.
+type Request struct {
+	Method string
+	Path   string
+	Want   func(t *testing.T, r *http.Request)
+
+	Status  int
+	JSON    any
+	JSONRaw string
+}
+
+// Handler is using a [Server] to mock http requests provided by the user.
+func Handler(t *testing.T, requests []Request) http.HandlerFunc {
+	t.Helper()
+
+	server := NewServer(t, requests)
+	t.Cleanup(server.close)
+
+	return server.handler
+}
+
+// NewServer returns a new mock server that closes itself at the end of the test.
+func NewServer(t *testing.T, requests []Request) *Server {
+	t.Helper()
+
+	o := &Server{t: t}
+	o.Server = httptest.NewServer(http.HandlerFunc(o.handler))
+	t.Cleanup(o.close)
+
+	o.Expect(requests)
+
+	return o
+}
+
+// Server embeds a [httptest.Server] that answers HTTP calls with a list of expected [Request].
+//
+// Request matching is based on the request count, and the user provided request will be
+// iterated over.
+//
+// A Server must be created using the [NewServer] function.
+type Server struct {
+	*httptest.Server
+
+	t *testing.T
+
+	requests []Request
+	index    int
+}
+
+// Expect adds requests to the list of requests expected by the [Server].
+func (m *Server) Expect(requests []Request) {
+	m.requests = append(m.requests, requests...)
+}
+
+func (m *Server) close() {
+	m.t.Helper()
+
+	m.Server.Close()
+
+	assert.EqualValues(m.t, len(m.requests), m.index, "expected more calls")
+}
+
+func (m *Server) handler(w http.ResponseWriter, r *http.Request) {
+	if testing.Verbose() {
+		m.t.Logf("call %d: %s %s\n", m.index, r.Method, r.RequestURI)
+	}
+
+	if m.index >= len(m.requests) {
+		m.t.Fatalf("received unknown call %d", m.index)
+	}
+
+	expected := m.requests[m.index]
+
+	expectedCall := expected.Method
+	foundCall := r.Method
+	if expected.Path != "" {
+		expectedCall += " " + expected.Path
+		foundCall += " " + r.RequestURI
+	}
+	require.Equal(m.t, expectedCall, foundCall) // nolint: testifylint
+
+	if expected.Want != nil {
+		expected.Want(m.t, r)
+	}
+
+	switch {
+	case expected.JSON != nil:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(expected.Status)
+		if err := json.NewEncoder(w).Encode(expected.JSON); err != nil {
+			m.t.Fatal(err)
+		}
+	case expected.JSONRaw != "":
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(expected.Status)
+		_, err := w.Write([]byte(expected.JSONRaw))
+		if err != nil {
+			m.t.Fatal(err)
+		}
+	default:
+		w.WriteHeader(expected.Status)
+	}
+
+	m.index++
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/floating_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/floating_ip.go
@@ -1,16 +1,13 @@
 package hcloud
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/url"
-	"strconv"
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/ctxutil"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema"
 )
 
@@ -54,26 +51,21 @@ const (
 // changeDNSPtr changes or resets the reverse DNS pointer for an IP address.
 // Pass a nil ptr to reset the reverse DNS pointer to its default value.
 func (f *FloatingIP) changeDNSPtr(ctx context.Context, client *Client, ip net.IP, ptr *string) (*Action, *Response, error) {
+	const opPath = "/floating_ips/%d/actions/change_dns_ptr"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, f.ID)
+
 	reqBody := schema.FloatingIPActionChangeDNSPtrRequest{
 		IP:     ip.String(),
 		DNSPtr: ptr,
 	}
-	reqBodyData, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	path := fmt.Sprintf("/floating_ips/%d/actions/change_dns_ptr", f.ID)
-	req, err := client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	respBody := schema.FloatingIPActionChangeDNSPtrResponse{}
-	resp, err := client.Do(req, &respBody)
+	respBody, resp, err := postRequest[schema.FloatingIPActionChangeDNSPtrResponse](ctx, client, reqPath, reqBody)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return ActionFromSchema(respBody.Action), resp, nil
 }
 
@@ -97,41 +89,33 @@ type FloatingIPClient struct {
 // GetByID retrieves a Floating IP by its ID. If the Floating IP does not exist,
 // nil is returned.
 func (c *FloatingIPClient) GetByID(ctx context.Context, id int64) (*FloatingIP, *Response, error) {
-	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/floating_ips/%d", id), nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	const opPath = "/floating_ips/%d"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	var body schema.FloatingIPGetResponse
-	resp, err := c.client.Do(req, &body)
+	reqPath := fmt.Sprintf(opPath, id)
+
+	respBody, resp, err := getRequest[schema.FloatingIPGetResponse](ctx, c.client, reqPath)
 	if err != nil {
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
 		return nil, resp, err
 	}
-	return FloatingIPFromSchema(body.FloatingIP), resp, nil
+
+	return FloatingIPFromSchema(respBody.FloatingIP), resp, nil
 }
 
 // GetByName retrieves a Floating IP by its name. If the Floating IP does not exist, nil is returned.
 func (c *FloatingIPClient) GetByName(ctx context.Context, name string) (*FloatingIP, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	floatingIPs, response, err := c.List(ctx, FloatingIPListOpts{Name: name})
-	if len(floatingIPs) == 0 {
-		return nil, response, err
-	}
-	return floatingIPs[0], response, err
+	return firstByName(name, func() ([]*FloatingIP, *Response, error) {
+		return c.List(ctx, FloatingIPListOpts{Name: name})
+	})
 }
 
 // Get retrieves a Floating IP by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Floating IP by its name. If the Floating IP does not exist, nil is returned.
 func (c *FloatingIPClient) Get(ctx context.Context, idOrName string) (*FloatingIP, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		return c.GetByID(ctx, id)
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // FloatingIPListOpts specifies options for listing Floating IPs.
@@ -157,22 +141,17 @@ func (l FloatingIPListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *FloatingIPClient) List(ctx context.Context, opts FloatingIPListOpts) ([]*FloatingIP, *Response, error) {
-	path := "/floating_ips?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
+	const opPath = "/floating_ips?%s"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+
+	respBody, resp, err := getRequest[schema.FloatingIPListResponse](ctx, c.client, reqPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 
-	var body schema.FloatingIPListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-	floatingIPs := make([]*FloatingIP, 0, len(body.FloatingIPs))
-	for _, s := range body.FloatingIPs {
-		floatingIPs = append(floatingIPs, FloatingIPFromSchema(s))
-	}
-	return floatingIPs, resp, nil
+	return allFromSchemaFunc(respBody.FloatingIPs, FloatingIPFromSchema), resp, nil
 }
 
 // All returns all Floating IPs.
@@ -182,22 +161,10 @@ func (c *FloatingIPClient) All(ctx context.Context) ([]*FloatingIP, error) {
 
 // AllWithOpts returns all Floating IPs for the given options.
 func (c *FloatingIPClient) AllWithOpts(ctx context.Context, opts FloatingIPListOpts) ([]*FloatingIP, error) {
-	allFloatingIPs := []*FloatingIP{}
-
-	err := c.client.all(func(page int) (*Response, error) {
+	return iterPages(func(page int) ([]*FloatingIP, *Response, error) {
 		opts.Page = page
-		floatingIPs, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allFloatingIPs = append(allFloatingIPs, floatingIPs...)
-		return resp, nil
+		return c.List(ctx, opts)
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allFloatingIPs, nil
 }
 
 // FloatingIPCreateOpts specifies options for creating a Floating IP.
@@ -216,10 +183,10 @@ func (o FloatingIPCreateOpts) Validate() error {
 	case FloatingIPTypeIPv4, FloatingIPTypeIPv6:
 		break
 	default:
-		return errors.New("missing or invalid type")
+		return invalidFieldValue(o, "Type", o.Type)
 	}
 	if o.HomeLocation == nil && o.Server == nil {
-		return errors.New("one of home location or server is required")
+		return missingOneOfFields(o, "HomeLocation", "Server")
 	}
 	return nil
 }
@@ -232,8 +199,15 @@ type FloatingIPCreateResult struct {
 
 // Create creates a Floating IP.
 func (c *FloatingIPClient) Create(ctx context.Context, opts FloatingIPCreateOpts) (FloatingIPCreateResult, *Response, error) {
+	result := FloatingIPCreateResult{}
+
+	const opPath = "/floating_ips"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := opPath
+
 	if err := opts.Validate(); err != nil {
-		return FloatingIPCreateResult{}, nil, err
+		return result, nil, err
 	}
 
 	reqBody := schema.FloatingIPCreateRequest{
@@ -250,38 +224,28 @@ func (c *FloatingIPClient) Create(ctx context.Context, opts FloatingIPCreateOpts
 	if opts.Labels != nil {
 		reqBody.Labels = &opts.Labels
 	}
-	reqBodyData, err := json.Marshal(reqBody)
+
+	respBody, resp, err := postRequest[schema.FloatingIPCreateResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
-		return FloatingIPCreateResult{}, nil, err
+		return result, resp, err
 	}
 
-	req, err := c.client.NewRequest(ctx, "POST", "/floating_ips", bytes.NewReader(reqBodyData))
-	if err != nil {
-		return FloatingIPCreateResult{}, nil, err
-	}
-
-	var respBody schema.FloatingIPCreateResponse
-	resp, err := c.client.Do(req, &respBody)
-	if err != nil {
-		return FloatingIPCreateResult{}, resp, err
-	}
-	var action *Action
+	result.FloatingIP = FloatingIPFromSchema(respBody.FloatingIP)
 	if respBody.Action != nil {
-		action = ActionFromSchema(*respBody.Action)
+		result.Action = ActionFromSchema(*respBody.Action)
 	}
-	return FloatingIPCreateResult{
-		FloatingIP: FloatingIPFromSchema(respBody.FloatingIP),
-		Action:     action,
-	}, resp, nil
+
+	return result, resp, nil
 }
 
 // Delete deletes a Floating IP.
 func (c *FloatingIPClient) Delete(ctx context.Context, floatingIP *FloatingIP) (*Response, error) {
-	req, err := c.client.NewRequest(ctx, "DELETE", fmt.Sprintf("/floating_ips/%d", floatingIP.ID), nil)
-	if err != nil {
-		return nil, err
-	}
-	return c.client.Do(req, nil)
+	const opPath = "/floating_ips/%d"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, floatingIP.ID)
+
+	return deleteRequestNoResult(ctx, c.client, reqPath)
 }
 
 // FloatingIPUpdateOpts specifies options for updating a Floating IP.
@@ -293,6 +257,11 @@ type FloatingIPUpdateOpts struct {
 
 // Update updates a Floating IP.
 func (c *FloatingIPClient) Update(ctx context.Context, floatingIP *FloatingIP, opts FloatingIPUpdateOpts) (*FloatingIP, *Response, error) {
+	const opPath = "/floating_ips/%d"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, floatingIP.ID)
+
 	reqBody := schema.FloatingIPUpdateRequest{
 		Description: opts.Description,
 		Name:        opts.Name,
@@ -300,68 +269,48 @@ func (c *FloatingIPClient) Update(ctx context.Context, floatingIP *FloatingIP, o
 	if opts.Labels != nil {
 		reqBody.Labels = &opts.Labels
 	}
-	reqBodyData, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	path := fmt.Sprintf("/floating_ips/%d", floatingIP.ID)
-	req, err := c.client.NewRequest(ctx, "PUT", path, bytes.NewReader(reqBodyData))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	respBody := schema.FloatingIPUpdateResponse{}
-	resp, err := c.client.Do(req, &respBody)
+	respBody, resp, err := putRequest[schema.FloatingIPUpdateResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return FloatingIPFromSchema(respBody.FloatingIP), resp, nil
 }
 
 // Assign assigns a Floating IP to a server.
 func (c *FloatingIPClient) Assign(ctx context.Context, floatingIP *FloatingIP, server *Server) (*Action, *Response, error) {
+	const opPath = "/floating_ips/%d/actions/assign"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, floatingIP.ID)
+
 	reqBody := schema.FloatingIPActionAssignRequest{
 		Server: server.ID,
 	}
-	reqBodyData, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	path := fmt.Sprintf("/floating_ips/%d/actions/assign", floatingIP.ID)
-	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var respBody schema.FloatingIPActionAssignResponse
-	resp, err := c.client.Do(req, &respBody)
+	respBody, resp, err := postRequest[schema.FloatingIPActionAssignResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return ActionFromSchema(respBody.Action), resp, nil
 }
 
 // Unassign unassigns a Floating IP from the currently assigned server.
 func (c *FloatingIPClient) Unassign(ctx context.Context, floatingIP *FloatingIP) (*Action, *Response, error) {
-	var reqBody schema.FloatingIPActionUnassignRequest
-	reqBodyData, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, nil, err
-	}
+	const opPath = "/floating_ips/%d/actions/unassign"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	path := fmt.Sprintf("/floating_ips/%d/actions/unassign", floatingIP.ID)
-	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf(opPath, floatingIP.ID)
 
-	var respBody schema.FloatingIPActionUnassignResponse
-	resp, err := c.client.Do(req, &respBody)
+	reqBody := schema.FloatingIPActionUnassignRequest{}
+
+	respBody, resp, err := postRequest[schema.FloatingIPActionUnassignResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
 		return nil, resp, err
 	}
+
 	return ActionFromSchema(respBody.Action), resp, nil
 }
 
@@ -382,24 +331,19 @@ type FloatingIPChangeProtectionOpts struct {
 
 // ChangeProtection changes the resource protection level of a Floating IP.
 func (c *FloatingIPClient) ChangeProtection(ctx context.Context, floatingIP *FloatingIP, opts FloatingIPChangeProtectionOpts) (*Action, *Response, error) {
+	const opPath = "/floating_ips/%d/actions/change_protection"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, floatingIP.ID)
+
 	reqBody := schema.FloatingIPActionChangeProtectionRequest{
 		Delete: opts.Delete,
 	}
-	reqBodyData, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	path := fmt.Sprintf("/floating_ips/%d/actions/change_protection", floatingIP.ID)
-	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	respBody := schema.FloatingIPActionChangeProtectionResponse{}
-	resp, err := c.client.Do(req, &respBody)
+	respBody, resp, err := postRequest[schema.FloatingIPActionChangeProtectionResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
 		return nil, resp, err
 	}
-	return ActionFromSchema(respBody.Action), resp, err
+
+	return ActionFromSchema(respBody.Action), resp, nil
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/hcloud.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/hcloud.go
@@ -1,5 +1,34 @@
-// Package hcloud is a library for the Hetzner Cloud API.
+/*
+Package hcloud is a library for the Hetzner Cloud API.
+
+The Hetzner Cloud API reference is available at https://docs.hetzner.cloud.
+
+Make sure to follow our API changelog available at https://docs.hetzner.cloud/changelog
+(or the RRS feed available at https://docs.hetzner.cloud/changelog/feed.rss) to be
+notified about additions, deprecations and removals.
+
+# Retry mechanism
+
+The [Client.Do] method will retry failed requests that match certain criteria. The
+default retry interval is defined by an exponential backoff algorithm truncated to 60s
+with jitter. The default maximal number of retries is 5.
+
+The following rules defines when a request can be retried:
+
+When the [http.Client] returned a network timeout error.
+
+When the API returned an HTTP error, with the status code:
+  - [http.StatusBadGateway]
+  - [http.StatusGatewayTimeout]
+
+When the API returned an application error, with the code:
+  - [ErrorCodeConflict]
+  - [ErrorCodeRateLimitExceeded]
+
+Changes to the retry policy might occur between releases, and will not be considered
+breaking changes.
+*/
 package hcloud
 
 // Version is the library's version following Semantic Versioning.
-const Version = "2.8.0" // x-release-please-version
+const Version = "2.21.1" // x-releaser-pleaser-version

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/iso.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/iso.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strconv"
 	"time"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/ctxutil"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema"
 )
 
@@ -40,40 +40,32 @@ type ISOClient struct {
 
 // GetByID retrieves an ISO by its ID.
 func (c *ISOClient) GetByID(ctx context.Context, id int64) (*ISO, *Response, error) {
-	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/isos/%d", id), nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	const opPath = "/isos/%d"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	var body schema.ISOGetResponse
-	resp, err := c.client.Do(req, &body)
+	reqPath := fmt.Sprintf(opPath, id)
+
+	respBody, resp, err := getRequest[schema.ISOGetResponse](ctx, c.client, reqPath)
 	if err != nil {
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
 		return nil, resp, err
 	}
-	return ISOFromSchema(body.ISO), resp, nil
+
+	return ISOFromSchema(respBody.ISO), resp, nil
 }
 
 // GetByName retrieves an ISO by its name.
 func (c *ISOClient) GetByName(ctx context.Context, name string) (*ISO, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	isos, response, err := c.List(ctx, ISOListOpts{Name: name})
-	if len(isos) == 0 {
-		return nil, response, err
-	}
-	return isos[0], response, err
+	return firstByName(name, func() ([]*ISO, *Response, error) {
+		return c.List(ctx, ISOListOpts{Name: name})
+	})
 }
 
 // Get retrieves an ISO by its ID if the input can be parsed as an integer, otherwise it retrieves an ISO by its name.
 func (c *ISOClient) Get(ctx context.Context, idOrName string) (*ISO, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		return c.GetByID(ctx, id)
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // ISOListOpts specifies options for listing isos.
@@ -115,22 +107,17 @@ func (l ISOListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *ISOClient) List(ctx context.Context, opts ISOListOpts) ([]*ISO, *Response, error) {
-	path := "/isos?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
+	const opPath = "/isos?%s"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+
+	respBody, resp, err := getRequest[schema.ISOListResponse](ctx, c.client, reqPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 
-	var body schema.ISOListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-	isos := make([]*ISO, 0, len(body.ISOs))
-	for _, i := range body.ISOs {
-		isos = append(isos, ISOFromSchema(i))
-	}
-	return isos, resp, nil
+	return allFromSchemaFunc(respBody.ISOs, ISOFromSchema), resp, nil
 }
 
 // All returns all ISOs.
@@ -140,20 +127,8 @@ func (c *ISOClient) All(ctx context.Context) ([]*ISO, error) {
 
 // AllWithOpts returns all ISOs for the given options.
 func (c *ISOClient) AllWithOpts(ctx context.Context, opts ISOListOpts) ([]*ISO, error) {
-	allISOs := []*ISO{}
-
-	err := c.client.all(func(page int) (*Response, error) {
+	return iterPages(func(page int) ([]*ISO, *Response, error) {
 		opts.Page = page
-		isos, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allISOs = append(allISOs, isos...)
-		return resp, nil
+		return c.List(ctx, opts)
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allISOs, nil
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema.go
@@ -49,6 +49,26 @@ func SchemaFromPrimaryIP(p *PrimaryIP) schema.PrimaryIP {
 	return c.SchemaFromPrimaryIP(p)
 }
 
+func SchemaFromPrimaryIPCreateOpts(o PrimaryIPCreateOpts) schema.PrimaryIPCreateRequest {
+	return c.SchemaFromPrimaryIPCreateOpts(o)
+}
+
+func SchemaFromPrimaryIPUpdateOpts(o PrimaryIPUpdateOpts) schema.PrimaryIPUpdateRequest {
+	return c.SchemaFromPrimaryIPUpdateOpts(o)
+}
+
+func SchemaFromPrimaryIPChangeDNSPtrOpts(o PrimaryIPChangeDNSPtrOpts) schema.PrimaryIPActionChangeDNSPtrRequest {
+	return c.SchemaFromPrimaryIPChangeDNSPtrOpts(o)
+}
+
+func SchemaFromPrimaryIPChangeProtectionOpts(o PrimaryIPChangeProtectionOpts) schema.PrimaryIPActionChangeProtectionRequest {
+	return c.SchemaFromPrimaryIPChangeProtectionOpts(o)
+}
+
+func SchemaFromPrimaryIPAssignOpts(o PrimaryIPAssignOpts) schema.PrimaryIPActionAssignRequest {
+	return c.SchemaFromPrimaryIPAssignOpts(o)
+}
+
 // ISOFromSchema converts a schema.ISO to an ISO.
 func ISOFromSchema(s schema.ISO) *ISO {
 	return c.ISOFromSchema(s)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/doc.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/doc.go
@@ -1,0 +1,4 @@
+// The schema package holds API schemas for the `hcloud-go` library.
+
+// Breaking changes may occur without notice. Do not use in production!
+package schema

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/id_or_name.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/id_or_name.go
@@ -1,0 +1,68 @@
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strconv"
+)
+
+// IDOrName can be used in API requests where either a resource id or name can be
+// specified.
+type IDOrName struct {
+	ID   int64
+	Name string
+}
+
+var _ json.Unmarshaler = (*IDOrName)(nil)
+var _ json.Marshaler = (*IDOrName)(nil)
+
+func (o IDOrName) MarshalJSON() ([]byte, error) {
+	if o.ID != 0 {
+		return json.Marshal(o.ID)
+	}
+	if o.Name != "" {
+		return json.Marshal(o.Name)
+	}
+
+	// We want to preserve the behavior of an empty interface{} to prevent breaking
+	// changes (marshaled to null when empty).
+	return json.Marshal(nil)
+}
+
+func (o *IDOrName) UnmarshalJSON(data []byte) error {
+	d := json.NewDecoder(bytes.NewBuffer(data))
+	// This ensures we won't lose precision on large IDs, see json.Number below
+	d.UseNumber()
+
+	var v any
+	if err := d.Decode(&v); err != nil {
+		return err
+	}
+
+	switch typed := v.(type) {
+	case string:
+		id, err := strconv.ParseInt(typed, 10, 64)
+		if err == nil {
+			o.ID = id
+		} else if typed != "" {
+			o.Name = typed
+		}
+	case json.Number:
+		id, err := typed.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: string(data),
+				Type:  reflect.TypeOf(*o),
+			}
+		}
+		o.ID = id
+	default:
+		return &json.UnmarshalTypeError{
+			Value: string(data),
+			Type:  reflect.TypeOf(*o),
+		}
+	}
+
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/load_balancer.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/load_balancer.go
@@ -251,7 +251,7 @@ type LoadBalancerDeleteServiceResponse struct {
 
 type LoadBalancerCreateRequest struct {
 	Name             string                              `json:"name"`
-	LoadBalancerType interface{}                         `json:"load_balancer_type"` // int or string
+	LoadBalancerType IDOrName                            `json:"load_balancer_type"`
 	Algorithm        *LoadBalancerCreateRequestAlgorithm `json:"algorithm,omitempty"`
 	Location         *string                             `json:"location,omitempty"`
 	NetworkZone      *string                             `json:"network_zone,omitempty"`
@@ -380,7 +380,7 @@ type LoadBalancerActionDisablePublicInterfaceResponse struct {
 }
 
 type LoadBalancerActionChangeTypeRequest struct {
-	LoadBalancerType interface{} `json:"load_balancer_type"` // int or string
+	LoadBalancerType IDOrName `json:"load_balancer_type"`
 }
 
 type LoadBalancerActionChangeTypeResponse struct {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/network.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/network.go
@@ -11,6 +11,7 @@ type Network struct {
 	Subnets               []NetworkSubnet   `json:"subnets"`
 	Routes                []NetworkRoute    `json:"routes"`
 	Servers               []int64           `json:"servers"`
+	LoadBalancers         []int64           `json:"load_balancers"`
 	Protection            NetworkProtection `json:"protection"`
 	Labels                map[string]string `json:"labels"`
 	ExposeRoutesToVSwitch bool              `json:"expose_routes_to_vswitch"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/pricing.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/pricing.go
@@ -2,12 +2,15 @@ package schema
 
 // Pricing defines the schema for pricing information.
 type Pricing struct {
-	Currency          string                    `json:"currency"`
-	VATRate           string                    `json:"vat_rate"`
-	Image             PricingImage              `json:"image"`
-	FloatingIP        PricingFloatingIP         `json:"floating_ip"`
-	FloatingIPs       []PricingFloatingIPType   `json:"floating_ips"`
-	PrimaryIPs        []PricingPrimaryIP        `json:"primary_ips"`
+	Currency string       `json:"currency"`
+	VATRate  string       `json:"vat_rate"`
+	Image    PricingImage `json:"image"`
+	// Deprecated: [Pricing.FloatingIP] is deprecated, use [Pricing.FloatingIPs] instead.
+	FloatingIP  PricingFloatingIP       `json:"floating_ip"`
+	FloatingIPs []PricingFloatingIPType `json:"floating_ips"`
+	PrimaryIPs  []PricingPrimaryIP      `json:"primary_ips"`
+	// Deprecated: [Pricing.Traffic] is deprecated and will report 0 after 2024-08-05.
+	// Use traffic pricing from [Pricing.ServerTypes] or [Pricing.LoadBalancerTypes] instead.
 	Traffic           PricingTraffic            `json:"traffic"`
 	ServerBackup      PricingServerBackup       `json:"server_backup"`
 	ServerTypes       []PricingServerType       `json:"server_types"`
@@ -72,6 +75,9 @@ type PricingServerTypePrice struct {
 	Location     string `json:"location"`
 	PriceHourly  Price  `json:"price_hourly"`
 	PriceMonthly Price  `json:"price_monthly"`
+
+	IncludedTraffic   uint64 `json:"included_traffic"`
+	PricePerTBTraffic Price  `json:"price_per_tb_traffic"`
 }
 
 // PricingLoadBalancerType defines the schema of pricing information for a Load Balancer type.
@@ -87,6 +93,9 @@ type PricingLoadBalancerTypePrice struct {
 	Location     string `json:"location"`
 	PriceHourly  Price  `json:"price_hourly"`
 	PriceMonthly Price  `json:"price_monthly"`
+
+	IncludedTraffic   uint64 `json:"included_traffic"`
+	PricePerTBTraffic Price  `json:"price_per_tb_traffic"`
 }
 
 // PricingGetResponse defines the schema of the response when retrieving pricing information.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/primary_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/primary_ip.go
@@ -31,6 +31,18 @@ type PrimaryIPDNSPTR struct {
 	IP     string `json:"ip"`
 }
 
+// PrimaryIPCreateOpts defines the request to
+// create a Primary IP.
+type PrimaryIPCreateRequest struct {
+	Name         string            `json:"name"`
+	Type         string            `json:"type"`
+	AssigneeType string            `json:"assignee_type"`
+	AssigneeID   *int64            `json:"assignee_id,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	AutoDelete   *bool             `json:"auto_delete,omitempty"`
+	Datacenter   string            `json:"datacenter,omitempty"`
+}
+
 // PrimaryIPCreateResponse defines the schema of the response
 // when creating a Primary IP.
 type PrimaryIPCreateResponse struct {
@@ -38,19 +50,27 @@ type PrimaryIPCreateResponse struct {
 	Action    *Action   `json:"action"`
 }
 
-// PrimaryIPGetResult defines the response when retrieving a single Primary IP.
-type PrimaryIPGetResult struct {
+// PrimaryIPGetResponse defines the response when retrieving a single Primary IP.
+type PrimaryIPGetResponse struct {
 	PrimaryIP PrimaryIP `json:"primary_ip"`
 }
 
-// PrimaryIPListResult defines the response when listing Primary IPs.
-type PrimaryIPListResult struct {
+// PrimaryIPListResponse defines the response when listing Primary IPs.
+type PrimaryIPListResponse struct {
 	PrimaryIPs []PrimaryIP `json:"primary_ips"`
 }
 
-// PrimaryIPUpdateResult defines the response
+// PrimaryIPUpdateOpts defines the request to
+// update a Primary IP.
+type PrimaryIPUpdateRequest struct {
+	Name       string            `json:"name,omitempty"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	AutoDelete *bool             `json:"auto_delete,omitempty"`
+}
+
+// PrimaryIPUpdateResponse defines the response
 // when updating a Primary IP.
-type PrimaryIPUpdateResult struct {
+type PrimaryIPUpdateResponse struct {
 	PrimaryIP PrimaryIP `json:"primary_ip"`
 }
 
@@ -59,4 +79,40 @@ type PrimaryIPUpdateResult struct {
 type PrimaryIPActionChangeDNSPtrRequest struct {
 	IP     string  `json:"ip"`
 	DNSPtr *string `json:"dns_ptr"`
+}
+
+// PrimaryIPActionChangeDNSPtrResponse defines the response when setting a reverse DNS
+// pointer for a IP address.
+type PrimaryIPActionChangeDNSPtrResponse struct {
+	Action Action `json:"action"`
+}
+
+// PrimaryIPActionAssignRequest defines the request to
+// assign a Primary IP to an assignee (usually a server).
+type PrimaryIPActionAssignRequest struct {
+	AssigneeID   int64  `json:"assignee_id"`
+	AssigneeType string `json:"assignee_type"`
+}
+
+// PrimaryIPActionAssignResponse defines the response when assigning a Primary IP to a
+// assignee.
+type PrimaryIPActionAssignResponse struct {
+	Action Action `json:"action"`
+}
+
+// PrimaryIPActionUnassignResponse defines the response to unassign a Primary IP.
+type PrimaryIPActionUnassignResponse struct {
+	Action Action `json:"action"`
+}
+
+// PrimaryIPActionChangeProtectionRequest defines the request to
+// change protection configuration of a Primary IP.
+type PrimaryIPActionChangeProtectionRequest struct {
+	Delete bool `json:"delete"`
+}
+
+// PrimaryIPActionChangeProtectionResponse defines the response when changing the
+// protection of a Primary IP.
+type PrimaryIPActionChangeProtectionResponse struct {
+	Action Action `json:"action"`
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server.go
@@ -99,8 +99,8 @@ type ServerListResponse struct {
 // create a server.
 type ServerCreateRequest struct {
 	Name             string                  `json:"name"`
-	ServerType       interface{}             `json:"server_type"` // int or string
-	Image            interface{}             `json:"image"`       // int or string
+	ServerType       IDOrName                `json:"server_type"`
+	Image            IDOrName                `json:"image"`
 	SSHKeys          []int64                 `json:"ssh_keys,omitempty"`
 	Location         string                  `json:"location,omitempty"`
 	Datacenter       string                  `json:"datacenter,omitempty"`
@@ -257,7 +257,7 @@ type ServerActionDisableRescueResponse struct {
 // ServerActionRebuildRequest defines the schema for the request to
 // rebuild a server.
 type ServerActionRebuildRequest struct {
-	Image interface{} `json:"image"` // int or string
+	Image IDOrName `json:"image"`
 }
 
 // ServerActionRebuildResponse defines the schema of the response when
@@ -270,7 +270,7 @@ type ServerActionRebuildResponse struct {
 // ServerActionAttachISORequest defines the schema for the request to
 // attach an ISO to a server.
 type ServerActionAttachISORequest struct {
-	ISO interface{} `json:"iso"` // int or string
+	ISO IDOrName `json:"iso"`
 }
 
 // ServerActionAttachISOResponse defines the schema of the response when
@@ -287,12 +287,6 @@ type ServerActionDetachISORequest struct{}
 // creating a detach_iso server action.
 type ServerActionDetachISOResponse struct {
 	Action Action `json:"action"`
-}
-
-// ServerActionEnableBackupRequest defines the schema for the request to
-// enable backup for a server.
-type ServerActionEnableBackupRequest struct {
-	BackupWindow *string `json:"backup_window,omitempty"`
 }
 
 // ServerActionEnableBackupResponse defines the schema of the response when
@@ -314,8 +308,8 @@ type ServerActionDisableBackupResponse struct {
 // ServerActionChangeTypeRequest defines the schema for the request to
 // change a server's type.
 type ServerActionChangeTypeRequest struct {
-	ServerType  interface{} `json:"server_type"` // int or string
-	UpgradeDisk bool        `json:"upgrade_disk"`
+	ServerType  IDOrName `json:"server_type"`
+	UpgradeDisk bool     `json:"upgrade_disk"`
 }
 
 // ServerActionChangeTypeResponse defines the schema of the response when

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server_type.go
@@ -2,15 +2,18 @@ package schema
 
 // ServerType defines the schema of a server type.
 type ServerType struct {
-	ID              int64                    `json:"id"`
-	Name            string                   `json:"name"`
-	Description     string                   `json:"description"`
-	Cores           int                      `json:"cores"`
-	Memory          float32                  `json:"memory"`
-	Disk            int                      `json:"disk"`
-	StorageType     string                   `json:"storage_type"`
-	CPUType         string                   `json:"cpu_type"`
-	Architecture    string                   `json:"architecture"`
+	ID           int64   `json:"id"`
+	Name         string  `json:"name"`
+	Description  string  `json:"description"`
+	Cores        int     `json:"cores"`
+	Memory       float32 `json:"memory"`
+	Disk         int     `json:"disk"`
+	StorageType  string  `json:"storage_type"`
+	CPUType      string  `json:"cpu_type"`
+	Architecture string  `json:"architecture"`
+
+	// Deprecated: [ServerType.IncludedTraffic] is deprecated and will always report 0 after 2024-08-05.
+	// Use [ServerType.Prices] instead to get the included traffic for each location.
 	IncludedTraffic int64                    `json:"included_traffic"`
 	Prices          []PricingServerTypePrice `json:"prices"`
 	Deprecated      bool                     `json:"deprecated"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/volume.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/volume.go
@@ -23,7 +23,7 @@ type VolumeCreateRequest struct {
 	Name      string             `json:"name"`
 	Size      int                `json:"size"`
 	Server    *int64             `json:"server,omitempty"`
-	Location  interface{}        `json:"location,omitempty"` // int, string, or nil
+	Location  *IDOrName          `json:"location,omitempty"`
 	Labels    *map[string]string `json:"labels,omitempty"`
 	Automount *bool              `json:"automount,omitempty"`
 	Format    *string            `json:"format,omitempty"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server_type.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/ctxutil"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema"
 )
 
@@ -20,7 +21,9 @@ type ServerType struct {
 	StorageType  StorageType
 	CPUType      CPUType
 	Architecture Architecture
-	// IncludedTraffic is the free traffic per month in bytes
+
+	// Deprecated: [ServerType.IncludedTraffic] is deprecated and will always report 0 after 2024-08-05.
+	// Use [ServerType.Pricings] instead to get the included traffic for each location.
 	IncludedTraffic int64
 	Pricings        []ServerTypeLocationPricing
 	DeprecatableResource
@@ -55,32 +58,27 @@ type ServerTypeClient struct {
 
 // GetByID retrieves a server type by its ID. If the server type does not exist, nil is returned.
 func (c *ServerTypeClient) GetByID(ctx context.Context, id int64) (*ServerType, *Response, error) {
-	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/server_types/%d", id), nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	const opPath = "/server_types/%d"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	var body schema.ServerTypeGetResponse
-	resp, err := c.client.Do(req, &body)
+	reqPath := fmt.Sprintf(opPath, id)
+
+	respBody, resp, err := getRequest[schema.ServerTypeGetResponse](ctx, c.client, reqPath)
 	if err != nil {
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
-	return ServerTypeFromSchema(body.ServerType), resp, nil
+
+	return ServerTypeFromSchema(respBody.ServerType), resp, nil
 }
 
 // GetByName retrieves a server type by its name. If the server type does not exist, nil is returned.
 func (c *ServerTypeClient) GetByName(ctx context.Context, name string) (*ServerType, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	serverTypes, response, err := c.List(ctx, ServerTypeListOpts{Name: name})
-	if len(serverTypes) == 0 {
-		return nil, response, err
-	}
-	return serverTypes[0], response, err
+	return firstByName(name, func() ([]*ServerType, *Response, error) {
+		return c.List(ctx, ServerTypeListOpts{Name: name})
+	})
 }
 
 // Get retrieves a server type by its ID if the input can be parsed as an integer, otherwise it
@@ -115,22 +113,17 @@ func (l ServerTypeListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *ServerTypeClient) List(ctx context.Context, opts ServerTypeListOpts) ([]*ServerType, *Response, error) {
-	path := "/server_types?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
+	const opPath = "/server_types?%s"
+	ctx = ctxutil.SetOpPath(ctx, opPath)
+
+	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+
+	respBody, resp, err := getRequest[schema.ServerTypeListResponse](ctx, c.client, reqPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 
-	var body schema.ServerTypeListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-	serverTypes := make([]*ServerType, 0, len(body.ServerTypes))
-	for _, s := range body.ServerTypes {
-		serverTypes = append(serverTypes, ServerTypeFromSchema(s))
-	}
-	return serverTypes, resp, nil
+	return allFromSchemaFunc(respBody.ServerTypes, ServerTypeFromSchema), resp, nil
 }
 
 // All returns all server types.
@@ -140,20 +133,8 @@ func (c *ServerTypeClient) All(ctx context.Context) ([]*ServerType, error) {
 
 // AllWithOpts returns all server types for the given options.
 func (c *ServerTypeClient) AllWithOpts(ctx context.Context, opts ServerTypeListOpts) ([]*ServerType, error) {
-	allServerTypes := []*ServerType{}
-
-	err := c.client.all(func(page int) (*Response, error) {
+	return iterPages(func(page int) ([]*ServerType, *Response, error) {
 		opts.Page = page
-		serverTypes, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allServerTypes = append(allServerTypes, serverTypes...)
-		return resp, nil
+		return c.List(ctx, opts)
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allServerTypes, nil
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_action_client_iface.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_action_client_iface.go
@@ -16,8 +16,12 @@ type IActionClient interface {
 	// when their value corresponds to their zero value or when they are empty.
 	List(ctx context.Context, opts ActionListOpts) ([]*Action, *Response, error)
 	// All returns all actions.
+	//
+	// Deprecated: It is required to pass in a list of IDs since 30 January 2025. Please use [ActionClient.AllWithOpts] instead.
 	All(ctx context.Context) ([]*Action, error)
 	// AllWithOpts returns all actions for the given options.
+	//
+	// It is required to set [ActionListOpts.ID]. Any other fields set in the opts are ignored.
 	AllWithOpts(ctx context.Context, opts ActionListOpts) ([]*Action, error)
 	// WatchOverallProgress watches several actions' progress until they complete
 	// with success or error. This watching happens in a goroutine and updates are
@@ -35,7 +39,7 @@ type IActionClient interface {
 	// timeout, use the [context.Context]. Once the method has stopped watching,
 	// both returned channels are closed.
 	//
-	// WatchOverallProgress uses the [WithPollBackoffFunc] of the [Client] to wait
+	// WatchOverallProgress uses the [WithPollOpts] of the [Client] to wait
 	// until sending the next request.
 	//
 	// Deprecated: WatchOverallProgress is deprecated, use [WaitForFunc] instead.
@@ -56,19 +60,19 @@ type IActionClient interface {
 	// timeout, use the [context.Context]. Once the method has stopped watching,
 	// both returned channels are closed.
 	//
-	// WatchProgress uses the [WithPollBackoffFunc] of the [Client] to wait until
+	// WatchProgress uses the [WithPollOpts] of the [Client] to wait until
 	// sending the next request.
 	//
 	// Deprecated: WatchProgress is deprecated, use [WaitForFunc] instead.
 	WatchProgress(ctx context.Context, action *Action) (<-chan int, <-chan error)
 	// WaitForFunc waits until all actions are completed by polling the API at the interval
-	// defined by [WithPollBackoffFunc]. An action is considered as complete when its status is
+	// defined by [WithPollOpts]. An action is considered as complete when its status is
 	// either [ActionStatusSuccess] or [ActionStatusError].
 	//
 	// The handleUpdate callback is called every time an action is updated.
 	WaitForFunc(ctx context.Context, handleUpdate func(update *Action) error, actions ...*Action) error
 	// WaitFor waits until all actions succeed by polling the API at the interval defined by
-	// [WithPollBackoffFunc]. An action is considered as succeeded when its status is either
+	// [WithPollOpts]. An action is considered as succeeded when its status is either
 	// [ActionStatusSuccess].
 	//
 	// If a single action fails, the function will stop waiting and the error set in the

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_load_balancer_client_iface.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_load_balancer_client_iface.go
@@ -64,7 +64,7 @@ type ILoadBalancerClient interface {
 	// ChangeType changes a Load Balancer's type.
 	ChangeType(ctx context.Context, loadBalancer *LoadBalancer, opts LoadBalancerChangeTypeOpts) (*Action, *Response, error)
 	// GetMetrics obtains metrics for a Load Balancer.
-	GetMetrics(ctx context.Context, lb *LoadBalancer, opts LoadBalancerGetMetricsOpts) (*LoadBalancerMetrics, *Response, error)
+	GetMetrics(ctx context.Context, loadBalancer *LoadBalancer, opts LoadBalancerGetMetricsOpts) (*LoadBalancerMetrics, *Response, error)
 	// ChangeDNSPtr changes or resets the reverse DNS pointer for a Load Balancer.
 	// Pass a nil ptr to reset the reverse DNS pointer to its default value.
 	ChangeDNSPtr(ctx context.Context, lb *LoadBalancer, ip string, ptr *string) (*Action, *Response, error)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_primary_ip_client_iface.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_primary_ip_client_iface.go
@@ -27,11 +27,11 @@ type IPrimaryIPClient interface {
 	// AllWithOpts returns all Primary IPs for the given options.
 	AllWithOpts(ctx context.Context, opts PrimaryIPListOpts) ([]*PrimaryIP, error)
 	// Create creates a Primary IP.
-	Create(ctx context.Context, reqBody PrimaryIPCreateOpts) (*PrimaryIPCreateResult, *Response, error)
+	Create(ctx context.Context, opts PrimaryIPCreateOpts) (*PrimaryIPCreateResult, *Response, error)
 	// Delete deletes a Primary IP.
 	Delete(ctx context.Context, primaryIP *PrimaryIP) (*Response, error)
 	// Update updates a Primary IP.
-	Update(ctx context.Context, primaryIP *PrimaryIP, reqBody PrimaryIPUpdateOpts) (*PrimaryIP, *Response, error)
+	Update(ctx context.Context, primaryIP *PrimaryIP, opts PrimaryIPUpdateOpts) (*PrimaryIP, *Response, error)
 	// Assign a Primary IP to a resource.
 	Assign(ctx context.Context, opts PrimaryIPAssignOpts) (*Action, *Response, error)
 	// Unassign a Primary IP from a resource.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_schema.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_schema.go
@@ -23,28 +23,22 @@ func (c *converterImpl) ActionFromSchema(source schema.Action) *Action {
 	if source.Error != nil {
 		pString = &source.Error.Code
 	}
-	var xstring string
 	if pString != nil {
-		xstring = *pString
+		hcloudAction.ErrorCode = *pString
 	}
-	hcloudAction.ErrorCode = xstring
 	var pString2 *string
 	if source.Error != nil {
 		pString2 = &source.Error.Message
 	}
-	var xstring2 string
 	if pString2 != nil {
-		xstring2 = *pString2
+		hcloudAction.ErrorMessage = *pString2
 	}
-	hcloudAction.ErrorMessage = xstring2
-	var pHcloudActionResourceList []*ActionResource
 	if source.Resources != nil {
-		pHcloudActionResourceList = make([]*ActionResource, len(source.Resources))
+		hcloudAction.Resources = make([]*ActionResource, len(source.Resources))
 		for i := 0; i < len(source.Resources); i++ {
-			pHcloudActionResourceList[i] = c.schemaActionResourceReferenceToPHcloudActionResource(source.Resources[i])
+			hcloudAction.Resources[i] = c.schemaActionResourceReferenceToPHcloudActionResource(source.Resources[i])
 		}
 	}
-	hcloudAction.Resources = pHcloudActionResourceList
 	return &hcloudAction
 }
 func (c *converterImpl) ActionsFromSchema(source []schema.Action) []*Action {
@@ -70,14 +64,12 @@ func (c *converterImpl) CertificateFromSchema(source schema.Certificate) *Certif
 	hcloudCertificate.DomainNames = source.DomainNames
 	hcloudCertificate.Fingerprint = source.Fingerprint
 	hcloudCertificate.Status = c.pSchemaCertificateStatusRefToPHcloudCertificateStatus(source.Status)
-	var hcloudCertificateUsedByRefList []CertificateUsedByRef
 	if source.UsedBy != nil {
-		hcloudCertificateUsedByRefList = make([]CertificateUsedByRef, len(source.UsedBy))
+		hcloudCertificate.UsedBy = make([]CertificateUsedByRef, len(source.UsedBy))
 		for i := 0; i < len(source.UsedBy); i++ {
-			hcloudCertificateUsedByRefList[i] = c.schemaCertificateUsedByRefToHcloudCertificateUsedByRef(source.UsedBy[i])
+			hcloudCertificate.UsedBy[i] = c.schemaCertificateUsedByRefToHcloudCertificateUsedByRef(source.UsedBy[i])
 		}
 	}
-	hcloudCertificate.UsedBy = hcloudCertificateUsedByRefList
 	return &hcloudCertificate
 }
 func (c *converterImpl) DatacenterFromSchema(source schema.Datacenter) *Datacenter {
@@ -112,42 +104,34 @@ func (c *converterImpl) FirewallFromSchema(source schema.Firewall) *Firewall {
 	hcloudFirewall.Name = source.Name
 	hcloudFirewall.Labels = source.Labels
 	hcloudFirewall.Created = c.timeTimeToTimeTime(source.Created)
-	var hcloudFirewallRuleList []FirewallRule
 	if source.Rules != nil {
-		hcloudFirewallRuleList = make([]FirewallRule, len(source.Rules))
+		hcloudFirewall.Rules = make([]FirewallRule, len(source.Rules))
 		for i := 0; i < len(source.Rules); i++ {
-			hcloudFirewallRuleList[i] = c.schemaFirewallRuleToHcloudFirewallRule(source.Rules[i])
+			hcloudFirewall.Rules[i] = c.schemaFirewallRuleToHcloudFirewallRule(source.Rules[i])
 		}
 	}
-	hcloudFirewall.Rules = hcloudFirewallRuleList
-	var hcloudFirewallResourceList []FirewallResource
 	if source.AppliedTo != nil {
-		hcloudFirewallResourceList = make([]FirewallResource, len(source.AppliedTo))
+		hcloudFirewall.AppliedTo = make([]FirewallResource, len(source.AppliedTo))
 		for j := 0; j < len(source.AppliedTo); j++ {
-			hcloudFirewallResourceList[j] = c.schemaFirewallResourceToHcloudFirewallResource(source.AppliedTo[j])
+			hcloudFirewall.AppliedTo[j] = c.schemaFirewallResourceToHcloudFirewallResource(source.AppliedTo[j])
 		}
 	}
-	hcloudFirewall.AppliedTo = hcloudFirewallResourceList
 	return &hcloudFirewall
 }
 func (c *converterImpl) FloatingIPFromSchema(source schema.FloatingIP) *FloatingIP {
 	var hcloudFloatingIP FloatingIP
 	hcloudFloatingIP.ID = source.ID
-	var xstring string
 	if source.Description != nil {
-		xstring = *source.Description
+		hcloudFloatingIP.Description = *source.Description
 	}
-	hcloudFloatingIP.Description = xstring
 	hcloudFloatingIP.Created = c.timeTimeToTimeTime(source.Created)
 	hcloudFloatingIP.IP = ipFromFloatingIPSchema(source)
 	hcloudFloatingIP.Network = networkFromFloatingIPSchema(source)
 	hcloudFloatingIP.Type = FloatingIPType(source.Type)
-	var pHcloudServer *Server
 	if source.Server != nil {
 		hcloudServer := serverFromInt64(*source.Server)
-		pHcloudServer = &hcloudServer
+		hcloudFloatingIP.Server = &hcloudServer
 	}
-	hcloudFloatingIP.Server = pHcloudServer
 	hcloudFloatingIP.DNSPtr = mapFromFloatingIPDNSPtrSchema(source.DNSPtr)
 	hcloudFloatingIP.HomeLocation = c.LocationFromSchema(source.HomeLocation)
 	hcloudFloatingIP.Blocked = source.Blocked
@@ -163,35 +147,27 @@ func (c *converterImpl) ISOFromSchema(source schema.ISO) *ISO {
 func (c *converterImpl) ImageFromSchema(source schema.Image) *Image {
 	var hcloudImage Image
 	hcloudImage.ID = source.ID
-	var xstring string
 	if source.Name != nil {
-		xstring = *source.Name
+		hcloudImage.Name = *source.Name
 	}
-	hcloudImage.Name = xstring
 	hcloudImage.Type = ImageType(source.Type)
 	hcloudImage.Status = ImageStatus(source.Status)
 	hcloudImage.Description = source.Description
-	var xfloat32 float32
 	if source.ImageSize != nil {
-		xfloat32 = *source.ImageSize
+		hcloudImage.ImageSize = *source.ImageSize
 	}
-	hcloudImage.ImageSize = xfloat32
 	hcloudImage.DiskSize = source.DiskSize
 	hcloudImage.Created = c.pTimeTimeToTimeTime(source.Created)
 	hcloudImage.CreatedFrom = c.pSchemaImageCreatedFromToPHcloudServer(source.CreatedFrom)
-	var pHcloudServer *Server
 	if source.BoundTo != nil {
 		hcloudServer := serverFromInt64(*source.BoundTo)
-		pHcloudServer = &hcloudServer
+		hcloudImage.BoundTo = &hcloudServer
 	}
-	hcloudImage.BoundTo = pHcloudServer
 	hcloudImage.RapidDeploy = source.RapidDeploy
 	hcloudImage.OSFlavor = source.OSFlavor
-	var xstring2 string
 	if source.OSVersion != nil {
-		xstring2 = *source.OSVersion
+		hcloudImage.OSVersion = *source.OSVersion
 	}
-	hcloudImage.OSVersion = xstring2
 	hcloudImage.Architecture = Architecture(source.Architecture)
 	hcloudImage.Protection = c.schemaImageProtectionToHcloudImageProtection(source.Protection)
 	hcloudImage.Deprecated = c.pTimeTimeToTimeTime(source.Deprecated)
@@ -204,47 +180,37 @@ func (c *converterImpl) LoadBalancerFromSchema(source schema.LoadBalancer) *Load
 	hcloudLoadBalancer.ID = source.ID
 	hcloudLoadBalancer.Name = source.Name
 	hcloudLoadBalancer.PublicNet = c.schemaLoadBalancerPublicNetToHcloudLoadBalancerPublicNet(source.PublicNet)
-	var hcloudLoadBalancerPrivateNetList []LoadBalancerPrivateNet
 	if source.PrivateNet != nil {
-		hcloudLoadBalancerPrivateNetList = make([]LoadBalancerPrivateNet, len(source.PrivateNet))
+		hcloudLoadBalancer.PrivateNet = make([]LoadBalancerPrivateNet, len(source.PrivateNet))
 		for i := 0; i < len(source.PrivateNet); i++ {
-			hcloudLoadBalancerPrivateNetList[i] = c.schemaLoadBalancerPrivateNetToHcloudLoadBalancerPrivateNet(source.PrivateNet[i])
+			hcloudLoadBalancer.PrivateNet[i] = c.schemaLoadBalancerPrivateNetToHcloudLoadBalancerPrivateNet(source.PrivateNet[i])
 		}
 	}
-	hcloudLoadBalancer.PrivateNet = hcloudLoadBalancerPrivateNetList
 	hcloudLoadBalancer.Location = c.LocationFromSchema(source.Location)
 	hcloudLoadBalancer.LoadBalancerType = c.LoadBalancerTypeFromSchema(source.LoadBalancerType)
 	hcloudLoadBalancer.Algorithm = c.schemaLoadBalancerAlgorithmToHcloudLoadBalancerAlgorithm(source.Algorithm)
-	var hcloudLoadBalancerServiceList []LoadBalancerService
 	if source.Services != nil {
-		hcloudLoadBalancerServiceList = make([]LoadBalancerService, len(source.Services))
+		hcloudLoadBalancer.Services = make([]LoadBalancerService, len(source.Services))
 		for j := 0; j < len(source.Services); j++ {
-			hcloudLoadBalancerServiceList[j] = c.LoadBalancerServiceFromSchema(source.Services[j])
+			hcloudLoadBalancer.Services[j] = c.LoadBalancerServiceFromSchema(source.Services[j])
 		}
 	}
-	hcloudLoadBalancer.Services = hcloudLoadBalancerServiceList
-	var hcloudLoadBalancerTargetList []LoadBalancerTarget
 	if source.Targets != nil {
-		hcloudLoadBalancerTargetList = make([]LoadBalancerTarget, len(source.Targets))
+		hcloudLoadBalancer.Targets = make([]LoadBalancerTarget, len(source.Targets))
 		for k := 0; k < len(source.Targets); k++ {
-			hcloudLoadBalancerTargetList[k] = c.LoadBalancerTargetFromSchema(source.Targets[k])
+			hcloudLoadBalancer.Targets[k] = c.LoadBalancerTargetFromSchema(source.Targets[k])
 		}
 	}
-	hcloudLoadBalancer.Targets = hcloudLoadBalancerTargetList
 	hcloudLoadBalancer.Protection = c.schemaLoadBalancerProtectionToHcloudLoadBalancerProtection(source.Protection)
 	hcloudLoadBalancer.Labels = source.Labels
 	hcloudLoadBalancer.Created = c.timeTimeToTimeTime(source.Created)
 	hcloudLoadBalancer.IncludedTraffic = source.IncludedTraffic
-	var xuint64 uint64
 	if source.OutgoingTraffic != nil {
-		xuint64 = *source.OutgoingTraffic
+		hcloudLoadBalancer.OutgoingTraffic = *source.OutgoingTraffic
 	}
-	hcloudLoadBalancer.OutgoingTraffic = xuint64
-	var xuint642 uint64
 	if source.IngoingTraffic != nil {
-		xuint642 = *source.IngoingTraffic
+		hcloudLoadBalancer.IngoingTraffic = *source.IngoingTraffic
 	}
-	hcloudLoadBalancer.IngoingTraffic = xuint642
 	return &hcloudLoadBalancer
 }
 func (c *converterImpl) LoadBalancerMetricsFromSchema(source *schema.LoadBalancerGetMetricsResponse) (*LoadBalancerMetrics, error) {
@@ -254,18 +220,16 @@ func (c *converterImpl) LoadBalancerMetricsFromSchema(source *schema.LoadBalance
 		hcloudLoadBalancerMetrics.Start = c.timeTimeToTimeTime((*source).Metrics.Start)
 		hcloudLoadBalancerMetrics.End = c.timeTimeToTimeTime((*source).Metrics.End)
 		hcloudLoadBalancerMetrics.Step = (*source).Metrics.Step
-		var mapStringHcloudLoadBalancerMetricsValueList map[string][]LoadBalancerMetricsValue
 		if (*source).Metrics.TimeSeries != nil {
-			mapStringHcloudLoadBalancerMetricsValueList = make(map[string][]LoadBalancerMetricsValue, len((*source).Metrics.TimeSeries))
+			hcloudLoadBalancerMetrics.TimeSeries = make(map[string][]LoadBalancerMetricsValue, len((*source).Metrics.TimeSeries))
 			for key, value := range (*source).Metrics.TimeSeries {
 				hcloudLoadBalancerMetricsValueList, err := loadBalancerMetricsTimeSeriesFromSchema(value)
 				if err != nil {
 					return nil, err
 				}
-				mapStringHcloudLoadBalancerMetricsValueList[key] = hcloudLoadBalancerMetricsValueList
+				hcloudLoadBalancerMetrics.TimeSeries[key] = hcloudLoadBalancerMetricsValueList
 			}
 		}
-		hcloudLoadBalancerMetrics.TimeSeries = mapStringHcloudLoadBalancerMetricsValueList
 		pHcloudLoadBalancerMetrics = &hcloudLoadBalancerMetrics
 	}
 	return pHcloudLoadBalancerMetrics, nil
@@ -300,22 +264,18 @@ func (c *converterImpl) LoadBalancerTargetFromSchema(source schema.LoadBalancerT
 	hcloudLoadBalancerTarget.Server = c.pSchemaLoadBalancerTargetServerToPHcloudLoadBalancerTargetServer(source.Server)
 	hcloudLoadBalancerTarget.LabelSelector = c.pSchemaLoadBalancerTargetLabelSelectorToPHcloudLoadBalancerTargetLabelSelector(source.LabelSelector)
 	hcloudLoadBalancerTarget.IP = c.pSchemaLoadBalancerTargetIPToPHcloudLoadBalancerTargetIP(source.IP)
-	var hcloudLoadBalancerTargetHealthStatusList []LoadBalancerTargetHealthStatus
 	if source.HealthStatus != nil {
-		hcloudLoadBalancerTargetHealthStatusList = make([]LoadBalancerTargetHealthStatus, len(source.HealthStatus))
+		hcloudLoadBalancerTarget.HealthStatus = make([]LoadBalancerTargetHealthStatus, len(source.HealthStatus))
 		for i := 0; i < len(source.HealthStatus); i++ {
-			hcloudLoadBalancerTargetHealthStatusList[i] = c.LoadBalancerTargetHealthStatusFromSchema(source.HealthStatus[i])
+			hcloudLoadBalancerTarget.HealthStatus[i] = c.LoadBalancerTargetHealthStatusFromSchema(source.HealthStatus[i])
 		}
 	}
-	hcloudLoadBalancerTarget.HealthStatus = hcloudLoadBalancerTargetHealthStatusList
-	var hcloudLoadBalancerTargetList []LoadBalancerTarget
 	if source.Targets != nil {
-		hcloudLoadBalancerTargetList = make([]LoadBalancerTarget, len(source.Targets))
+		hcloudLoadBalancerTarget.Targets = make([]LoadBalancerTarget, len(source.Targets))
 		for j := 0; j < len(source.Targets); j++ {
-			hcloudLoadBalancerTargetList[j] = c.LoadBalancerTargetFromSchema(source.Targets[j])
+			hcloudLoadBalancerTarget.Targets[j] = c.LoadBalancerTargetFromSchema(source.Targets[j])
 		}
 	}
-	hcloudLoadBalancerTarget.Targets = hcloudLoadBalancerTargetList
 	hcloudLoadBalancerTarget.UsePrivateIP = source.UsePrivateIP
 	return hcloudLoadBalancerTarget
 }
@@ -340,14 +300,12 @@ func (c *converterImpl) LoadBalancerTypeFromSchema(source schema.LoadBalancerTyp
 	hcloudLoadBalancerType.MaxServices = source.MaxServices
 	hcloudLoadBalancerType.MaxTargets = source.MaxTargets
 	hcloudLoadBalancerType.MaxAssignedCertificates = source.MaxAssignedCertificates
-	var hcloudLoadBalancerTypeLocationPricingList []LoadBalancerTypeLocationPricing
 	if source.Prices != nil {
-		hcloudLoadBalancerTypeLocationPricingList = make([]LoadBalancerTypeLocationPricing, len(source.Prices))
+		hcloudLoadBalancerType.Pricings = make([]LoadBalancerTypeLocationPricing, len(source.Prices))
 		for i := 0; i < len(source.Prices); i++ {
-			hcloudLoadBalancerTypeLocationPricingList[i] = c.LoadBalancerTypeLocationPricingFromSchema(source.Prices[i])
+			hcloudLoadBalancerType.Pricings[i] = c.LoadBalancerTypeLocationPricingFromSchema(source.Prices[i])
 		}
 	}
-	hcloudLoadBalancerType.Pricings = hcloudLoadBalancerTypeLocationPricingList
 	hcloudLoadBalancerType.Deprecated = source.Deprecated
 	return &hcloudLoadBalancerType
 }
@@ -357,6 +315,8 @@ func (c *converterImpl) LoadBalancerTypeLocationPricingFromSchema(source schema.
 	hcloudLoadBalancerTypeLocationPricing.Location = &hcloudLocation
 	hcloudLoadBalancerTypeLocationPricing.Hourly = c.PriceFromSchema(source.PriceHourly)
 	hcloudLoadBalancerTypeLocationPricing.Monthly = c.PriceFromSchema(source.PriceMonthly)
+	hcloudLoadBalancerTypeLocationPricing.IncludedTraffic = source.IncludedTraffic
+	hcloudLoadBalancerTypeLocationPricing.PerTBTraffic = c.PriceFromSchema(source.PricePerTBTraffic)
 	return hcloudLoadBalancerTypeLocationPricing
 }
 func (c *converterImpl) LocationFromSchema(source schema.Location) *Location {
@@ -378,31 +338,32 @@ func (c *converterImpl) NetworkFromSchema(source schema.Network) *Network {
 	hcloudNetwork.Created = c.timeTimeToTimeTime(source.Created)
 	netIPNet := ipNetFromString(source.IPRange)
 	hcloudNetwork.IPRange = &netIPNet
-	var hcloudNetworkSubnetList []NetworkSubnet
 	if source.Subnets != nil {
-		hcloudNetworkSubnetList = make([]NetworkSubnet, len(source.Subnets))
+		hcloudNetwork.Subnets = make([]NetworkSubnet, len(source.Subnets))
 		for i := 0; i < len(source.Subnets); i++ {
-			hcloudNetworkSubnetList[i] = c.NetworkSubnetFromSchema(source.Subnets[i])
+			hcloudNetwork.Subnets[i] = c.NetworkSubnetFromSchema(source.Subnets[i])
 		}
 	}
-	hcloudNetwork.Subnets = hcloudNetworkSubnetList
-	var hcloudNetworkRouteList []NetworkRoute
 	if source.Routes != nil {
-		hcloudNetworkRouteList = make([]NetworkRoute, len(source.Routes))
+		hcloudNetwork.Routes = make([]NetworkRoute, len(source.Routes))
 		for j := 0; j < len(source.Routes); j++ {
-			hcloudNetworkRouteList[j] = c.NetworkRouteFromSchema(source.Routes[j])
+			hcloudNetwork.Routes[j] = c.NetworkRouteFromSchema(source.Routes[j])
 		}
 	}
-	hcloudNetwork.Routes = hcloudNetworkRouteList
-	var pHcloudServerList []*Server
 	if source.Servers != nil {
-		pHcloudServerList = make([]*Server, len(source.Servers))
+		hcloudNetwork.Servers = make([]*Server, len(source.Servers))
 		for k := 0; k < len(source.Servers); k++ {
 			hcloudServer := serverFromInt64(source.Servers[k])
-			pHcloudServerList[k] = &hcloudServer
+			hcloudNetwork.Servers[k] = &hcloudServer
 		}
 	}
-	hcloudNetwork.Servers = pHcloudServerList
+	if source.LoadBalancers != nil {
+		hcloudNetwork.LoadBalancers = make([]*LoadBalancer, len(source.LoadBalancers))
+		for l := 0; l < len(source.LoadBalancers); l++ {
+			hcloudLoadBalancer := loadBalancerFromInt64(source.LoadBalancers[l])
+			hcloudNetwork.LoadBalancers[l] = &hcloudLoadBalancer
+		}
+	}
 	hcloudNetwork.Protection = c.schemaNetworkProtectionToHcloudNetworkProtection(source.Protection)
 	hcloudNetwork.Labels = source.Labels
 	hcloudNetwork.ExposeRoutesToVSwitch = source.ExposeRoutesToVSwitch
@@ -474,11 +435,9 @@ func (c *converterImpl) PrimaryIPFromSchema(source schema.PrimaryIP) *PrimaryIP 
 	hcloudPrimaryIP.Type = PrimaryIPType(source.Type)
 	hcloudPrimaryIP.Protection = c.schemaPrimaryIPProtectionToHcloudPrimaryIPProtection(source.Protection)
 	hcloudPrimaryIP.DNSPtr = mapFromPrimaryIPDNSPtrSchema(source.DNSPtr)
-	var xint64 int64
 	if source.AssigneeID != nil {
-		xint64 = *source.AssigneeID
+		hcloudPrimaryIP.AssigneeID = *source.AssigneeID
 	}
-	hcloudPrimaryIP.AssigneeID = xint64
 	hcloudPrimaryIP.AssigneeType = source.AssigneeType
 	hcloudPrimaryIP.AutoDelete = source.AutoDelete
 	hcloudPrimaryIP.Blocked = source.Blocked
@@ -507,14 +466,12 @@ func (c *converterImpl) SchemaFromAction(source *Action) schema.Action {
 		schemaAction2.Started = c.timeTimeToTimeTime((*source).Started)
 		schemaAction2.Finished = timeToTimePtr((*source).Finished)
 		schemaAction2.Error = schemaActionErrorFromAction((*source))
-		var schemaActionResourceReferenceList []schema.ActionResourceReference
 		if (*source).Resources != nil {
-			schemaActionResourceReferenceList = make([]schema.ActionResourceReference, len((*source).Resources))
+			schemaAction2.Resources = make([]schema.ActionResourceReference, len((*source).Resources))
 			for i := 0; i < len((*source).Resources); i++ {
-				schemaActionResourceReferenceList[i] = c.pHcloudActionResourceToSchemaActionResourceReference((*source).Resources[i])
+				schemaAction2.Resources[i] = c.pHcloudActionResourceToSchemaActionResourceReference((*source).Resources[i])
 			}
 		}
-		schemaAction2.Resources = schemaActionResourceReferenceList
 		schemaAction = schemaAction2
 	}
 	return schemaAction
@@ -544,14 +501,12 @@ func (c *converterImpl) SchemaFromCertificate(source *Certificate) schema.Certif
 		schemaCertificate2.DomainNames = (*source).DomainNames
 		schemaCertificate2.Fingerprint = (*source).Fingerprint
 		schemaCertificate2.Status = c.pHcloudCertificateStatusToPSchemaCertificateStatusRef((*source).Status)
-		var schemaCertificateUsedByRefList []schema.CertificateUsedByRef
 		if (*source).UsedBy != nil {
-			schemaCertificateUsedByRefList = make([]schema.CertificateUsedByRef, len((*source).UsedBy))
+			schemaCertificate2.UsedBy = make([]schema.CertificateUsedByRef, len((*source).UsedBy))
 			for i := 0; i < len((*source).UsedBy); i++ {
-				schemaCertificateUsedByRefList[i] = c.hcloudCertificateUsedByRefToSchemaCertificateUsedByRef((*source).UsedBy[i])
+				schemaCertificate2.UsedBy[i] = c.hcloudCertificateUsedByRefToSchemaCertificateUsedByRef((*source).UsedBy[i])
 			}
 		}
-		schemaCertificate2.UsedBy = schemaCertificateUsedByRefList
 		schemaCertificate = schemaCertificate2
 	}
 	return schemaCertificate
@@ -595,22 +550,18 @@ func (c *converterImpl) SchemaFromFirewall(source *Firewall) schema.Firewall {
 		schemaFirewall2.Name = (*source).Name
 		schemaFirewall2.Labels = (*source).Labels
 		schemaFirewall2.Created = c.timeTimeToTimeTime((*source).Created)
-		var schemaFirewallRuleList []schema.FirewallRule
 		if (*source).Rules != nil {
-			schemaFirewallRuleList = make([]schema.FirewallRule, len((*source).Rules))
+			schemaFirewall2.Rules = make([]schema.FirewallRule, len((*source).Rules))
 			for i := 0; i < len((*source).Rules); i++ {
-				schemaFirewallRuleList[i] = c.hcloudFirewallRuleToSchemaFirewallRule((*source).Rules[i])
+				schemaFirewall2.Rules[i] = c.hcloudFirewallRuleToSchemaFirewallRule((*source).Rules[i])
 			}
 		}
-		schemaFirewall2.Rules = schemaFirewallRuleList
-		var schemaFirewallResourceList []schema.FirewallResource
 		if (*source).AppliedTo != nil {
-			schemaFirewallResourceList = make([]schema.FirewallResource, len((*source).AppliedTo))
+			schemaFirewall2.AppliedTo = make([]schema.FirewallResource, len((*source).AppliedTo))
 			for j := 0; j < len((*source).AppliedTo); j++ {
-				schemaFirewallResourceList[j] = c.SchemaFromFirewallResource((*source).AppliedTo[j])
+				schemaFirewall2.AppliedTo[j] = c.SchemaFromFirewallResource((*source).AppliedTo[j])
 			}
 		}
-		schemaFirewall2.AppliedTo = schemaFirewallResourceList
 		schemaFirewall = schemaFirewall2
 	}
 	return schemaFirewall
@@ -619,22 +570,18 @@ func (c *converterImpl) SchemaFromFirewallCreateOpts(source FirewallCreateOpts) 
 	var schemaFirewallCreateRequest schema.FirewallCreateRequest
 	schemaFirewallCreateRequest.Name = source.Name
 	schemaFirewallCreateRequest.Labels = stringMapToStringMapPtr(source.Labels)
-	var schemaFirewallRuleRequestList []schema.FirewallRuleRequest
 	if source.Rules != nil {
-		schemaFirewallRuleRequestList = make([]schema.FirewallRuleRequest, len(source.Rules))
+		schemaFirewallCreateRequest.Rules = make([]schema.FirewallRuleRequest, len(source.Rules))
 		for i := 0; i < len(source.Rules); i++ {
-			schemaFirewallRuleRequestList[i] = c.hcloudFirewallRuleToSchemaFirewallRuleRequest(source.Rules[i])
+			schemaFirewallCreateRequest.Rules[i] = c.hcloudFirewallRuleToSchemaFirewallRuleRequest(source.Rules[i])
 		}
 	}
-	schemaFirewallCreateRequest.Rules = schemaFirewallRuleRequestList
-	var schemaFirewallResourceList []schema.FirewallResource
 	if source.ApplyTo != nil {
-		schemaFirewallResourceList = make([]schema.FirewallResource, len(source.ApplyTo))
+		schemaFirewallCreateRequest.ApplyTo = make([]schema.FirewallResource, len(source.ApplyTo))
 		for j := 0; j < len(source.ApplyTo); j++ {
-			schemaFirewallResourceList[j] = c.SchemaFromFirewallResource(source.ApplyTo[j])
+			schemaFirewallCreateRequest.ApplyTo[j] = c.SchemaFromFirewallResource(source.ApplyTo[j])
 		}
 	}
-	schemaFirewallCreateRequest.ApplyTo = schemaFirewallResourceList
 	return schemaFirewallCreateRequest
 }
 func (c *converterImpl) SchemaFromFirewallResource(source FirewallResource) schema.FirewallResource {
@@ -646,14 +593,12 @@ func (c *converterImpl) SchemaFromFirewallResource(source FirewallResource) sche
 }
 func (c *converterImpl) SchemaFromFirewallSetRulesOpts(source FirewallSetRulesOpts) schema.FirewallActionSetRulesRequest {
 	var schemaFirewallActionSetRulesRequest schema.FirewallActionSetRulesRequest
-	var schemaFirewallRuleRequestList []schema.FirewallRuleRequest
 	if source.Rules != nil {
-		schemaFirewallRuleRequestList = make([]schema.FirewallRuleRequest, len(source.Rules))
+		schemaFirewallActionSetRulesRequest.Rules = make([]schema.FirewallRuleRequest, len(source.Rules))
 		for i := 0; i < len(source.Rules); i++ {
-			schemaFirewallRuleRequestList[i] = c.hcloudFirewallRuleToSchemaFirewallRuleRequest(source.Rules[i])
+			schemaFirewallActionSetRulesRequest.Rules[i] = c.hcloudFirewallRuleToSchemaFirewallRuleRequest(source.Rules[i])
 		}
 	}
-	schemaFirewallActionSetRulesRequest.Rules = schemaFirewallRuleRequestList
 	return schemaFirewallActionSetRulesRequest
 }
 func (c *converterImpl) SchemaFromFloatingIP(source *FloatingIP) schema.FloatingIP {
@@ -685,12 +630,10 @@ func (c *converterImpl) SchemaFromISO(source *ISO) schema.ISO {
 		schemaISO2.Name = (*source).Name
 		schemaISO2.Description = (*source).Description
 		schemaISO2.Type = string((*source).Type)
-		var pString *string
 		if (*source).Architecture != nil {
 			xstring := string(*(*source).Architecture)
-			pString = &xstring
+			schemaISO2.Architecture = &xstring
 		}
-		schemaISO2.Architecture = pString
 		schemaISO2.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
 		schemaISO = schemaISO2
 	}
@@ -710,35 +653,29 @@ func (c *converterImpl) SchemaFromLoadBalancer(source *LoadBalancer) schema.Load
 		schemaLoadBalancer2.ID = (*source).ID
 		schemaLoadBalancer2.Name = (*source).Name
 		schemaLoadBalancer2.PublicNet = c.hcloudLoadBalancerPublicNetToSchemaLoadBalancerPublicNet((*source).PublicNet)
-		var schemaLoadBalancerPrivateNetList []schema.LoadBalancerPrivateNet
 		if (*source).PrivateNet != nil {
-			schemaLoadBalancerPrivateNetList = make([]schema.LoadBalancerPrivateNet, len((*source).PrivateNet))
+			schemaLoadBalancer2.PrivateNet = make([]schema.LoadBalancerPrivateNet, len((*source).PrivateNet))
 			for i := 0; i < len((*source).PrivateNet); i++ {
-				schemaLoadBalancerPrivateNetList[i] = c.hcloudLoadBalancerPrivateNetToSchemaLoadBalancerPrivateNet((*source).PrivateNet[i])
+				schemaLoadBalancer2.PrivateNet[i] = c.hcloudLoadBalancerPrivateNetToSchemaLoadBalancerPrivateNet((*source).PrivateNet[i])
 			}
 		}
-		schemaLoadBalancer2.PrivateNet = schemaLoadBalancerPrivateNetList
 		schemaLoadBalancer2.Location = c.SchemaFromLocation((*source).Location)
 		schemaLoadBalancer2.LoadBalancerType = c.SchemaFromLoadBalancerType((*source).LoadBalancerType)
 		schemaLoadBalancer2.Protection = c.hcloudLoadBalancerProtectionToSchemaLoadBalancerProtection((*source).Protection)
 		schemaLoadBalancer2.Labels = (*source).Labels
 		schemaLoadBalancer2.Created = c.timeTimeToTimeTime((*source).Created)
-		var schemaLoadBalancerServiceList []schema.LoadBalancerService
 		if (*source).Services != nil {
-			schemaLoadBalancerServiceList = make([]schema.LoadBalancerService, len((*source).Services))
+			schemaLoadBalancer2.Services = make([]schema.LoadBalancerService, len((*source).Services))
 			for j := 0; j < len((*source).Services); j++ {
-				schemaLoadBalancerServiceList[j] = c.SchemaFromLoadBalancerService((*source).Services[j])
+				schemaLoadBalancer2.Services[j] = c.SchemaFromLoadBalancerService((*source).Services[j])
 			}
 		}
-		schemaLoadBalancer2.Services = schemaLoadBalancerServiceList
-		var schemaLoadBalancerTargetList []schema.LoadBalancerTarget
 		if (*source).Targets != nil {
-			schemaLoadBalancerTargetList = make([]schema.LoadBalancerTarget, len((*source).Targets))
+			schemaLoadBalancer2.Targets = make([]schema.LoadBalancerTarget, len((*source).Targets))
 			for k := 0; k < len((*source).Targets); k++ {
-				schemaLoadBalancerTargetList[k] = c.SchemaFromLoadBalancerTarget((*source).Targets[k])
+				schemaLoadBalancer2.Targets[k] = c.SchemaFromLoadBalancerTarget((*source).Targets[k])
 			}
 		}
-		schemaLoadBalancer2.Targets = schemaLoadBalancerTargetList
 		schemaLoadBalancer2.Algorithm = c.hcloudLoadBalancerAlgorithmToSchemaLoadBalancerAlgorithm((*source).Algorithm)
 		schemaLoadBalancer2.IncludedTraffic = (*source).IncludedTraffic
 		schemaLoadBalancer2.OutgoingTraffic = mapZeroUint64ToNil((*source).OutgoingTraffic)
@@ -760,27 +697,23 @@ func (c *converterImpl) SchemaFromLoadBalancerAddServiceOpts(source LoadBalancer
 func (c *converterImpl) SchemaFromLoadBalancerCreateOpts(source LoadBalancerCreateOpts) schema.LoadBalancerCreateRequest {
 	var schemaLoadBalancerCreateRequest schema.LoadBalancerCreateRequest
 	schemaLoadBalancerCreateRequest.Name = source.Name
-	schemaLoadBalancerCreateRequest.LoadBalancerType = anyFromLoadBalancerType(source.LoadBalancerType)
+	schemaLoadBalancerCreateRequest.LoadBalancerType = c.pHcloudLoadBalancerTypeToSchemaIDOrName(source.LoadBalancerType)
 	schemaLoadBalancerCreateRequest.Algorithm = c.pHcloudLoadBalancerAlgorithmToPSchemaLoadBalancerCreateRequestAlgorithm(source.Algorithm)
 	schemaLoadBalancerCreateRequest.Location = c.pHcloudLocationToPString(source.Location)
 	schemaLoadBalancerCreateRequest.NetworkZone = stringPtrFromNetworkZone(source.NetworkZone)
 	schemaLoadBalancerCreateRequest.Labels = stringMapToStringMapPtr(source.Labels)
-	var schemaLoadBalancerCreateRequestTargetList []schema.LoadBalancerCreateRequestTarget
 	if source.Targets != nil {
-		schemaLoadBalancerCreateRequestTargetList = make([]schema.LoadBalancerCreateRequestTarget, len(source.Targets))
+		schemaLoadBalancerCreateRequest.Targets = make([]schema.LoadBalancerCreateRequestTarget, len(source.Targets))
 		for i := 0; i < len(source.Targets); i++ {
-			schemaLoadBalancerCreateRequestTargetList[i] = c.hcloudLoadBalancerCreateOptsTargetToSchemaLoadBalancerCreateRequestTarget(source.Targets[i])
+			schemaLoadBalancerCreateRequest.Targets[i] = c.hcloudLoadBalancerCreateOptsTargetToSchemaLoadBalancerCreateRequestTarget(source.Targets[i])
 		}
 	}
-	schemaLoadBalancerCreateRequest.Targets = schemaLoadBalancerCreateRequestTargetList
-	var schemaLoadBalancerCreateRequestServiceList []schema.LoadBalancerCreateRequestService
 	if source.Services != nil {
-		schemaLoadBalancerCreateRequestServiceList = make([]schema.LoadBalancerCreateRequestService, len(source.Services))
+		schemaLoadBalancerCreateRequest.Services = make([]schema.LoadBalancerCreateRequestService, len(source.Services))
 		for j := 0; j < len(source.Services); j++ {
-			schemaLoadBalancerCreateRequestServiceList[j] = c.hcloudLoadBalancerCreateOptsServiceToSchemaLoadBalancerCreateRequestService(source.Services[j])
+			schemaLoadBalancerCreateRequest.Services[j] = c.hcloudLoadBalancerCreateOptsServiceToSchemaLoadBalancerCreateRequestService(source.Services[j])
 		}
 	}
-	schemaLoadBalancerCreateRequest.Services = schemaLoadBalancerCreateRequestServiceList
 	schemaLoadBalancerCreateRequest.PublicInterface = source.PublicInterface
 	schemaLoadBalancerCreateRequest.Network = c.pHcloudNetworkToPInt64(source.Network)
 	return schemaLoadBalancerCreateRequest
@@ -791,11 +724,9 @@ func (c *converterImpl) SchemaFromLoadBalancerCreateOptsTargetServer(source Load
 	if source.Server != nil {
 		pInt64 = &source.Server.ID
 	}
-	var xint64 int64
 	if pInt64 != nil {
-		xint64 = *pInt64
+		schemaLoadBalancerCreateRequestTargetServer.ID = *pInt64
 	}
-	schemaLoadBalancerCreateRequestTargetServer.ID = xint64
 	return schemaLoadBalancerCreateRequestTargetServer
 }
 func (c *converterImpl) SchemaFromLoadBalancerServerTarget(source LoadBalancerTargetServer) schema.LoadBalancerTargetServer {
@@ -829,23 +760,19 @@ func (c *converterImpl) SchemaFromLoadBalancerTarget(source LoadBalancerTarget) 
 	schemaLoadBalancerTarget.Server = c.pHcloudLoadBalancerTargetServerToPSchemaLoadBalancerTargetServer(source.Server)
 	schemaLoadBalancerTarget.LabelSelector = c.pHcloudLoadBalancerTargetLabelSelectorToPSchemaLoadBalancerTargetLabelSelector(source.LabelSelector)
 	schemaLoadBalancerTarget.IP = c.pHcloudLoadBalancerTargetIPToPSchemaLoadBalancerTargetIP(source.IP)
-	var schemaLoadBalancerTargetHealthStatusList []schema.LoadBalancerTargetHealthStatus
 	if source.HealthStatus != nil {
-		schemaLoadBalancerTargetHealthStatusList = make([]schema.LoadBalancerTargetHealthStatus, len(source.HealthStatus))
+		schemaLoadBalancerTarget.HealthStatus = make([]schema.LoadBalancerTargetHealthStatus, len(source.HealthStatus))
 		for i := 0; i < len(source.HealthStatus); i++ {
-			schemaLoadBalancerTargetHealthStatusList[i] = c.SchemaFromLoadBalancerTargetHealthStatus(source.HealthStatus[i])
+			schemaLoadBalancerTarget.HealthStatus[i] = c.SchemaFromLoadBalancerTargetHealthStatus(source.HealthStatus[i])
 		}
 	}
-	schemaLoadBalancerTarget.HealthStatus = schemaLoadBalancerTargetHealthStatusList
 	schemaLoadBalancerTarget.UsePrivateIP = source.UsePrivateIP
-	var schemaLoadBalancerTargetList []schema.LoadBalancerTarget
 	if source.Targets != nil {
-		schemaLoadBalancerTargetList = make([]schema.LoadBalancerTarget, len(source.Targets))
+		schemaLoadBalancerTarget.Targets = make([]schema.LoadBalancerTarget, len(source.Targets))
 		for j := 0; j < len(source.Targets); j++ {
-			schemaLoadBalancerTargetList[j] = c.SchemaFromLoadBalancerTarget(source.Targets[j])
+			schemaLoadBalancerTarget.Targets[j] = c.SchemaFromLoadBalancerTarget(source.Targets[j])
 		}
 	}
-	schemaLoadBalancerTarget.Targets = schemaLoadBalancerTargetList
 	return schemaLoadBalancerTarget
 }
 func (c *converterImpl) SchemaFromLoadBalancerTargetHealthStatus(source LoadBalancerTargetHealthStatus) schema.LoadBalancerTargetHealthStatus {
@@ -865,14 +792,12 @@ func (c *converterImpl) SchemaFromLoadBalancerType(source *LoadBalancerType) sch
 		schemaLoadBalancerType2.MaxServices = (*source).MaxServices
 		schemaLoadBalancerType2.MaxTargets = (*source).MaxTargets
 		schemaLoadBalancerType2.MaxAssignedCertificates = (*source).MaxAssignedCertificates
-		var schemaPricingLoadBalancerTypePriceList []schema.PricingLoadBalancerTypePrice
 		if (*source).Pricings != nil {
-			schemaPricingLoadBalancerTypePriceList = make([]schema.PricingLoadBalancerTypePrice, len((*source).Pricings))
+			schemaLoadBalancerType2.Prices = make([]schema.PricingLoadBalancerTypePrice, len((*source).Pricings))
 			for i := 0; i < len((*source).Pricings); i++ {
-				schemaPricingLoadBalancerTypePriceList[i] = c.SchemaFromLoadBalancerTypeLocationPricing((*source).Pricings[i])
+				schemaLoadBalancerType2.Prices[i] = c.SchemaFromLoadBalancerTypeLocationPricing((*source).Pricings[i])
 			}
 		}
-		schemaLoadBalancerType2.Prices = schemaPricingLoadBalancerTypePriceList
 		schemaLoadBalancerType2.Deprecated = (*source).Deprecated
 		schemaLoadBalancerType = schemaLoadBalancerType2
 	}
@@ -883,6 +808,8 @@ func (c *converterImpl) SchemaFromLoadBalancerTypeLocationPricing(source LoadBal
 	schemaPricingLoadBalancerTypePrice.Location = c.pHcloudLocationToString(source.Location)
 	schemaPricingLoadBalancerTypePrice.PriceHourly = c.hcloudPriceToSchemaPrice(source.Hourly)
 	schemaPricingLoadBalancerTypePrice.PriceMonthly = c.hcloudPriceToSchemaPrice(source.Monthly)
+	schemaPricingLoadBalancerTypePrice.IncludedTraffic = source.IncludedTraffic
+	schemaPricingLoadBalancerTypePrice.PricePerTBTraffic = c.hcloudPriceToSchemaPrice(source.PerTBTraffic)
 	return schemaPricingLoadBalancerTypePrice
 }
 func (c *converterImpl) SchemaFromLoadBalancerUpdateServiceOpts(source LoadBalancerUpdateServiceOpts) schema.LoadBalancerActionUpdateServiceRequest {
@@ -918,30 +845,30 @@ func (c *converterImpl) SchemaFromNetwork(source *Network) schema.Network {
 		schemaNetwork2.Name = (*source).Name
 		schemaNetwork2.Created = c.timeTimeToTimeTime((*source).Created)
 		schemaNetwork2.IPRange = c.pNetIPNetToString((*source).IPRange)
-		var schemaNetworkSubnetList []schema.NetworkSubnet
 		if (*source).Subnets != nil {
-			schemaNetworkSubnetList = make([]schema.NetworkSubnet, len((*source).Subnets))
+			schemaNetwork2.Subnets = make([]schema.NetworkSubnet, len((*source).Subnets))
 			for i := 0; i < len((*source).Subnets); i++ {
-				schemaNetworkSubnetList[i] = c.SchemaFromNetworkSubnet((*source).Subnets[i])
+				schemaNetwork2.Subnets[i] = c.SchemaFromNetworkSubnet((*source).Subnets[i])
 			}
 		}
-		schemaNetwork2.Subnets = schemaNetworkSubnetList
-		var schemaNetworkRouteList []schema.NetworkRoute
 		if (*source).Routes != nil {
-			schemaNetworkRouteList = make([]schema.NetworkRoute, len((*source).Routes))
+			schemaNetwork2.Routes = make([]schema.NetworkRoute, len((*source).Routes))
 			for j := 0; j < len((*source).Routes); j++ {
-				schemaNetworkRouteList[j] = c.SchemaFromNetworkRoute((*source).Routes[j])
+				schemaNetwork2.Routes[j] = c.SchemaFromNetworkRoute((*source).Routes[j])
 			}
 		}
-		schemaNetwork2.Routes = schemaNetworkRouteList
-		var int64List []int64
 		if (*source).Servers != nil {
-			int64List = make([]int64, len((*source).Servers))
+			schemaNetwork2.Servers = make([]int64, len((*source).Servers))
 			for k := 0; k < len((*source).Servers); k++ {
-				int64List[k] = c.pHcloudServerToInt64((*source).Servers[k])
+				schemaNetwork2.Servers[k] = c.pHcloudServerToInt64((*source).Servers[k])
 			}
 		}
-		schemaNetwork2.Servers = int64List
+		if (*source).LoadBalancers != nil {
+			schemaNetwork2.LoadBalancers = make([]int64, len((*source).LoadBalancers))
+			for l := 0; l < len((*source).LoadBalancers); l++ {
+				schemaNetwork2.LoadBalancers[l] = c.pHcloudLoadBalancerToInt64((*source).LoadBalancers[l])
+			}
+		}
 		schemaNetwork2.Protection = c.hcloudNetworkProtectionToSchemaNetworkProtection((*source).Protection)
 		schemaNetwork2.Labels = (*source).Labels
 		schemaNetwork2.ExposeRoutesToVSwitch = (*source).ExposeRoutesToVSwitch
@@ -1001,40 +928,32 @@ func (c *converterImpl) SchemaFromPricing(source Pricing) schema.Pricing {
 	schemaPricing.VATRate = source.Image.PerGBMonth.VATRate
 	schemaPricing.Image = c.schemaFromImagePricing(source.Image)
 	schemaPricing.FloatingIP = c.schemaFromFloatingIPPricing(source.FloatingIP)
-	var schemaPricingFloatingIPTypeList []schema.PricingFloatingIPType
 	if source.FloatingIPs != nil {
-		schemaPricingFloatingIPTypeList = make([]schema.PricingFloatingIPType, len(source.FloatingIPs))
+		schemaPricing.FloatingIPs = make([]schema.PricingFloatingIPType, len(source.FloatingIPs))
 		for i := 0; i < len(source.FloatingIPs); i++ {
-			schemaPricingFloatingIPTypeList[i] = c.schemaFromFloatingIPTypePricing(source.FloatingIPs[i])
+			schemaPricing.FloatingIPs[i] = c.schemaFromFloatingIPTypePricing(source.FloatingIPs[i])
 		}
 	}
-	schemaPricing.FloatingIPs = schemaPricingFloatingIPTypeList
-	var schemaPricingPrimaryIPList []schema.PricingPrimaryIP
 	if source.PrimaryIPs != nil {
-		schemaPricingPrimaryIPList = make([]schema.PricingPrimaryIP, len(source.PrimaryIPs))
+		schemaPricing.PrimaryIPs = make([]schema.PricingPrimaryIP, len(source.PrimaryIPs))
 		for j := 0; j < len(source.PrimaryIPs); j++ {
-			schemaPricingPrimaryIPList[j] = c.schemaFromPrimaryIPPricing(source.PrimaryIPs[j])
+			schemaPricing.PrimaryIPs[j] = c.schemaFromPrimaryIPPricing(source.PrimaryIPs[j])
 		}
 	}
-	schemaPricing.PrimaryIPs = schemaPricingPrimaryIPList
 	schemaPricing.Traffic = c.schemaFromTrafficPricing(source.Traffic)
 	schemaPricing.ServerBackup = c.hcloudServerBackupPricingToSchemaPricingServerBackup(source.ServerBackup)
-	var schemaPricingServerTypeList []schema.PricingServerType
 	if source.ServerTypes != nil {
-		schemaPricingServerTypeList = make([]schema.PricingServerType, len(source.ServerTypes))
+		schemaPricing.ServerTypes = make([]schema.PricingServerType, len(source.ServerTypes))
 		for k := 0; k < len(source.ServerTypes); k++ {
-			schemaPricingServerTypeList[k] = c.schemaFromServerTypePricing(source.ServerTypes[k])
+			schemaPricing.ServerTypes[k] = c.schemaFromServerTypePricing(source.ServerTypes[k])
 		}
 	}
-	schemaPricing.ServerTypes = schemaPricingServerTypeList
-	var schemaPricingLoadBalancerTypeList []schema.PricingLoadBalancerType
 	if source.LoadBalancerTypes != nil {
-		schemaPricingLoadBalancerTypeList = make([]schema.PricingLoadBalancerType, len(source.LoadBalancerTypes))
+		schemaPricing.LoadBalancerTypes = make([]schema.PricingLoadBalancerType, len(source.LoadBalancerTypes))
 		for l := 0; l < len(source.LoadBalancerTypes); l++ {
-			schemaPricingLoadBalancerTypeList[l] = c.schemaFromLoadBalancerTypePricing(source.LoadBalancerTypes[l])
+			schemaPricing.LoadBalancerTypes[l] = c.schemaFromLoadBalancerTypePricing(source.LoadBalancerTypes[l])
 		}
 	}
-	schemaPricing.LoadBalancerTypes = schemaPricingLoadBalancerTypeList
 	schemaPricing.Volume = c.schemaFromVolumePricing(source.Volume)
 	return schemaPricing
 }
@@ -1059,6 +978,44 @@ func (c *converterImpl) SchemaFromPrimaryIP(source *PrimaryIP) schema.PrimaryIP 
 	}
 	return schemaPrimaryIP
 }
+func (c *converterImpl) SchemaFromPrimaryIPAssignOpts(source PrimaryIPAssignOpts) schema.PrimaryIPActionAssignRequest {
+	var schemaPrimaryIPActionAssignRequest schema.PrimaryIPActionAssignRequest
+	schemaPrimaryIPActionAssignRequest.AssigneeID = source.AssigneeID
+	schemaPrimaryIPActionAssignRequest.AssigneeType = source.AssigneeType
+	return schemaPrimaryIPActionAssignRequest
+}
+func (c *converterImpl) SchemaFromPrimaryIPChangeDNSPtrOpts(source PrimaryIPChangeDNSPtrOpts) schema.PrimaryIPActionChangeDNSPtrRequest {
+	var schemaPrimaryIPActionChangeDNSPtrRequest schema.PrimaryIPActionChangeDNSPtrRequest
+	schemaPrimaryIPActionChangeDNSPtrRequest.IP = source.IP
+	pString := source.DNSPtr
+	schemaPrimaryIPActionChangeDNSPtrRequest.DNSPtr = &pString
+	return schemaPrimaryIPActionChangeDNSPtrRequest
+}
+func (c *converterImpl) SchemaFromPrimaryIPChangeProtectionOpts(source PrimaryIPChangeProtectionOpts) schema.PrimaryIPActionChangeProtectionRequest {
+	var schemaPrimaryIPActionChangeProtectionRequest schema.PrimaryIPActionChangeProtectionRequest
+	schemaPrimaryIPActionChangeProtectionRequest.Delete = source.Delete
+	return schemaPrimaryIPActionChangeProtectionRequest
+}
+func (c *converterImpl) SchemaFromPrimaryIPCreateOpts(source PrimaryIPCreateOpts) schema.PrimaryIPCreateRequest {
+	var schemaPrimaryIPCreateRequest schema.PrimaryIPCreateRequest
+	schemaPrimaryIPCreateRequest.Name = source.Name
+	schemaPrimaryIPCreateRequest.Type = string(source.Type)
+	schemaPrimaryIPCreateRequest.AssigneeType = source.AssigneeType
+	schemaPrimaryIPCreateRequest.AssigneeID = source.AssigneeID
+	schemaPrimaryIPCreateRequest.Labels = source.Labels
+	schemaPrimaryIPCreateRequest.AutoDelete = source.AutoDelete
+	schemaPrimaryIPCreateRequest.Datacenter = source.Datacenter
+	return schemaPrimaryIPCreateRequest
+}
+func (c *converterImpl) SchemaFromPrimaryIPUpdateOpts(source PrimaryIPUpdateOpts) schema.PrimaryIPUpdateRequest {
+	var schemaPrimaryIPUpdateRequest schema.PrimaryIPUpdateRequest
+	schemaPrimaryIPUpdateRequest.Name = source.Name
+	if source.Labels != nil {
+		schemaPrimaryIPUpdateRequest.Labels = (*source.Labels)
+	}
+	schemaPrimaryIPUpdateRequest.AutoDelete = source.AutoDelete
+	return schemaPrimaryIPUpdateRequest
+}
 func (c *converterImpl) SchemaFromSSHKey(source *SSHKey) schema.SSHKey {
 	var schemaSSHKey schema.SSHKey
 	if source != nil {
@@ -1082,14 +1039,12 @@ func (c *converterImpl) SchemaFromServer(source *Server) schema.Server {
 		schemaServer2.Status = string((*source).Status)
 		schemaServer2.Created = c.timeTimeToTimeTime((*source).Created)
 		schemaServer2.PublicNet = c.SchemaFromServerPublicNet((*source).PublicNet)
-		var schemaServerPrivateNetList []schema.ServerPrivateNet
 		if (*source).PrivateNet != nil {
-			schemaServerPrivateNetList = make([]schema.ServerPrivateNet, len((*source).PrivateNet))
+			schemaServer2.PrivateNet = make([]schema.ServerPrivateNet, len((*source).PrivateNet))
 			for i := 0; i < len((*source).PrivateNet); i++ {
-				schemaServerPrivateNetList[i] = c.SchemaFromServerPrivateNet((*source).PrivateNet[i])
+				schemaServer2.PrivateNet[i] = c.SchemaFromServerPrivateNet((*source).PrivateNet[i])
 			}
 		}
-		schemaServer2.PrivateNet = schemaServerPrivateNetList
 		schemaServer2.ServerType = c.SchemaFromServerType((*source).ServerType)
 		schemaServer2.IncludedTraffic = (*source).IncludedTraffic
 		schemaServer2.OutgoingTraffic = mapZeroUint64ToNil((*source).OutgoingTraffic)
@@ -1102,24 +1057,20 @@ func (c *converterImpl) SchemaFromServer(source *Server) schema.Server {
 		schemaServer2.Image = c.pHcloudImageToPSchemaImage((*source).Image)
 		schemaServer2.Protection = c.hcloudServerProtectionToSchemaServerProtection((*source).Protection)
 		schemaServer2.Labels = (*source).Labels
-		var int64List []int64
 		if (*source).Volumes != nil {
-			int64List = make([]int64, len((*source).Volumes))
+			schemaServer2.Volumes = make([]int64, len((*source).Volumes))
 			for j := 0; j < len((*source).Volumes); j++ {
-				int64List[j] = int64FromVolume((*source).Volumes[j])
+				schemaServer2.Volumes[j] = int64FromVolume((*source).Volumes[j])
 			}
 		}
-		schemaServer2.Volumes = int64List
 		schemaServer2.PrimaryDiskSize = (*source).PrimaryDiskSize
 		schemaServer2.PlacementGroup = c.pHcloudPlacementGroupToPSchemaPlacementGroup((*source).PlacementGroup)
-		var int64List2 []int64
 		if (*source).LoadBalancers != nil {
-			int64List2 = make([]int64, len((*source).LoadBalancers))
+			schemaServer2.LoadBalancers = make([]int64, len((*source).LoadBalancers))
 			for k := 0; k < len((*source).LoadBalancers); k++ {
-				int64List2[k] = c.pHcloudLoadBalancerToInt64((*source).LoadBalancers[k])
+				schemaServer2.LoadBalancers[k] = c.pHcloudLoadBalancerToInt64((*source).LoadBalancers[k])
 			}
 		}
-		schemaServer2.LoadBalancers = int64List2
 		schemaServer = schemaServer2
 	}
 	return schemaServer
@@ -1128,14 +1079,12 @@ func (c *converterImpl) SchemaFromServerPrivateNet(source ServerPrivateNet) sche
 	var schemaServerPrivateNet schema.ServerPrivateNet
 	schemaServerPrivateNet.Network = c.pHcloudNetworkToInt64(source.Network)
 	schemaServerPrivateNet.IP = stringFromIP(source.IP)
-	var stringList []string
 	if source.Aliases != nil {
-		stringList = make([]string, len(source.Aliases))
+		schemaServerPrivateNet.AliasIPs = make([]string, len(source.Aliases))
 		for i := 0; i < len(source.Aliases); i++ {
-			stringList[i] = stringFromIP(source.Aliases[i])
+			schemaServerPrivateNet.AliasIPs[i] = stringFromIP(source.Aliases[i])
 		}
 	}
-	schemaServerPrivateNet.AliasIPs = stringList
 	schemaServerPrivateNet.MACAddress = source.MACAddress
 	return schemaServerPrivateNet
 }
@@ -1143,22 +1092,18 @@ func (c *converterImpl) SchemaFromServerPublicNet(source ServerPublicNet) schema
 	var schemaServerPublicNet schema.ServerPublicNet
 	schemaServerPublicNet.IPv4 = c.SchemaFromServerPublicNetIPv4(source.IPv4)
 	schemaServerPublicNet.IPv6 = c.SchemaFromServerPublicNetIPv6(source.IPv6)
-	var int64List []int64
 	if source.FloatingIPs != nil {
-		int64List = make([]int64, len(source.FloatingIPs))
+		schemaServerPublicNet.FloatingIPs = make([]int64, len(source.FloatingIPs))
 		for i := 0; i < len(source.FloatingIPs); i++ {
-			int64List[i] = int64FromFloatingIP(source.FloatingIPs[i])
+			schemaServerPublicNet.FloatingIPs[i] = int64FromFloatingIP(source.FloatingIPs[i])
 		}
 	}
-	schemaServerPublicNet.FloatingIPs = int64List
-	var schemaServerFirewallList []schema.ServerFirewall
 	if source.Firewalls != nil {
-		schemaServerFirewallList = make([]schema.ServerFirewall, len(source.Firewalls))
+		schemaServerPublicNet.Firewalls = make([]schema.ServerFirewall, len(source.Firewalls))
 		for j := 0; j < len(source.Firewalls); j++ {
-			schemaServerFirewallList[j] = serverFirewallSchemaFromFirewallStatus(source.Firewalls[j])
+			schemaServerPublicNet.Firewalls[j] = serverFirewallSchemaFromFirewallStatus(source.Firewalls[j])
 		}
 	}
-	schemaServerPublicNet.Firewalls = schemaServerFirewallList
 	return schemaServerPublicNet
 }
 func (c *converterImpl) SchemaFromServerPublicNetIPv4(source ServerPublicNetIPv4) schema.ServerPublicNetIPv4 {
@@ -1191,14 +1136,12 @@ func (c *converterImpl) SchemaFromServerType(source *ServerType) schema.ServerTy
 		schemaServerType2.CPUType = string((*source).CPUType)
 		schemaServerType2.Architecture = string((*source).Architecture)
 		schemaServerType2.IncludedTraffic = (*source).IncludedTraffic
-		var schemaPricingServerTypePriceList []schema.PricingServerTypePrice
 		if (*source).Pricings != nil {
-			schemaPricingServerTypePriceList = make([]schema.PricingServerTypePrice, len((*source).Pricings))
+			schemaServerType2.Prices = make([]schema.PricingServerTypePrice, len((*source).Pricings))
 			for i := 0; i < len((*source).Pricings); i++ {
-				schemaPricingServerTypePriceList[i] = c.schemaFromServerTypeLocationPricing((*source).Pricings[i])
+				schemaServerType2.Prices[i] = c.schemaFromServerTypeLocationPricing((*source).Pricings[i])
 			}
 		}
-		schemaServerType2.Prices = schemaPricingServerTypePriceList
 		schemaServerType2.Deprecated = isDeprecationNotNil((*source).DeprecatableResource.Deprecation)
 		schemaServerType2.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
 		schemaServerType = schemaServerType2
@@ -1231,57 +1174,45 @@ func (c *converterImpl) ServerFromSchema(source schema.Server) *Server {
 	hcloudServer.Status = ServerStatus(source.Status)
 	hcloudServer.Created = c.timeTimeToTimeTime(source.Created)
 	hcloudServer.PublicNet = c.ServerPublicNetFromSchema(source.PublicNet)
-	var hcloudServerPrivateNetList []ServerPrivateNet
 	if source.PrivateNet != nil {
-		hcloudServerPrivateNetList = make([]ServerPrivateNet, len(source.PrivateNet))
+		hcloudServer.PrivateNet = make([]ServerPrivateNet, len(source.PrivateNet))
 		for i := 0; i < len(source.PrivateNet); i++ {
-			hcloudServerPrivateNetList[i] = c.ServerPrivateNetFromSchema(source.PrivateNet[i])
+			hcloudServer.PrivateNet[i] = c.ServerPrivateNetFromSchema(source.PrivateNet[i])
 		}
 	}
-	hcloudServer.PrivateNet = hcloudServerPrivateNetList
 	hcloudServer.ServerType = c.ServerTypeFromSchema(source.ServerType)
 	hcloudServer.Datacenter = c.DatacenterFromSchema(source.Datacenter)
 	hcloudServer.IncludedTraffic = source.IncludedTraffic
-	var xuint64 uint64
 	if source.OutgoingTraffic != nil {
-		xuint64 = *source.OutgoingTraffic
+		hcloudServer.OutgoingTraffic = *source.OutgoingTraffic
 	}
-	hcloudServer.OutgoingTraffic = xuint64
-	var xuint642 uint64
 	if source.IngoingTraffic != nil {
-		xuint642 = *source.IngoingTraffic
+		hcloudServer.IngoingTraffic = *source.IngoingTraffic
 	}
-	hcloudServer.IngoingTraffic = xuint642
-	var xstring string
 	if source.BackupWindow != nil {
-		xstring = *source.BackupWindow
+		hcloudServer.BackupWindow = *source.BackupWindow
 	}
-	hcloudServer.BackupWindow = xstring
 	hcloudServer.RescueEnabled = source.RescueEnabled
 	hcloudServer.Locked = source.Locked
 	hcloudServer.ISO = c.pSchemaISOToPHcloudISO(source.ISO)
 	hcloudServer.Image = c.pSchemaImageToPHcloudImage(source.Image)
 	hcloudServer.Protection = c.schemaServerProtectionToHcloudServerProtection(source.Protection)
 	hcloudServer.Labels = source.Labels
-	var pHcloudVolumeList []*Volume
 	if source.Volumes != nil {
-		pHcloudVolumeList = make([]*Volume, len(source.Volumes))
+		hcloudServer.Volumes = make([]*Volume, len(source.Volumes))
 		for j := 0; j < len(source.Volumes); j++ {
-			pHcloudVolumeList[j] = volumeFromInt64(source.Volumes[j])
+			hcloudServer.Volumes[j] = volumeFromInt64(source.Volumes[j])
 		}
 	}
-	hcloudServer.Volumes = pHcloudVolumeList
 	hcloudServer.PrimaryDiskSize = source.PrimaryDiskSize
 	hcloudServer.PlacementGroup = c.pSchemaPlacementGroupToPHcloudPlacementGroup(source.PlacementGroup)
-	var pHcloudLoadBalancerList []*LoadBalancer
 	if source.LoadBalancers != nil {
-		pHcloudLoadBalancerList = make([]*LoadBalancer, len(source.LoadBalancers))
+		hcloudServer.LoadBalancers = make([]*LoadBalancer, len(source.LoadBalancers))
 		for k := 0; k < len(source.LoadBalancers); k++ {
 			hcloudLoadBalancer := loadBalancerFromInt64(source.LoadBalancers[k])
-			pHcloudLoadBalancerList[k] = &hcloudLoadBalancer
+			hcloudServer.LoadBalancers[k] = &hcloudLoadBalancer
 		}
 	}
-	hcloudServer.LoadBalancers = pHcloudLoadBalancerList
 	return &hcloudServer
 }
 func (c *converterImpl) ServerMetricsFromSchema(source *schema.ServerGetMetricsResponse) (*ServerMetrics, error) {
@@ -1291,18 +1222,16 @@ func (c *converterImpl) ServerMetricsFromSchema(source *schema.ServerGetMetricsR
 		hcloudServerMetrics.Start = c.timeTimeToTimeTime((*source).Metrics.Start)
 		hcloudServerMetrics.End = c.timeTimeToTimeTime((*source).Metrics.End)
 		hcloudServerMetrics.Step = (*source).Metrics.Step
-		var mapStringHcloudServerMetricsValueList map[string][]ServerMetricsValue
 		if (*source).Metrics.TimeSeries != nil {
-			mapStringHcloudServerMetricsValueList = make(map[string][]ServerMetricsValue, len((*source).Metrics.TimeSeries))
+			hcloudServerMetrics.TimeSeries = make(map[string][]ServerMetricsValue, len((*source).Metrics.TimeSeries))
 			for key, value := range (*source).Metrics.TimeSeries {
 				hcloudServerMetricsValueList, err := serverMetricsTimeSeriesFromSchema(value)
 				if err != nil {
 					return nil, err
 				}
-				mapStringHcloudServerMetricsValueList[key] = hcloudServerMetricsValueList
+				hcloudServerMetrics.TimeSeries[key] = hcloudServerMetricsValueList
 			}
 		}
-		hcloudServerMetrics.TimeSeries = mapStringHcloudServerMetricsValueList
 		pHcloudServerMetrics = &hcloudServerMetrics
 	}
 	return pHcloudServerMetrics, nil
@@ -1312,14 +1241,12 @@ func (c *converterImpl) ServerPrivateNetFromSchema(source schema.ServerPrivateNe
 	hcloudNetwork := networkFromInt64(source.Network)
 	hcloudServerPrivateNet.Network = &hcloudNetwork
 	hcloudServerPrivateNet.IP = ipFromString(source.IP)
-	var netIPList []net.IP
 	if source.AliasIPs != nil {
-		netIPList = make([]net.IP, len(source.AliasIPs))
+		hcloudServerPrivateNet.Aliases = make([]net.IP, len(source.AliasIPs))
 		for i := 0; i < len(source.AliasIPs); i++ {
-			netIPList[i] = ipFromString(source.AliasIPs[i])
+			hcloudServerPrivateNet.Aliases[i] = ipFromString(source.AliasIPs[i])
 		}
 	}
-	hcloudServerPrivateNet.Aliases = netIPList
 	hcloudServerPrivateNet.MACAddress = source.MACAddress
 	return hcloudServerPrivateNet
 }
@@ -1327,22 +1254,18 @@ func (c *converterImpl) ServerPublicNetFromSchema(source schema.ServerPublicNet)
 	var hcloudServerPublicNet ServerPublicNet
 	hcloudServerPublicNet.IPv4 = c.ServerPublicNetIPv4FromSchema(source.IPv4)
 	hcloudServerPublicNet.IPv6 = c.ServerPublicNetIPv6FromSchema(source.IPv6)
-	var pHcloudFloatingIPList []*FloatingIP
 	if source.FloatingIPs != nil {
-		pHcloudFloatingIPList = make([]*FloatingIP, len(source.FloatingIPs))
+		hcloudServerPublicNet.FloatingIPs = make([]*FloatingIP, len(source.FloatingIPs))
 		for i := 0; i < len(source.FloatingIPs); i++ {
-			pHcloudFloatingIPList[i] = floatingIPFromInt64(source.FloatingIPs[i])
+			hcloudServerPublicNet.FloatingIPs[i] = floatingIPFromInt64(source.FloatingIPs[i])
 		}
 	}
-	hcloudServerPublicNet.FloatingIPs = pHcloudFloatingIPList
-	var pHcloudServerFirewallStatusList []*ServerFirewallStatus
 	if source.Firewalls != nil {
-		pHcloudServerFirewallStatusList = make([]*ServerFirewallStatus, len(source.Firewalls))
+		hcloudServerPublicNet.Firewalls = make([]*ServerFirewallStatus, len(source.Firewalls))
 		for j := 0; j < len(source.Firewalls); j++ {
-			pHcloudServerFirewallStatusList[j] = firewallStatusFromSchemaServerFirewall(source.Firewalls[j])
+			hcloudServerPublicNet.Firewalls[j] = firewallStatusFromSchemaServerFirewall(source.Firewalls[j])
 		}
 	}
-	hcloudServerPublicNet.Firewalls = pHcloudServerFirewallStatusList
 	return hcloudServerPublicNet
 }
 func (c *converterImpl) ServerPublicNetIPv4FromSchema(source schema.ServerPublicNetIPv4) ServerPublicNetIPv4 {
@@ -1374,14 +1297,12 @@ func (c *converterImpl) ServerTypeFromSchema(source schema.ServerType) *ServerTy
 	hcloudServerType.CPUType = CPUType(source.CPUType)
 	hcloudServerType.Architecture = Architecture(source.Architecture)
 	hcloudServerType.IncludedTraffic = source.IncludedTraffic
-	var hcloudServerTypeLocationPricingList []ServerTypeLocationPricing
 	if source.Prices != nil {
-		hcloudServerTypeLocationPricingList = make([]ServerTypeLocationPricing, len(source.Prices))
+		hcloudServerType.Pricings = make([]ServerTypeLocationPricing, len(source.Prices))
 		for i := 0; i < len(source.Prices); i++ {
-			hcloudServerTypeLocationPricingList[i] = c.serverTypePricingFromSchema(source.Prices[i])
+			hcloudServerType.Pricings[i] = c.serverTypePricingFromSchema(source.Prices[i])
 		}
 	}
-	hcloudServerType.Pricings = hcloudServerTypeLocationPricingList
 	hcloudServerType.DeprecatableResource = c.schemaDeprecatableResourceToHcloudDeprecatableResource(source.DeprecatableResource)
 	return &hcloudServerType
 }
@@ -1390,12 +1311,10 @@ func (c *converterImpl) VolumeFromSchema(source schema.Volume) *Volume {
 	hcloudVolume.ID = source.ID
 	hcloudVolume.Name = source.Name
 	hcloudVolume.Status = VolumeStatus(source.Status)
-	var pHcloudServer *Server
 	if source.Server != nil {
 		hcloudServer := serverFromInt64(*source.Server)
-		pHcloudServer = &hcloudServer
+		hcloudVolume.Server = &hcloudServer
 	}
-	hcloudVolume.Server = pHcloudServer
 	hcloudVolume.Location = c.LocationFromSchema(source.Location)
 	hcloudVolume.Size = source.Size
 	hcloudVolume.Format = source.Format
@@ -1416,30 +1335,24 @@ func (c *converterImpl) hcloudCertificateUsedByRefToSchemaCertificateUsedByRef(s
 }
 func (c *converterImpl) hcloudDatacenterServerTypesToSchemaDatacenterServerTypes(source DatacenterServerTypes) schema.DatacenterServerTypes {
 	var schemaDatacenterServerTypes schema.DatacenterServerTypes
-	var int64List []int64
 	if source.Supported != nil {
-		int64List = make([]int64, len(source.Supported))
+		schemaDatacenterServerTypes.Supported = make([]int64, len(source.Supported))
 		for i := 0; i < len(source.Supported); i++ {
-			int64List[i] = int64FromServerType(source.Supported[i])
+			schemaDatacenterServerTypes.Supported[i] = int64FromServerType(source.Supported[i])
 		}
 	}
-	schemaDatacenterServerTypes.Supported = int64List
-	var int64List2 []int64
 	if source.AvailableForMigration != nil {
-		int64List2 = make([]int64, len(source.AvailableForMigration))
+		schemaDatacenterServerTypes.AvailableForMigration = make([]int64, len(source.AvailableForMigration))
 		for j := 0; j < len(source.AvailableForMigration); j++ {
-			int64List2[j] = int64FromServerType(source.AvailableForMigration[j])
+			schemaDatacenterServerTypes.AvailableForMigration[j] = int64FromServerType(source.AvailableForMigration[j])
 		}
 	}
-	schemaDatacenterServerTypes.AvailableForMigration = int64List2
-	var int64List3 []int64
 	if source.Available != nil {
-		int64List3 = make([]int64, len(source.Available))
+		schemaDatacenterServerTypes.Available = make([]int64, len(source.Available))
 		for k := 0; k < len(source.Available); k++ {
-			int64List3[k] = int64FromServerType(source.Available[k])
+			schemaDatacenterServerTypes.Available[k] = int64FromServerType(source.Available[k])
 		}
 	}
-	schemaDatacenterServerTypes.Available = int64List3
 	return schemaDatacenterServerTypes
 }
 func (c *converterImpl) hcloudDeprecatableResourceToSchemaDeprecatableResource(source DeprecatableResource) schema.DeprecatableResource {
@@ -1450,22 +1363,18 @@ func (c *converterImpl) hcloudDeprecatableResourceToSchemaDeprecatableResource(s
 func (c *converterImpl) hcloudFirewallRuleToSchemaFirewallRule(source FirewallRule) schema.FirewallRule {
 	var schemaFirewallRule schema.FirewallRule
 	schemaFirewallRule.Direction = string(source.Direction)
-	var stringList []string
 	if source.SourceIPs != nil {
-		stringList = make([]string, len(source.SourceIPs))
+		schemaFirewallRule.SourceIPs = make([]string, len(source.SourceIPs))
 		for i := 0; i < len(source.SourceIPs); i++ {
-			stringList[i] = stringFromIPNet(source.SourceIPs[i])
+			schemaFirewallRule.SourceIPs[i] = stringFromIPNet(source.SourceIPs[i])
 		}
 	}
-	schemaFirewallRule.SourceIPs = stringList
-	var stringList2 []string
 	if source.DestinationIPs != nil {
-		stringList2 = make([]string, len(source.DestinationIPs))
+		schemaFirewallRule.DestinationIPs = make([]string, len(source.DestinationIPs))
 		for j := 0; j < len(source.DestinationIPs); j++ {
-			stringList2[j] = stringFromIPNet(source.DestinationIPs[j])
+			schemaFirewallRule.DestinationIPs[j] = stringFromIPNet(source.DestinationIPs[j])
 		}
 	}
-	schemaFirewallRule.DestinationIPs = stringList2
 	schemaFirewallRule.Protocol = string(source.Protocol)
 	schemaFirewallRule.Port = source.Port
 	schemaFirewallRule.Description = source.Description
@@ -1474,22 +1383,18 @@ func (c *converterImpl) hcloudFirewallRuleToSchemaFirewallRule(source FirewallRu
 func (c *converterImpl) hcloudFirewallRuleToSchemaFirewallRuleRequest(source FirewallRule) schema.FirewallRuleRequest {
 	var schemaFirewallRuleRequest schema.FirewallRuleRequest
 	schemaFirewallRuleRequest.Direction = string(source.Direction)
-	var stringList []string
 	if source.SourceIPs != nil {
-		stringList = make([]string, len(source.SourceIPs))
+		schemaFirewallRuleRequest.SourceIPs = make([]string, len(source.SourceIPs))
 		for i := 0; i < len(source.SourceIPs); i++ {
-			stringList[i] = stringFromIPNet(source.SourceIPs[i])
+			schemaFirewallRuleRequest.SourceIPs[i] = stringFromIPNet(source.SourceIPs[i])
 		}
 	}
-	schemaFirewallRuleRequest.SourceIPs = stringList
-	var stringList2 []string
 	if source.DestinationIPs != nil {
-		stringList2 = make([]string, len(source.DestinationIPs))
+		schemaFirewallRuleRequest.DestinationIPs = make([]string, len(source.DestinationIPs))
 		for j := 0; j < len(source.DestinationIPs); j++ {
-			stringList2[j] = stringFromIPNet(source.DestinationIPs[j])
+			schemaFirewallRuleRequest.DestinationIPs[j] = stringFromIPNet(source.DestinationIPs[j])
 		}
 	}
-	schemaFirewallRuleRequest.DestinationIPs = stringList2
 	schemaFirewallRuleRequest.Protocol = string(source.Protocol)
 	schemaFirewallRuleRequest.Port = source.Port
 	schemaFirewallRuleRequest.Description = source.Description
@@ -1563,14 +1468,12 @@ func (c *converterImpl) hcloudLoadBalancerServiceHTTPToPSchemaLoadBalancerServic
 	var schemaLoadBalancerServiceHTTP schema.LoadBalancerServiceHTTP
 	schemaLoadBalancerServiceHTTP.CookieName = source.CookieName
 	schemaLoadBalancerServiceHTTP.CookieLifetime = intSecondsFromDuration(source.CookieLifetime)
-	var int64List []int64
 	if source.Certificates != nil {
-		int64List = make([]int64, len(source.Certificates))
+		schemaLoadBalancerServiceHTTP.Certificates = make([]int64, len(source.Certificates))
 		for i := 0; i < len(source.Certificates); i++ {
-			int64List[i] = int64FromCertificate(source.Certificates[i])
+			schemaLoadBalancerServiceHTTP.Certificates[i] = int64FromCertificate(source.Certificates[i])
 		}
 	}
-	schemaLoadBalancerServiceHTTP.Certificates = int64List
 	schemaLoadBalancerServiceHTTP.RedirectHTTP = source.RedirectHTTP
 	schemaLoadBalancerServiceHTTP.StickySessions = source.StickySessions
 	return &schemaLoadBalancerServiceHTTP
@@ -1619,12 +1522,10 @@ func (c *converterImpl) intISOFromSchema(source schema.ISO) ISO {
 	hcloudISO.Name = source.Name
 	hcloudISO.Description = source.Description
 	hcloudISO.Type = ISOType(source.Type)
-	var pHcloudArchitecture *Architecture
 	if source.Architecture != nil {
 		hcloudArchitecture := Architecture(*source.Architecture)
-		pHcloudArchitecture = &hcloudArchitecture
+		hcloudISO.Architecture = &hcloudArchitecture
 	}
-	hcloudISO.Architecture = pHcloudArchitecture
 	var pTimeTime *time.Time
 	if source.DeprecatableResource.Deprecation != nil {
 		pTimeTime = &source.DeprecatableResource.Deprecation.UnavailableAfter
@@ -1712,12 +1613,10 @@ func (c *converterImpl) pHcloudISOToPSchemaISO(source *ISO) *schema.ISO {
 		schemaISO.Name = (*source).Name
 		schemaISO.Description = (*source).Description
 		schemaISO.Type = string((*source).Type)
-		var pString *string
 		if (*source).Architecture != nil {
 			xstring := string(*(*source).Architecture)
-			pString = &xstring
+			schemaISO.Architecture = &xstring
 		}
-		schemaISO.Architecture = pString
 		schemaISO.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
 		pSchemaISO = &schemaISO
 	}
@@ -1736,12 +1635,10 @@ func (c *converterImpl) pHcloudLoadBalancerAddServiceOptsHTTPToPSchemaLoadBalanc
 	if source != nil {
 		var schemaLoadBalancerActionAddServiceRequestHTTP schema.LoadBalancerActionAddServiceRequestHTTP
 		schemaLoadBalancerActionAddServiceRequestHTTP.CookieName = (*source).CookieName
-		var pInt *int
 		if (*source).CookieLifetime != nil {
 			xint := intSecondsFromDuration(*(*source).CookieLifetime)
-			pInt = &xint
+			schemaLoadBalancerActionAddServiceRequestHTTP.CookieLifetime = &xint
 		}
-		schemaLoadBalancerActionAddServiceRequestHTTP.CookieLifetime = pInt
 		schemaLoadBalancerActionAddServiceRequestHTTP.Certificates = int64SlicePtrFromCertificatePtrSlice((*source).Certificates)
 		schemaLoadBalancerActionAddServiceRequestHTTP.RedirectHTTP = (*source).RedirectHTTP
 		schemaLoadBalancerActionAddServiceRequestHTTP.StickySessions = (*source).StickySessions
@@ -1768,18 +1665,14 @@ func (c *converterImpl) pHcloudLoadBalancerAddServiceOptsHealthCheckToPSchemaLoa
 		var schemaLoadBalancerActionAddServiceRequestHealthCheck schema.LoadBalancerActionAddServiceRequestHealthCheck
 		schemaLoadBalancerActionAddServiceRequestHealthCheck.Protocol = string((*source).Protocol)
 		schemaLoadBalancerActionAddServiceRequestHealthCheck.Port = (*source).Port
-		var pInt *int
 		if (*source).Interval != nil {
 			xint := intSecondsFromDuration(*(*source).Interval)
-			pInt = &xint
+			schemaLoadBalancerActionAddServiceRequestHealthCheck.Interval = &xint
 		}
-		schemaLoadBalancerActionAddServiceRequestHealthCheck.Interval = pInt
-		var pInt2 *int
 		if (*source).Timeout != nil {
 			xint2 := intSecondsFromDuration(*(*source).Timeout)
-			pInt2 = &xint2
+			schemaLoadBalancerActionAddServiceRequestHealthCheck.Timeout = &xint2
 		}
-		schemaLoadBalancerActionAddServiceRequestHealthCheck.Timeout = pInt2
 		schemaLoadBalancerActionAddServiceRequestHealthCheck.Retries = (*source).Retries
 		schemaLoadBalancerActionAddServiceRequestHealthCheck.HTTP = c.pHcloudLoadBalancerAddServiceOptsHealthCheckHTTPToPSchemaLoadBalancerActionAddServiceRequestHealthCheckHTTP((*source).HTTP)
 		pSchemaLoadBalancerActionAddServiceRequestHealthCheck = &schemaLoadBalancerActionAddServiceRequestHealthCheck
@@ -1800,12 +1693,10 @@ func (c *converterImpl) pHcloudLoadBalancerCreateOptsServiceHTTPToPSchemaLoadBal
 	if source != nil {
 		var schemaLoadBalancerCreateRequestServiceHTTP schema.LoadBalancerCreateRequestServiceHTTP
 		schemaLoadBalancerCreateRequestServiceHTTP.CookieName = (*source).CookieName
-		var pInt *int
 		if (*source).CookieLifetime != nil {
 			xint := intSecondsFromDuration(*(*source).CookieLifetime)
-			pInt = &xint
+			schemaLoadBalancerCreateRequestServiceHTTP.CookieLifetime = &xint
 		}
-		schemaLoadBalancerCreateRequestServiceHTTP.CookieLifetime = pInt
 		schemaLoadBalancerCreateRequestServiceHTTP.Certificates = int64SlicePtrFromCertificatePtrSlice((*source).Certificates)
 		schemaLoadBalancerCreateRequestServiceHTTP.RedirectHTTP = (*source).RedirectHTTP
 		schemaLoadBalancerCreateRequestServiceHTTP.StickySessions = (*source).StickySessions
@@ -1832,18 +1723,14 @@ func (c *converterImpl) pHcloudLoadBalancerCreateOptsServiceHealthCheckToPSchema
 		var schemaLoadBalancerCreateRequestServiceHealthCheck schema.LoadBalancerCreateRequestServiceHealthCheck
 		schemaLoadBalancerCreateRequestServiceHealthCheck.Protocol = string((*source).Protocol)
 		schemaLoadBalancerCreateRequestServiceHealthCheck.Port = (*source).Port
-		var pInt *int
 		if (*source).Interval != nil {
 			xint := intSecondsFromDuration(*(*source).Interval)
-			pInt = &xint
+			schemaLoadBalancerCreateRequestServiceHealthCheck.Interval = &xint
 		}
-		schemaLoadBalancerCreateRequestServiceHealthCheck.Interval = pInt
-		var pInt2 *int
 		if (*source).Timeout != nil {
 			xint2 := intSecondsFromDuration(*(*source).Timeout)
-			pInt2 = &xint2
+			schemaLoadBalancerCreateRequestServiceHealthCheck.Timeout = &xint2
 		}
-		schemaLoadBalancerCreateRequestServiceHealthCheck.Timeout = pInt2
 		schemaLoadBalancerCreateRequestServiceHealthCheck.Retries = (*source).Retries
 		schemaLoadBalancerCreateRequestServiceHealthCheck.HTTP = c.pHcloudLoadBalancerCreateOptsServiceHealthCheckHTTPToPSchemaLoadBalancerCreateRequestServiceHealthCheckHTTP((*source).HTTP)
 		pSchemaLoadBalancerCreateRequestServiceHealthCheck = &schemaLoadBalancerCreateRequestServiceHealthCheck
@@ -1896,17 +1783,25 @@ func (c *converterImpl) pHcloudLoadBalancerToInt64(source *LoadBalancer) int64 {
 	}
 	return xint64
 }
+func (c *converterImpl) pHcloudLoadBalancerTypeToSchemaIDOrName(source *LoadBalancerType) schema.IDOrName {
+	var schemaIDOrName schema.IDOrName
+	if source != nil {
+		var schemaIDOrName2 schema.IDOrName
+		schemaIDOrName2.ID = (*source).ID
+		schemaIDOrName2.Name = (*source).Name
+		schemaIDOrName = schemaIDOrName2
+	}
+	return schemaIDOrName
+}
 func (c *converterImpl) pHcloudLoadBalancerUpdateServiceOptsHTTPToPSchemaLoadBalancerActionUpdateServiceRequestHTTP(source *LoadBalancerUpdateServiceOptsHTTP) *schema.LoadBalancerActionUpdateServiceRequestHTTP {
 	var pSchemaLoadBalancerActionUpdateServiceRequestHTTP *schema.LoadBalancerActionUpdateServiceRequestHTTP
 	if source != nil {
 		var schemaLoadBalancerActionUpdateServiceRequestHTTP schema.LoadBalancerActionUpdateServiceRequestHTTP
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.CookieName = (*source).CookieName
-		var pInt *int
 		if (*source).CookieLifetime != nil {
 			xint := intSecondsFromDuration(*(*source).CookieLifetime)
-			pInt = &xint
+			schemaLoadBalancerActionUpdateServiceRequestHTTP.CookieLifetime = &xint
 		}
-		schemaLoadBalancerActionUpdateServiceRequestHTTP.CookieLifetime = pInt
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.Certificates = int64SlicePtrFromCertificatePtrSlice((*source).Certificates)
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.RedirectHTTP = (*source).RedirectHTTP
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.StickySessions = (*source).StickySessions
@@ -1933,18 +1828,14 @@ func (c *converterImpl) pHcloudLoadBalancerUpdateServiceOptsHealthCheckToPSchema
 		var schemaLoadBalancerActionUpdateServiceRequestHealthCheck schema.LoadBalancerActionUpdateServiceRequestHealthCheck
 		schemaLoadBalancerActionUpdateServiceRequestHealthCheck.Protocol = stringPtrFromLoadBalancerServiceProtocol((*source).Protocol)
 		schemaLoadBalancerActionUpdateServiceRequestHealthCheck.Port = (*source).Port
-		var pInt *int
 		if (*source).Interval != nil {
 			xint := intSecondsFromDuration(*(*source).Interval)
-			pInt = &xint
+			schemaLoadBalancerActionUpdateServiceRequestHealthCheck.Interval = &xint
 		}
-		schemaLoadBalancerActionUpdateServiceRequestHealthCheck.Interval = pInt
-		var pInt2 *int
 		if (*source).Timeout != nil {
 			xint2 := intSecondsFromDuration(*(*source).Timeout)
-			pInt2 = &xint2
+			schemaLoadBalancerActionUpdateServiceRequestHealthCheck.Timeout = &xint2
 		}
-		schemaLoadBalancerActionUpdateServiceRequestHealthCheck.Timeout = pInt2
 		schemaLoadBalancerActionUpdateServiceRequestHealthCheck.Retries = (*source).Retries
 		schemaLoadBalancerActionUpdateServiceRequestHealthCheck.HTTP = c.pHcloudLoadBalancerUpdateServiceOptsHealthCheckHTTPToPSchemaLoadBalancerActionUpdateServiceRequestHealthCheckHTTP((*source).HTTP)
 		pSchemaLoadBalancerActionUpdateServiceRequestHealthCheck = &schemaLoadBalancerActionUpdateServiceRequestHealthCheck
@@ -2085,35 +1976,27 @@ func (c *converterImpl) pSchemaImageToPHcloudImage(source *schema.Image) *Image 
 	if source != nil {
 		var hcloudImage Image
 		hcloudImage.ID = (*source).ID
-		var xstring string
 		if (*source).Name != nil {
-			xstring = *(*source).Name
+			hcloudImage.Name = *(*source).Name
 		}
-		hcloudImage.Name = xstring
 		hcloudImage.Type = ImageType((*source).Type)
 		hcloudImage.Status = ImageStatus((*source).Status)
 		hcloudImage.Description = (*source).Description
-		var xfloat32 float32
 		if (*source).ImageSize != nil {
-			xfloat32 = *(*source).ImageSize
+			hcloudImage.ImageSize = *(*source).ImageSize
 		}
-		hcloudImage.ImageSize = xfloat32
 		hcloudImage.DiskSize = (*source).DiskSize
 		hcloudImage.Created = c.pTimeTimeToTimeTime((*source).Created)
 		hcloudImage.CreatedFrom = c.pSchemaImageCreatedFromToPHcloudServer((*source).CreatedFrom)
-		var pHcloudServer *Server
 		if (*source).BoundTo != nil {
 			hcloudServer := serverFromInt64(*(*source).BoundTo)
-			pHcloudServer = &hcloudServer
+			hcloudImage.BoundTo = &hcloudServer
 		}
-		hcloudImage.BoundTo = pHcloudServer
 		hcloudImage.RapidDeploy = (*source).RapidDeploy
 		hcloudImage.OSFlavor = (*source).OSFlavor
-		var xstring2 string
 		if (*source).OSVersion != nil {
-			xstring2 = *(*source).OSVersion
+			hcloudImage.OSVersion = *(*source).OSVersion
 		}
-		hcloudImage.OSVersion = xstring2
 		hcloudImage.Architecture = Architecture((*source).Architecture)
 		hcloudImage.Protection = c.schemaImageProtectionToHcloudImageProtection((*source).Protection)
 		hcloudImage.Deprecated = c.pTimeTimeToTimeTime((*source).Deprecated)
@@ -2129,14 +2012,12 @@ func (c *converterImpl) pSchemaLoadBalancerServiceHTTPToHcloudLoadBalancerServic
 		var hcloudLoadBalancerServiceHTTP2 LoadBalancerServiceHTTP
 		hcloudLoadBalancerServiceHTTP2.CookieName = (*source).CookieName
 		hcloudLoadBalancerServiceHTTP2.CookieLifetime = durationFromIntSeconds((*source).CookieLifetime)
-		var pHcloudCertificateList []*Certificate
 		if (*source).Certificates != nil {
-			pHcloudCertificateList = make([]*Certificate, len((*source).Certificates))
+			hcloudLoadBalancerServiceHTTP2.Certificates = make([]*Certificate, len((*source).Certificates))
 			for i := 0; i < len((*source).Certificates); i++ {
-				pHcloudCertificateList[i] = certificateFromInt64((*source).Certificates[i])
+				hcloudLoadBalancerServiceHTTP2.Certificates[i] = certificateFromInt64((*source).Certificates[i])
 			}
 		}
-		hcloudLoadBalancerServiceHTTP2.Certificates = pHcloudCertificateList
 		hcloudLoadBalancerServiceHTTP2.RedirectHTTP = (*source).RedirectHTTP
 		hcloudLoadBalancerServiceHTTP2.StickySessions = (*source).StickySessions
 		hcloudLoadBalancerServiceHTTP = hcloudLoadBalancerServiceHTTP2
@@ -2217,30 +2098,24 @@ func (c *converterImpl) schemaCertificateUsedByRefToHcloudCertificateUsedByRef(s
 }
 func (c *converterImpl) schemaDatacenterServerTypesToHcloudDatacenterServerTypes(source schema.DatacenterServerTypes) DatacenterServerTypes {
 	var hcloudDatacenterServerTypes DatacenterServerTypes
-	var pHcloudServerTypeList []*ServerType
 	if source.Supported != nil {
-		pHcloudServerTypeList = make([]*ServerType, len(source.Supported))
+		hcloudDatacenterServerTypes.Supported = make([]*ServerType, len(source.Supported))
 		for i := 0; i < len(source.Supported); i++ {
-			pHcloudServerTypeList[i] = serverTypeFromInt64(source.Supported[i])
+			hcloudDatacenterServerTypes.Supported[i] = serverTypeFromInt64(source.Supported[i])
 		}
 	}
-	hcloudDatacenterServerTypes.Supported = pHcloudServerTypeList
-	var pHcloudServerTypeList2 []*ServerType
 	if source.AvailableForMigration != nil {
-		pHcloudServerTypeList2 = make([]*ServerType, len(source.AvailableForMigration))
+		hcloudDatacenterServerTypes.AvailableForMigration = make([]*ServerType, len(source.AvailableForMigration))
 		for j := 0; j < len(source.AvailableForMigration); j++ {
-			pHcloudServerTypeList2[j] = serverTypeFromInt64(source.AvailableForMigration[j])
+			hcloudDatacenterServerTypes.AvailableForMigration[j] = serverTypeFromInt64(source.AvailableForMigration[j])
 		}
 	}
-	hcloudDatacenterServerTypes.AvailableForMigration = pHcloudServerTypeList2
-	var pHcloudServerTypeList3 []*ServerType
 	if source.Available != nil {
-		pHcloudServerTypeList3 = make([]*ServerType, len(source.Available))
+		hcloudDatacenterServerTypes.Available = make([]*ServerType, len(source.Available))
 		for k := 0; k < len(source.Available); k++ {
-			pHcloudServerTypeList3[k] = serverTypeFromInt64(source.Available[k])
+			hcloudDatacenterServerTypes.Available[k] = serverTypeFromInt64(source.Available[k])
 		}
 	}
-	hcloudDatacenterServerTypes.Available = pHcloudServerTypeList3
 	return hcloudDatacenterServerTypes
 }
 func (c *converterImpl) schemaDeprecatableResourceToHcloudDeprecatableResource(source schema.DeprecatableResource) DeprecatableResource {
@@ -2258,22 +2133,18 @@ func (c *converterImpl) schemaFirewallResourceToHcloudFirewallResource(source sc
 func (c *converterImpl) schemaFirewallRuleToHcloudFirewallRule(source schema.FirewallRule) FirewallRule {
 	var hcloudFirewallRule FirewallRule
 	hcloudFirewallRule.Direction = FirewallRuleDirection(source.Direction)
-	var netIPNetList []net.IPNet
 	if source.SourceIPs != nil {
-		netIPNetList = make([]net.IPNet, len(source.SourceIPs))
+		hcloudFirewallRule.SourceIPs = make([]net.IPNet, len(source.SourceIPs))
 		for i := 0; i < len(source.SourceIPs); i++ {
-			netIPNetList[i] = ipNetFromString(source.SourceIPs[i])
+			hcloudFirewallRule.SourceIPs[i] = ipNetFromString(source.SourceIPs[i])
 		}
 	}
-	hcloudFirewallRule.SourceIPs = netIPNetList
-	var netIPNetList2 []net.IPNet
 	if source.DestinationIPs != nil {
-		netIPNetList2 = make([]net.IPNet, len(source.DestinationIPs))
+		hcloudFirewallRule.DestinationIPs = make([]net.IPNet, len(source.DestinationIPs))
 		for j := 0; j < len(source.DestinationIPs); j++ {
-			netIPNetList2[j] = ipNetFromString(source.DestinationIPs[j])
+			hcloudFirewallRule.DestinationIPs[j] = ipNetFromString(source.DestinationIPs[j])
 		}
 	}
-	hcloudFirewallRule.DestinationIPs = netIPNetList2
 	hcloudFirewallRule.Protocol = FirewallRuleProtocol(source.Protocol)
 	hcloudFirewallRule.Port = source.Port
 	hcloudFirewallRule.Description = source.Description
@@ -2298,14 +2169,12 @@ func (c *converterImpl) schemaFromFloatingIPTypeLocationPricing(source FloatingI
 func (c *converterImpl) schemaFromFloatingIPTypePricing(source FloatingIPTypePricing) schema.PricingFloatingIPType {
 	var schemaPricingFloatingIPType schema.PricingFloatingIPType
 	schemaPricingFloatingIPType.Type = string(source.Type)
-	var schemaPricingFloatingIPTypePriceList []schema.PricingFloatingIPTypePrice
 	if source.Pricings != nil {
-		schemaPricingFloatingIPTypePriceList = make([]schema.PricingFloatingIPTypePrice, len(source.Pricings))
+		schemaPricingFloatingIPType.Prices = make([]schema.PricingFloatingIPTypePrice, len(source.Pricings))
 		for i := 0; i < len(source.Pricings); i++ {
-			schemaPricingFloatingIPTypePriceList[i] = c.schemaFromFloatingIPTypeLocationPricing(source.Pricings[i])
+			schemaPricingFloatingIPType.Prices[i] = c.schemaFromFloatingIPTypeLocationPricing(source.Pricings[i])
 		}
 	}
-	schemaPricingFloatingIPType.Prices = schemaPricingFloatingIPTypePriceList
 	return schemaPricingFloatingIPType
 }
 func (c *converterImpl) schemaFromImagePricing(source ImagePricing) schema.PricingImage {
@@ -2319,41 +2188,33 @@ func (c *converterImpl) schemaFromLoadBalancerTypePricing(source LoadBalancerTyp
 	if source.LoadBalancerType != nil {
 		pInt64 = &source.LoadBalancerType.ID
 	}
-	var xint64 int64
 	if pInt64 != nil {
-		xint64 = *pInt64
+		schemaPricingLoadBalancerType.ID = *pInt64
 	}
-	schemaPricingLoadBalancerType.ID = xint64
 	var pString *string
 	if source.LoadBalancerType != nil {
 		pString = &source.LoadBalancerType.Name
 	}
-	var xstring string
 	if pString != nil {
-		xstring = *pString
+		schemaPricingLoadBalancerType.Name = *pString
 	}
-	schemaPricingLoadBalancerType.Name = xstring
-	var schemaPricingLoadBalancerTypePriceList []schema.PricingLoadBalancerTypePrice
 	if source.Pricings != nil {
-		schemaPricingLoadBalancerTypePriceList = make([]schema.PricingLoadBalancerTypePrice, len(source.Pricings))
+		schemaPricingLoadBalancerType.Prices = make([]schema.PricingLoadBalancerTypePrice, len(source.Pricings))
 		for i := 0; i < len(source.Pricings); i++ {
-			schemaPricingLoadBalancerTypePriceList[i] = c.SchemaFromLoadBalancerTypeLocationPricing(source.Pricings[i])
+			schemaPricingLoadBalancerType.Prices[i] = c.SchemaFromLoadBalancerTypeLocationPricing(source.Pricings[i])
 		}
 	}
-	schemaPricingLoadBalancerType.Prices = schemaPricingLoadBalancerTypePriceList
 	return schemaPricingLoadBalancerType
 }
 func (c *converterImpl) schemaFromPrimaryIPPricing(source PrimaryIPPricing) schema.PricingPrimaryIP {
 	var schemaPricingPrimaryIP schema.PricingPrimaryIP
 	schemaPricingPrimaryIP.Type = source.Type
-	var schemaPricingPrimaryIPTypePriceList []schema.PricingPrimaryIPTypePrice
 	if source.Pricings != nil {
-		schemaPricingPrimaryIPTypePriceList = make([]schema.PricingPrimaryIPTypePrice, len(source.Pricings))
+		schemaPricingPrimaryIP.Prices = make([]schema.PricingPrimaryIPTypePrice, len(source.Pricings))
 		for i := 0; i < len(source.Pricings); i++ {
-			schemaPricingPrimaryIPTypePriceList[i] = c.schemaFromPrimaryIPTypePricing(source.Pricings[i])
+			schemaPricingPrimaryIP.Prices[i] = c.schemaFromPrimaryIPTypePricing(source.Pricings[i])
 		}
 	}
-	schemaPricingPrimaryIP.Prices = schemaPricingPrimaryIPTypePriceList
 	return schemaPricingPrimaryIP
 }
 func (c *converterImpl) schemaFromPrimaryIPTypePricing(source PrimaryIPTypePricing) schema.PricingPrimaryIPTypePrice {
@@ -2369,6 +2230,8 @@ func (c *converterImpl) schemaFromServerTypeLocationPricing(source ServerTypeLoc
 	schemaPricingServerTypePrice.Location = c.pHcloudLocationToString(source.Location)
 	schemaPricingServerTypePrice.PriceHourly = c.hcloudPriceToSchemaPrice(source.Hourly)
 	schemaPricingServerTypePrice.PriceMonthly = c.hcloudPriceToSchemaPrice(source.Monthly)
+	schemaPricingServerTypePrice.IncludedTraffic = source.IncludedTraffic
+	schemaPricingServerTypePrice.PricePerTBTraffic = c.hcloudPriceToSchemaPrice(source.PerTBTraffic)
 	return schemaPricingServerTypePrice
 }
 func (c *converterImpl) schemaFromServerTypePricing(source ServerTypePricing) schema.PricingServerType {
@@ -2377,28 +2240,22 @@ func (c *converterImpl) schemaFromServerTypePricing(source ServerTypePricing) sc
 	if source.ServerType != nil {
 		pInt64 = &source.ServerType.ID
 	}
-	var xint64 int64
 	if pInt64 != nil {
-		xint64 = *pInt64
+		schemaPricingServerType.ID = *pInt64
 	}
-	schemaPricingServerType.ID = xint64
 	var pString *string
 	if source.ServerType != nil {
 		pString = &source.ServerType.Name
 	}
-	var xstring string
 	if pString != nil {
-		xstring = *pString
+		schemaPricingServerType.Name = *pString
 	}
-	schemaPricingServerType.Name = xstring
-	var schemaPricingServerTypePriceList []schema.PricingServerTypePrice
 	if source.Pricings != nil {
-		schemaPricingServerTypePriceList = make([]schema.PricingServerTypePrice, len(source.Pricings))
+		schemaPricingServerType.Prices = make([]schema.PricingServerTypePrice, len(source.Pricings))
 		for i := 0; i < len(source.Pricings); i++ {
-			schemaPricingServerTypePriceList[i] = c.schemaFromServerTypeLocationPricing(source.Pricings[i])
+			schemaPricingServerType.Prices[i] = c.schemaFromServerTypeLocationPricing(source.Pricings[i])
 		}
 	}
-	schemaPricingServerType.Prices = schemaPricingServerTypePriceList
 	return schemaPricingServerType
 }
 func (c *converterImpl) schemaFromTrafficPricing(source TrafficPricing) schema.PricingTraffic {
@@ -2484,6 +2341,8 @@ func (c *converterImpl) serverTypePricingFromSchema(source schema.PricingServerT
 	hcloudServerTypeLocationPricing.Location = &hcloudLocation
 	hcloudServerTypeLocationPricing.Hourly = c.PriceFromSchema(source.PriceHourly)
 	hcloudServerTypeLocationPricing.Monthly = c.PriceFromSchema(source.PriceMonthly)
+	hcloudServerTypeLocationPricing.IncludedTraffic = source.IncludedTraffic
+	hcloudServerTypeLocationPricing.PerTBTraffic = c.PriceFromSchema(source.PricePerTBTraffic)
 	return hcloudServerTypeLocationPricing
 }
 func (c *converterImpl) timeTimeToTimeTime(source time.Time) time.Time {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_server_client_iface.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_server_client_iface.go
@@ -62,9 +62,8 @@ type IServerClient interface {
 	AttachISO(ctx context.Context, server *Server, iso *ISO) (*Action, *Response, error)
 	// DetachISO detaches the currently attached ISO from a server.
 	DetachISO(ctx context.Context, server *Server) (*Action, *Response, error)
-	// EnableBackup enables backup for a server. Pass in an empty backup window to let the
-	// API pick a window for you. See the API documentation at docs.hetzner.cloud for a list
-	// of valid backup windows.
+	// EnableBackup enables backup for a server.
+	// The window parameter is deprecated and will be ignored.
 	EnableBackup(ctx context.Context, server *Server, window string) (*Action, *Response, error)
 	// DisableBackup disables backup for a server.
 	DisableBackup(ctx context.Context, server *Server) (*Action, *Response, error)

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -95,7 +95,9 @@ func newManager() (*hetznerManager, error) {
 		hcloud.WithToken(token),
 		hcloud.WithHTTPClient(httpClient),
 		hcloud.WithApplication("cluster-autoscaler", version.ClusterAutoscalerVersion),
-		hcloud.WithPollBackoffFunc(hcloud.ExponentialBackoff(2, 500*time.Millisecond)),
+		hcloud.WithPollOpts(hcloud.PollOpts{
+			BackoffFunc: hcloud.ExponentialBackoff(2, 500*time.Millisecond),
+		}),
 		hcloud.WithDebugWriter(&debugWriter{}),
 	}
 
@@ -252,7 +254,7 @@ func (m *hetznerManager) deleteByNode(node *apiv1.Node) error {
 }
 
 func (m *hetznerManager) deleteServer(server *hcloud.Server) error {
-	_, err := m.client.Server.Delete(m.apiCallContext, server)
+	_, _, err := m.client.Server.DeleteWithResult(m.apiCallContext, server)
 	return err
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area provider/hetzner

#### What this PR does / why we need it:

Update hcloud-go from v2.8.0 to v2.21.1
- [Changelog](https://github.com/hetznercloud/hcloud-go/blob/main/CHANGELOG.md)
- [Diff](https://github.com/hetznercloud/hcloud-go/compare/v2.8.0...v2.21.1)

Generated by:

```bash
UPSTREAM_REF=v2.21.1 hack/update-vendor.sh

```

#### Special notes for your reviewer:

We have updated two deprecated methods.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
