### PR TITLE
 Fix instance name extraction for placeholder nodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -204,18 +204,24 @@ type AwsInstanceRef struct {
 	Name       string
 }
 
-var validAwsRefIdRegex = regexp.MustCompile(fmt.Sprintf(`^aws\:\/\/\/[-0-9a-z]*\/[-0-9a-z]*(\/[-0-9a-z\.]*)?$|aws\:\/\/\/[-0-9a-z]*\/%s.*$`, placeholderInstanceNamePrefix))
+var validAwsRefIdRegex = regexp.MustCompile(fmt.Sprintf(`^aws\:\/\/\/[-0-9a-z]*\/([-0-9a-z]*)(\/[-0-9a-z\.]*)?$|aws\:\/\/\/[-0-9a-z]*\/(%s.*)$`, placeholderInstanceNamePrefix))
 
 // AwsRefFromProviderId creates AwsInstanceRef object from provider id which
 // must be in format: aws:///zone/name
 func AwsRefFromProviderId(id string) (*AwsInstanceRef, error) {
-	if validAwsRefIdRegex.FindStringSubmatch(id) == nil {
+	matches := validAwsRefIdRegex.FindStringSubmatch(id)
+	if matches == nil || len(matches) != 4 {
 		return nil, fmt.Errorf("wrong id: expected format aws:///<zone>/<name>, got %v", id)
 	}
-	splitted := strings.Split(id[7:], "/")
+
+	name := matches[1]
+	if name == "" {
+		name = matches[3]
+	}
+
 	return &AwsInstanceRef{
 		ProviderID: id,
-		Name:       splitted[1],
+		Name:       name,
 	}, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -204,7 +204,7 @@ type AwsInstanceRef struct {
 	Name       string
 }
 
-var validAwsRefIdRegex = regexp.MustCompile(fmt.Sprintf(`^aws\:\/\/\/[-0-9a-z]*\/([-0-9a-z]*)(\/[-0-9a-z\.]*)?$|aws\:\/\/\/[-0-9a-z]*\/(%s.*)$`, placeholderInstanceNamePrefix))
+var validAwsRefIdRegex = regexp.MustCompile(fmt.Sprintf(`^aws\:\/\/\/[-0-9a-z]*\/(%s.*)$|aws\:\/\/\/[-0-9a-z]*\/([-0-9a-z]*)(\/[-0-9a-z\.]*)?$`, placeholderInstanceNamePrefix))
 
 // AwsRefFromProviderId creates AwsInstanceRef object from provider id which
 // must be in format: aws:///zone/name
@@ -214,9 +214,11 @@ func AwsRefFromProviderId(id string) (*AwsInstanceRef, error) {
 		return nil, fmt.Errorf("wrong id: expected format aws:///<zone>/<name>, got %v", id)
 	}
 
-	name := matches[1]
-	if name == "" {
-		name = matches[3]
+	var name string
+	if strings.Contains(id, placeholderInstanceNamePrefix) {
+		name = matches[1]
+	} else {
+		name = matches[2]
 	}
 
 	return &AwsInstanceRef{

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -306,6 +306,15 @@ func TestAwsRefFromProviderId(t *testing.T) {
 				ProviderID: "aws:///eu-central-1c/i-placeholder-K3-EKS-spotr5xlasgsubnet02af43b02922e710f-10QH9H0C8PG7O-14",
 			},
 		},
+		{
+			// ref: https://github.com/kubernetes/autoscaler/issues/8305
+			provID: "aws:///us-east-1a/i-placeholder-some/arbitrary/cluster/local",
+			expErr: false,
+			expRef: &AwsInstanceRef{
+				Name:       "i-placeholder-some/arbitrary/cluster/local",
+				ProviderID: "aws:///us-east-1a/i-placeholder-some/arbitrary/cluster/local",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes the instance name extraction for placeholder nodes when the ASG name contains `/` character.

Previously, the instance name was incorrectly parsed and truncated, which caused cluster-autoscaler to fail to associate the placeholder node with its corresponding ASG.

**Incorrect behavior (before):**
```
Provider ID: aws:///eu-south-2a/i-placeholder-k8s-node/edge-prod-aeus2a/rika-test-1
Name: i-placeholder-k8s-node
```

**Correct behavior (after this PR):**
```
Provider ID: aws:///eu-south-2a/i-placeholder-k8s-node/edge-prod-aeus2a/rika-test-1
Name: i-placeholder-k8s-node/edge-prod-aeus2a/rika-test-1
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8305

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
