### PR TITLE
Change names for certificate keys in secret

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh
+++ b/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh
@@ -55,7 +55,7 @@ openssl req -new -key ${TMP_DIR}/serverKey.pem -out ${TMP_DIR}/server.csr -subj 
 openssl x509 -req -in ${TMP_DIR}/server.csr -CA ${TMP_DIR}/caCert.pem -CAkey ${TMP_DIR}/caKey.pem -CAcreateserial -out ${TMP_DIR}/serverCert.pem -days 100000 -extensions SAN -extensions v3_req -extfile ${TMP_DIR}/server.conf
 
 echo "Uploading certs to the cluster."
-kubectl create secret --namespace=kube-system generic vpa-tls-certs --from-file=${TMP_DIR}/caKey.pem --from-file=${TMP_DIR}/caCert.pem --from-file=${TMP_DIR}/serverKey.pem --from-file=${TMP_DIR}/serverCert.pem
+kubectl create secret --namespace=kube-system generic vpa-tls-certs --from-file=ca.key=${TMP_DIR}/caKey.pem --from-file=ca.crt=${TMP_DIR}/caCert.pem --from-file=tls.key=${TMP_DIR}/serverKey.pem --from-file=tls.crt=${TMP_DIR}/serverCert.pem
 
 if [ "${1:-unset}" = "e2e" ]; then
   openssl genrsa -out ${TMP_DIR}/e2eCaKey.pem 2048

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -60,9 +60,9 @@ const (
 
 var (
 	certsConfiguration = &certsConfig{
-		clientCaFile:  flag.String("client-ca-file", "/etc/tls-certs/caCert.pem", "Path to CA PEM file."),
-		tlsCertFile:   flag.String("tls-cert-file", "/etc/tls-certs/serverCert.pem", "Path to server certificate PEM file."),
-		tlsPrivateKey: flag.String("tls-private-key", "/etc/tls-certs/serverKey.pem", "Path to server certificate key PEM file."),
+		clientCaFile:  flag.String("client-ca-file", "/etc/tls-certs/ca.crt", "Path to CA PEM file."),
+		tlsCertFile:   flag.String("tls-cert-file", "/etc/tls-certs/tls.crt", "Path to server certificate PEM file."),
+		tlsPrivateKey: flag.String("tls-private-key", "/etc/tls-certs/tls.key", "Path to server certificate key PEM file."),
 		reload:        flag.Bool("reload-cert", false, "If set to true, reload leaf and CA certificates when changed."),
 	}
 	ciphers              = flag.String("tls-ciphers", "", "A comma-separated or colon-separated list of ciphers to accept.  Only works when min-tls-version is set to tls1_2.")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #8460

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

Key names in the generated `vpa-tls-certs` are different. Now cert-manager compatible.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
