### PR TITLE
Introduce API changes and feature gate CPU startup boost

### DIFF
--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -372,8 +372,93 @@ spec:
                           - Auto
                           - "Off"
                           type: string
+                        startupBoost:
+                          description: |-
+                            StartupBoost specifies the startup boost policy for the container.
+                            This overrides any pod-level startup boost policy.
+                          properties:
+                            cpu:
+                              description: |-
+                                CPU specifies the CPU startup boost policy.
+                                If this field is not set, no startup boost is applied.
+                              properties:
+                                duration:
+                                  description: |-
+                                    Duration indicates for how long to keep the pod boosted after it goes to Ready.
+                                    Defaults to 0s.
+                                  type: string
+                                factor:
+                                  description: |-
+                                    Factor specifies the factor to apply to the CPU request.
+                                    This field is to be used only when Type is "Factor".
+                                  format: int32
+                                  type: integer
+                                quantity:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Quantity specifies the absolute CPU resource quantity.
+                                    This field is to be used only when Type is "Quantity".
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: |-
+                                    Type specifies the kind of boost to apply.
+                                    Supported values are: "Factor", "Quantity".
+                                    Defaults to "Factor".
+                                  enum:
+                                  - Factor
+                                  - Quantity
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                          type: object
                       type: object
                     type: array
+                type: object
+              startupBoost:
+                description: StartupBoost specifies the startup boost policy for the
+                  pod.
+                properties:
+                  cpu:
+                    description: |-
+                      CPU specifies the CPU startup boost policy.
+                      If this field is not set, no startup boost is applied.
+                    properties:
+                      duration:
+                        description: |-
+                          Duration indicates for how long to keep the pod boosted after it goes to Ready.
+                          Defaults to 0s.
+                        type: string
+                      factor:
+                        description: |-
+                          Factor specifies the factor to apply to the CPU request.
+                          This field is to be used only when Type is "Factor".
+                        format: int32
+                        type: integer
+                      quantity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Quantity specifies the absolute CPU resource quantity.
+                          This field is to be used only when Type is "Quantity".
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type:
+                        description: |-
+                          Type specifies the kind of boost to apply.
+                          Supported values are: "Factor", "Quantity".
+                          Defaults to "Factor".
+                        enum:
+                        - Factor
+                        - Quantity
+                        type: string
+                    required:
+                    - type
+                    type: object
                 type: object
               targetRef:
                 description: |-

