### PR TITLE
[VPA] Use factory start to fill caches instead of separate informers

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -120,9 +120,10 @@ func main() {
 	defer close(stopCh)
 	factory.Start(stopCh)
 	informerMap := factory.WaitForCacheSync(stopCh)
-	for informerType, synced := range informerMap {
+	for kind, synced := range informerMap {
 		if !synced {
-			klog.V(0).InfoS("Initial sync failed", "kind", informerType)
+			klog.ErrorS(nil, fmt.Sprintf("Could not sync cache for the %s informer", kind.String()))
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
 	}
 

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -234,9 +235,10 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 
 	factory.Start(stopCh)
 	informerMap := factory.WaitForCacheSync(stopCh)
-	for informerType, synced := range informerMap {
+	for kind, synced := range informerMap {
 		if !synced {
-			klog.V(0).InfoS("Initial sync failed", "kind", informerType)
+			klog.ErrorS(nil, fmt.Sprintf("Could not sync cache for the %s informer", kind.String()))
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
 	}
 

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -136,17 +136,6 @@ func NewControllerFetcher(config *rest.Config, kubeClient kube_client.Interface,
 		cronJob:               factory.Batch().V1().CronJobs().Informer(),
 	}
 
-	for kind, informer := range informersMap {
-		stopCh := make(chan struct{})
-		go informer.Run(stopCh)
-		synced := cache.WaitForCacheSync(stopCh, informer.HasSynced)
-		if !synced {
-			klog.V(0).InfoS("Initial sync failed", "kind", kind)
-		} else {
-			klog.InfoS("Initial sync completed", "kind", kind)
-		}
-	}
-
 	scaleNamespacer := scale.New(restClient, mapper, dynamic.LegacyAPIPathResolverFunc, resolver)
 	return &controllerFetcher{
 		scaleNamespacer:              scaleNamespacer,

--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -91,18 +91,6 @@ func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Int
 		cronJob:               factory.Batch().V1().CronJobs().Informer(),
 	}
 
-	for kind, informer := range informersMap {
-		stopCh := make(chan struct{})
-		go informer.Run(stopCh)
-		synced := cache.WaitForCacheSync(stopCh, informer.HasSynced)
-		if !synced {
-			klog.ErrorS(nil, "Could not sync cache for "+string(kind))
-			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
-		} else {
-			klog.InfoS("Initial sync completed", "kind", kind)
-		}
-	}
-
 	scaleNamespacer := scale.New(restClient, mapper, dynamic.LegacyAPIPathResolverFunc, resolver)
 	return &vpaTargetSelectorFetcher{
 		scaleNamespacer: scaleNamespacer,

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -189,9 +190,10 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 
 	factory.Start(stopCh)
 	informerMap := factory.WaitForCacheSync(stopCh)
-	for informerType, synced := range informerMap {
+	for kind, synced := range informerMap {
 		if !synced {
-			klog.V(0).InfoS("Initial sync failed", "kind", informerType)
+			klog.ErrorS(nil, fmt.Sprintf("Could not sync cache for the %s informer", kind.String()))
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
 	}
 

--- a/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
+++ b/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 )
 
 // LimitRangeCalculator calculates limit range items that has the same effect as all limit range items present in the cluster.
@@ -55,13 +54,6 @@ func NewLimitsRangeCalculator(f informers.SharedInformerFactory) (*limitsChecker
 		return nil, fmt.Errorf("NewLimitsRangeCalculator requires a SharedInformerFactory but got nil")
 	}
 	limitRangeLister := f.Core().V1().LimitRanges().Lister()
-	stopCh := make(chan struct{})
-	informer := f.Core().V1().LimitRanges().Informer()
-	go informer.Run(stopCh)
-	ok := cache.WaitForCacheSync(stopCh, informer.HasSynced)
-	if !ok {
-		return nil, fmt.Errorf("informer did not sync")
-	}
 	return &limitsChecker{limitRangeLister}, nil
 }
 

--- a/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator_test.go
@@ -138,6 +138,9 @@ func TestGetContainerLimitRangeItem(t *testing.T) {
 			cs := fake.NewSimpleClientset(tc.limitRanges...)
 			factory := informers.NewSharedInformerFactory(cs, 0)
 			lc, err := NewLimitsRangeCalculator(factory)
+
+			factory.Start(t.Context().Done())
+			_ = factory.WaitForCacheSync(t.Context().Done())
 			if assert.NoError(t, err) {
 				limitRange, err := lc.GetContainerLimitRangeItem(testNamespace)
 				if tc.expectedErr == nil {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
VPA controllers initialize a few informers, but the informers in `targetSelectorFetcher` and `controllerFetcher` are duplicated. If we start them one by one, it leads to a warning message because the caches are already synchronized.  
We can use the factory (it was made for this purpose) that was used to create these informers to start them and wait for all caches to sync.
Then caches will be populated without any warning messages.
```
I0621 01:27:41.171294   84656 reflector.go:430] "Caches populated" type="*v1.CronJob" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285"
I0621 01:27:41.171294   84656 reflector.go:430] "Caches populated" type="*v1.Job" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285"
I0621 01:27:41.171385   84656 reflector.go:430] "Caches populated" type="*v1.LimitRange" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285"
I0621 01:27:41.266254   84656 reflector.go:430] "Caches populated" type="*v1.StatefulSet" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285"
I0621 01:27:41.267590   84656 reflector.go:430] "Caches populated" type="*v1.ReplicationController" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285"
I0621 01:27:41.268791   84656 reflector.go:430] "Caches populated" type="*v1.DaemonSet" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285"
I0621 01:27:41.270992   84656 reflector.go:430] "Caches populated" type="*v1.ReplicaSet" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285"
I0621 01:27:41.273464   84656 reflector.go:430] "Caches populated" type="*v1.Deployment" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285"
```

Potentially, we could start the factory elsewhere, for example inside the `RunOnce` function of the updater.  
However, that would move it too far from the initialization logic, which might lead to bugs.  
So I decided to place the factory start function closer to the `NewSharedInformerFactory` call, right after all informers for this factory are initialized.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8256

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
