### PR TITLE
feat(chart): VPA Updater resources, affinity, nodeSelector, tolerations

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -4,7 +4,7 @@ WARNING: This chart is currently under development and is not ready for producti
 
 Automatically adjust resources for your workloads
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
 
@@ -29,7 +29,10 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| admissionController.affinity | object | `{}` |  |
+| admissionController.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].key | string | `"app.kubernetes.io/component"` |  |
+| admissionController.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].operator | string | `"In"` |  |
+| admissionController.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0] | string | `"admission-controller"` |  |
+| admissionController.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey | string | `"kubernetes.io/hostname"` |  |
 | admissionController.enabled | bool | `true` |  |
 | admissionController.extraArgs | list | `[]` |  |
 | admissionController.extraEnv | list | `[]` |  |
@@ -73,7 +76,10 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 | podSecurityContext.runAsNonRoot | bool | `true` |  |
 | podSecurityContext.runAsUser | int | `65534` |  |
 | rbac.create | bool | `true` |  |
-| recommender.affinity | object | `{}` |  |
+| recommender.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].key | string | `"app.kubernetes.io/component"` |  |
+| recommender.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].operator | string | `"In"` |  |
+| recommender.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0] | string | `"recommender"` |  |
+| recommender.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey | string | `"kubernetes.io/hostname"` |  |
 | recommender.enabled | bool | `true` |  |
 | recommender.extraArgs | list | `[]` |  |
 | recommender.extraEnv | list | `[]` |  |
@@ -99,6 +105,10 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 | recommender.serviceAccount.create | bool | `true` |  |
 | recommender.serviceAccount.labels | object | `{}` |  |
 | recommender.tolerations | list | `[]` |  |
+| updater.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].key | string | `"app.kubernetes.io/component"` |  |
+| updater.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].operator | string | `"In"` |  |
+| updater.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0] | string | `"updater"` |  |
+| updater.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey | string | `"kubernetes.io/hostname"` |  |
 | updater.enabled | bool | `true` |  |
 | updater.extraArgs | list | `[]` |  |
 | updater.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -110,6 +120,7 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 | updater.leaderElection.resourceName | string | `"vpa-updater-lease"` |  |
 | updater.leaderElection.resourceNamespace | string | `""` |  |
 | updater.leaderElection.retryPeriod | string | `"2s"` |  |
+| updater.nodeSelector | object | `{}` |  |
 | updater.podAnnotations | object | `{}` |  |
 | updater.podDisruptionBudget.enabled | bool | `true` |  |
 | updater.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
@@ -121,3 +132,4 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 | updater.serviceAccount.annotations | object | `{}` |  |
 | updater.serviceAccount.create | bool | `true` |  |
 | updater.serviceAccount.labels | object | `{}` |  |
+| updater.tolerations | list | `[]` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -35,6 +35,18 @@ spec:
       {{- with .Values.updater.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.updater.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.updater.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.updater.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: updater
           image: {{ include "vertical-pod-autoscaler.updater.image" . }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -75,7 +75,16 @@ admissionController:
   nodeSelector: {}
 
   # Affinity for pod assignment.
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/component
+            operator: In
+            values:
+            - admission-controller
+        topologyKey: kubernetes.io/hostname
 
   # List of node taints to tolerate.
   tolerations: []
@@ -158,7 +167,16 @@ recommender:
   nodeSelector: {}
 
   # Affinity rules for scheduling the Recommender.
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/component
+            operator: In
+            values:
+            - recommender
+        topologyKey: kubernetes.io/hostname
 
   # Tolerations for scheduling the Recommender.
   tolerations: []
@@ -223,6 +241,24 @@ updater:
     labels: {}
     # Annotations to add to the Updater service account.
     annotations: {}
+
+  # Affinity rules for scheduling the Updater.
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/component
+            operator: In
+            values:
+            - updater
+        topologyKey: kubernetes.io/hostname
+
+  # Node selector labels for scheduling the Updater.
+  nodeSelector: {}
+
+  # Tolerations for scheduling the Updater.
+  tolerations: []
   
   # Leader election configuration for the Updater.
   # When running multiple replicas, leader election ensures only one instance is actively processing.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
- Helm chart support resources, affinity, tolerations, nodeSelector for VPA Updater
- Config affinity for high availability as discussed in
  - https://github.com/kubernetes/autoscaler/pull/8675#issuecomment-3430986496
  - https://github.com/kubernetes/autoscaler/pull/8675#issuecomment-3431059579

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates #8587

#### Special notes for your reviewer:
Quick test with this `vpa.yaml`
```yaml
updater:
  resources:
    limits:
      cpu: 100m
      memory: 800Mi
    requests:
      cpu: 50m
      memory: 500Mi
  nodeSelector:
    kubernetes.io/os: linux
  tolerations:
  - operator: Exists
```

```console
helm upgrade --install vpa ./vertical-pod-autoscaler/charts/vertical-pod-autoscaler/ \
  -n vpa --create-namespace \
  -f vpa.yaml
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
