### PR TITLE
Fix simulator/dynamicresources/snapshot unit test

### DIFF
--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_test.go
@@ -633,7 +633,7 @@ func TestSnapshotForkCommitRevert(t *testing.T) {
 
 		addedSlices := []*resourceapi.ResourceSlice{addedNodeSlice.DeepCopy()}
 		if err := s.AddNodeResourceSlices(*addedNodeSlice.Spec.NodeName, addedSlices); err != nil {
-			t.Fatalf("failed to add %s resource slices: %v", addedNodeSlice.Spec.NodeName, err)
+			t.Fatalf("failed to add %s resource slices: %v", *addedNodeSlice.Spec.NodeName, err)
 		}
 		if err := s.AddClaims([]*resourceapi.ResourceClaim{addedClaim}); err != nil {
 			t.Fatalf("failed to add %s claim: %v", addedClaim.Name, err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Before:

```
$ go test ./simulator/dynamicresources/snapshot/
# k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot
# [k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot]
simulator/dynamicresources/snapshot/snapshot_test.go:636:4: (*testing.common).Fatalf format %s has arg addedNodeSlice.Spec.NodeName of wrong type *string
FAIL    k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot [build failed]
FAIL
```

After:

```
$ go test ./simulator/dynamicresources/snapshot/
ok      k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot        0.069s
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```