### PR TITLE
Update deployment.yaml to add volumeattachments permission

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/clusterapi/examples/deployment.yaml
@@ -108,6 +108,7 @@ rules:
     - storageclasses
     - csidrivers
     - csistoragecapacities
+    - volumeattachments
     verbs:
     - get
     - list


### PR DESCRIPTION
Add "volumeattachments".  See similar changes in https://github.com/kubernetes/autoscaler/commit/e79b5b86356ef5ec2fc5099824e876530f0e2d73



#### What this PR does / why we need it:
Add `volumeattachments` permission to clusterapi example.yaml