--- a/vertical-pod-autoscaler/docs/api.md
+++ b/vertical-pod-autoscaler/docs/api.md
@@ -48,6 +48,7 @@ _Appears in:_
 | `maxAllowed` _[ResourceList](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcelist-v1-core)_ | Specifies the maximum amount of resources that will be recommended<br />for the container. The default is no maximum. |  |  |
 | `controlledResources` _[ResourceName](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcename-v1-core)_ | Specifies the type of recommendations that will be computed<br />(and possibly applied) by VPA.<br />If not specified, the default of [ResourceCPU, ResourceMemory] will be used. |  |  |
 | `controlledValues` _[ContainerControlledValues](#containercontrolledvalues)_ | Specifies which resource values should be controlled.<br />The default is "RequestsAndLimits". |  | Enum: [RequestsAndLimits RequestsOnly] <br /> |
+| `startupBoost` _[StartupBoost](#startupboost)_ | startupBoost specifies the startup boost policy for the container.<br />This overrides any pod-level startup boost policy.<br />The startup boost policy takes precedence over the rest of the fields in<br />this struct, except for ContainerName and ControlledValues. |  |  |
 
 
 #### ContainerScalingMode
@@ -199,6 +200,41 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `containerRecommendations` _[RecommendedContainerResources](#recommendedcontainerresources) array_ | Resources recommended by the autoscaler for each container. |  |  |
+
+
+#### StartupBoost
+
+
+
+StartupBoost defines the startup boost policy.
+
+
+
+_Appears in:_
+- [ContainerResourcePolicy](#containerresourcepolicy)
+- [VerticalPodAutoscalerSpec](#verticalpodautoscalerspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `cpu` _[GenericStartupBoost](#genericstartupboost)_ | cpu specifies the CPU startup boost policy.<br />If this field is not set, no startup boost is applied. |  |  |
+
+
+#### StartupBoostType
+
+_Underlying type:_ _string_
+
+StartupBoostType is the type of startup boost.
+
+_Validation:_
+- Enum: [Factor Quantity]
+
+_Appears in:_
+- [GenericStartupBoost](#genericstartupboost)
+
+| Field | Description |
+| --- | --- |
+| `Factor` | FactorStartupBoostType applies a factor to the resource.<br /> |
+| `Quantity` | QuantityStartupBoostType applies a fixed quantity to the resource.<br /> |
 
 
 #### UpdateMode
@@ -377,6 +413,7 @@ _Appears in:_
 | `updatePolicy` _[PodUpdatePolicy](#podupdatepolicy)_ | Describes the rules on how changes are applied to the pods.<br />If not specified, all fields in the `PodUpdatePolicy` are set to their<br />default values. |  |  |
 | `resourcePolicy` _[PodResourcePolicy](#podresourcepolicy)_ | Controls how the autoscaler computes recommended resources.<br />The resource policy may be used to set constraints on the recommendations<br />for individual containers.<br />If any individual containers need to be excluded from getting the VPA recommendations, then<br />it must be disabled explicitly by setting mode to "Off" under containerPolicies.<br />If not specified, the autoscaler computes recommended resources for all containers in the pod,<br />without additional constraints. |  |  |
 | `recommenders` _[VerticalPodAutoscalerRecommenderSelector](#verticalpodautoscalerrecommenderselector) array_ | Recommender responsible for generating recommendation for this object.<br />List should be empty (then the default recommender will generate the<br />recommendation) or contain exactly one recommender. |  |  |
+| `startupBoost` _[StartupBoost](#startupboost)_ | startupBoost specifies the startup boost policy for the pod. |  |  |
 
 
 #### VerticalPodAutoscalerStatus

--- a/vertical-pod-autoscaler/docs/features.md
+++ b/vertical-pod-autoscaler/docs/features.md
@@ -7,6 +7,7 @@
 - [CPU Recommendation Rounding](#cpu-recommendation-rounding)
 - [Memory Recommendation Rounding](#memory-recommendation-rounding)
 - [In-Place Updates](#in-place-updates-inplaceorrecreate)
+- [CPU Startup Boost](#cpu-startup-boost)
 
 ## Limits control
 
@@ -80,7 +81,7 @@ To enable this feature, set the `--round-memory-bytes` flag when running the VPA
 
 ## In-Place Updates (`InPlaceOrRecreate`)
 
-> [!WARNING] 
+> [!WARNING]
 > FEATURE STATE: VPA v1.4.0 [alpha]
 
 VPA supports in-place updates to reduce disruption when applying resource recommendations. This feature leverages Kubernetes' in-place update capabilities (which is in beta as of Kubernetes 1.33) to modify container resources without requiring pod recreation.
@@ -124,7 +125,7 @@ Enable the feature by setting the following flags in VPA components ( for both u
 
 ```bash
 --feature-gates=InPlaceOrRecreate=true
-``` 
+```
 
 ### Limitations
 
@@ -152,3 +153,60 @@ VPA provides metrics to track in-place update operations:
 * `vpa_vpas_with_in_place_updatable_pods_total`: Number of VPAs with pods eligible for in-place updates
 * `vpa_vpas_with_in_place_updated_pods_total`: Number of VPAs with successfully in-place updated pods
 * `vpa_updater_failed_in_place_update_attempts_total`: Number of failed attempts to update pods in-place.
+
+## CPU Startup Boost
+
+> [!WARNING]
+> FEATURE STATE: VPA v1.5.0 [alpha]
+
+The CPU Startup Boost feature allows VPA to temporarily increase CPU requests and limits for containers during pod startup. This can help workloads that have high CPU demands during their initialization phase, such as Java applications, to start faster. Once the pod is considered `Ready` and an optional duration has passed, VPA scales the CPU resources back down to their normal levels using an in-place resize.
+
+For more details, see [AEP-7862: CPU Startup Boost](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost).
+
+### Usage
+
+CPU Startup Boost is configured via the `startupBoost` field in the `VerticalPodAutoscalerSpec` or within the per-container `containerPolicies`. This allows for both global and per-container boost configurations.
+
+This example enables a startup boost for all containers in the targeted deployment. The CPU will be multiplied by a factor of 3 for 10 seconds after the pod becomes ready.
+
+```yaml
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: example-vpa
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: example
+  updatePolicy:
+    updateMode: "Recreate"
+  startupBoost:
+    cpu:
+      value: "3"
+      duration: 10s
+```
+
+### Behavior
+
+1.  When a pod managed by the VPA is created, the VPA Admission Controller applies the CPU boost.
+2.  The VPA Updater monitors the pod. Once the pod's condition is `Ready` and the `startupBoost.cpu.duration` has elapsed, it scales the CPU resources down in-place.
+3.  The scale-down/unboost target is either the VPA recommendation (if VPA is enabled for the container) or the original CPU resources defined in the pod spec.
+
+### Requirements
+
+*   Kubernetes 1.33+ with the `InPlacePodVerticalScaling` feature gate enabled.
+*   VPA version 1.5.0+ with the `CPUStartupBoost` feature gate enabled.
+
+### Configuration
+
+Enable the feature by setting the `CPUStartupBoost` feature gate in the VPA admission-controller and updater components:
+
+```bash
+--feature-gates=CPUStartupBoost=true
+```
+
+The `startupBoost` field has the following sub-fields:
+*   `cpu.type`: The type of boost. Can be `Factor` (default) to multiply the CPU, or `Quantity` to set a specific CPU value.
+*   `cpu.value`: The magnitude of the boost. A multiplier (e.g., "2") for `Factor` type, or a resource quantity (e.g., "500m") for `Quantity` type.
+*   `cpu.duration`: (Optional) How long to keep the boost active *after* the pod becomes `Ready`. Defaults to `0s`.

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -14,7 +14,7 @@ This document is auto-generated from the flag definitions in the VPA admission-c
 | `address` | string |  ":8944" | The address to expose Prometheus metrics.  |
 | `alsologtostderr` |  |  | log to standard error as well as files (no effect when -logtostderr=true) |
 | `client-ca-file` | string |  "/etc/tls-certs/caCert.pem" | Path to CA PEM file.  |
-| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>InPlaceOrRecreate=true\|false (ALPHA - default=false) |
+| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>CPUStartupBoost=true\|false (ALPHA - default=false)<br>InPlaceOrRecreate=true\|false (ALPHA - default=false) |
 | `ignored-vpa-object-namespaces` | string |  | A comma-separated list of namespaces to ignore when searching for VPA objects. Leave empty to avoid ignoring any namespaces. These namespaces will not be cleaned by the garbage collector. |
 | `kube-api-burst` | float |  100 | QPS burst limit when making requests to Kubernetes apiserver  |
 | `kube-api-qps` | float |  50 | QPS limit when making requests to Kubernetes apiserver  |
@@ -68,7 +68,7 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `cpu-integer-post-processor-enabled` |  |  | Enable the cpu-integer recommendation post processor. The post processor will round up CPU recommendations to a whole CPU for pods which were opted in by setting an appropriate label on VPA object (experimental) |
 | `external-metrics-cpu-metric` | string |  | ALPHA.  Metric to use with external metrics provider for CPU usage. |
 | `external-metrics-memory-metric` | string |  | ALPHA.  Metric to use with external metrics provider for memory usage. |
-| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>InPlaceOrRecreate=true\|false (ALPHA - default=false) |
+| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>CPUStartupBoost=true\|false (ALPHA - default=false)<br>InPlaceOrRecreate=true\|false (ALPHA - default=false) |
 | `history-length` | string |  "8d" | How much time back prometheus have to be queried to get historical metrics  |
 | `history-resolution` | string |  "1h" | Resolution at which Prometheus is queried for historical metrics  |
 | `humanize-memory` |  |  | DEPRECATED: Convert memory values in recommendations to the highest appropriate SI unit with up to 2 decimal places for better readability. This flag is deprecated and will be removed in a future version. Use --round-memory-bytes instead. |
@@ -144,7 +144,7 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `eviction-rate-burst` | int |  1 | Burst of pods that can be evicted.  |
 | `eviction-rate-limit` | float |  | Number of pods that can be evicted per seconds. A rate limit set to 0 or -1 will disable<br>the rate limiter. (default -1) |
 | `eviction-tolerance` | float |  0.5 | Fraction of replica count that can be evicted for update, if more than one pod can be evicted.  |
-| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>InPlaceOrRecreate=true\|false (ALPHA - default=false) |
+| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>CPUStartupBoost=true\|false (ALPHA - default=false)<br>InPlaceOrRecreate=true\|false (ALPHA - default=false) |
 | `ignored-vpa-object-namespaces` | string |  | A comma-separated list of namespaces to ignore when searching for VPA objects. Leave empty to avoid ignoring any namespaces. These namespaces will not be cleaned by the garbage collector. |
 | `in-recommendation-bounds-eviction-lifetime-threshold` |  |  12h0m0s | duration   Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range  |
 | `kube-api-burst` | float |  100 | QPS burst limit when making requests to Kubernetes apiserver  |

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -163,7 +163,14 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 					return fmt.Errorf("controlledValues shouldn't be specified if container scaling mode is off")
 				}
 			}
+			if err := validateStartupBoost(policy.StartupBoost, isCreate); err != nil {
+				return fmt.Errorf("invalid startupBoost in container %s: %v", policy.ContainerName, err)
+			}
 		}
+	}
+
+	if err := validateStartupBoost(vpa.Spec.StartupBoost, isCreate); err != nil {
+		return fmt.Errorf("invalid startupBoost: %v", err)
 	}
 
 	if isCreate && vpa.Spec.TargetRef == nil {
@@ -174,6 +181,42 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 		return fmt.Errorf("the current version of VPA object shouldn't specify more than one recommenders")
 	}
 
+	return nil
+}
+
+func validateStartupBoost(startupBoost *vpa_types.StartupBoost, isCreate bool) error {
+	if startupBoost == nil {
+		return nil
+	}
+
+	if !features.Enabled(features.CPUStartupBoost) && isCreate {
+		return fmt.Errorf("in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost)
+	}
+
+	cpuBoost := startupBoost.CPU
+	if cpuBoost == nil {
+		return nil
+	}
+	boostType := cpuBoost.Type
+
+	switch boostType {
+	case vpa_types.FactorStartupBoostType:
+		if cpuBoost.Factor == nil {
+			return fmt.Errorf("StartupBoost.CPU.Factor is required when Type is Factor")
+		}
+		if *cpuBoost.Factor < 1 {
+			return fmt.Errorf("invalid StartupBoost.CPU.Factor: must be >= 1 for Type Factor")
+		}
+	case vpa_types.QuantityStartupBoostType:
+		if cpuBoost.Quantity == nil {
+			return fmt.Errorf("StartupBoost.CPU.Quantity is required when Type is Quantity")
+		}
+		if err := validateCPUResolution(*cpuBoost.Quantity); err != nil {
+			return fmt.Errorf("invalid StartupBoost.CPU.Quantity: %v", err)
+		}
+	default:
+		return fmt.Errorf("unexpected StartupBoost.CPU.Type value %s", boostType)
+	}
 	return nil
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	autoscaling "k8s.io/api/autoscaling/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -45,12 +46,21 @@ func TestValidateVPA(t *testing.T) {
 	scalingModeOff := vpa_types.ContainerScalingModeOff
 	controlledValuesRequestsAndLimits := vpa_types.ContainerControlledValuesRequestsAndLimits
 	inPlaceOrRecreateUpdateMode := vpa_types.UpdateModeInPlaceOrRecreate
+	badCPUBoostFactor := int32(0)
+	validCPUBoostFactor := int32(2)
+	badCPUBoostQuantity := resource.MustParse("187500u")
+	validCPUBoostQuantity := resource.MustParse("100m")
+	badCPUBoostType := vpa_types.StartupBoostType("bad")
+	validCPUBoostTypeFactor := vpa_types.FactorStartupBoostType
+	validCPUBoostTypeQuantity := vpa_types.QuantityStartupBoostType
+
 	tests := []struct {
 		name                                 string
 		vpa                                  vpa_types.VerticalPodAutoscaler
 		isCreate                             bool
 		expectError                          error
 		inPlaceOrRecreateFeatureGateDisabled bool
+		cpuStartupBoostFeatureGateDisabled   bool
 	}{
 		{
 			name: "empty update",
@@ -319,12 +329,253 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "top-level startupBoost with feature gate disabled",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					StartupBoost: &vpa_types.StartupBoost{
+						CPU: &vpa_types.GenericStartupBoost{
+							Factor: &validCPUBoostFactor,
+						},
+					},
+				},
+			},
+			isCreate:                           true,
+			cpuStartupBoostFeatureGateDisabled: true,
+			expectError:                        fmt.Errorf("invalid startupBoost: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
+		},
+		{
+			name: "container startupBoost with feature gate disabled",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								StartupBoost: &vpa_types.StartupBoost{
+									CPU: &vpa_types.GenericStartupBoost{
+										Factor: &validCPUBoostFactor,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isCreate:                           true,
+			cpuStartupBoostFeatureGateDisabled: true,
+			expectError:                        fmt.Errorf("invalid startupBoost in container loot box: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
+		},
+		{
+			name: "top-level startupBoost with bad factor",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					StartupBoost: &vpa_types.StartupBoost{
+						CPU: &vpa_types.GenericStartupBoost{
+							Type:   vpa_types.FactorStartupBoostType,
+							Factor: &badCPUBoostFactor,
+						},
+					},
+				},
+			},
+			isCreate:    true,
+			expectError: fmt.Errorf("invalid startupBoost: invalid StartupBoost.CPU.Factor: must be >= 1 for Type Factor"),
+		},
+		{
+			name: "container startupBoost with bad factor",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								StartupBoost: &vpa_types.StartupBoost{
+									CPU: &vpa_types.GenericStartupBoost{
+										Type:   vpa_types.FactorStartupBoostType,
+										Factor: &badCPUBoostFactor,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isCreate:    true,
+			expectError: fmt.Errorf("invalid startupBoost in container loot box: invalid StartupBoost.CPU.Factor: must be >= 1 for Type Factor"),
+		},
+		{
+			name: "top-level startupBoost with bad quantity",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					StartupBoost: &vpa_types.StartupBoost{
+						CPU: &vpa_types.GenericStartupBoost{
+							Type:     validCPUBoostTypeQuantity,
+							Quantity: &badCPUBoostQuantity,
+						},
+					},
+				},
+			},
+			isCreate:    true,
+			expectError: fmt.Errorf("invalid startupBoost: invalid StartupBoost.CPU.Quantity: CPU [%v] must be a whole number of milli CPUs", &badCPUBoostQuantity),
+		},
+		{
+			name: "container startupBoost with bad quantity",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								StartupBoost: &vpa_types.StartupBoost{
+									CPU: &vpa_types.GenericStartupBoost{
+										Type:     validCPUBoostTypeQuantity,
+										Quantity: &badCPUBoostQuantity,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isCreate:    true,
+			expectError: fmt.Errorf("invalid startupBoost in container loot box: invalid StartupBoost.CPU.Quantity: CPU [%v] must be a whole number of milli CPUs", &badCPUBoostQuantity),
+		},
+		{
+			name: "top-level startupBoost with bad type",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					StartupBoost: &vpa_types.StartupBoost{
+						CPU: &vpa_types.GenericStartupBoost{
+							Type: badCPUBoostType,
+						},
+					},
+				},
+			},
+			isCreate:    true,
+			expectError: fmt.Errorf("invalid startupBoost: unexpected StartupBoost.CPU.Type value bad"),
+		},
+		{
+			name: "container startupBoost with bad type",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								StartupBoost: &vpa_types.StartupBoost{
+									CPU: &vpa_types.GenericStartupBoost{
+										Type: badCPUBoostType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isCreate:    true,
+			expectError: fmt.Errorf("invalid startupBoost in container loot box: unexpected StartupBoost.CPU.Type value bad"),
+		},
+		{
+			name: "top-level startupBoost with valid factor",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					StartupBoost: &vpa_types.StartupBoost{
+						CPU: &vpa_types.GenericStartupBoost{
+							Type:   validCPUBoostTypeFactor,
+							Factor: &validCPUBoostFactor,
+						},
+					},
+				},
+			},
+			isCreate: true,
+		},
+		{
+			name: "container startupBoost with valid factor",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								StartupBoost: &vpa_types.StartupBoost{
+									CPU: &vpa_types.GenericStartupBoost{
+										Type:   validCPUBoostTypeFactor,
+										Factor: &validCPUBoostFactor,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isCreate: true,
+		},
+		{
+			name: "top-level startupBoost with valid quantity",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					StartupBoost: &vpa_types.StartupBoost{
+						CPU: &vpa_types.GenericStartupBoost{
+							Type:     validCPUBoostTypeQuantity,
+							Quantity: &validCPUBoostQuantity,
+						},
+					},
+				},
+			},
+			isCreate: true,
+		},
+		{
+			name: "container startupBoost with valid quantity",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								StartupBoost: &vpa_types.StartupBoost{
+									CPU: &vpa_types.GenericStartupBoost{
+										Type:     validCPUBoostTypeQuantity,
+										Quantity: &validCPUBoostQuantity,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isCreate: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
 			if !tc.inPlaceOrRecreateFeatureGateDisabled {
 				featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlaceOrRecreate, true)
 			}
+			featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.CPUStartupBoost, !tc.cpuStartupBoostFeatureGateDisabled)
 			err := ValidateVPA(&tc.vpa, tc.isCreate)
 			if tc.expectError == nil {
 				assert.NoError(t, err)

--- a/vertical-pod-autoscaler/pkg/features/features.go
+++ b/vertical-pod-autoscaler/pkg/features/features.go
@@ -40,6 +40,12 @@ const (
 	// In each feature gate description, you must specify "components".
 	// The feature must be enabled by the --feature-gates argument on each listed component.
 
+	// alpha: v1.5.0
+	// components: admission-controller, updater
+
+	// CPUStartupBoost enables the CPU startup boost feature.
+	CPUStartupBoost featuregate.Feature = "CPUStartupBoost"
+
 	// alpha: v1.4.0
 	// components: admission-controller, updater
 

--- a/vertical-pod-autoscaler/pkg/features/versioned_features.go
+++ b/vertical-pod-autoscaler/pkg/features/versioned_features.go
@@ -27,6 +27,9 @@ import (
 
 // Entries are alphabetized.
 var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+	CPUStartupBoost: {
+		{Version: version.MustParse("1.5"), Default: false, PreRelease: featuregate.Alpha},
+	},
 	InPlaceOrRecreate: {
 		{Version: version.MustParse("1.4"), Default: false, PreRelease: featuregate.Alpha},
 	},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change


#### What this PR does / why we need it:
API Extension: Adds a startupBoost field to the VerticalPodAutoscalerSpec and ContainerResourcePolicy to allow users to define a boost factor or quantity and a
duration.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/7862


#### Does this PR introduce a user-facing change?
```
Users can now configure a startupBoost policy in the VPA spec. 
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: (https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost#aep-7862-cpu-startup-boost)
```
