### PR TITLE
Update VPA version.go to 1.6.0 for release

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -21,7 +21,7 @@ package common
 var gitCommit = ""
 
 // versionCore is the version of VPA.
-const versionCore = "1.5.0"
+const versionCore = "1.6.0"
 
 // VerticalPodAutoscalerVersion returns the version of the VPA.
 func VerticalPodAutoscalerVersion() string {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Part of release - https://github.com/kubernetes/autoscaler/issues/8497. The 1.5.0 branch is already cut here: https://github.com/kubernetes/autoscaler/tree/vpa-release-1.5

#### Does this PR introduce a user-facing change?
```
NONE

```
