### PR TITLE
Adding ForceDelete to cloudproviders / adding support for force delete failed instance azure

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_auto_scaling_group.go
@@ -150,6 +150,11 @@ func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
 	return asg.manager.DeleteInstances(nodeIds)
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (asg *Asg) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // Id returns asg id.
 func (asg *Asg) Id() string {
 	return asg.id

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -349,6 +349,11 @@ func (ng *AwsNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return ng.awsManager.DeleteInstances(refs)
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *AwsNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // Id returns asg id.
 func (ng *AwsNodeGroup) Id() string {
 	return ng.asg.Name

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -446,6 +446,11 @@ func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
+	return as.ForceDeleteNodes(nodes)
+}
+
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (as *AgentPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
 	refs := make([]*azureRef, 0, len(nodes))
 	for _, node := range nodes {
 		belongs, err := as.Belongs(node)
@@ -463,17 +468,12 @@ func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 		refs = append(refs, ref)
 	}
 
-	err = as.deleteOutdatedDeployments()
+	err := as.deleteOutdatedDeployments()
 	if err != nil {
-		klog.Warningf("DeleteNodes: failed to cleanup outdated deployments with err: %v.", err)
+		klog.Warningf("ForceDeleteNodes: failed to cleanup outdated deployments with err: %v.", err)
 	}
 
 	return as.DeleteInstances(refs)
-}
-
-// ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (as *AgentPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
-	return cloudprovider.ErrNotImplemented
 }
 
 // Debug returns a debug string for the agent pool.

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -471,6 +471,11 @@ func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
 	return as.DeleteInstances(refs)
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (as *AgentPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // Debug returns a debug string for the agent pool.
 func (as *AgentPool) Debug() string {
 	return fmt.Sprintf("%s (%d:%d)", as.Name, as.MinSize(), as.MaxSize())

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -429,14 +429,14 @@ func (as *AgentPool) DeleteInstances(instances []*azureRef) error {
 		}
 	}
 
-	klog.V(6).Infof("DeleteInstances: invalidating cache")
+	klog.V(3).Infof("DeleteInstances: invalidating cache")
 	as.manager.invalidateCache()
 	return nil
 }
 
 // DeleteNodes deletes the nodes from the group.
 func (as *AgentPool) DeleteNodes(nodes []*apiv1.Node) error {
-	klog.V(6).Infof("Delete nodes requested: %v\n", nodes)
+	klog.V(3).Infof("Delete nodes requested: %v\n", nodes)
 	indexes, _, err := as.GetVMIndexes()
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -603,7 +603,7 @@ func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
 func (scaleSet *ScaleSet) ForceDeleteNodes(nodes []*apiv1.Node) error {
-	klog.V(8).Infof("Delete nodes requested: %q\n", nodes)
+	klog.V(5).Infof("Delete nodes requested: %q\n", nodes)
 	refs := make([]*azureRef, 0, len(nodes))
 	hasUnregisteredNodes := false
 	for _, node := range nodes {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -598,12 +598,14 @@ func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
 	if int(size) <= scaleSet.MinSize() {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
+	return scaleSet.ForceDeleteNodes(nodes)
+}
 
-	// Distinguish between unregistered node deletion and normal node deletion
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (scaleSet *ScaleSet) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	klog.V(8).Infof("Delete nodes requested: %q\n", nodes)
 	refs := make([]*azureRef, 0, len(nodes))
 	hasUnregisteredNodes := false
-	unregisteredRefs := make([]*azureRef, 0, len(nodes))
-
 	for _, node := range nodes {
 		belongs, err := scaleSet.Belongs(node)
 		if err != nil {
@@ -620,26 +622,10 @@ func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
 		ref := &azureRef{
 			Name: node.Spec.ProviderID,
 		}
-
-		if node.Annotations[cloudprovider.FakeNodeReasonAnnotation] == cloudprovider.FakeNodeUnregistered {
-			klog.V(5).Infof("Node: %s type is unregistered..Appending to the unregistered list", node.Name)
-			unregisteredRefs = append(unregisteredRefs, ref)
-		} else {
-			refs = append(refs, ref)
-		}
-	}
-
-	if len(unregisteredRefs) > 0 {
-		klog.V(3).Infof("Removing unregisteredNodes: %v", unregisteredRefs)
-		return scaleSet.DeleteInstances(unregisteredRefs, true)
+		refs = append(refs, ref)
 	}
 
 	return scaleSet.DeleteInstances(refs, hasUnregisteredNodes)
-}
-
-// ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (scaleSet *ScaleSet) ForceDeleteNodes(nodes []*apiv1.Node) error {
-	return cloudprovider.ErrNotImplemented
 }
 
 // Id returns ScaleSet id.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -637,6 +637,11 @@ func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
 	return scaleSet.DeleteInstances(refs, hasUnregisteredNodes)
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (scaleSet *ScaleSet) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // Id returns ScaleSet id.
 func (scaleSet *ScaleSet) Id() string {
 	return scaleSet.Name

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -589,7 +589,7 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(future *azure.Future, requiredI
 
 // DeleteNodes deletes the nodes from the group.
 func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
-	klog.V(8).Infof("Delete nodes requested: %q\n", nodes)
+	klog.V(3).Infof("Delete nodes requested: %q\n", nodes)
 	size, err := scaleSet.getScaleSetSize()
 	if err != nil {
 		return err
@@ -603,7 +603,7 @@ func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
 func (scaleSet *ScaleSet) ForceDeleteNodes(nodes []*apiv1.Node) error {
-	klog.V(5).Infof("Delete nodes requested: %q\n", nodes)
+	klog.V(3).Infof("Delete nodes requested: %q\n", nodes)
 	refs := make([]*azureRef, 0, len(nodes))
 	hasUnregisteredNodes := false
 	for _, node := range nodes {

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -312,6 +312,11 @@ func (vmPool *VMPool) Belongs(node *apiv1.Node) (bool, error) {
 	return true, nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (agentPool *VMsPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group.
 func (vmPool *VMPool) DecreaseTargetSize(delta int) error {
 	// The TargetSize of a VMPool is automatically adjusted after node deletions.

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -313,7 +313,7 @@ func (vmPool *VMPool) Belongs(node *apiv1.Node) (bool, error) {
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
-func (agentPool *VMsPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
+func (agentPool *VMPool) ForceDeleteNodes(nodes []*apiv1.Node) error {
 	return cloudprovider.ErrNotImplemented
 }
 

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -315,6 +315,11 @@ func (asg *Asg) DeleteNodes(nodes []*apiv1.Node) error {
 	return asg.baiducloudManager.ScaleDownCluster(nodeID)
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (asg *Asg) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // Belongs returns true if the given node belongs to the NodeGroup.
 func (asg *Asg) Belongs(instanceID string) (bool, error) {
 	targetAsg, err := asg.baiducloudManager.GetAsgForInstance(instanceID)

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_node_group.go
@@ -132,6 +132,11 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_node_group.go
@@ -152,6 +152,11 @@ func (ng *brightboxNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *brightboxNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This
 // function doesn't permit to delete any existing node and can be used
 // only to reduce the request for new nodes that have not been yet

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_node_group.go
@@ -189,6 +189,11 @@ func (ng *cherryNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *cherryNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // getNodesToDelete safely gets all of the nodes added to the delete queue.
 // "safely", as in it locks, gets and then releases the queue.
 func (ng *cherryNodeGroup) getNodesToDelete() []*apiv1.Node {

--- a/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_node_group.go
@@ -144,6 +144,11 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -195,6 +195,12 @@ type NodeGroup interface {
 	// should wait until node group size is updated. Implementation required.
 	DeleteNodes([]*apiv1.Node) error
 
+	// ForceDeleteNodes deletes nodes from this node group, without checking for
+	// constraints like minimal size validation etc. Error is returned either on
+	// failure or if the given node doesn't belong to this node group. This function
+	// should wait until node group size is updated.
+	ForceDeleteNodes([]*apiv1.Node) error
+
 	// DecreaseTargetSize decreases the target size of the node group. This function
 	// doesn't permit to delete any existing node and can be used only to reduce the
 	// request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_node_group.go
@@ -123,6 +123,11 @@ func (asg *asg) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (asg *asg) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // Id returns cluster id.
 func (asg *asg) Id() string {
 	return asg.cluster.ID

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -177,6 +177,11 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *nodegroup) ForceDeleteNodes(nodes []*corev1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group.
 // This function doesn't permit to delete any existing node and can be
 // used only to reduce the request for new nodes that have not been

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -139,6 +139,11 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/equinixmetal/node_group.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/node_group.go
@@ -226,6 +226,11 @@ func (ng *equinixMetalNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *equinixMetalNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the cluster node_count in Equinix Metal.
 func (ng *equinixMetalNodeGroup) DecreaseTargetSize(delta int) error {
 	if delta >= 0 {

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -131,6 +131,11 @@ func (n *instancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *instancePoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
@@ -136,6 +136,11 @@ func (n *sksNodepoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *sksNodepoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_node_group.go
@@ -122,6 +122,11 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -311,6 +311,11 @@ func (mig *gceMig) DeleteNodes(nodes []*apiv1.Node) error {
 	return mig.gceManager.DeleteInstances(refs)
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (mig *gceMig) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // Id returns mig url.
 func (mig *gceMig) Id() string {
 	return GenerateMigUrl(mig.domainUrl, mig.gceRef)

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -214,6 +214,11 @@ func (n *hetznerNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *hetznerNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_auto_scaling_group.go
@@ -146,6 +146,11 @@ func (asg *AutoScalingGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (asg *AutoScalingGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -103,6 +103,11 @@ func (n *nodePool) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *nodePool) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_node_group.go
@@ -111,6 +111,11 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -238,6 +238,11 @@ func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (nodeGroup *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // IncreaseSize increases NodeGroup size.
 func (nodeGroup *NodeGroup) IncreaseSize(delta int) error {
 	if delta <= 0 {

--- a/cluster-autoscaler/cloudprovider/kwok/kwok_nodegroups.go
+++ b/cluster-autoscaler/cloudprovider/kwok/kwok_nodegroups.go
@@ -120,6 +120,11 @@ func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (nodeGroup *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_node_group.go
@@ -126,6 +126,11 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_nodegroup.go
@@ -139,6 +139,11 @@ func (ng *magnumNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *magnumNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the cluster node_count in magnum.
 func (ng *magnumNodeGroup) DecreaseTargetSize(delta int) error {
 	ng.clusterUpdateLock.Lock()

--- a/cluster-autoscaler/cloudprovider/mocks/NodeGroup.go
+++ b/cluster-autoscaler/cloudprovider/mocks/NodeGroup.go
@@ -125,6 +125,20 @@ func (_m *NodeGroup) DeleteNodes(_a0 []*v1.Node) error {
 	return r0
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (_m *NodeGroup) ForceDeleteNodes(_a0 []*v1.Node) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]*v1.Node) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Exist provides a mock function with given fields:
 func (_m *NodeGroup) Exist() bool {
 	ret := _m.Called()

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
@@ -107,6 +107,11 @@ func (ip *InstancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return ip.manager.DeleteInstances(*ip, refs)
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ip *InstancePoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the instance-pool based node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
@@ -182,6 +182,11 @@ func (np *nodePool) DeleteNodes(nodes []*apiv1.Node) (err error) {
 	return deleteInstancesErr
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (np *nodePool) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_node_group.go
@@ -166,6 +166,11 @@ func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup.go
@@ -134,6 +134,11 @@ func (ng *nodeGroup) DeleteNodes(toDelete []*corev1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *nodeGroup) ForceDeleteNodes(nodes []*corev1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 func (ng *nodeGroup) findNodeByProviderID(providerID string) (*node, error) {
 	nodes, err := ng.nodes()
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
@@ -134,6 +134,11 @@ func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_auto_scaling_group.go
@@ -231,6 +231,11 @@ func (asg *tcAsg) DeleteNodes(nodes []*apiv1.Node) error {
 	return asg.tencentcloudManager.DeleteInstances(refs)
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (asg *tcAsg) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // Id returns asg id.
 func (asg *tcAsg) Id() string {
 	return asg.tencentcloudRef.ID

--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -453,6 +453,11 @@ func (tng *TestNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (tng *TestNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return tng.DeleteNodes(nodes)
+}
+
 // Id returns an unique identifier of the node group.
 func (tng *TestNodeGroup) Id() string {
 	tng.Lock()

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine_auto_scaling_group.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine_auto_scaling_group.go
@@ -106,6 +106,11 @@ func (asg *AutoScalingGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return asg.manager.DeleteScalingInstances(asg.asgId, instanceIds)
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (asg *AutoScalingGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 func (asg *AutoScalingGroup) belongs(node *apiv1.Node) (bool, error) {
 	instanceId, err := ecsInstanceFromProviderId(node.Spec.ProviderID)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_node_group.go
@@ -129,6 +129,11 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	return nil
 }
 
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (n *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
 // DecreaseTargetSize decreases the target size of the node group. This function
 // doesn't permit to delete any existing node and can be used only to reduce the
 // request for new nodes that have not been yet fulfilled. Delta should be negative.

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -297,6 +297,8 @@ type AutoscalingOptions struct {
 	ProvisioningRequestEnabled bool
 	// AsyncNodeGroupsEnabled tells if CA creates/deletes node groups asynchronously.
 	AsyncNodeGroupsEnabled bool
+	// ForceDeleteFailedNodes is used to enable/disable ignoring min size constraints during removal of failed nodes
+	ForceDeleteFailedNodes bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -868,8 +868,15 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() {
 		nodeGroup := nodeGroups[nodeGroupId]
 		if nodeGroup == nil {
 			err = fmt.Errorf("node group %s not found", nodeGroupId)
-		} else if nodesToDelete, err = overrideNodesToDeleteForZeroOrMax(a.NodeGroupDefaults, nodeGroup, nodesToDelete); err == nil {
-			err = nodeGroup.DeleteNodes(nodesToDelete)
+		} else if nodesToDelete, err = overrideNodesToDeleteForZeroOrMax(a.NodeGroupDefaults, nodeGroup, nodesToDelete); err == nil && len(nodesToDelete) > 0 {
+			if a.ForceDeleteFailedNodes {
+				err = nodeGroup.ForceDeleteNodes(nodesToDelete)
+				if errors.Is(err, cloudprovider.ErrNotImplemented) {
+					err = nodeGroup.DeleteNodes(nodesToDelete)
+				}
+			} else {
+				err = nodeGroup.DeleteNodes(nodesToDelete)
+			}
 		}
 
 		if err != nil {

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1533,400 +1533,397 @@ func TestStaticAutoscalerRunOnceWithBypassedSchedulers(t *testing.T) {
 }
 
 func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
-	// setup
-	provider := &mockprovider.CloudProvider{}
-
-	// Create context with mocked lister registry.
-	options := config.AutoscalingOptions{
-		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
-			ScaleDownUnneededTime:         time.Minute,
-			ScaleDownUnreadyTime:          time.Minute,
-			ScaleDownUtilizationThreshold: 0.5,
-			MaxNodeProvisionTime:          10 * time.Second,
+	testCases := []struct {
+		forceDeleteEnabled     bool
+		forceDeleteImplemented bool
+	}{
+		{
+			forceDeleteEnabled:     false,
+			forceDeleteImplemented: false,
 		},
-		EstimatorName:                estimator.BinpackingEstimatorName,
-		ScaleDownEnabled:             true,
-		MaxNodesTotal:                10,
-		MaxCoresTotal:                10,
-		MaxMemoryTotal:               100000,
-		ExpendablePodsPriorityCutoff: 10,
+		{
+			forceDeleteEnabled:     true,
+			forceDeleteImplemented: false,
+		},
+		{
+			forceDeleteEnabled:     true,
+			forceDeleteImplemented: true,
+		},
 	}
-	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("forceDeleteEnabled=%t,forceDeleteImplemented=%t", tc.forceDeleteEnabled, tc.forceDeleteImplemented), func(t *testing.T) {
+			// setup
+			provider := &mockprovider.CloudProvider{}
 
-	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
-	assert.NoError(t, err)
+			// Create context with mocked lister registry.
+			options := config.AutoscalingOptions{
+				NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+					ScaleDownUnneededTime:         time.Minute,
+					ScaleDownUnreadyTime:          time.Minute,
+					ScaleDownUtilizationThreshold: 0.5,
+					MaxNodeProvisionTime:          10 * time.Second,
+				},
+				EstimatorName:                estimator.BinpackingEstimatorName,
+				ScaleDownEnabled:             true,
+				MaxNodesTotal:                10,
+				MaxCoresTotal:                10,
+				MaxMemoryTotal:               100000,
+				ExpendablePodsPriorityCutoff: 10,
+				ForceDeleteFailedNodes:       tc.forceDeleteEnabled,
+			}
+			processorCallbacks := newStaticAutoscalerProcessorCallbacks()
+			var deleteMethod string
+			if tc.forceDeleteEnabled {
+				deleteMethod = "ForceDeleteNodes"
+			} else {
+				deleteMethod = "DeleteNodes"
+			}
 
-	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
-		OkTotalUnreadyCount: 1,
+			context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil)
+			assert.NoError(t, err)
+
+			clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
+				OkTotalUnreadyCount: 1,
+			}
+
+			nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults)
+			asyncNodeGroupStateChecker := asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker()
+			clusterState := clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
+			autoscaler := &StaticAutoscaler{
+				AutoscalingContext:    &context,
+				clusterStateRegistry:  clusterState,
+				lastScaleUpTime:       time.Now(),
+				lastScaleDownFailTime: time.Now(),
+				processorCallbacks:    processorCallbacks,
+			}
+
+			nodeGroupA := &mockprovider.NodeGroup{}
+			nodeGroupB := &mockprovider.NodeGroup{}
+
+			// Three nodes with out-of-resources errors
+			nodeGroupA.On("Exist").Return(true)
+			nodeGroupA.On("Autoprovisioned").Return(false)
+			nodeGroupA.On("TargetSize").Return(5, nil)
+			nodeGroupA.On("Id").Return("A")
+			mockDeleteNodes(nodeGroupA, tc.forceDeleteEnabled, tc.forceDeleteImplemented)
+			nodeGroupA.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
+			nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "A1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
+				},
+				{
+					Id: "A2",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+					},
+				},
+				{
+					Id: "A3",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
+						},
+					},
+				},
+				{
+					Id: "A4",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
+						},
+					},
+				},
+				{
+					Id: "A5",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "QUOTA",
+						},
+					},
+				},
+				{
+					Id: "A6",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OtherErrorClass,
+							ErrorCode:  "OTHER",
+						},
+					},
+				},
+			}, nil).Twice()
+
+			nodeGroupB.On("Exist").Return(true)
+			nodeGroupB.On("Autoprovisioned").Return(false)
+			nodeGroupB.On("TargetSize").Return(5, nil)
+			nodeGroupB.On("Id").Return("B")
+			mockDeleteNodes(nodeGroupB, tc.forceDeleteEnabled, tc.forceDeleteImplemented)
+			nodeGroupB.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
+			nodeGroupB.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "B1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
+				},
+			}, nil)
+
+			provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupA})
+			provider.On("NodeGroupForNode", mock.Anything).Return(
+				func(node *apiv1.Node) cloudprovider.NodeGroup {
+					if strings.HasPrefix(node.Spec.ProviderID, "A") {
+						return nodeGroupA
+					}
+					if strings.HasPrefix(node.Spec.ProviderID, "B") {
+						return nodeGroupB
+					}
+					return nil
+				}, nil)
+			provider.On("HasInstance", mock.Anything).Return(
+				func(node *apiv1.Node) bool {
+					return false
+				}, nil)
+
+			now := time.Now()
+
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+			// propagate nodes info in cluster state
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+
+			// delete nodes with create errors
+			autoscaler.deleteCreatedNodesWithErrors()
+
+			// nodes should be deleted
+			expectedDeleteCalls := 1
+			if tc.forceDeleteEnabled {
+				nodeGroupA.AssertNumberOfCalls(t, "ForceDeleteNodes", expectedDeleteCalls)
+				if !tc.forceDeleteImplemented {
+					nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+				}
+			} else {
+				nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+			}
+
+			// check delete was called on correct nodes
+			nodeGroupA.AssertCalled(t, deleteMethod, mock.MatchedBy(
+				func(nodes []*apiv1.Node) bool {
+					if len(nodes) != 4 {
+						return false
+					}
+					names := make(map[string]bool)
+					for _, node := range nodes {
+						names[node.Spec.ProviderID] = true
+					}
+					return names["A3"] && names["A4"] && names["A5"] && names["A6"]
+				}))
+
+			// TODO assert that scaleup was failed (separately for QUOTA and RESOURCE_POOL_EXHAUSTED)
+
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+
+			// propagate nodes info in cluster state again
+			// no changes in what provider returns
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+
+			// delete nodes with create errors
+			autoscaler.deleteCreatedNodesWithErrors()
+
+			// nodes should be deleted again
+			expectedDeleteCalls += 1
+			if tc.forceDeleteEnabled {
+				nodeGroupA.AssertNumberOfCalls(t, "ForceDeleteNodes", expectedDeleteCalls)
+				if !tc.forceDeleteImplemented {
+					nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+				}
+			} else {
+				nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+			}
+
+			nodeGroupA.AssertCalled(t, deleteMethod, mock.MatchedBy(
+				func(nodes []*apiv1.Node) bool {
+					if len(nodes) != 4 {
+						return false
+					}
+					names := make(map[string]bool)
+					for _, node := range nodes {
+						names[node.Spec.ProviderID] = true
+					}
+					return names["A3"] && names["A4"] && names["A5"] && names["A6"]
+				}))
+
+			// TODO assert that scaleup is not failed again
+
+			// restub node group A so nodes are no longer reporting errors
+			nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "A1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
+				},
+				{
+					Id: "A2",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+					},
+				},
+				{
+					Id: "A3",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceDeleting,
+					},
+				},
+				{
+					Id: "A4",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceDeleting,
+					},
+				},
+				{
+					Id: "A5",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceDeleting,
+					},
+				},
+				{
+					Id: "A6",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceDeleting,
+					},
+				},
+			}, nil)
+
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+
+			// update cluster state
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+
+			// delete nodes with create errors
+			autoscaler.deleteCreatedNodesWithErrors()
+
+			// we expect no more Delete Nodes, don't increase expectedDeleteCalls
+			if tc.forceDeleteEnabled {
+				nodeGroupA.AssertNumberOfCalls(t, "ForceDeleteNodes", expectedDeleteCalls)
+				if !tc.forceDeleteImplemented {
+					nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+				}
+			} else {
+				nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
+			}
+
+			// failed node not included by NodeGroupForNode
+			nodeGroupC := &mockprovider.NodeGroup{}
+			nodeGroupC.On("Exist").Return(true)
+			nodeGroupC.On("Autoprovisioned").Return(false)
+			nodeGroupC.On("TargetSize").Return(1, nil)
+			nodeGroupC.On("Id").Return("C")
+			mockDeleteNodes(nodeGroupC, tc.forceDeleteEnabled, tc.forceDeleteImplemented)
+			nodeGroupC.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
+			nodeGroupC.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "C1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "QUOTA",
+						},
+					},
+				},
+			}, nil)
+			provider = &mockprovider.CloudProvider{}
+			provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupC})
+			provider.On("NodeGroupForNode", mock.Anything).Return(nil, nil)
+			provider.On("HasInstance", mock.Anything).Return(
+				func(node *apiv1.Node) bool {
+					return false
+				}, nil)
+
+			clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+			autoscaler.clusterStateRegistry = clusterState
+
+			// update cluster state
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, time.Now())
+
+			// No nodes are deleted when failed nodes don't have matching node groups
+			autoscaler.deleteCreatedNodesWithErrors()
+			nodeGroupC.AssertNumberOfCalls(t, deleteMethod, 0)
+
+			// Node group with getOptions error gets no deletes.
+			nodeGroupError := &mockprovider.NodeGroup{}
+			nodeGroupError.On("Exist").Return(true)
+			nodeGroupError.On("Autoprovisioned").Return(false)
+			nodeGroupError.On("TargetSize").Return(1, nil)
+			nodeGroupError.On("Id").Return("E")
+			mockDeleteNodes(nodeGroupError, tc.forceDeleteEnabled, tc.forceDeleteImplemented)
+			nodeGroupError.On("GetOptions", options.NodeGroupDefaults).Return(nil, fmt.Errorf("Failed to get options"))
+			nodeGroupError.On("Nodes").Return([]cloudprovider.Instance{
+				{
+					Id: "E1",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceRunning,
+					},
+				},
+				{
+
+					Id: "E2",
+					Status: &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceCreating,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass: cloudprovider.OutOfResourcesErrorClass,
+							ErrorCode:  "QUOTA",
+						},
+					},
+				},
+			}, nil)
+
+			provider = &mockprovider.CloudProvider{}
+			provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupError})
+			provider.On("NodeGroupForNode", mock.Anything).Return(
+				func(node *apiv1.Node) cloudprovider.NodeGroup {
+					if strings.HasPrefix(node.Spec.ProviderID, "E") {
+						return nodeGroupError
+					}
+					return nil
+				}, nil).Times(2)
+
+			clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
+			clusterState.RefreshCloudProviderNodeInstancesCache()
+			autoscaler.CloudProvider = provider
+			autoscaler.clusterStateRegistry = clusterState
+			// propagate nodes info in cluster state
+			clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
+
+			// delete nodes with create errors
+			autoscaler.deleteCreatedNodesWithErrors()
+
+			nodeGroupError.AssertNumberOfCalls(t, deleteMethod, 0)
+		})
 	}
+}
 
-	nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults)
-	asyncNodeGroupStateChecker := asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker()
-	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
-	autoscaler := &StaticAutoscaler{
-		AutoscalingContext:    &context,
-		clusterStateRegistry:  clusterState,
-		lastScaleUpTime:       time.Now(),
-		lastScaleDownFailTime: time.Now(),
-		processorCallbacks:    processorCallbacks,
+func mockDeleteNodes(nodeGroup *mockprovider.NodeGroup, forceDeleteEnabled, forceDeleteImplemented bool) {
+	if forceDeleteEnabled {
+		m := nodeGroup.On("ForceDeleteNodes", mock.Anything)
+		if forceDeleteImplemented {
+			m.Return(nil)
+		} else {
+			m.Return(cloudprovider.ErrNotImplemented)
+			nodeGroup.On("DeleteNodes", mock.Anything).Return(nil)
+		}
+	} else {
+		nodeGroup.On("DeleteNodes", mock.Anything).Return(nil)
 	}
-
-	nodeGroupA := &mockprovider.NodeGroup{}
-	nodeGroupB := &mockprovider.NodeGroup{}
-
-	// Three nodes with out-of-resources errors
-	nodeGroupA.On("Exist").Return(true)
-	nodeGroupA.On("Autoprovisioned").Return(false)
-	nodeGroupA.On("TargetSize").Return(5, nil)
-	nodeGroupA.On("Id").Return("A")
-	nodeGroupA.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupA.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
-	nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "A1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-			Id: "A2",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-			},
-		},
-		{
-			Id: "A3",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
-				},
-			},
-		},
-		{
-			Id: "A4",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "RESOURCE_POOL_EXHAUSTED",
-				},
-			},
-		},
-		{
-			Id: "A5",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "QUOTA",
-				},
-			},
-		},
-		{
-			Id: "A6",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OtherErrorClass,
-					ErrorCode:  "OTHER",
-				},
-			},
-		},
-	}, nil).Twice()
-
-	nodeGroupB.On("Exist").Return(true)
-	nodeGroupB.On("Autoprovisioned").Return(false)
-	nodeGroupB.On("TargetSize").Return(5, nil)
-	nodeGroupB.On("Id").Return("B")
-	nodeGroupB.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupB.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
-	nodeGroupB.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "B1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-	}, nil)
-
-	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupA})
-	provider.On("NodeGroupForNode", mock.Anything).Return(
-		func(node *apiv1.Node) cloudprovider.NodeGroup {
-			if strings.HasPrefix(node.Spec.ProviderID, "A") {
-				return nodeGroupA
-			}
-			if strings.HasPrefix(node.Spec.ProviderID, "B") {
-				return nodeGroupB
-			}
-			return nil
-		}, nil)
-	provider.On("HasInstance", mock.Anything).Return(
-		func(node *apiv1.Node) bool {
-			return false
-		}, nil)
-
-	now := time.Now()
-
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-	// propagate nodes info in cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	// nodes should be deleted
-	expectedDeleteCalls := 1
-	nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
-
-	// check delete was called on correct nodes
-	nodeGroupA.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
-		func(nodes []*apiv1.Node) bool {
-			if len(nodes) != 4 {
-				return false
-			}
-			names := make(map[string]bool)
-			for _, node := range nodes {
-				names[node.Spec.ProviderID] = true
-			}
-			return names["A3"] && names["A4"] && names["A5"] && names["A6"]
-		}))
-
-	// TODO assert that scaleup was failed (separately for QUOTA and RESOURCE_POOL_EXHAUSTED)
-
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-
-	// propagate nodes info in cluster state again
-	// no changes in what provider returns
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	// nodes should be deleted again
-	expectedDeleteCalls += 1
-	nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
-
-	nodeGroupA.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
-		func(nodes []*apiv1.Node) bool {
-			if len(nodes) != 4 {
-				return false
-			}
-			names := make(map[string]bool)
-			for _, node := range nodes {
-				names[node.Spec.ProviderID] = true
-			}
-			return names["A3"] && names["A4"] && names["A5"] && names["A6"]
-		}))
-
-	// TODO assert that scaleup is not failed again
-
-	// restub node group A so nodes are no longer reporting errors
-	nodeGroupA.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "A1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-			Id: "A2",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-			},
-		},
-		{
-			Id: "A3",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceDeleting,
-			},
-		},
-		{
-			Id: "A4",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceDeleting,
-			},
-		},
-		{
-			Id: "A5",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceDeleting,
-			},
-		},
-		{
-			Id: "A6",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceDeleting,
-			},
-		},
-	}, nil)
-
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-
-	// update cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	// we expect no more Delete Nodes, don't increase expectedDeleteCalls
-	nodeGroupA.AssertNumberOfCalls(t, "DeleteNodes", expectedDeleteCalls)
-
-	// failed node not included by NodeGroupForNode
-	nodeGroupC := &mockprovider.NodeGroup{}
-	nodeGroupC.On("Exist").Return(true)
-	nodeGroupC.On("Autoprovisioned").Return(false)
-	nodeGroupC.On("TargetSize").Return(1, nil)
-	nodeGroupC.On("Id").Return("C")
-	nodeGroupC.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupC.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
-	nodeGroupC.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "C1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "QUOTA",
-				},
-			},
-		},
-	}, nil)
-	provider = &mockprovider.CloudProvider{}
-	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupC})
-	provider.On("NodeGroupForNode", mock.Anything).Return(nil, nil)
-	provider.On("HasInstance", mock.Anything).Return(
-		func(node *apiv1.Node) bool {
-			return false
-		}, nil)
-
-	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-	autoscaler.clusterStateRegistry = clusterState
-
-	// update cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, time.Now())
-
-	// No nodes are deleted when failed nodes don't have matching node groups
-	autoscaler.deleteCreatedNodesWithErrors()
-	nodeGroupC.AssertNumberOfCalls(t, "DeleteNodes", 0)
-
-	nodeGroupAtomic := &mockprovider.NodeGroup{}
-	nodeGroupAtomic.On("Exist").Return(true)
-	nodeGroupAtomic.On("Autoprovisioned").Return(false)
-	nodeGroupAtomic.On("TargetSize").Return(3, nil)
-	nodeGroupAtomic.On("Id").Return("D")
-	nodeGroupAtomic.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupAtomic.On("GetOptions", options.NodeGroupDefaults).Return(
-		&config.NodeGroupAutoscalingOptions{
-			ZeroOrMaxNodeScaling: true,
-		}, nil)
-	nodeGroupAtomic.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "D1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-			Id: "D2",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-			Id: "D3",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OtherErrorClass,
-					ErrorCode:  "OTHER",
-				},
-			},
-		},
-	}, nil).Twice()
-	provider = &mockprovider.CloudProvider{}
-	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupAtomic})
-	provider.On("NodeGroupForNode", mock.Anything).Return(
-		func(node *apiv1.Node) cloudprovider.NodeGroup {
-			if strings.HasPrefix(node.Spec.ProviderID, "D") {
-				return nodeGroupAtomic
-			}
-			return nil
-		}, nil).Times(3)
-
-	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-	autoscaler.CloudProvider = provider
-	autoscaler.clusterStateRegistry = clusterState
-	// propagate nodes info in cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	nodeGroupAtomic.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
-		func(nodes []*apiv1.Node) bool {
-			if len(nodes) != 3 {
-				return false
-			}
-			names := make(map[string]bool)
-			for _, node := range nodes {
-				names[node.Spec.ProviderID] = true
-			}
-			return names["D1"] && names["D2"] && names["D3"]
-		}))
-
-	// Node group with getOptions error gets no deletes.
-	nodeGroupError := &mockprovider.NodeGroup{}
-	nodeGroupError.On("Exist").Return(true)
-	nodeGroupError.On("Autoprovisioned").Return(false)
-	nodeGroupError.On("TargetSize").Return(1, nil)
-	nodeGroupError.On("Id").Return("E")
-	nodeGroupError.On("DeleteNodes", mock.Anything).Return(nil)
-	nodeGroupError.On("GetOptions", options.NodeGroupDefaults).Return(nil, fmt.Errorf("Failed to get options"))
-	nodeGroupError.On("Nodes").Return([]cloudprovider.Instance{
-		{
-			Id: "E1",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceRunning,
-			},
-		},
-		{
-
-			Id: "E2",
-			Status: &cloudprovider.InstanceStatus{
-				State: cloudprovider.InstanceCreating,
-				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass: cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:  "QUOTA",
-				},
-			},
-		},
-	}, nil)
-
-	provider = &mockprovider.CloudProvider{}
-	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroupError})
-	provider.On("NodeGroupForNode", mock.Anything).Return(
-		func(node *apiv1.Node) cloudprovider.NodeGroup {
-			if strings.HasPrefix(node.Spec.ProviderID, "E") {
-				return nodeGroupError
-			}
-			return nil
-		}, nil).Times(2)
-
-	clusterState = clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, context.LogRecorder, NewBackoff(), nodeGroupConfigProcessor, asyncNodeGroupStateChecker)
-	clusterState.RefreshCloudProviderNodeInstancesCache()
-	autoscaler.CloudProvider = provider
-	autoscaler.clusterStateRegistry = clusterState
-	// propagate nodes info in cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, nil, now)
-
-	// delete nodes with create errors
-	autoscaler.deleteCreatedNodesWithErrors()
-
-	nodeGroupError.AssertNumberOfCalls(t, "DeleteNodes", 0)
 }
 
 type candidateTrackingFakePlanner struct {

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -42,8 +42,10 @@ func (f *FakeNodeGroup) IncreaseSize(delta int) error       { return nil }
 func (f *FakeNodeGroup) AtomicIncreaseSize(delta int) error { return cloudprovider.ErrNotImplemented }
 func (f *FakeNodeGroup) DecreaseTargetSize(delta int) error { return nil }
 func (f *FakeNodeGroup) DeleteNodes([]*apiv1.Node) error    { return nil }
-func (f *FakeNodeGroup) Id() string                         { return f.id }
-func (f *FakeNodeGroup) Debug() string                      { return f.id }
+
+func (f *FakeNodeGroup) ForceDeleteNodes([]*apiv1.Node) error { return nil }
+func (f *FakeNodeGroup) Id() string                           { return f.id }
+func (f *FakeNodeGroup) Debug() string                        { return f.id }
 func (f *FakeNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 	return []cloudprovider.Instance{}, nil
 }

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -271,6 +271,7 @@ var (
 	asyncNodeGroupsEnabled      = flag.Bool("async-node-groups", false, "Whether clusterautoscaler creates and deletes node groups asynchronously. Experimental: requires cloud provider supporting async node group operations, enable at your own risk.")
 	proactiveScaleupEnabled     = flag.Bool("enable-proactive-scaleup", false, "Whether to enable/disable proactive scale-ups, defaults to false")
 	podInjectionLimit           = flag.Int("pod-injection-limit", 5000, "Limits total number of pods while injecting fake pods. If unschedulable pods already exceeds the limit, pod injection is disabled but pods are not truncated.")
+	forceDeleteFailedNodes      = flag.Bool("force-delete-failed-nodes", false, "Whether to enable force deletion of failed nodes, regardless of the min size of the node group the belong to.")
 )
 
 func isFlagPassed(name string) bool {
@@ -447,6 +448,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		BypassedSchedulers:                      scheduler_util.GetBypassedSchedulersMap(*bypassedSchedulers),
 		ProvisioningRequestEnabled:              *provisioningRequestsEnabled,
 		AsyncNodeGroupsEnabled:                  *asyncNodeGroupsEnabled,
+		ForceDeleteFailedNodes:                  *forceDeleteFailedNodes,
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
DeleteNodes checks if the node group is below
its min size. If it is and a scale up fails,
CA is unable to clean up the instances
with errors, which causes CA ending up in
an error loop. Using ForceDeleteNodes instead,
so the min size won't be validated when
removing failed instances.

Adding support for azure.
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
need forceDeleteFailedNodes for previous release versions

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ensure created nodes with errors are deleted
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
