### PR TITLE
Fix a race condition in TestNodeLoadFromExistingTaints

### DIFF
--- a/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
-	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
+	nodeprocessors "k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -205,7 +205,7 @@ func TestRemovableAt(t *testing.T) {
 
 			n := NewNodes(&fakeScaleDownTimeGetter{}, &resource.LimitsFinder{})
 			n.Update(removableNodes, time.Now())
-			gotEmptyToRemove, gotDrainToRemove, _ := n.RemovableAt(&ctx, nodes.ScaleDownContext{
+			gotEmptyToRemove, gotDrainToRemove, _ := n.RemovableAt(&ctx, nodeprocessors.ScaleDownContext{
 				ActuationStatus:     as,
 				ResourcesLeft:       resource.Limits{},
 				ResourcesWithLimits: []string{},
@@ -218,7 +218,6 @@ func TestRemovableAt(t *testing.T) {
 }
 
 func TestNodeLoadFromExistingTaints(t *testing.T) {
-
 	deletionCandidateTaint := taints.DeletionCandidateTaint()
 	currentTime := time.Now()
 
@@ -274,8 +273,6 @@ func TestNodeLoadFromExistingTaints(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			currentTime = time.Now()
 
 			nodes := NewNodes(nil, nil)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`TestNodeLoadFromExistingTaints` creates a `currentTime` variable set to `time.Now()`, and a bunch of test objects with time values offset from that variable. This is all standard practice, but then the test iterates over test cases, calls `t.Parallel()`, and overwrites `currentTime` with `time.Now()` again. This makes `go test -race` fail, because multiple goroutines are writing `currentTime` at once. It also doesn't seem to make sense in the context of the test, because the other test objects are still offset from the original value.

Removing the second write to `currentTime` seems to be the correct fix here. Also renamed one import because it collided with a local variable name used throughout this test file.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```