### PR TITLE
Switch e2e test with feature flag to use framework.WithFeatureGate

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -37,7 +36,6 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/e2e/utils"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	framework_deployment "k8s.io/kubernetes/test/e2e/framework/deployment"
@@ -467,27 +465,4 @@ func WaitForPodsUpdatedWithoutEviction(f *framework.Framework, initialPods *apiv
 	})
 	framework.Logf("finished waiting for at least one pod to be updated without eviction")
 	return err
-}
-
-// checkPerVPAConfigTestsEnabled checks if the PerVPAConfig feature gate is enabled
-// in the VPA recommender.
-func checkPerVPAConfigTestsEnabled(f *framework.Framework) {
-	ginkgo.By("Checking PerVPAConfig feature gate is enabled for recommender")
-	deploy, err := f.ClientSet.AppsV1().Deployments(VpaNamespace).Get(context.TODO(), "vpa-recommender", metav1.GetOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(deploy.Spec.Template.Spec.Containers).To(gomega.HaveLen(1))
-	vpaRecommenderPod := deploy.Spec.Template.Spec.Containers[0]
-	gomega.Expect(vpaRecommenderPod.Name).To(gomega.Equal("recommender"))
-	if !anyContainsSubstring(vpaRecommenderPod.Args, fmt.Sprintf("%s=true", string(features.PerVPAConfig))) {
-		ginkgo.Skip("Skipping suite: PerVPAConfig feature gate is not enabled for the VPA recommender")
-	}
-}
-
-func anyContainsSubstring(arr []string, substr string) bool {
-	for _, s := range arr {
-		if strings.Contains(s, substr) {
-			return true
-		}
-	}
-	return false
 }

--- a/vertical-pod-autoscaler/hack/run-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-locally.sh
@@ -90,7 +90,7 @@ kind load docker-image localhost:5001/write-metrics:dev
 export FEATURE_GATES=""
 export TEST_WITH_FEATURE_GATES_ENABLED=""
 
-if [ "${ENABLE_ALL_FEATURE_GATES:-}" == "yes" ] ; then
+if [ "${ENABLE_ALL_FEATURE_GATES:-}" == "true" ] ; then
   export FEATURE_GATES='AllAlpha=true,AllBeta=true'
   export TEST_WITH_FEATURE_GATES_ENABLED="true"
 fi

--- a/vertical-pod-autoscaler/hack/run-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-locally.sh
@@ -87,6 +87,14 @@ echo "  loading image into kind"
 kind load docker-image localhost:5001/write-metrics:dev
 
 
+export FEATURE_GATES=""
+export TEST_WITH_FEATURE_GATES_ENABLED=""
+
+if [ "${ENABLE_ALL_FEATURE_GATES:-}" == "yes" ] ; then
+  export FEATURE_GATES='AllAlpha=true,AllBeta=true'
+  export TEST_WITH_FEATURE_GATES_ENABLED="true"
+fi
+
 case ${SUITE} in
   recommender|recommender-externalmetrics|updater|admission-controller|actuation|full-vpa)
     ${SCRIPT_ROOT}/hack/vpa-down.sh

--- a/vertical-pod-autoscaler/hack/run-e2e-tests.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-tests.sh
@@ -46,11 +46,17 @@ export GO111MODULE=on
 
 export WORKSPACE=${WORKSPACE:-/workspace/_artifacts}
 
+SKIP="--ginkgo.skip=\[Feature\:OffByDefault\]"
+
+if [ "${TEST_WITH_FEATURE_GATES_ENABLED:-}" == "true" ]; then
+  SKIP=""
+fi
+
 case ${SUITE} in
   recommender|updater|admission-controller|actuation|full-vpa)
     export KUBECONFIG=$HOME/.kube/config
     pushd ${SCRIPT_ROOT}/e2e
-    go test ./v1/*go -v --test.timeout=150m --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=${WORKSPACE} --disable-log-dump --ginkgo.timeout=150m
+    go test ./v1/*go -v --test.timeout=150m --args --ginkgo.v=true --ginkgo.focus="\[VPA\] \[${SUITE}\]" --report-dir=${WORKSPACE} --disable-log-dump --ginkgo.timeout=150m ${SKIP}
     V1_RESULT=$?
     popd
     echo v1 test result: ${V1_RESULT}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

At the moment our e2e coverage for feature flags (default to off) isn't great.

My thinking is to copy k/k and have 2 sets of jobs that execute:
1. e2e tests that exclude tests that have their feature gates set to disabled by default
2. e2e tests that include tests that require their featute gates to be enabled

I plan to do this using gingko labels.

WithFeatureGate adds a label `Feature:OffByDefault` which we can use to ignore or include, depending on which e2e test job is running.

If everyone is in agreement that this is a way forward, I'll go update the remaining e2e tests and add the correct feature gate for them.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc omerap12
/cc kamarabbas99

(Kam, I've seen you've put the CPU Boost PR up, so I figured I'd tag you on this since you've got recently relevant experience with e2e tests and feature gates, let me know what you think of this change)