### PR TITLE
Add verify script to detect dead code

### DIFF
--- a/hack/verify-vpa.sh
+++ b/hack/verify-vpa.sh
@@ -19,7 +19,9 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-VPA_FLAGS_SCRIPT="${KUBE_ROOT}/vertical-pod-autoscaler/hack/verify-vpa-flags.sh"
+VPA_VERIFY_SCRIPTS="${KUBE_ROOT}/vertical-pod-autoscaler/hack/verify-*.sh"
 
-echo "Running VPA flags verification..."
-"$VPA_FLAGS_SCRIPT"
+for script in $VPA_VERIFY_SCRIPTS; do
+  echo "Running VPA verification script ${script}..."
+  "${script}"
+done

--- a/vertical-pod-autoscaler/hack/update-codegen.sh
+++ b/vertical-pod-autoscaler/hack/update-codegen.sh
@@ -20,9 +20,11 @@ set -o pipefail
 
 GO_CMD=${1:-go}
 CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-CODEGEN_PKG=$($GO_CMD list -m -mod=readonly -f "{{.Dir}}" k8s.io/code-generator)
 cd "${CURRENT_DIR}/.."
+go mod download
+CODEGEN_PKG=$($GO_CMD list -m -mod=readonly -f "{{.Dir}}" k8s.io/code-generator)
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 # shellcheck source=/dev/null
 source "${CODEGEN_PKG}/kube_codegen.sh"

--- a/vertical-pod-autoscaler/hack/verify-deadcode-elimination.sh
+++ b/vertical-pod-autoscaler/hack/verify-deadcode-elimination.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script verifies if the golang linker is eliminating dead code in
+# various components we care about, such as kube-apiserver, kubelet and others
+# Usage: `hack/verify-deadcode-elimination.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${SCRIPT_ROOT}"
+COMPONENTS=("admission-controller" "recommender" "updater")
+FAILED=false
+
+# Install whydeadcode
+go install github.com/aarzilli/whydeadcode@latest
+
+# Prefer full path for running zeitgeist
+WHYDEADCODE_BIN="$(which whydeadcode)"
+
+for binary in "${COMPONENTS[@]}"; do
+  echo "Processing ${binary} ..."
+  pushd "pkg/${binary}"
+  output=$(GOLDFLAGS=-dumpdep go build -ldflags=-dumpdep -o "${binary}" 2>&1 | grep "\->" | ${WHYDEADCODE_BIN} 2>&1)
+  if [[ -n "$output" ]]; then
+    echo "golang linker is not eliminating dead code in ${binary}, please check the trace output below:"
+    echo "(NOTE: that there may be false positives, but the first trace should be a real issue)"
+    echo "$output"
+    FAILED=true
+    FAILED_BINARIES+=("${binary}")
+  fi
+
+  # Find the binary and print its size
+  echo "Finding ${binary} binary and checking its size:"
+    ls -altrh "${binary}"
+  echo ""
+  popd
+done
+
+if [[ "$FAILED" == "true" ]]; then
+  echo "Dead code elimination check failed for the following binaries:"
+  for failed_binary in "${FAILED_BINARIES[@]}"; do
+    echo "  - ${failed_binary}"
+  done
+  exit 1
+fi


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Dead code causes the outputted Go binary to be larger. Upstream kubernetes recently put effort into ensuring that Kubernetes doesn't include dead code.
We should copy this, if reasonable to do so, to save storage and bandwidth costs.

#### Which issue(s) this PR fixes:

Fixes #8270

#### Special notes for your reviewer:

I've modified the verify script to run all `verify-.sh`scripts for the VPA. It seems that the codegen hasn't been run in a while, which I'll fix in another PR

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
