### PR TITLE
[AKS VMs Pool] Add the missing labels/taints for VMs pool 1.31

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -460,7 +460,9 @@ func (vmPool *VMPool) TemplateNodeInfo() (*schedulerframework.NodeInfo, error) {
 		return nil, err
 	}
 
-	template, err := buildNodeTemplateFromVMPool(ap, vmPool.manager.config.Location, vmPool.sku)
+	inputLabels := map[string]string{}
+	inputTaints := ""
+	template, err := buildNodeTemplateFromVMPool(ap, vmPool.manager.config.Location, vmPool.sku, inputLabels, inputTaints)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?** (bug, cleanup, documentation, feature) bug
**What this PR does / why we need it?**:

Add the missing labels and taints to the VM pool. Previously, we relied solely on the NodeLabel and NodeTaints properties from the versioned AP to build the node template for scale-from-zero scenarios. However, some critical system labels and taints are added by AgentBaker and stored in the unversioned AP data model. These are essential for proper scale-up behavior. The values will now be passed to CAS via the ConfigMap under the nodeGroup spec..

**Does this PR introduce a user-facing change?**
No
**WorkItem**
<!--- NOTE: REPLACE THIS LINE WITH THE WORKITEM SUFFIXED WITH "https://dev.azure.com/msazure/CloudNativeCompute". Currently, this CAS repo is under  "https://dev.azure.com/AzureContainerUpstream", workItems are under "https://dev.azure.com/msazure/CloudNativeCompute" and ADO doesn't support cross-linking.---->

**Testing**
- [X] Unit tests
- [X] E2E tests (we can custom branches on standalone env only)
- [ ] Other tests (eg. manual testing).

<details>
<summary>Cherry-pick details</summary>

**Is this a cherry-picked PR?**
- [ ] Yes. Include original PR.
```
```
- [ ] No. On which internal versions / branches is this PR getting cherry-picked ?
```
```

**Is this PR getting merged on [upstream](https://github.com/kubernetes/autoscaler) ?**
- [ ] Yes. Which branches / versions including master?
```
```
- [ ] No. Why?
```
```
</details>

<br>

**Special notes for your reviewer**:

**Additional Documentation**:

Fx the VMs labels/taints

----
#### AI description  (iteration 1)
#### PR Classification
This PR introduces a new feature by adding support for custom labels and taints in the VMs pool configuration.

#### PR Summary
The changes extend node template generation by merging existing agent pool settings with user-specified labels and taints for Azure node pools, improving configuration flexibility and correctness.
- `azure_template.go`: Modified buildNodeTemplateFromVMPool to accept additional labels and taints parameters and merge them into the template, and updated the taints data type to use structured taints.
- `azure_template_test.go`: Added tests to verify node template generation and deduplication of taints from both agent pool and spec inputs.
- `azure_vms_pool.go`: Updated the VMPool struct and its constructor to include labels and taints, ensuring they are passed to the node template builder. <!-- GitOpsUserAgent...

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
