### PR TITLE
feat(vpa/updater): Add `VPA` resource `name` and `namespace` to success and fail resource updates counter metrics

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -289,12 +289,13 @@ func (u *updater) RunOnce(ctx context.Context) {
 			err = u.inPlaceRateLimiter.Wait(ctx)
 			if err != nil {
 				klog.V(0).InfoS("In-place rate limiter wait failed for in-place resize", "error", err)
+				metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, "InPlaceUpdateRateLimiterWaitFailed")
 				return
 			}
 			err := inPlaceLimiter.InPlaceUpdate(pod, vpa, u.eventRecorder)
 			if err != nil {
 				klog.V(0).InfoS("In-place resize failed, falling back to eviction", "error", err, "pod", klog.KObj(pod))
-				metrics_updater.RecordFailedInPlaceUpdate(vpaSize, "InPlaceUpdateError")
+				metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, "InPlaceUpdateError")
 				podsForEviction = append(podsForEviction, pod)
 				continue
 			}
@@ -310,13 +311,14 @@ func (u *updater) RunOnce(ctx context.Context) {
 			err = u.evictionRateLimiter.Wait(ctx)
 			if err != nil {
 				klog.V(0).InfoS("Eviction rate limiter wait failed", "error", err)
+				metrics_updater.RecordFailedEviction(vpaSize, vpa.Name, vpa.Namespace, updateMode, "EvictionRateLimiterWaitFailed")
 				return
 			}
 			klog.V(2).InfoS("Evicting pod", "pod", klog.KObj(pod))
 			evictErr := evictionLimiter.Evict(pod, vpa, u.eventRecorder)
 			if evictErr != nil {
 				klog.V(0).InfoS("Eviction failed", "error", evictErr, "pod", klog.KObj(pod))
-				metrics_updater.RecordFailedEviction(vpaSize, updateMode, "EvictionError")
+				metrics_updater.RecordFailedEviction(vpaSize, vpa.Name, vpa.Namespace, updateMode, "EvictionError")
 			} else {
 				withEvicted = true
 				metrics_updater.AddEvictedPod(vpaSize, updateMode)

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -300,7 +300,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 				continue
 			}
 			withInPlaceUpdated = true
-			metrics_updater.AddInPlaceUpdatedPod(vpaSize)
+			metrics_updater.AddInPlaceUpdatedPod(vpaSize, vpa.Name, vpa.Namespace)
 		}
 
 		for _, pod := range podsForEviction {
@@ -321,7 +321,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 				metrics_updater.RecordFailedEviction(vpaSize, vpa.Name, vpa.Namespace, updateMode, "EvictionError")
 			} else {
 				withEvicted = true
-				metrics_updater.AddEvictedPod(vpaSize, updateMode)
+				metrics_updater.AddEvictedPod(vpaSize, vpa.Name, vpa.Namespace, updateMode)
 			}
 		}
 

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
@@ -89,7 +89,7 @@ var (
 			Namespace: metricsNamespace,
 			Name:      "failed_eviction_attempts_total",
 			Help:      "Number of failed attempts to update Pods by eviction",
-		}, []string{"vpa_size_log2", "update_mode", "reason"},
+		}, []string{"vpa_size_log2", "update_mode", "reason", "vpa_name", "vpa_namespace"},
 	)
 
 	inPlaceUpdatableCount = prometheus.NewGaugeVec(
@@ -129,7 +129,7 @@ var (
 			Namespace: metricsNamespace,
 			Name:      "failed_in_place_update_attempts_total",
 			Help:      "Number of failed attempts to update Pods in-place.",
-		}, []string{"vpa_size_log2", "reason"},
+		}, []string{"vpa_size_log2", "reason", "vpa_name", "vpa_namespace"},
 	)
 
 	functionLatency = metrics.CreateExecutionTimeMetric(metricsNamespace,
@@ -205,10 +205,10 @@ func AddEvictedPod(vpaSize int, mode vpa_types.UpdateMode) {
 	evictedCount.WithLabelValues(strconv.Itoa(log2), string(mode)).Inc()
 }
 
-// RecordFailedEviction increases the counter of failed eviction attempts by given VPA size, update mode and reason
-func RecordFailedEviction(vpaSize int, mode vpa_types.UpdateMode, reason string) {
+// RecordFailedEviction increases the counter of failed eviction attempts by given VPA size, name, namespace, update mode and reason
+func RecordFailedEviction(vpaSize int, vpaName string, vpaNamespace string, mode vpa_types.UpdateMode, reason string) {
 	log2 := metrics.GetVpaSizeLog2(vpaSize)
-	failedEvictionAttempts.WithLabelValues(strconv.Itoa(log2), string(mode), reason).Inc()
+	failedEvictionAttempts.WithLabelValues(strconv.Itoa(log2), string(mode), reason, vpaName, vpaNamespace).Inc()
 }
 
 // NewInPlaceUpdatablePodsCounter returns a wrapper for counting Pods which are matching in-place update criteria
@@ -232,10 +232,10 @@ func AddInPlaceUpdatedPod(vpaSize int) {
 	inPlaceUpdatedCount.WithLabelValues(strconv.Itoa(log2)).Inc()
 }
 
-// RecordFailedInPlaceUpdate increases the counter of failed in-place update attempts by given VPA size and reason
-func RecordFailedInPlaceUpdate(vpaSize int, reason string) {
+// RecordFailedInPlaceUpdate increases the counter of failed in-place update attempts by given VPA size, name, namespace and reason
+func RecordFailedInPlaceUpdate(vpaSize int, vpaName string, vpaNamespace string, reason string) {
 	log2 := metrics.GetVpaSizeLog2(vpaSize)
-	failedInPlaceUpdateAttempts.WithLabelValues(strconv.Itoa(log2), reason).Inc()
+	failedInPlaceUpdateAttempts.WithLabelValues(strconv.Itoa(log2), reason, vpaName, vpaNamespace).Inc()
 }
 
 // Add increases the counter for the given VPA size

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
@@ -65,7 +65,7 @@ var (
 			Namespace: metricsNamespace,
 			Name:      "evicted_pods_total",
 			Help:      "Number of Pods evicted by Updater to apply a new recommendation.",
-		}, []string{"vpa_size_log2", "update_mode"},
+		}, []string{"vpa_size_log2", "update_mode", "vpa_name", "vpa_namespace"},
 	)
 
 	vpasWithEvictablePodsCount = prometheus.NewGaugeVec(
@@ -105,7 +105,7 @@ var (
 			Namespace: metricsNamespace,
 			Name:      "in_place_updated_pods_total",
 			Help:      "Number of Pods updated in-place by Updater to apply a new recommendation.",
-		}, []string{"vpa_size_log2"},
+		}, []string{"vpa_size_log2", "vpa_name", "vpa_namespace"},
 	)
 
 	vpasWithInPlaceUpdatablePodsCount = prometheus.NewGaugeVec(
@@ -200,9 +200,9 @@ func NewVpasWithEvictedPodsCounter() *UpdateModeAndSizeBasedGauge {
 }
 
 // AddEvictedPod increases the counter of pods evicted by Updater, by given VPA size
-func AddEvictedPod(vpaSize int, mode vpa_types.UpdateMode) {
+func AddEvictedPod(vpaSize int, vpaName string, vpaNamespace string, mode vpa_types.UpdateMode) {
 	log2 := metrics.GetVpaSizeLog2(vpaSize)
-	evictedCount.WithLabelValues(strconv.Itoa(log2), string(mode)).Inc()
+	evictedCount.WithLabelValues(strconv.Itoa(log2), string(mode), vpaName, vpaNamespace).Inc()
 }
 
 // RecordFailedEviction increases the counter of failed eviction attempts by given VPA size, name, namespace, update mode and reason
@@ -227,9 +227,9 @@ func NewVpasWithInPlaceUpdatedPodsCounter() *SizeBasedGauge {
 }
 
 // AddInPlaceUpdatedPod increases the counter of pods updated in place by Updater, by given VPA size
-func AddInPlaceUpdatedPod(vpaSize int) {
+func AddInPlaceUpdatedPod(vpaSize int, vpaName string, vpaNamespace string) {
 	log2 := metrics.GetVpaSizeLog2(vpaSize)
-	inPlaceUpdatedCount.WithLabelValues(strconv.Itoa(log2)).Inc()
+	inPlaceUpdatedCount.WithLabelValues(strconv.Itoa(log2), vpaName, vpaNamespace).Inc()
 }
 
 // RecordFailedInPlaceUpdate increases the counter of failed in-place update attempts by given VPA size, name, namespace and reason

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -27,30 +27,36 @@ import (
 
 func TestAddEvictedPod(t *testing.T) {
 	testCases := []struct {
-		desc    string
-		vpaSize int
-		mode    vpa_types.UpdateMode
-		log2    string
+		desc         string
+		vpaSize      int
+		mode         vpa_types.UpdateMode
+		log2         string
+		vpaName      string
+		vpaNamespace string
 	}{
 		{
-			desc:    "VPA size 5, mode Auto",
-			vpaSize: 5,
-			mode:    vpa_types.UpdateModeAuto,
-			log2:    "2",
+			desc:         "VPA size 5, mode Auto",
+			vpaSize:      5,
+			mode:         vpa_types.UpdateModeAuto,
+			log2:         "2",
+			vpaName:      "vpa-5",
+			vpaNamespace: "vpa-ns-5",
 		},
 		{
-			desc:    "VPA size 10, mode Off",
-			vpaSize: 10,
-			mode:    vpa_types.UpdateModeOff,
-			log2:    "3",
+			desc:         "VPA size 10, mode Off",
+			vpaSize:      10,
+			mode:         vpa_types.UpdateModeOff,
+			log2:         "3",
+			vpaName:      "vpa-10",
+			vpaNamespace: "vpa-ns-10",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Cleanup(evictedCount.Reset)
-			AddEvictedPod(tc.vpaSize, tc.mode)
-			val := testutil.ToFloat64(evictedCount.WithLabelValues(tc.log2, string(tc.mode)))
+			AddEvictedPod(tc.vpaSize, tc.vpaName, tc.vpaNamespace, tc.mode)
+			val := testutil.ToFloat64(evictedCount.WithLabelValues(tc.log2, string(tc.mode), tc.vpaName, tc.vpaNamespace))
 			if val != 1 {
 				t.Errorf("Unexpected value for evictedCount metric with labels (%s, %s): got %v, want 1", tc.log2, string(tc.mode), val)
 			}
@@ -100,27 +106,33 @@ func TestRecordFailedEviction(t *testing.T) {
 
 func TestAddInPlaceUpdatedPod(t *testing.T) {
 	testCases := []struct {
-		desc    string
-		vpaSize int
-		log2    string
+		desc         string
+		vpaSize      int
+		log2         string
+		vpaName      string
+		vpaNamespace string
 	}{
 		{
-			desc:    "VPA size 10",
-			vpaSize: 10,
-			log2:    "3",
+			desc:         "VPA size 10",
+			vpaSize:      10,
+			log2:         "3",
+			vpaName:      "vpa-10",
+			vpaNamespace: "vpa-ns-10",
 		},
 		{
-			desc:    "VPA size 1",
-			vpaSize: 1,
-			log2:    "0",
+			desc:         "VPA size 1",
+			vpaSize:      1,
+			log2:         "0",
+			vpaName:      "vpa-1",
+			vpaNamespace: "vpa-ns-1",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Cleanup(inPlaceUpdatedCount.Reset)
-			AddInPlaceUpdatedPod(tc.vpaSize)
-			val := testutil.ToFloat64(inPlaceUpdatedCount.WithLabelValues(tc.log2))
+			AddInPlaceUpdatedPod(tc.vpaSize, tc.vpaName, tc.vpaNamespace)
+			val := testutil.ToFloat64(inPlaceUpdatedCount.WithLabelValues(tc.log2, tc.vpaName, tc.vpaNamespace))
 			if val != 1 {
 				t.Errorf("Unexpected value for InPlaceUpdatedPod metric with labels (%s): got %v, want 1", tc.log2, val)
 			}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -60,31 +60,37 @@ func TestAddEvictedPod(t *testing.T) {
 
 func TestRecordFailedEviction(t *testing.T) {
 	testCases := []struct {
-		desc    string
-		vpaSize int
-		mode    vpa_types.UpdateMode
-		reason  string
-		log2    string
+		desc         string
+		vpaSize      int
+		mode         vpa_types.UpdateMode
+		reason       string
+		log2         string
+		vpaName      string
+		vpaNamespace string
 	}{
 		{
-			desc:    "VPA size 2, some reason",
-			vpaSize: 2,
-			reason:  "some_reason",
-			log2:    "1",
+			desc:         "VPA size 2, some reason",
+			vpaSize:      2,
+			reason:       "some_reason",
+			log2:         "1",
+			vpaName:      "vpa-2",
+			vpaNamespace: "vpa-2-ns",
 		},
 		{
-			desc:    "VPA size 20, another reason",
-			vpaSize: 20,
-			reason:  "another_reason",
-			log2:    "4",
+			desc:         "VPA size 20, another reason",
+			vpaSize:      20,
+			reason:       "another_reason",
+			log2:         "4",
+			vpaName:      "vpa-20",
+			vpaNamespace: "vpa-20-ns",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Cleanup(failedEvictionAttempts.Reset)
-			RecordFailedEviction(tc.vpaSize, tc.mode, tc.reason)
-			val := testutil.ToFloat64(failedEvictionAttempts.WithLabelValues(tc.log2, string(tc.mode), tc.reason))
+			RecordFailedEviction(tc.vpaSize, tc.vpaName, tc.vpaNamespace, tc.mode, tc.reason)
+			val := testutil.ToFloat64(failedEvictionAttempts.WithLabelValues(tc.log2, string(tc.mode), tc.reason, tc.vpaName, tc.vpaNamespace))
 			if val != 1 {
 				t.Errorf("Unexpected value for FailedEviction metric with labels (%s, %s): got %v, want 1", tc.log2, tc.reason, val)
 			}
@@ -124,30 +130,36 @@ func TestAddInPlaceUpdatedPod(t *testing.T) {
 
 func TestRecordFailedInPlaceUpdate(t *testing.T) {
 	testCases := []struct {
-		desc    string
-		vpaSize int
-		reason  string
-		log2    string
+		desc         string
+		vpaSize      int
+		reason       string
+		log2         string
+		vpaName      string
+		vpaNamespace string
 	}{
 		{
-			desc:    "VPA size 2, some reason",
-			vpaSize: 2,
-			reason:  "some_reason",
-			log2:    "1",
+			desc:         "VPA size 2, some reason",
+			vpaSize:      2,
+			reason:       "some_reason",
+			log2:         "1",
+			vpaName:      "vpa-2",
+			vpaNamespace: "vpa-2-ns",
 		},
 		{
-			desc:    "VPA size 20, another reason",
-			vpaSize: 20,
-			reason:  "another_reason",
-			log2:    "4",
+			desc:         "VPA size 20, another reason",
+			vpaSize:      20,
+			reason:       "another_reason",
+			log2:         "4",
+			vpaName:      "vpa-20",
+			vpaNamespace: "vpa-20-ns",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Cleanup(failedInPlaceUpdateAttempts.Reset)
-			RecordFailedInPlaceUpdate(tc.vpaSize, tc.reason)
-			val := testutil.ToFloat64(failedInPlaceUpdateAttempts.WithLabelValues(tc.log2, tc.reason))
+			RecordFailedInPlaceUpdate(tc.vpaSize, tc.vpaName, tc.vpaNamespace, tc.reason)
+			val := testutil.ToFloat64(failedInPlaceUpdateAttempts.WithLabelValues(tc.log2, tc.reason, tc.vpaName, tc.vpaNamespace))
 			if val != 1 {
 				t.Errorf("Unexpected value for FailedInPlaceUpdate metric with labels (%s, %s): got %v, want 1", tc.log2, tc.reason, val)
 			}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR introduces two additional labels (since `vpa` resources are _namespaced_ we need to include both fields):

- `vpa_name`: the __name__ of the __VPA resource that manages the Pod__ that gets updated
- `vpa_namespace`: the __namespace__ of the __VPA resource that manages the Pod__ that gets updated

 for the `vpa-updater` _success_ and _fail_ resource update operations metrics:

- [evicted_pods_total](https://github.com/kubernetes/autoscaler/blob/a9cb59fdd2dd888529af74929313f3f55c73e7c9/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go#L63-L69) total __successful__ evictions
- [failed_eviction_attempts_total](https://github.com/kubernetes/autoscaler/blob/a9cb59fdd2dd888529af74929313f3f55c73e7c9/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go#L87-L93) total __failed__ evictions
- [in_place_updated_pods_total](https://github.com/kubernetes/autoscaler/blob/a9cb59fdd2dd888529af74929313f3f55c73e7c9/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go#L103-L109) total __successful__ _in-place_ updates
- [failed_in_place_update_attempts_total](https://github.com/kubernetes/autoscaler/blob/a9cb59fdd2dd888529af74929313f3f55c73e7c9/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go#L127-L133) total __failed__ _in-place_ updates

that add `VPA` resource context and allow a more detailed monitoring of the update operations per workload.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/8444

#### Special notes for your reviewer:

The cardinality of the emitted metrics will be increased by the number of `vpa` resources, controlled by the `vpa-updater` instance.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add `VPA` resource `name` and `namespace` as labels to `vpa-updater` counter metrics. The two new labels improve the metrics context, allowing measurement of successful and failed, workload-based, resource updates.
```

<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->