### PR TITLE
CA clusterapi: move more tests to TestConfigBuilder interface

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_autodiscovery_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_autodiscovery_test.go
@@ -198,23 +198,23 @@ func Test_parseAutoDiscovery(t *testing.T) {
 func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 	for _, tc := range []struct {
 		name                string
-		testSpec            TestSpec
+		testConfig          *TestConfig
 		autoDiscoveryConfig *clusterAPIAutoDiscoveryConfig
 		additionalLabels    map[string]string
 		shouldMatch         bool
 	}{{
 		name:                "no clustername, namespace, or label selector specified should match any MachineSet",
-		testSpec:            createTestSpec(RandomString(6), RandomString(6), RandomString(6), 1, false, nil, nil),
+		testConfig:          NewTestConfigBuilder().ForMachineSet().WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{labelSelector: labels.NewSelector()},
 		shouldMatch:         true,
 	}, {
 		name:                "no clustername, namespace, or label selector specified should match any MachineDeployment",
-		testSpec:            createTestSpec(RandomString(6), RandomString(6), RandomString(6), 1, true, nil, nil),
+		testConfig:          NewTestConfigBuilder().ForMachineDeployment().WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{labelSelector: labels.NewSelector()},
 		shouldMatch:         true,
 	}, {
-		name:     "clustername specified does not match MachineSet, namespace matches, no labels specified",
-		testSpec: createTestSpec("default", RandomString(6), RandomString(6), 1, false, nil, nil),
+		name:       "clustername specified does not match MachineSet, namespace matches, no labels specified",
+		testConfig: NewTestConfigBuilder().ForMachineSet().WithNamespace("default").WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
 			namespace:     "default",
@@ -222,8 +222,8 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		},
 		shouldMatch: false,
 	}, {
-		name:     "clustername specified does not match MachineDeployment, namespace matches, no labels specified",
-		testSpec: createTestSpec("default", RandomString(6), RandomString(6), 1, true, nil, nil),
+		name:       "clustername specified does not match MachineDeployment, namespace matches, no labels specified",
+		testConfig: NewTestConfigBuilder().ForMachineDeployment().WithNamespace("default").WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
 			namespace:     "default",
@@ -231,8 +231,8 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		},
 		shouldMatch: false,
 	}, {
-		name:     "namespace specified does not match MachineSet, clusterName matches, no labels specified",
-		testSpec: createTestSpec(RandomString(6), "foo", RandomString(6), 1, false, nil, nil),
+		name:       "namespace specified does not match MachineSet, clusterName matches, no labels specified",
+		testConfig: NewTestConfigBuilder().ForMachineSet().WithClusterName("foo").WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
 			namespace:     "default",
@@ -240,8 +240,8 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		},
 		shouldMatch: false,
 	}, {
-		name:     "clustername specified does not match MachineDeployment, namespace matches, no labels specified",
-		testSpec: createTestSpec(RandomString(6), "foo", RandomString(6), 1, true, nil, nil),
+		name:       "clustername specified does not match MachineDeployment, namespace matches, no labels specified",
+		testConfig: NewTestConfigBuilder().ForMachineDeployment().WithClusterName("foo").WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
 			namespace:     "default",
@@ -249,8 +249,8 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		},
 		shouldMatch: false,
 	}, {
-		name:     "namespace and clusterName matches MachineSet, no labels specified",
-		testSpec: createTestSpec("default", "foo", RandomString(6), 1, false, nil, nil),
+		name:       "namespace and clusterName matches MachineSet, no labels specified",
+		testConfig: NewTestConfigBuilder().ForMachineSet().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
 			namespace:     "default",
@@ -258,8 +258,8 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		},
 		shouldMatch: true,
 	}, {
-		name:     "namespace and clusterName matches MachineDeployment, no labels specified",
-		testSpec: createTestSpec("default", "foo", RandomString(6), 1, true, nil, nil),
+		name:       "namespace and clusterName matches MachineDeployment, no labels specified",
+		testConfig: NewTestConfigBuilder().ForMachineDeployment().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
 			namespace:     "default",
@@ -267,8 +267,8 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		},
 		shouldMatch: true,
 	}, {
-		name:     "namespace and clusterName matches MachineSet, does not match label selector",
-		testSpec: createTestSpec("default", "foo", RandomString(6), 1, false, nil, nil),
+		name:       "namespace and clusterName matches MachineSet, does not match label selector",
+		testConfig: NewTestConfigBuilder().ForMachineSet().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
 			namespace:     "default",
@@ -276,8 +276,8 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		},
 		shouldMatch: false,
 	}, {
-		name:     "namespace and clusterName matches MachineDeployment, does not match label selector",
-		testSpec: createTestSpec("default", "foo", RandomString(6), 1, true, nil, nil),
+		name:       "namespace and clusterName matches MachineDeployment, does not match label selector",
+		testConfig: NewTestConfigBuilder().ForMachineDeployment().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
 			namespace:     "default",
@@ -286,7 +286,7 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		shouldMatch: false,
 	}, {
 		name:             "namespace, clusterName, and label selector matches MachineSet",
-		testSpec:         createTestSpec("default", "foo", RandomString(6), 1, false, nil, nil),
+		testConfig:       NewTestConfigBuilder().ForMachineSet().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		additionalLabels: map[string]string{"color": "green"},
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
@@ -296,7 +296,7 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		shouldMatch: true,
 	}, {
 		name:             "namespace, clusterName, and label selector matches MachineDeployment",
-		testSpec:         createTestSpec("default", "foo", RandomString(6), 1, true, nil, nil),
+		testConfig:       NewTestConfigBuilder().ForMachineDeployment().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		additionalLabels: map[string]string{"color": "green"},
 		autoDiscoveryConfig: &clusterAPIAutoDiscoveryConfig{
 			clusterName:   "foo",
@@ -306,10 +306,9 @@ func Test_allowedByAutoDiscoverySpec(t *testing.T) {
 		shouldMatch: true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			testConfigs := createTestConfigs(tc.testSpec)
-			resource := testConfigs[0].machineSet
-			if tc.testSpec.rootIsMachineDeployment {
-				resource = testConfigs[0].machineDeployment
+			resource := tc.testConfig.machineSet
+			if tc.testConfig.machineDeployment != nil {
+				resource = tc.testConfig.machineDeployment
 			}
 			if tc.additionalLabels != nil {
 				resource.SetLabels(labels.Merge(resource.GetLabels(), tc.additionalLabels))

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -1282,21 +1282,21 @@ func TestMachineKeyFromFailedProviderID(t *testing.T) {
 func Test_machineController_allowedByAutoDiscoverySpecs(t *testing.T) {
 	for _, tc := range []struct {
 		name               string
-		testSpec           TestSpec
+		testConfig         *TestConfig
 		autoDiscoverySpecs []*clusterAPIAutoDiscoveryConfig
 		additionalLabels   map[string]string
 		shouldMatch        bool
 	}{{
-		name:     "autodiscovery specs includes permissive spec that should match any MachineSet",
-		testSpec: createTestSpec(RandomString(6), RandomString(6), RandomString(6), 1, false, nil, nil),
+		name:       "autodiscovery specs includes permissive spec that should match any MachineSet",
+		testConfig: NewTestConfigBuilder().ForMachineSet().WithNodeCount(1).Build(),
 		autoDiscoverySpecs: []*clusterAPIAutoDiscoveryConfig{
 			{labelSelector: labels.NewSelector()},
 			{clusterName: "foo", namespace: "bar", labelSelector: labels.Nothing()},
 		},
 		shouldMatch: true,
 	}, {
-		name:     "autodiscovery specs includes permissive spec that should match any MachineDeployment",
-		testSpec: createTestSpec(RandomString(6), RandomString(6), RandomString(6), 1, true, nil, nil),
+		name:       "autodiscovery specs includes permissive spec that should match any MachineDeployment",
+		testConfig: NewTestConfigBuilder().ForMachineDeployment().WithNodeCount(1).Build(),
 		autoDiscoverySpecs: []*clusterAPIAutoDiscoveryConfig{
 			{labelSelector: labels.NewSelector()},
 			{clusterName: "foo", namespace: "bar", labelSelector: labels.Nothing()},
@@ -1304,7 +1304,7 @@ func Test_machineController_allowedByAutoDiscoverySpecs(t *testing.T) {
 		shouldMatch: true,
 	}, {
 		name:             "autodiscovery specs includes a restrictive spec that should match specific MachineSet",
-		testSpec:         createTestSpec("default", "foo", RandomString(6), 1, false, nil, nil),
+		testConfig:       NewTestConfigBuilder().ForMachineSet().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		additionalLabels: map[string]string{"color": "green"},
 		autoDiscoverySpecs: []*clusterAPIAutoDiscoveryConfig{
 			{clusterName: "foo", namespace: "default", labelSelector: labels.SelectorFromSet(labels.Set{"color": "green"})},
@@ -1313,7 +1313,7 @@ func Test_machineController_allowedByAutoDiscoverySpecs(t *testing.T) {
 		shouldMatch: true,
 	}, {
 		name:             "autodiscovery specs includes a restrictive spec that should match specific MachineDeployment",
-		testSpec:         createTestSpec("default", "foo", RandomString(6), 1, true, nil, nil),
+		testConfig:       NewTestConfigBuilder().ForMachineDeployment().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		additionalLabels: map[string]string{"color": "green"},
 		autoDiscoverySpecs: []*clusterAPIAutoDiscoveryConfig{
 			{clusterName: "foo", namespace: "default", labelSelector: labels.SelectorFromSet(labels.Set{"color": "green"})},
@@ -1322,7 +1322,7 @@ func Test_machineController_allowedByAutoDiscoverySpecs(t *testing.T) {
 		shouldMatch: true,
 	}, {
 		name:             "autodiscovery specs does not include any specs that should match specific MachineSet",
-		testSpec:         createTestSpec("default", "foo", RandomString(6), 1, false, nil, nil),
+		testConfig:       NewTestConfigBuilder().ForMachineSet().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		additionalLabels: map[string]string{"color": "green"},
 		autoDiscoverySpecs: []*clusterAPIAutoDiscoveryConfig{
 			{clusterName: "test", namespace: "default", labelSelector: labels.SelectorFromSet(labels.Set{"color": "blue"})},
@@ -1331,7 +1331,7 @@ func Test_machineController_allowedByAutoDiscoverySpecs(t *testing.T) {
 		shouldMatch: false,
 	}, {
 		name:             "autodiscovery specs does not include any specs that should match specific MachineDeployment",
-		testSpec:         createTestSpec("default", "foo", RandomString(6), 1, true, nil, nil),
+		testConfig:       NewTestConfigBuilder().ForMachineDeployment().WithNamespace("default").WithClusterName("foo").WithNodeCount(1).Build(),
 		additionalLabels: map[string]string{"color": "green"},
 		autoDiscoverySpecs: []*clusterAPIAutoDiscoveryConfig{
 			{clusterName: "test", namespace: "default", labelSelector: labels.SelectorFromSet(labels.Set{"color": "blue"})},
@@ -1340,10 +1340,9 @@ func Test_machineController_allowedByAutoDiscoverySpecs(t *testing.T) {
 		shouldMatch: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			testConfigs := createTestConfigs(tc.testSpec)
-			resource := testConfigs[0].machineSet
-			if tc.testSpec.rootIsMachineDeployment {
-				resource = testConfigs[0].machineDeployment
+			resource := tc.testConfig.machineSet
+			if tc.testConfig.machineDeployment != nil {
+				resource = tc.testConfig.machineDeployment
 			}
 			if tc.additionalLabels != nil {
 				resource.SetLabels(labels.Merge(resource.GetLabels(), tc.additionalLabels))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In #8537 @elmiko created a cleaner test interface for the clusterapi provider. This PR moves more of the tests to that interface.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```