### PR TITLE
Fallback to eviction when InPlaceUpdate fail

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -279,8 +279,9 @@ func (u *updater) RunOnce(ctx context.Context) {
 			}
 			err := inPlaceLimiter.InPlaceUpdate(pod, vpa, u.eventRecorder)
 			if err != nil {
-				klog.V(0).InfoS("In-place update failed", "error", err, "pod", klog.KObj(pod))
+				klog.V(0).InfoS("In-place resize failed, falling back to eviction", "error", err, "pod", klog.KObj(pod))
 				metrics_updater.RecordFailedInPlaceUpdate(vpaSize, "InPlaceUpdateError")
+				podsForEviction = append(podsForEviction, pod)
 				continue
 			}
 			withInPlaceUpdated = true

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -18,6 +18,7 @@ package logic
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -55,6 +56,7 @@ func TestRunOnce_Mode(t *testing.T) {
 	tests := []struct {
 		name                  string
 		updateMode            vpa_types.UpdateMode
+		shouldInPlaceFail     bool
 		expectFetchCalls      bool
 		expectedEvictionCount int
 		expectedInPlacedCount int
@@ -64,6 +66,7 @@ func TestRunOnce_Mode(t *testing.T) {
 		{
 			name:                  "with Auto mode",
 			updateMode:            vpa_types.UpdateModeAuto,
+			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 5,
 			expectedInPlacedCount: 0,
@@ -73,6 +76,7 @@ func TestRunOnce_Mode(t *testing.T) {
 		{
 			name:                  "with Initial mode",
 			updateMode:            vpa_types.UpdateModeInitial,
+			shouldInPlaceFail:     false,
 			expectFetchCalls:      false,
 			expectedEvictionCount: 0,
 			expectedInPlacedCount: 0,
@@ -82,6 +86,7 @@ func TestRunOnce_Mode(t *testing.T) {
 		{
 			name:                  "with Off mode",
 			updateMode:            vpa_types.UpdateModeOff,
+			shouldInPlaceFail:     false,
 			expectFetchCalls:      false,
 			expectedEvictionCount: 0,
 			expectedInPlacedCount: 0,
@@ -91,6 +96,7 @@ func TestRunOnce_Mode(t *testing.T) {
 		{
 			name:                  "with InPlaceOrRecreate mode expecting in-place updates",
 			updateMode:            vpa_types.UpdateModeInPlaceOrRecreate,
+			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
 			expectedInPlacedCount: 5,
@@ -100,6 +106,7 @@ func TestRunOnce_Mode(t *testing.T) {
 		{
 			name:                  "with InPlaceOrRecreate mode expecting fallback to evictions",
 			updateMode:            vpa_types.UpdateModeInPlaceOrRecreate,
+			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 5,
 			expectedInPlacedCount: 0,
@@ -109,11 +116,22 @@ func TestRunOnce_Mode(t *testing.T) {
 		{
 			name:                  "with InPlaceOrRecreate mode expecting no evictions or in-place",
 			updateMode:            vpa_types.UpdateModeInPlaceOrRecreate,
+			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
 			expectedInPlacedCount: 0,
 			canEvict:              false,
 			canInPlaceUpdate:      utils.InPlaceDeferred,
+		},
+		{
+			name:                  "with InPlaceOrRecreate mode and failed in-place update",
+			updateMode:            vpa_types.UpdateModeInPlaceOrRecreate,
+			shouldInPlaceFail:     true,
+			expectFetchCalls:      true,
+			expectedEvictionCount: 5, // All pods should be evicted after in-place update fails
+			expectedInPlacedCount: 5, // All pods attempt in-place update first
+			canEvict:              true,
+			canInPlaceUpdate:      utils.InPlaceApproved,
 		},
 	}
 	for _, tc := range tests {
@@ -121,6 +139,7 @@ func TestRunOnce_Mode(t *testing.T) {
 			testRunOnceBase(
 				t,
 				tc.updateMode,
+				tc.shouldInPlaceFail,
 				newFakeValidator(true),
 				tc.expectFetchCalls,
 				tc.expectedEvictionCount,
@@ -159,6 +178,7 @@ func TestRunOnce_Status(t *testing.T) {
 			testRunOnceBase(
 				t,
 				vpa_types.UpdateModeAuto,
+				false,
 				tc.statusValidator,
 				tc.expectFetchCalls,
 				tc.expectedEvictionCount,
@@ -172,6 +192,7 @@ func TestRunOnce_Status(t *testing.T) {
 func testRunOnceBase(
 	t *testing.T,
 	updateMode vpa_types.UpdateMode,
+	shouldInPlaceFail bool,
 	statusValidator status.Validator,
 	expectFetchCalls bool,
 	expectedEvictionCount int,
@@ -213,7 +234,11 @@ func testRunOnceBase(
 		pods[i].Labels = labels
 
 		inplace.On("CanInPlaceUpdate", pods[i]).Return(canInPlaceUpdate)
-		inplace.On("InPlaceUpdate", pods[i], nil).Return(nil)
+		if shouldInPlaceFail {
+			inplace.On("InPlaceUpdate", pods[i], nil).Return(fmt.Errorf("in-place update failed"))
+		} else {
+			inplace.On("InPlaceUpdate", pods[i], nil).Return(nil)
+		}
 
 		eviction.On("CanEvict", pods[i]).Return(true)
 		eviction.On("Evict", pods[i], nil).Return(nil)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As discussed in #8288, when InPlaceUpdate (resize) fail we fallback to eviction.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
part of #8288

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fallback to eviction when InPlaceUpdate fail 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
