### PR TITLE
Correctly wrap the ErrNodeInvalidOwner error

### DIFF
--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -210,7 +210,7 @@ func (f *controllerFetcher) getParentOfController(ctx context.Context, controlle
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("unhandled targetRef %s / %s / %s, last error %v",
+		return nil, fmt.Errorf("unhandled targetRef %s / %s / %s, last error %w",
 			controllerKey.ApiVersion, controllerKey.Kind, controllerKey.Name, err)
 	}
 

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
@@ -389,7 +389,7 @@ func TestControllerFetcher(t *testing.T) {
 				},
 			}},
 			expectedKey:   nil,
-			expectedError: fmt.Errorf("unhandled targetRef v1 / Node / node, last error node is not a valid owner"),
+			expectedError: fmt.Errorf("unhandled targetRef v1 / Node / node, last error %w", ErrNodeInvalidOwner),
 		},
 		{
 			name: "custom resource with no scale subresource",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This suppresses the errors similar to this:
```
api.go:175] "Failed to get parent controller for pod" err="unhandled targetRef v1 / Node / kind-control-plane, last error node is not a valid owner" pod="kube-system/kube-apiserver-kind-control-plane"
```

This was mostly fixed in https://github.com/kubernetes/autoscaler/pull/7632, but the error wrapping wasn't done correctly.
This PR fixes that error wrapping.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8461

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
vpa-updater and vpa-admission-controller no longer excessively log fail to get pod controller: (...) last error node is not a valid owner
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
