### PR TITLE
Fixes multiple cluster autoscaler with different configmap, lease and release name

### DIFF
--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -31,7 +31,7 @@ rules:
     resources:
       - endpoints
     resourceNames:
-      - cluster-autoscaler
+      - {{ template "cluster-autoscaler.fullname" . }}
     verbs:
       - get
       - update
@@ -118,12 +118,15 @@ rules:
     - get
   - apiGroups:
       - ""
+    resourceNames:
+    - {{ default "cluster-autoscaler" .Values.extraArgs.status-config-map-name }}
     resources:
       - configmaps
     verbs:
       - list
       - watch
       - get
+      - update
   - apiGroups:
     - coordination.k8s.io
     resources:
@@ -133,7 +136,7 @@ rules:
   - apiGroups:
     - coordination.k8s.io
     resourceNames:
-    - cluster-autoscaler
+    - {{ default "cluster-autoscaler" .Values.extraArgs.leader-elect-resource-name }}
     resources:
     - leases
     verbs:

--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -119,7 +119,7 @@ rules:
   - apiGroups:
       - ""
     resourceNames:
-    - {{ default "cluster-autoscaler" .Values.extraArgs.status-config-map-name }}
+    - {{ default "cluster-autoscaler" (index .Values.extraArgs "status-config-map-name") }}
     resources:
       - configmaps
     verbs:
@@ -136,7 +136,7 @@ rules:
   - apiGroups:
     - coordination.k8s.io
     resourceNames:
-    - {{ default "cluster-autoscaler" .Values.extraArgs.leader-elect-resource-name }}
+    - {{ default "cluster-autoscaler" (index .Values.extraArgs "leader-elect-resource-name") }}
     resources:
     - leases
     verbs:

--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -118,15 +118,12 @@ rules:
     - get
   - apiGroups:
       - ""
-    resourceNames:
-    - {{ default "cluster-autoscaler" (index .Values.extraArgs "status-config-map-name") }}
     resources:
       - configmaps
     verbs:
       - list
       - watch
       - get
-      - update
   - apiGroups:
     - coordination.k8s.io
     resources:

--- a/charts/cluster-autoscaler/templates/role.yaml
+++ b/charts/cluster-autoscaler/templates/role.yaml
@@ -22,7 +22,7 @@ rules:
     resources:
       - configmaps
     resourceNames:
-      - cluster-autoscaler-status
+      - {{ default "cluster-autoscaler-status" (index .Values.extraArgs "status-config-map-name") }}
 {{- if (include "cluster-autoscaler.priorityExpanderEnabled" .) }}
       - cluster-autoscaler-priority-expander
 {{- end }}
@@ -77,7 +77,7 @@ rules:
   - apiGroups:
     - coordination.k8s.io
     resourceNames:
-    - cluster-autoscaler
+    - {{ default "cluster-autoscaler" (index .Values.extraArgs "leader-elect-resource-name") }}
     resources:
     - leases
     verbs:


### PR DESCRIPTION
**Issue**: The current Helm template doesn't work properly when there are multiple Cluster Autoscalers in the same namespace.

## Use case

Example Helm Values:

```yaml
... TRUNCATED
extraArgs:
  logtostderr: true
  stderrthreshold: info
  v: 4
  skip-nodes-with-local-storage: false
  leader-elect-resource-name: cluster-autoscaler-${SUFFIX_NAME}
  status-config-map-name: cluster-autoscaler-status-${SUFFIX_NAME}
  user-agent: cluster-autoscaler-${SUFFIX_NAME}
...TRUNCATED
```

Example Release:

```hcl
resource "helm_release" "cluster_autoscaler_gpu" {
  name       = "cluster-autoscaler-gpu"
  repository = "https://kubernetes.github.io/autoscaler"
  chart      = "cluster-autoscaler"
  namespace  = "kube-addons"
  version    = local.cluster_autoscaler.helm_version
  values = [templatefile("${path.module}/helm-values/cluster-autoscaler-values.yml.tmpl", {
      SUFFIX_NAME  = "gpu"
      NODE_GROUP   = 
      MIN_SIZE     = 
      MAX_SIZE     = 
      CA_VERSION   = 
    })
  ]
}
```