### PR TITLE
feat: improve external gPRC ca example

### DIFF
--- a/cluster-autoscaler/cloudprovider/externalgrpc/examples/certmanager-manifests/ca.yaml
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/examples/certmanager-manifests/ca.yaml
@@ -7,6 +7,7 @@ spec:
   isCA: true
   commonName: selfsigned-ca
   secretName: ca-root-secret
+  duration: 87600h
   privateKey:
     algorithm: ECDSA
     size: 256


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
This PR adds the duration field to the self-signed CA certificate examples for the external gRPC cloud provider.
Both cluster-autoscaler-grpc-client-cert and cluster-autoscaler-grpc-server-cert are set to use a duration of 87600h.
If users apply these example manifests as-is, they may encounter errors like the following:
```
externalgrpc_cloud_provider.go:79] Error on gRPC call NodeGroups: rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2025-07-03T12:20:01Z is after 2025-06-25T08:36:59Z"
```

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
