### PR TITLE
cas: enable overridable node GPU config during cloud provider tests

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -45,6 +45,9 @@ type OnNodeGroupDeleteFunc func(string) error
 // HasInstance is a function called to determine if a node has been removed from the cloud provider.
 type HasInstance func(string) (bool, error)
 
+// NodeGpuConfig is a function that returns the GPU config for a given node.
+type NodeGpuConfig func(node *apiv1.Node) *cloudprovider.GpuConfig
+
 // TestCloudProvider is a dummy cloud provider to be used in tests.
 type TestCloudProvider struct {
 	sync.Mutex
@@ -59,6 +62,7 @@ type TestCloudProvider struct {
 	machineTemplates  map[string]*framework.NodeInfo
 	priceModel        cloudprovider.PricingModel
 	resourceLimiter   *cloudprovider.ResourceLimiter
+	nodeGpuConfig     func(node *apiv1.Node) *cloudprovider.GpuConfig
 }
 
 // TestCloudProviderBuilder is used to create CloudProvider
@@ -127,6 +131,14 @@ func (b *TestCloudProviderBuilder) WithHasInstance(hasInstance HasInstance) *Tes
 	return b
 }
 
+// WithNodeGpuConfig adds has custom node gpu config handler to provider
+func (b *TestCloudProviderBuilder) WithNodeGpuConfig(nodeGpuConfig NodeGpuConfig) *TestCloudProviderBuilder {
+	b.builders = append(b.builders, func(p *TestCloudProvider) {
+		p.nodeGpuConfig = nodeGpuConfig
+	})
+	return b
+}
+
 // Build returns a built test cloud provider
 func (b *TestCloudProviderBuilder) Build() *TestCloudProvider {
 	p := &TestCloudProvider{
@@ -163,6 +175,9 @@ func (tcp *TestCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
 // GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
 // any GPUs, it returns nil.
 func (tcp *TestCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
+	if tcp.nodeGpuConfig != nil {
+		return tcp.nodeGpuConfig(node)
+	}
 	return gpu.GetNodeGPUFromCloudProvider(tcp, node)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR introduces scaffolding to enable per-cloud provider tests node GPU config responses.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
