### PR TITLE
Add e2e tests for CPU startup boost

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -244,14 +244,30 @@ func InstallRawVPA(f *framework.Framework, obj interface{}) error {
 
 // AnnotatePod adds annotation for an existing pod.
 func AnnotatePod(f *framework.Framework, podName, annotationName, annotationValue string) {
-	bytes, err := json.Marshal([]utils.PatchRecord{{
+	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), podName, metav1.GetOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to get pod.")
+
+	patches := []utils.PatchRecord{}
+	if pod.Annotations == nil {
+		patches = append(patches, utils.PatchRecord{
+			Op:    "add",
+			Path:  "/metadata/annotations",
+			Value: make(map[string]string),
+		})
+	}
+
+	patches = append(patches, utils.PatchRecord{
 		Op:    "add",
-		Path:  fmt.Sprintf("/metadata/annotations/%v", annotationName),
+		Path:  fmt.Sprintf("/metadata/annotations/%s", annotationName),
 		Value: annotationValue,
-	}})
-	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Patch(context.TODO(), podName, types.JSONPatchType, bytes, metav1.PatchOptions{})
+	})
+
+	bytes, err := json.Marshal(patches)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	patchedPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Patch(context.TODO(), podName, types.JSONPatchType, bytes, metav1.PatchOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to patch pod.")
-	gomega.Expect(pod.Annotations[annotationName]).To(gomega.Equal(annotationValue))
+	gomega.Expect(patchedPod.Annotations[annotationName]).To(gomega.Equal(annotationValue))
 }
 
 // ParseQuantityOrDie parses quantity from string and dies with an error if

--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -356,6 +356,121 @@ var _ = FullVpaE2eDescribe("Pods under VPA with non-recognized recommender expli
 	})
 })
 
+var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
+	var (
+		rc *ResourceConsumer
+	)
+	replicas := 3
+
+	ginkgo.AfterEach(func() {
+		rc.CleanUp()
+	})
+
+	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
+	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+
+	ginkgo.Describe("have CPU startup boost recommendation applied", func() {
+		ginkgo.BeforeEach(func() {
+			waitForVpaWebhookRegistration(f)
+		})
+
+		f.It("to all containers of a pod", framework.WithFeatureGate(features.CPUStartupBoost), func() {
+			ns := f.Namespace.Name
+			ginkgo.By("Setting up a VPA CRD with CPUStartupBoost")
+			targetRef := &autoscaling.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "hamster",
+			}
+
+			containerName := utils.GetHamsterContainerNameByIndex(0)
+			factor := int32(100)
+			vpaCRD := test.VerticalPodAutoscaler().
+				WithName("hamster-vpa").
+				WithNamespace(f.Namespace.Name).
+				WithTargetRef(targetRef).
+				WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
+				WithContainer(containerName).
+				WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor, nil, "10s").
+				Get()
+			utils.InstallVPA(f, vpaCRD)
+
+			ginkgo.By("Setting up a hamster deployment")
+			rc = NewDynamicResourceConsumer("hamster", ns, KindDeployment,
+				replicas,
+				1,             /*initCPUTotal*/
+				10,            /*initMemoryTotal*/
+				1,             /*initCustomMetric*/
+				initialCPU,    /*cpuRequest*/
+				initialMemory, /*memRequest*/
+				f.ClientSet,
+				f.ScalesGetter)
+
+			// Pods should be created with boosted CPU (10m * 100 = 1000m)
+			err := waitForResourceRequestInRangeInPods(
+				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
+				ParseQuantityOrDie("900m"), ParseQuantityOrDie("1100m"))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Pods should be scaled back down in-place after they become Ready and
+			// StartupBoost.CPU.Duration has elapsed
+			err = waitForResourceRequestInRangeInPods(
+				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
+				ParseQuantityOrDie(minimalCPULowerBound), ParseQuantityOrDie(minimalCPUUpperBound))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		f.It("to a subset of containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), func() {
+			ns := f.Namespace.Name
+
+			ginkgo.By("Setting up a VPA CRD with CPUStartupBoost")
+			targetRef := &autoscaling.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "hamster",
+			}
+
+			containerName := utils.GetHamsterContainerNameByIndex(0)
+			factor := int32(100)
+			vpaCRD := test.VerticalPodAutoscaler().
+				WithName("hamster-vpa").
+				WithNamespace(f.Namespace.Name).
+				WithTargetRef(targetRef).
+				WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
+				WithContainer(containerName).
+				WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor, nil, "10s").
+				Get()
+
+			utils.InstallVPA(f, vpaCRD)
+
+			ginkgo.By("Setting up a hamster deployment")
+			rc = NewDynamicResourceConsumer("hamster", ns, KindDeployment,
+				replicas,
+				1,             /*initCPUTotal*/
+				10,            /*initMemoryTotal*/
+				1,             /*initCustomMetric*/
+				initialCPU,    /*cpuRequest*/
+				initialMemory, /*memRequest*/
+				f.ClientSet,
+				f.ScalesGetter)
+
+			// Pods should be created with boosted CPU (10m * 100 = 1000m)
+			err := waitForResourceRequestInRangeInPods(
+				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
+				ParseQuantityOrDie("900m"), ParseQuantityOrDie("1100m"))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Pods should be scaled back down in-place after they become Ready and
+			// StartupBoost.CPU.Duration has elapsed
+			err = waitForResourceRequestInRangeInPods(
+				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
+				ParseQuantityOrDie(minimalCPULowerBound), ParseQuantityOrDie(minimalCPUUpperBound))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+})
+
 var _ = FullVpaE2eDescribe("OOMing pods under VPA", func() {
 	const replicas = 3
 


### PR DESCRIPTION
#### What type of PR is this?

e2e tests

#### What this PR does / why we need it:

This PR adds the e2e tests for CPU startup boost

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: (https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost#aep-7862-cpu-startup-boost)
```

```release-note
NONE
```
