### PR TITLE
Add capacity buffers scale up events

### DIFF
--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -369,3 +369,12 @@ func ContainsCustomResources(resources []string) bool {
 	}
 	return false
 }
+
+// NodeGroupListToMapById returns a map of node group ID to nonode group
+func NodeGroupListToMapById(nodeGroups []NodeGroup) map[string]NodeGroup {
+	result := make(map[string]NodeGroup)
+	for _, nodeGroup := range nodeGroups {
+		result[nodeGroup.Id()] = nodeGroup
+	}
+	return result
+}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -192,9 +192,14 @@ func buildAutoscaler(ctx context.Context, debuggingSnapshotter debuggingsnapshot
 			capacitybufferClient, capacitybufferClientError = capacityclient.NewCapacityBufferClientFromConfig(restConfig)
 		}
 		if capacitybufferClientError == nil && capacitybufferClient != nil {
-			bufferPodInjector := cbprocessor.NewCapacityBufferPodListProcessor(capacitybufferClient, []string{common.ActiveProvisioningStrategy})
+			buffersPodsRegistry := cbprocessor.NewDefaultCapacityBuffersFakePodsRegistry()
+			bufferPodInjector := cbprocessor.NewCapacityBufferPodListProcessor(
+				capacitybufferClient,
+				[]string{common.ActiveProvisioningStrategy},
+				buffersPodsRegistry)
 			podListProcessor = pods.NewCombinedPodListProcessor([]pods.PodListProcessor{bufferPodInjector, podListProcessor})
-			opts.Processors.ScaleUpStatusProcessor = status.NewCombinedScaleUpStatusProcessor([]status.ScaleUpStatusProcessor{cbprocessor.NewFakePodsScaleUpStatusProcessor(), opts.Processors.ScaleUpStatusProcessor})
+			opts.Processors.ScaleUpStatusProcessor = status.NewCombinedScaleUpStatusProcessor([]status.ScaleUpStatusProcessor{
+				cbprocessor.NewFakePodsScaleUpStatusProcessor(buffersPodsRegistry), opts.Processors.ScaleUpStatusProcessor})
 		}
 	}
 

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
@@ -143,7 +143,7 @@ func TestPodListProcessor(t *testing.T) {
 			fakeBuffersClient := buffersfake.NewSimpleClientset(test.objectsInBuffersClient...)
 			fakeCapacityBuffersClient, _ := client.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, nil, nil)
 
-			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed})
+			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, NewDefaultCapacityBuffersFakePodsRegistry())
 			resUnschedulablePods, err := processor.Process(nil, test.unschedulablePods)
 			assert.Equal(t, err != nil, test.expectError)
 

--- a/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
@@ -17,46 +17,109 @@ limitations under the License.
 package capacitybufferpodlister
 
 import (
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
+	v1alpha1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
-	"k8s.io/klog/v2"
 )
 
 // FakePodsScaleUpStatusProcessor is a ScaleUpStatusProcessor used for filtering out fake pods from scaleup status.
-type FakePodsScaleUpStatusProcessor struct{}
+type FakePodsScaleUpStatusProcessor struct {
+	buffersRegistry *capacityBuffersFakePodsRegistry
+}
+
+type bufferInfo struct {
+	buffer         *v1alpha1.CapacityBuffer
+	numberOfPods   int
+	reasonMessages []string
+}
 
 // NewFakePodsScaleUpStatusProcessor return an instance of FakePodsScaleUpStatusProcessor
