### PR TITLE
dependabot: add release-note-none label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
   open-pull-requests-limit: 0 # setting this to 0 means only allowing security updates, see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
   labels:
     - "area/vertical-pod-autoscaler"
+    - "release-note-none"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/pkg/recommender"
   schedule:
@@ -17,6 +18,7 @@ updates:
   open-pull-requests-limit: 3
   labels:
     - "area/vertical-pod-autoscaler"
+    - "release-note-none"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/pkg/updater"
   schedule:
@@ -27,6 +29,7 @@ updates:
   open-pull-requests-limit: 3
   labels:
     - "area/vertical-pod-autoscaler"
+    - "release-note-none"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/pkg/admission-controller"
   schedule:
@@ -37,12 +40,15 @@ updates:
   open-pull-requests-limit: 3
   labels:
     - "area/vertical-pod-autoscaler"
+    - "release-note-none"
 - package-ecosystem: gomod
   directory: "/addon-resizer"
   schedule:
     interval: daily
   target-branch: "addon-resizer-release-1.8"
   open-pull-requests-limit: 3
+  labels:
+    - "release-note-none"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
@@ -50,3 +56,4 @@ updates:
   open-pull-requests-limit: 3
   labels:
     - "area/dependency"
+    - "release-note-none"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR adds the "release-note-none" label to dependabot-originating PRs, now that we are requiring a valid release note on PRs before they merge.

Ref:

- https://github.com/kubernetes/test-infra/pull/35066

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
