### PR TITLE
Feat: partitionable devices support

### DIFF
--- a/cluster-autoscaler/simulator/dynamicresources/utils/utilization.go
+++ b/cluster-autoscaler/simulator/dynamicresources/utils/utilization.go
@@ -18,9 +18,11 @@ package utils
 
 import (
 	"fmt"
+	"slices"
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/utils/ptr"
 )
@@ -44,7 +46,7 @@ func CalculateDynamicResourceUtilization(nodeInfo *framework.NodeInfo) (map[stri
 			poolDevices := getAllDevices(currentSlices)
 			allocatedDeviceNames := allocatedDevices[driverName][poolName]
 			unallocated, allocated := splitDevicesByAllocation(poolDevices, allocatedDeviceNames)
-			result[driverName][poolName] = calculatePoolUtil(unallocated, allocated)
+			result[driverName][poolName] = calculatePoolUtil(unallocated, allocated, currentSlices)
 		}
 	}
 	return result, nil
@@ -70,10 +72,127 @@ func HighestDynamicResourceUtilization(nodeInfo *framework.NodeInfo) (v1.Resourc
 	return highestResourceName, highestUtil, nil
 }
 
-func calculatePoolUtil(unallocated, allocated []resourceapi.Device) float64 {
-	numAllocated := float64(len(allocated))
-	numUnallocated := float64(len(unallocated))
-	return numAllocated / (numAllocated + numUnallocated)
+// calculatePoolUtil assumes that nodes pools are either partitionable (shared) or atomic (non-partitionable):
+//
+//  1. Partitionable (Shared) Utilization:
+//     Identifies the single highest utilization ratio across all counters in a counterSet, the utilization of each counterSet is then averaged across all partitionable devices in the resourceSlice.
+//     For example, if a GPU pool has shared counter with counters for memory and compute cycles, and the memory's counter is at 80% utilization, and the compute cycles' counter is at 50%,
+//     the partitionable utilization for the pool would be 80% for that device. If there is another shared counter at 60%, the total partitionable utilization would be 70%.
+//
+//  2. Atomic (Non-partitionable) Utilization:
+//     Calculated as the simple ratio of allocated devices to total devices for all devices
+//     that do not support shared counters.
+func calculatePoolUtil(unallocated, allocated []resourceapi.Device, resourceSlices []*resourceapi.ResourceSlice) float64 {
+
+	isPartitionablePool := slices.ContainsFunc(resourceSlices, isPartitionable)
+
+	if !isPartitionablePool {
+		return calculateAtomicDevicesPoolUtilization(allocated, append(unallocated, allocated...))
+	}
+
+	sharedCounters := []resourceapi.CounterSet{}
+	for _, slice := range resourceSlices {
+		sharedCounters = append(sharedCounters, slice.Spec.SharedCounters...)
+	}
+	return calculatePartitionableDevicesPoolUtilization(allocated, append(unallocated, allocated...), sharedCounters)
+}
+
+// isPartitionable checks if a resource slice is partitionable by checking if it has shared counters defined.
+func isPartitionable(slice *resourceapi.ResourceSlice) bool {
+	return len(slice.Spec.SharedCounters) != 0
+}
+
+// calculateAtomicDevicesPoolUtilization calculates the utilization of atomic (non-partitionable) devices in a pool. the input devices must be atomic devices only.
+// the calculation is based on the ratio of allocated devices to total devices.
+func calculateAtomicDevicesPoolUtilization(allocated, total []resourceapi.Device) float64 {
+	if len(total) == 0 {
+		return 0
+	}
+
+	return float64(len(allocated)) / float64(len(total))
+}
+
+// calculatePartitionableDevicesPoolUtilization calculates the utilization of partitionable devices in a pool. the input devices must be partitionable devices only.
+// the calculation is based on shared counters defined in the resource slices, it is assumed that each shared counter represents a partitionable device,
+// for each shared counter, we find the highest utilized counter and use that as the utilization for that partitionable device.
+// the final utilization is the average of all partitionable devices' utilizations.
+func calculatePartitionableDevicesPoolUtilization(allocated, total []resourceapi.Device, sharedCounters []resourceapi.CounterSet) float64 {
+
+	uniquePartitionableDevicesCount := getUniquePartitionableDevicesCount(total)
+	if uniquePartitionableDevicesCount == 0 {
+		return 0
+	}
+
+	var partitionableUtilization float64 = 0
+	allocatedConsumedCounters := calculateConsumedCounters(allocated)
+
+	for _, counterSet := range sharedCounters {
+		// for each counter set, find the highest utilization counter
+		highestCounterUtilization := 0.0
+		for counterName, counter := range counterSet.Counters {
+			if counter.Value.IsZero() {
+				continue
+			}
+			if allocatedValue, exists := allocatedConsumedCounters[counterSet.Name][counterName]; exists {
+				utilization := allocatedValue.AsApproximateFloat64() / counter.Value.AsApproximateFloat64()
+				if utilization > highestCounterUtilization {
+					highestCounterUtilization = utilization
+				}
+			}
+		}
+		// We assume that each counter set represents a unique partitionable device.
+		partitionableUtilization += highestCounterUtilization / float64(uniquePartitionableDevicesCount)
+	}
+
+	return partitionableUtilization
+}
+
+// calculateConsumedCounters calculates the total counters consumed by a list of devices
+func calculateConsumedCounters(devices []resourceapi.Device) map[string]map[string]resource.Quantity {
+	countersConsumed := map[string]map[string]resource.Quantity{}
+	for _, device := range devices {
+		if device.ConsumesCounters == nil {
+			continue
+		}
+		for _, consumedCounter := range device.ConsumesCounters {
+			countersConsumed = addCounterSetToMapping(consumedCounter.CounterSet, consumedCounter.Counters, countersConsumed)
+		}
+	}
+	return countersConsumed
+}
+
+// addCounterSetToMapping updates existingMapping with the provided counters under the specified counterSetName.
+func addCounterSetToMapping(counterSetName string, counters map[string]resourceapi.Counter, existingMapping map[string]map[string]resource.Quantity) map[string]map[string]resource.Quantity {
+	for counterName, counter := range counters {
+		if _, ok := existingMapping[counterSetName]; !ok {
+			existingMapping[counterSetName] = map[string]resource.Quantity{}
+		}
+		if _, ok := existingMapping[counterSetName][counterName]; !ok {
+			existingMapping[counterSetName][counterName] = resource.Quantity{}
+		}
+		v := existingMapping[counterSetName][counterName]
+		v.Add(counter.Value)
+		existingMapping[counterSetName][counterName] = v
+	}
+	return existingMapping
+}
+
+// getUniquePartitionableDevicesCount returns the count of unique partitionable devices in the provided list.
+// a partitionable device can be represented by multiple devices with different names and properties, and for utilization purposes we'd like to count the hardware and not the software.
+func getUniquePartitionableDevicesCount(devices []resourceapi.Device) int {
+	consumedCounters := map[string]bool{}
+	for _, device := range devices {
+		// the assumption here is that a partitionable device will consume the actual resources from the hardware, which will be represented by consumedCounters.
+		// if a device consumes multiple counters of the same device, we count them both at the same time in order to not "overcount" devices with multiple counters, the assumption here is that a device will always consume some of every resource in a device. (f.e. a GPU DRA request cannot use VRAM without using GPU cycles and vice versa)
+		if device.ConsumesCounters != nil {
+			for _, consumedCounter := range device.ConsumesCounters {
+				if _, exists := consumedCounters[consumedCounter.CounterSet]; !exists {
+					consumedCounters[consumedCounter.CounterSet] = true
+				}
+			}
+		}
+	}
+	return len(consumedCounters)
 }
 
 func splitDevicesByAllocation(devices []resourceapi.Device, allocatedNames []string) (unallocated, allocated []resourceapi.Device) {

--- a/cluster-autoscaler/simulator/dynamicresources/utils/utilization_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/utils/utilization_test.go
@@ -25,6 +25,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
@@ -143,6 +144,101 @@ func TestDynamicResourceUtilization(t *testing.T) {
 			wantHighestUtilizationName: apiv1.ResourceName(fmt.Sprintf("%s/%s", fooDriver, "pool1")),
 		},
 		{
+			testName: "partitionable devices, 2/4 partitions used",
+			nodeInfo: framework.NewNodeInfo(node,
+				testResourceSlicesWithPartitionableDevices(fooDriver, "pool1", "node", 1, 4, 2, "gpu-0"),
+				testPodsWithCustomClaims("pod", fooDriver, "pool1", "node", []string{"gpu-0-partition-0", "gpu-0-partition-1"})...,
+			),
+			wantUtilization: map[string]map[string]float64{
+				fooDriver: {
+					"pool1": 0.5,
+				},
+			},
+			wantHighestUtilization:     0.5,
+			wantHighestUtilizationName: apiv1.ResourceName(fmt.Sprintf("%s/%s", fooDriver, "pool1")),
+		},
+		{
+			testName: "partitionable devices, multiple pods, 2/4 partitions used",
+			nodeInfo: framework.NewNodeInfo(node,
+				testResourceSlicesWithPartitionableDevices(fooDriver, "pool1", "node", 1, 4, 2, "gpu-0"),
+				mergeLists(
+					testPodsWithCustomClaims("pod-0", fooDriver, "pool1", "node", []string{"gpu-0-partition-0"}),
+					testPodsWithCustomClaims("pod-1", fooDriver, "pool1", "node", []string{"gpu-0-partition-1"}),
+				)...,
+			),
+			wantUtilization: map[string]map[string]float64{
+				fooDriver: {
+					"pool1": 0.5,
+				},
+			},
+			wantHighestUtilization:     0.5,
+			wantHighestUtilizationName: apiv1.ResourceName(fmt.Sprintf("%s/%s", fooDriver, "pool1")),
+		},
+		{
+			testName: "partitionable devices, multiple pools",
+			nodeInfo: framework.NewNodeInfo(node,
+				mergeLists(
+					testResourceSlicesWithPartitionableDevices(fooDriver, "pool0", "node", 1, 4, 2, "gpu-0"),
+					testResourceSlicesWithPartitionableDevices(fooDriver, "pool1", "node", 1, 4, 2, "gpu-0"),
+					testResourceSlicesWithPartitionableDevices(fooDriver, "pool2", "node", 1, 4, 2, "gpu-1"),
+				),
+				mergeLists(
+					testPodsWithCustomClaims("pod0", fooDriver, "pool0", "node", []string{"gpu-0-partition-0", "gpu-0-partition-1"}),
+					testPodsWithCustomClaims("pod1", fooDriver, "pool1", "node", []string{"gpu-0"}),
+				)...,
+			),
+			wantUtilization: map[string]map[string]float64{
+				fooDriver: {
+					"pool0": 0.5,
+					"pool1": 1,
+					"pool2": 0,
+				},
+			},
+			wantHighestUtilization:     1,
+			wantHighestUtilizationName: apiv1.ResourceName(fmt.Sprintf("%s/%s", fooDriver, "pool1")),
+		},
+		{
+			testName: "multi-counter partitionable devices",
+			nodeInfo: framework.NewNodeInfo(node,
+				addPartitionableDeviceToResourceSlices(
+					testResourceSlicesWithPartitionableDevices(fooDriver, "pool1", "node", 1, 4, 2, "gpu-0"),
+					fooDriver,
+					"pool1",
+					"gpu-0-uneven-partition",
+					map[string]resource.Quantity{
+						"memory": resource.MustParse("1Gi"),
+						"cpu":    resource.MustParse("500m"),
+					},
+					// cpu is a new counter type not tracked by the pool yet; total=1 makes the 500m consumption a 50% ratio.
+					map[string]resource.Quantity{
+						"cpu": resource.MustParse("1"),
+					},
+				),
+				testPodsWithCustomClaims("pod", fooDriver, "pool1", "node", []string{"gpu-0-uneven-partition"})...,
+			),
+			wantUtilization: map[string]map[string]float64{
+				fooDriver: {
+					"pool1": 0.5,
+				},
+			},
+			wantHighestUtilization:     0.5,
+			wantHighestUtilizationName: apiv1.ResourceName(fmt.Sprintf("%s/%s", fooDriver, "pool1")),
+		},
+		{
+			testName: "multi-GPU partitionable devices, 2/8 partitions used",
+			nodeInfo: framework.NewNodeInfo(node,
+				testResourceSlicesWithPartitionableDevices(fooDriver, "pool1", "node", 1, 4, 2, "gpu-0", "gpu-1"),
+				testPodsWithCustomClaims("pod", fooDriver, "pool1", "node", []string{"gpu-0-partition-0", "gpu-0-partition-1"})...,
+			),
+			wantUtilization: map[string]map[string]float64{
+				fooDriver: {
+					"pool1": 0.25,
+				},
+			},
+			wantHighestUtilization:     0.25,
+			wantHighestUtilizationName: apiv1.ResourceName(fmt.Sprintf("%s/%s", fooDriver, "pool1")),
+		},
+		{
 			testName: "Single Pod with AdminAccess ResourceClaim doesn't count for utilization",
 			nodeInfo: framework.NewNodeInfo(node,
 				testResourceSlices(fooDriver, "pool1", "node", 0, 10, 1),
@@ -211,17 +307,520 @@ func TestDynamicResourceUtilization(t *testing.T) {
 	}
 }
 
+func TestCalculateAtomicDevicesPoolUtilization(t *testing.T) {
+	for _, tc := range []struct {
+		testName        string
+		allocated       []resourceapi.Device
+		unallocated     []resourceapi.Device
+		wantUtilization float64
+	}{
+		{
+			testName:        "no devices",
+			allocated:       []resourceapi.Device{},
+			unallocated:     []resourceapi.Device{},
+			wantUtilization: 0,
+		},
+		{
+			testName:        "no allocated devices",
+			allocated:       []resourceapi.Device{},
+			unallocated:     []resourceapi.Device{{Name: "dev-0"}, {Name: "dev-1"}},
+			wantUtilization: 0,
+		},
+		{
+			testName:        "all devices allocated",
+			allocated:       []resourceapi.Device{{Name: "dev-0"}, {Name: "dev-1"}},
+			unallocated:     []resourceapi.Device{},
+			wantUtilization: 1,
+		},
+		{
+			testName:        "partial allocation",
+			allocated:       []resourceapi.Device{{Name: "dev-0"}},
+			unallocated:     []resourceapi.Device{{Name: "dev-1"}, {Name: "dev-2"}},
+			wantUtilization: 1.0 / 3.0,
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			total := append(tc.allocated, tc.unallocated...)
+			utilization := calculateAtomicDevicesPoolUtilization(tc.allocated, total)
+			if utilization != tc.wantUtilization {
+				t.Errorf("calculateAtomicDevicesPoolUtilization() = %v, want %v", utilization, tc.wantUtilization)
+			}
+		})
+	}
+}
+
+func TestCalculatePartitionableDevicesPoolUtilization(t *testing.T) {
+	for _, tc := range []struct {
+		testName        string
+		allocated       []resourceapi.Device
+		unallocated     []resourceapi.Device
+		sharedCounters  []resourceapi.CounterSet
+		wantUtilization float64
+	}{
+		{
+			testName:        "no devices",
+			allocated:       []resourceapi.Device{},
+			unallocated:     []resourceapi.Device{},
+			sharedCounters:  []resourceapi.CounterSet{},
+			wantUtilization: 0,
+		},
+		{
+			testName:  "no allocated devices",
+			allocated: []resourceapi.Device{},
+			unallocated: []resourceapi.Device{
+				{
+					Name: "dev-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("10Gi")},
+							},
+						},
+					},
+				},
+			},
+			sharedCounters: []resourceapi.CounterSet{
+				{
+					Name: "counter-set-0",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("10Gi")},
+					},
+				},
+			},
+			wantUtilization: 0,
+		},
+		{
+			testName: "partial allocation",
+			allocated: []resourceapi.Device{
+				{
+					Name: "dev-0-partition-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+							},
+						},
+					},
+				},
+			},
+			unallocated: []resourceapi.Device{
+				{
+					Name: "dev-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("10Gi")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-0-partition-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+							},
+						},
+					},
+				},
+			},
+			sharedCounters: []resourceapi.CounterSet{
+				{
+					Name: "counter-set-0",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("10Gi")},
+					},
+				},
+			},
+			wantUtilization: 0.5,
+		},
+		{
+			testName: "full allocation of one device, all partitions used",
+			allocated: []resourceapi.Device{
+				{
+					Name: "dev-0-partition-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-0-partition-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+							},
+						},
+					},
+				},
+			},
+			unallocated: []resourceapi.Device{
+				{
+					Name: "dev-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("10Gi")},
+							},
+						},
+					},
+				},
+			},
+			sharedCounters: []resourceapi.CounterSet{
+				{
+					Name: "counter-set-0",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("10Gi")},
+					},
+				},
+			},
+			wantUtilization: 1,
+		},
+		{
+			testName: "full allocation of one device, 1 device used",
+			allocated: []resourceapi.Device{
+				{
+					Name: "dev-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("10Gi")},
+							},
+						},
+					},
+				},
+			},
+			unallocated: []resourceapi.Device{
+				{
+					Name: "dev-0-partition-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-0-partition-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+							},
+						},
+					},
+				},
+			},
+			sharedCounters: []resourceapi.CounterSet{
+				{
+					Name: "counter-set-0",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("10Gi")},
+					},
+				},
+			},
+			wantUtilization: 1,
+		},
+		{
+			testName: "full allocation of one device, multiple counters used",
+			allocated: []resourceapi.Device{
+				{
+					Name: "dev-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("10Gi")},
+								"cores":  {Value: resource.MustParse("8")},
+							},
+						},
+					},
+				},
+			},
+			unallocated: []resourceapi.Device{
+				{
+					Name: "dev-0-partition-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+								"cores":  {Value: resource.MustParse("6")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-0-partition-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+								"cores":  {Value: resource.MustParse("2")},
+							},
+						},
+					},
+				},
+			},
+			sharedCounters: []resourceapi.CounterSet{
+				{
+					Name: "counter-set-0",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("10Gi")},
+						"cores":  {Value: resource.MustParse("16")},
+					},
+				},
+			},
+			wantUtilization: 1,
+		},
+		{
+			testName: "partial allocation of one device, multiple counters used",
+			allocated: []resourceapi.Device{
+				{
+					Name: "dev-0-partition-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+								"cores":  {Value: resource.MustParse("6")},
+							},
+						},
+					},
+				},
+			},
+			unallocated: []resourceapi.Device{
+				{
+					Name: "dev-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("10Gi")},
+								"cores":  {Value: resource.MustParse("8")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-0-partition-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("5Gi")},
+								"cores":  {Value: resource.MustParse("2")},
+							},
+						},
+					},
+				},
+			},
+			sharedCounters: []resourceapi.CounterSet{
+				{
+					Name: "counter-set-0",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("10Gi")},
+						"cores":  {Value: resource.MustParse("8")},
+					},
+				},
+			},
+			wantUtilization: 0.75,
+		},
+		{
+			testName: "complex allocation of multiple devices, multiple counters used",
+			allocated: []resourceapi.Device{
+				{
+					Name: "dev-0-partition-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("25Gi")},
+								"cores":  {Value: resource.MustParse("8")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-0-partition-2",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("50Gi")},
+								"cores":  {Value: resource.MustParse("8")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-1-partition-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-1",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("50Gi")},
+								"cores":  {Value: resource.MustParse("16")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-1-partition-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-1",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("50Gi")},
+								"cores":  {Value: resource.MustParse("16")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-2",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-2",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("100Gi")},
+								"cores":  {Value: resource.MustParse("32")},
+							},
+						},
+					},
+				},
+			},
+			unallocated: []resourceapi.Device{
+				{
+					Name: "dev-0",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("100Gi")},
+								"cores":  {Value: resource.MustParse("32")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-0-partition-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-0",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("25Gi")},
+								"cores":  {Value: resource.MustParse("16")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-1",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("100Gi")},
+								"cores":  {Value: resource.MustParse("32")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-2",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-2",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("100Gi")},
+								"cores":  {Value: resource.MustParse("32")},
+							},
+						},
+					},
+				},
+				{
+					Name: "dev-3",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: "counter-set-3",
+							Counters: map[string]resourceapi.Counter{
+								"memory": {Value: resource.MustParse("100Gi")},
+								"cores":  {Value: resource.MustParse("32")},
+							},
+						},
+					},
+				},
+			},
+			sharedCounters: []resourceapi.CounterSet{
+				{
+					Name: "counter-set-0",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("100Gi")},
+						"cores":  {Value: resource.MustParse("32")},
+					},
+				},
+				{
+					Name: "counter-set-1",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("100Gi")},
+						"cores":  {Value: resource.MustParse("32")},
+					},
+				},
+				{
+					Name: "counter-set-2",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("100Gi")},
+						"cores":  {Value: resource.MustParse("32")},
+					},
+				},
+				{
+					Name: "counter-set-3",
+					Counters: map[string]resourceapi.Counter{
+						"memory": {Value: resource.MustParse("100Gi")},
+						"cores":  {Value: resource.MustParse("32")},
+					},
+				},
+			},
+			wantUtilization: 0.6875,
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			total := append(tc.allocated, tc.unallocated...)
+			utilization := calculatePartitionableDevicesPoolUtilization(tc.allocated, total, tc.sharedCounters)
+			if utilization != tc.wantUtilization {
+				t.Errorf("calculatePartitionableDevicesPoolUtilization() = %v, want %v", utilization, tc.wantUtilization)
+			}
+		})
+	}
+}
+
 func testResourceSlices(driverName, poolName, nodeName string, poolGen, deviceCount, devicesPerSlice int64) []*resourceapi.ResourceSlice {
 	sliceCount := deviceCount / devicesPerSlice
 
-	deviceIndex := 0
 	var result []*resourceapi.ResourceSlice
 	for sliceIndex := range sliceCount {
 		sliceName := fmt.Sprintf("%s-%s-slice-%d", driverName, poolName, sliceIndex)
 		var devices []resourceapi.Device
-		for range devicesPerSlice {
-			devices = append(devices, resourceapi.Device{Name: fmt.Sprintf("%s-%s-dev-%d", driverName, poolName, deviceIndex)})
-			deviceIndex++
+		for sliceDeviceIndex := range devicesPerSlice {
+			devices = append(devices, resourceapi.Device{Name: fmt.Sprintf("%s-%s-dev-%d", driverName, poolName, sliceIndex*devicesPerSlice+sliceDeviceIndex)})
 		}
 		result = append(result, &resourceapi.ResourceSlice{
 			ObjectMeta: metav1.ObjectMeta{Name: sliceName, UID: types.UID(sliceName)},
@@ -234,6 +833,143 @@ func testResourceSlices(driverName, poolName, nodeName string, poolGen, deviceCo
 		})
 	}
 	return result
+}
+
+func testResourceSlicesWithPartitionableDevices(driverName, poolName, nodeName string, poolGen, partitionCount, slicecount int, deviceNames ...string) []*resourceapi.ResourceSlice {
+	sliceName := fmt.Sprintf("%s-%s-slice", driverName, poolName)
+	var devices []resourceapi.Device
+	for _, deviceName := range deviceNames {
+		for i := 0; i < partitionCount; i++ {
+			devices = append(
+				devices,
+				resourceapi.Device{
+					Name: fmt.Sprintf("%s-partition-%d", deviceName, i),
+					Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+						"memory": {
+							Value: resource.MustParse("10Gi"),
+						},
+						"cpu": {
+							Value: resource.MustParse("1000m"),
+						},
+					},
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{
+							CounterSet: fmt.Sprintf("%s-counter-set", deviceName),
+							Counters: map[string]resourceapi.Counter{
+								"memory": {
+									Value: resource.MustParse("10Gi"),
+								},
+								"cpu": {
+									Value: resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			)
+		}
+		devices = append(devices,
+			resourceapi.Device{
+				Name: deviceName,
+				Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+					"memory": {
+						Value: resource.MustParse(fmt.Sprintf("%dGi", 10*partitionCount)),
+					},
+					"cpu": {
+						Value: resource.MustParse(fmt.Sprintf("%dm", 100*partitionCount)),
+					},
+				},
+				ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+					{
+						CounterSet: fmt.Sprintf("%s-counter-set", deviceName),
+						Counters: map[string]resourceapi.Counter{
+							"memory": {
+								Value: resource.MustParse(fmt.Sprintf("%dGi", 10*partitionCount)),
+							},
+							"cpu": {
+								Value: resource.MustParse(fmt.Sprintf("%dm", 100*partitionCount)),
+							},
+						},
+					},
+				},
+			},
+		)
+	}
+	resourceSlice := &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: sliceName, UID: types.UID(sliceName)},
+		Spec: resourceapi.ResourceSliceSpec{
+			Driver:   driverName,
+			NodeName: &nodeName,
+			Pool:     resourceapi.ResourcePool{Name: poolName, Generation: int64(poolGen), ResourceSliceCount: int64(slicecount)},
+			Devices:  devices,
+		},
+	}
+
+	sharedCounters := make([]resourceapi.CounterSet, 0, len(deviceNames))
+	for _, deviceName := range deviceNames {
+		sharedCounters = append(sharedCounters, resourceapi.CounterSet{
+			Name: fmt.Sprintf("%s-counter-set", deviceName),
+			Counters: map[string]resourceapi.Counter{
+				"memory": {
+					Value: resource.MustParse(fmt.Sprintf("%dGi", 10*partitionCount)),
+				},
+				"cpu": {
+					Value: resource.MustParse(fmt.Sprintf("%dm", 100*partitionCount)),
+				},
+			},
+		})
+	}
+
+	countersSlice := &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-counters", sliceName), UID: types.UID(fmt.Sprintf("%s-counters", sliceName))},
+		Spec: resourceapi.ResourceSliceSpec{
+			Driver:         driverName,
+			NodeName:       &nodeName,
+			Pool:           resourceapi.ResourcePool{Name: poolName, Generation: int64(poolGen), ResourceSliceCount: int64(slicecount)},
+			SharedCounters: sharedCounters,
+		},
+	}
+
+	return []*resourceapi.ResourceSlice{resourceSlice, countersSlice}
+}
+
+// addPartitionableDeviceToResourceSlices appends a new partition device to an existing set of partitionable resource slices.
+// The device will consume from the existing pool's CounterSet.
+// additionalSharedCounters adds new counter types (with their totals) to the existing SharedCounterSet,
+// which is necessary when the new device consumes counter types not already tracked by the pool.
+func addPartitionableDeviceToResourceSlices(resourceSlices []*resourceapi.ResourceSlice, driverName, poolName, deviceName string, consumedCounters map[string]resource.Quantity, additionalSharedCounters map[string]resource.Quantity) []*resourceapi.ResourceSlice {
+	devicesResourceSlice := resourceSlices[0]
+	countersResourceSlice := resourceSlices[1]
+
+	// Use the existing pool's CounterSet name so the device is counted as a partition of the same physical device.
+	counterSetName := countersResourceSlice.Spec.SharedCounters[0].Name
+
+	counters := make(map[string]resourceapi.Counter, len(consumedCounters))
+	for name, qty := range consumedCounters {
+		counters[name] = resourceapi.Counter{Value: qty.DeepCopy()}
+	}
+	device := resourceapi.Device{
+		Name: deviceName,
+		ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+			{
+				CounterSet: counterSetName,
+				Counters:   counters,
+			},
+		},
+	}
+	devicesResourceSlice.Spec.Devices = append(devicesResourceSlice.Spec.Devices, device)
+
+	// Add any new counter types (with their totals) to the existing SharedCounterSet.
+	for i, cs := range countersResourceSlice.Spec.SharedCounters {
+		if cs.Name == counterSetName {
+			for name, qty := range additionalSharedCounters {
+				countersResourceSlice.Spec.SharedCounters[i].Counters[name] = resourceapi.Counter{Value: qty.DeepCopy()}
+			}
+			break
+		}
+	}
+
+	return []*resourceapi.ResourceSlice{devicesResourceSlice, countersResourceSlice}
 }
 
 func testPodsWithClaims(driverName, poolName, nodeName string, deviceCount, devicesPerPod int64, adminAccess bool, podIndexOffset int) []*framework.PodInfo {
@@ -278,6 +1014,28 @@ func testPodsWithClaims(driverName, poolName, nodeName string, deviceCount, devi
 	return result
 }
 
+func testPodsWithCustomClaims(podName, driverName, poolName, nodeName string, devices []string) []*framework.PodInfo {
+	pod := test.BuildTestPod(fmt.Sprintf("%s-%s-%s-pod", podName, driverName, poolName), 1, 1)
+	claimName := fmt.Sprintf("%s-claim", pod.Name)
+	claim := &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, UID: types.UID(claimName)},
+		Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{},
+			},
+		},
+	}
+	for i, device := range devices {
+		claim.Status.Allocation.Devices.Results = append(claim.Status.Allocation.Devices.Results, resourceapi.DeviceRequestAllocationResult{
+			Request: fmt.Sprintf("request-%d", i),
+			Driver:  driverName,
+			Pool:    poolName,
+			Device:  device,
+		})
+	}
+	return []*framework.PodInfo{framework.NewPodInfo(pod, []*resourceapi.ResourceClaim{claim})}
+}
+
 // testPodsWithMixedAdminAccessClaims creates Pods with ResourceClaims that have mixed AdminAccess settings.
 func testPodsWithMixedAdminAccessClaims(driverName, poolName, nodeName string, deviceCount int64, adminAccessPattern []bool, podIndexOffset int) []*framework.PodInfo {
 	pis := testPodsWithClaims(driverName, poolName, nodeName, deviceCount, int64(len(adminAccessPattern)), true, podIndexOffset)
@@ -300,4 +1058,185 @@ func mergeLists[T any](sliceLists ...[]T) []T {
 		}
 	}
 	return result
