### PR TITLE
chore(autoscaler): fix typo in Autoscaler interface comment

### DIFF
--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -78,7 +78,7 @@ type Autoscaler interface {
 	ExitCleanUp()
 	// LastScaleUpTime is a time of the last scale up
 	LastScaleUpTime() time.Time
-	// LastScaleUpTime is a time of the last scale down
+	// LastScaleDownDeleteTime is a time of the last scale down
 	LastScaleDownDeleteTime() time.Time
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig autoscaling

#### What this PR does / why we need it:

This PR fixes a typo in the comment of the `Autoscaler` interface.  
The comment for the method `LastScaleDownDeleteTime()` was incorrectly copied from `LastScaleUpTime()` and referenced "scale up" instead of "scale down".

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Just a minor cleanup to improve comment correctness and readability.

#### Does this PR introduce a user-facing change?
```release-note
NONE