### PR TITLE
Revert "Fix the setup-go Github action caching"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,18 +15,14 @@ jobs:
   test-and-verify:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5.1.0
+        with:
+          go-version: '1.22.2'
+
       - uses: actions/checkout@v4.2.2
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/autoscaler
-
-      - name: Set up Go
-        uses: actions/setup-go@v5.5.0
-        with:
-          go-version: '1.24.0'
-          cache-dependency-path: |
-             ${{ env.GOPATH}}/src/k8s.io/autoscaler/cluster-autoscaler/go.sum
-             ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum
-             ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/e2e/go.sum
 
       - name: Apt-get
         run: sudo apt-get install libseccomp-dev -qq

--- a/hack/for-go-proj.sh
+++ b/hack/for-go-proj.sh
@@ -52,7 +52,7 @@ for project_name in ${PROJECT_NAMES[*]}; do
         if [[ -n $(find . -name "Godeps.json") ]]; then
           godep go test -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e)
         else
-          go test -count=1  -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e | grep -v cluster-autoscaler/apis)
+          go test -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e | grep -v cluster-autoscaler/apis)
         fi
         ;;
       *)
@@ -71,6 +71,6 @@ if [ "${CMD}" = "build" ] || [ "${CMD}" == "test" ]; then
   # Default analyzers that go test runs according to https://github.com/golang/go/blob/52624e533fe52329da5ba6ebb9c37712048168e0/src/cmd/go/internal/test/test.go#L649
   # This doesn't include the `printf` analyzer until cluster-autoscaler libraries are updated.
   ANALYZERS="atomic,bool,buildtags,directive,errorsas,ifaceassert,nilfunc,slog,stringintconv,tests"
-  go test -count=1 ./... -vet="${ANALYZERS}"
+  go test ./... -vet="${ANALYZERS}"
   popd
 fi


### PR DESCRIPTION
Reverts kubernetes/autoscaler#8192

It seems this has contributed to some tests not running, which isn't ideal.