### PR TITLE
Add created node group to considered node groups during scale-up

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -232,6 +232,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 		if aErr != nil {
 			return scaleUpStatus, aErr
 		}
+		nodeGroups = appendCreatedNodeGroups(nodeGroups, oldId, createNodeGroupResults)
 	}
 
 	scaleUpInfos, aErr := o.balanceScaleUps(now, bestOption.NodeGroup, newNodes, nodeInfos, schedulablePodGroups)
@@ -843,4 +844,15 @@ func GetPodsAwaitingEvaluation(egs []*equivalence.PodGroup, bestOption string) [
 		}
 	}
 	return awaitsEvaluation
+}
+
+func appendCreatedNodeGroups(nodeGroups []cloudprovider.NodeGroup, bestOptionNodeGroupId string, results []nodegroups.CreateNodeGroupResult) []cloudprovider.NodeGroup {
+	for _, result := range results {
+		for _, ng := range result.AllCreatedNodeGroups() {
+			if ng.Id() != bestOptionNodeGroupId {
+				nodeGroups = append(nodeGroups, ng)
+			}
+		}
+	}
+	return nodeGroups
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Node group to be created may have different id than the created node group. Newly created node group was not propagated to scale up status `ConsideredNodeGroups` field causing warnings.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