+}
+
+func TestGetUniquePartitionableDevicesCount(t *testing.T) {
+	for _, tc := range []struct {
+		testName  string
+		devices   []resourceapi.Device
+		wantCount int
+	}{
+		{
+			testName:  "no devices",
+			devices:   []resourceapi.Device{},
+			wantCount: 0,
+		},
+		{
+			testName: "single atomic device (no counters)",
+			devices: []resourceapi.Device{
+				{Name: "gpu-0"},
+			},
+			wantCount: 0,
+		},
+		{
+			testName: "multiple atomic devices (no counters)",
+			devices: []resourceapi.Device{
+				{Name: "gpu-0"},
+				{Name: "gpu-1"},
+				{Name: "cpu-0"},
+			},
+			wantCount: 0,
+		},
+		{
+			testName: "single partitionable device",
+			devices: []resourceapi.Device{
+				{
+					Name: "gpu-0-whole",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			testName: "single GPU partitioned into 4 devices",
+			devices: []resourceapi.Device{
+				{
+					Name: "gpu-0-whole",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+				{
+					Name: "gpu-0-half-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+				{
+					Name: "gpu-0-half-2",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+				{
+					Name: "gpu-0-quarter-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			testName: "two GPUs each partitioned into 2 devices",
+			devices: []resourceapi.Device{
+				{
+					Name: "gpu-0-whole",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+				{
+					Name: "gpu-0-half",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+				{
+					Name: "gpu-1-whole",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-1-counters"},
+					},
+				},
+				{
+					Name: "gpu-1-half",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-1-counters"},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+		{
+			testName: "mixed atomic and partitionable devices",
+			devices: []resourceapi.Device{
+				{Name: "cpu-0"}, // Atomic
+				{
+					Name: "gpu-0-whole",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+				{
+					Name: "gpu-0-half",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			testName: "complex multi-GPU scenario",
+			devices: []resourceapi.Device{
+				{
+					Name: "gpu-0-whole",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+				{
+					Name: "gpu-0-half-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+				{
+					Name: "gpu-0-quarter-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-0-counters"},
+					},
+				},
+				{
+					Name: "gpu-1-whole",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-1-counters"},
+					},
+				},
+				{
+					Name: "gpu-1-half-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-1-counters"},
+					},
+				},
+				{
+					Name: "gpu-2-whole",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+						{CounterSet: "gpu-2-counters"},
+					},
+				},
+			},
+			wantCount: 3,
+		},
+		{
+			testName: "device with no counter consumption entries",
+			devices: []resourceapi.Device{
+				{
+					Name:             "device-1",
+					ConsumesCounters: []resourceapi.DeviceCounterConsumption{},
+				},
+			},
+			wantCount: 0, // Should be treated as atomic, not partitionable
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			count := getUniquePartitionableDevicesCount(tc.devices)
+
+			if count != tc.wantCount {
+				t.Errorf("getUniquePartitionableDevicesCount() = %v, want %v", count, tc.wantCount)
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Adds support for partitionable devices when calculating DRA utilization

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/8053

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
DRA: partitionable devices support
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
