### PR TITLE
Do not consider pod PreemptionPolicy while determining whether pod is expendable

### DIFF
--- a/cluster-autoscaler/core/utils/expendable.go
+++ b/cluster-autoscaler/core/utils/expendable.go
@@ -64,7 +64,5 @@ func FilterOutExpendablePods(pods []*apiv1.Pod, expendablePodsPriorityCutoff int
 
 // IsExpendablePod tests if pod is expendable for give priority cutoff
 func IsExpendablePod(pod *apiv1.Pod, expendablePodsPriorityCutoff int) bool {
-	preemptLowerPriority := pod.Spec.PreemptionPolicy == nil || *pod.Spec.PreemptionPolicy == apiv1.PreemptLowerPriority
-	lowPriority := pod.Spec.Priority != nil && int(*pod.Spec.Priority) < expendablePodsPriorityCutoff
-	return preemptLowerPriority && lowPriority
+	return pod.Spec.Priority != nil && int(*pod.Spec.Priority) < expendablePodsPriorityCutoff
 }

--- a/cluster-autoscaler/core/utils/expendable_test.go
+++ b/cluster-autoscaler/core/utils/expendable_test.go
@@ -88,7 +88,7 @@ func TestFilterOutExpendablePods(t *testing.T) {
 	assert.Equal(t, podWaitingForPreemption2, res[2])
 }
 
-func TestIsExpandablePod(t *testing.T) {
+func TestIsExpendablePod(t *testing.T) {
 	preemptLowerPriorityPolicy := apiv1.PreemptLowerPriority
 	neverPolicy := apiv1.PreemptNever
 
@@ -150,7 +150,7 @@ func TestIsExpandablePod(t *testing.T) {
 			name:   "pod priority set, never preemption policy, higher cutoff",
 			pod:    withPodPriority(BuildTestPod("p", 0, 0), -1, &neverPolicy),
 			cutoff: 0,
-			want:   false,
+			want:   true,
 		},
 		{
 			name:   "pod priority set, never preemption policy, equal cutoff",


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Change https://github.com/kubernetes/autoscaler/pull/6577 added a support for considering preemption policies into expendable pods evaluation, this is not correct as this property describes whether the created pod can evict other pods - thus should be considered only within scheduler and its framework. This change removes the policy out of the consideration, effectively rolling back the patch made in ttps://github.com/kubernetes/autoscaler/pull/6577

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Expendable pods no longer depend on preemptionPolicy setting
```
