### PR TITLE
Change `make test-unit` to have the same go test parameters as `make test-in-docker`

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -58,7 +58,7 @@ test-build-tags:
 	done
 
 test-unit: clean build
-	go test --test.short -race ./... ${TAGS_FLAG}
+	go test --test.short -race ./... -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}
 
 dev-release: dev-release-arch-$(GOARCH)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`make test-in-docker` was changed to disable the printf analyzer, but `make test-unit` wasn't for some reason. The current master isn't compatible with the printf analyzer, so `make test-unit` fails on master without this change.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```