### PR TITLE
OCI Cloudprovider feature Backport for 1.30

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -40,6 +40,8 @@ const (
 	nodepoolTags          = "nodepoolTags"
 	min                   = "min"
 	max                   = "max"
+	minSize               = "minSize"
+	maxSize               = "maxSize"
 )
 
 var (
@@ -216,8 +218,8 @@ func autoDiscoverNodeGroups(m *ociManagerImpl, okeClient okeClient, nodeGroup no
 			nodepool := &nodePool{}
 			nodepool.id = *nodePoolSummary.Id
 			// set minSize-maxSize from nodepool free form tags, or else use nodeGroupAutoDiscovery configuration
-			nodepool.minSize = getIntFromMap(nodePoolSummary.FreeformTags, "minSize", nodeGroup.minSize)
-			nodepool.maxSize = getIntFromMap(nodePoolSummary.FreeformTags, "maxSize", nodeGroup.maxSize)
+			nodepool.minSize = getIntFromMap(nodePoolSummary.FreeformTags, minSize, nodeGroup.minSize)
+			nodepool.maxSize = getIntFromMap(nodePoolSummary.FreeformTags, maxSize, nodeGroup.maxSize)
 
 			nodepool.manager = nodeGroup.manager
 			nodepool.kubeClient = nodeGroup.kubeClient

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
@@ -6,10 +6,12 @@ package nodepools
 
 import (
 	"context"
+	"fmt"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/nodepools/consts"
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -18,6 +20,10 @@ import (
 
 	ocicommon "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/common"
 	oke "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/containerengine"
+)
+
+const (
+	autoDiscoveryCompartment = "ocid1.compartment.oc1.test-region.test"
 )
 
 func TestNodePoolFromArgs(t *testing.T) {
@@ -318,8 +324,15 @@ func TestBuildGenericLabels(t *testing.T) {
 
 type mockOKEClient struct{}
 
-func (c mockOKEClient) GetNodePool(context.Context, oke.GetNodePoolRequest) (oke.GetNodePoolResponse, error) {
-	return oke.GetNodePoolResponse{}, nil
+func (c mockOKEClient) GetNodePool(ctx context.Context, req oke.GetNodePoolRequest) (oke.GetNodePoolResponse, error) {
+	return oke.GetNodePoolResponse{
+		NodePool: oke.NodePool{
+			Id: req.NodePoolId,
+			NodeConfigDetails: &oke.NodePoolNodeConfigDetails{
+				Size: common.Int(1),
+			},
+		},
+	}, nil
 }
 func (c mockOKEClient) UpdateNodePool(context.Context, oke.UpdateNodePoolRequest) (oke.UpdateNodePoolResponse, error) {
 	return oke.UpdateNodePoolResponse{}, nil
@@ -333,7 +346,39 @@ func (c mockOKEClient) DeleteNode(context.Context, oke.DeleteNodeRequest) (oke.D
 	}, nil
 }
 
-func (c mockOKEClient) ListNodePools(context.Context, oke.ListNodePoolsRequest) (oke.ListNodePoolsResponse, error) {
+func (c mockOKEClient) ListNodePools(ctx context.Context, req oke.ListNodePoolsRequest) (oke.ListNodePoolsResponse, error) {
+	// below test data added for auto-discovery tests
+	if req.CompartmentId != nil && *req.CompartmentId == autoDiscoveryCompartment {
+		freeformTags1 := map[string]string{
+			"ca-managed": "true",
+		}
+		freeformTags2 := map[string]string{
+			"ca-managed": "true",
+			"minSize":    "4",
+			"maxSize":    "10",
+		}
+		definedTags := map[string]map[string]interface{}{
+			"namespace": {
+				"foo": "bar",
+			},
+		}
+		resp := oke.ListNodePoolsResponse{
+			Items: []oke.NodePoolSummary{
+				{
+					Id:           common.String("node-pool-1"),
+					FreeformTags: freeformTags1,
+					DefinedTags:  definedTags,
+				},
+				{
+					Id:           common.String("node-pool-2"),
+					FreeformTags: freeformTags2,
+					DefinedTags:  definedTags,
+				},
+			},
+		}
+		return resp, nil
+	}
+
 	return oke.ListNodePoolsResponse{}, nil
 }
 
@@ -390,8 +435,41 @@ func TestRemoveInstance(t *testing.T) {
 	}
 }
 
+func TestNodeGroupAutoDiscovery(t *testing.T) {
+	var nodeGroupArg = fmt.Sprintf("clusterId:ocid1.cluster.oc1.test-region.test,compartmentId:%s,nodepoolTags:ca-managed=true&namespace.foo=bar,min:1,max:5", autoDiscoveryCompartment)
+	nodeGroup, err := nodeGroupFromArg(nodeGroupArg)
+	if err != nil {
+		t.Errorf("Error: #{err}")
+	}
+	nodePoolCache := newNodePoolCache(nil)
+	nodePoolCache.okeClient = mockOKEClient{}
+
+	cloudConfig := &ocicommon.CloudConfig{}
+	cloudConfig.Global.RefreshInterval = 5 * time.Minute
+	cloudConfig.Global.CompartmentID = autoDiscoveryCompartment
+
+	manager := &ociManagerImpl{
+		nodePoolCache:   nodePoolCache,
+		nodeGroups:      []nodeGroupAutoDiscovery{*nodeGroup},
+		okeClient:       mockOKEClient{},
+		cfg:             cloudConfig,
+		staticNodePools: map[string]NodePool{},
+	}
+	// test data to use as initial nodepools
+	nodepool2 := &nodePool{
+		id: "node-pool-2", minSize: 1, maxSize: 5,
+	}
+	manager.staticNodePools[nodepool2.id] = nodepool2
+	nodepool3 := &nodePool{
+		id: "node-pool-3", minSize: 2, maxSize: 5,
+	}
+	manager.staticNodePools[nodepool3.id] = nodepool3
+
+	manager.forceRefresh()
+}
+
 func TestNodeGroupFromArg(t *testing.T) {
-	var nodeGroupArg = "clusterId:ocid1.cluster.oc1.test-region.test,compartmentId:ocid1.compartment.oc1.test-region.test,nodepoolTags:ca-managed=true&namespace.foo=bar,min:1,max:5"
+	var nodeGroupArg = fmt.Sprintf("clusterId:ocid1.cluster.oc1.test-region.test,compartmentId:%s,nodepoolTags:ca-managed=true&namespace.foo=bar,min:1,max:5", autoDiscoveryCompartment)
 	nodeGroupAutoDiscovery, err := nodeGroupFromArg(nodeGroupArg)
 	if err != nil {
 		t.Errorf("Error: #{err}")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR has a cherry-picked commit from master and will merge it to release branch cluster-autoscaler-release-1.30 so that next release would have it. 
- https://github.com/kubernetes/autoscaler/pull/8491/commits 

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
OCI: enable nodepool min and max values with node-group-auto-discovery
```

```docs

```