### PR TITLE
change kwok nodegroup annotation key, and update documentation

### DIFF
--- a/cluster-autoscaler/cloudprovider/kwok/README.md
+++ b/cluster-autoscaler/cloudprovider/kwok/README.md
@@ -81,13 +81,13 @@ kubectl create configmap kwok-provider-templates --from-file=templates=template-
 ```
 Replace `template-nodes.yaml` with the path to your template nodes file.
 
-If you are using your template nodes in the `kwok-provider-templates` ConfigMap, make sure you have set the correct value for `nodegroups.fromNodeLabelKey`/`nodegroups.fromNodeAnnotation`. Not doing so will make CA not scale up nodes (it won't throw any error either).
+If you are using your template nodes in the `kwok-provider-templates` ConfigMap, make sure you have set the correct value for `nodegroups.fromNodeLabelKey`/`nodegroups.fromNodeAnnotationKey`. Not doing so will make CA not scale up nodes (it won't throw any error either).
 
 If you want to use dynamic template nodes,
 
 Set `readNodesFrom` in `kwok-provider-config` ConfigMap to `cluster`. This tells the kwok provider to use live nodes from the cluster as template nodes.
 
-If you are using live nodes from the cluster as template nodes in the `kwok-provider-templates` ConfigMap, make sure you have set the correct value for `nodegroups.fromNodeLabelKey`/`nodegroups.fromNodeAnnotation`. Not doing so will make CA not scale up nodes (it won't throw any error either).
+If you are using live nodes from the cluster as template nodes in the `kwok-provider-templates` ConfigMap, make sure you have set the correct value for `nodegroups.fromNodeLabelKey`/`nodegroups.fromNodeAnnotationKey`. Not doing so will make CA not scale up nodes (it won't throw any error either).
 
 ### For local development
 1. Point your kubeconfig to the cluster where you want to test your changes
@@ -158,11 +158,11 @@ nodegroups:
   # nodegroup2: [node2]
   fromNodeLabelKey: "node.kubernetes.io/instance-type"
 
-  # fromNodeAnnotation's value is used to group nodes together into nodegroups
+  # fromNodeAnnotationKey's value is used to group nodes together into nodegroups
   # (basically same as `fromNodeLabelKey` except based on annotation)
-  # you can specify either of `fromNodeLabelKey` OR `fromNodeAnnotation`
+  # you can specify either of `fromNodeLabelKey` OR `fromNodeAnnotationKey`
   # (both are not allowed)
-  fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 # nodes specifies node level config
 nodes:
   # skipTaint is used to enable/disable adding kwok provider taint on the template nodes
@@ -211,7 +211,7 @@ kwok provider config is a configuration to change the behavior of the kwok provi
 
 ### Gotchas
 1. The kwok provider by default taints the template nodes with `kwok-provider: true` taint so that production workloads don't get scheduled on these nodes accidentally. You have to tolerate the taint to schedule your workload on the nodes created by the kwok provider. You can turn this off by setting `nodes.skipTaint: true` in the kwok provider config.
-2. Make sure the label/annotation for `fromNodeLabelKey`/`fromNodeAnnotation` in the kwok provider config is actually present on the template nodes. If it isn't present on the template nodes, the kwok provider will not be able to create new nodes.
+2. Make sure the label/annotation for `fromNodeLabelKey`/`fromNodeAnnotationKey` in the kwok provider config is actually present on the template nodes. If it isn't present on the template nodes, the kwok provider will not be able to create new nodes.
 3. Note that the kwok provider makes the following changes to all the template nodes:
 (pseudocode)
 ```

--- a/cluster-autoscaler/cloudprovider/kwok/kwok_config.go
+++ b/cluster-autoscaler/cloudprovider/kwok/kwok_config.go
@@ -111,12 +111,12 @@ func LoadConfigFile(kubeClient kubeclient.Interface) (*KwokProviderConfig, error
 	}
 
 	if strings.TrimSpace(kwokConfig.Nodegroups.FromNodeLabelKey) == "" &&
