### PR TITLE
Fix completions set to 1 being recognized as work queue.

### DIFF
--- a/cluster-autoscaler/processors/podinjection/job_controller.go
+++ b/cluster-autoscaler/processors/podinjection/job_controller.go
@@ -56,8 +56,8 @@ func desiredReplicasFromJob(job *batchv1.Job) int {
 	return max(desiredReplicas, 0)
 }
 
-// isWorkQueueJob returns true if the job is a work queue job (Completions is 1 or nil and Parallelism >=0)
+// isWorkQueueJob returns true if the job is a work queue job (Completions is nil and Parallelism >=0)
 // work queue jobs should have replicas equal to Parallelism regardless in case of no Succeeded
 func isWorkQueueJob(job *batchv1.Job) bool {
-	return (job.Spec.Completions == nil || *(job.Spec.Completions) == 1) && job.Spec.Parallelism != nil && *(job.Spec.Parallelism) >= 0
+	return job.Spec.Completions == nil && job.Spec.Parallelism != nil && *(job.Spec.Parallelism) >= 0
 }

--- a/cluster-autoscaler/processors/podinjection/job_controller_test.go
+++ b/cluster-autoscaler/processors/podinjection/job_controller_test.go
@@ -75,6 +75,19 @@ func TestDesiredReplicasFromJob(t *testing.T) {
 			wantReplicas: 5,
 		},
 		{
+			name: "Parallelism is large while completion is 1",
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Completions: &one,
+					Parallelism: &ten,
+				},
+				Status: batchv1.JobStatus{
+					Succeeded: 0,
+				},
+			},
+			wantReplicas: 1,
+		},
+		{
 			name: "Work queue with succeeded pods",
 			job: &batchv1.Job{
 				Spec: batchv1.JobSpec{


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Without it, CA can inject fake pods much more than what's needed, resulting in huge unnecessary scale-ups.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Documentation for work queue in jobs: https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs

It says `For a work queue Job, you must leave .spec.completions unset, and set .spec.parallelism to a non-negative integer.`. 

I have also tested it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed incorrect calculations for estimated number of replicas needed for jobs during proactive scale-ups.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
