### PR TITLE
Fix capacity buffers injector order in pod list processor

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -193,7 +193,7 @@ func buildAutoscaler(context ctx.Context, debuggingSnapshotter debuggingsnapshot
 		}
 		if capacitybufferClientError == nil && capacitybufferClient != nil {
 			bufferPodInjector := cbprocessor.NewCapacityBufferPodListProcessor(capacitybufferClient, []string{common.ActiveProvisioningStrategy})
-			podListProcessor.AddProcessor(bufferPodInjector)
+			podListProcessor = pods.NewCombinedPodListProcessor([]pods.PodListProcessor{bufferPodInjector, podListProcessor})
 			opts.Processors.ScaleUpStatusProcessor = status.NewCombinedScaleUpStatusProcessor([]status.ScaleUpStatusProcessor{cbprocessor.NewFakePodsScaleUpStatusProcessor(), opts.Processors.ScaleUpStatusProcessor})
 		}
 	}


### PR DESCRIPTION
Cherry-pick [Fix capacity buffers injector order in pod list processor](https://github.com/kubernetes/autoscaler/commit/ee760e6cf86dc634014cb30debc934c7650cd517)