### PR TITLE
feat(vpa-chart): add chart logic for the vpa recommender

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -4,7 +4,7 @@ WARNING: This chart is currently under development and is not ready for producti
 
 Automatically adjust resources for your workloads
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
 
@@ -63,3 +63,31 @@ The Vertical Pod Autoscaler (VPA) automatically adjusts the CPU and memory resou
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `nil` |  |
 | rbac.create | bool | `true` |  |
+| recommender.affinity | object | `{}` |  |
+| recommender.enabled | bool | `true` |  |
+| recommender.extraArgs | list | `[]` |  |
+| recommender.extraEnv | list | `[]` |  |
+| recommender.image.pullPolicy | string | `"IfNotPresent"` |  |
+| recommender.image.repository | string | `"registry.k8s.io/autoscaling/vpa-recommender"` |  |
+| recommender.image.tag | string | `nil` |  |
+| recommender.leaderElection.enabled | string | `nil` |  |
+| recommender.leaderElection.leaseDuration | string | `"15s"` |  |
+| recommender.leaderElection.renewDeadline | string | `"10s"` |  |
+| recommender.leaderElection.resourceName | string | `"vpa-recommender-lease"` |  |
+| recommender.leaderElection.resourceNamespace | string | `""` |  |
+| recommender.leaderElection.retryPeriod | string | `"2s"` |  |
+| recommender.nodeSelector | object | `{}` |  |
+| recommender.podAnnotations | object | `{}` |  |
+| recommender.podDisruptionBudget.enabled | bool | `true` |  |
+| recommender.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
+| recommender.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
+| recommender.podLabels | object | `{}` |  |
+| recommender.replicas | int | `2` |  |
+| recommender.resources.limits.cpu | string | `"200m"` |  |
+| recommender.resources.limits.memory | string | `"1000Mi"` |  |
+| recommender.resources.requests.cpu | string | `"50m"` |  |
+| recommender.resources.requests.memory | string | `"500Mi"` |  |
+| recommender.serviceAccount.annotations | object | `{}` |  |
+| recommender.serviceAccount.create | bool | `true` |  |
+| recommender.serviceAccount.labels | object | `{}` |  |
+| recommender.tolerations | list | `[]` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
@@ -80,3 +80,26 @@ Create the name of the namespace to use
 {{- define "common.names.namespace" -}}
 {{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{/*
+recommender
+*/}}
+{{- define "vertical-pod-autoscaler.recommender.fullname" -}}
+{{ include "vertical-pod-autoscaler.fullname" . }}-recommender
+{{- end }}
+
+{{- define "vertical-pod-autoscaler.recommender.labels" -}}
+{{ include "vertical-pod-autoscaler.labels" . }}
+app.kubernetes.io/component: recommender
+app.kubernetes.io/component-instance: {{ .Release.Name }}-recommender
+{{- end }}
+
+{{- define "vertical-pod-autoscaler.recommender.selectorLabels" -}}
+{{ include "vertical-pod-autoscaler.selectorLabels" . }}
+app.kubernetes.io/component: recommender
+{{- end }}
+
+{{- define "vertical-pod-autoscaler.recommender.image" -}}
+{{- printf "%s:%s" .Values.recommender.image.repository (default .Chart.AppVersion .Values.recommender.image.tag) }}
+{{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-clusterrolebindings.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-clusterrolebindings.yaml
@@ -1,0 +1,78 @@
+{{- if and (.Values.recommender.enabled) .Values.rbac.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-metrics-reader
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-actor
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-actor
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-status-actor
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-status-actor
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-checkpoint-actor
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-checkpoint-actor
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-target-reader
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-target-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-clusterroles.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-clusterroles.yaml
@@ -1,0 +1,158 @@
+{{- if and (.Values.recommender.enabled) .Values.rbac.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-metrics-reader
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - "metrics.k8s.io"
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-actor
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - "poc.autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-status-actor
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - "autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalers/status
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-checkpoint-actor
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - "poc.autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalercheckpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+- apiGroups:
+  - "autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalercheckpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-target-reader
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*/scale'
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.recommender.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.recommender.replicas }}
+  {{- with .Values.recommender.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "vertical-pod-autoscaler.recommender.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vertical-pod-autoscaler.recommender.selectorLabels" . | nindent 8 }}
+      {{- with .Values.recommender.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.recommender.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      containers:
+      - name: recommender
+        image: {{ include "vertical-pod-autoscaler.recommender.image" . }}
+        imagePullPolicy: {{ .Values.recommender.image.pullPolicy }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- with .Values.recommender.extraEnv }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        args:
+        - --v=4
+        - --stderrthreshold=info
+        {{- /* Smart auto-enable: if enabled is null, auto-enable when replicas > 1 */ -}}
+        {{- $leaderElectionEnabled := .Values.recommender.leaderElection.enabled }}
+        {{- if eq $leaderElectionEnabled nil }}
+          {{- $leaderElectionEnabled = gt (int .Values.recommender.replicas) 1 }}
+        {{- end }}
+        {{- if $leaderElectionEnabled }}
+        - --leader-elect=true
+        - --leader-elect-resource-namespace={{ .Values.recommender.leaderElection.resourceNamespace | default .Release.Namespace }}
+        - --leader-elect-resource-name={{ .Values.recommender.leaderElection.resourceName }}
+        - --leader-elect-lease-duration={{ .Values.recommender.leaderElection.leaseDuration }}
+        - --leader-elect-renew-deadline={{ .Values.recommender.leaderElection.renewDeadline }}
+        - --leader-elect-retry-period={{ .Values.recommender.leaderElection.retryPeriod }}
+        {{- end }}
+        {{- with .Values.recommender.extraArgs }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        ports:
+        - name: prometheus
+          containerPort: 8942
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health-check
+            port: prometheus
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health-check
+            port: prometheus
+            scheme: HTTP
+          periodSeconds: 10
+          failureThreshold: 3
+        {{- with .Values.recommender.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.recommender.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.recommender.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.recommender.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-leader-election-rbac.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-leader-election-rbac.yaml
@@ -1,0 +1,51 @@
+{{- if and (.Values.recommender.enabled) .Values.rbac.create -}}
+{{- /* Smart auto-enable: if enabled is null, auto-enable when replicas > 1 */ -}}
+{{- $leaderElectionEnabled := .Values.recommender.leaderElection.enabled }}
+{{- if eq $leaderElectionEnabled nil }}
+  {{- $leaderElectionEnabled = gt (int .Values.recommender.replicas) 1 }}
+{{- end }}
+{{- if $leaderElectionEnabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-leader-locking
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resourceNames:
+  - vpa-recommender
+  - vpa-recommender-lease
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-leader-locking
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-leader-locking
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-pdb.yaml
@@ -1,0 +1,19 @@
+{{- if and (.Values.recommender.enabled) .Values.recommender.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vertical-pod-autoscaler.recommender.selectorLabels" . | nindent 6 }}
+  {{- if .Values.recommender.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.recommender.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.recommender.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.recommender.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-serviceaccount.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if and (.Values.recommender.enabled) .Values.recommender.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+  {{- with .Values.recommender.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.recommender.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -95,3 +95,81 @@ admissionController:
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
     maxUnavailable:
     # maxUnavailable: 1
+
+recommender:
+  enabled: true
+  image:
+    # Image repository for the Recommender default container.
+    repository: registry.k8s.io/autoscaling/vpa-recommender
+    # Image tag for the Recommender default container; this will default to `.Chart.AppVersion` if not set
+    tag:
+    # Image pull policy for the Recommender default container.
+    pullPolicy: IfNotPresent
+
+  serviceAccount:
+    # If `true`, create a new `ServiceAccount` for the Recommender.
+    create: true
+    # Labels to add to the Recommender service account.
+    labels: {}
+    # Annotations to add to the Recommender service account.
+    annotations: {}
+
+  # Number of Recommender replicas to create.
+  replicas: 2
+
+  # Labels to add to the Recommender pod.
+  podLabels: {}
+
+  # Annotations to add to the Recommender pod.
+  podAnnotations: {}
+
+  # Additional environment variables for the Recommender default container.
+  extraEnv: []
+
+  # Additional args for the Recommender default container.
+  extraArgs: []
+
+  # Resources for the Recommender default container.
+  resources:
+    limits:
+      cpu: 200m
+      memory: 1000Mi
+    requests:
+      cpu: 50m
+      memory: 500Mi
+
+  # Node selector labels for scheduling the Recommender.
+  nodeSelector: {}
+
+  # Affinity rules for scheduling the Recommender.
+  affinity: {}
+
+  # Tolerations for scheduling the Recommender.
+  tolerations: []
+
+  # Leader election configuration for the Recommender.
+  # When running multiple replicas, leader election ensures only one instance is actively processing.
+  leaderElection:
+    # Enable leader election. If not set (null), automatically enabled when replicas > 1
+    enabled:
+    # Namespace for the lease resource. Defaults to Release.Namespace if not set.
+    resourceNamespace: ""
+    # Name of the lease resource.
+    resourceName: "vpa-recommender-lease"
+    # Duration that non-leader candidates will wait after observing a leadership renewal.
+    leaseDuration: "15s"
+    # Interval between attempts by the acting master to renew a leadership slot.
+    renewDeadline: "10s"
+    # Duration the clients should wait between attempting acquisition and renewal of a leadership.
+    retryPeriod: "2s"
+
+  # PodDisruptionBudget for the Recommender.
+  podDisruptionBudget:
+    enabled: true
+    # -- (int or string) Minimum number/percentage of pods that must be available after the eviction.
+    # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
+    minAvailable: 1
+    # -- (int or string) Maximum number/percentage of pods that can be unavailable after the eviction.
+    # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
+    maxUnavailable:
+    # maxUnavailable: 1


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Part of: https://github.com/kubernetes/autoscaler/issues/8587

Adds to the VPA helm chart:

For vpa-recommender:
- Deployment
- ServiceAccount
- RBAC (ClusterRole, RoleBinding)
- ConfigMap (optional tuning parameters)
- PodDisruptionBudget
- nodeSelector / affinity / tolerations

Updates chart version to `0.4.0`.

#### What type of PR is this?

/kind feature

You can test it out by using this:
```bash
helm upgrade --install vpa ./vertical-pod-autoscaler/charts/vertical-pod-autoscaler/ \
  -n vpa --create-namespace \
  --set recommender.enabled=true \
  --set recommender.replicas=2 \
  --set recommender.image.tag=1.5.0 \
  --set recommender.image.pullPolicy=Always \
  --set-json 'recommender.podLabels={"environment":"test","team":"autoscaling"}' \
  --set-json 'recommender.podAnnotations={"prometheus.io/scrape":"true","prometheus.io/port":"8942"}' \
  --set-json 'recommender.serviceAccount.labels={"app":"vpa"}' \
  --set-json 'recommender.serviceAccount.annotations={"example.com/owner":"platform-team"}' \
  --set-json 'recommender.nodeSelector={"kubernetes.io/os":"linux"}' \
  --set-json 'recommender.tolerations=[{"key":"dedicated","operator":"Equal","value":"system","effect":"NoSchedule"}]' \
  --set-json 'recommender.affinity={"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"weight":100,"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/component","operator":"In","values":["recommender"]}]},"topologyKey":"kubernetes.io/hostname"}}]}}' \
  --set recommender.resources.limits.cpu=500m \
  --set recommender.resources.limits.memory=2Gi \
  --set recommender.resources.requests.cpu=100m \
  --set recommender.resources.requests.memory=512Mi \
  --set-json 'recommender.extraArgs=["--v=5","--pod-recommendation-min-cpu-millicores=15","--pod-recommendation-min-memory-mb=100","--leader-elect=true","--leader-elect-resource-namespace=vpa"]' \
  --set-json 'recommender.extraEnv=[{"name":"LOG_LEVEL","value":"debug"},{"name":"GOMAXPROCS","value":"4"}]' \
  --set recommender.podDisruptionBudget.enabled=true \
  --set recommender.podDisruptionBudget.minAvailable=1
```


#### Special notes for your reviewer:
I was mostly just following the existing manifests in `veritcal-pod-autoscaler/deploy/*.yaml`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```