### PR TITLE
Omit fake pods during eviction

### DIFF
--- a/cluster-autoscaler/core/scaledown/actuation/drain.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain.go
@@ -27,6 +27,7 @@ import (
 	kube_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
 	kubelet_config "k8s.io/kubernetes/pkg/kubelet/apis/config"
@@ -275,6 +276,8 @@ func (e Evictor) evictPod(ctx *acontext.AutoscalingContext, podToEvict *apiv1.Po
 func podsToEvict(nodeInfo *framework.NodeInfo, evictDsByDefault bool) (dsPods, nonDsPods []*apiv1.Pod) {
 	for _, podInfo := range nodeInfo.Pods() {
 		if pod_util.IsMirrorPod(podInfo.Pod) {
+			continue
+		} else if fake.IsFake(podInfo.Pod) {
 			continue
 		} else if pod_util.IsDaemonSetPod(podInfo.Pod) {
 			dsPods = append(dsPods, podInfo.Pod)

--- a/cluster-autoscaler/core/scaledown/actuation/drain_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	simulator_fake "k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/daemonset"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -683,6 +684,11 @@ func TestPodsToEvict(t *testing.T) {
 			wantDsPods:    []*apiv1.Pod{},
 			wantNonDsPods: []*apiv1.Pod{},
 		},
+		"fake pods are never returned": {
+			pods:          []*apiv1.Pod{fakePod("pod-1"), fakePod("pod-2")},
+			wantDsPods:    []*apiv1.Pod{},
+			wantNonDsPods: []*apiv1.Pod{},
+		},
 		"non-DS pods are correctly returned": {
 			pods:          []*apiv1.Pod{regularPod("pod-1"), regularPod("pod-2")},
 			wantDsPods:    []*apiv1.Pod{},
@@ -764,6 +770,10 @@ func mirrorPod(name string) *apiv1.Pod {
 			},
 		},
 	}
+}
+
+func fakePod(name string) *apiv1.Pod {
+	return simulator_fake.WithFakePodAnnotation(regularPod(name))
 }
 
 func dsPod(name string, evictable bool) *apiv1.Pod {

--- a/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor.go
+++ b/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor.go
@@ -20,6 +20,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
 )
 
 const (
@@ -50,7 +51,7 @@ func (p *EnforceInjectedPodsLimitProcessor) Process(ctx *context.AutoscalingCont
 	var unschedulablePodsAfterProcessing []*apiv1.Pod
 
 	for _, pod := range unschedulablePods {
-		if IsFake(pod) {
+		if fake.IsFake(pod) {
 			if removedFakePodsCount < numberOfFakePodsToRemove {
 				removedFakePodsCount += 1
 				continue

--- a/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor_test.go
+++ b/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
 )
 
 func TestEnforceInjectedPodsLimitProcessor(t *testing.T) {
@@ -110,7 +111,7 @@ func TestEnforceInjectedPodsLimitProcessor(t *testing.T) {
 func numberOfFakePods(pods []*apiv1.Pod) int {
 	numberOfFakePods := 0
 	for _, pod := range pods {
-		if IsFake(pod) {
+		if fake.IsFake(pod) {
 			numberOfFakePods += 1
 		}
 	}

--- a/cluster-autoscaler/processors/podinjection/pod_injection_processor_test.go
+++ b/cluster-autoscaler/processors/podinjection/pod_injection_processor_test.go
@@ -32,6 +32,7 @@ import (
 	podinjectionbackoff "k8s.io/autoscaler/cluster-autoscaler/processors/podinjection/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -382,8 +383,7 @@ func TestMakeFakePods(t *testing.T) {
 		assert.Equal(t, fakePod.Name, fmt.Sprintf("%s-copy-%d", samplePod.Name, idx+1))
 		assert.Equal(t, fakePod.UID, types.UID(fmt.Sprintf("%s-%d", string(ownerUid), idx+1)))
 		assert.Equal(t, "", fakePod.Spec.NodeName)
-		assert.NotNil(t, fakePod.Annotations)
-		assert.Equal(t, fakePod.Annotations[FakePodAnnotationKey], FakePodAnnotationValue)
+		assert.True(t, fake.IsFake(fakePod))
 	}
 
 	// Test case: Zero fake pod count

--- a/cluster-autoscaler/processors/podinjection/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/podinjection/scale_up_status_processor.go
@@ -26,6 +26,7 @@ import (
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	podinjectionbackoff "k8s.io/autoscaler/cluster-autoscaler/processors/podinjection/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
 	"k8s.io/klog/v2"
 )
 
@@ -63,7 +64,7 @@ func filterFakePods[T any](podsWrappers []T, getPod func(T) *apiv1.Pod, resource
 
 	for _, podsWrapper := range podsWrappers {
 		currentPod := getPod(podsWrapper)
-		if !IsFake(currentPod) {
+		if !fake.IsFake(currentPod) {
 			filteredPodsSouces = append(filteredPodsSouces, podsWrapper)
 			continue
 		}
@@ -86,7 +87,7 @@ func filterFakePods[T any](podsWrappers []T, getPod func(T) *apiv1.Pod, resource
 func extractFakePodsControllersUIDs(NoScaleUpInfos []status.NoScaleUpInfo) map[types.UID]bool {
 	uids := make(map[types.UID]bool)
 	for _, NoScaleUpInfo := range NoScaleUpInfos {
-		if IsFake(NoScaleUpInfo.Pod) {
+		if fake.IsFake(NoScaleUpInfo.Pod) {
 			uids[NoScaleUpInfo.Pod.UID] = true
 		}
 	}

--- a/cluster-autoscaler/processors/podinjection/scale_up_status_processor_test.go
+++ b/cluster-autoscaler/processors/podinjection/scale_up_status_processor_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	podinjectionbackoff "k8s.io/autoscaler/cluster-autoscaler/processors/podinjection/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
 
@@ -82,7 +83,7 @@ func createPod(name string, isFake bool) *apiv1.Pod {
 		if !isFake {
 			return
 		}
-		*p = *withFakePodAnnotation(p)
+		*p = *fake.WithFakePodAnnotation(p)
 	})
 }
 

--- a/cluster-autoscaler/simulator/fake/pod.go
+++ b/cluster-autoscaler/simulator/fake/pod.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+)
+
+const (
+	// FakePodAnnotationKey the key for pod type.
+	FakePodAnnotationKey = "podtype"
+	// FakePodAnnotationValue the value for a fake pod,
+	FakePodAnnotationValue = "fakepod"
+)
+
+// IsFake returns true if the a pod is marked as fake and false otherwise,
+func IsFake(pod *apiv1.Pod) bool {
+	if pod.Annotations == nil {
+		return false
+	}
+	return pod.Annotations[FakePodAnnotationKey] == FakePodAnnotationValue
+}
+
+// WithFakePodAnnotation adds annotation of key `FakePodAnnotationKey` with value `FakePodAnnotationValue` to passed pod.
+// WithFakePodAnnotation also creates a new annotations map if original pod.Annotations is nil.
+func WithFakePodAnnotation(pod *apiv1.Pod) *apiv1.Pod {
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string, 1)
+	}
+	pod.Annotations[FakePodAnnotationKey] = FakePodAnnotationValue
+	return pod
+}

--- a/cluster-autoscaler/simulator/fake/pod_test.go
+++ b/cluster-autoscaler/simulator/fake/pod_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestIsFake(t *testing.T) {
+	testCases := []struct {
+		name string
+		pod  *apiv1.Pod
+		want bool
+	}{
+		{
+			name: "real pod",
+			pod:  test.BuildTestPod("real", 10, 10),
+			want: false,
+		},
+		{
+			name: "fake pod",
+			pod:  WithFakePodAnnotation(test.BuildTestPod("fake", 10, 10)),
+			want: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsFake(tc.pod)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWithFakePodAnnotation(t *testing.T) {
+	pod := test.BuildTestPod("pod", 10, 10)
+	assert.Equal(t, map[string]string{}, pod.Annotations)
+	pod = WithFakePodAnnotation(pod)
+	assert.NotNil(t, pod.Annotations)
+	assert.Equal(t, FakePodAnnotationValue, pod.Annotations[FakePodAnnotationKey])
+}


### PR DESCRIPTION
#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:

When using fake (virtual) pods, Cluster Autoscaler tries to evict them during a scale-down, triggering NotFound error. Fake pods should be omitted during eviction.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

