### PR TITLE
hetzner: add node.kubernetes.io/instance-type label to template

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -389,6 +389,7 @@ func buildNodeGroupLabels(n *hetznerNodeGroup) (map[string]string, error) {
 
 	labels := map[string]string{
 		apiv1.LabelInstanceType:              n.instanceType,
+		apiv1.LabelInstanceTypeStable:        n.instanceType,
 		apiv1.LabelTopologyRegion:            n.region,
 		apiv1.LabelArchStable:                archLabel,
 		"csi.hetzner.cloud/location":         n.region,


### PR DESCRIPTION
apiv1.LabelInstanceType is the beta.kubernetes.io label, so we should consider both that and the stable node.kubernetes.io label in the template.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

none

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
cloudprovider/hetzner now includes `node.kubernetes.io/instance-type` in the node template, not only `beta.kubernetes.io/instance-type`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
