### PR TITLE
Bump VPA version to 1.4.2

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -21,7 +21,7 @@ package common
 var gitCommit = ""
 
 // versionCore is the version of VPA.
-const versionCore = "1.4.1"
+const versionCore = "1.4.2"
 
 // VerticalPodAutoscalerVersion returns the version of the VPA.
 func VerticalPodAutoscalerVersion() string {


### PR DESCRIPTION
#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:

Bump VPA version to 1.4.2 in preparation for release [(https://github.com/kubernetes/autoscaler/issues/8189)](https://github.com/kubernetes/autoscaler/issues/8468)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

