### PR TITLE
Emit event when pod is updated in-place

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -155,10 +155,7 @@ func (ip *PodsInPlaceRestrictionImpl) InPlaceUpdate(podToUpdate *apiv1.Pod, vpa 
 		return fmt.Errorf("no resource patches were calculated to apply")
 	}
 
-	// TODO(maxcao13): If this keeps getting called on the same object with the same reason, it is considered a patch request.
-	// And we fail to have the corresponding rbac for it. So figure out if we need this later.
-	// Do we even need to emit an event? The node might reject the resize request. If so, should we rename this to InPlaceResizeAttempted?
-	// eventRecorder.Event(podToUpdate, apiv1.EventTypeNormal, "InPlaceResizedByVPA", "Pod was resized in place by VPA Updater.")
+	eventRecorder.Event(podToUpdate, apiv1.EventTypeNormal, "InPlaceResizedByVPA", "Pod was resized in place by VPA Updater.")
 
 	singleGroupStats, present := ip.creatorToSingleGroupStatsMap[cr]
 	if !present {

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	baseclocktest "k8s.io/utils/clock/testing"
 
@@ -377,5 +378,50 @@ func TestInPlaceAtLeastOne(t *testing.T) {
 	for _, pod := range pods[1:] {
 		err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
 		assert.Error(t, err, "Error expected")
+	}
+}
+
+func TestInPlaceUpdate_EventEmission(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlaceOrRecreate, true)
+
+	replicas := int32(5)
+	livePods := 5
+	tolerance := 0.1
+
+	rc := apiv1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ReplicationController",
+		},
+		Spec: apiv1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	pods := make([]*apiv1.Pod, livePods)
+	for i := range pods {
+		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get()
+	}
+
+	basicVpa := getBasicVpa()
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc())
+	assert.NoError(t, err)
+	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
+	assert.NoError(t, err)
+	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+	eventRecorder := record.NewFakeRecorder(10)
+
+	err = inplace.InPlaceUpdate(pods[0], basicVpa, eventRecorder)
+	assert.NoError(t, err)
+
+	select {
+	case event := <-eventRecorder.Events:
+		assert.Contains(t, event, "InPlaceResizedByVPA")
+	case <-time.After(1 * time.Second):
+		assert.Fail(t, "timeout waiting for event")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Improve observability for in-place updates by VPA


Fixes #

#### Special notes for your reviewer:
The patch rejection would cause the function to error out before the event is recorded so we should be good to emit an event here.

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
