### PR TITLE
Move golangci-lint for VPA to its own job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,12 +43,6 @@ jobs:
         env:
           GO111MODULE: auto
 
-      - name: golangci-lint - vertical-pod-autoscaler
-        uses: golangci/golangci-lint-action@v8
-        with:
-          args: --timeout=30m
-          working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler/vertical-pod-autoscaler
-
       - name: Test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler
         run: hack/for-go-proj.sh test

--- a/.github/workflows/vpa-golangci-lint.yaml
+++ b/.github/workflows/vpa-golangci-lint.yaml
@@ -1,10 +1,10 @@
 name: Tests
 
 on:
-  - push:
+  push:
     paths:
       - 'vertical-pod-autoscaler/**'
-  - pull_request:
+  pull_request:
     paths:
       - 'vertical-pod-autoscaler/**'
 

--- a/.github/workflows/vpa-golangci-lint.yaml
+++ b/.github/workflows/vpa-golangci-lint.yaml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          path: ${{ env.GOPATH }}/src/k8s.io/autoscaler
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.0'

--- a/.github/workflows/vpa-golangci-lint.yaml
+++ b/.github/workflows/vpa-golangci-lint.yaml
@@ -1,4 +1,4 @@
-name: Tests
+name: Golangci-lint
 
 on:
   push:

--- a/.github/workflows/vpa-golangci-lint.yaml
+++ b/.github/workflows/vpa-golangci-lint.yaml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  - push:
+    paths:
+      - 'vertical-pod-autoscaler/**'
+  - pull_request:
+    paths:
+      - 'vertical-pod-autoscaler/**'
+
+env:
+  GOPATH: ${{ github.workspace }}/go
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.0'
+          cache-dependency-path: |
+             ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum
+             ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/e2e/go.sum
+
+      - name: golangci-lint - vertical-pod-autoscaler
+        uses: golangci/golangci-lint-action@v8
+        with:
+          args: --timeout=30m
+          working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler/vertical-pod-autoscaler

--- a/.github/workflows/vpa-golangci-lint.yaml
+++ b/.github/workflows/vpa-golangci-lint.yaml
@@ -1,4 +1,4 @@
-name: Golangci-lint
+name: Lint
 
 on:
   push:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   golangci:
-    name: lint
+    name: golangci-lint - VPA
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -39,7 +39,8 @@ Also refer to the [FAQ](./docs/faq.md) for more.
 
 ## Components and Architecture
 
-The Vertical Pod Autoscaler consists of three parts. The recommender, updater and admission-controller. Read more about them on the [components](./docs/components.md) page.
+The Vertical Pod Autoscaler consists of three parts. The recommender, updater and admission-controller.
+Read more about them on the [components](./docs/components.md) page.
 
 ## Features and Known limitations
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Disk space on GitHub Actions is running out. This moves over a single job in the hopes we can same some disk space. 
It's the easiest job to move over for now, more may be moved later.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
