### PR TITLE
[vpa-release-1.2] Automated cherry pick of #8204: include pod namespace when logging updates

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
@@ -88,7 +88,7 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
 		klog.V(2).Infof("can't calculate recommendations, one of vpa(%+v), pod(%+v) is nil", vpa, pod)
 		return nil, nil, nil
 	}
-	klog.V(2).Infof("updating requirements for pod %s.", pod.Name)
+	klog.V(2).Infof("updating requirements for pod %s.", klog.KObj(pod))
 
 	var annotations vpa_api_util.ContainerToAnnotationsMap
 	recommendedPodResources := &vpa_types.RecommendedPodResources{}


### PR DESCRIPTION
Cherry pick of #8204 on vpa-release-1.2.

#8204: include pod namespace when logging updates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.