### PR TITLE
adding env variable EnableLabelPrediction

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -136,7 +136,7 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	cfg.VMType = providerazureconsts.VMTypeVMSS
 	cfg.MaxDeploymentsCount = int64(defaultMaxDeploymentsCount)
 	cfg.StrictCacheUpdates = false
-	cfg.EnableLabelPredictionsOnTemplate = false
+	cfg.EnableLabelPredictionsOnTemplate = true
 
 	// Config file overrides defaults
 	if configReader != nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -103,6 +103,9 @@ type Config struct {
 
 	// EnableFastDeleteOnFailedProvisioning defines whether to delete the experimental faster VMSS instance deletion on failed provisioning
 	EnableFastDeleteOnFailedProvisioning bool `json:"enableFastDeleteOnFailedProvisioning,omitempty" yaml:"enableFastDeleteOnFailedProvisioning,omitempty"`
+
+	// EnableLabelPrediction defines whether to enable self-hosted label prediction for nodes
+	EnableLabelPrediction bool `json:"enableLabelPrediction,omitempty" yaml:"enableLabelPrediction,omitempty"`
 }
 
 // These are only here for backward compabitility. Their equivalent exists in providerazure.Config with a different name.
@@ -133,6 +136,7 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	cfg.VMType = providerazureconsts.VMTypeVMSS
 	cfg.MaxDeploymentsCount = int64(defaultMaxDeploymentsCount)
 	cfg.StrictCacheUpdates = false
+	cfg.EnableLabelPrediction = false
 
 	// Config file overrides defaults
 	if configReader != nil {
@@ -306,6 +310,9 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 		return nil, err
 	}
 	if _, err = assignBoolFromEnvIfExists(&cfg.EnableFastDeleteOnFailedProvisioning, "AZURE_ENABLE_FAST_DELETE_ON_FAILED_PROVISIONING"); err != nil {
+		return nil, err
+	}
+	if _, err = assignBoolFromEnvIfExists(&cfg.EnableLabelPrediction, "AZURE_ENABLE_LABEL_PREDICTION"); err != nil {
 		return nil, err
 	}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -104,8 +104,8 @@ type Config struct {
 	// EnableFastDeleteOnFailedProvisioning defines whether to delete the experimental faster VMSS instance deletion on failed provisioning
 	EnableFastDeleteOnFailedProvisioning bool `json:"enableFastDeleteOnFailedProvisioning,omitempty" yaml:"enableFastDeleteOnFailedProvisioning,omitempty"`
 
-	// EnableLabelPrediction defines whether to enable self-hosted label prediction for nodes
-	EnableLabelPrediction bool `json:"enableLabelPrediction,omitempty" yaml:"enableLabelPrediction,omitempty"`
+	// EnableLabelPredictionsOnTemplate defines whether to enable label predictions on the template when scaling from zero
+	EnableLabelPredictionsOnTemplate bool `json:"enableLabelPredictionsOnTemplate,omitempty" yaml:"enableLabelPredictionsOnTemplate,omitempty"`
 }
 
 // These are only here for backward compabitility. Their equivalent exists in providerazure.Config with a different name.
@@ -136,7 +136,7 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	cfg.VMType = providerazureconsts.VMTypeVMSS
 	cfg.MaxDeploymentsCount = int64(defaultMaxDeploymentsCount)
 	cfg.StrictCacheUpdates = false
