### PR TITLE
correct labels for dependabot PRs to master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
   labels:
     - "area/vertical-pod-autoscaler"
     - "release-note-none"
+    - "ok-to-test"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/pkg/recommender"
   schedule:
@@ -19,6 +20,7 @@ updates:
   labels:
     - "area/vertical-pod-autoscaler"
     - "release-note-none"
+    - "ok-to-test"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/pkg/updater"
   schedule:
@@ -30,6 +32,7 @@ updates:
   labels:
     - "area/vertical-pod-autoscaler"
     - "release-note-none"
+    - "ok-to-test"
 - package-ecosystem: docker
   directory: "/vertical-pod-autoscaler/pkg/admission-controller"
   schedule:
@@ -41,6 +44,7 @@ updates:
   labels:
     - "area/vertical-pod-autoscaler"
     - "release-note-none"
+    - "ok-to-test"
 - package-ecosystem: gomod
   directory: "/addon-resizer"
   schedule:
@@ -49,6 +53,8 @@ updates:
   open-pull-requests-limit: 3
   labels:
     - "release-note-none"
+    - "area/addon-resizer"
+    - "ok-to-test"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
@@ -57,3 +63,4 @@ updates:
   labels:
     - "area/dependency"
     - "release-note-none"
+    - "ok-to-test"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Ensure we have (1) area, (2) release-note-none, and (3) ok-to-test labels on all dependabot PRs to master branch so we don't have to do that manually before merging

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
