### PR TITLE
Increase range for expected VPA CPU recommendations in e2e

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -91,13 +91,6 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 				WithTargetRef(targetRef).
 				WithContainer(containerName).
 				WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
-				AppendRecommendation(
-					test.Recommendation().
-						WithContainer(containerName).
-						WithTarget("250m", "200Mi").
-						WithLowerBound("250m", "200Mi").
-						WithUpperBound("250m", "200Mi").
-						GetContainerResources()).
 				Get()
 
 			InstallVPA(f, vpaCRD)
@@ -114,7 +107,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 			rc.ConsumeCPU(600 * replicas)
 			err = waitForResourceRequestInRangeInPods(
 				f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-				ParseQuantityOrDie("500m"), ParseQuantityOrDie("1300m"))
+				ParseQuantityOrDie("600m"), ParseQuantityOrDie("1800m"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
@@ -162,13 +155,6 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 				WithNamespace(f.Namespace.Name).
 				WithTargetRef(targetRef).
 				WithContainer(containerName).
-				AppendRecommendation(
-					test.Recommendation().
-						WithContainer(containerName).
-						WithTarget("250m", "200Mi").
-						WithLowerBound("250m", "200Mi").
-						WithUpperBound("250m", "200Mi").
-						GetContainerResources()).
 				Get()
 
 			InstallVPA(f, vpaCRD)
@@ -185,7 +171,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 			rc.ConsumeCPU(600 * replicas)
 			err = waitForResourceRequestInRangeInPods(
 				f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-				ParseQuantityOrDie("500m"), ParseQuantityOrDie("1300m"))
+				ParseQuantityOrDie("600m"), ParseQuantityOrDie("1800m"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
@@ -248,13 +234,6 @@ var _ = FullVpaE2eDescribe("Pods under VPA with default recommender explicitly c
 			WithNamespace(f.Namespace.Name).
 			WithTargetRef(targetRef).
 			WithContainer(containerName).
-			AppendRecommendation(
-				test.Recommendation().
-					WithContainer(containerName).
-					WithTarget("250m", "200Mi").
-					WithLowerBound("250m", "200Mi").
-					WithUpperBound("250m", "200Mi").
-					GetContainerResources()).
 			Get()
 
 		InstallVPA(f, vpaCRD)
@@ -272,7 +251,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with default recommender explicitly c
 		rc.ConsumeCPU(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
 			f, pollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1300m"))
+			ParseQuantityOrDie("600m"), ParseQuantityOrDie("1800m"))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:
These tests can get flaky because the resource consumer consumes 1800 m CPU which can be unevenly distributed across 3 pods which can lead to failure.

Also the tests don't need to append recommendations since vpa-recommender is running in this suite.

Similar PR before: https://github.com/kubernetes/autoscaler/pull/4469

