### PR TITLE
Fix(VPA): updater in-place metrics initialization

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -212,12 +212,12 @@ func (u *updater) RunOnce(ctx context.Context) {
 	// wrappers for metrics which are computed every loop run
 	controlledPodsCounter := metrics_updater.NewControlledPodsCounter()
 	evictablePodsCounter := metrics_updater.NewEvictablePodsCounter()
-	inPlaceUpdatablePodsCounter := metrics_updater.NewInPlaceUpdtateablePodsCounter()
+	inPlaceUpdatablePodsCounter := metrics_updater.NewInPlaceUpdatablePodsCounter()
 	vpasWithEvictablePodsCounter := metrics_updater.NewVpasWithEvictablePodsCounter()
 	vpasWithEvictedPodsCounter := metrics_updater.NewVpasWithEvictedPodsCounter()
 
-	vpasWithInPlaceUpdatablePodsCounter := metrics_updater.NewVpasWithInPlaceUpdtateablePodsCounter()
-	vpasWithInPlaceUpdatedPodsCounter := metrics_updater.NewVpasWithInPlaceUpdtatedPodsCounter()
+	vpasWithInPlaceUpdatablePodsCounter := metrics_updater.NewVpasWithInPlaceUpdatablePodsCounter()
+	vpasWithInPlaceUpdatedPodsCounter := metrics_updater.NewVpasWithInPlaceUpdatedPodsCounter()
 
 	// using defer to protect against 'return' after evictionRateLimiter.Wait
 	defer controlledPodsCounter.Observe()

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
@@ -164,19 +164,19 @@ func AddEvictedPod(vpaSize int) {
 	evictedCount.WithLabelValues(strconv.Itoa(log2)).Inc()
 }
 
-// NewInPlaceUpdtateablePodsCounter returns a wrapper for counting Pods which are matching in-place update criteria
-func NewInPlaceUpdtateablePodsCounter() *SizeBasedGauge {
-	return newSizeBasedGauge(evictableCount)
+// NewInPlaceUpdatablePodsCounter returns a wrapper for counting Pods which are matching in-place update criteria
+func NewInPlaceUpdatablePodsCounter() *SizeBasedGauge {
+	return newSizeBasedGauge(inPlaceUpdatableCount)
 }
 
-// NewVpasWithInPlaceUpdtateablePodsCounter returns a wrapper for counting VPA objects with Pods matching in-place update criteria
-func NewVpasWithInPlaceUpdtateablePodsCounter() *SizeBasedGauge {
-	return newSizeBasedGauge(vpasWithEvictablePodsCount)
+// NewVpasWithInPlaceUpdatablePodsCounter returns a wrapper for counting VPA objects with Pods matching in-place update criteria
+func NewVpasWithInPlaceUpdatablePodsCounter() *SizeBasedGauge {
+	return newSizeBasedGauge(vpasWithInPlaceUpdatablePodsCount)
 }
 
-// NewVpasWithInPlaceUpdtatedPodsCounter returns a wrapper for counting VPA objects with evicted Pods
-func NewVpasWithInPlaceUpdtatedPodsCounter() *SizeBasedGauge {
-	return newSizeBasedGauge(vpasWithEvictedPodsCount)
+// NewVpasWithInPlaceUpdatedPodsCounter returns a wrapper for counting VPA objects with in-place updated Pods
+func NewVpasWithInPlaceUpdatedPodsCounter() *SizeBasedGauge {
+	return newSizeBasedGauge(vpasWithInPlaceUpdatedPodsCount)
 }
 
 // AddInPlaceUpdatedPod increases the counter of pods updated in place by Updater, by given VPA size


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
The in-place metric constructors in the vpa-updater used an incorrect `GaugeVec` during initialization, which caused the metrics not to be exported.

If you check them using the `curl` command, you will notice that the metrics are missing:
```sh
$ curl -s http://127.0.0.1:8943/metrics | grep in_place
$ echo $?
1

$ curl -s http://127.0.0.1:8943/metrics | grep in_place | wc -l
0
```

After the patch, this command will return the result:
```sh
$ curl -s http://127.0.0.1:8943/metrics  | grep in_place
# HELP vpa_updater_in_place_Updatable_pods_total Number of Pods matching in place update criteria.
# TYPE vpa_updater_in_place_Updatable_pods_total gauge
vpa_updater_in_place_Updatable_pods_total{vpa_size_log2="0"} 0
vpa_updater_in_place_Updatable_pods_total{vpa_size_log2="1"} 0
vpa_updater_in_place_Updatable_pods_total{vpa_size_log2="10"} 0
vpa_updater_in_place_Updatable_pods_total{vpa_size_log2="11"} 0
vpa_updater_in_place_Updatable_pods_total{vpa_size_log2="12"} 0
...

$ curl -s http://127.0.0.1:8943/metrics  | grep in_place | wc -l
66
```

The patch also fixes some misspellings.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
