### PR TITLE
cluster-autoscaler: update charts directory in E2E

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/test/e2e/e2e_suite_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/e2e/e2e_suite_test.go
@@ -149,7 +149,7 @@ func ensureHelmValues(values map[string]interface{}) {
 		GinkgoLogr.Info(fmt.Sprintf(format, v...))
 	})).To(Succeed())
 
-	chart, err := loader.Load("../../../../../charts/cluster-autoscaler")
+	chart, err := loader.Load("../../../../../cluster-autoscaler/charts/cluster-autoscaler")
 	Expect(err).NotTo(HaveOccurred())
 
 	get := action.NewGet(helmCfg)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

This change moved the `cluster-autoscaler` charts directory into the `cluster-autoscaler/` source directory:

https://github.com/kubernetes/autoscaler/pull/8617

This PR reflects that change in the CA E2E flow so that we can continue to leverage the chart to install CA on an E2E cluster using Azure infrastructure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
