### PR TITLE
docs: update `StartupBoost.CPU.Type` to be required and fix examples

### DIFF
--- a/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost/README.md
+++ b/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost/README.md
@@ -138,20 +138,19 @@ type CPUStartupBoost struct {
 ```
 
 `StartupBoost` will contain the following fields:
-  * [Optional] `StartupBoost.CPU.Type` (type: `string`): A string that specifies
+  * [Required] `StartupBoost.CPU.Type` (type: `string`): A string that specifies
   the kind of boost to apply. Supported values are:
     * `Factor`: The `StartupBoost.CPU.Factor` field will be interpreted as a
     multiplier for the recommended CPU request. For example, a value of `2` will
     double the CPU request.
     * `Quantity`: The `StartupBoost.CPU.Quantity` field will be interpreted as an
-    absolute CPU resource quantity (e.g., `"500m"`, `"1"`) to be used as the CPU
+    additional CPU resource quantity (e.g., `"500m"`, `"1"`) to be added to the existing CPU
     request or limit during the boost phase.
-    * If not specified, `StartupBoost.CPU.Type` defaults to `Factor`.
 
   * [Optional] `StartupBoost.CPU.Factor`: (type: `integer`): The factor to apply to the CPU request. Defaults to 1 if not specified.
      * If `StartupBoost.CPU.Type`is `Factor`, this field is required.
      * If `StartupBoost.CPU.Type`is `Quantity`, this field is not allowed.
-  * [Optional] `StartupBoost.CPU.Quantity`: (type: `resource.Quantity`): The absolute CPU resource quantity.
+  * [Optional] `StartupBoost.CPU.Quantity`: (type: `resource.Quantity`): The additional CPU resource quantity.
      * If `StartupBoost.CPU.Type`is `Quantity`, this field is required.
      * If `StartupBoost.CPU.Type`is `Factor`, this field is not allowed.
   * [Optional] `StartupBoost.CPU.Duration` (type: `duration`): if specified, it
@@ -301,6 +300,7 @@ spec:
     updateMode: "Off"
   startupBoost:
     cpu:
+      type: "Factor"
       factor: 3
       duration: 10s
 ```
@@ -337,6 +337,7 @@ spec:
     updateMode: "Auto"
   startupBoost:
     cpu:
+      type: "Factor"
       factor: 3
       duration: 10s
 ```
@@ -392,12 +393,14 @@ spec:
     name: example
   startupBoost:
     cpu:
+      type: "Factor"
       factor: 2
   resourcePolicy:
     containerPolicies:
       - containerName: "disable-cpu-boost-for-this-container"
         startupBoost:
           cpu:
+            type: "Factor"
             factor: 1
 ```
 
@@ -436,6 +439,7 @@ spec:
 
 ## Implementation History
 
+* 2025-10-04: Update `startupBoost.cpu.type` field to correctly indicate it is a required field, not optional. The field has no default value and must be explicitly set to either "Factor" or "Quantity".
 * 2025-08-05: Make some API changes and clarify behavior during and after boost period in the workflow section.
 * 2025-06-23: Decouple Startup CPU Boost from InPlaceOrRecreate mode, allow
 users to specify a `startupBoost` config in `VerticalPodAutoscalerSpec` and in


### PR DESCRIPTION
<!--
Add one of the following kinds:
/kind documentation
-->
```
Fixed: Documentation for VPA StartupBoost.CPU.Type field to correctly indicate it is a required field, not optional. The field has no default value and must be explicitly set to either "Factor" or "Quantity".

Action Required: If you are using VPA StartupBoost feature, ensure your VPA configurations include the required `type` field under `startupBoost.cpu`.

Documentation: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost#api-changes
```

Fixed #8608

The StartupBoost.CPU.Type field is required in the VPA configuration, but the documentation incorrectly marked it as optional and some examples were missing the field entirely. This PR updates the documentation to reflect the actual implementation.

Changes:
- Updated documentation to mark StartupBoost.CPU.Type as [Required] instead of [Optional]
   - See [here](https://github.com/kubernetes/autoscaler/blob/experimental-cpu-boost/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L131-L132)
- Removed incorrect statement about Type defaulting to "Factor". Since it's a required field, one of the types should be configured.
- Added missing type: "Factor" field in YAML examples. Other examples noted "Quantity" and did not require updates.

These changes align the documentation with the actual implementation in the code, where the `Type` field is marked with the `+required` tag. This will help users avoid the "unexpected StartupBoost.CPU.Type value" error when applying VPA configurations.

Testing:
- Verified all YAML examples in the documentation are valid and complete
- Ensured documentation accurately reflects the struct definition and validation requirements
- `./hack/verify-all.sh` executed
   - Note, `Verifying ./hack/../hack/verify-gofmt.sh` does express `FAILED` but that shouldn't be in scope of this change