### PR TITLE
feat(nodeScaleDownTime): add a new metric to track unprocessed nodes during scaleDown

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -354,6 +354,8 @@ type AutoscalingOptions struct {
 	CapacitybufferControllerEnabled bool
 	// CapacitybufferPodInjectionEnabled tells if CA should injects fake pods for capacity buffers that are ready for provisioning
 	CapacitybufferPodInjectionEnabled bool
+	// MaxNodeSkipEvalTimeTrackerEnabled is used to enabled/disable the tracking of maximum evaluation time of a node being skipped during ScaleDown.
+	MaxNodeSkipEvalTimeTrackerEnabled bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -232,6 +232,7 @@ var (
 	nodeDeletionCandidateTTL                     = flag.Duration("node-deletion-candidate-ttl", time.Duration(0), "Maximum time a node can be marked as removable before the marking becomes stale. This sets the TTL of Cluster-Autoscaler's state if the Cluste-Autoscaler deployment becomes inactive")
 	capacitybufferControllerEnabled              = flag.Bool("capacity-buffer-controller-enabled", false, "Whether to enable the default controller for capacity buffers or not")
 	capacitybufferPodInjectionEnabled            = flag.Bool("capacity-buffer-pod-injection-enabled", false, "Whether to enable pod list processor that processes ready capacity buffers and injects fake pods accordingly")
+	maxNodeSkipEvalTimeTrackerEnabled            = flag.Bool("max-node-skip-eval-time-tracker-enabled", false, "Whether to enable the tracking of the maximum time of node being skipped during ScaleDown")
 
 	// Deprecated flags
 	ignoreTaintsFlag = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
@@ -422,6 +423,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		NodeDeletionCandidateTTL:                     *nodeDeletionCandidateTTL,
 		CapacitybufferControllerEnabled:              *capacitybufferControllerEnabled,
 		CapacitybufferPodInjectionEnabled:            *capacitybufferPodInjectionEnabled,
+		MaxNodeSkipEvalTimeTrackerEnabled:            *maxNodeSkipEvalTimeTrackerEnabled,
 	}
 }
 

--- a/cluster-autoscaler/core/scaledown/nodeevaltracker/max_node_skip_eval_time.go
+++ b/cluster-autoscaler/core/scaledown/nodeevaltracker/max_node_skip_eval_time.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeevaltracker
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+)
+
+// MaxNodeSkipEvalTime is a time tracker for the biggest evaluation time of a node during ScaleDown
+type MaxNodeSkipEvalTime struct {
+	// lastEvalTime is the time of previous currentlyUnneededNodeNames parsing
+	lastEvalTime time.Time
+	// nodeNamesWithTimeStamps is maps of nodeNames with their time of last successful evaluation
+	nodeNamesWithTimeStamps map[string]time.Time
+}
+
+// NewMaxNodeSkipEvalTime returns LongestNodeScaleDownEvalTime with lastEvalTime set to currentTime
+func NewMaxNodeSkipEvalTime(currentTime time.Time) *MaxNodeSkipEvalTime {
+	return &MaxNodeSkipEvalTime{lastEvalTime: currentTime}
+}
+
+// Retrieves the time of the last evaluation of a node.
+func (l *MaxNodeSkipEvalTime) get(nodeName string) time.Time {
+	if _, ok := l.nodeNamesWithTimeStamps[nodeName]; ok {
+		return l.nodeNamesWithTimeStamps[nodeName]
+	}
+	return l.lastEvalTime
+}
+
+// getMin() returns the minimum time in nodeNamesWithTimeStamps or time of last evaluation
+func (l *MaxNodeSkipEvalTime) getMin() time.Time {
+	minimumTime := l.lastEvalTime
+	for _, val := range l.nodeNamesWithTimeStamps {
+		if minimumTime.After(val) {
+			minimumTime = val
+		}
+	}
+	return minimumTime
+}
+
+// Update returns the longest evaluation time for the nodes in nodeNamesWithTimeStamps
+// and changes nodeNamesWithTimeStamps for nodeNames.
+func (l *MaxNodeSkipEvalTime) Update(nodeNames []string, currentTime time.Time) time.Duration {
+	newNodes := make(map[string]time.Time)
+	for _, nodeName := range nodeNames {
+		newNodes[nodeName] = l.get(nodeName)
+	}
+	l.nodeNamesWithTimeStamps = newNodes
+	l.lastEvalTime = currentTime
+	minimumTime := l.getMin()
+	longestDuration := currentTime.Sub(minimumTime)
+	metrics.ObserveMaxNodeSkipEvalDurationSeconds(longestDuration)
+	return longestDuration
+}

