### PR TITLE
deps(hetzner): update vendored hcloud-go to v2.24.0

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/client.go
@@ -304,6 +304,7 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body io.Re
 		return nil, err
 	}
 	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Accept", "application/json")
 
 	if !c.tokenValid {
 		return nil, errors.New("Authorization token contains invalid characters")

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/deprecation.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/deprecation.go
@@ -22,8 +22,8 @@ type DeprecationInfo struct {
 	UnavailableAfter time.Time
 }
 
-// DeprecatableResource implements the [Deprecatable] interface and can be embedded in structs for Resources that can be
-// deprecated.
+// DeprecatableResource implements the [Deprecatable] interface and can be embedded in structs for Resources that can
+// be deprecated.
 type DeprecatableResource struct {
 	Deprecation *DeprecationInfo
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/error.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/error.go
@@ -30,16 +30,26 @@ const (
 	ErrorCodeConflict              ErrorCode = "conflict"                // The resource has changed during the request, please retry
 	ErrorCodeRobotUnavailable      ErrorCode = "robot_unavailable"       // Robot was not available. The caller may retry the operation after a short delay
 	ErrorCodeResourceLocked        ErrorCode = "resource_locked"         // The resource is locked. The caller should contact support
+	ErrorCodeServerError           ErrorCode = "server_error"            // Error within the API backend
+	ErrorCodeTokenReadonly         ErrorCode = "token_readonly"          // The token is only allowed to perform GET requests
+	ErrorCodeTimeout               ErrorCode = "timeout"                 // The request could not be answered in time, please retry
 	ErrorUnsupportedError          ErrorCode = "unsupported_error"       // The given resource does not support this
 	ErrorDeprecatedAPIEndpoint     ErrorCode = "deprecated_api_endpoint" // The request can not be answered because the API functionality was removed
 
 	// Server related error codes.
 
-	ErrorCodeInvalidServerType     ErrorCode = "invalid_server_type"     // The server type does not fit for the given server or is deprecated
-	ErrorCodeServerNotStopped      ErrorCode = "server_not_stopped"      // The action requires a stopped server
-	ErrorCodeNetworksOverlap       ErrorCode = "networks_overlap"        // The network IP range overlaps with one of the server networks
-	ErrorCodePlacementError        ErrorCode = "placement_error"         // An error during the placement occurred
-	ErrorCodeServerAlreadyAttached ErrorCode = "server_already_attached" // The server is already attached to the resource
+	ErrorCodeInvalidServerType           ErrorCode = "invalid_server_type"            // The server type does not fit for the given server or is deprecated
+	ErrorCodeServerNotStopped            ErrorCode = "server_not_stopped"             // The action requires a stopped server
+	ErrorCodeNetworksOverlap             ErrorCode = "networks_overlap"               // The network IP range overlaps with one of the server networks
+	ErrorCodePlacementError              ErrorCode = "placement_error"                // An error during the placement occurred
+	ErrorCodeServerAlreadyAttached       ErrorCode = "server_already_attached"        // The server is already attached to the resource
+	ErrorCodePrimaryIPAssigned           ErrorCode = "primary_ip_assigned"            // The specified Primary IP is already assigned to a server
+	ErrorCodePrimaryIPDatacenterMismatch ErrorCode = "primary_ip_datacenter_mismatch" // The specified Primary IP is in a different datacenter
+	ErrorCodePrimaryIPVersionMismatch    ErrorCode = "primary_ip_version_mismatch"    // The specified Primary IP has the wrong IP Version
+	ErrorCodeServerHasIPv4               ErrorCode = "server_has_ipv4"                // The Server already has an ipv4 address
+	ErrorCodeServerHasIPv6               ErrorCode = "server_has_ipv6"                // The Server already has an ipv6 address
+	ErrorCodePrimaryIPAlreadyAssigned    ErrorCode = "primary_ip_already_assigned"    // Primary IP is already assigned to a different Server
+	ErrorCodeServerIsLoadBalancerTarget  ErrorCode = "server_is_load_balancer_target" // The Server IPv4 address is a loadbalancer target
 
 	// Load Balancer related error codes.
 
@@ -52,6 +62,7 @@ const (
 	ErrorCodeLoadBalancerAlreadyAttached      ErrorCode = "load_balancer_already_attached"        // The Load Balancer is already attached to a network
 	ErrorCodeTargetsWithoutUsePrivateIP       ErrorCode = "targets_without_use_private_ip"        // The Load Balancer has targets that use the public IP instead of the private IP
 	ErrorCodeLoadBalancerNotAttachedToNetwork ErrorCode = "load_balancer_not_attached_to_network" // The Load Balancer is not attached to a network
+	ErrorCodeMissingIPv4                      ErrorCode = "missing_ipv4"                          // The server that you are trying to add as a public target does not have a public IPv4 address
 
 	// Network related error codes.
 
@@ -66,12 +77,14 @@ const (
 
 	// Firewall related error codes.
 
-	ErrorCodeFirewallAlreadyApplied   ErrorCode = "firewall_already_applied"    // Firewall was already applied on resource
-	ErrorCodeFirewallAlreadyRemoved   ErrorCode = "firewall_already_removed"    // Firewall was already removed from the resource
-	ErrorCodeIncompatibleNetworkType  ErrorCode = "incompatible_network_type"   // The Network type is incompatible for the given resource
-	ErrorCodeResourceInUse            ErrorCode = "resource_in_use"             // Firewall must not be in use to be deleted
-	ErrorCodeServerAlreadyAdded       ErrorCode = "server_already_added"        // Server added more than one time to resource
-	ErrorCodeFirewallResourceNotFound ErrorCode = "firewall_resource_not_found" // Resource a firewall should be attached to / detached from not found
+	ErrorCodeFirewallAlreadyApplied         ErrorCode = "firewall_already_applied"           // Firewall was already applied on resource
+	ErrorCodeFirewallAlreadyRemoved         ErrorCode = "firewall_already_removed"           // Firewall was already removed from the resource
+	ErrorCodeIncompatibleNetworkType        ErrorCode = "incompatible_network_type"          // The Network type is incompatible for the given resource
+	ErrorCodeResourceInUse                  ErrorCode = "resource_in_use"                    // Firewall must not be in use to be deleted
+	ErrorCodeServerAlreadyAdded             ErrorCode = "server_already_added"               // Server added more than one time to resource
+	ErrorCodeFirewallResourceNotFound       ErrorCode = "firewall_resource_not_found"        // Resource a firewall should be attached to / detached from not found
+	ErrorCodeFirewallManagedByLabelSelector ErrorCode = "firewall_managed_by_label_selector" // Firewall is applied via a Label Selector and cannot be removed manually
+	ErrorCodePrivateNetOnlyServer           ErrorCode = "private_net_only_server"            // The Server the Firewall should be applied to has no public interface
 
 	// Certificate related error codes.
 
@@ -82,6 +95,7 @@ const (
 	ErrorCodeCATooManyDuplicateCertificates                 ErrorCode = "ca_too_many_duplicate_certificates"                    // Certificate Authority: Too many duplicate certificates
 	ErrorCodeCloudNotVerifyDomainDelegatedToZone            ErrorCode = "could_not_verify_domain_delegated_to_zone"             // Could not verify domain delegated to zone
 	ErrorCodeDNSZoneNotFound                                ErrorCode = "dns_zone_not_found"                                    // DNS zone not found
+	ErrorCodeDNSZoneIsSecondaryZone                         ErrorCode = "dns_zone_is_secondary_zone"                            // DNS zone is a secondary zone
 
 	// Deprecated error codes.
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/actionutil/actions.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/actionutil/actions.go
@@ -3,6 +3,8 @@ package actionutil
 import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud"
 
 // AppendNext return the action and the next actions in a new slice.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func AppendNext(action *hcloud.Action, nextActions []*hcloud.Action) []*hcloud.Action {
 	all := make([]*hcloud.Action, 0, 1+len(nextActions))
 	all = append(all, action)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/ctxutil/ctxutil.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/ctxutil/ctxutil.go
@@ -12,6 +12,8 @@ type key struct{}
 var opPathKey = key{}
 
 // SetOpPath processes the operation path and save it in the context before returning it.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func SetOpPath(ctx context.Context, path string) context.Context {
 	path, _, _ = strings.Cut(path, "?")
 	path = strings.ReplaceAll(path, "%d", "-")
@@ -21,6 +23,8 @@ func SetOpPath(ctx context.Context, path string) context.Context {
 }
 
 // OpPath returns the operation path from the context.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func OpPath(ctx context.Context) string {
 	result, ok := ctx.Value(opPathKey).(string)
 	if !ok {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/doc.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/doc.go
@@ -1,4 +1,4 @@
 // Package exp is a namespace that holds experimental features for the `hcloud-go` library.
 //
-// Breaking changes may occur without notice. Do not use in production!
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 package exp

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/envutil/env.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/envutil/env.go
@@ -14,6 +14,8 @@ import (
 // For both cases, the returned value may be empty.
 //
 // The value from the environment takes precedence over the value from the file.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func LookupEnvWithFile(key string) (string, error) {
 	// Check if the value is set in the environment (e.g. HCLOUD_TOKEN)
 	value, ok := os.LookupEnv(key)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/randutil/id.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/randutil/id.go
@@ -8,6 +8,8 @@ import (
 
 // GenerateID returns a hex encoded random string with a len of 8 chars similar to
 // "2873fce7".
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func GenerateID() string {
 	b := make([]byte, 4)
 	_, err := rand.Read(b)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/sshutil/ssh_key.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/kit/sshutil/ssh_key.go
@@ -11,6 +11,8 @@ import (
 
 // GenerateKeyPair generates a new ed25519 ssh key pair, and returns the private key and
 // the public key respectively.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func GenerateKeyPair() ([]byte, []byte, error) {
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -54,6 +56,8 @@ type privateKeyWithPublicKey interface {
 }
 
 // GeneratePublicKey generate a public key from the provided private key.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func GeneratePublicKey(privBytes []byte) ([]byte, error) {
 	priv, err := ssh.ParseRawPrivateKey(privBytes)
 	if err != nil {
@@ -74,6 +78,8 @@ func GeneratePublicKey(privBytes []byte) ([]byte, error) {
 }
 
 // GetPublicKeyFingerprint generate the finger print for the provided public key.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func GetPublicKeyFingerprint(pubBytes []byte) (string, error) {
 	pub, _, _, _, err := ssh.ParseAuthorizedKey(pubBytes)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/labelutil/selector.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/labelutil/selector.go
@@ -6,10 +6,12 @@ import (
 	"strings"
 )
 
-// Selector combines the label set into a [label selector](https://docs.hetzner.cloud/#label-selector) that only selects
+// Selector combines the label set into a [label selector](https://docs.hetzner.cloud/reference/cloud#label-selector) that only selects
 // resources have all specified labels set.
 //
 // The selector string can be used to filter resources when listing, for example with [hcloud.ServerClient.AllWithOpts()].
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func Selector(labels map[string]string) string {
 	selectors := make([]string, 0, len(labels))
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/mockutil/http.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/exp/mockutil/http.go
@@ -28,6 +28,8 @@ type Request struct {
 }
 
 // Handler is using a [Server] to mock http requests provided by the user.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func Handler(t *testing.T, requests []Request) http.HandlerFunc {
 	t.Helper()
 
@@ -38,6 +40,8 @@ func Handler(t *testing.T, requests []Request) http.HandlerFunc {
 }
 
 // NewServer returns a new mock server that closes itself at the end of the test.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func NewServer(t *testing.T, requests []Request) *Server {
 	t.Helper()
 
@@ -56,6 +60,8 @@ func NewServer(t *testing.T, requests []Request) *Server {
 // iterated over.
 //
 // A Server must be created using the [NewServer] function.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 type Server struct {
 	*httptest.Server
 
@@ -66,6 +72,8 @@ type Server struct {
 }
 
 // Expect adds requests to the list of requests expected by the [Server].
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
 func (m *Server) Expect(requests []Request) {
 	m.requests = append(m.requests, requests...)
 }

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/firewall.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/firewall.go
@@ -73,6 +73,9 @@ type FirewallResource struct {
 	Type          FirewallResourceType
 	Server        *FirewallResourceServer
 	LabelSelector *FirewallResourceLabelSelector
+	// AppliedToResources is only used if the Type is FirewallResourceTypeLabelSelector.
+	// FirewallResources contained here cannot be of type FirewallResourceTypeLabelSelector.
+	AppliedToResources []FirewallResource
 }
 
 // FirewallResourceServer represents a Server to apply a Firewall on.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/hcloud.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/hcloud.go
@@ -31,4 +31,4 @@ breaking changes.
 package hcloud
 
 // Version is the library's version following Semantic Versioning.
-const Version = "2.21.1" // x-releaser-pleaser-version
+const Version = "2.24.0" // x-releaser-pleaser-version

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/load_balancer.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/load_balancer.go
@@ -765,6 +765,7 @@ func (c *LoadBalancerClient) ChangeAlgorithm(ctx context.Context, loadBalancer *
 type LoadBalancerAttachToNetworkOpts struct {
 	Network *Network
 	IP      net.IP
+	IPRange *net.IPNet
 }
 
 // AttachToNetwork attaches a Load Balancer to a network.
@@ -779,6 +780,9 @@ func (c *LoadBalancerClient) AttachToNetwork(ctx context.Context, loadBalancer *
 	}
 	if opts.IP != nil {
 		reqBody.IP = Ptr(opts.IP.String())
+	}
+	if opts.IPRange != nil {
+		reqBody.IPRange = Ptr(opts.IPRange.String())
 	}
 
 	respBody, resp, err := postRequest[schema.LoadBalancerActionAttachToNetworkResponse](ctx, c.client, reqPath, reqBody)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/pricing.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/pricing.go
@@ -9,6 +9,9 @@ import (
 
 // Pricing specifies pricing information for various resources.
 type Pricing struct {
+	Currency string
+	VATRate  string
+
 	Image ImagePricing
 	// Deprecated: [Pricing.FloatingIP] is deprecated, use [Pricing.FloatingIPs] instead.
 	FloatingIP  FloatingIPPricing

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/firewall.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/firewall.go
@@ -52,9 +52,10 @@ type FirewallCreateRequest struct {
 
 // FirewallResource defines the schema of a resource to apply the new Firewall on.
 type FirewallResource struct {
-	Type          string                         `json:"type"`
-	Server        *FirewallResourceServer        `json:"server,omitempty"`
-	LabelSelector *FirewallResourceLabelSelector `json:"label_selector,omitempty"`
+	Type               string                         `json:"type"`
+	Server             *FirewallResourceServer        `json:"server,omitempty"`
+	LabelSelector      *FirewallResourceLabelSelector `json:"label_selector,omitempty"`
+	AppliedToResources []FirewallResource             `json:"applied_to_resources,omitempty"`
 }
 
 // FirewallResourceLabelSelector defines the schema of a LabelSelector to apply a Firewall on.

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/load_balancer.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/load_balancer.go
@@ -353,6 +353,7 @@ type LoadBalancerActionChangeAlgorithmResponse struct {
 type LoadBalancerActionAttachToNetworkRequest struct {
 	Network int64   `json:"network"`
 	IP      *string `json:"ip,omitempty"`
+	IPRange *string `json:"ip_range,omitempty"`
 }
 
 type LoadBalancerActionAttachToNetworkResponse struct {

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/primary_ip.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/primary_ip.go
@@ -34,13 +34,13 @@ type PrimaryIPDNSPTR struct {
 // PrimaryIPCreateOpts defines the request to
 // create a Primary IP.
 type PrimaryIPCreateRequest struct {
-	Name         string            `json:"name"`
-	Type         string            `json:"type"`
-	AssigneeType string            `json:"assignee_type"`
-	AssigneeID   *int64            `json:"assignee_id,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	AutoDelete   *bool             `json:"auto_delete,omitempty"`
-	Datacenter   string            `json:"datacenter,omitempty"`
+	Name         string             `json:"name"`
+	Type         string             `json:"type"`
+	AssigneeType string             `json:"assignee_type"`
+	AssigneeID   *int64             `json:"assignee_id,omitempty"`
+	Labels       *map[string]string `json:"labels,omitempty"`
+	AutoDelete   *bool              `json:"auto_delete,omitempty"`
+	Datacenter   string             `json:"datacenter,omitempty"`
 }
 
 // PrimaryIPCreateResponse defines the schema of the response
@@ -63,9 +63,9 @@ type PrimaryIPListResponse struct {
 // PrimaryIPUpdateOpts defines the request to
 // update a Primary IP.
 type PrimaryIPUpdateRequest struct {
-	Name       string            `json:"name,omitempty"`
-	Labels     map[string]string `json:"labels,omitempty"`
-	AutoDelete *bool             `json:"auto_delete,omitempty"`
+	Name       string             `json:"name,omitempty"`
+	Labels     *map[string]string `json:"labels,omitempty"`
+	AutoDelete *bool              `json:"auto_delete,omitempty"`
 }
 
 // PrimaryIPUpdateResponse defines the response

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server.go
@@ -362,6 +362,7 @@ type ServerActionAttachToNetworkRequest struct {
 	Network  int64     `json:"network"`
 	IP       *string   `json:"ip,omitempty"`
 	AliasIPs []*string `json:"alias_ips,omitempty"`
+	IPRange  *string   `json:"ip_range,omitempty"`
 }
 
 // ServerActionAttachToNetworkResponse defines the schema of the response when

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/schema/server_type.go
@@ -5,6 +5,7 @@ type ServerType struct {
 	ID           int64   `json:"id"`
 	Name         string  `json:"name"`
 	Description  string  `json:"description"`
+	Category     string  `json:"category"`
 	Cores        int     `json:"cores"`
 	Memory       float32 `json:"memory"`
 	Disk         int     `json:"disk"`

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server.go
@@ -905,6 +905,7 @@ type ServerAttachToNetworkOpts struct {
 	Network  *Network
 	IP       net.IP
 	AliasIPs []net.IP
+	IPRange  *net.IPNet
 }
 
 // AttachToNetwork attaches a server to a network.
@@ -922,6 +923,10 @@ func (c *ServerClient) AttachToNetwork(ctx context.Context, server *Server, opts
 	}
 	for _, aliasIP := range opts.AliasIPs {
 		reqBody.AliasIPs = append(reqBody.AliasIPs, Ptr(aliasIP.String()))
+	}
+
+	if opts.IPRange != nil {
+		reqBody.IPRange = Ptr(opts.IPRange.String())
 	}
 
 	respBody, resp, err := postRequest[schema.ServerActionAttachToNetworkResponse](ctx, c.client, reqPath, reqBody)

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server_type.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/server_type.go
@@ -15,6 +15,7 @@ type ServerType struct {
 	ID           int64
 	Name         string
 	Description  string
+	Category     string
 	Cores        int
 	Memory       float32
 	Disk         int

--- a/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_schema.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud/zz_schema.go
@@ -247,14 +247,12 @@ func (c *converterImpl) LoadBalancerServiceFromSchema(source schema.LoadBalancer
 func (c *converterImpl) LoadBalancerServiceHealthCheckFromSchema(source *schema.LoadBalancerServiceHealthCheck) LoadBalancerServiceHealthCheck {
 	var hcloudLoadBalancerServiceHealthCheck LoadBalancerServiceHealthCheck
 	if source != nil {
-		var hcloudLoadBalancerServiceHealthCheck2 LoadBalancerServiceHealthCheck
-		hcloudLoadBalancerServiceHealthCheck2.Protocol = LoadBalancerServiceProtocol((*source).Protocol)
-		hcloudLoadBalancerServiceHealthCheck2.Port = (*source).Port
-		hcloudLoadBalancerServiceHealthCheck2.Interval = durationFromIntSeconds((*source).Interval)
-		hcloudLoadBalancerServiceHealthCheck2.Timeout = durationFromIntSeconds((*source).Timeout)
-		hcloudLoadBalancerServiceHealthCheck2.Retries = (*source).Retries
-		hcloudLoadBalancerServiceHealthCheck2.HTTP = c.pSchemaLoadBalancerServiceHealthCheckHTTPToPHcloudLoadBalancerServiceHealthCheckHTTP((*source).HTTP)
-		hcloudLoadBalancerServiceHealthCheck = hcloudLoadBalancerServiceHealthCheck2
+		hcloudLoadBalancerServiceHealthCheck.Protocol = LoadBalancerServiceProtocol((*source).Protocol)
+		hcloudLoadBalancerServiceHealthCheck.Port = (*source).Port
+		hcloudLoadBalancerServiceHealthCheck.Interval = durationFromIntSeconds((*source).Interval)
+		hcloudLoadBalancerServiceHealthCheck.Timeout = durationFromIntSeconds((*source).Timeout)
+		hcloudLoadBalancerServiceHealthCheck.Retries = (*source).Retries
+		hcloudLoadBalancerServiceHealthCheck.HTTP = c.pSchemaLoadBalancerServiceHealthCheckHTTPToPHcloudLoadBalancerServiceHealthCheckHTTP((*source).HTTP)
 	}
 	return hcloudLoadBalancerServiceHealthCheck
 }
@@ -414,6 +412,8 @@ func (c *converterImpl) PriceFromSchema(source schema.Price) Price {
 }
 func (c *converterImpl) PricingFromSchema(source schema.Pricing) Pricing {
 	var hcloudPricing Pricing
+	hcloudPricing.Currency = source.Currency
+	hcloudPricing.VATRate = source.VATRate
 	hcloudPricing.Image = imagePricingFromSchema(source)
 	hcloudPricing.FloatingIP = floatingIPPricingFromSchema(source)
 	hcloudPricing.FloatingIPs = floatingIPTypePricingFromSchema(source)
@@ -458,21 +458,19 @@ func (c *converterImpl) SSHKeyFromSchema(source schema.SSHKey) *SSHKey {
 func (c *converterImpl) SchemaFromAction(source *Action) schema.Action {
 	var schemaAction schema.Action
 	if source != nil {
-		var schemaAction2 schema.Action
-		schemaAction2.ID = (*source).ID
-		schemaAction2.Status = string((*source).Status)
-		schemaAction2.Command = (*source).Command
-		schemaAction2.Progress = (*source).Progress
-		schemaAction2.Started = c.timeTimeToTimeTime((*source).Started)
-		schemaAction2.Finished = timeToTimePtr((*source).Finished)
-		schemaAction2.Error = schemaActionErrorFromAction((*source))
+		schemaAction.ID = (*source).ID
+		schemaAction.Status = string((*source).Status)
+		schemaAction.Command = (*source).Command
+		schemaAction.Progress = (*source).Progress
+		schemaAction.Started = c.timeTimeToTimeTime((*source).Started)
+		schemaAction.Finished = timeToTimePtr((*source).Finished)
+		schemaAction.Error = schemaActionErrorFromAction((*source))
 		if (*source).Resources != nil {
-			schemaAction2.Resources = make([]schema.ActionResourceReference, len((*source).Resources))
+			schemaAction.Resources = make([]schema.ActionResourceReference, len((*source).Resources))
 			for i := 0; i < len((*source).Resources); i++ {
-				schemaAction2.Resources[i] = c.pHcloudActionResourceToSchemaActionResourceReference((*source).Resources[i])
+				schemaAction.Resources[i] = c.pHcloudActionResourceToSchemaActionResourceReference((*source).Resources[i])
 			}
 		}
-		schemaAction = schemaAction2
 	}
 	return schemaAction
 }
@@ -489,38 +487,34 @@ func (c *converterImpl) SchemaFromActions(source []*Action) []schema.Action {
 func (c *converterImpl) SchemaFromCertificate(source *Certificate) schema.Certificate {
 	var schemaCertificate schema.Certificate
 	if source != nil {
-		var schemaCertificate2 schema.Certificate
-		schemaCertificate2.ID = (*source).ID
-		schemaCertificate2.Name = (*source).Name
-		schemaCertificate2.Labels = (*source).Labels
-		schemaCertificate2.Type = string((*source).Type)
-		schemaCertificate2.Certificate = (*source).Certificate
-		schemaCertificate2.Created = c.timeTimeToTimeTime((*source).Created)
-		schemaCertificate2.NotValidBefore = c.timeTimeToTimeTime((*source).NotValidBefore)
-		schemaCertificate2.NotValidAfter = c.timeTimeToTimeTime((*source).NotValidAfter)
-		schemaCertificate2.DomainNames = (*source).DomainNames
-		schemaCertificate2.Fingerprint = (*source).Fingerprint
-		schemaCertificate2.Status = c.pHcloudCertificateStatusToPSchemaCertificateStatusRef((*source).Status)
+		schemaCertificate.ID = (*source).ID
+		schemaCertificate.Name = (*source).Name
+		schemaCertificate.Labels = (*source).Labels
+		schemaCertificate.Type = string((*source).Type)
+		schemaCertificate.Certificate = (*source).Certificate
+		schemaCertificate.Created = c.timeTimeToTimeTime((*source).Created)
+		schemaCertificate.NotValidBefore = c.timeTimeToTimeTime((*source).NotValidBefore)
+		schemaCertificate.NotValidAfter = c.timeTimeToTimeTime((*source).NotValidAfter)
+		schemaCertificate.DomainNames = (*source).DomainNames
+		schemaCertificate.Fingerprint = (*source).Fingerprint
+		schemaCertificate.Status = c.pHcloudCertificateStatusToPSchemaCertificateStatusRef((*source).Status)
 		if (*source).UsedBy != nil {
-			schemaCertificate2.UsedBy = make([]schema.CertificateUsedByRef, len((*source).UsedBy))
+			schemaCertificate.UsedBy = make([]schema.CertificateUsedByRef, len((*source).UsedBy))
 			for i := 0; i < len((*source).UsedBy); i++ {
-				schemaCertificate2.UsedBy[i] = c.hcloudCertificateUsedByRefToSchemaCertificateUsedByRef((*source).UsedBy[i])
+				schemaCertificate.UsedBy[i] = c.hcloudCertificateUsedByRefToSchemaCertificateUsedByRef((*source).UsedBy[i])
 			}
 		}
-		schemaCertificate = schemaCertificate2
 	}
 	return schemaCertificate
 }
 func (c *converterImpl) SchemaFromDatacenter(source *Datacenter) schema.Datacenter {
 	var schemaDatacenter schema.Datacenter
 	if source != nil {
-		var schemaDatacenter2 schema.Datacenter
-		schemaDatacenter2.ID = (*source).ID
-		schemaDatacenter2.Name = (*source).Name
-		schemaDatacenter2.Description = (*source).Description
-		schemaDatacenter2.Location = c.SchemaFromLocation((*source).Location)
-		schemaDatacenter2.ServerTypes = c.hcloudDatacenterServerTypesToSchemaDatacenterServerTypes((*source).ServerTypes)
-		schemaDatacenter = schemaDatacenter2
+		schemaDatacenter.ID = (*source).ID
+		schemaDatacenter.Name = (*source).Name
+		schemaDatacenter.Description = (*source).Description
+		schemaDatacenter.Location = c.SchemaFromLocation((*source).Location)
+		schemaDatacenter.ServerTypes = c.hcloudDatacenterServerTypesToSchemaDatacenterServerTypes((*source).ServerTypes)
 	}
 	return schemaDatacenter
 }
@@ -545,24 +539,22 @@ func (c *converterImpl) SchemaFromError(source Error) schema.Error {
 func (c *converterImpl) SchemaFromFirewall(source *Firewall) schema.Firewall {
 	var schemaFirewall schema.Firewall
 	if source != nil {
-		var schemaFirewall2 schema.Firewall
-		schemaFirewall2.ID = (*source).ID
-		schemaFirewall2.Name = (*source).Name
-		schemaFirewall2.Labels = (*source).Labels
-		schemaFirewall2.Created = c.timeTimeToTimeTime((*source).Created)
+		schemaFirewall.ID = (*source).ID
+		schemaFirewall.Name = (*source).Name
+		schemaFirewall.Labels = (*source).Labels
+		schemaFirewall.Created = c.timeTimeToTimeTime((*source).Created)
 		if (*source).Rules != nil {
-			schemaFirewall2.Rules = make([]schema.FirewallRule, len((*source).Rules))
+			schemaFirewall.Rules = make([]schema.FirewallRule, len((*source).Rules))
 			for i := 0; i < len((*source).Rules); i++ {
-				schemaFirewall2.Rules[i] = c.hcloudFirewallRuleToSchemaFirewallRule((*source).Rules[i])
+				schemaFirewall.Rules[i] = c.hcloudFirewallRuleToSchemaFirewallRule((*source).Rules[i])
 			}
 		}
 		if (*source).AppliedTo != nil {
-			schemaFirewall2.AppliedTo = make([]schema.FirewallResource, len((*source).AppliedTo))
+			schemaFirewall.AppliedTo = make([]schema.FirewallResource, len((*source).AppliedTo))
 			for j := 0; j < len((*source).AppliedTo); j++ {
-				schemaFirewall2.AppliedTo[j] = c.SchemaFromFirewallResource((*source).AppliedTo[j])
+				schemaFirewall.AppliedTo[j] = c.SchemaFromFirewallResource((*source).AppliedTo[j])
 			}
 		}
-		schemaFirewall = schemaFirewall2
 	}
 	return schemaFirewall
 }
@@ -589,6 +581,12 @@ func (c *converterImpl) SchemaFromFirewallResource(source FirewallResource) sche
 	schemaFirewallResource.Type = string(source.Type)
 	schemaFirewallResource.Server = c.pHcloudFirewallResourceServerToPSchemaFirewallResourceServer(source.Server)
 	schemaFirewallResource.LabelSelector = c.pHcloudFirewallResourceLabelSelectorToPSchemaFirewallResourceLabelSelector(source.LabelSelector)
+	if source.AppliedToResources != nil {
+		schemaFirewallResource.AppliedToResources = make([]schema.FirewallResource, len(source.AppliedToResources))
+		for i := 0; i < len(source.AppliedToResources); i++ {
+			schemaFirewallResource.AppliedToResources[i] = c.SchemaFromFirewallResource(source.AppliedToResources[i])
+		}
+	}
 	return schemaFirewallResource
 }
 func (c *converterImpl) SchemaFromFirewallSetRulesOpts(source FirewallSetRulesOpts) schema.FirewallActionSetRulesRequest {
@@ -604,38 +602,34 @@ func (c *converterImpl) SchemaFromFirewallSetRulesOpts(source FirewallSetRulesOp
 func (c *converterImpl) SchemaFromFloatingIP(source *FloatingIP) schema.FloatingIP {
 	var schemaFloatingIP schema.FloatingIP
 	if source != nil {
-		var schemaFloatingIP2 schema.FloatingIP
-		schemaFloatingIP2.ID = (*source).ID
+		schemaFloatingIP.ID = (*source).ID
 		pString := (*source).Description
-		schemaFloatingIP2.Description = &pString
-		schemaFloatingIP2.Created = c.timeTimeToTimeTime((*source).Created)
-		schemaFloatingIP2.IP = floatingIPToIPString((*source))
-		schemaFloatingIP2.Type = string((*source).Type)
-		schemaFloatingIP2.Server = c.pHcloudServerToPInt64((*source).Server)
-		schemaFloatingIP2.DNSPtr = floatingIPDNSPtrSchemaFromMap((*source).DNSPtr)
-		schemaFloatingIP2.HomeLocation = c.SchemaFromLocation((*source).HomeLocation)
-		schemaFloatingIP2.Blocked = (*source).Blocked
-		schemaFloatingIP2.Protection = c.hcloudFloatingIPProtectionToSchemaFloatingIPProtection((*source).Protection)
-		schemaFloatingIP2.Labels = (*source).Labels
-		schemaFloatingIP2.Name = (*source).Name
-		schemaFloatingIP = schemaFloatingIP2
+		schemaFloatingIP.Description = &pString
+		schemaFloatingIP.Created = c.timeTimeToTimeTime((*source).Created)
+		schemaFloatingIP.IP = floatingIPToIPString((*source))
+		schemaFloatingIP.Type = string((*source).Type)
+		schemaFloatingIP.Server = c.pHcloudServerToPInt64((*source).Server)
+		schemaFloatingIP.DNSPtr = floatingIPDNSPtrSchemaFromMap((*source).DNSPtr)
+		schemaFloatingIP.HomeLocation = c.SchemaFromLocation((*source).HomeLocation)
+		schemaFloatingIP.Blocked = (*source).Blocked
+		schemaFloatingIP.Protection = c.hcloudFloatingIPProtectionToSchemaFloatingIPProtection((*source).Protection)
+		schemaFloatingIP.Labels = (*source).Labels
+		schemaFloatingIP.Name = (*source).Name
 	}
 	return schemaFloatingIP
 }
 func (c *converterImpl) SchemaFromISO(source *ISO) schema.ISO {
 	var schemaISO schema.ISO
 	if source != nil {
-		var schemaISO2 schema.ISO
-		schemaISO2.ID = (*source).ID
-		schemaISO2.Name = (*source).Name
-		schemaISO2.Description = (*source).Description
-		schemaISO2.Type = string((*source).Type)
+		schemaISO.ID = (*source).ID
+		schemaISO.Name = (*source).Name
+		schemaISO.Description = (*source).Description
+		schemaISO.Type = string((*source).Type)
 		if (*source).Architecture != nil {
 			xstring := string(*(*source).Architecture)
-			schemaISO2.Architecture = &xstring
+			schemaISO.Architecture = &xstring
 		}
-		schemaISO2.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
-		schemaISO = schemaISO2
+		schemaISO.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
 	}
 	return schemaISO
 }
@@ -649,38 +643,36 @@ func (c *converterImpl) SchemaFromImage(source *Image) schema.Image {
 func (c *converterImpl) SchemaFromLoadBalancer(source *LoadBalancer) schema.LoadBalancer {
 	var schemaLoadBalancer schema.LoadBalancer
 	if source != nil {
-		var schemaLoadBalancer2 schema.LoadBalancer
-		schemaLoadBalancer2.ID = (*source).ID
-		schemaLoadBalancer2.Name = (*source).Name
-		schemaLoadBalancer2.PublicNet = c.hcloudLoadBalancerPublicNetToSchemaLoadBalancerPublicNet((*source).PublicNet)
+		schemaLoadBalancer.ID = (*source).ID
+		schemaLoadBalancer.Name = (*source).Name
+		schemaLoadBalancer.PublicNet = c.hcloudLoadBalancerPublicNetToSchemaLoadBalancerPublicNet((*source).PublicNet)
 		if (*source).PrivateNet != nil {
-			schemaLoadBalancer2.PrivateNet = make([]schema.LoadBalancerPrivateNet, len((*source).PrivateNet))
+			schemaLoadBalancer.PrivateNet = make([]schema.LoadBalancerPrivateNet, len((*source).PrivateNet))
 			for i := 0; i < len((*source).PrivateNet); i++ {
-				schemaLoadBalancer2.PrivateNet[i] = c.hcloudLoadBalancerPrivateNetToSchemaLoadBalancerPrivateNet((*source).PrivateNet[i])
+				schemaLoadBalancer.PrivateNet[i] = c.hcloudLoadBalancerPrivateNetToSchemaLoadBalancerPrivateNet((*source).PrivateNet[i])
 			}
 		}
-		schemaLoadBalancer2.Location = c.SchemaFromLocation((*source).Location)
-		schemaLoadBalancer2.LoadBalancerType = c.SchemaFromLoadBalancerType((*source).LoadBalancerType)
-		schemaLoadBalancer2.Protection = c.hcloudLoadBalancerProtectionToSchemaLoadBalancerProtection((*source).Protection)
-		schemaLoadBalancer2.Labels = (*source).Labels
-		schemaLoadBalancer2.Created = c.timeTimeToTimeTime((*source).Created)
+		schemaLoadBalancer.Location = c.SchemaFromLocation((*source).Location)
+		schemaLoadBalancer.LoadBalancerType = c.SchemaFromLoadBalancerType((*source).LoadBalancerType)
+		schemaLoadBalancer.Protection = c.hcloudLoadBalancerProtectionToSchemaLoadBalancerProtection((*source).Protection)
+		schemaLoadBalancer.Labels = (*source).Labels
+		schemaLoadBalancer.Created = c.timeTimeToTimeTime((*source).Created)
 		if (*source).Services != nil {
-			schemaLoadBalancer2.Services = make([]schema.LoadBalancerService, len((*source).Services))
+			schemaLoadBalancer.Services = make([]schema.LoadBalancerService, len((*source).Services))
 			for j := 0; j < len((*source).Services); j++ {
-				schemaLoadBalancer2.Services[j] = c.SchemaFromLoadBalancerService((*source).Services[j])
+				schemaLoadBalancer.Services[j] = c.SchemaFromLoadBalancerService((*source).Services[j])
 			}
 		}
 		if (*source).Targets != nil {
-			schemaLoadBalancer2.Targets = make([]schema.LoadBalancerTarget, len((*source).Targets))
+			schemaLoadBalancer.Targets = make([]schema.LoadBalancerTarget, len((*source).Targets))
 			for k := 0; k < len((*source).Targets); k++ {
-				schemaLoadBalancer2.Targets[k] = c.SchemaFromLoadBalancerTarget((*source).Targets[k])
+				schemaLoadBalancer.Targets[k] = c.SchemaFromLoadBalancerTarget((*source).Targets[k])
 			}
 		}
-		schemaLoadBalancer2.Algorithm = c.hcloudLoadBalancerAlgorithmToSchemaLoadBalancerAlgorithm((*source).Algorithm)
-		schemaLoadBalancer2.IncludedTraffic = (*source).IncludedTraffic
-		schemaLoadBalancer2.OutgoingTraffic = mapZeroUint64ToNil((*source).OutgoingTraffic)
-		schemaLoadBalancer2.IngoingTraffic = mapZeroUint64ToNil((*source).IngoingTraffic)
-		schemaLoadBalancer = schemaLoadBalancer2
+		schemaLoadBalancer.Algorithm = c.hcloudLoadBalancerAlgorithmToSchemaLoadBalancerAlgorithm((*source).Algorithm)
+		schemaLoadBalancer.IncludedTraffic = (*source).IncludedTraffic
+		schemaLoadBalancer.OutgoingTraffic = mapZeroUint64ToNil((*source).OutgoingTraffic)
+		schemaLoadBalancer.IngoingTraffic = mapZeroUint64ToNil((*source).IngoingTraffic)
 	}
 	return schemaLoadBalancer
 }
@@ -784,22 +776,20 @@ func (c *converterImpl) SchemaFromLoadBalancerTargetHealthStatus(source LoadBala
 func (c *converterImpl) SchemaFromLoadBalancerType(source *LoadBalancerType) schema.LoadBalancerType {
 	var schemaLoadBalancerType schema.LoadBalancerType
 	if source != nil {
-		var schemaLoadBalancerType2 schema.LoadBalancerType
-		schemaLoadBalancerType2.ID = (*source).ID
-		schemaLoadBalancerType2.Name = (*source).Name
-		schemaLoadBalancerType2.Description = (*source).Description
-		schemaLoadBalancerType2.MaxConnections = (*source).MaxConnections
-		schemaLoadBalancerType2.MaxServices = (*source).MaxServices
-		schemaLoadBalancerType2.MaxTargets = (*source).MaxTargets
-		schemaLoadBalancerType2.MaxAssignedCertificates = (*source).MaxAssignedCertificates
+		schemaLoadBalancerType.ID = (*source).ID
+		schemaLoadBalancerType.Name = (*source).Name
+		schemaLoadBalancerType.Description = (*source).Description
+		schemaLoadBalancerType.MaxConnections = (*source).MaxConnections
+		schemaLoadBalancerType.MaxServices = (*source).MaxServices
+		schemaLoadBalancerType.MaxTargets = (*source).MaxTargets
+		schemaLoadBalancerType.MaxAssignedCertificates = (*source).MaxAssignedCertificates
 		if (*source).Pricings != nil {
-			schemaLoadBalancerType2.Prices = make([]schema.PricingLoadBalancerTypePrice, len((*source).Pricings))
+			schemaLoadBalancerType.Prices = make([]schema.PricingLoadBalancerTypePrice, len((*source).Pricings))
 			for i := 0; i < len((*source).Pricings); i++ {
-				schemaLoadBalancerType2.Prices[i] = c.SchemaFromLoadBalancerTypeLocationPricing((*source).Pricings[i])
+				schemaLoadBalancerType.Prices[i] = c.SchemaFromLoadBalancerTypeLocationPricing((*source).Pricings[i])
 			}
 		}
-		schemaLoadBalancerType2.Deprecated = (*source).Deprecated
-		schemaLoadBalancerType = schemaLoadBalancerType2
+		schemaLoadBalancerType.Deprecated = (*source).Deprecated
 	}
 	return schemaLoadBalancerType
 }
@@ -824,55 +814,51 @@ func (c *converterImpl) SchemaFromLoadBalancerUpdateServiceOpts(source LoadBalan
 func (c *converterImpl) SchemaFromLocation(source *Location) schema.Location {
 	var schemaLocation schema.Location
 	if source != nil {
-		var schemaLocation2 schema.Location
-		schemaLocation2.ID = (*source).ID
-		schemaLocation2.Name = (*source).Name
-		schemaLocation2.Description = (*source).Description
-		schemaLocation2.Country = (*source).Country
-		schemaLocation2.City = (*source).City
-		schemaLocation2.Latitude = (*source).Latitude
-		schemaLocation2.Longitude = (*source).Longitude
-		schemaLocation2.NetworkZone = string((*source).NetworkZone)
-		schemaLocation = schemaLocation2
+		schemaLocation.ID = (*source).ID
+		schemaLocation.Name = (*source).Name
+		schemaLocation.Description = (*source).Description
+		schemaLocation.Country = (*source).Country
+		schemaLocation.City = (*source).City
+		schemaLocation.Latitude = (*source).Latitude
+		schemaLocation.Longitude = (*source).Longitude
+		schemaLocation.NetworkZone = string((*source).NetworkZone)
 	}
 	return schemaLocation
 }
 func (c *converterImpl) SchemaFromNetwork(source *Network) schema.Network {
 	var schemaNetwork schema.Network
 	if source != nil {
-		var schemaNetwork2 schema.Network
-		schemaNetwork2.ID = (*source).ID
-		schemaNetwork2.Name = (*source).Name
-		schemaNetwork2.Created = c.timeTimeToTimeTime((*source).Created)
-		schemaNetwork2.IPRange = c.pNetIPNetToString((*source).IPRange)
+		schemaNetwork.ID = (*source).ID
+		schemaNetwork.Name = (*source).Name
+		schemaNetwork.Created = c.timeTimeToTimeTime((*source).Created)
+		schemaNetwork.IPRange = c.pNetIPNetToString((*source).IPRange)
 		if (*source).Subnets != nil {
-			schemaNetwork2.Subnets = make([]schema.NetworkSubnet, len((*source).Subnets))
+			schemaNetwork.Subnets = make([]schema.NetworkSubnet, len((*source).Subnets))
 			for i := 0; i < len((*source).Subnets); i++ {
-				schemaNetwork2.Subnets[i] = c.SchemaFromNetworkSubnet((*source).Subnets[i])
+				schemaNetwork.Subnets[i] = c.SchemaFromNetworkSubnet((*source).Subnets[i])
 			}
 		}
 		if (*source).Routes != nil {
-			schemaNetwork2.Routes = make([]schema.NetworkRoute, len((*source).Routes))
+			schemaNetwork.Routes = make([]schema.NetworkRoute, len((*source).Routes))
 			for j := 0; j < len((*source).Routes); j++ {
-				schemaNetwork2.Routes[j] = c.SchemaFromNetworkRoute((*source).Routes[j])
+				schemaNetwork.Routes[j] = c.SchemaFromNetworkRoute((*source).Routes[j])
 			}
 		}
 		if (*source).Servers != nil {
-			schemaNetwork2.Servers = make([]int64, len((*source).Servers))
+			schemaNetwork.Servers = make([]int64, len((*source).Servers))
 			for k := 0; k < len((*source).Servers); k++ {
-				schemaNetwork2.Servers[k] = c.pHcloudServerToInt64((*source).Servers[k])
+				schemaNetwork.Servers[k] = c.pHcloudServerToInt64((*source).Servers[k])
 			}
 		}
 		if (*source).LoadBalancers != nil {
-			schemaNetwork2.LoadBalancers = make([]int64, len((*source).LoadBalancers))
+			schemaNetwork.LoadBalancers = make([]int64, len((*source).LoadBalancers))
 			for l := 0; l < len((*source).LoadBalancers); l++ {
-				schemaNetwork2.LoadBalancers[l] = c.pHcloudLoadBalancerToInt64((*source).LoadBalancers[l])
+				schemaNetwork.LoadBalancers[l] = c.pHcloudLoadBalancerToInt64((*source).LoadBalancers[l])
 			}
 		}
-		schemaNetwork2.Protection = c.hcloudNetworkProtectionToSchemaNetworkProtection((*source).Protection)
-		schemaNetwork2.Labels = (*source).Labels
-		schemaNetwork2.ExposeRoutesToVSwitch = (*source).ExposeRoutesToVSwitch
-		schemaNetwork = schemaNetwork2
+		schemaNetwork.Protection = c.hcloudNetworkProtectionToSchemaNetworkProtection((*source).Protection)
+		schemaNetwork.Labels = (*source).Labels
+		schemaNetwork.ExposeRoutesToVSwitch = (*source).ExposeRoutesToVSwitch
 	}
 	return schemaNetwork
 }
@@ -904,14 +890,12 @@ func (c *converterImpl) SchemaFromPagination(source Pagination) schema.MetaPagin
 func (c *converterImpl) SchemaFromPlacementGroup(source *PlacementGroup) schema.PlacementGroup {
 	var schemaPlacementGroup schema.PlacementGroup
 	if source != nil {
-		var schemaPlacementGroup2 schema.PlacementGroup
-		schemaPlacementGroup2.ID = (*source).ID
-		schemaPlacementGroup2.Name = (*source).Name
-		schemaPlacementGroup2.Labels = (*source).Labels
-		schemaPlacementGroup2.Created = c.timeTimeToTimeTime((*source).Created)
-		schemaPlacementGroup2.Servers = (*source).Servers
-		schemaPlacementGroup2.Type = string((*source).Type)
-		schemaPlacementGroup = schemaPlacementGroup2
+		schemaPlacementGroup.ID = (*source).ID
+		schemaPlacementGroup.Name = (*source).Name
+		schemaPlacementGroup.Labels = (*source).Labels
+		schemaPlacementGroup.Created = c.timeTimeToTimeTime((*source).Created)
+		schemaPlacementGroup.Servers = (*source).Servers
+		schemaPlacementGroup.Type = string((*source).Type)
 	}
 	return schemaPlacementGroup
 }
@@ -960,21 +944,19 @@ func (c *converterImpl) SchemaFromPricing(source Pricing) schema.Pricing {
 func (c *converterImpl) SchemaFromPrimaryIP(source *PrimaryIP) schema.PrimaryIP {
 	var schemaPrimaryIP schema.PrimaryIP
 	if source != nil {
-		var schemaPrimaryIP2 schema.PrimaryIP
-		schemaPrimaryIP2.ID = (*source).ID
-		schemaPrimaryIP2.IP = primaryIPToIPString((*source))
-		schemaPrimaryIP2.Labels = (*source).Labels
-		schemaPrimaryIP2.Name = (*source).Name
-		schemaPrimaryIP2.Type = string((*source).Type)
-		schemaPrimaryIP2.Protection = c.hcloudPrimaryIPProtectionToSchemaPrimaryIPProtection((*source).Protection)
-		schemaPrimaryIP2.DNSPtr = primaryIPDNSPtrSchemaFromMap((*source).DNSPtr)
-		schemaPrimaryIP2.AssigneeID = mapZeroInt64ToNil((*source).AssigneeID)
-		schemaPrimaryIP2.AssigneeType = (*source).AssigneeType
-		schemaPrimaryIP2.AutoDelete = (*source).AutoDelete
-		schemaPrimaryIP2.Blocked = (*source).Blocked
-		schemaPrimaryIP2.Created = c.timeTimeToTimeTime((*source).Created)
-		schemaPrimaryIP2.Datacenter = c.SchemaFromDatacenter((*source).Datacenter)
-		schemaPrimaryIP = schemaPrimaryIP2
+		schemaPrimaryIP.ID = (*source).ID
+		schemaPrimaryIP.IP = primaryIPToIPString((*source))
+		schemaPrimaryIP.Labels = (*source).Labels
+		schemaPrimaryIP.Name = (*source).Name
+		schemaPrimaryIP.Type = string((*source).Type)
+		schemaPrimaryIP.Protection = c.hcloudPrimaryIPProtectionToSchemaPrimaryIPProtection((*source).Protection)
+		schemaPrimaryIP.DNSPtr = primaryIPDNSPtrSchemaFromMap((*source).DNSPtr)
+		schemaPrimaryIP.AssigneeID = mapZeroInt64ToNil((*source).AssigneeID)
+		schemaPrimaryIP.AssigneeType = (*source).AssigneeType
+		schemaPrimaryIP.AutoDelete = (*source).AutoDelete
+		schemaPrimaryIP.Blocked = (*source).Blocked
+		schemaPrimaryIP.Created = c.timeTimeToTimeTime((*source).Created)
+		schemaPrimaryIP.Datacenter = c.SchemaFromDatacenter((*source).Datacenter)
 	}
 	return schemaPrimaryIP
 }
@@ -1002,7 +984,7 @@ func (c *converterImpl) SchemaFromPrimaryIPCreateOpts(source PrimaryIPCreateOpts
 	schemaPrimaryIPCreateRequest.Type = string(source.Type)
 	schemaPrimaryIPCreateRequest.AssigneeType = source.AssigneeType
 	schemaPrimaryIPCreateRequest.AssigneeID = source.AssigneeID
-	schemaPrimaryIPCreateRequest.Labels = source.Labels
+	schemaPrimaryIPCreateRequest.Labels = stringMapToStringMapPtr(source.Labels)
 	schemaPrimaryIPCreateRequest.AutoDelete = source.AutoDelete
 	schemaPrimaryIPCreateRequest.Datacenter = source.Datacenter
 	return schemaPrimaryIPCreateRequest
@@ -1010,68 +992,62 @@ func (c *converterImpl) SchemaFromPrimaryIPCreateOpts(source PrimaryIPCreateOpts
 func (c *converterImpl) SchemaFromPrimaryIPUpdateOpts(source PrimaryIPUpdateOpts) schema.PrimaryIPUpdateRequest {
 	var schemaPrimaryIPUpdateRequest schema.PrimaryIPUpdateRequest
 	schemaPrimaryIPUpdateRequest.Name = source.Name
-	if source.Labels != nil {
-		schemaPrimaryIPUpdateRequest.Labels = (*source.Labels)
-	}
+	schemaPrimaryIPUpdateRequest.Labels = source.Labels
 	schemaPrimaryIPUpdateRequest.AutoDelete = source.AutoDelete
 	return schemaPrimaryIPUpdateRequest
 }
 func (c *converterImpl) SchemaFromSSHKey(source *SSHKey) schema.SSHKey {
 	var schemaSSHKey schema.SSHKey
 	if source != nil {
-		var schemaSSHKey2 schema.SSHKey
-		schemaSSHKey2.ID = (*source).ID
-		schemaSSHKey2.Name = (*source).Name
-		schemaSSHKey2.Fingerprint = (*source).Fingerprint
-		schemaSSHKey2.PublicKey = (*source).PublicKey
-		schemaSSHKey2.Labels = (*source).Labels
-		schemaSSHKey2.Created = c.timeTimeToTimeTime((*source).Created)
-		schemaSSHKey = schemaSSHKey2
+		schemaSSHKey.ID = (*source).ID
+		schemaSSHKey.Name = (*source).Name
+		schemaSSHKey.Fingerprint = (*source).Fingerprint
+		schemaSSHKey.PublicKey = (*source).PublicKey
+		schemaSSHKey.Labels = (*source).Labels
+		schemaSSHKey.Created = c.timeTimeToTimeTime((*source).Created)
 	}
 	return schemaSSHKey
 }
 func (c *converterImpl) SchemaFromServer(source *Server) schema.Server {
 	var schemaServer schema.Server
 	if source != nil {
-		var schemaServer2 schema.Server
-		schemaServer2.ID = (*source).ID
-		schemaServer2.Name = (*source).Name
-		schemaServer2.Status = string((*source).Status)
-		schemaServer2.Created = c.timeTimeToTimeTime((*source).Created)
-		schemaServer2.PublicNet = c.SchemaFromServerPublicNet((*source).PublicNet)
+		schemaServer.ID = (*source).ID
+		schemaServer.Name = (*source).Name
+		schemaServer.Status = string((*source).Status)
+		schemaServer.Created = c.timeTimeToTimeTime((*source).Created)
+		schemaServer.PublicNet = c.SchemaFromServerPublicNet((*source).PublicNet)
 		if (*source).PrivateNet != nil {
-			schemaServer2.PrivateNet = make([]schema.ServerPrivateNet, len((*source).PrivateNet))
+			schemaServer.PrivateNet = make([]schema.ServerPrivateNet, len((*source).PrivateNet))
 			for i := 0; i < len((*source).PrivateNet); i++ {
-				schemaServer2.PrivateNet[i] = c.SchemaFromServerPrivateNet((*source).PrivateNet[i])
+				schemaServer.PrivateNet[i] = c.SchemaFromServerPrivateNet((*source).PrivateNet[i])
 			}
 		}
-		schemaServer2.ServerType = c.SchemaFromServerType((*source).ServerType)
-		schemaServer2.IncludedTraffic = (*source).IncludedTraffic
-		schemaServer2.OutgoingTraffic = mapZeroUint64ToNil((*source).OutgoingTraffic)
-		schemaServer2.IngoingTraffic = mapZeroUint64ToNil((*source).IngoingTraffic)
-		schemaServer2.BackupWindow = mapEmptyStringToNil((*source).BackupWindow)
-		schemaServer2.RescueEnabled = (*source).RescueEnabled
-		schemaServer2.ISO = c.pHcloudISOToPSchemaISO((*source).ISO)
-		schemaServer2.Locked = (*source).Locked
-		schemaServer2.Datacenter = c.SchemaFromDatacenter((*source).Datacenter)
-		schemaServer2.Image = c.pHcloudImageToPSchemaImage((*source).Image)
-		schemaServer2.Protection = c.hcloudServerProtectionToSchemaServerProtection((*source).Protection)
-		schemaServer2.Labels = (*source).Labels
+		schemaServer.ServerType = c.SchemaFromServerType((*source).ServerType)
+		schemaServer.IncludedTraffic = (*source).IncludedTraffic
+		schemaServer.OutgoingTraffic = mapZeroUint64ToNil((*source).OutgoingTraffic)
+		schemaServer.IngoingTraffic = mapZeroUint64ToNil((*source).IngoingTraffic)
+		schemaServer.BackupWindow = mapEmptyStringToNil((*source).BackupWindow)
+		schemaServer.RescueEnabled = (*source).RescueEnabled
+		schemaServer.ISO = c.pHcloudISOToPSchemaISO((*source).ISO)
+		schemaServer.Locked = (*source).Locked
+		schemaServer.Datacenter = c.SchemaFromDatacenter((*source).Datacenter)
+		schemaServer.Image = c.pHcloudImageToPSchemaImage((*source).Image)
+		schemaServer.Protection = c.hcloudServerProtectionToSchemaServerProtection((*source).Protection)
+		schemaServer.Labels = (*source).Labels
 		if (*source).Volumes != nil {
-			schemaServer2.Volumes = make([]int64, len((*source).Volumes))
+			schemaServer.Volumes = make([]int64, len((*source).Volumes))
 			for j := 0; j < len((*source).Volumes); j++ {
-				schemaServer2.Volumes[j] = int64FromVolume((*source).Volumes[j])
+				schemaServer.Volumes[j] = int64FromVolume((*source).Volumes[j])
 			}
 		}
-		schemaServer2.PrimaryDiskSize = (*source).PrimaryDiskSize
-		schemaServer2.PlacementGroup = c.pHcloudPlacementGroupToPSchemaPlacementGroup((*source).PlacementGroup)
+		schemaServer.PrimaryDiskSize = (*source).PrimaryDiskSize
+		schemaServer.PlacementGroup = c.pHcloudPlacementGroupToPSchemaPlacementGroup((*source).PlacementGroup)
 		if (*source).LoadBalancers != nil {
-			schemaServer2.LoadBalancers = make([]int64, len((*source).LoadBalancers))
+			schemaServer.LoadBalancers = make([]int64, len((*source).LoadBalancers))
 			for k := 0; k < len((*source).LoadBalancers); k++ {
-				schemaServer2.LoadBalancers[k] = c.pHcloudLoadBalancerToInt64((*source).LoadBalancers[k])
+				schemaServer.LoadBalancers[k] = c.pHcloudLoadBalancerToInt64((*source).LoadBalancers[k])
 			}
 		}
-		schemaServer = schemaServer2
 	}
 	return schemaServer
 }
@@ -1125,45 +1101,42 @@ func (c *converterImpl) SchemaFromServerPublicNetIPv6(source ServerPublicNetIPv6
 func (c *converterImpl) SchemaFromServerType(source *ServerType) schema.ServerType {
 	var schemaServerType schema.ServerType
 	if source != nil {
-		var schemaServerType2 schema.ServerType
-		schemaServerType2.ID = (*source).ID
-		schemaServerType2.Name = (*source).Name
-		schemaServerType2.Description = (*source).Description
-		schemaServerType2.Cores = (*source).Cores
-		schemaServerType2.Memory = (*source).Memory
-		schemaServerType2.Disk = (*source).Disk
-		schemaServerType2.StorageType = string((*source).StorageType)
-		schemaServerType2.CPUType = string((*source).CPUType)
-		schemaServerType2.Architecture = string((*source).Architecture)
-		schemaServerType2.IncludedTraffic = (*source).IncludedTraffic
+		schemaServerType.ID = (*source).ID
+		schemaServerType.Name = (*source).Name
+		schemaServerType.Description = (*source).Description
+		schemaServerType.Category = (*source).Category
+		schemaServerType.Cores = (*source).Cores
+		schemaServerType.Memory = (*source).Memory
+		schemaServerType.Disk = (*source).Disk
+		schemaServerType.StorageType = string((*source).StorageType)
+		schemaServerType.CPUType = string((*source).CPUType)
+		schemaServerType.Architecture = string((*source).Architecture)
+		schemaServerType.IncludedTraffic = (*source).IncludedTraffic
 		if (*source).Pricings != nil {
-			schemaServerType2.Prices = make([]schema.PricingServerTypePrice, len((*source).Pricings))
+			schemaServerType.Prices = make([]schema.PricingServerTypePrice, len((*source).Pricings))
 			for i := 0; i < len((*source).Pricings); i++ {
-				schemaServerType2.Prices[i] = c.schemaFromServerTypeLocationPricing((*source).Pricings[i])
+				schemaServerType.Prices[i] = c.schemaFromServerTypeLocationPricing((*source).Pricings[i])
 			}
 		}
-		schemaServerType2.Deprecated = isDeprecationNotNil((*source).DeprecatableResource.Deprecation)
-		schemaServerType2.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
-		schemaServerType = schemaServerType2
+		schemaServerType.Deprecated = isDeprecationNotNil((*source).DeprecatableResource.Deprecation)
+		schemaServerType.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
 	}
 	return schemaServerType
 }
 func (c *converterImpl) SchemaFromVolume(source *Volume) schema.Volume {
 	var schemaVolume schema.Volume
 	if source != nil {
-		var schemaVolume2 schema.Volume
-		schemaVolume2.ID = (*source).ID
-		schemaVolume2.Name = (*source).Name
-		schemaVolume2.Server = c.pHcloudServerToPInt64((*source).Server)
-		schemaVolume2.Status = string((*source).Status)
-		schemaVolume2.Location = c.SchemaFromLocation((*source).Location)
-		schemaVolume2.Size = (*source).Size
-		schemaVolume2.Format = (*source).Format
-		schemaVolume2.Protection = c.hcloudVolumeProtectionToSchemaVolumeProtection((*source).Protection)
-		schemaVolume2.Labels = (*source).Labels
-		schemaVolume2.LinuxDevice = (*source).LinuxDevice
-		schemaVolume2.Created = c.timeTimeToTimeTime((*source).Created)
-		schemaVolume = schemaVolume2
+		schemaVolume.ID = (*source).ID
+		schemaVolume.Name = (*source).Name
+		schemaVolume.Server = c.pHcloudServerToPInt64((*source).Server)
+		schemaVolume.Status = string((*source).Status)
+		schemaVolume.Location = c.SchemaFromLocation((*source).Location)
+		schemaVolume.Size = (*source).Size
+		schemaVolume.Format = (*source).Format
+		schemaVolume.Protection = c.hcloudVolumeProtectionToSchemaVolumeProtection((*source).Protection)
+		schemaVolume.Labels = (*source).Labels
+		schemaVolume.LinuxDevice = (*source).LinuxDevice
+		schemaVolume.Created = c.timeTimeToTimeTime((*source).Created)
 	}
 	return schemaVolume
 }
@@ -1290,6 +1263,7 @@ func (c *converterImpl) ServerTypeFromSchema(source schema.ServerType) *ServerTy
 	hcloudServerType.ID = source.ID
 	hcloudServerType.Name = source.Name
 	hcloudServerType.Description = source.Description
+	hcloudServerType.Category = source.Category
 	hcloudServerType.Cores = source.Cores
 	hcloudServerType.Memory = source.Memory
 	hcloudServerType.Disk = source.Disk
@@ -1561,10 +1535,8 @@ func (c *converterImpl) intSchemaFromImage(source Image) schema.Image {
 func (c *converterImpl) pHcloudActionResourceToSchemaActionResourceReference(source *ActionResource) schema.ActionResourceReference {
 	var schemaActionResourceReference schema.ActionResourceReference
 	if source != nil {
-		var schemaActionResourceReference2 schema.ActionResourceReference
-		schemaActionResourceReference2.ID = (*source).ID
-		schemaActionResourceReference2.Type = string((*source).Type)
-		schemaActionResourceReference = schemaActionResourceReference2
+		schemaActionResourceReference.ID = (*source).ID
+		schemaActionResourceReference.Type = string((*source).Type)
 	}
 	return schemaActionResourceReference
 }
@@ -1786,10 +1758,8 @@ func (c *converterImpl) pHcloudLoadBalancerToInt64(source *LoadBalancer) int64 {
 func (c *converterImpl) pHcloudLoadBalancerTypeToSchemaIDOrName(source *LoadBalancerType) schema.IDOrName {
 	var schemaIDOrName schema.IDOrName
 	if source != nil {
-		var schemaIDOrName2 schema.IDOrName
-		schemaIDOrName2.ID = (*source).ID
-		schemaIDOrName2.Name = (*source).Name
-		schemaIDOrName = schemaIDOrName2
+		schemaIDOrName.ID = (*source).ID
+		schemaIDOrName.Name = (*source).Name
 	}
 	return schemaIDOrName
 }
@@ -2009,18 +1979,16 @@ func (c *converterImpl) pSchemaImageToPHcloudImage(source *schema.Image) *Image 
 func (c *converterImpl) pSchemaLoadBalancerServiceHTTPToHcloudLoadBalancerServiceHTTP(source *schema.LoadBalancerServiceHTTP) LoadBalancerServiceHTTP {
 	var hcloudLoadBalancerServiceHTTP LoadBalancerServiceHTTP
 	if source != nil {
-		var hcloudLoadBalancerServiceHTTP2 LoadBalancerServiceHTTP
-		hcloudLoadBalancerServiceHTTP2.CookieName = (*source).CookieName
-		hcloudLoadBalancerServiceHTTP2.CookieLifetime = durationFromIntSeconds((*source).CookieLifetime)
+		hcloudLoadBalancerServiceHTTP.CookieName = (*source).CookieName
+		hcloudLoadBalancerServiceHTTP.CookieLifetime = durationFromIntSeconds((*source).CookieLifetime)
 		if (*source).Certificates != nil {
-			hcloudLoadBalancerServiceHTTP2.Certificates = make([]*Certificate, len((*source).Certificates))
+			hcloudLoadBalancerServiceHTTP.Certificates = make([]*Certificate, len((*source).Certificates))
 			for i := 0; i < len((*source).Certificates); i++ {
-				hcloudLoadBalancerServiceHTTP2.Certificates[i] = certificateFromInt64((*source).Certificates[i])
+				hcloudLoadBalancerServiceHTTP.Certificates[i] = certificateFromInt64((*source).Certificates[i])
 			}
 		}
-		hcloudLoadBalancerServiceHTTP2.RedirectHTTP = (*source).RedirectHTTP
-		hcloudLoadBalancerServiceHTTP2.StickySessions = (*source).StickySessions
-		hcloudLoadBalancerServiceHTTP = hcloudLoadBalancerServiceHTTP2
+		hcloudLoadBalancerServiceHTTP.RedirectHTTP = (*source).RedirectHTTP
+		hcloudLoadBalancerServiceHTTP.StickySessions = (*source).StickySessions
 	}
 	return hcloudLoadBalancerServiceHTTP
 }
@@ -2128,6 +2096,12 @@ func (c *converterImpl) schemaFirewallResourceToHcloudFirewallResource(source sc
 	hcloudFirewallResource.Type = FirewallResourceType(source.Type)
 	hcloudFirewallResource.Server = c.pSchemaFirewallResourceServerToPHcloudFirewallResourceServer(source.Server)
 	hcloudFirewallResource.LabelSelector = c.pSchemaFirewallResourceLabelSelectorToPHcloudFirewallResourceLabelSelector(source.LabelSelector)
+	if source.AppliedToResources != nil {
+		hcloudFirewallResource.AppliedToResources = make([]FirewallResource, len(source.AppliedToResources))
+		for i := 0; i < len(source.AppliedToResources); i++ {
+			hcloudFirewallResource.AppliedToResources[i] = c.schemaFirewallResourceToHcloudFirewallResource(source.AppliedToResources[i])
+		}
+	}
 	return hcloudFirewallResource
 }
 func (c *converterImpl) schemaFirewallRuleToHcloudFirewallRule(source schema.FirewallRule) FirewallRule {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area provider/hetzner

#### What this PR does / why we need it:
Update hcloud-go from v2.21.1 to v2.24.0

[Changelog](https://github.com/hetznercloud/hcloud-go/blob/main/CHANGELOG.md)
[Diff](https://github.com/hetznercloud/hcloud-go/compare/v2.21.1...v2.24.0)


Preparing for an upcoming PR that will add the ability to add an optional subnet configuration per pool. (Update to hcloud-go v2.24.0 adds the ability to do this) 

References about this:

https://github.com/kubernetes/autoscaler/pull/8334
https://github.com/kubernetes/autoscaler/issues/5263
https://github.com/hetznercloud/terraform-provider-hcloud/issues/672
https://github.com/hetznercloud/terraform-provider-hcloud/issues/844
https://github.com/hetznercloud/hcloud-go/pull/723



Generated by:
```
UPSTREAM_REF=v2.24.0 hack/update-vendor.sh
```


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
