### PR TITLE
read min and max values from nodepool tags for oci autodiscovery

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -412,10 +412,34 @@ func (m *ociManagerImpl) TaintToPreventFurtherSchedulingOnRestart(nodes []*apiv1
 func (m *ociManagerImpl) forceRefresh() error {
 	// auto discover node groups
 	if m.nodeGroups != nil {
-		// empty previous nodepool map to do an auto discovery
+		// create a copy of m.staticNodePools to use it in comparison
+		staticNodePoolsCopy := make(map[string]NodePool)
+		for k, v := range m.staticNodePools {
+			staticNodePoolsCopy[k] = v
+		}
+
+		// empty previous nodepool map to do a fresh auto discovery
 		m.staticNodePools = make(map[string]NodePool)
+
+		// run auto-discovery
 		for _, nodeGroup := range m.nodeGroups {
 			autoDiscoverNodeGroups(m, m.okeClient, nodeGroup)
+		}
+
+		// compare the new and previous nodepool list to log the updates
+		for nodepoolId, nodepool := range m.staticNodePools {
+			if _, ok := staticNodePoolsCopy[nodepoolId]; !ok {
+				klog.Infof("New nodepool discovered. [id: %s ,minSize: %d, maxSize:%d]", nodepool.Id(), nodepool.MinSize(), nodepool.MaxSize())
+			} else if staticNodePoolsCopy[nodepoolId].MinSize() != nodepool.MinSize() || staticNodePoolsCopy[nodepoolId].MaxSize() != nodepool.MaxSize() {
+				klog.Infof("Nodepool min/max sizes are updated. [id: %s ,minSize: %d, maxSize:%d]", nodepool.Id(), nodepool.MinSize(), nodepool.MaxSize())
+			}
+		}
+
+		// log if there are nodepools removed from the list
+		for k := range staticNodePoolsCopy {
+			if _, ok := m.staticNodePools[k]; !ok {
+				klog.Infof("Previously auto-discovered nodepool removed from the managed nodepool list. nodepoolid: %s", k)
+			}
 		}
 	}
 	// rebuild nodepool cache


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR is to enhance the way node-group-auto-discovery parameter works. 

node-group-auto-discovery parameter already accepts min/max values from the user but all the nodepools captured by discovery options will inherit the same min/max values and there is no way to set nodepool specific values. 

With this change, users will be able to set nodepool specific min/max values by setting nodepool tags **minSize** and **maxSize**.

Lets suppose the cluster has 2 nodepools with the nodepool tags;
nodepool1 -> autoDiscover=true, minSize=2, maxSize=5
nodepool2 -> autoDiscover=true

And the **node-group-auto-discovery parameter** has values **min:1, max:3**. Then the nodepool sizes will be determined as;
nodepool1 -> min:2, max:5
nodepool2 -> min:1, max:3

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
It was tested on OCI. The v=4 logs are as below.
```
I0829 15:22:27.610593       1 oci_manager.go:360] node group auto discovery spec constructed: &{manager:<nil> kubeClient:<nil> clusterId:ocid1.clusterinteg.oc1.phx.aaaaaaaanfwwmxts7otqy5adgpggkgzycfoikxympk6woplbxc7cb22hjkdq compartmentId:ocid1.compartment.oc1..aaaaaaaa4jbgtpkasgxxx7gyirg7xby227rblq7dsduopn7neeca2yennfma tags:map[autoDiscover:true] minSize:1 maxSize:3}

I0829 15:58:39.694616       1 oci_manager.go:229] auto discovered nodepool in compartment : ocid1.compartment.oc1..aaaaaaaa4jbgtpkasgxxx7gyirg7xby227rblq7dsduopn7neeca2yennfma , nodepoolid: ocid1.nodepoolinteg.oc1.phx.aaaaaaaase6yj4ukfjrhq5utxtlb6ofnlzdolplcnlkgdhqsxnyiyirlyyxq ,minSize: 2, maxSize:5

I0829 15:58:39.694630       1 oci_manager.go:229] auto discovered nodepool in compartment : ocid1.compartment.oc1..aaaaaaaa4jbgtpkasgxxx7gyirg7xby227rblq7dsduopn7neeca2yennfma , nodepoolid: ocid1.nodepoolinteg.oc1.phx.aaaaaaaa6sn34zt42e2ebxfqelyvxynafbgyjcmdio3illy7yn4x7pxsu3hq ,minSize: 1, maxSize:3
```

#### Does this PR introduce a user-facing change?
```release-note
OCI: enable nodepool min and max values with node-group-auto-discovery
```

```docs

```
