### PR TITLE
cluster-autoscaler/cloudstack: Add project-id support for multi-project environments

### DIFF
--- a/cluster-autoscaler/cloudprovider/cloudstack/README.md
+++ b/cluster-autoscaler/cloudprovider/cloudstack/README.md
@@ -28,8 +28,12 @@ that is suitable for your environment.
 api-url = <CloudStack API URL>
 api-key = <CloudStack API Key>
 secret-key = <CloudStack API Secret>
+project-id = <CloudStack Project ID>  # Optional: required for multi-project environments
 ```
 The access token needs to be able to execute the `listKubernetesClusters` and `scaleKubernetesCluster` APIs.
+
+**Note:** The `project-id` parameter is optional but required when working with clusters in CloudStack projects. 
+If not specified, the API will use the default project associated with the API credentials.
 
 To create the secret, use the following command:
 ```bash

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_option.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_option.go
@@ -97,6 +97,7 @@ func createConfig(opts ...option) (*managerConfig, error) {
 			APIKey:    config.Global.APIKey,
 			SecretKey: config.Global.SecretKey,
 			Endpoint:  config.Global.APIURL,
+			ProjectID: config.Global.ProjectID,
 		}
 	}
 

--- a/cluster-autoscaler/cloudprovider/cloudstack/service/cks.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/service/cks.go
@@ -74,7 +74,8 @@ type VirtualMachine struct {
 
 // cksService implements the CKSService interface
 type cksService struct {
-	client APIClient
+	client    APIClient
+	projectID string
 }
 
 func virtaulMachinesToMap(vms []*VirtualMachine) map[string]*VirtualMachine {
@@ -89,9 +90,16 @@ func virtaulMachinesToMap(vms []*VirtualMachine) map[string]*VirtualMachine {
 
 func (service *cksService) GetClusterDetails(clusterID string) (*Cluster, error) {
 	var out ListClusterResponse
-	_, err := service.client.NewRequest("listKubernetesClusters", map[string]string{
+	params := map[string]string{
 		"id": clusterID,
-	}, &out)
+	}
+	
+	// Include projectid if configured to support multi-project CloudStack environments
+	if service.projectID != "" {
+		params["projectid"] = service.projectID
+	}
+	
+	_, err := service.client.NewRequest("listKubernetesClusters", params, &out)
 
 	if err != nil {
 		return nil, fmt.Errorf("Unable to fetch cluster details : %v", err)
@@ -108,10 +116,17 @@ func (service *cksService) GetClusterDetails(clusterID string) (*Cluster, error)
 
 func (service *cksService) ScaleCluster(clusterID string, workerCount int) (*Cluster, error) {
 	var out ClusterResponse
-	_, err := service.client.NewRequest("scaleKubernetesCluster", map[string]string{
+	params := map[string]string{
 		"id":   clusterID,
 		"size": strconv.Itoa(workerCount),
-	}, &out)
+	}
+	
+	// Include projectid if configured to support multi-project CloudStack environments
+	if service.projectID != "" {
+		params["projectid"] = service.projectID
+	}
+	
+	_, err := service.client.NewRequest("scaleKubernetesCluster", params, &out)
 
 	if err != nil {
 		return nil, fmt.Errorf("Unable to scale cluster : %v", err)
@@ -123,10 +138,17 @@ func (service *cksService) ScaleCluster(clusterID string, workerCount int) (*Clu
 
 func (service *cksService) RemoveNodesFromCluster(clusterID string, nodeIDs ...string) (*Cluster, error) {
 	var out ClusterResponse
-	_, err := service.client.NewRequest("scaleKubernetesCluster", map[string]string{
+	params := map[string]string{
 		"id":      clusterID,
 		"nodeids": strings.Join(nodeIDs[:], ","),
-	}, &out)
+	}
+	
+	// Include projectid if configured to support multi-project CloudStack environments
+	if service.projectID != "" {
+		params["projectid"] = service.projectID
+	}
+	
+	_, err := service.client.NewRequest("scaleKubernetesCluster", params, &out)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to delete %v from cluster : %v", nodeIDs, err)
 	}
@@ -143,6 +165,7 @@ func (service *cksService) Close() {
 func NewCKSService(config *Config) CKSService {
 	client := NewAPIClient(config)
 	return &cksService{
-		client: client,
+		client:    client,
+		projectID: config.ProjectID,
 	}
 }

--- a/cluster-autoscaler/cloudprovider/cloudstack/service/client.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/service/client.go
@@ -49,6 +49,7 @@ type Config struct {
 	APIKey       string
 	SecretKey    string
 	Endpoint     string
+	ProjectID    string
 	Timeout      int
 	PollInterval int
 }


### PR DESCRIPTION
cluster-autoscaler/cloudstack: Add project-id support for multi-project environments

This commit adds support for the optional project-id parameter in CloudStack cloud provider configuration. This is required for clusters running in CloudStack projects, as the listKubernetesClusters API returns empty results when querying by cluster ID without the projectid parameter in multi-project environments.

Changes:
- Add ProjectID field to service.Config struct
- Pass ProjectID from cloud-config to service configuration
- Include projectid parameter in all CKS API calls when configured:
  * listKubernetesClusters (GetClusterDetails)
  * scaleKubernetesCluster (ScaleCluster and RemoveNodesFromCluster)
- Update README.md to document the optional project-id parameter

The project-id parameter is optional and backwards compatible. If not specified, the API uses the default project associated with the credentials.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a critical issue where the cluster-autoscaler fails to work with Kubernetes clusters running in CloudStack projects. 

**Problem:** The autoscaler currently ignores the `project-id` configured in the cloud-config and doesn't include the `projectid` parameter in API calls to CloudStack. This causes the `listKubernetesClusters` API to return empty results even when the cluster exists, resulting in continuous errors:

```
Failed to refresh cloud provider config: Unable to fetch cluster with id: <cluster-id>
```

**Solution:** This PR adds support for the optional `project-id` parameter by:

1. Adding a `ProjectID` field to the service configuration
2. Including the `projectid` parameter in all CloudStack API calls when configured
3. Maintaining backward compatibility (parameter is optional)

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

- The `project-id` parameter is **optional** and maintains full backward compatibility
- If not specified, the API uses the default project associated with the credentials
- All existing unit tests pass successfully (35 tests)
- The fix has been validated in a production CloudStack environment (Linube) with Kubernetes v1.33.1
- The implementation follows the same pattern used in other CloudStack API calls

**Testing performed:**
```bash
cd cluster-autoscaler
go test ./cloudprovider/cloudstack/... -v
# Result: PASS (all 35 tests passed)
```

#### Does this PR introduce a user-facing change?

```release-note
cluster-autoscaler/cloudstack: Add optional project-id support for multi-project CloudStack environments. Users can now specify project-id in cloud-config to use autoscaler with clusters in CloudStack projects.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [CloudStack API Documentation](https://cloudstack.apache.org/api/apidocs-4.21/)
- [Updated README with project-id configuration](https://github.com/kubernetes/autoscaler/blob/fix/cloudstack-project-id-support/cluster-autoscaler/cloudprovider/cloudstack/README.md)
```
```