### PR TITLE
Deprecate ProvisioningRequest v1beta1

### DIFF
--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_provisioningrequests.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_provisioningrequests.yaml
@@ -227,6 +227,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: v1beta1 ProvisioningRequest is deprecated
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_provisioningrequests.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_provisioningrequests.yaml
@@ -228,7 +228,7 @@ spec:
       name: Age
       type: date
     deprecated: true
-    deprecationWarning: v1beta1 ProvisioningRequest is deprecated
+    deprecationWarning: autoscaling.k8s.io/v1beta1 API is deprecated
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
@@ -29,6 +29,7 @@ import (
 // +genclient
 // +kubebuilder:storageversions
 // +kubebuilder:resource:shortName=provreq;provreqs
+// +k8s:prerelease-lifecycle-gen=true
 
 // ProvisioningRequest is a way to express additional capacity
 // that we would like to provision in the cluster. Cluster Autoscaler
@@ -38,6 +39,10 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:prerelease-lifecycle-gen:introduced=1.29.0
+// +k8s:prerelease-lifecycle-gen:deprecated=1.35.0
+// +k8s:prerelease-lifecycle-gen:replacement=autoscaling,v1,ProvisioningRequest
+// +kubebuilder:deprecatedversion:warning=v1beta1 ProvisioningRequest is deprecated
 type ProvisioningRequest struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata

--- a/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
@@ -40,9 +40,9 @@ import (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.29.0
-// +k8s:prerelease-lifecycle-gen:deprecated=1.35.0
+// +k8s:prerelease-lifecycle-gen:deprecated=1.34.0
 // +k8s:prerelease-lifecycle-gen:replacement=autoscaling,v1,ProvisioningRequest
-// +kubebuilder:deprecatedversion:warning=v1beta1 ProvisioningRequest is deprecated
+// +kubebuilder:deprecatedversion:warning=autoscaling.k8s.io/v1beta1 API is deprecated
 type ProvisioningRequest struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind api-change
/kind deprecation

#### What this PR does / why we need it:
v1 ProvisioningRequest has already been available for over a year and should be deprecated as per https://kubernetes.io/docs/reference/using-api/deprecation-policy/ 

#### Does this PR introduce a user-facing change?

Users will now see `v1beta1 ProvisioningRequest is deprecated` message when using v1beta1 ProvisioningRequest.

```release-note
Deprecate ProvisioningRequest v1beta1
```
