### PR TITLE
[VPA] Add prometheus bearer auth support

### DIFF
--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -55,8 +55,6 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `add-dir-header` |  |  | If true, adds the file directory to the header of the log messages |
 | `address` | string |  ":8942" | The address to expose Prometheus metrics.  |
 | `alsologtostderr` |  |  | log to standard error as well as files (no effect when -logtostderr=true) |
-| `bearer-token` | string |  | The bearer token used in the Prometheus server bearer token auth |
-| `bearer-token-file` | string |  | Path to the bearer token file used for authentication by the Prometheus server |
 | `checkpoints-gc-interval` |  |  10m0s | duration                       How often orphaned checkpoints should be garbage collected  |
 | `checkpoints-timeout` |  |  1m0s | duration                           Timeout for writing checkpoints since the start of the recommender's main loop  |
 | `confidence-interval-cpu` |  |  24h0m0s | duration                       The time interval used for computing the confidence multiplier for the CPU lower and upper bound. Default: 24h  |
@@ -107,6 +105,8 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `pod-recommendation-min-memory-mb` | float |  250 | Minimum memory recommendation for a pod  |
 | `profiling` | int |  | Is debug/pprof endpoenabled |
 | `prometheus-address` | string |  "http://prometheus.monitoring.svc" | Where to reach for Prometheus metrics  |
+| `prometheus-bearer-token` | string |  | The bearer token used in the Prometheus server bearer token auth |
+| `prometheus-bearer-token-file` | string |  | Path to the bearer token file used for authentication by the Prometheus server |
 | `prometheus-cadvisor-job-name` | string |  "kubernetes-cadvisor" | Name of the prometheus job name which scrapes the cAdvisor metrics  |
 | `prometheus-insecure` |  |  | Skip tls verify if https is used in the prometheus-address |
 | `prometheus-query-timeout` | string |  "5m" | How long to wait before killing long queries  |

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -55,6 +55,8 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `add-dir-header` |  |  | If true, adds the file directory to the header of the log messages |
 | `address` | string |  ":8942" | The address to expose Prometheus metrics.  |
 | `alsologtostderr` |  |  | log to standard error as well as files (no effect when -logtostderr=true) |
+| `bearer-token` | string |  | The bearer token used in the Prometheus server bearer token auth |
+| `bearer-token-file` | string |  | Path to the bearer token file used for authentication by the Prometheus server |
 | `checkpoints-gc-interval` |  |  10m0s | duration                       How often orphaned checkpoints should be garbage collected  |
 | `checkpoints-timeout` |  |  1m0s | duration                           Timeout for writing checkpoints since the start of the recommender's main loop  |
 | `confidence-interval-cpu` |  |  24h0m0s | duration                       The time interval used for computing the confidence multiplier for the CPU lower and upper bound. Default: 24h  |
@@ -106,6 +108,7 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `profiling` | int |  | Is debug/pprof endpoenabled |
 | `prometheus-address` | string |  "http://prometheus.monitoring.svc" | Where to reach for Prometheus metrics  |
 | `prometheus-cadvisor-job-name` | string |  "kubernetes-cadvisor" | Name of the prometheus job name which scrapes the cAdvisor metrics  |
+| `prometheus-insecure` |  |  | Skip tls verify if https is used in the prometheus-address |
 | `prometheus-query-timeout` | string |  "5m" | How long to wait before killing long queries  |
 | `recommendation-lower-bound-cpu-percentile` | float |  0.5 | CPU usage percentile that will be used for the lower bound on CPU recommendation.  |
 | `recommendation-lower-bound-memory-percentile` | float |  0.5 | Memory usage percentile that will be used for the lower bound on memory recommendation.  |

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -18,6 +18,7 @@ package history
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"sort"
@@ -34,22 +35,50 @@ import (
 	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
 )
 
