### PR TITLE
Fix log message when balancing similar node groups

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/label_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/label_nodegroups.go
@@ -37,7 +37,7 @@ func areLabelsSame(n1, n2 *framework.NodeInfo, labels []string) bool {
 		}
 		val2, exists := n2.Node().ObjectMeta.Labels[label]
 		if !exists {
-			klog.V(8).Infof("%s label not present on %s", label, n1.Node().Name)
+			klog.V(8).Infof("%s label not present on %s", label, n2.Node().Name)
 			return false
 		}
 		if val1 != val2 {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When comparing sets of labels between two NodeInfo instances, the log message is printing the name of the wrong node.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
