### PR TITLE
Update VPA defaults to 1.5.1 in the vpa-release-1.5 branch

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -21,7 +21,7 @@ package common
 var gitCommit = ""
 
 // versionCore is the version of VPA.
-const versionCore = "1.5.0"
+const versionCore = "1.5.1"
 
 // VerticalPodAutoscalerVersion returns the version of the VPA.
 func VerticalPodAutoscalerVersion() string {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
VPA 1.5.1 release, see [#8468](https://github.com/kubernetes/autoscaler/issues/8591).
 
#### Does this PR introduce a user-facing change?

```
NONE
```
