### PR TITLE
chore: cherry-pick forceDeleteFailedNodes into release branch 1.32

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -309,6 +309,8 @@ type AutoscalingOptions struct {
 	CheckCapacityProvisioningRequestBatchTimebox time.Duration
 	// ForceDeleteLongUnregisteredNodes is used to enable/disable ignoring min size constraints during removal of long unregistered nodes
 	ForceDeleteLongUnregisteredNodes bool
+	// ForceDeleteFailedNodes is used to enable/disable ignoring min size constraints during removal of failed nodes
+	ForceDeleteFailedNodes bool
 	// DynamicResourceAllocationEnabled configures whether logic for handling DRA objects is enabled.
 	DynamicResourceAllocationEnabled bool
 }

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -866,8 +866,15 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() {
 		nodeGroup := nodeGroups[nodeGroupId]
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
-		} else if nodesToDelete, err = overrideNodesToDeleteForZeroOrMax(a.NodeGroupDefaults, nodeGroup, nodesToDelete); err == nil {
-			err = nodeGroup.DeleteNodes(nodesToDelete)
+		} else if nodesToDelete, err = overrideNodesToDeleteForZeroOrMax(a.NodeGroupDefaults, nodeGroup, nodesToDelete); err == nil && len(nodesToDelete) > 0 {
+			if a.ForceDeleteFailedNodes {
+				err = nodeGroup.ForceDeleteNodes(nodesToDelete)
+				if errors.Is(err, cloudprovider.ErrNotImplemented) {
+					err = nodeGroup.DeleteNodes(nodesToDelete)
+				}
+			} else {
+				err = nodeGroup.DeleteNodes(nodesToDelete)
+			}
 		}
 
 		if err != nil {

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1572,400 +1572,397 @@ func TestStaticAutoscalerRunOnceWithBypassedSchedulers(t *testing.T) {
 }
 
 func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
-	// setup
-	provider := &mockprovider.CloudProvider{}
-
-	// Create context with mocked lister registry.
-	options := config.AutoscalingOptions{
-		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
-			ScaleDownUnneededTime:         time.Minute,
-			ScaleDownUnreadyTime:          time.Minute,
-			ScaleDownUtilizationThreshold: 0.5,
-			MaxNodeProvisionTime:          10 * time.Second,
+	testCases := []struct {
+		forceDeleteEnabled     bool
+		forceDeleteImplemented bool
+	}{
+		{
+			forceDeleteEnabled:     false,
+			forceDeleteImplemented: false,
 		},
-		EstimatorName:                estimator.BinpackingEstimatorName,
-		ScaleDownEnabled:             true,
-		MaxNodesTotal:                10,
-		MaxCoresTotal:                10,
-		MaxMemoryTotal:               100000,
-		ExpendablePodsPriorityCutoff: 10,
+		{
+			forceDeleteEnabled:     true,
+			forceDeleteImplemented: false,
+		},
+		{
+			forceDeleteEnabled:     true,
+			forceDeleteImplemented: true,
+		},
 	}
-	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("forceDeleteEnabled=%t,forceDeleteImplemented=%t", tc.forceDeleteEnabled, tc.forceDeleteImplemented), func(t *testing.T) {
+			// setup
+			provider := &mockprovider.CloudProvider{}
 
-	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
-	assert.NoError(t, err)
+			// Create context with mocked lister registry.
+			options := config.AutoscalingOptions{
+				NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+					ScaleDownUnneededTime:         time.Minute,
+					ScaleDownUnreadyTime:          time.Minute,
+					ScaleDownUtilizationThreshold: 0.5,
+					MaxNodeProvisionTime:          10 * time.Second,
+				},
+				EstimatorName:                estimator.BinpackingEstimatorName,
+				ScaleDownEnabled:             true,
+				MaxNodesTotal:                10,
+				MaxCoresTotal:                10,
+				MaxMemoryTotal:               100000,
+				ExpendablePodsPriorityCutoff: 10,
+				ForceDeleteFailedNodes:       tc.forceDeleteEnabled,
+			}
+			processorCallbacks := newStaticAutoscalerProcessorCallbacks()
+			var deleteMethod string
+			if tc.forceDeleteEnabled {
+				deleteMethod = "ForceDeleteNodes"
+			} else {
+				deleteMethod = "DeleteNodes"
+			}
 
-	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
-		OkTotalUnreadyCount: 1,
+			context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
+			assert.NoError(t, err)
+
+			clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
+				OkTotalUnreadyCount: 1,
+			}
+
+			nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults)
+			asyncNodeGroupStateChecker := asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker()
+			clusterState := clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
+			autoscaler := &StaticAutoscaler{
+				AutoscalingContext:    &context,
+				clusterStateRegistry:  clusterState,
+				lastScaleUpTime:       time.Now(),
+				lastScaleDownFailTime: time.Now(),
+				processorCallbacks:    processorCallbacks,
+			}
+
+			nodeGroupA := &mockprovider.NodeGroup{}
+			nodeGroupB := &mockprovider.NodeGroup{}
+
+			// Three nodes with out-of-resources errors
+			nodeGroupA.On("Exist").Return(true)
+			nodeGroupA.On("Autoprovisioned").Return(false)
+			nodeGroupA.On("TargetSize").Return(5, nil)
+			nodeGroupA.On("Id").Return("A")
+			mockDeleteNodes(nodeGroupA, tc.forceDeleteEnabled, tc.forceDeleteImplemented)
+			nodeGroupA.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
+			nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "A1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
+				},
+				{
+					Id: "A2",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+					},
+				},
+				{
+					Id: "A3",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
+						},
+					},
+				},
+				{
+					Id: "A4",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
+						},
+					},
+				},
+				{
+					Id: "A5",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "QUOTA",
+						},
+					},
+				},
+				{
+					Id: "A6",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OtherErrorClass,
+							ErrorCode:  "OTHER",
+						},
+					},
+				},
+			}, nil).Twice()
+
+			nodeGroupB.On("Exist").Return(true)
+			nodeGroupB.On("Autoprovisioned").Return(false)
+			nodeGroupB.On("TargetSize").Return(5, nil)
+			nodeGroupB.On("Id").Return("B")
+			mockDeleteNodes(nodeGroupB, tc.forceDeleteEnabled, tc.forceDeleteImplemented)
+			nodeGroupB.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
+			nodeGroupB.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "B1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
+				},
+			}, nil)
+
+			provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupA})
+			provider.On("NodeGroupForNode", mock.Anything).Return(
+				func(node *apiv1.Node) cloudprovider.NodeGroup {
+					if strings.HasPrefix(node.Spec.ProviderID, "A") {
+						return nodeGroupA
+					}
+					if strings.HasPrefix(node.Spec.ProviderID, "B") {
+						return nodeGroupB
+					}
+					return nil
+				}, nil)
+			provider.On("HasInstance", mock.Anything).Return(
+				func(node *apiv1.Node) bool {
+					return false
+				}, nil)
+
+			now := time.Now()
+
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+			// propagate nodes info in cluster state
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+
+			// delete nodes with create errors
+			autoscaler.deleteCreatedNodesWithErrors()
+
+			// nodes should be deleted
+			expectedDeleteCalls := 1
+			if tc.forceDeleteEnabled {
+				nodeGroupA.AssertNumberOfCalls(t, "ForceDeleteNodes", expectedDeleteCalls)
+				if !tc.forceDeleteImplemented {
+					nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+				}
+			} else {
+				nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+			}
+
+			// check delete was called on correct nodes
+			nodeGroupA.AssertCalled(t, deleteMethod, mock.MatchedBy(
+				func(nodes []*apiv1.Node) bool {
+					if len(nodes) != 4 {
+						return false
+					}
+					names := make(map[string]bool)
+					for _, node := range nodes {
+						names[node.Spec.ProviderID] = true
+					}
+					return names["A3"] && names["A4"] && names["A5"] && names["A6"]
+				}))
+
+			// TODO assert that scaleup was failed (separately for QUOTA and RESOURCE_POOL_EXHAUSTED)
+
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+
+			// propagate nodes info in cluster state again
+			// no changes in what provider returns
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+
+			// delete nodes with create errors
+			autoscaler.deleteCreatedNodesWithErrors()
+
+			// nodes should be deleted again
+			expectedDeleteCalls += 1
+			if tc.forceDeleteEnabled {
+				nodeGroupA.AssertNumberOfCalls(t, "ForceDeleteNodes", expectedDeleteCalls)
+				if !tc.forceDeleteImplemented {
+					nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+				}
+			} else {
+				nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+			}
+
+			nodeGroupA.AssertCalled(t, deleteMethod, mock.MatchedBy(
+				func(nodes []*apiv1.Node) bool {
+					if len(nodes) != 4 {
+						return false
+					}
+					names := make(map[string]bool)
+					for _, node := range nodes {
+						names[node.Spec.ProviderID] = true
+					}
+					return names["A3"] && names["A4"] && names["A5"] && names["A6"]
+				}))
+
+			// TODO assert that scaleup is not failed again
+
+			// restub node group A so nodes are no longer reporting errors
+			nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "A1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
+				},
+				{
+					Id: "A2",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+					},
+				},
+				{
+					Id: "A3",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceDeleting,
+					},
+				},
+				{
+					Id: "A4",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceDeleting,
+					},
+				},
+				{
+					Id: "A5",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceDeleting,
+					},
+				},
+				{
+					Id: "A6",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceDeleting,
+					},
+				},
+			}, nil)
+
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+
+			// update cluster state
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+
+			// delete nodes with create errors
+			autoscaler.deleteCreatedNodesWithErrors()
+
+			// we expect no more Delete Nodes, don't increase expectedDeleteCalls
+			if tc.forceDeleteEnabled {
+				nodeGroupA.AssertNumberOfCalls(t, "ForceDeleteNodes", expectedDeleteCalls)
+				if !tc.forceDeleteImplemented {
+					nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+				}
+			} else {
+				nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+			}
+
+			// failed node not included by NodeGroupForNode
+			nodeGroupC := &mockprovider.NodeGroup{}
+			nodeGroupC.On("Exist").Return(true)
+			nodeGroupC.On("Autoprovisioned").Return(false)
+			nodeGroupC.On("TargetSize").Return(1, nil)
+			nodeGroupC.On("Id").Return("C")
+			mockDeleteNodes(nodeGroupC, tc.forceDeleteEnabled, tc.forceDeleteImplemented)
+			nodeGroupC.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
+			nodeGroupC.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "C1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "QUOTA",
+						},
+					},
+				},
+			}, nil)
+			provider = &mockprovider.CloudProvider{}
+			provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupC})
+			provider.On("NodeGroupForNode", mock.Anything).Return(nil, nil)
+			provider.On("HasInstance", mock.Anything).Return(
+				func(node *apiv1.Node) bool {
+					return false
+				}, nil)
+
+			clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+			autoscaler.clusterStateRegistry = clusterState
+
+			// update cluster state
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, time.Now())
+
+			// No nodes are deleted when failed nodes don't have matching node groups
+			autoscaler.deleteCreatedNodesWithErrors()
+			nodeGroupC.AssertNumberOfCalls(t, deleteMethod, 0)
+
+			// Node group with getOptions error gets no deletes.
+			nodeGroupError := &mockprovider.NodeGroup{}
+			nodeGroupError.On("Exist").Return(true)
+			nodeGroupError.On("Autoprovisioned").Return(false)
+			nodeGroupError.On("TargetSize").Return(1, nil)
+			nodeGroupError.On("Id").Return("E")
+			mockDeleteNodes(nodeGroupError, tc.forceDeleteEnabled, tc.forceDeleteImplemented)
+			nodeGroupError.On("GetOptions", options.NodeGroupDefaults).Return(nil, fmt.Errorf("Failed to get options"))
+			nodeGroupError.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "E1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
+				},
+				{
+
+					Id: "E2",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "QUOTA",
+						},
+					},
+				},
+			}, nil)
+
+			provider = &mockprovider.CloudProvider{}
+			provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupError})
+			provider.On("NodeGroupForNode", mock.Anything).Return(
+				func(node *apiv1.Node) cloudprovider.NodeGroup {
+					if strings.HasPrefix(node.Spec.ProviderID, "E") {
+						return nodeGroupError
+					}
+					return nil
+				}, nil).Times(2)
+
+			clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+			autoscaler.CloudProvider = provider
+			autoscaler.clusterStateRegistry = clusterState
+			// propagate nodes info in cluster state
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+
+			// delete nodes with create errors
+			autoscaler.deleteCreatedNodesWithErrors()
+
+			nodeGroupError.AssertNumberOfCalls(t, deleteMethod, 0)
+		})
 	}
