### PR TITLE
docs: Update VPA udpate mode docs

### DIFF
--- a/vertical-pod-autoscaler/docs/quickstart.md
+++ b/vertical-pod-autoscaler/docs/quickstart.md
@@ -14,16 +14,16 @@ each controller that you want to have automatically computed resource requiremen
 This will be most commonly a **Deployment**.
 There are five modes in which *VPAs* operate:
 
-- `"Auto"` (**Deprecated**): VPA assigns resource requests on pod creation as well as updates
+- `"Auto"` [__deprecated__]: VPA assigns resource requests on pod creation as well as updates
   them on existing pods using the preferred update mechanism. Currently, this is
   equivalent to `"Recreate"` (see below). **This mode is deprecated and will be removed in a future API version.**
   **Use explicit modes like "Recreate", "Initial", or "InPlaceOrRecreate" instead.**
-- `"Recreate"`: VPA assigns resource requests on pod creation as well as updates
+- `"Recreate"` [__default__]: VPA assigns resource requests on pod creation as well as updates
   them on existing pods by evicting them when the requested resources differ significantly
   from the new recommendation (respecting the Pod Disruption Budget, if defined).
   This mode should be used rarely, only if you need to ensure that the pods are restarted
   whenever the resource request changes.
-- `"InPlaceOrRecreate"`[__alpha feature__]: VPA assigns resource requests on pod creation as well as updates
+- `"InPlaceOrRecreate"`[__beta feature__]: VPA assigns resource requests on pod creation as well as updates
   them on existing pods by leveraging [Kubernetes `in-place` update](https://kubernetes.io/blog/2025/05/16/kubernetes-v1-33-in-place-pod-resize-beta/) capability.
   If `in-place` update fails, it falls back to evicting the pods, performing a _recreation_.
   For more details, see the [In-Place Updates documentation](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/features.md#in-place-updates-inplaceorrecreate).


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR:
- denotes which is the default update mode
- updates the feature state of `InPlaceOrRecreate` from alpha to beta
- unifies the styling of update mode tags

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