-// PrometheusBasicAuthTransport contains the username and password of prometheus server
+// PrometheusBasicAuthTransport injects basic auth headers into HTTP requests.
 type PrometheusBasicAuthTransport struct {
 	Username string
 	Password string
+	Base     http.RoundTripper
 }
 
 // RoundTrip function injects the username and password in the request's basic auth header
 func (t *PrometheusBasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.SetBasicAuth(t.Username, t.Password)
-	return http.DefaultTransport.RoundTrip(req)
+	// Use default transport if none specified
+	rt := t.Base
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	// Clone the request to avoid modifying the original
+	cloned := req.Clone(req.Context())
+	cloned.SetBasicAuth(t.Username, t.Password)
+	return rt.RoundTrip(cloned)
+}
+
+// PrometheusBearerTokenAuthTransport injects bearer token into HTTP requests.
+type PrometheusBearerTokenAuthTransport struct {
+	Token string
+	Base  http.RoundTripper
+}
+
+// RoundTrip function injects the bearer token in the request's Authorization header
+func (bt *PrometheusBearerTokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt := bt.Base
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	cloned := req.Clone(req.Context())
+	cloned.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bt.Token))
+	return rt.RoundTrip(cloned)
 }
 
 // PrometheusHistoryProviderConfig allow to select which metrics
 // should be queried to get real resource utilization.
 type PrometheusHistoryProviderConfig struct {
 	Address                                          string
+	Insecure                                         bool
 	QueryTimeout                                     time.Duration
 	HistoryLength, HistoryResolution                 string
 	PodLabelPrefix, PodLabelsMetricName              string
@@ -57,7 +86,17 @@ type PrometheusHistoryProviderConfig struct {
 	CtrNamespaceLabel, CtrPodNameLabel, CtrNameLabel string
 	CadvisorMetricsJobName                           string
 	Namespace                                        string
-	PrometheusBasicAuthTransport
+
+	Authentication PrometheusCredentials
+}
+
+// PrometheusCredentials keeps credentials for Prometheus API. The Username + Password pair is mutually exclusive with
+// the BearerToken field. It's handled in the CLI flags. But if BearerToken is set, it will have priority over the basic auth.
+// If both are empty, no authentication is used.
+type PrometheusCredentials struct {
+	Username    string
+	Password    string
+	BearerToken string
 }
 
 // PodHistory represents history of usage and labels for a given pod.
@@ -91,23 +130,33 @@ type prometheusHistoryProvider struct {
 
 // NewPrometheusHistoryProvider constructs a history provider that gets data from Prometheus.
 func NewPrometheusHistoryProvider(config PrometheusHistoryProviderConfig) (HistoryProvider, error) {
-	promConfig := promapi.Config{
-		Address:      config.Address,
-		RoundTripper: promapi.DefaultRoundTripper,
+	prometheusTransport := promapi.DefaultRoundTripper
+
+	if config.Insecure {
+		prometheusTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	if config.Username != "" && config.Password != "" {
-		transport := &PrometheusBasicAuthTransport{
-			Username: config.Username,
-			Password: config.Password,
+	if config.Authentication.BearerToken != "" {
+		prometheusTransport = &PrometheusBearerTokenAuthTransport{
+			Token: config.Authentication.BearerToken,
+			Base:  prometheusTransport,
 		}
-		promConfig.RoundTripper = transport
+	} else if config.Authentication.Username != "" && config.Authentication.Password != "" {
+		prometheusTransport = &PrometheusBasicAuthTransport{
+			Username: config.Authentication.Username,
+			Password: config.Authentication.Password,
+			Base:     prometheusTransport,
+		}
 	}
 
 	roundTripper := metrics_recommender.NewPrometheusRoundTripperCounter(
-		metrics_recommender.NewPrometheusRoundTripperDuration(promConfig.RoundTripper),
+		metrics_recommender.NewPrometheusRoundTripperDuration(prometheusTransport),
 	)
-	promConfig.RoundTripper = roundTripper
+
+	promConfig := promapi.Config{
+		Address:      config.Address,
+		RoundTripper: roundTripper,
+	}
 
 	promClient, err := promapi.NewClient(promConfig)
 	if err != nil {

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -372,7 +372,7 @@ func TestPrometheusAuth(t *testing.T) {
 		_, err := prov.GetClusterHistory()
 
 		assert.Nil(t, err)
-		assert.Equal(t, capturedRequest.Header.Get("Authorization"), "Basic dXNlcjpwYXNzd29yZA==")
+		assert.Equal(t, capturedRequest.Header.Get("Authorization"), "Basic dXNlcjpwYXNzd29yZA==") // "user:password"
 	})
 
 	t.Run("Bearer token auth", func(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -384,4 +384,18 @@ func TestPrometheusAuth(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, capturedRequest.Header.Get("Authorization"), "Bearer token")
 	})
+
+	t.Run("Basic auth and Bearer token auth are set at once", func(t *testing.T) {
+		// if both auth methods are set we prefer Bearer token
+		cfg.Authentication.BearerToken = "token"
+		cfg.Authentication.Username = "user"
+		cfg.Authentication.Password = "password"
+
+		prov, _ := NewPrometheusHistoryProvider(cfg)
+		_, err := prov.GetClusterHistory()
+
+		assert.Nil(t, err)
+		assert.NotContains(t, capturedRequest.Header.Get("Authorization"), "Basic")
+		assert.Equal(t, capturedRequest.Header.Get("Authorization"), "Bearer token")
+	})
 }

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -71,6 +71,7 @@ var (
 // Prometheus history provider flags
 var (
 	prometheusAddress   = flag.String("prometheus-address", "http://prometheus.monitoring.svc", `Where to reach for Prometheus metrics`)
+	prometheusInsecure  = flag.Bool("prometheus-insecure", false, `Skip tls verify if https is used in the prometheus-address`)
 	prometheusJobName   = flag.String("prometheus-cadvisor-job-name", "kubernetes-cadvisor", `Name of the prometheus job name which scrapes the cAdvisor metrics`)
 	historyLength       = flag.String("history-length", "8d", `How much time back prometheus have to be queried to get historical metrics`)
 	historyResolution   = flag.String("history-resolution", "1h", `Resolution at which Prometheus is queried for historical metrics`)
@@ -84,6 +85,8 @@ var (
 	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
 	username            = flag.String("username", "", "The username used in the prometheus server basic auth")
 	password            = flag.String("password", "", "The password used in the prometheus server basic auth")
+	bearerToken         = flag.String("bearer-token", "", "The bearer token used in the Prometheus server bearer token auth")
+	bearerTokenFile     = flag.String("bearer-token-file", "", "Path to the bearer token file used for authentication by the Prometheus server")
 )
 
 // External metrics provider flags
@@ -146,6 +149,20 @@ func main() {
 
 	if *routines.MinCheckpointsPerRun != 10 { // Default value is 10
 		klog.InfoS("DEPRECATION WARNING: The 'min-checkpoints' flag is deprecated and has no effect. It will be removed in a future release.")
+	}
+
+	if *bearerToken != "" && *bearerTokenFile != "" && *username != "" {
+		klog.ErrorS(nil, "--bearer-token, --bearer-token-file and --username are mutually exclusive and can't be set together.")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
+
+	if *bearerTokenFile != "" {
+		fileContent, err := os.ReadFile(*bearerTokenFile)
+		if err != nil {
+			klog.ErrorS(err, "Unable to read bearer token file")
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		}
+		*bearerToken = strings.TrimSpace(string(fileContent))
 	}
 
 	ctx := context.Background()
@@ -304,6 +321,7 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 	} else {
 		config := history.PrometheusHistoryProviderConfig{
 			Address:                *prometheusAddress,
+			Insecure:               *prometheusInsecure,
 			QueryTimeout:           promQueryTimeout,
 			HistoryLength:          *historyLength,
 			HistoryResolution:      *historyResolution,
@@ -316,9 +334,10 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 			CtrNameLabel:           *ctrNameLabel,
 			CadvisorMetricsJobName: *prometheusJobName,
 			Namespace:              commonFlag.VpaObjectNamespace,
-			PrometheusBasicAuthTransport: history.PrometheusBasicAuthTransport{
-				Username: *username,
-				Password: *password,
+			Authentication: history.PrometheusCredentials{
+				BearerToken: *bearerToken,
+				Username:    *username,
+				Password:    *password,
 			},
 		}
 		provider, err := history.NewPrometheusHistoryProvider(config)

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -159,7 +159,7 @@ func main() {
 	if *bearerTokenFile != "" {
 		fileContent, err := os.ReadFile(*bearerTokenFile)
 		if err != nil {
-			klog.ErrorS(err, "Unable to read bearer token file")
+			klog.ErrorS(err, "Unable to read bearer token file", "filename", *bearerTokenFile)
 			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
 		*bearerToken = strings.TrimSpace(string(fileContent))

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -70,23 +70,23 @@ var (
 
 // Prometheus history provider flags
 var (
-	prometheusAddress   = flag.String("prometheus-address", "http://prometheus.monitoring.svc", `Where to reach for Prometheus metrics`)
-	prometheusInsecure  = flag.Bool("prometheus-insecure", false, `Skip tls verify if https is used in the prometheus-address`)
-	prometheusJobName   = flag.String("prometheus-cadvisor-job-name", "kubernetes-cadvisor", `Name of the prometheus job name which scrapes the cAdvisor metrics`)
-	historyLength       = flag.String("history-length", "8d", `How much time back prometheus have to be queried to get historical metrics`)
-	historyResolution   = flag.String("history-resolution", "1h", `Resolution at which Prometheus is queried for historical metrics`)
-	queryTimeout        = flag.String("prometheus-query-timeout", "5m", `How long to wait before killing long queries`)
-	podLabelPrefix      = flag.String("pod-label-prefix", "pod_label_", `Which prefix to look for pod labels in metrics`)
-	podLabelsMetricName = flag.String("metric-for-pod-labels", "up{job=\"kubernetes-pods\"}", `Which metric to look for pod labels in metrics`)
-	podNamespaceLabel   = flag.String("pod-namespace-label", "kubernetes_namespace", `Label name to look for pod namespaces`)
-	podNameLabel        = flag.String("pod-name-label", "kubernetes_pod_name", `Label name to look for pod names`)
-	ctrNamespaceLabel   = flag.String("container-namespace-label", "namespace", `Label name to look for container namespaces`)
-	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container pod names`)
-	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
-	username            = flag.String("username", "", "The username used in the prometheus server basic auth")
-	password            = flag.String("password", "", "The password used in the prometheus server basic auth")
-	bearerToken         = flag.String("prometheus-bearer-token", "", "The bearer token used in the Prometheus server bearer token auth")
-	bearerTokenFile     = flag.String("prometheus-bearer-token-file", "", "Path to the bearer token file used for authentication by the Prometheus server")
+	prometheusAddress         = flag.String("prometheus-address", "http://prometheus.monitoring.svc", `Where to reach for Prometheus metrics`)
+	prometheusInsecure        = flag.Bool("prometheus-insecure", false, `Skip tls verify if https is used in the prometheus-address`)
+	prometheusJobName         = flag.String("prometheus-cadvisor-job-name", "kubernetes-cadvisor", `Name of the prometheus job name which scrapes the cAdvisor metrics`)
+	historyLength             = flag.String("history-length", "8d", `How much time back prometheus have to be queried to get historical metrics`)
+	historyResolution         = flag.String("history-resolution", "1h", `Resolution at which Prometheus is queried for historical metrics`)
+	queryTimeout              = flag.String("prometheus-query-timeout", "5m", `How long to wait before killing long queries`)
+	podLabelPrefix            = flag.String("pod-label-prefix", "pod_label_", `Which prefix to look for pod labels in metrics`)
+	podLabelsMetricName       = flag.String("metric-for-pod-labels", "up{job=\"kubernetes-pods\"}", `Which metric to look for pod labels in metrics`)
+	podNamespaceLabel         = flag.String("pod-namespace-label", "kubernetes_namespace", `Label name to look for pod namespaces`)
+	podNameLabel              = flag.String("pod-name-label", "kubernetes_pod_name", `Label name to look for pod names`)
+	ctrNamespaceLabel         = flag.String("container-namespace-label", "namespace", `Label name to look for container namespaces`)
+	ctrPodNameLabel           = flag.String("container-pod-name-label", "pod_name", `Label name to look for container pod names`)
+	ctrNameLabel              = flag.String("container-name-label", "name", `Label name to look for container names`)
+	username                  = flag.String("username", "", "The username used in the prometheus server basic auth")
+	password                  = flag.String("password", "", "The password used in the prometheus server basic auth")
+	prometheusBearerToken     = flag.String("prometheus-bearer-token", "", "The bearer token used in the Prometheus server bearer token auth")
+	prometheusBearerTokenFile = flag.String("prometheus-bearer-token-file", "", "Path to the bearer token file used for authentication by the Prometheus server")
 )
 
 // External metrics provider flags
@@ -151,18 +151,18 @@ func main() {
 		klog.InfoS("DEPRECATION WARNING: The 'min-checkpoints' flag is deprecated and has no effect. It will be removed in a future release.")
 	}
 
-	if *bearerToken != "" && *bearerTokenFile != "" && *username != "" {
+	if *prometheusBearerToken != "" && *prometheusBearerTokenFile != "" && *username != "" {
 		klog.ErrorS(nil, "--bearer-token, --bearer-token-file and --username are mutually exclusive and can't be set together.")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
-	if *bearerTokenFile != "" {
-		fileContent, err := os.ReadFile(*bearerTokenFile)
+	if *prometheusBearerTokenFile != "" {
+		fileContent, err := os.ReadFile(*prometheusBearerTokenFile)
 		if err != nil {
-			klog.ErrorS(err, "Unable to read bearer token file", "filename", *bearerTokenFile)
+			klog.ErrorS(err, "Unable to read bearer token file", "filename", *prometheusBearerTokenFile)
 			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
-		*bearerToken = strings.TrimSpace(string(fileContent))
+		*prometheusBearerToken = strings.TrimSpace(string(fileContent))
 	}
 
 	ctx := context.Background()
@@ -335,7 +335,7 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 			CadvisorMetricsJobName: *prometheusJobName,
 			Namespace:              commonFlag.VpaObjectNamespace,
 			Authentication: history.PrometheusCredentials{
-				BearerToken: *bearerToken,
+				BearerToken: *prometheusBearerToken,
 				Username:    *username,
 				Password:    *password,
 			},

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -85,8 +85,8 @@ var (
 	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
 	username            = flag.String("username", "", "The username used in the prometheus server basic auth")
 	password            = flag.String("password", "", "The password used in the prometheus server basic auth")
-	bearerToken         = flag.String("bearer-token", "", "The bearer token used in the Prometheus server bearer token auth")
-	bearerTokenFile     = flag.String("bearer-token-file", "", "Path to the bearer token file used for authentication by the Prometheus server")
+	bearerToken         = flag.String("prometheus-bearer-token", "", "The bearer token used in the Prometheus server bearer token auth")
+	bearerTokenFile     = flag.String("prometheus-bearer-token-file", "", "Path to the bearer token file used for authentication by the Prometheus server")
 )
 
 // External metrics provider flags


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR adds several flags for the Prometheus historical provider:

- `prometheus-insecure` – Skip TLS verification. Prometheus may use a TLS certificate, and accessing it over https:// could result in an unknown CA certificate error if the certificate is self-signed or untrusted.
- `prometheus-bearer-token` – Use a bearer token for authentication.
- `prometheus-bearer-token-file` – Read the bearer token from a file. This is useful when using [kube-rbac-proxy ](https://github.com/brancz/kube-rbac-proxy)and a service account token is mounted into the pod.

Bearer token authentication and basic authentication are mutually exclusive, as both use the Authorization header. Only one of the following combinations should be set: username + password, bearer-token, or bearer-token-file.

Additionally, the authentication middleware logic was updated to follow best practices by cloning the request rather than modifying the original one.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
