### PR TITLE
Fix proactive scale up injecting fake pods for scheduling gated pods

### DIFF
--- a/cluster-autoscaler/processors/podinjection/pod_injection_processor.go
+++ b/cluster-autoscaler/processors/podinjection/pod_injection_processor.go
@@ -26,6 +26,7 @@ import (
 	podinjectionbackoff "k8s.io/autoscaler/cluster-autoscaler/processors/podinjection/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/klog/v2"
 )
 
@@ -56,14 +57,19 @@ func (p *PodInjectionPodListProcessor) Process(autoscalingCtx *ca_context.Autosc
 
 	nodeInfos, err := autoscalingCtx.ClusterSnapshot.ListNodeInfos()
 	if err != nil {
-		klog.Errorf("Failed to list nodeInfos from cluster snapshot: %v", err)
 		return unschedulablePods, fmt.Errorf("failed to list nodeInfos from cluster snapshot: %v", err)
 	}
 	scheduledPods := podsFromNodeInfos(nodeInfos)
 
-	groupedPods := groupPods(append(scheduledPods, unschedulablePods...), controllers)
-	var podsToInject []*apiv1.Pod
+	allPods, err := autoscalingCtx.AllPodLister().List()
+	if err != nil {
+		return unschedulablePods, fmt.Errorf("failed to list all pods from all pod lister: %v", err)
+	}
+	schedulingGatedPods := kube_util.SchedulingGatedPods(allPods)
 
+	groupedPods := groupPods(append(append(scheduledPods, unschedulablePods...), schedulingGatedPods...), controllers)
+
+	var podsToInject []*apiv1.Pod
 	for _, groupedPod := range groupedPods {
 		var fakePodCount = groupedPod.fakePodCount()
 		fakePods := makeFakePods(groupedPod.ownerUid, groupedPod.sample, fakePodCount)

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -359,6 +359,24 @@ func BuildTestNode(name string, millicpuCapacity int64, memCapacity int64) *apiv
 	return node
 }
 
+// WithSchedulingGatedStatus upserts the condition with type PodScheduled to be of status false
+// and reason PodReasonSchedulingGated
+func WithSchedulingGatedStatus(pod *apiv1.Pod) *apiv1.Pod {
+	gatedPodCondition := apiv1.PodCondition{
+		Type:   apiv1.PodScheduled,
+		Status: apiv1.ConditionFalse,
+		Reason: apiv1.PodReasonSchedulingGated,
+	}
+	for index := range pod.Status.Conditions {
+		if pod.Status.Conditions[index].Type == apiv1.PodScheduled {
+			pod.Status.Conditions[index] = gatedPodCondition
+			return pod
+		}
+	}
+	pod.Status.Conditions = append(pod.Status.Conditions, gatedPodCondition)
+	return pod
+}
+
 // WithAllocatable adds specified milliCpu and memory to Allocatable of the node in-place.
 func WithAllocatable(node *apiv1.Node, millicpuAllocatable, memAllocatable int64) *apiv1.Node {
 	node.Status.Allocatable[apiv1.ResourceCPU] = *resource.NewMilliQuantity(millicpuAllocatable, resource.DecimalSI)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Proactive scale up is listing the controllers, check the desired replicas and inject fake pods to proactively scale up even before these pods are created and marked as unschedulable.

Proactive scale up is using the following formula for the number of fake pods to inject per controller:

Number of fake pods = number of controller desired pods - (scheduled pods + unschedualable pods + unprocessed pods) 

The problem here is that scheduling gated pods are not being excluded along with unschedualable and unprocessed so proactive scale up injects fake pods for these gated pods ignoring the condition. that happens each loop which leads to not scaling down that empty space.

This PR subtracts the number of pods with scheduling gates from the number of fake pods to inject.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
* `ctx.AllPodLister().List()` should be using a lister, so we are not having extra api call here to list the pods rather we just get it from cache.
* In `PodInjectionPodListProcessor` in case of any error filtering out scheduling gated pods, I choose to only log a warning and not return an error so it doesn't block the rest of the processors as `CombinedPodListProcessor` stops the processing in case any one returns an error, which means any following processor (all others) will not be executed

#### Does this PR introduce a user-facing change?
```release-note
fix: exclude gated pods from proactive scale up
```
