### PR TITLE
Apply CPU startup boost in admission controller if its set

### DIFF
--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -24,6 +24,7 @@ This document is auto-generated from the flag definitions in the VPA admission-c
 | `log-file` | string |  | If non-empty, use this log file (no effect when -logtostderr=true) |
 | `log-file-max-size` | int |  1800 | uDefines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited.  |
 | `logtostderr` |  |  true | log to standard error instead of files  |
+| `max-allowed-cpu-boost` |  |  | quantity         Maximum amount of CPU that will be applied for a container with boost. |
 | `min-tls-version` | string |  | The minimum TLS version to accept.  Must be set to either tls1_2  or tls1_3. (default "tls1_2") |
 | `one-output` | severity |  | If true, only write logs to their native level (vs also writing to each lower severity level; no effect when -logtostderr=true) |
 | `port` | int |  8000 | The port to listen on.  |

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
@@ -21,10 +21,13 @@ import (
 	"strings"
 
 	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	resourcehelpers "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/resources"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
@@ -37,13 +40,15 @@ const (
 
 type resourcesUpdatesPatchCalculator struct {
 	recommendationProvider recommendation.Provider
+	maxAllowedCPUBoost     resource.Quantity
 }
 
 // NewResourceUpdatesCalculator returns a calculator for
 // resource update patches.
-func NewResourceUpdatesCalculator(recommendationProvider recommendation.Provider) Calculator {
+func NewResourceUpdatesCalculator(recommendationProvider recommendation.Provider, maxAllowedCPUBoost resource.QuantityValue) Calculator {
 	return &resourcesUpdatesPatchCalculator{
 		recommendationProvider: recommendationProvider,
+		maxAllowedCPUBoost:     maxAllowedCPUBoost.Quantity,
 	}
 }
 
@@ -59,15 +64,43 @@ func (c *resourcesUpdatesPatchCalculator) CalculatePatches(pod *core.Pod, vpa *v
 		return []resource_admission.PatchRecord{}, fmt.Errorf("failed to calculate resource patch for pod %s/%s: %v", pod.Namespace, pod.Name, err)
 	}
 
+	if vpa_api_util.GetUpdateMode(vpa) == vpa_types.UpdateModeOff {
+		// If update mode is "Off", we don't want to apply any recommendations,
+		// but we still want to apply startup boost.
+		for i := range containersResources {
+			containersResources[i].Requests = nil
+			containersResources[i].Limits = nil
+		}
+		annotationsPerContainer = vpa_api_util.ContainerToAnnotationsMap{}
+	}
+
 	if annotationsPerContainer == nil {
 		annotationsPerContainer = vpa_api_util.ContainerToAnnotationsMap{}
 	}
 
 	updatesAnnotation := []string{}
-	for i, containerResources := range containersResources {
-		newPatches, newUpdatesAnnotation := getContainerPatch(pod, i, annotationsPerContainer, containerResources)
-		result = append(result, newPatches...)
-		updatesAnnotation = append(updatesAnnotation, newUpdatesAnnotation)
+	cpuStartupBoostEnabled := features.Enabled(features.CPUStartupBoost)
+	for i := range containersResources {
+
+		// Apply startup boost if configured
+		if cpuStartupBoostEnabled {
+			// Get the container resource policy to check for scaling mode.
+			policy := vpa_api_util.GetContainerResourcePolicy(pod.Spec.Containers[i].Name, vpa.Spec.ResourcePolicy)
+			if policy != nil && policy.Mode != nil && *policy.Mode == vpa_types.ContainerScalingModeOff {
+				continue
+			}
+			boostPatches, err := c.applyCPUStartupBoost(&pod.Spec.Containers[i], vpa, &containersResources[i])
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, boostPatches...)
+		}
+
+		newPatches, newUpdatesAnnotation := getContainerPatch(pod, i, annotationsPerContainer, containersResources[i])
+		if len(newPatches) > 0 {
+			result = append(result, newPatches...)
+			updatesAnnotation = append(updatesAnnotation, newUpdatesAnnotation)
+		}
 	}
 
 	if len(updatesAnnotation) > 0 {
@@ -107,4 +140,122 @@ func appendPatchesAndAnnotations(patches []resource_admission.PatchRecord, annot
 		annotations = append(annotations, fmt.Sprintf("%s %s", resource, resourceName))
 	}
 	return patches, annotations
+}
+
+func (c *resourcesUpdatesPatchCalculator) applyCPUStartupBoost(container *core.Container, vpa *vpa_types.VerticalPodAutoscaler, containerResources *vpa_api_util.ContainerResources) ([]resource_admission.PatchRecord, error) {
+	var patches []resource_admission.PatchRecord
+
+	startupBoostPolicy := getContainerStartupBoostPolicy(container, vpa)
+	if startupBoostPolicy == nil {
+		return nil, nil
+	}
+
+	err := c.applyControlledCPUResources(container, vpa, containerResources, startupBoostPolicy)
+	if err != nil {
+		return nil, err
+	}
+
+	originalResources, err := annotations.GetOriginalResourcesAnnotationValue(container)
+	if err != nil {
+		return nil, err
+	}
+	patches = append(patches, GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, originalResources))
+
+	return patches, nil
+}
+
+func getContainerStartupBoostPolicy(container *core.Container, vpa *vpa_types.VerticalPodAutoscaler) *vpa_types.StartupBoost {
+	policy := vpa_api_util.GetContainerResourcePolicy(container.Name, vpa.Spec.ResourcePolicy)
+	startupBoost := vpa.Spec.StartupBoost
+	if policy != nil && policy.StartupBoost != nil {
+		startupBoost = policy.StartupBoost
+	}
+	return startupBoost
+}
+
+func (c *resourcesUpdatesPatchCalculator) calculateBoostedCPUValue(baseCPU resource.Quantity, startupBoost *vpa_types.StartupBoost) (*resource.Quantity, error) {
+	boostType := startupBoost.CPU.Type
+	if boostType == "" {
+		boostType = vpa_types.FactorStartupBoostType
+	}
+
+	switch boostType {
+	case vpa_types.FactorStartupBoostType:
+		if startupBoost.CPU.Factor == nil {
+			return nil, fmt.Errorf("startupBoost.CPU.Factor is required when Type is Factor or not specified")
+		}
+		factor := *startupBoost.CPU.Factor
+		if factor < 1 {
+			return nil, fmt.Errorf("boost factor must be >= 1")
+		}
+		boostedCPUMilli := baseCPU.MilliValue()
+		boostedCPUMilli = int64(float64(boostedCPUMilli) * float64(factor))
+		return resource.NewMilliQuantity(boostedCPUMilli, resource.DecimalSI), nil
+	case vpa_types.QuantityStartupBoostType:
+		if startupBoost.CPU.Quantity == nil {
+			return nil, fmt.Errorf("startupBoost.CPU.Quantity is required when Type is Quantity")
+		}
+		quantity := *startupBoost.CPU.Quantity
+		boostedCPUMilli := baseCPU.MilliValue() + quantity.MilliValue()
+		return resource.NewMilliQuantity(boostedCPUMilli, resource.DecimalSI), nil
+	default:
+		return nil, fmt.Errorf("unsupported startup boost type: %s", startupBoost.CPU.Type)
+	}
+}
+
+func (c *resourcesUpdatesPatchCalculator) calculateBoostedCPU(recommendedCPU, originalCPU resource.Quantity, startupBoost *vpa_types.StartupBoost) (*resource.Quantity, error) {
+	baseCPU := recommendedCPU
+	if baseCPU.IsZero() {
+		baseCPU = originalCPU
+	}
+
+	if startupBoost == nil {
+		return &baseCPU, nil
+	}
+
+	boostedCPU, err := c.calculateBoostedCPUValue(baseCPU, startupBoost)
+	if err != nil {
+		return nil, err
+	}
+
+	if !c.maxAllowedCPUBoost.IsZero() && boostedCPU.Cmp(c.maxAllowedCPUBoost) > 0 {
+		return &c.maxAllowedCPUBoost, nil
+	}
+	return boostedCPU, nil
+}
+
+func (c *resourcesUpdatesPatchCalculator) applyControlledCPUResources(container *core.Container, vpa *vpa_types.VerticalPodAutoscaler, containerResources *vpa_api_util.ContainerResources, startupBoostPolicy *vpa_types.StartupBoost) error {
+	controlledValues := vpa_api_util.GetContainerControlledValues(container.Name, vpa.Spec.ResourcePolicy)
+
+	recommendedRequest := containerResources.Requests[core.ResourceCPU]
+	originalRequest := container.Resources.Requests[core.ResourceCPU]
+	boostedRequest, err := c.calculateBoostedCPU(recommendedRequest, originalRequest, startupBoostPolicy)
+	if err != nil {
+		return err
+	}
+
+	if containerResources.Requests == nil {
+		containerResources.Requests = core.ResourceList{}
+	}
+	containerResources.Requests[core.ResourceCPU] = *boostedRequest
+
+	switch controlledValues {
+	case vpa_types.ContainerControlledValuesRequestsOnly:
+		vpa_api_util.CapRecommendationToContainerLimit(containerResources.Requests, container.Resources.Limits)
+	case vpa_types.ContainerControlledValuesRequestsAndLimits:
+		if containerResources.Limits == nil {
+			containerResources.Limits = core.ResourceList{}
+		}
+		originalLimit := container.Resources.Limits[core.ResourceCPU]
+		if originalLimit.IsZero() {
+			originalLimit = container.Resources.Requests[core.ResourceCPU]
+		}
+		recommendedLimit := containerResources.Limits[core.ResourceCPU]
+		boostedLimit, err := c.calculateBoostedCPU(recommendedLimit, originalLimit, startupBoostPolicy)
+		if err != nil {
+			return err
+		}
+		containerResources.Limits[core.ResourceCPU] = *boostedLimit
+	}
+	return nil
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates_test.go
@@ -24,9 +24,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
@@ -289,11 +292,22 @@ func TestCalculatePatches_ResourceUpdates(t *testing.T) {
 				addAnnotationRequest([][]string{{cpu}}, limit),
 			},
 		},
+		{
+			name: "no recommendation present",
+			pod: test.Pod().
+				AddContainer(core.Container{}).
+				AddContainerStatus(test.ContainerStatus().
+					WithCPULimit(resource.MustParse("0")).Get()).Get(),
+			namespace:            "default",
+			recommendResources:   make([]vpa_api_util.ContainerResources, 1),
+			recommendAnnotations: vpa_api_util.ContainerToAnnotationsMap{},
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			frp := fakeRecommendationProvider{tc.recommendResources, tc.recommendAnnotations, tc.recommendError}
-			c := NewResourceUpdatesCalculator(&frp)
+			c := NewResourceUpdatesCalculator(&frp, resource.QuantityValue{})
 			patches, err := c.CalculatePatches(tc.pod, test.VerticalPodAutoscaler().WithContainer("test").WithName("name").Get())
 			if tc.expectError == nil {
 				assert.NoError(t, err)
@@ -335,7 +349,7 @@ func TestGetPatches_TwoReplacementResources(t *testing.T) {
 	}
 	recommendAnnotations := vpa_api_util.ContainerToAnnotationsMap{}
 	frp := fakeRecommendationProvider{recommendResources, recommendAnnotations, nil}
-	c := NewResourceUpdatesCalculator(&frp)
+	c := NewResourceUpdatesCalculator(&frp, resource.QuantityValue{})
 	patches, err := c.CalculatePatches(pod, test.VerticalPodAutoscaler().WithName("name").WithContainer("test").Get())
 	assert.NoError(t, err)
 	// Order of updates for cpu and unobtanium depends on order of iterating a map, both possible results are valid.
@@ -348,5 +362,396 @@ func TestGetPatches_TwoReplacementResources(t *testing.T) {
 		cpuFirstUnobtaniumSecond := addAnnotationRequest([][]string{{cpu, unobtanium}}, request)
 		unobtaniumFirstCpuSecond := addAnnotationRequest([][]string{{unobtanium, cpu}}, request)
 		AssertPatchOneOf(t, patches[2], []resource_admission.PatchRecord{cpuFirstUnobtaniumSecond, unobtaniumFirstCpuSecond})
+	}
+}
+
+func TestCalculatePatches_StartupBoost(t *testing.T) {
+	factor2 := int32(2)
+	factor3 := int32(3)
+	quantity := resource.MustParse("500m")
+	invalidFactor := int32(0)
+	invalidQuantity := resource.MustParse("200m")
+	tests := []struct {
+		name                 string
+		pod                  *core.Pod
+		vpa                  *vpa_types.VerticalPodAutoscaler
+		recommendResources   []vpa_api_util.ContainerResources
+		recommendAnnotations vpa_api_util.ContainerToAnnotationsMap
+		recommendError       error
+		maxAllowedCpu        resource.QuantityValue
+		expectPatches        []resource_admission.PatchRecord
+		expectError          error
+		featureGateEnabled   bool
+	}{
+		{
+			name: "startup boost factor",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("1m"),
+								},
+								Limits: core.ResourceList{
+									cpu: resource.MustParse("1m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa: test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor2, nil, "10s").Get(),
+			recommendResources: []vpa_api_util.ContainerResources{
+				{
+					Requests: core.ResourceList{
+						cpu: resource.MustParse("100m"),
+					},
+					Limits: core.ResourceList{
+						cpu: resource.MustParse("100m"),
+					},
+				},
+			},
+			maxAllowedCpu:      resource.QuantityValue{},
+			featureGateEnabled: true,
+			expectPatches: []resource_admission.PatchRecord{
+				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
+				addResourceRequestPatch(0, cpu, "200m"),
+				addResourceLimitPatch(0, cpu, "200m"),
+				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
+			},
+		},
+		{
+			name: "startup boost factor with 0s duration",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("1m"),
+								},
+								Limits: core.ResourceList{
+									cpu: resource.MustParse("1m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa: test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor2, nil, "0s").Get(),
+			recommendResources: []vpa_api_util.ContainerResources{
+				{
+					Requests: core.ResourceList{
+						cpu: resource.MustParse("100m"),
+					},
+					Limits: core.ResourceList{
+						cpu: resource.MustParse("100m"),
+					},
+				},
+			},
+			maxAllowedCpu:      resource.QuantityValue{},
+			featureGateEnabled: true,
+			expectPatches: []resource_admission.PatchRecord{
+				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
+				addResourceRequestPatch(0, cpu, "200m"),
+				addResourceLimitPatch(0, cpu, "200m"),
+				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
+			},
+		},
+		{
+			name: "startup boost quantity",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("1m"),
+								},
+								Limits: core.ResourceList{
+									cpu: resource.MustParse("1m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa: test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.QuantityStartupBoostType, nil, &quantity, "10s").Get(),
+			recommendResources: []vpa_api_util.ContainerResources{
+				{
+					Requests: core.ResourceList{
+						cpu: resource.MustParse("100m"),
+					},
+					Limits: core.ResourceList{
+						cpu: resource.MustParse("100m"),
+					},
+				},
+			},
+			maxAllowedCpu:      resource.QuantityValue{},
+			featureGateEnabled: true,
+			expectPatches: []resource_admission.PatchRecord{
+				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
+				addResourceRequestPatch(0, cpu, "600m"),
+				addResourceLimitPatch(0, cpu, "600m"),
+				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
+			},
+		},
+		{
+			name: "feature gate disabled",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa: test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor2, nil, "10s").Get(),
+			recommendResources: []vpa_api_util.ContainerResources{
+				{
+					Requests: core.ResourceList{
+						cpu: resource.MustParse("100m"),
+					},
+				},
+			},
+			maxAllowedCpu:      resource.QuantityValue{},
+			featureGateEnabled: false,
+			expectPatches: []resource_admission.PatchRecord{
+				addResourceRequestPatch(0, cpu, "100m"),
+				addAnnotationRequest([][]string{{cpu}}, "request"),
+			},
+		},
+		{
+			name: "invalid factor",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("1m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa: test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &invalidFactor, nil, "10s").Get(),
+			recommendResources: []vpa_api_util.ContainerResources{
+				{
+					Requests: core.ResourceList{
+						cpu: resource.MustParse("100m"),
+					},
+				},
+			},
+			maxAllowedCpu:      resource.QuantityValue{},
+			featureGateEnabled: true,
+			expectError:        fmt.Errorf("boost factor must be >= 1"),
+		},
+		{
+			name: "quantity less than request",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("400m"),
+								},
+								Limits: core.ResourceList{
+									cpu: resource.MustParse("400m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa: test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.QuantityStartupBoostType, nil, &invalidQuantity, "10s").Get(),
+			recommendResources: []vpa_api_util.ContainerResources{
+				{
+					Requests: core.ResourceList{
+						cpu: resource.MustParse("500m"),
+					},
+					Limits: core.ResourceList{
+						cpu: resource.MustParse("500m"),
+					},
+				},
+			},
+			maxAllowedCpu:      resource.QuantityValue{},
+			featureGateEnabled: true,
+			expectPatches: []resource_admission.PatchRecord{
+				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"400m\"},\"limits\":{\"cpu\":\"400m\"}}"),
+				addResourceRequestPatch(0, cpu, "700m"),
+				addResourceLimitPatch(0, cpu, "700m"),
+				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
+			},
+		},
+		{
+			name: "startup boost capped",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("1m"),
+								},
+								Limits: core.ResourceList{
+									cpu: resource.MustParse("1m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa: test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor3, nil, "1s").Get(),
+			recommendResources: []vpa_api_util.ContainerResources{
+				{
+					Requests: core.ResourceList{
+						cpu: resource.MustParse("20m"),
+					},
+					Limits: core.ResourceList{
+						cpu: resource.MustParse("20m"),
+					},
+				},
+			},
+			maxAllowedCpu:      resource.QuantityValue{Quantity: resource.MustParse("40m")},
+			featureGateEnabled: true,
+			expectPatches: []resource_admission.PatchRecord{
+				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
+				addResourceRequestPatch(0, cpu, "40m"),
+				addResourceLimitPatch(0, cpu, "40m"),
+				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
+			},
+		},
+		{
+			name: "startup boost with scaling mode off",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa: test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor2, nil, "10s").WithScalingMode("container1", vpa_types.ContainerScalingModeOff).Get(),
+			recommendResources: []vpa_api_util.ContainerResources{
+				{
+					Requests: core.ResourceList{
+						cpu: resource.MustParse("1"),
+					},
+				},
+			},
+			maxAllowedCpu:      resource.QuantityValue{},
+			featureGateEnabled: true,
+			expectPatches:      []resource_admission.PatchRecord{},
+		},
+		{
+			name: "startup boost no recommendation",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("100m"),
+								},
+								Limits: core.ResourceList{
+									cpu: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa:                test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor2, nil, "10s").Get(),
+			recommendResources: make([]vpa_api_util.ContainerResources, 1),
+			maxAllowedCpu:      resource.QuantityValue{},
+			featureGateEnabled: true,
+			expectPatches: []resource_admission.PatchRecord{
+				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"100m\"}}"),
+				addResourceRequestPatch(0, cpu, "200m"),
+				addResourceLimitPatch(0, cpu, "200m"),
+				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
+			},
+		},
+		{
+			name: "startup boost with ControlledValues=RequestsOnly",
+			pod: &core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Name: "container1",
+							Resources: core.ResourceRequirements{
+								Requests: core.ResourceList{
+									cpu: resource.MustParse("100m"),
+								},
+								Limits: core.ResourceList{
+									cpu: resource.MustParse("300m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			vpa: test.VerticalPodAutoscaler().WithName("name").WithContainer("container1").WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor2, nil, "10s").WithControlledValues("container1", vpa_types.ContainerControlledValuesRequestsOnly).Get(),
+			recommendResources: []vpa_api_util.ContainerResources{
+				{
+					Requests: core.ResourceList{
+						cpu: resource.MustParse("100m"),
+					},
+				},
+			},
+			maxAllowedCpu:      resource.QuantityValue{},
+			featureGateEnabled: true,
+			expectPatches: []resource_admission.PatchRecord{
+				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"300m\"}}"),
+				addResourceRequestPatch(0, cpu, "200m"),
+				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request"),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.CPUStartupBoost, tc.featureGateEnabled)
+
+			frp := fakeRecommendationProvider{tc.recommendResources, tc.recommendAnnotations, tc.recommendError}
+			c := NewResourceUpdatesCalculator(&frp, tc.maxAllowedCpu)
+			patches, err := c.CalculatePatches(tc.pod, tc.vpa)
+			if tc.expectError == nil {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Equal(t, tc.expectError.Error(), err.Error())
+				}
+			}
+			if assert.Len(t, patches, len(tc.expectPatches), fmt.Sprintf("got %+v, want %+v", patches, tc.expectPatches)) {
+				for i, gotPatch := range patches {
+					if !EqPatch(gotPatch, tc.expectPatches[i]) {
+						t.Errorf("Expected patch at position %d to be %+v, got %+v", i, tc.expectPatches[i], gotPatch)
+					}
+				}
+			}
+		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
@@ -69,7 +69,7 @@ func (m *matcher) GetMatchingVPA(ctx context.Context, pod *core.Pod) *vpa_types.
 
 	var controllingVpa *vpa_types.VerticalPodAutoscaler
 	for _, vpaConfig := range configs {
-		if vpa_api_util.GetUpdateMode(vpaConfig) == vpa_types.UpdateModeOff {
+		if vpa_api_util.GetUpdateMode(vpaConfig) == vpa_types.UpdateModeOff && vpaConfig.Spec.StartupBoost == nil {
 			continue
 		}
 		if vpaConfig.Spec.TargetRef == nil {

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"encoding/json"
+
+	core "k8s.io/api/core/v1"
+)
+
+const (
+	// StartupCPUBoostAnnotation is the annotation set on a pod when a CPU boost is applied.
+	// The value of the annotation is the original resource specification of the container.
+	StartupCPUBoostAnnotation = "startup-cpu-boost"
+)
+
+// OriginalResources contains the original resources of a container.
+type OriginalResources struct {
+	Requests core.ResourceList `json:"requests"`
+	Limits   core.ResourceList `json:"limits"`
+}
+
+// GetOriginalResourcesAnnotationValue returns the annotation value for the original resources.
+func GetOriginalResourcesAnnotationValue(container *core.Container) (string, error) {
+	original := OriginalResources{
+		Requests: core.ResourceList{},
+		Limits:   core.ResourceList{},
+	}
+	if cpu, ok := container.Resources.Requests[core.ResourceCPU]; ok {
+		original.Requests[core.ResourceCPU] = cpu
+	}
+	if mem, ok := container.Resources.Requests[core.ResourceMemory]; ok {
+		original.Requests[core.ResourceMemory] = mem
+	}
+	if cpu, ok := container.Resources.Limits[core.ResourceCPU]; ok {
+		original.Limits[core.ResourceCPU] = cpu
+	}
+	if mem, ok := container.Resources.Limits[core.ResourceMemory]; ok {
+		original.Limits[core.ResourceMemory] = mem
+	}
+	b, err := json.Marshal(original)
+	return string(b), err
+}
+
+// GetOriginalResourcesFromAnnotation returns the original resources from the annotation.
+func GetOriginalResourcesFromAnnotation(pod *core.Pod) (*OriginalResources, error) {
+	val, ok := pod.Annotations[StartupCPUBoostAnnotation]
+	if !ok {
+		return nil, nil
+	}
+	var original OriginalResources
+	err := json.Unmarshal([]byte(val), &original)
+	if err != nil {
+		return nil, err
+	}
+	return &original, nil
+}

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetOriginalResourcesAnnotationValue(t *testing.T) {
+	testCases := []struct {
+		name      string
+		container *core.Container
+		expected  *OriginalResources
+		expectErr bool
+	}{
+		{
+			name: "full resources",
+			container: &core.Container{
+				Resources: core.ResourceRequirements{
+					Requests: core.ResourceList{
+						core.ResourceCPU:    resource.MustParse("1"),
+						core.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: core.ResourceList{
+						core.ResourceCPU:    resource.MustParse("2"),
+						core.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			expected: &OriginalResources{
+				Requests: core.ResourceList{
+					core.ResourceCPU:    resource.MustParse("1"),
+					core.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: core.ResourceList{
+					core.ResourceCPU:    resource.MustParse("2"),
+					core.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "only requests",
+			container: &core.Container{
+				Resources: core.ResourceRequirements{
+					Requests: core.ResourceList{
+						core.ResourceCPU:    resource.MustParse("1"),
+						core.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			expected: &OriginalResources{
+				Requests: core.ResourceList{
+					core.ResourceCPU:    resource.MustParse("1"),
+					core.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: core.ResourceList{},
+			},
+			expectErr: false,
+		},
+		{
+			name: "no resources",
+			container: &core.Container{
+				Resources: core.ResourceRequirements{},
+			},
+			expected: &OriginalResources{
+				Requests: core.ResourceList{},
+				Limits:   core.ResourceList{},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, err := GetOriginalResourcesAnnotationValue(tc.container)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			var got OriginalResources
+			err = json.Unmarshal([]byte(val), &got)
+			assert.NoError(t, err)
+			assert.True(t, tc.expected.Requests.Cpu().Equal(*got.Requests.Cpu()), "CPU requests do not match")
+			assert.True(t, tc.expected.Requests.Memory().Equal(*got.Requests.Memory()), "Memory requests do not match")
+			assert.True(t, tc.expected.Limits.Cpu().Equal(*got.Limits.Cpu()), "CPU limits do not match")
+			assert.True(t, tc.expected.Limits.Memory().Equal(*got.Limits.Memory()), "Memory limits do not match")
+		})
+	}
+}
+
+func TestGetOriginalResourcesFromAnnotation(t *testing.T) {
+	testCases := []struct {
+		name      string
+		pod       *core.Pod
+		expected  *OriginalResources
+		expectErr bool
+	}{
+		{
+			name: "valid annotation",
+			pod: &core.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						StartupCPUBoostAnnotation: `{"requests":{"cpu":"1","memory":"1Gi"},"limits":{"cpu":"2","memory":"2Gi"}}`,
+					},
+				},
+			},
+			expected: &OriginalResources{
+				Requests: core.ResourceList{
+					core.ResourceCPU:    resource.MustParse("1"),
+					core.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: core.ResourceList{
+					core.ResourceCPU:    resource.MustParse("2"),
+					core.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "no annotation",
+			pod: &core.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected:  nil,
+			expectErr: false,
+		},
+		{
+			name: "invalid json",
+			pod: &core.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						StartupCPUBoostAnnotation: "invalid-json",
+					},
+				},
+			},
+			expected:  nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GetOriginalResourcesFromAnnotation(tc.pod)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			if tc.expected == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+				assert.True(t, tc.expected.Requests.Cpu().Equal(*got.Requests.Cpu()), "CPU requests do not match")
+				assert.True(t, tc.expected.Requests.Memory().Equal(*got.Requests.Memory()), "Memory requests do not match")
+				assert.True(t, tc.expected.Limits.Cpu().Equal(*got.Limits.Cpu()), "CPU limits do not match")
+				assert.True(t, tc.expected.Limits.Memory().Equal(*got.Limits.Memory()), "Memory limits do not match")
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -136,7 +136,7 @@ func getCappedRecommendationForContainer(
 		}
 		// TODO: If limits and policy are conflicting, set some condition on the VPA.
 		if containerControlledValues == vpa_types.ContainerControlledValuesRequestsOnly {
-			annotations = capRecommendationToContainerLimit(recommendation, containerLimits)
+			annotations = CapRecommendationToContainerLimit(recommendation, containerLimits)
 			if genAnnotations {
 				cappingAnnotations = append(cappingAnnotations, annotations...)
 			}
@@ -150,9 +150,9 @@ func getCappedRecommendationForContainer(
 	return cappedRecommendations, cappingAnnotations, nil
 }
 
-// capRecommendationToContainerLimit makes sure recommendation is not above current limit for the container.
+// CapRecommendationToContainerLimit makes sure recommendation is not above current limit for the container.
 // If this function makes adjustments appropriate annotations are returned.
-func capRecommendationToContainerLimit(recommendation apiv1.ResourceList, containerLimits apiv1.ResourceList) []string {
+func CapRecommendationToContainerLimit(recommendation apiv1.ResourceList, containerLimits apiv1.ResourceList) []string {
 	annotations := make([]string, 0)
 	// Iterate over limits set in the container. Unset means Infinite limit.
 	for resourceName, limit := range containerLimits {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:



#### Which issue(s) this PR fixes:
Introduces changes in the admission-controller component to apply cpu startup boost if its set in the vpa spec.
Also the original cpu request is added in annotation to verify if the updater correctly reverts back to original state.

#### Does this PR introduce a user-facing change?
```
Users can now configure a startupBoost policy in the VPA spec. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: (https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost#aep-7862-cpu-startup-boost)
```

```release-note
Apply CPU startup boost in admission controller if its set
```