+}
 
-	nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults)
-	asyncNodeGroupStateChecker := asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker()
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
-	autoscaler := &StaticAutoscaler{
-		AutoscalingContext:    &context,
-		clusterStateRegistry:  clusterState,
-		lastScaleUpTime:       time.Now(),
-		lastScaleDownFailTime: time.Now(),
-		processorCallbacks:    processorCallbacks,
+func mockDeleteNodes(nodeGroup *mockprovider.NodeGroup, forceDeleteEnabled, forceDeleteImplemented bool) {
+	if forceDeleteEnabled {
+		m := nodeGroup.On("ForceDeleteNodes", mock.Anything)
+		if forceDeleteImplemented {
+			m.Return(nil)
+		} else {
+			m.Return(cloudprovider.ErrNotImplemented)
+			nodeGroup.On("DeleteNodes", mock.Anything).Return(nil)
+		}
+	} else {
+		nodeGroup.On("DeleteNodes", mock.Anything).Return(nil)
 	}
-
-	nodeGroupA := &mockprovider.NodeGroup{}
-	nodeGroupB := &mockprovider.NodeGroup{}
-
-	// Three nodes with out-of-resources errors
-	nodeGroupA.On("Exist").Return(true)
-	nodeGroupA.On("Autoprovisioned").Return(false)
-	nodeGroupA.On("TargetSize").Return(5, nil)
-	nodeGroupA.On("Id").Return("A")
-	nodeGroupA.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupA.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
-	nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "A1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-			Id: "A2",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-			},
-		},
-		{
-			Id: "A3",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
-				},
-			},
-		},
-		{
-			Id: "A4",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
-				},
-			},
-		},
-		{
-			Id: "A5",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "QUOTA",
-				},
-			},
-		},
-		{
-			Id: "A6",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OtherErrorClass,
-					ErrorCode:  "OTHER",
-				},
-			},
-		},
-	}, nil).Twice()
-
-	nodeGroupB.On("Exist").Return(true)
-	nodeGroupB.On("Autoprovisioned").Return(false)
-	nodeGroupB.On("TargetSize").Return(5, nil)
-	nodeGroupB.On("Id").Return("B")
-	nodeGroupB.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupB.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
-	nodeGroupB.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "B1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-	}, nil)
-
-	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupA})
-	provider.On("NodeGroupForNode", mock.Anything).Return(
-		func(node *apiv1.Node) cloudprovider.NodeGroup {
-			if strings.HasPrefix(node.Spec.ProviderID, "A") {
-				return nodeGroupA
-			}
-			if strings.HasPrefix(node.Spec.ProviderID, "B") {
-				return nodeGroupB
-			}
-			return nil
-		}, nil)
-	provider.On("HasInstance", mock.Anything).Return(
-		func(node *apiv1.Node) bool {
-			return false
-		}, nil)
-
-	now := time.Now()
-
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-	// propagate nodes info in cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	// nodes should be deleted
-	expectedDeleteCalls := 1
-	nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
-
-	// check delete was called on correct nodes
-	nodeGroupA.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
-		func(nodes []*apiv1.Node) bool {
-			if len(nodes) != 4 {
-				return false
-			}
-			names := make(map[string]bool)
-			for _, node := range nodes {
-				names[node.Spec.ProviderID] = true
-			}
-			return names["A3"] && names["A4"] && names["A5"] && names["A6"]
-		}))
-
-	// TODO assert that scaleup was failed (separately for QUOTA and RESOURCE_POOL_EXHAUSTED)
-
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-
-	// propagate nodes info in cluster state again
-	// no changes in what provider returns
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	// nodes should be deleted again
-	expectedDeleteCalls += 1
-	nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
-
-	nodeGroupA.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
-		func(nodes []*apiv1.Node) bool {
-			if len(nodes) != 4 {
-				return false
-			}
-			names := make(map[string]bool)
-			for _, node := range nodes {
-				names[node.Spec.ProviderID] = true
-			}
-			return names["A3"] && names["A4"] && names["A5"] && names["A6"]
-		}))
-
-	// TODO assert that scaleup is not failed again
-
-	// restub node group A so nodes are no longer reporting errors
-	nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "A1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-			Id: "A2",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-			},
-		},
-		{
-			Id: "A3",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceDeleting,
-			},
-		},
-		{
-			Id: "A4",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceDeleting,
-			},
-		},
-		{
-			Id: "A5",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceDeleting,
-			},
-		},
-		{
-			Id: "A6",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceDeleting,
-			},
-		},
-	}, nil)
-
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-
-	// update cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	// we expect no more Delete Nodes, don't increase expectedDeleteCalls
-	nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
-
-	// failed node not included by NodeGroupForNode
-	nodeGroupC := &mockprovider.NodeGroup{}
-	nodeGroupC.On("Exist").Return(true)
-	nodeGroupC.On("Autoprovisioned").Return(false)
-	nodeGroupC.On("TargetSize").Return(1, nil)
-	nodeGroupC.On("Id").Return("C")
-	nodeGroupC.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupC.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
-	nodeGroupC.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "C1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "QUOTA",
-				},
-			},
-		},
-	}, nil)
-	provider = &mockprovider.CloudProvider{}
-	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupC})
-	provider.On("NodeGroupForNode", mock.Anything).Return(nil, nil)
-	provider.On("HasInstance", mock.Anything).Return(
-		func(node *apiv1.Node) bool {
-			return false
-		}, nil)
-
-	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-	autoscaler.clusterStateRegistry = clusterState
-
-	// update cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, time.Now())
-
-	// No nodes are deleted when failed nodes don't have matching node groups
-	autoscaler.deleteCreatedNodesWithErrors()
-	nodeGroupC.AssertNumberOfCalls(t, "DeleteNodes", 0)
-
-	nodeGroupAtomic := &mockprovider.NodeGroup{}
-	nodeGroupAtomic.On("Exist").Return(true)
-	nodeGroupAtomic.On("Autoprovisioned").Return(false)
-	nodeGroupAtomic.On("TargetSize").Return(3, nil)
-	nodeGroupAtomic.On("Id").Return("D")
-	nodeGroupAtomic.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupAtomic.On("GetOptions", options.NodeGroupDefaults).Return(
-		&config.NodeGroupAutoscalingOptions{
-			ZeroOrMaxNodeScaling: true,
-		}, nil)
-	nodeGroupAtomic.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "D1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-			Id: "D2",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-			Id: "D3",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OtherErrorClass,
-					ErrorCode:  "OTHER",
-				},
-			},
-		},
-	}, nil).Twice()
-	provider = &mockprovider.CloudProvider{}
-	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupAtomic})
-	provider.On("NodeGroupForNode", mock.Anything).Return(
-		func(node *apiv1.Node) cloudprovider.NodeGroup {
-			if strings.HasPrefix(node.Spec.ProviderID, "D") {
-				return nodeGroupAtomic
-			}
-			return nil
-		}, nil).Times(3)
-
-	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-	autoscaler.CloudProvider = provider
-	autoscaler.clusterStateRegistry = clusterState
-	// propagate nodes info in cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	nodeGroupAtomic.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
-		func(nodes []*apiv1.Node) bool {
-			if len(nodes) != 3 {
-				return false
-			}
-			names := make(map[string]bool)
-			for _, node := range nodes {
-				names[node.Spec.ProviderID] = true
-			}
-			return names["D1"] && names["D2"] && names["D3"]
-		}))
-
-	// Node group with getOptions error gets no deletes.
-	nodeGroupError := &mockprovider.NodeGroup{}
-	nodeGroupError.On("Exist").Return(true)
-	nodeGroupError.On("Autoprovisioned").Return(false)
-	nodeGroupError.On("TargetSize").Return(1, nil)
-	nodeGroupError.On("Id").Return("E")
-	nodeGroupError.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupError.On("GetOptions", options.NodeGroupDefaults).Return(nil, fmt.Errorf("Failed to get options"))
-	nodeGroupError.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "E1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-
-			Id: "E2",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "QUOTA",
-				},
-			},
-		},
-	}, nil)
-
-	provider = &mockprovider.CloudProvider{}
-	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupError})
-	provider.On("NodeGroupForNode", mock.Anything).Return(
-		func(node *apiv1.Node) cloudprovider.NodeGroup {
-			if strings.HasPrefix(node.Spec.ProviderID, "E") {
-				return nodeGroupError
-			}
-			return nil
-		}, nil).Times(2)
-
-	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-	autoscaler.CloudProvider = provider
-	autoscaler.clusterStateRegistry = clusterState
-	// propagate nodes info in cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	nodeGroupError.AssertNumberOfCalls(t, "DeleteNodes", 0)
 }
 
 type candidateTrackingFakePlanner struct {

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -281,6 +281,7 @@ var (
 	checkCapacityProvisioningRequestMaxBatchSize = flag.Int("check-capacity-provisioning-request-max-batch-size", 10, "Maximum number of provisioning requests to process in a single batch.")
 	checkCapacityProvisioningRequestBatchTimebox = flag.Duration("check-capacity-provisioning-request-batch-timebox", 10*time.Second, "Maximum time to process a batch of provisioning requests.")
 	forceDeleteLongUnregisteredNodes             = flag.Bool("force-delete-unregistered-nodes", false, "Whether to enable force deletion of long unregistered nodes, regardless of the min size of the node group the belong to.")
+	forceDeleteFailedNodes                       = flag.Bool("force-delete-failed-nodes", false, "Whether to enable force deletion of failed nodes, regardless of the min size of the node group the belong to.")
 	enableDynamicResourceAllocation              = flag.Bool("enable-dynamic-resource-allocation", false, "Whether logic for handling DRA (Dynamic Resource Allocation) objects is enabled.")
 )
 
@@ -461,6 +462,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		CheckCapacityProvisioningRequestMaxBatchSize: *checkCapacityProvisioningRequestMaxBatchSize,
 		CheckCapacityProvisioningRequestBatchTimebox: *checkCapacityProvisioningRequestBatchTimebox,
 		ForceDeleteLongUnregisteredNodes:             *forceDeleteLongUnregisteredNodes,
+		ForceDeleteFailedNodes:                       *forceDeleteFailedNodes,
 		DynamicResourceAllocationEnabled:             *enableDynamicResourceAllocation,
 	}
 }


### PR DESCRIPTION
DeleteNodes checks if the node group is below
its min size. If it is and a scale up fails,
CA is unable to clean up the instances
with errors, which causes CA ending up in
an error loop. Using ForceDeleteNodes instead,
so the min size won't be validated when
removing failed instances. 

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Need ForceDeleteFailedNodes in previous releases

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ensure created nodes with errors are deleted
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
