### PR TITLE
Exit when stopped leading

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -403,7 +403,8 @@ func main() {
 					run(healthCheck, debuggingSnapshotter)
 				},
 				OnStoppedLeading: func() {
-					klog.Fatalf("lost master")
+					klog.Fatalf("lost master. Shutting down.")
+					klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 				},
 			},
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
In case of flapping failures that affected the leading pod like flapping network, we noticed that the same pod tried to reaquire the lock after losing it instead of allowing another helthy pod unaffected by the failure to aquire the lock and become leader.

This pull request changes the behaviour to work in accordance with other k8s components, like kube scheduler, in leader election configuration, where if the leader pod stopped leading it exits the process and let another pod take leadership while k8s creates a new pod to replace the old leader.

#### Does this PR introduce a user-facing change?
NONE



