### PR TITLE
[Feature] Make GPU utils function neutral for vendor's resource names

### DIFF
--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -26,6 +26,8 @@ import (
 )
 
 const (
+	// ResourceAMDGPU is the name of the AMD GPU resource.
+	ResourceAMDGPU = "amd.com/gpu"
 	// ResourceNvidiaGPU is the name of the Nvidia GPU resource.
 	ResourceNvidiaGPU = "nvidia.com/gpu"
 	// ResourceDirectX is the name of the DirectX resource on windows.
@@ -34,6 +36,14 @@ const (
 	// don't specify what type of GPU his pod wants.
 	DefaultGPUType = "nvidia-tesla-k80"
 )
+
+// GPUVendorResourceNames centralized list of all known GPU vendor extended resource names.
+// Extend this slice if new vendor resource names are added.
+var GPUVendorResourceNames = []apiv1.ResourceName{
+	ResourceNvidiaGPU,
+	ResourceAMDGPU,
+	ResourceDirectX,
+}
 
 const (
 	// MetricsGenericGPU - for when there is no information about GPU type
@@ -109,15 +119,41 @@ func validateGpuType(availableGPUTypes map[string]struct{}, gpu string) string {
 // if the drivers are installed and GPU is ready to use.
 func NodeHasGpu(GPULabel string, node *apiv1.Node) bool {
 	_, hasGpuLabel := node.Labels[GPULabel]
-	gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[ResourceNvidiaGPU]
-	return hasGpuLabel || (hasGpuAllocatable && !gpuAllocatable.IsZero())
+	if hasGpuLabel {
+		return true
+	}
+	// Check for extended resources as well
+	for _, gpuVendorResourceName := range GPUVendorResourceNames {
+		gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[gpuVendorResourceName]
+		if hasGpuAllocatable && !gpuAllocatable.IsZero() {
+			return true
+		}
+	}
+	return false
 }
 
 // PodRequestsGpu returns true if a given pod has GPU request.
 func PodRequestsGpu(pod *apiv1.Pod) bool {
 	podRequests := podutils.PodRequests(pod)
-	_, gpuFound := podRequests[ResourceNvidiaGPU]
-	return gpuFound
+	for _, gpuVendorResourceName := range GPUVendorResourceNames {
+		if _, found := podRequests[gpuVendorResourceName]; found {
+			return true
+		}
+	}
+	return false
+}
+
+// DetectNodeGPUResourceName inspects the node's allocatable resources and returns the first
+// known GPU extended resource name that has non-zero allocatable. Falls back to Nvidia for
+// backward compatibility if none are found but a GPU label is present.
+func DetectNodeGPUResourceName(node *apiv1.Node) apiv1.ResourceName {
+	for _, rn := range GPUVendorResourceNames {
+		if qty, ok := node.Status.Allocatable[rn]; ok && !qty.IsZero() {
+			return rn
+		}
+	}
+	// Fallback: preserve previous behavior (defaulting to Nvidia) if label existed
+	return ResourceNvidiaGPU
 }
 
 // GetNodeGPUFromCloudProvider returns the GPU the node has. Returned GPU has the GPU label of the
@@ -125,7 +161,11 @@ func PodRequestsGpu(pod *apiv1.Pod) bool {
 func GetNodeGPUFromCloudProvider(provider cloudprovider.CloudProvider, node *apiv1.Node) *cloudprovider.GpuConfig {
 	gpuLabel := provider.GPULabel()
 	if NodeHasGpu(gpuLabel, node) {
-		return &cloudprovider.GpuConfig{Label: gpuLabel, Type: node.Labels[gpuLabel], ExtendedResourceName: ResourceNvidiaGPU}
+		return &cloudprovider.GpuConfig{
+			Label:                gpuLabel,
+			Type:                 node.Labels[gpuLabel],
+			ExtendedResourceName: DetectNodeGPUResourceName(node),
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

1. Add support for AMD device plugin advertised GPU resource name `amd.com/gpu`.
2. Make sure the gpu package functions are neutral to auto detect GPU based on all known vendor's GPU resource name.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Hi @feiskyer @x13n @BigDarkClown , this PR is adding support to include `amd.com/gpu` as one of known GPU resource names, also make sure the GPU package functions could auto detect GPU resources based on all existing vendor's k8s resource names.

#### Does this PR introduce a user-facing change?

```release-note
Add amd.com/gpu as a supported GPU resource name
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
