### PR TITLE
fix: not failing the main loop when one NodeGroup fails on TemplateNodeInfo()

### DIFF
--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
@@ -140,12 +140,10 @@ func (p *MixedTemplateNodeInfoProvider) Process(ctx *context.AutoscalingContext,
 		// working nodes in the node groups. By default CA tries to use a real-world example.
 		nodeInfo, err := simulator.SanitizedTemplateNodeInfoFromNodeGroup(nodeGroup, daemonsets, taintConfig)
 		if err != nil {
-			if errors.Is(err, cloudprovider.ErrNotImplemented) {
-				continue
-			} else {
+			if !errors.Is(err, cloudprovider.ErrNotImplemented) {
 				klog.Errorf("Unable to build proper template node for %s: %v", id, err)
-				return map[string]*framework.NodeInfo{}, caerror.ToAutoscalerError(caerror.CloudProviderError, err)
 			}
+			continue
 		}
 		result[id] = nodeInfo
 	}

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
@@ -302,6 +302,35 @@ func TestGetNodeInfosCacheExpired(t *testing.T) {
 
 }
 
+func TestProcessHandlesTemplateNodeInfoErrors(t *testing.T) {
+	now := time.Now()
+
+	tn := BuildTestNode("tn", 1000, 1000)
+	tni := framework.NewTestNodeInfo(tn)
+
+	provider := testprovider.NewTestCloudProviderBuilder().WithMachineTemplates(
+		map[string]*framework.NodeInfo{"ng2": tni}).Build()
+
+	provider.AddNodeGroup("ng1", 0, 10, 0)
+	provider.AddNodeGroup("ng2", 0, 10, 0)
+
+	ctx := context.AutoscalingContext{
+		CloudProvider:   provider,
+		ClusterSnapshot: testsnapshot.NewTestSnapshotOrDie(t),
+	}
+
+	res, err := NewMixedTemplateNodeInfoProvider(&cacheTtl, false).Process(&ctx, []*apiv1.Node{}, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+
+	// Should not fail despite ng1 error - continues processing
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(res))
+
+	_, found := res["ng2"]
+	assert.True(t, found)
+	_, found = res["ng1"]
+	assert.False(t, found) // ng1 skipped due to template error
+}
+
 func assertEqualNodeCapacities(t *testing.T, expected, actual *apiv1.Node) {
 	t.Helper()
 	assert.NotEqual(t, actual.Status, nil, "")


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
As of today:
- The core loop has been calling provider to construct node template for each NodeGroup (through `NodeGroup.TemplateNodeInfo()`)
  - These templates will be used when scaling up from zero without prior cache
- In `MixedTemplateNodeInfoProvider` specifically, one NodeGroup failing this call would result in the core loop failing, halting all other operations.
  - This is an issue. Failure from one NodeGroup should not be as fatal as it is today.

This change:
- Instead of failing and returning error, the NodeGroup will be skipped instead.
  - Other NodeGroups can continue to be templated, and other CAS operations can continue as usual

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
* Fix an issue where CAS does not operate when NodeGroups fails to be templated by cloud provider
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
