### PR TITLE
Allow atomic scale down of partially healthy node groups

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -485,7 +485,9 @@ func (tng *TestNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	id := tng.id
 	tng.targetSize -= len(nodes)
 	tng.Unlock()
-	if tng.opts != nil && tng.opts.ZeroOrMaxNodeScaling && tng.targetSize != 0 {
+	allNodes, _ := tng.Nodes()
+	currentSize := len(allNodes)
+	if tng.opts != nil && tng.opts.ZeroOrMaxNodeScaling && tng.targetSize != 0 && currentSize != len(nodes) {
 		return fmt.Errorf("TestNodeGroup: attempted to partially scale down a node group that should be scaled down atomically")
 	}
 	for _, node := range nodes {

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -67,6 +67,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/utilization"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/annotations"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -2800,17 +2801,17 @@ func TestFilterOutYoungPods(t *testing.T) {
 	p2 := BuildTestPod("p2", 500, 1000)
 	p2.CreationTimestamp = metav1.NewTime(now.Add(-1 * time.Minute))
 	p2.Annotations = map[string]string{
-		podScaleUpDelayAnnotationKey: "5m",
+		annotations.PodScaleUpDelayAnnotationKey: "5m",
 	}
 	p3 := BuildTestPod("p3", 500, 1000)
 	p3.CreationTimestamp = metav1.NewTime(now.Add(-1 * time.Minute))
 	p3.Annotations = map[string]string{
-		podScaleUpDelayAnnotationKey: "2m",
+		annotations.PodScaleUpDelayAnnotationKey: "2m",
 	}
 	p4 := BuildTestPod("p4", 500, 1000)
 	p4.CreationTimestamp = metav1.NewTime(now.Add(-1 * time.Minute))
 	p4.Annotations = map[string]string{
-		podScaleUpDelayAnnotationKey: "error",
+		annotations.PodScaleUpDelayAnnotationKey: "error",
 	}
 
 	tests := []struct {

--- a/cluster-autoscaler/processors/nodes/scale_down_set_processor.go
+++ b/cluster-autoscaler/processors/nodes/scale_down_set_processor.go
@@ -17,9 +17,15 @@ limitations under the License.
 package nodes
 
 import (
+	"slices"
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/annotations"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/klogx"
 	klog "k8s.io/klog/v2"
 )
@@ -72,7 +78,7 @@ func (p *CompositeScaleDownSetProcessor) CleanUp() {
 type AtomicResizeFilteringProcessor struct {
 }
 
-// FilterUnremovableNodes marks all candidate nodes as unremovable if ZeroOrMaxNodeScaling is enabled and number of nodes to remove are not equal to target size
+// FilterUnremovableNodes marks all candidate nodes as unremovable if ZeroOrMaxNodeScaling is enabled and number of nodes to remove are not equal to target or current size
 func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(ctx *context.AutoscalingContext, scaleDownCtx *ScaleDownContext, candidates []simulator.NodeToBeRemoved) ([]simulator.NodeToBeRemoved, []simulator.UnremovableNode) {
 	nodesToBeRemoved := []simulator.NodeToBeRemoved{}
 	unremovableNodes := []simulator.UnremovableNode{}
@@ -80,6 +86,11 @@ func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(ctx *context.Aut
 	atomicQuota := klogx.NodesLoggingQuota()
 	standardQuota := klogx.NodesLoggingQuota()
 	nodesByGroup := map[cloudprovider.NodeGroup][]simulator.NodeToBeRemoved{}
+	allNodes, err := allNodes(ctx.ClusterSnapshot)
+	if err != nil {
+		klog.Errorf("failed to read all nodes from the cluster snapshot for filtering unremovable nodes, err: %s", err)
+	}
+
 	for _, node := range candidates {
 		nodeGroup, err := ctx.CloudProvider.NodeGroupForNode(node.Node)
 		if err != nil {
@@ -103,26 +114,77 @@ func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(ctx *context.Aut
 	}
 	klogx.V(2).Over(atomicQuota).Infof("Considering %d other nodes for atomic scale down", -atomicQuota.Left())
 	klogx.V(2).Over(standardQuota).Infof("Considering %d other nodes for standard scale down", -atomicQuota.Left())
-	for nodeGroup, nodes := range nodesByGroup {
+	for nodeGroup, consideredNodes := range nodesByGroup {
 		ngSize, err := nodeGroup.TargetSize()
 		if err != nil {
 			klog.Errorf("Nodes from group %s will not scale down, failed to get target size: %s", nodeGroup.Id(), err)
-			for _, node := range nodes {
+			for _, node := range consideredNodes {
 				unremovableNodes = append(unremovableNodes, simulator.UnremovableNode{Node: node.Node, Reason: simulator.UnexpectedError})
 			}
 			continue
 		}
-		if ngSize == len(nodes) {
-			klog.V(2).Infof("Scheduling atomic scale down for all %v nodes from node group %s", len(nodes), nodeGroup.Id())
-			nodesToBeRemoved = append(nodesToBeRemoved, nodes...)
+		if ngSize == len(consideredNodes) {
+			klog.V(2).Infof("Scheduling atomic scale down for all %v nodes from node group %s", len(consideredNodes), nodeGroup.Id())
+			nodesToBeRemoved = append(nodesToBeRemoved, consideredNodes...)
 		} else {
-			klog.V(2).Infof("Skipping scale down for %v nodes from node group %s, all %v nodes have to be scaled down atomically", len(nodes), nodeGroup.Id(), ngSize)
-			for _, node := range nodes {
-				unremovableNodes = append(unremovableNodes, simulator.UnremovableNode{Node: node.Node, Reason: simulator.AtomicScaleDownFailed})
+			registeredNodes, err := p.getAllRegisteredNodesForNodeGroup(nodeGroup, allNodes)
+			if err != nil {
+				klog.Errorf("Failed to get registered nodes for group %s: %v", nodeGroup.Id(), err)
+				unremovableNodes = p.atomicScaleDownFailed(consideredNodes, ngSize, unremovableNodes, nodeGroup)
+			} else if len(registeredNodes) == len(consideredNodes) {
+				klog.V(2).Infof("Scheduling atomic scale down for all %v registered nodes from node group %s", len(consideredNodes), nodeGroup.Id())
+				nodesToBeRemoved = append(nodesToBeRemoved, consideredNodes...)
+			} else {
+				unremovableNodes = p.atomicScaleDownFailed(consideredNodes, len(registeredNodes), unremovableNodes, nodeGroup)
 			}
 		}
 	}
 	return nodesToBeRemoved, unremovableNodes
+}
+
+func (p *AtomicResizeFilteringProcessor) atomicScaleDownFailed(nodes []simulator.NodeToBeRemoved, ngSize int, unremovableNodes []simulator.UnremovableNode, nodeGroup cloudprovider.NodeGroup) []simulator.UnremovableNode {
+	klog.V(2).Infof("Skipping scale down for %v nodes from node group %s, all %v nodes have to be scaled down atomically", len(nodes), nodeGroup.Id(), ngSize)
+	unremovableNodes = slices.Grow(unremovableNodes, len(nodes))
+	for _, node := range nodes {
+		unremovableNodes = append(unremovableNodes, simulator.UnremovableNode{Node: node.Node, Reason: simulator.AtomicScaleDownFailed})
+	}
+	return unremovableNodes
+}
+
+func allNodes(s clustersnapshot.ClusterSnapshot) ([]*v1.Node, error) {
+	nodeInfos, err := s.ListNodeInfos()
+	if err != nil {
+		// This should never happen, List() returns err only because scheduler interface requires it.
+		return nil, err
+	}
+	nodes := make([]*v1.Node, len(nodeInfos))
+	for i, ni := range nodeInfos {
+		nodes[i] = ni.Node()
+	}
+	return nodes, nil
+}
+
+func (p *AtomicResizeFilteringProcessor) getAllRegisteredNodesForNodeGroup(nodeGroup cloudprovider.NodeGroup, allNodes []*v1.Node) ([]*v1.Node, error) {
+	allNodesInNodeGroup, err := nodeGroup.Nodes()
+	if err != nil {
+		return nil, err
+	}
+	nodeByNodeName := map[string]cloudprovider.Instance{}
+	for _, node := range allNodesInNodeGroup {
+		nodeByNodeName[node.Id] = node
+	}
+	var registeredNodesForNodeGroup []*v1.Node
+	for _, node := range allNodes {
+		if val, ok := node.Annotations[annotations.NodeUpcomingAnnotation]; ok {
+			if res, ok := strconv.ParseBool(val); ok == nil && res {
+				continue
+			}
+		}
+		if _, ok := nodeByNodeName[node.Spec.ProviderID]; ok {
+			registeredNodesForNodeGroup = append(registeredNodesForNodeGroup, node)
+		}
+	}
+	return registeredNodesForNodeGroup, nil
 }
 
 // CleanUp is called at CA termination

--- a/cluster-autoscaler/utils/annotations/annotations.go
+++ b/cluster-autoscaler/utils/annotations/annotations.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+const (
+	// NodeUpcomingAnnotation is an annotation CA adds to nodes which are upcoming.
+	NodeUpcomingAnnotation = "cluster-autoscaler.k8s.io/upcoming-node"
+
+	// PodScaleUpDelayAnnotationKey is an annotation how long pod can wait to be scaled up.
+	PodScaleUpDelayAnnotationKey = "cluster-autoscaler.kubernetes.io/pod-scale-up-delay"
+)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
After introduction of `AllowNonAtomicScaleUpToMax` autoscaling option scale down does not work for zero-or-max node pools which have fewer nodes than pool's target size (e.g. due to node creation errors). CA scales such pools down only if the number of underutilized nodes is equal to pool's target size. This PR changes the scale down behavior, that is, onwards **cluster-autoscaler will also allow scale down of atomic node pools if number of underutilized nodes is equal to the number of currently registered nodes of the node pool (e.g. equal to number of healthy instances).

#### Special notes for your reviewer:
PR was tested manually on GKE cluster using zero-or-max scaling node pool.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
