### PR TITLE
[cluster-autoscaler-release-1.30] Fix cool down status condition to trigger scale down

### DIFF
--- a/cluster-autoscaler/core/scaledown/status/status.go
+++ b/cluster-autoscaler/core/scaledown/status/status.go
@@ -100,6 +100,8 @@ const (
 	ScaleDownInCooldown
 	// ScaleDownInProgress - the scale down wasn't attempted, because a previous scale-down was still in progress.
 	ScaleDownInProgress
+	// ScaleDownNoCandidates - the scale down was skipped because of no scale down candidates.
+	ScaleDownNoCandidates
 )
 
 // NodeDeleteResultType denotes the type of the result of node deletion. It provides deeper

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -626,7 +626,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 
 		metrics.UpdateDurationFromStart(metrics.FindUnneeded, unneededStart)
 
-		scaleDownInCooldown := a.isScaleDownInCooldown(currentTime, scaleDownCandidates)
+		scaleDownInCooldown := a.isScaleDownInCooldown(currentTime)
 		klog.V(4).Infof("Scale down status: lastScaleUpTime=%s lastScaleDownDeleteTime=%v "+
 			"lastScaleDownFailTime=%s scaleDownForbidden=%v scaleDownInCooldown=%v",
 			a.lastScaleUpTime, a.lastScaleDownDeleteTime, a.lastScaleDownFailTime,
@@ -703,8 +703,8 @@ func (a *StaticAutoscaler) updateSoftDeletionTaints(allNodes []*apiv1.Node) {
 	}
 }
 
-func (a *StaticAutoscaler) isScaleDownInCooldown(currentTime time.Time, scaleDownCandidates []*apiv1.Node) bool {
-	scaleDownInCooldown := a.processorCallbacks.disableScaleDownForLoop || len(scaleDownCandidates) == 0
+func (a *StaticAutoscaler) isScaleDownInCooldown(currentTime time.Time) bool {
+	scaleDownInCooldown := a.processorCallbacks.disableScaleDownForLoop
 
 	if a.ScaleDownDelayTypeLocal {
 		return scaleDownInCooldown

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -2599,28 +2599,35 @@ func TestCleaningSoftTaintsInScaleDown(t *testing.T) {
 	tests := []struct {
 		name                          string
 		testNodes                     []*apiv1.Node
-		expectedScaleDownCoolDown     bool
+		scaleDownInCoolDown           bool
 		expectedNodesWithSoftTaints   []*apiv1.Node
 		expectedNodesWithNoSoftTaints []*apiv1.Node
 	}{
 		{
-			name:                          "Soft tainted nodes are cleaned in case of scale down is in cool down",
+			name:                          "Soft tainted nodes are cleaned when scale down skipped",
 			testNodes:                     nodesToHaveNoTaints,
-			expectedScaleDownCoolDown:     true,
+			scaleDownInCoolDown:           false,
 			expectedNodesWithSoftTaints:   []*apiv1.Node{},
 			expectedNodesWithNoSoftTaints: nodesToHaveNoTaints,
 		},
 		{
-			name:                          "Soft tainted nodes are not cleaned in case of scale down isn't in cool down",
+			name:                          "Soft tainted nodes are cleaned when scale down in cooldown",
+			testNodes:                     nodesToHaveNoTaints,
+			scaleDownInCoolDown:           true,
+			expectedNodesWithSoftTaints:   []*apiv1.Node{},
+			expectedNodesWithNoSoftTaints: nodesToHaveNoTaints,
+		},
+		{
+			name:                          "Soft tainted nodes are not cleaned when scale down requested",
 			testNodes:                     nodesToHaveTaints,
-			expectedScaleDownCoolDown:     false,
+			scaleDownInCoolDown:           false,
 			expectedNodesWithSoftTaints:   nodesToHaveTaints,
 			expectedNodesWithNoSoftTaints: []*apiv1.Node{},
 		},
 		{
-			name:                          "Soft tainted nodes are cleaned only from min sized node group in case of scale down isn't in cool down",
+			name:                          "Soft tainted nodes are cleaned only from min sized node group when scale down requested",
 			testNodes:                     append(nodesToHaveNoTaints, nodesToHaveTaints...),
-			expectedScaleDownCoolDown:     false,
+			scaleDownInCoolDown:           false,
 			expectedNodesWithSoftTaints:   nodesToHaveTaints,
 			expectedNodesWithNoSoftTaints: nodesToHaveNoTaints,
 		},
@@ -2631,12 +2638,12 @@ func TestCleaningSoftTaintsInScaleDown(t *testing.T) {
 			fakeClient := buildFakeClient(t, test.testNodes...)
 
 			autoscaler := buildStaticAutoscaler(t, provider, test.testNodes, test.testNodes, fakeClient)
+			autoscaler.processorCallbacks.disableScaleDownForLoop = test.scaleDownInCoolDown
+			assert.Equal(t, autoscaler.isScaleDownInCooldown(time.Now()), test.scaleDownInCoolDown)
 
 			err := autoscaler.RunOnce(time.Now())
 
 			assert.NoError(t, err)
-			candidates, _ := autoscaler.processors.ScaleDownNodeProcessor.GetScaleDownCandidates(autoscaler.AutoscalingContext, test.testNodes)
-			assert.Equal(t, test.expectedScaleDownCoolDown, autoscaler.isScaleDownInCooldown(time.Now(), candidates))
 
 			assertNodesSoftTaintsStatus(t, fakeClient, test.expectedNodesWithSoftTaints, true)
 			assertNodesSoftTaintsStatus(t, fakeClient, test.expectedNodesWithNoSoftTaints, false)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This is a manual cherry-pick of the following PRs:

- https://github.com/kubernetes/autoscaler/pull/7954
- https://github.com/kubernetes/autoscaler/pull/7995
- https://github.com/kubernetes/autoscaler/pull/7997
- https://github.com/kubernetes/autoscaler/pull/8034

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix cool down status condition to trigger scale down
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