-	cfg.EnableLabelPrediction = false
+	cfg.EnableLabelPredictionsOnTemplate = false
 
 	// Config file overrides defaults
 	if configReader != nil {
@@ -312,7 +312,7 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	if _, err = assignBoolFromEnvIfExists(&cfg.EnableFastDeleteOnFailedProvisioning, "AZURE_ENABLE_FAST_DELETE_ON_FAILED_PROVISIONING"); err != nil {
 		return nil, err
 	}
-	if _, err = assignBoolFromEnvIfExists(&cfg.EnableLabelPrediction, "AZURE_ENABLE_LABEL_PREDICTION"); err != nil {
+	if _, err = assignBoolFromEnvIfExists(&cfg.EnableLabelPredictionsOnTemplate, "AZURE_ENABLE_LABEL_PREDICTIONS_ON_TEMPLATE"); err != nil {
 		return nil, err
 	}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -90,7 +90,7 @@ type ScaleSet struct {
 
 	enableFastDeleteOnFailedProvisioning bool
 
-	enableLabelPrediction bool
+	enableLabelPredictionsOnTemplate bool
 }
 
 // NewScaleSet creates a new NewScaleSet.
@@ -110,11 +110,11 @@ func NewScaleSet(spec *dynamic.NodeGroupSpec, az *AzureManager, curSize int64, d
 			instancesRefreshJitter: az.config.VmssVmsCacheJitter,
 		},
 
-		enableForceDelete:         az.config.EnableForceDelete,
-		enableDynamicInstanceList: az.config.EnableDynamicInstanceList,
-		enableDetailedCSEMessage:  az.config.EnableDetailedCSEMessage,
-		enableLabelPrediction:     az.config.EnableLabelPrediction,
-		dedicatedHost:             dedicatedHost,
+		enableForceDelete:                az.config.EnableForceDelete,
+		enableDynamicInstanceList:        az.config.EnableDynamicInstanceList,
+		enableDetailedCSEMessage:         az.config.EnableDetailedCSEMessage,
+		enableLabelPredictionsOnTemplate: az.config.EnableLabelPredictionsOnTemplate,
+		dedicatedHost:                    dedicatedHost,
 	}
 
 	if az.config.VmssVirtualMachinesCacheTTLInSeconds != 0 {
@@ -665,7 +665,7 @@ func (scaleSet *ScaleSet) TemplateNodeInfo() (*framework.NodeInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	node, err := buildNodeFromTemplate(scaleSet.Name, template, scaleSet.manager, scaleSet.enableDynamicInstanceList, scaleSet.enableLabelPrediction)
+	node, err := buildNodeFromTemplate(scaleSet.Name, template, scaleSet.manager, scaleSet.enableDynamicInstanceList, scaleSet.enableLabelPredictionsOnTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -89,6 +89,8 @@ type ScaleSet struct {
 	dedicatedHost bool
 
 	enableFastDeleteOnFailedProvisioning bool
+
+	enableLabelPrediction bool
 }
 
 // NewScaleSet creates a new NewScaleSet.
@@ -111,6 +113,7 @@ func NewScaleSet(spec *dynamic.NodeGroupSpec, az *AzureManager, curSize int64, d
 		enableForceDelete:         az.config.EnableForceDelete,
 		enableDynamicInstanceList: az.config.EnableDynamicInstanceList,
 		enableDetailedCSEMessage:  az.config.EnableDetailedCSEMessage,
+		enableLabelPrediction:     az.config.EnableLabelPrediction,
 		dedicatedHost:             dedicatedHost,
 	}
 
@@ -662,7 +665,7 @@ func (scaleSet *ScaleSet) TemplateNodeInfo() (*framework.NodeInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	node, err := buildNodeFromTemplate(scaleSet.Name, template, scaleSet.manager, scaleSet.enableDynamicInstanceList)
+	node, err := buildNodeFromTemplate(scaleSet.Name, template, scaleSet.manager, scaleSet.enableDynamicInstanceList, scaleSet.enableLabelPrediction)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_template.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_template.go
@@ -211,7 +211,7 @@ func buildNodeTemplateFromVMPool(vmsPool armcontainerservice.AgentPool, location
 	}, nil
 }
 
-func buildNodeFromTemplate(nodeGroupName string, template NodeTemplate, manager *AzureManager, enableDynamicInstanceList bool) (*apiv1.Node, error) {
+func buildNodeFromTemplate(nodeGroupName string, template NodeTemplate, manager *AzureManager, enableDynamicInstanceList bool, enableLabelPrediction bool) (*apiv1.Node, error) {
 	node := apiv1.Node{}
 	nodeName := fmt.Sprintf("%s-asg-%d", nodeGroupName, rand.Int63())
 
@@ -272,7 +272,7 @@ func buildNodeFromTemplate(nodeGroupName string, template NodeTemplate, manager 
 	node.Status.Allocatable = node.Status.Capacity
 
 	if template.VMSSNodeTemplate != nil {
-		node = processVMSSTemplate(template, nodeName, node)
+		node = processVMSSTemplate(template, nodeName, node, enableLabelPrediction)
 	} else if template.VMPoolNodeTemplate != nil {
 		node = processVMPoolTemplate(template, nodeName, node)
 	} else {
@@ -298,7 +298,7 @@ func processVMPoolTemplate(template NodeTemplate, nodeName string, node apiv1.No
 	return node
 }
 
-func processVMSSTemplate(template NodeTemplate, nodeName string, node apiv1.Node) apiv1.Node {
+func processVMSSTemplate(template NodeTemplate, nodeName string, node apiv1.Node, enableLabelPrediction bool) apiv1.Node {
 	// NodeLabels
 	if template.VMSSNodeTemplate.Tags != nil {
 		for k, v := range template.VMSSNodeTemplate.Tags {
@@ -324,45 +324,47 @@ func processVMSSTemplate(template NodeTemplate, nodeName string, node apiv1.Node
 		labels = extractLabelsFromTags(template.VMSSNodeTemplate.Tags)
 	}
 
-	// Add the agentpool label, its value should come from the VMSS poolName tag
-	// NOTE: The plan is for agentpool label to be deprecated in favor of the aks-prefixed one
-	// We will have to live with both labels for a while
-	if node.Labels[legacyPoolNameTag] != "" {
-		labels[legacyAgentPoolNodeLabelKey] = node.Labels[legacyPoolNameTag]
-		labels[agentPoolNodeLabelKey] = node.Labels[legacyPoolNameTag]
-	}
-	if node.Labels[poolNameTag] != "" {
-		labels[legacyAgentPoolNodeLabelKey] = node.Labels[poolNameTag]
-		labels[agentPoolNodeLabelKey] = node.Labels[poolNameTag]
-	}
+	if enableLabelPrediction {
+		// Add the agentpool label, its value should come from the VMSS poolName tag
+		// NOTE: The plan is for agentpool label to be deprecated in favor of the aks-prefixed one
+		// We will have to live with both labels for a while
+		if node.Labels[legacyPoolNameTag] != "" {
+			labels[legacyAgentPoolNodeLabelKey] = node.Labels[legacyPoolNameTag]
+			labels[agentPoolNodeLabelKey] = node.Labels[legacyPoolNameTag]
+		}
+		if node.Labels[poolNameTag] != "" {
+			labels[legacyAgentPoolNodeLabelKey] = node.Labels[poolNameTag]
+			labels[agentPoolNodeLabelKey] = node.Labels[poolNameTag]
+		}
 
-	// Add the storage profile and storage tier labels for vmss node
-	if template.VMSSNodeTemplate.OSDisk != nil {
-		// ephemeral
-		if template.VMSSNodeTemplate.OSDisk.DiffDiskSettings != nil && template.VMSSNodeTemplate.OSDisk.DiffDiskSettings.Option == compute.Local {
-			labels[legacyStorageProfileNodeLabelKey] = "ephemeral"
-			labels[storageProfileNodeLabelKey] = "ephemeral"
-		} else {
-			labels[legacyStorageProfileNodeLabelKey] = "managed"
-			labels[storageProfileNodeLabelKey] = "managed"
+		// Add the storage profile and storage tier labels for vmss node
+		if template.VMSSNodeTemplate.OSDisk != nil {
+			// ephemeral
+			if template.VMSSNodeTemplate.OSDisk.DiffDiskSettings != nil && template.VMSSNodeTemplate.OSDisk.DiffDiskSettings.Option == compute.Local {
+				labels[legacyStorageProfileNodeLabelKey] = "ephemeral"
+				labels[storageProfileNodeLabelKey] = "ephemeral"
+			} else {
+				labels[legacyStorageProfileNodeLabelKey] = "managed"
+				labels[storageProfileNodeLabelKey] = "managed"
+			}
+			if template.VMSSNodeTemplate.OSDisk.ManagedDisk != nil {
+				labels[legacyStorageTierNodeLabelKey] = string(template.VMSSNodeTemplate.OSDisk.ManagedDisk.StorageAccountType)
+				labels[storageTierNodeLabelKey] = string(template.VMSSNodeTemplate.OSDisk.ManagedDisk.StorageAccountType)
+			}
+			// Add ephemeral-storage value
+			if template.VMSSNodeTemplate.OSDisk.DiskSizeGB != nil {
+				node.Status.Capacity[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(int64(int(*template.VMSSNodeTemplate.OSDisk.DiskSizeGB)*1024*1024*1024), resource.DecimalSI)
+				klog.V(4).Infof("OS Disk Size from template is: %d", *template.VMSSNodeTemplate.OSDisk.DiskSizeGB)
+				klog.V(4).Infof("Setting ephemeral storage to: %v", node.Status.Capacity[apiv1.ResourceEphemeralStorage])
+			}
 		}
-		if template.VMSSNodeTemplate.OSDisk.ManagedDisk != nil {
-			labels[legacyStorageTierNodeLabelKey] = string(template.VMSSNodeTemplate.OSDisk.ManagedDisk.StorageAccountType)
-			labels[storageTierNodeLabelKey] = string(template.VMSSNodeTemplate.OSDisk.ManagedDisk.StorageAccountType)
-		}
-		// Add ephemeral-storage value
-		if template.VMSSNodeTemplate.OSDisk.DiskSizeGB != nil {
-			node.Status.Capacity[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(int64(int(*template.VMSSNodeTemplate.OSDisk.DiskSizeGB)*1024*1024*1024), resource.DecimalSI)
-			klog.V(4).Infof("OS Disk Size from template is: %d", *template.VMSSNodeTemplate.OSDisk.DiskSizeGB)
-			klog.V(4).Infof("Setting ephemeral storage to: %v", node.Status.Capacity[apiv1.ResourceEphemeralStorage])
-		}
-	}
 
-	// If we are on GPU-enabled SKUs, append the accelerator
-	// label so that CA makes better decision when scaling from zero for GPU pools
-	if isNvidiaEnabledSKU(template.SkuName) {
-		labels[GPULabel] = "nvidia"
-		labels[legacyGPULabel] = "nvidia"
+		// If we are on GPU-enabled SKUs, append the accelerator
+		// label so that CA makes better decision when scaling from zero for GPU pools
+		if isNvidiaEnabledSKU(template.SkuName) {
+			labels[GPULabel] = "nvidia"
+			labels[legacyGPULabel] = "nvidia"
+		}
 	}
 
 	// Extract allocatables from tags

--- a/cluster-autoscaler/cloudprovider/azure/azure_template.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_template.go
@@ -364,7 +364,7 @@ func processVMSSTemplate(template NodeTemplate, nodeName string, node apiv1.Node
 	}
 
 	// Add ephemeral-storage value
-	if template.VMSSNodeTemplate.OSDisk.DiskSizeGB != nil {
+	if template.VMSSNodeTemplate.OSDisk != nil && template.VMSSNodeTemplate.OSDisk.DiskSizeGB != nil {
 		node.Status.Capacity[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(int64(int(*template.VMSSNodeTemplate.OSDisk.DiskSizeGB)*1024*1024*1024), resource.DecimalSI)
 		klog.V(4).Infof("OS Disk Size from template is: %d", *template.VMSSNodeTemplate.OSDisk.DiskSizeGB)
 		klog.V(4).Infof("Setting ephemeral storage to: %v", node.Status.Capacity[apiv1.ResourceEphemeralStorage])

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -469,7 +469,7 @@ func (vmPool *VMPool) TemplateNodeInfo() (*framework.NodeInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	node, err := buildNodeFromTemplate(vmPool.agentPoolName, template, vmPool.manager, vmPool.manager.config.EnableDynamicInstanceList)
+	node, err := buildNodeFromTemplate(vmPool.agentPoolName, template, vmPool.manager, vmPool.manager.config.EnableDynamicInstanceList, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug /kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Added a new environment variable for label prediction, allowing self-hosted users to operate without relying entirely on input labels.

#### Which issue(s) this PR fixes:
Conflicts labeling upstream.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adding this label modifies the behavior of scaling from zero nodes. By default, this functionality is enabled, but it can be overridden if needed—primarily to avoid conflicts with existing AKS labels. To use label prediction instead of relying solely on input labels, self-hosted users can configure the EnableLabelPredictionsOnTemplate setting, which remains the recommended approach.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
