### PR TITLE
CA: build images without attestation manifests

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -70,6 +70,7 @@ make-image: make-image-arch-$(GOARCH)
 make-image-arch-%:
 	GOOS=$(GOOS) docker buildx build --pull --platform linux/$* \
 		--build-arg "GOARCH=$*" \
+		--provenance=false \
 		-t ${IMAGE}-$*:${TAG} \
 		-f Dockerfile .
 	@echo "Image ${TAG}${FOR_PROVIDER}-$* completed"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

From the `docker buildx build` documentation:

`--provenance string             Shorthand for "--attest=type=provenance"`

This PR sets `--provenance=false` for `cluster-autoscaler` docker image builds to allow better ergonomics for including architecture-specific images (e.g., `registry.k8s.io/autoscaling/cluster-autoscaler-amd64:v1.34.1`) into a cross-arch manifest (e.g., `registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.1`).

Otherwise we will include attestation manifests data in the resultant image build, and run into errors like this one:


```
docker manifest create gcr.io/k8s-staging-autoscaling/cluster-autoscaler:v1.30.7 \
      gcr.io/k8s-staging-autoscaling/cluster-autoscaler-amd64:v1.30.7 gcr.io/k8s-staging-autoscaling/cluster-autoscaler-arm64:v1.30.7 gcr.io/k8s-staging-autoscaling/cluster-autoscaler-s390x:v1.30.7
gcr.io/k8s-staging-autoscaling/cluster-autoscaler-amd64:v1.30.7 is a manifest list
```

Credit to @cpuguy83

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Build images without attestation manifests
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