-func NewFakePodsScaleUpStatusProcessor() *FakePodsScaleUpStatusProcessor {
-	return &FakePodsScaleUpStatusProcessor{}
+func NewFakePodsScaleUpStatusProcessor(buffersRegistry *capacityBuffersFakePodsRegistry) *FakePodsScaleUpStatusProcessor {
+	return &FakePodsScaleUpStatusProcessor{buffersRegistry: buffersRegistry}
 }
 
 // Process updates scaleupStatus to remove all capacity buffer fake pods from
 // PodsRemainUnschedulable, PodsAwaitEvaluation & PodsTriggeredScaleup
-func (a *FakePodsScaleUpStatusProcessor) Process(_ *ca_context.AutoscalingContext, scaleUpStatus *status.ScaleUpStatus) {
-	scaleUpStatus.PodsRemainUnschedulable = filterFakePods(scaleUpStatus.PodsRemainUnschedulable, func(noScaleUpInfo status.NoScaleUpInfo) *apiv1.Pod { return noScaleUpInfo.Pod }, "PodsRemainUnschedulable")
-	scaleUpStatus.PodsAwaitEvaluation = filterFakePods(scaleUpStatus.PodsAwaitEvaluation, func(pod *apiv1.Pod) *apiv1.Pod { return pod }, "PodsAwaitEvaluation")
-	scaleUpStatus.PodsTriggeredScaleUp = filterFakePods(scaleUpStatus.PodsTriggeredScaleUp, func(pod *apiv1.Pod) *apiv1.Pod { return pod }, "PodsTriggeredScaleUp")
+func (p *FakePodsScaleUpStatusProcessor) Process(context *ca_context.AutoscalingContext, scaleUpStatus *status.ScaleUpStatus) {
+	var fakePodsRemainUnschedulable []status.NoScaleUpInfo
+	var fakePodsTriggeredScaleUp []*apiv1.Pod
+
+	scaleUpStatus.PodsRemainUnschedulable, fakePodsRemainUnschedulable = filterOutCapacityBuffersPod(scaleUpStatus.PodsRemainUnschedulable, func(noScaleUpInfo status.NoScaleUpInfo) *apiv1.Pod { return noScaleUpInfo.Pod })
+	scaleUpStatus.PodsTriggeredScaleUp, fakePodsTriggeredScaleUp = filterOutCapacityBuffersPod(scaleUpStatus.PodsTriggeredScaleUp, func(pod *apiv1.Pod) *apiv1.Pod { return pod })
+	scaleUpStatus.PodsAwaitEvaluation, _ = filterOutCapacityBuffersPod(scaleUpStatus.PodsAwaitEvaluation, func(pod *apiv1.Pod) *apiv1.Pod { return pod })
+
+	p.createBuffersNoScaleUpEvents(context, scaleUpStatus, fakePodsRemainUnschedulable)
+	p.createBuffersScaleUpEvents(context, scaleUpStatus, fakePodsTriggeredScaleUp)
 }
 
-// filterFakePods removes capacity buffer fake pods from the input list of T using passed getPod(T)
-// Returns a list containing only non-fake pods
-func filterFakePods[T any](podsWrappers []T, getPod func(T) *apiv1.Pod, resourceName string) []T {
-	filteredPodsSources := make([]T, 0)
-	removedPods := make([]*apiv1.Pod, 0)
+func (p *FakePodsScaleUpStatusProcessor) createBuffersNoScaleUpEvents(context *ca_context.AutoscalingContext, scaleUpStatus *status.ScaleUpStatus, fakePodsRemainUnschedulable []status.NoScaleUpInfo) {
+	if scaleUpStatus.Result != status.ScaleUpSuccessful && scaleUpStatus.Result != status.ScaleUpError {
+		consideredNodeGroupsMap := cloudprovider.NodeGroupListToMapById(scaleUpStatus.ConsideredNodeGroups)
+		buffersInfo := map[string]*bufferInfo{}
+		for _, noScaleUpInfo := range fakePodsRemainUnschedulable {
+			parentCapacityBuffer, found := p.buffersRegistry.fakePodsUIDToBuffer[string(noScaleUpInfo.Pod.UID)]
+			if found {
+				bufferUID := string(parentCapacityBuffer.UID)
+				if _, found := buffersInfo[bufferUID]; !found {
+					buffersInfo[bufferUID] = &bufferInfo{
+						buffer: parentCapacityBuffer,
+					}
+				}
+				buffersInfo[bufferUID].numberOfPods += 1
+				buffersInfo[bufferUID].reasonMessages = append(buffersInfo[bufferUID].reasonMessages,
+					status.ReasonsMessage(scaleUpStatus.Result, noScaleUpInfo, consideredNodeGroupsMap))
+			}
+		}
 
+		for _, bufferInfo := range buffersInfo {
+			context.Recorder.Eventf(bufferInfo.buffer, apiv1.EventTypeNormal, "NotTriggerScaleUp",
+				"capacity buffer %d fake pods didn't trigger scale-up: %s",
+				bufferInfo.numberOfPods, strings.Join(bufferInfo.reasonMessages, ","))
+		}
+	}
+}
+
+func (p *FakePodsScaleUpStatusProcessor) createBuffersScaleUpEvents(context *ca_context.AutoscalingContext, scaleUpStatus *status.ScaleUpStatus, fakePodsTriggeredScaleUp []*apiv1.Pod) {
+	if len(scaleUpStatus.ScaleUpInfos) > 0 && len(fakePodsTriggeredScaleUp) > 0 {
+		buffersInfo := map[string]*bufferInfo{}
+		for _, pod := range fakePodsTriggeredScaleUp {
+			parentCapacityBuffer, found := p.buffersRegistry.fakePodsUIDToBuffer[string(pod.UID)]
+			if found {
+				bufferUID := string(parentCapacityBuffer.UID)
+				if _, found := buffersInfo[bufferUID]; !found {
+					buffersInfo[bufferUID] = &bufferInfo{
+						buffer: parentCapacityBuffer,
+					}
+				}
+				buffersInfo[bufferUID].numberOfPods += 1
+			}
+		}
+		for _, bufferInfo := range buffersInfo {
+			context.Recorder.Eventf(bufferInfo.buffer, apiv1.EventTypeNormal, "TriggeredScaleUp",
+				"capacity buffer %d fake pods triggered scale-up: %v", bufferInfo.numberOfPods, scaleUpStatus.ScaleUpInfos)
+		}
+	}
+}
+
+// filterOutCapacityBuffersPod filters out the fake pods created for capcity biffers
+// from the input list of T using passed getPod(T) and returns a the filtered and the filtered out lists
+func filterOutCapacityBuffersPod[T any](podsWrappers []T, getPod func(T) *apiv1.Pod) ([]T, []T) {
+	filteredPodsSources := make([]T, 0)
+	filteredOutPodsSources := make([]T, 0)
 	for _, podsWrapper := range podsWrappers {
 		currentPod := getPod(podsWrapper)
-		if !isFakeCapacityBuffersPod(currentPod) {
+		if isFakeCapacityBuffersPod(currentPod) {
+			filteredOutPodsSources = append(filteredOutPodsSources, podsWrapper)
+		} else {
 			filteredPodsSources = append(filteredPodsSources, podsWrapper)
-			continue
 		}
-		removedPods = append(removedPods, currentPod)
 	}
-
-	klog.Infof("Filtered out %d pods from %s", len(removedPods), resourceName)
-	return filteredPodsSources
+	return filteredPodsSources, filteredOutPodsSources
 }
 
 // CleanUp is called at CA termination
-func (a *FakePodsScaleUpStatusProcessor) CleanUp() {}
+func (p *FakePodsScaleUpStatusProcessor) CleanUp() {}

--- a/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor_test.go
@@ -17,14 +17,30 @@ limitations under the License.
 package capacitybufferpodlister
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1alpha1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	kube_record "k8s.io/client-go/tools/record"
 )
+
+type testReason struct {
+	message string
+}
+
+func (tr *testReason) Reasons() []string {
+	return []string{tr.message}
+}
 
 func TestProcess(t *testing.T) {
 	testCases := map[string]struct {
@@ -66,12 +82,231 @@ func TestProcess(t *testing.T) {
 			}
 			autoscalingCtx := &ca_context.AutoscalingContext{}
 
-			p := NewFakePodsScaleUpStatusProcessor()
+			p := NewFakePodsScaleUpStatusProcessor(NewDefaultCapacityBuffersFakePodsRegistry())
 			p.Process(autoscalingCtx, scaleUpStatus)
 
 			assert.ElementsMatch(t, tc.expectedPodsRemainUnschedulable, extractPodsFromNoScaleUpInfo(scaleUpStatus.PodsRemainUnschedulable))
 			assert.ElementsMatch(t, tc.expectedPodsAwaitEvaluation, scaleUpStatus.PodsAwaitEvaluation)
 			assert.ElementsMatch(t, tc.expectedPodsTriggeredScaleUp, scaleUpStatus.PodsTriggeredScaleUp)
+		})
+	}
+}
+
+func TestBuffersEvent(t *testing.T) {
+	nodeGroup1 := testprovider.NewTestNodeGroup("ng_1", 10, 0, 5, true, true, "some_type", map[string]string{}, []apiv1.Taint{})
+	nodeGroup2 := testprovider.NewTestNodeGroup("ng_2", 20, 3, 8, true, true, "some_other_type", map[string]string{}, []apiv1.Taint{})
+	consideredNodeGroups := []cloudprovider.NodeGroup{nodeGroup1, nodeGroup2}
+	scaleUpInfo1 := nodegroupset.ScaleUpInfo{
+		Group:       nodeGroup1,
+		CurrentSize: 5,
+		NewSize:     6,
+		MaxSize:     nodeGroup1.MaxSize(),
+	}
+	scaleUpInfo2 := nodegroupset.ScaleUpInfo{
+		Group:       nodeGroup2,
+		CurrentSize: 8,
+		NewSize:     9,
+		MaxSize:     nodeGroup1.MaxSize(),
+	}
+	buffer1 := &v1alpha1.CapacityBuffer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "buffer_1",
+			UID:  "buffer_1",
+		},
+	}
+	buffer2 := &v1alpha1.CapacityBuffer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "buffer_2",
+			UID:  "buffer_2",
+		},
+	}
+
+	notSchedulableReason := &testReason{"not schedulable for testing"}
+	alsoNotSchedulableReason := &testReason{"also not schedulable for testing"}
+	reasons := map[string]status.Reasons{
+		nodeGroup1.Id(): notSchedulableReason,
+		nodeGroup2.Id(): alsoNotSchedulableReason,
+	}
+	testCases := map[string]struct {
+		state                       *status.ScaleUpStatus
+		buffersRegistry             *capacityBuffersFakePodsRegistry
+		expectedTriggeredScaleUp    int
+		expectedNotTriggeredScaleUp int
+	}{
+		"One fake pod, successful scale up": {
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			state: &status.ScaleUpStatus{
+				Result:                  status.ScaleUpSuccessful,
+				ConsideredNodeGroups:    consideredNodeGroups,
+				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{scaleUpInfo1},
+				PodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
+				PodsRemainUnschedulable: []status.NoScaleUpInfo{},
+				PodsAwaitEvaluation:     []*apiv1.Pod{},
+			},
+			expectedTriggeredScaleUp:    1,
+			expectedNotTriggeredScaleUp: 0,
+		},
+		"One fake pod, error scale up": {
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			state: &status.ScaleUpStatus{
+				Result:                  status.ScaleUpError,
+				ConsideredNodeGroups:    consideredNodeGroups,
+				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{{}},
+				PodsTriggeredScaleUp:    []*apiv1.Pod{},
+				PodsRemainUnschedulable: []status.NoScaleUpInfo{},
+				PodsAwaitEvaluation:     []*apiv1.Pod{},
+			},
+			expectedTriggeredScaleUp:    0,
+			expectedNotTriggeredScaleUp: 0,
+		},
+		"One fake pod, empty scale up infos": {
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			state: &status.ScaleUpStatus{
+				Result:                  status.ScaleUpError,
+				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{},
+				PodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
+				PodsRemainUnschedulable: []status.NoScaleUpInfo{},
+				PodsAwaitEvaluation:     []*apiv1.Pod{},
+			},
+			expectedTriggeredScaleUp:    0,
+			expectedNotTriggeredScaleUp: 0,
+		},
+		"One fake pod, with no node in Registry": {
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{}),
+			state: &status.ScaleUpStatus{
+				Result:                  status.ScaleUpError,
+				ConsideredNodeGroups:    consideredNodeGroups,
+				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{},
+				PodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
+				PodsRemainUnschedulable: []status.NoScaleUpInfo{},
+				PodsAwaitEvaluation:     []*apiv1.Pod{},
+			},
+			expectedTriggeredScaleUp:    0,
+			expectedNotTriggeredScaleUp: 0,
+		},
+		"One fake pod, unschedulalble": {
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			state: &status.ScaleUpStatus{
+				Result:               status.ScaleUpNoOptionsAvailable,
+				ConsideredNodeGroups: consideredNodeGroups,
+				ScaleUpInfos:         []nodegroupset.ScaleUpInfo{},
+				PodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false)},
+				PodsRemainUnschedulable: []status.NoScaleUpInfo{
+					{
+						Pod:                createPod("fake-pod-1", true),
+						RejectedNodeGroups: reasons,
+					},
+				},
+				PodsAwaitEvaluation: []*apiv1.Pod{},
+			},
+			expectedTriggeredScaleUp:    0,
+			expectedNotTriggeredScaleUp: 1,
+		},
+		"One fake pod, unschedulalble with error": {
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			state: &status.ScaleUpStatus{
+				Result:               status.ScaleUpError,
+				ConsideredNodeGroups: consideredNodeGroups,
+				ScaleUpInfos:         []nodegroupset.ScaleUpInfo{},
+				PodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false)},
+				PodsRemainUnschedulable: []status.NoScaleUpInfo{
+					{
+						Pod:                createPod("fake-pod-1", true),
+						RejectedNodeGroups: reasons,
+					},
+				},
+				PodsAwaitEvaluation: []*apiv1.Pod{},
+			},
+			expectedTriggeredScaleUp:    0,
+			expectedNotTriggeredScaleUp: 0,
+		},
+		"two fake pods for same buffer, one triggers scale up and the other doesn't": {
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1, "fake-pod-2": buffer1}),
+			state: &status.ScaleUpStatus{
+				Result:               status.ScaleUpNoOptionsAvailable,
+				ConsideredNodeGroups: consideredNodeGroups,
+				ScaleUpInfos:         []nodegroupset.ScaleUpInfo{scaleUpInfo1},
+				PodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
+				PodsRemainUnschedulable: []status.NoScaleUpInfo{
+					{
+						Pod:                createPod("fake-pod-2", true),
+						RejectedNodeGroups: reasons,
+					},
+				},
+				PodsAwaitEvaluation: []*apiv1.Pod{},
+			},
+			expectedTriggeredScaleUp:    1,
+			expectedNotTriggeredScaleUp: 1,
+		},
+		"multiple pods for multiple buffers with mixed conditions": {
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{
+				"fake-pod-1": buffer1,
+				"fake-pod-2": buffer1,
+				"fake-pod-3": buffer2,
+				"fake-pod-4": buffer2,
+				"fake-pod-5": buffer2,
+			}),
+			state: &status.ScaleUpStatus{
+				Result:               status.ScaleUpNoOptionsAvailable,
+				ScaleUpInfos:         []nodegroupset.ScaleUpInfo{scaleUpInfo1, scaleUpInfo2},
+				ConsideredNodeGroups: consideredNodeGroups,
+				PodsTriggeredScaleUp: []*apiv1.Pod{
+					createPod("pod-1", false),
+					createPod("fake-pod-2", true),
+					createPod("fake-pod-4", true),
+					createPod("fake-pod-5", true),
+				},
+				PodsRemainUnschedulable: []status.NoScaleUpInfo{
+					{
+						Pod:                createPod("fake-pod-1", true),
+						RejectedNodeGroups: reasons,
+					},
+					{
+						Pod:                createPod("fake-pod-3", true),
+						RejectedNodeGroups: reasons,
+					},
+					{
+						Pod:                createPod("pod-2", false),
+						RejectedNodeGroups: reasons,
+					},
+				},
+				PodsAwaitEvaluation: []*apiv1.Pod{},
+			},
+			expectedTriggeredScaleUp:    2,
+			expectedNotTriggeredScaleUp: 2,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			fakeRecorder := kube_record.NewFakeRecorder(5)
+			ctx := &context.AutoscalingContext{
+				AutoscalingKubeClients: context.AutoscalingKubeClients{
+					Recorder: fakeRecorder,
+				},
+			}
+			p := NewFakePodsScaleUpStatusProcessor(tc.buffersRegistry)
+			p.Process(ctx, tc.state)
+
+			triggeredScaleUp := 0
+			notTriggerScaleUp := 0
+			for eventsLeft := true; eventsLeft; {
+				select {
+				case event := <-fakeRecorder.Events:
+					if strings.Contains(event, "TriggeredScaleUp") {
+						triggeredScaleUp += 1
+					} else if strings.Contains(event, "NotTriggerScaleUp") {
+						notTriggerScaleUp += 1
+					} else {
+						t.Fatalf("Test case '%v' failed. Unexpected event %v", name, event)
+					}
+				default:
+					eventsLeft = false
+				}
+			}
+			assert.Equal(t, tc.expectedTriggeredScaleUp, triggeredScaleUp)
+			assert.Equal(t, tc.expectedNotTriggeredScaleUp, notTriggerScaleUp)
+
 		})
 	}
 }

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
@@ -36,7 +36,7 @@ type EventingScaleUpStatusProcessor struct{}
 // Process processes the state of the cluster after a scale-up by emitting
 // relevant events for pods depending on their post scale-up status.
 func (p *EventingScaleUpStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus) {
-	consideredNodeGroupsMap := nodeGroupListToMapById(status.ConsideredNodeGroups)
+	consideredNodeGroupsMap := cloudprovider.NodeGroupListToMapById(status.ConsideredNodeGroups)
 	if status.Result != ScaleUpSuccessful && status.Result != ScaleUpError {
 		for _, noScaleUpInfo := range status.PodsRemainUnschedulable {
 			autoscalingCtx.Recorder.Event(noScaleUpInfo.Pod, apiv1.EventTypeNormal, "NotTriggerScaleUp",
@@ -91,12 +91,4 @@ func ReasonsMessage(scaleUpStatus ScaleUpResult, noScaleUpInfo NoScaleUpInfo, co
 		messages = append(messages, fmt.Sprintf("%d %s", count, msg))
 	}
 	return strings.Join(messages, ", ")
-}
-
-func nodeGroupListToMapById(nodeGroups []cloudprovider.NodeGroup) map[string]cloudprovider.NodeGroup {
-	result := make(map[string]cloudprovider.NodeGroup)
-	for _, nodeGroup := range nodeGroups {
-		result[nodeGroup.Id()] = nodeGroup
-	}
-	return result
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Add events to capacity buffers objects when buffer causes scale up or fails to do so.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
1. In pod list processor we inject fake pods with capacity buffer fake pod annotation 
2. in status processor we filter out these pods so we don't create events for fake pods

This changes is mainly caching fake pods to buffer objects in step 1. then in step 2 we use that mapping to get the buffer object from fake pods objects and create scale up events for the buffers

#### Does this PR introduce a user-facing change?
```release-note
Add capacity buffers scale up events
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE