### PR TITLE
Update VPA default version to 1.5.0

### DIFF
--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
-          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.4.2
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.5.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.4.2
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.5.0
         imagePullPolicy: Always
         args:
           - --recommender-name=performance

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.4.2
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.5.0
         imagePullPolicy: Always
         args:
           - --recommender-name=frugal

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.4.2
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.5.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: updater
-          image: registry.k8s.io/autoscaling/vpa-updater:1.4.2
+          image: registry.k8s.io/autoscaling/vpa-updater:1.5.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -1,7 +1,7 @@
 # Vertical Pod Autoscaler Flags
 This document contains the flags for all VPA components.
 
-To view the most recent _release_ of flags for all VPA components, consult the release tag [flags(1.4.2)](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-1.4.2/vertical-pod-autoscaler/docs/flags.md) documentation.
+To view the most recent _release_ of flags for all VPA components, consult the release tag [flags(1.5.0)](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-1.5.0/vertical-pod-autoscaler/docs/flags.md) documentation.
 
 > **Note:** This document is auto-generated from the default branch (master) of the VPA repository.
 

--- a/vertical-pod-autoscaler/docs/installation.md
+++ b/vertical-pod-autoscaler/docs/installation.md
@@ -16,6 +16,7 @@ The current default version is Vertical Pod Autoscaler 1.3.1
 
 | VPA version     | Kubernetes version                                              |
 |-----------------|-----------------------------------------------------------------|
+| 1.5.x           | 1.28+ (1.33+ when using `InPlaceOrRecreate` )                   |
 | 1.4.x           | 1.28+ (1.33+ when using `InPlaceOrRecreate` Alpha Feature Gate) |
 | 1.3.x           | 1.28+                                                           |
 | 1.2.x           | 1.27+                                                           |

--- a/vertical-pod-autoscaler/hack/generate-flags.sh
+++ b/vertical-pod-autoscaler/hack/generate-flags.sh
@@ -21,7 +21,7 @@ set -o pipefail
 SCRIPT_ROOT=$(realpath $(dirname "${BASH_SOURCE[0]}"))/..
 TARGET_FILE="${SCRIPT_ROOT}/docs/flags.md"
 COMPONENTS=("admission-controller" "recommender" "updater")
-DEFAULT_TAG="1.4.2"
+DEFAULT_TAG="1.5.0"
 
 # Function to extract flags from a binary
 extract_flags() {

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -54,7 +54,7 @@ if [ $# -eq 0 ]; then
 fi
 
 DEFAULT_REGISTRY="registry.k8s.io/autoscaling"
-DEFAULT_TAG="1.4.2"
+DEFAULT_TAG="1.5.0"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}

--- a/vertical-pod-autoscaler/hack/vpa-up.sh
+++ b/vertical-pod-autoscaler/hack/vpa-up.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
-DEFAULT_TAG="1.4.2"
+DEFAULT_TAG="1.5.0"
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}
 
 if [ "${TAG_TO_APPLY}" == "${DEFAULT_TAG}" ]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

VPA 1.5.0 release, see https://github.com/kubernetes/autoscaler/issues/8497

#### Does this PR introduce a user-facing change?
```
None 
```