### PR TITLE
feat(vpa/updater): Add a new counter metric to measure the total number of failed Pods evictions attempts

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -302,6 +302,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 			evictErr := evictionLimiter.Evict(pod, vpa, u.eventRecorder)
 			if evictErr != nil {
 				klog.V(0).InfoS("Eviction failed", "error", evictErr, "pod", klog.KObj(pod))
+				metrics_updater.RecordFailedEviction(vpaSize, updateMode, "EvictionError")
 			} else {
 				withEvicted = true
 				metrics_updater.AddEvictedPod(vpaSize, updateMode)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR features a new `failed_eviction_attempts_total` [counter](evicted_pods_total) metric in the `vpa-updater` so that we can track both the successful _Pod_(s) evictions, via `evicted_pods_total` and the _failed_ attempts. Having this additional metric will allow us to calculate the _success_/_failure_ rates of the evictions.

The implementation approach follows the already existing pattern of the _in-place_ resource updates [metrics](https://github.com/kubernetes/autoscaler/blob/9b8558e24cf29fbe4806d24ea8308fb2d6a898aa/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go#L87-L125), where we have a 

- [in_place_updated_pods_total](https://github.com/kubernetes/autoscaler/blob/9b8558e24cf29fbe4806d24ea8308fb2d6a898aa/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go#L95-L101)
- [failed_in_place_update_attempts_total](https://github.com/kubernetes/autoscaler/blob/9b8558e24cf29fbe4806d24ea8308fb2d6a898aa/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go#L119-L125)

to track both _patch_ requests outcomes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/8427

<!--
#### Special notes for your reviewer:
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new counter metric to the VPA Updater, measuring the total number of failed Pods evictions.
```

<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->
