### PR TITLE
chore: bump golangci lint to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
           GO111MODULE: auto
 
       - name: golangci-lint - vertical-pod-autoscaler
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           args: --timeout=30m
           working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler/vertical-pod-autoscaler

--- a/vertical-pod-autoscaler/.golangci.yaml
+++ b/vertical-pod-autoscaler/.golangci.yaml
@@ -1,14 +1,18 @@
+version: "2"
 linters:
+  default: none
   enable:
     - forbidigo
+  settings:
+    forbidigo:
+      forbid:
+        # Forbid use of archived package "github.com/pkg/errors". Context: https://github.com/kubernetes/autoscaler/pull/7845
+        - pkg: github.com/pkg/errors
+      analyze-types: true
+formatters:
+  enable:
     - goimports
-
-linters-settings:
-  forbidigo:
-    forbid:
-      # Forbid use of archived package "github.com/pkg/errors". Context: https://github.com/kubernetes/autoscaler/pull/7845
-      - pkg: github.com/pkg/errors
-    analyze-types: true
-
-  goimports:
-    local-prefixes: "k8s.io/autoscaler/vertical-pod-autoscaler"
+  settings:
+    goimports:
+      local-prefixes:
+        - k8s.io/autoscaler/vertical-pod-autoscaler


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
version 2 of golangci-lint. its been out for a little while now.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
None

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
bump golangci-lint to v2
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