-		strings.TrimSpace(kwokConfig.Nodegroups.FromNodeLabelAnnotation) == "" {
-		return nil, fmt.Errorf("please specify either 'nodegroups.fromNodeLabelKey' or 'nodegroups.fromNodeAnnotation' in kwok provider config (currently empty or undefined)")
+		strings.TrimSpace(kwokConfig.Nodegroups.FromNodeAnnotationKey) == "" {
+		return nil, fmt.Errorf("please specify either 'nodegroups.fromNodeLabelKey' or 'nodegroups.fromNodeAnnotationKey' in kwok provider config (currently empty or undefined)")
 	}
 	if strings.TrimSpace(kwokConfig.Nodegroups.FromNodeLabelKey) != "" &&
-		strings.TrimSpace(kwokConfig.Nodegroups.FromNodeLabelAnnotation) != "" {
-		return nil, fmt.Errorf("please specify either 'nodegroups.fromNodeLabelKey' or 'nodegroups.fromNodeAnnotation' in kwok provider config (you can't use both)")
+		strings.TrimSpace(kwokConfig.Nodegroups.FromNodeAnnotationKey) != "" {
+		return nil, fmt.Errorf("please specify either 'nodegroups.fromNodeLabelKey' or 'nodegroups.fromNodeAnnotationKey' in kwok provider config (you can't use both)")
 	}
 
 	if strings.TrimSpace(kwokConfig.Nodegroups.FromNodeLabelKey) != "" {
@@ -124,7 +124,7 @@ func LoadConfigFile(kubeClient kubeclient.Interface) (*KwokProviderConfig, error
 		kwokConfig.status.key = kwokConfig.Nodegroups.FromNodeLabelKey
 	} else {
 		kwokConfig.status.groupNodesBy = groupNodesByAnnotation
-		kwokConfig.status.key = kwokConfig.Nodegroups.FromNodeLabelAnnotation
+		kwokConfig.status.key = kwokConfig.Nodegroups.FromNodeAnnotationKey
 	}
 
 	if kwokConfig.Nodes == nil {

--- a/cluster-autoscaler/cloudprovider/kwok/kwok_config_test.go
+++ b/cluster-autoscaler/cloudprovider/kwok/kwok_config_test.go
@@ -49,9 +49,9 @@ nodegroups:
   # nodegroup1: [node1,node3]
   # nodegroup2: [node2]
   fromNodeLabelKey: "kwok-nodegroup"
-  # you can either specify fromNodeLabelKey OR fromNodeAnnotation
+  # you can either specify fromNodeLabelKey OR fromNodeAnnotationKey
   # (both are not allowed)
-  # fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  # fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 nodes:
   gpuConfig:
     # to tell kwok provider what label should be considered as GPU label
@@ -77,9 +77,9 @@ nodegroups:
   # nodegroup1: [node1,node3]
   # nodegroup2: [node2]
   fromNodeLabelKey: "kwok-nodegroup"
-  # you can either specify fromNodeLabelKey OR fromNodeAnnotation
+  # you can either specify fromNodeLabelKey OR fromNodeAnnotationKey
   # (both are not allowed)
-  # fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  # fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 nodes:
   skipTaint: true
   gpuConfig:
@@ -104,9 +104,9 @@ nodegroups:
   # nodegroup1: [node1,node3]
   # nodegroup2: [node2]
   fromNodeLabelKey: "kwok-nodegroup"
-  # you can either specify fromNodeLabelKey OR fromNodeAnnotation
+  # you can either specify fromNodeLabelKey OR fromNodeAnnotationKey
   # (both are not allowed)
-  # fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  # fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 nodes:
   gpuConfig:
     # to tell kwok provider what label should be considered as GPU label
@@ -131,9 +131,9 @@ nodegroups:
   # nodegroup1: [node1,node3]
   # nodegroup2: [node2]
   fromNodeLabelKey: "kwok-nodegroup"
-  # you can either specify fromNodeLabelKey OR fromNodeAnnotation
+  # you can either specify fromNodeLabelKey OR fromNodeAnnotationKey
   # (both are not allowed)
-  # fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  # fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 nodes:
   skipTaint: true
   gpuConfig:
@@ -159,9 +159,9 @@ nodegroups:
   # nodegroup1: [node1,node3]
   # nodegroup2: [node2]
   fromNodeLabelKey: "node.kubernetes.io/instance-type"
-  # you can either specify fromNodeLabelKey OR fromNodeAnnotation
+  # you can either specify fromNodeLabelKey OR fromNodeAnnotationKey
   # (both are not allowed)
-  # fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  # fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 nodes:
   gpuConfig:
     # to tell kwok provider what label should be considered as GPU label
@@ -185,9 +185,9 @@ nodegroups:
   # nodegroup1: [node1,node3]
   # nodegroup2: [node2]
   fromNodeLabelKey: "node.kubernetes.io/instance-type"
-  # you can either specify fromNodeLabelKey OR fromNodeAnnotation
+  # you can either specify fromNodeLabelKey OR fromNodeAnnotationKey
   # (both are not allowed)
-  # fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  # fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 nodes:
   gpuConfig:
     # to tell kwok provider what label should be considered as GPU label
@@ -213,9 +213,9 @@ nodegroups:
   # nodegroup1: [node1,node3]
   # nodegroup2: [node2]
   fromNodeLabelKey: "node.kubernetes.io/instance-type"
-  # you can either specify fromNodeLabelKey OR fromNodeAnnotation
+  # you can either specify fromNodeLabelKey OR fromNodeAnnotationKey
   # (both are not allowed)
-  # fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  # fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 nodes:
   gpuConfig:
     # to tell kwok provider what label should be considered as GPU label

--- a/cluster-autoscaler/cloudprovider/kwok/kwok_types.go
+++ b/cluster-autoscaler/cloudprovider/kwok/kwok_types.go
@@ -63,8 +63,8 @@ type NodeGroup struct {
 
 // NodegroupsConfig defines options for creating nodegroups
 type NodegroupsConfig struct {
-	FromNodeLabelKey        string `json:"fromNodeLabelKey" yaml:"fromNodeLabelKey"`
-	FromNodeLabelAnnotation string `json:"fromNodeLabelAnnotation" yaml:"fromNodeLabelAnnotation"`
+	FromNodeLabelKey      string `json:"fromNodeLabelKey" yaml:"fromNodeLabelKey"`
+	FromNodeAnnotationKey string `json:"fromNodeAnnotationKey" yaml:"fromNodeAnnotationKey"`
 }
 
 // NodeConfig defines config options for the nodes

--- a/cluster-autoscaler/cloudprovider/kwok/samples/dynamic_nodegroups_config.yaml
+++ b/cluster-autoscaler/cloudprovider/kwok/samples/dynamic_nodegroups_config.yaml
@@ -9,9 +9,9 @@ nodegroups:
   # nodegroup1: [node1,node3]
   # nodegroup2: [node2]
   fromNodeLabelKey: "node.kubernetes.io/instance-type"
-  # you can either specify fromNodeLabelKey OR fromNodeAnnotation
+  # you can either specify fromNodeLabelKey OR fromNodeAnnotationKey
   # (both are not allowed)
-  # fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  # fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 
 nodes:
   # kwok provider adds a taint on the template nodes

--- a/cluster-autoscaler/cloudprovider/kwok/samples/static_nodegroups_config.yaml
+++ b/cluster-autoscaler/cloudprovider/kwok/samples/static_nodegroups_config.yaml
@@ -9,9 +9,9 @@ nodegroups:
   # nodegroup1: [node1,node3]
   # nodegroup2: [node2]
   fromNodeLabelKey: "node.kubernetes.io/instance-type"
-  # you can either specify fromNodeLabelKey OR fromNodeAnnotation
+  # you can either specify fromNodeLabelKey OR fromNodeAnnotationKey
   # (both are not allowed)
-  # fromNodeAnnotation: "eks.amazonaws.com/nodegroup"
+  # fromNodeAnnotationKey: "eks.amazonaws.com/nodegroup"
 nodes:
   # kwok provider adds a taint on the template nodes
   # so that even if you run the provider in a production cluster


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The KWOK cloud provider for Cluster Autoscaler states that you can specify either `nodegroups.fromNodeLabelKey` or `nodegroups.FromNodeAnnotation` to build the CA nodegroups in the provider.  However, the actual value in the source code is `fromNodeLabelKey` or `fromNodeLabelAnnotation`.

This PR changes the internal name for the annotation config to `fromNodeAnnotationKey` to match the same format as `fromNodeLabelKey`, and it updates the documentation and examples to match.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
change the KWOK cloud provider config from `nodegroups.fromNodeLabelAnnotation` to `nodegroups.fromNodeAnnotationKey`
```

#### Testing done
I spun this up in a local Kubernetes cluster; the log entry when the config value is incorrect now shows:

```
I0917 19:02:42.673778       1 main.go:341] Cluster Autoscaler 1.34.1
I0917 19:02:42.676368       1 framework.go:412] "the scheduler starts to work with those plugins" Plugins={"PreEnqueue":{"Enabled":[{"Name":"SchedulingGates","Weight":0},{"Name":"DynamicResources","Weight":0},{"Name":"DefaultPreemption","Weight":0}],"Disabled":null},"QueueSort":{"Enabled":[{"Name":"PrioritySort","Weight":0}],"D
isabled":null},"PreFilter":{"Enabled":[{"Name":"NodeAffinity","Weight":0},{"Name":"NodePorts","Weight":0},{"Name":"NodeResourcesFit","Weight":0},{"Name":"VolumeRestrictions","Weight":0},{"Name":"NodeVolumeLimits","Weight":0},{"Name":"VolumeBinding","Weight":0},{"Name":"VolumeZone","Weight":0},{"Name":"PodTopologySpread","Weight
":0},{"Name":"InterPodAffinity","Weight":0},{"Name":"DynamicResources","Weight":0}],"Disabled":null},"Filter":{"Enabled":[{"Name":"NodeUnschedulable","Weight":0},{"Name":"NodeName","Weight":0},{"Name":"TaintToleration","Weight":0},{"Name":"NodeAffinity","Weight":0},{"Name":"NodePorts","Weight":0},{"Name":"NodeResourcesFit","Wei
ght":0},{"Name":"VolumeRestrictions","Weight":0},{"Name":"NodeVolumeLimits","Weight":0},{"Name":"VolumeBinding","Weight":0},{"Name":"VolumeZone","Weight":0},{"Name":"PodTopologySpread","Weight":0},{"Name":"InterPodAffinity","Weight":0},{"Name":"DynamicResources","Weight":0}],"Disabled":null},"PostFilter":{"Enabled":[{"Name":"Dy
namicResources","Weight":0},{"Name":"DefaultPreemption","Weight":0}],"Disabled":null},"PreScore":{"Enabled":[{"Name":"TaintToleration","Weight":0},{"Name":"NodeAffinity","Weight":0},{"Name":"NodeResourcesFit","Weight":0},{"Name":"VolumeBinding","Weight":0},{"Name":"PodTopologySpread","Weight":0},{"Name":"InterPodAffinity","Weig
ht":0},{"Name":"NodeResourcesBalancedAllocation","Weight":0}],"Disabled":null},"Score":{"Enabled":[{"Name":"TaintToleration","Weight":3},{"Name":"NodeAffinity","Weight":2},{"Name":"NodeResourcesFit","Weight":1},{"Name":"VolumeBinding","Weight":1},{"Name":"PodTopologySpread","Weight":2},{"Name":"InterPodAffinity","Weight":2},{"N
ame":"NodeResourcesBalancedAllocation","Weight":1},{"Name":"ImageLocality","Weight":1}],"Disabled":null},"Reserve":{"Enabled":[{"Name":"VolumeBinding","Weight":0},{"Name":"DynamicResources","Weight":0}],"Disabled":null},"Permit":{"Enabled":null,"Disabled":null},"PreBind":{"Enabled":[{"Name":"VolumeBinding","Weight":0},{"Name":"
DynamicResources","Weight":0}],"Disabled":null},"Bind":{"Enabled":[{"Name":"DefaultBinder","Weight":0}],"Disabled":null},"PostBind":{"Enabled":null,"Disabled":null},"MultiPoint":{"Enabled":null,"Disabled":null}}
I0917 19:02:42.681857       1 cloud_provider_builder.go:30] Building kwok cloud provider.
I0917 19:02:42.682191       1 kwok_config.go:64] env variable 'KWOK_PROVIDER_CONFIGMAP' is empty (defaulting to 'kwok-provider-config')
I0917 19:02:42.682199       1 kwok_config.go:56] got current pod namespace 'kube-system'
F0917 19:02:42.683109       1 kwok_provider.go:214] failed to load kwok provider config: please specify either 'nodegroups.fromNodeLabelKey' or 'nodegroups.fromNodeAnnotationKey' in kwok provider config (currently empty or undefined)```

When the correct config value is specified, the KWOK cloud provider is able to spin up nodes.