### PR TITLE
Give sig-autoscaling-leads approval of the AEP directory

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,3 +4,17 @@ aliases:
     - jackfrancis
     - raywainman
     - towca
+  sig-autoscaling-vpa-approvers:
+    - kwiesmueller
+    - jbartosik
+    - voelzmo
+    - raywainman
+    - adrianmoisey
+    - omerap12
+  sig-autoscaling-vpa-reviewers:
+    - kwiesmueller
+    - jbartosik
+    - voelzmo
+    - raywainman
+    - adrianmoisey
+    - omerap12

--- a/vertical-pod-autoscaler/OWNERS
+++ b/vertical-pod-autoscaler/OWNERS
@@ -1,17 +1,7 @@
 approvers:
-- kwiesmueller
-- jbartosik
-- voelzmo
-- raywainman
-- adrianmoisey
-- omerap12
+- sig-autoscaling-vpa-approvers
 reviewers:
-- kwiesmueller
-- jbartosik
-- voelzmo
-- raywainman
-- adrianmoisey
-- omerap12
+- sig-autoscaling-vpa-reviewers
 emeritus_approvers:
 - schylek # 2022-09-30
 - kgolab # 2025-02-21

--- a/vertical-pod-autoscaler/enhancements/OWNERS
+++ b/vertical-pod-autoscaler/enhancements/OWNERS
@@ -1,0 +1,7 @@
+# Disable inheritance as we want to only give sig-autoscaling-leads approval to this directory
+options:
+  no_parent_owners: true
+approvers:
+- sig-autoscaling-leads
+reviewers:
+- sig-autoscaling-vpa-reviewers


### PR DESCRIPTION
As discussed in sig-autoscaling meeting on 2025-06-30, this is to try follow a similar pattern to the KEP process by getting a tech lead's buy in before merging an AEP.

/kind cleanup
/area vertical-pod-autoscaler