### PR TITLE
docs: Document VPA incompatibility with pod-level resources stanza

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -48,7 +48,7 @@ You can also read about the [features](./docs/features.md) and [known limitation
 > [!IMPORTANT]
 > At the moment, VPA is not compatible with workloads that define pod-level `resources` stanzas. Work has started to add pod-level resources support for VPA, for more details see [AEP-7571](https://github.com/kubernetes/autoscaler/pull/8586). Users of VPA may encounter the following issues if they enable VPA for a workload with a pod-level resources stanza defined:
 > * When the admission-controller tries to set a container-level limit higher than the pod-level limit, the operation is prohibited, and the pod will not be created.
-> * When the admission-controller tries to set the newly recommended container-level requests, their total value cannot exceed the pod-level requests. For example, if the pod-level memory request is 100Mi, but the newly recommended total of container-level requests is 250Mi, the pod will fail to be created.
+> * When the admission-controller tries to set the newly recommended container-level requests, their total value cannot exceed the pod-level request or limit. For example, if the pod-level memory request is 100Mi, but the newly recommended total of container-level requests is 250Mi, the pod will fail to be created.
 
 ## Related links
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area vertical-pod-autoscaler

#### What this PR does / why we need it:

Document VPA incompatibility with the pod-level `resources` stanza. I think it would make sense to notify VPA users.