### PR TITLE
feat(chart): affinity, tolerations, nodeSelector for VPA Admission Controller

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -22,6 +22,7 @@ The Vertical Pod Autoscaler (VPA) automatically adjusts the CPU and memory resou
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| admissionController.affinity | object | `{}` |  |
 | admissionController.enabled | bool | `true` |  |
 | admissionController.extraArgs | list | `[]` |  |
 | admissionController.extraEnv | list | `[]` |  |
@@ -52,6 +53,7 @@ The Vertical Pod Autoscaler (VPA) automatically adjusts the CPU and memory resou
 | admissionController.tls.existingSecret | string | `""` |  |
 | admissionController.tls.key | string | `""` |  |
 | admissionController.tls.secretName | string | `"vpa-tls-certs"` |  |
+| admissionController.tolerations | list | `[]` |  |
 | admissionController.volumeMounts[0].mountPath | string | `"/etc/tls-certs"` |  |
 | admissionController.volumeMounts[0].name | string | `"tls-certs"` |  |
 | admissionController.volumeMounts[0].readOnly | bool | `true` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -35,6 +35,18 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+      {{- with .Values.admissionController.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admissionController.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admissionController.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: admission-controller
           image: {{ include "vertical-pod-autoscaler.admissionController.image" . }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -68,6 +68,12 @@ admissionController:
   # Node selector labels for scheduling the Admission Controller.
   nodeSelector: {}
 
+  # Affinity for pod assignment.
+  affinity: {}
+
+  # List of node taints to tolerate.
+  tolerations: []
+
   tls:
     secretName: vpa-tls-certs
     caCert: ""


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Helm chart support `affinity, tolerations, nodeSelector` for VPA Admission Controller

#### Which issue(s) this PR fixes:
Relates #8587

#### Special notes for your reviewer:
Quick test with this `vpa.yaml`
```yaml
admissionController:
  nodeSelector:
    kubernetes.io/os: linux
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux
  tolerations:
  - operator: Exists
```

```console
helm upgrade --install vpa ./vertical-pod-autoscaler/charts/vertical-pod-autoscaler/ \
  -n vpa --create-namespace \
  -f vpa.yaml
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
