### PR TITLE
[AKS HOBO][1.31 release] Add support for hosted-on-behalf-of systempool autoscaling

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -107,11 +107,17 @@ type azureCache struct {
 }
 
 func newAzureCache(client *azClient, cacheTTL time.Duration, config Config) (*azureCache, error) {
+	nodeResourceGroup := config.ResourceGroup
+	// Hosted (on-behalf-of) system pool node resources are in the AKS internal resource group within AME tenants,
+	// which differs from the MC_* resource group found in the customer subscription.
+	if config.HostedResourceGroup != "" {
+		nodeResourceGroup = config.HostedResourceGroup
+	}
 	cache := &azureCache{
 		interrupt:            make(chan struct{}),
 		azClient:             client,
 		refreshInterval:      cacheTTL,
-		resourceGroup:        config.ResourceGroup,
+		resourceGroup:        nodeResourceGroup,
 		clusterResourceGroup: config.ClusterResourceGroup,
 		clusterName:          config.ClusterName,
 		enableVMsAgentPool:   config.EnableVMsAgentPool,

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -65,6 +65,15 @@ type Config struct {
 	// It can override the default public ARM endpoint for VMs pool scale operations.
 	ARMBaseURLForAPClient string `json:"armBaseURLForAPClient" yaml:"armBaseURLForAPClient"`
 
+	// Hosted (on-behalf-of) system pool configuration for automatic cluster.
+	// HostedSubscriptionID is the subscription ID of the hosted resources under AKS internal tenant.
+	HostedSubscriptionID string `json:"hostedSubscriptionID" yaml:"hostedSubscriptionID"`
+	// HostedResourceGroup is the resource group of the hosted resources under AKS internal tenant.
+	HostedResourceGroup string `json:"hostedResourceGroup" yaml:"hostedResourceGroup"`
+	// HostedResourceProxyURL is the URL to use for retrieving hosted resources under AKS internal tenant.
+	// It can override the default public ARM endpoint for operations like VM/SKU GET.
+	HostedResourceProxyURL string `json:"hostedResourceProxyURL" yaml:"hostedResourceProxyURL"`
+
 	// AuthMethod determines how to authorize requests for the Azure
 	// cloud. Valid options are "principal" (= the traditional
 	// service principle approach) and "cli" (= load az command line
@@ -223,6 +232,15 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	if _, err = assignFromEnvIfExists(&cfg.SubscriptionID, "ARM_SUBSCRIPTION_ID"); err != nil {
 		return nil, err
 	}
+	if _, err = assignFromEnvIfExists(&cfg.HostedResourceProxyURL, "HOSTED_RESOURCE_PROXY_URL"); err != nil {
+		return nil, err
+	}
+	if _, err = assignFromEnvIfExists(&cfg.HostedSubscriptionID, "HOSTED_SUBSCRIPTION_ID"); err != nil {
+		return nil, err
+	}
+	if _, err = assignFromEnvIfExists(&cfg.HostedResourceGroup, "HOSTED_RESOURCE_GROUP"); err != nil {
+		return nil, err
+	}
 	if _, err = assignBoolFromEnvIfExists(&cfg.UseManagedIdentityExtension, "ARM_USE_MANAGED_IDENTITY_EXTENSION"); err != nil {
 		return nil, err
 	}
@@ -378,6 +396,17 @@ func (cfg *Config) getAzureClientConfig(authorizer autorest.Authorizer, env *azu
 			Duration: time.Duration(cfg.CloudProviderBackoffDuration) * time.Second,
 			Jitter:   cfg.CloudProviderBackoffJitter,
 		}
+	}
+
+	// A proxy service is required to access resources for the Hosted (on-behalf-of) system pool within automatic clusters.
+	if cfg.HostedResourceProxyURL != "" {
+		azClientConfig.ResourceManagerEndpoint = cfg.HostedResourceProxyURL
+	}
+
+	// Hosted (on-behalf-of) system pool resources are hosted under AKS internal tenant and subscription.
+	// it is different from the customer subscription where the cluster is created.
+	if cfg.HostedSubscriptionID != "" {
+		azClientConfig.SubscriptionID = cfg.HostedSubscriptionID
 	}
 
 	if cfg.HasExtendedLocation() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature, cherry-pick https://github.com/kubernetes/autoscaler/pull/8596

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
azure: Add support for hosted-on-behalf-of systempool autoscaling
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
