### PR TITLE
AEP-8026: Allow oomBumpUpRatio=1 and oomMinBumpUp=0

### DIFF
--- a/vertical-pod-autoscaler/enhancements/8026-per-vpa-component-configuration/README.md
+++ b/vertical-pod-autoscaler/enhancements/8026-per-vpa-component-configuration/README.md
@@ -89,11 +89,14 @@ spec:
 * `oomBumpUpRatio` (Quantity):
   - Multiplier applied to memory recommendations after OOM events
   - Represented as a Quantity (e.g., "1.5")
-  - Must be greater than 1
+  - Must be greater than or equal to 1
+  - Setting to 1 effectively disables the OOM ratio-based increase
   - Controls how aggressively memory is increased after container crashes
 
 * `oomMinBumpUp` (bytes): 
   - Minimum absolute memory increase after OOM events
+  - Setting to 0 effectively disables the OOM minimum increase
+  - When both `oomBumpUpRatio` = 1 and `oomMinBumpUp` = 0, OOM-based memory increases are completely disabled
   - Ensures meaningful increases even for small containers
 
 * `memoryAggregationInterval` (duration):
@@ -172,7 +175,7 @@ The `PerVPAConfig` feature requires VPA version 1.5.0 or higher. The feature is 
 ### Validation via CEL and Testing
 
 Initial validation rules (CEL):
-* `oomMinBumpUp` > 0
+* `oomMinBumpUp` >= 0
 * `memoryAggregationInterval` > 0
 * `evictAfterOOMThreshold` > 0
 * `memoryAggregationIntervalCount` > 0
@@ -180,7 +183,7 @@ Initial validation rules (CEL):
 Validation via Admission Controller:
 Some components cann't be validated using Common Expression Language (CEL). This validation is performed within the admission controller.
 
-* `oomBumpUpRatio` – Using Kubernetes Quantity type for validation. The value must be greater than 1.
+* `oomBumpUpRatio` – Using Kubernetes Quantity type for validation. The value must be greater than or equal to 1.
 
 Additional validation rules will be added as new parameters are introduced.
 E2E tests will be included to verify:


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allow `oomBumpUpRatio=1` and `oomMinBumpUp=0` to disable OOM-based memory increases
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
/assign @adrianmoisey 