--- a/cluster-autoscaler/core/scaledown/nodeevaltracker/max_node_skip_eval_time_test.go
+++ b/cluster-autoscaler/core/scaledown/nodeevaltracker/max_node_skip_eval_time_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeevaltracker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaxNodeSkipEvalTime(t *testing.T) {
+	type testCase struct {
+		name                       string
+		unprocessedNodes           [][]string
+		wantMaxSkipEvalTimeSeconds []int
+	}
+	start := time.Now()
+	testCases := []testCase{
+		{
+			name:                       "Only one node is skipped in one iteration",
+			unprocessedNodes:           [][]string{{}, {"n1"}, {}, {}},
+			wantMaxSkipEvalTimeSeconds: []int{0, 1, 0, 0},
+		},
+		{
+			name:                       "No nodes are skipped in the first iteration",
+			unprocessedNodes:           [][]string{{}, {"n1", "n2"}, {"n2", "n3"}, {}},
+			wantMaxSkipEvalTimeSeconds: []int{0, 1, 2, 0},
+		},
+		{
+			name:                       "Some nodes are skipped in the first iteration",
+			unprocessedNodes:           [][]string{{"n1", "n2"}, {"n1", "n2"}, {"n2", "n3"}, {}},
+			wantMaxSkipEvalTimeSeconds: []int{1, 2, 3, 0},
+		},
+		{
+			name:                       "Overlapping node sets are skipped in different iteration",
+			unprocessedNodes:           [][]string{{}, {"n1", "n2"}, {"n1"}, {"n2"}, {}},
+			wantMaxSkipEvalTimeSeconds: []int{0, 1, 2, 1, 0},
+		},
+		{
+			name:                       "Disjoint node sets are skipped in each iteration",
+			unprocessedNodes:           [][]string{{"n1"}, {"n2"}, {"n3"}, {"n4"}, {}},
+			wantMaxSkipEvalTimeSeconds: []int{1, 1, 1, 1, 0},
+		},
+		{
+			name:                       "None of the nodes are skipped in each iteration",
+			unprocessedNodes:           [][]string{{}, {}, {}},
+			wantMaxSkipEvalTimeSeconds: []int{0, 0, 0},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			timestamp := start
+			maxNodeSkipEvalTime := NewMaxNodeSkipEvalTime(start)
+			for i := 0; i < len(tc.unprocessedNodes); i++ {
+				timestamp = timestamp.Add(1 * time.Second)
+				assert.Equal(t, time.Duration(tc.wantMaxSkipEvalTimeSeconds[i])*time.Second, maxNodeSkipEvalTime.Update(tc.unprocessedNodes[i], timestamp))
+				assert.Equal(t, len(tc.unprocessedNodes[i]), len(maxNodeSkipEvalTime.nodeNamesWithTimeStamps))
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds a new metric to the exported prometheus metrics list: MaxNodeSkipEvalTime

We want to track nodes that were unprocessed during ScaleDown. If a node was skipped multiple times consecutively, we store only the earliest time it happened. The difference between current time and the earliest time among all unprocessed nodes will give us the maximum evaluation time of node being skipped during ScaleDown at this moment in time. This time can give us an indication of possible throttling and helps to better monitor what happens during ScaleDown.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None
<!--
#### Special notes for your reviewer: 
-->
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduced a new metric, tracking time to process all nodes in scale down simulations. `--max-node-skip-eval-time-tracker-enabled` flag enables the new metric.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
