### PR TITLE
feat(chart): VPA Updater deployment

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -4,7 +4,7 @@ WARNING: This chart is currently under development and is not ready for producti
 
 Automatically adjust resources for your workloads
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
 
@@ -93,3 +93,10 @@ The Vertical Pod Autoscaler (VPA) automatically adjusts the CPU and memory resou
 | recommender.serviceAccount.create | bool | `true` |  |
 | recommender.serviceAccount.labels | object | `{}` |  |
 | recommender.tolerations | list | `[]` |  |
+| updater.enabled | bool | `true` |  |
+| updater.image.pullPolicy | string | `"IfNotPresent"` |  |
+| updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` |  |
+| updater.image.tag | string | `nil` |  |
+| updater.podAnnotations | object | `{}` |  |
+| updater.podLabels | object | `{}` |  |
+| updater.replicas | int | `1` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
@@ -75,6 +75,29 @@ Create the name of the tls secret to use
 
 
 {{/*
+updater
+*/}}
+{{- define "vertical-pod-autoscaler.updater.fullname" -}}
+{{ include "vertical-pod-autoscaler.fullname" . }}-updater
+{{- end }}
+
+{{- define "vertical-pod-autoscaler.updater.labels" -}}
+{{ include "vertical-pod-autoscaler.labels" . }}
+app.kubernetes.io/component: updater
+app.kubernetes.io/component-instance: {{ .Release.Name }}-updater
+{{- end }}
+
+{{- define "vertical-pod-autoscaler.updater.selectorLabels" -}}
+{{ include "vertical-pod-autoscaler.selectorLabels" . }}
+app.kubernetes.io/component: updater
+{{- end }}
+
+{{- define "vertical-pod-autoscaler.updater.image" -}}
+{{- printf "%s:%s" .Values.updater.image.repository (default .Chart.AppVersion .Values.updater.image.tag) }}
+{{- end }}
+
+
+{{/*
 Create the name of the namespace to use
 */}}
 {{- define "common.names.namespace" -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.updater.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.updater.replicas }}
+  selector:
+    matchLabels:
+      {{- include "vertical-pod-autoscaler.updater.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vertical-pod-autoscaler.updater.selectorLabels" . | nindent 8 }}
+      {{- with .Values.updater.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.updater.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      containers:
+        - name: updater
+          image: {{ include "vertical-pod-autoscaler.updater.image" . }}
+          imagePullPolicy: {{ .Values.updater.image.pullPolicy }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: prometheus
+              containerPort: 8943
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: prometheus
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health-check
+              port: prometheus
+              scheme: HTTP
+            periodSeconds: 10
+            failureThreshold: 3
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -179,3 +179,22 @@ recommender:
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
     maxUnavailable:
     # maxUnavailable: 1
+
+updater:
+  enabled: true
+  image:
+    # Image repository for the Updater default container.
+    repository: registry.k8s.io/autoscaling/vpa-updater
+    # Image tag for the Updater default container; this will default to `.Chart.AppVersion` if not set
+    tag:
+    # Image pull policy for the Updater default container.
+    pullPolicy: IfNotPresent
+  
+  # Number of Updater replicas to create.
+  replicas: 1
+
+  # Labels to add to the Updater pod.
+  podLabels: {}
+
+  # Annotations to add to the Updater pod.
+  podAnnotations: {}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
VPA Updater add deployment

#### Which issue(s) this PR fixes:
Relates #8587

#### Special notes for your reviewer:
Quick test with this `vpa.yaml`
```yaml
updater:
  enabled: true
  image:
    repository: registry.k8s.io/autoscaling/vpa-updater
    tag: 1.5.1
    pullPolicy: Always
  podLabels:
    foo: bar
  podAnnotations:
    foo: bar
```

```console
helm upgrade --install vpa ./vertical-pod-autoscaler/charts/vertical-pod-autoscaler/ \
  -n vpa --create-namespace \
  -f vpa.yaml
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
