### PR TITLE
OCI provider: Avoid interpreting HTTP 404 as success on delete

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
@@ -98,9 +98,7 @@ func (c *nodePoolCache) removeInstance(nodePoolID, instanceID string, nodeName s
 		statusSuccess := statusCode >= 200 && statusCode < 300
 		success = statusSuccess ||
 			// 409 means the instance is already going to be processed for deletion
-			statusCode == http.StatusConflict ||
-			// 404 means it is probably already deleted and our cache may be stale
-			statusCode == http.StatusNotFound
+			statusCode == http.StatusConflict
 		if !success {
 			status := httpResp.Status
 			klog.Infof("Received error status %s while deleting node %q", status, instanceID)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:


This change addresses an issue in the OCI (OKE) provider where a `HTTP 404 Error Code: NotAuthorizedOrNotFound` response from the [OCI Delete Node API call](https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/NodePool/DeleteNode) is misinterpreted and reported as a _successful_ node deletion..

As the OCI provider error message above indicates, the `404` is just as likely to be caused by the user lacking the necessary permissions to delete the node (i.e. `NotAuthorizedOrNotFound`). The provider also adds its own _hard_ taint `ignore-taint.cluster-autoscaler.kubernetes.io/oke-impending-node-termination` to the node (that is _already drained_), which unlike the CA's own `ToBeDeletedByClusterAutoscaler` taint, is not released when a scale down fails.  
The result is that many nodes may end up inadvertently left drained and tainted with no ability to fix itself.

To avoid this situation, we should interpret any `HTTP 404` on the Delete Node API call as an error and let the CA orchestration logic decide what to do about the failed scale down. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
n/a
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
n/a
```
