### PR TITLE
feat: add evictAfterOOMThreshold per vpa

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
@@ -254,6 +254,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.updatePolicy.minReplicas
+      name: MinReplicas
+      priority: 1
+      type: integer
+    - jsonPath: .spec.updatePolicy.evictAfterOOMThreshold
+      name: OOMThreshold
+      priority: 1
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -425,6 +433,14 @@ spec:
                   If not specified, all fields in the `PodUpdatePolicy` are set to their
                   default values.
                 properties:
+                  evictAfterOOMThreshold:
+                    description: |-
+                      EvictAfterOOMThreshold specifies the time to wait after an OOM event before
+                      considering the pod for eviction. Pods that have OOMed in less than this threshold
+                      since start will be evicted.
+                    format: duration
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
                   evictionRequirements:
                     description: |-
                       EvictionRequirements is a list of EvictionRequirements that need to
@@ -478,6 +494,10 @@ spec:
                     - Auto
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: evictAfterOOMThreshold must be greater than 0
+                  rule: '!has(self.evictAfterOOMThreshold) || duration(self.evictAfterOOMThreshold)
+                    > duration(''0s'')'
             required:
             - targetRef
             type: object

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -254,6 +254,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.updatePolicy.minReplicas
+      name: MinReplicas
+      priority: 1
+      type: integer
+    - jsonPath: .spec.updatePolicy.evictAfterOOMThreshold
+      name: OOMThreshold
+      priority: 1
+      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -425,6 +433,14 @@ spec:
                   If not specified, all fields in the `PodUpdatePolicy` are set to their
                   default values.
                 properties:
+                  evictAfterOOMThreshold:
+                    description: |-
+                      EvictAfterOOMThreshold specifies the time to wait after an OOM event before
+                      considering the pod for eviction. Pods that have OOMed in less than this threshold
+                      since start will be evicted.
+                    format: duration
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
                   evictionRequirements:
                     description: |-
                       EvictionRequirements is a list of EvictionRequirements that need to
@@ -478,6 +494,10 @@ spec:
                     - Auto
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: evictAfterOOMThreshold must be greater than 0
+                  rule: '!has(self.evictAfterOOMThreshold) || duration(self.evictAfterOOMThreshold)
+                    > duration(''0s'')'
             required:
             - targetRef
             type: object

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -140,7 +140,7 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `add-dir-header` |  |  | If true, adds the file directory to the header of the log messages |
 | `address` | string |  ":8943" | The address to expose Prometheus metrics.  |
 | `alsologtostderr` |  |  | log to standard error as well as files (no effect when -logtostderr=true) |
-| `evict-after-oom-threshold` |  |  10m0s | duration                              Evict pod that has OOMed in less than evict-after-oom-threshold since start.  |
+| `evict-after-oom-threshold` |  |  10m0s | duration                              The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start.  |
 | `eviction-rate-burst` | int |  1 | Burst of pods that can be evicted.  |
 | `eviction-rate-limit` | float |  | Number of pods that can be evicted per seconds. A rate limit set to 0 or -1 will disable<br>the rate limiter. (default -1) |
 | `eviction-tolerance` | float |  0.5 | Fraction of replica count that can be evicted for update, if more than one pod can be evicted.  |
@@ -174,4 +174,3 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `v,` |  | : 4 | , --v Level                                                         set the log level verbosity  (default 4) |
 | `vmodule` | moduleSpec |  | comma-separated list of pattern=N settings for file-filtered logging |
 | `vpa-object-namespace` | string |  | Specifies the namespace to search for VPA objects. Leave empty to include all namespaces. If provided, the garbage collector will only clean this namespace. |
-

--- a/vertical-pod-autoscaler/e2e/utils/common.go
+++ b/vertical-pod-autoscaler/e2e/utils/common.go
@@ -81,6 +81,9 @@ var RecommenderLabels = map[string]string{"app": "vpa-recommender"}
 // HamsterLabels are labels of hamster app
 var HamsterLabels = map[string]string{"app": "hamster"}
 
+// OOMLabels are labels for OOM test pods
+var OOMLabels = map[string]string{"app": "oom-test"}
+
 // SIGDescribe adds sig-autoscaling tag to test description.
 // Takes args that are passed to ginkgo.Describe.
 func SIGDescribe(scenario, name string, args ...interface{}) bool {

--- a/vertical-pod-autoscaler/e2e/v1/admission_controller.go
+++ b/vertical-pod-autoscaler/e2e/v1/admission_controller.go
@@ -956,32 +956,6 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
 				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: oomBumpUpRatio must be greater than or equal to 1.0, got -1",
 			},
 			{
-				name: "Invalid oomBumpUpRatio (string value)",
-				vpaJSON: `{
-            "apiVersion": "autoscaling.k8s.io/v1",
-            "kind": "VerticalPodAutoscaler",
-            "metadata": {"name": "oom-test-vpa"},
-            "spec": {
-                "targetRef": {
-                    "apiVersion": "apps/v1",
-                    "kind": "Deployment",
-                    "name": "oom-test"
-                },
-                "updatePolicy": {
-                    "updateMode": "Auto"
-                },
-                "resourcePolicy": {
-                    "containerPolicies": [{
-                        "containerName": "*",
-                        "oomBumpUpRatio": "not-a-number",
-                        "oomMinBumpUp": 104857600
-                    }]
-                }
-            }
-        }`,
-				expectedErr: "admission webhook \"vpa\\.k8s\\.io\" denied the request: quantities must match the regular expression",
-			},
-			{
 				name: "Invalid oomBumpUpRatio (less than 1)",
 				vpaJSON: `{
             "apiVersion": "autoscaling.k8s.io/v1",
@@ -1032,6 +1006,32 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
             }
         }`,
 				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: oomMinBumpUp must be greater than or equal to 0, got -1 bytes",
+			},
+			{
+				name: "Invalid oomBumpUpRatio (string value)",
+				vpaJSON: `{
+            "apiVersion": "autoscaling.k8s.io/v1",
+            "kind": "VerticalPodAutoscaler",
+            "metadata": {"name": "oom-test-vpa"},
+            "spec": {
+                "targetRef": {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "name": "oom-test"
+                },
+                "updatePolicy": {
+                    "updateMode": "Auto"
+                },
+                "resourcePolicy": {
+                    "containerPolicies": [{
+                        "containerName": "*",
+                        "oomBumpUpRatio": "not-a-number",
+                        "oomMinBumpUp": 104857600
+                    }]
+                }
+            }
+        }`,
+				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: quantities must match the regular expression",
 			},
 		}
 		for _, tc := range testCases {

--- a/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/e2e/utils"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
@@ -440,6 +441,7 @@ func runOomingReplicationController(c clientset.Interface, ns, name string, repl
 		Namespace:   ns,
 		Timeout:     timeoutRC,
 		Replicas:    replicas,
+		Labels:      utils.OOMLabels,
 		Annotations: make(map[string]string),
 		MemRequest:  1024 * 1024 * 1024,
 		MemLimit:    1024 * 1024 * 1024,

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -144,6 +144,14 @@ func GetHamsterPods(f *framework.Framework) (*apiv1.PodList, error) {
 	return f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), options)
 }
 
+// GetOOMPods returns running OOM test pods (matched by utils.OOMLabels)
+func GetOOMPods(f *framework.Framework) (*apiv1.PodList, error) {
+	// TODO(omerap12): merge GetHamsterPods and GetOOMPods functions.
+	label := labels.SelectorFromSet(labels.Set(utils.OOMLabels))
+	options := metav1.ListOptions{LabelSelector: label.String(), FieldSelector: getPodSelectorExcludingDonePodsOrDie()}
+	return f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), options)
+}
+
 // NewTestCronJob returns a CronJob for test purposes.
 func NewTestCronJob(name, schedule string, replicas int32) *batchv1.CronJob {
 	backoffLimit := utils.DefaultHamsterBackoffLimit
@@ -302,6 +310,21 @@ func WaitForPodsEvicted(f *framework.Framework, podList *apiv1.PodList) error {
 	})
 }
 
+// WaitForPodsEvictedOOM waits until some pods from the list are evicted.
+// TODO(omerap12): merge this with WaitForPodsEvicted
+func WaitForPodsEvictedOOM(f *framework.Framework, podList *apiv1.PodList) error {
+	initialPodSet := MakePodSet(podList)
+
+	return wait.PollUntilContextTimeout(context.Background(), utils.PollInterval, utils.PollTimeout, true, func(ctx context.Context) (done bool, err error) {
+		currentPodList, err := GetOOMPods(f)
+		if err != nil {
+			return false, err
+		}
+		currentPodSet := MakePodSet(currentPodList)
+		return GetEvictedPodsCount(currentPodSet, initialPodSet) > 0, nil
+	})
+}
+
 // WerePodsSuccessfullyRestarted returns true if some pods from initialPodSet have been
 // successfully restarted comparing to currentPodSet (pods were evicted and
 // are running).
@@ -337,6 +360,16 @@ func GetEvictedPodsCount(currentPodSet PodSet, initialPodSet PodSet) int {
 func CheckNoPodsEvicted(f *framework.Framework, initialPodSet PodSet) {
 	time.Sleep(VpaEvictionTimeout)
 	currentPodList, err := GetHamsterPods(f)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "unexpected error when listing hamster pods to check number of pod evictions")
+	restarted := GetEvictedPodsCount(MakePodSet(currentPodList), initialPodSet)
+	gomega.Expect(restarted).To(gomega.Equal(0), "there should be no pod evictions")
+}
+
+// CheckNoPodsEvictedOOM waits for long enough period for VPA to start evicting
+// TODO(omerap12): merge this CheckNoPodsEvicted
+func CheckNoPodsEvictedOOM(f *framework.Framework, initialPodSet PodSet) {
+	time.Sleep(VpaEvictionTimeout)
+	currentPodList, err := GetOOMPods(f)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "unexpected error when listing hamster pods to check number of pod evictions")
 	restarted := GetEvictedPodsCount(MakePodSet(currentPodList), initialPodSet)
 	gomega.Expect(restarted).To(gomega.Equal(0), "there should be no pod evictions")

--- a/vertical-pod-autoscaler/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/e2e/v1/updater.go
@@ -23,9 +23,11 @@ import (
 
 	autoscaling "k8s.io/api/autoscaling/v1"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/e2e/utils"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -207,6 +209,126 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 	})
 })
 
+var _ = UpdaterE2eDescribe("Updater with PerVPAConfig", func() {
+	const replicas = 3
+	const statusUpdateInterval = 10 * time.Second
+	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
+	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+
+	f.It("does not evict pods when OOM duration exceeds threshold", framework.WithFeatureGate(features.PerVPAConfig), func() {
+		ginkgo.By("Setting up the Admission Controller status")
+		stopCh := make(chan struct{})
+		statusUpdater := status.NewUpdater(
+			f.ClientSet,
+			status.AdmissionControllerStatusName,
+			utils.VpaNamespace,
+			statusUpdateInterval,
+			"e2e test",
+		)
+		defer func() {
+			ginkgo.By("Deleting the Admission Controller status")
+			close(stopCh)
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
+				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		statusUpdater.Run(stopCh)
+
+		// Use a very short threshold (1 second)
+		// Pods that take longer than 1 second to OOM will NOT be considered "quick OOM"
+		threshold := 1 * time.Second
+
+		ginkgo.By("Setting up VPA with very short evictAfterOOMThreshold (1 second)")
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		vpaCRD := newOOMTestVPA(f.Namespace.Name, "hamster-vpa", "hamster", containerName, threshold)
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Creating deployment that will OOM (takes >1 second to OOM)")
+		runOomingReplicationController(f.ClientSet, f.Namespace.Name, "hamster", replicas)
+
+		ginkgo.By("Waiting for pods to OOM and restart")
+		gomega.Eventually(func() bool {
+			podList, err := GetOOMPods(f)
+			if err != nil {
+				return false
+			}
+			for _, pod := range podList.Items {
+				for _, cs := range pod.Status.ContainerStatuses {
+					if cs.LastTerminationState.Terminated != nil &&
+						cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
+						framework.Logf("Pod %s container %s was OOMKilled", pod.Name, cs.Name)
+						return true
+					}
+				}
+			}
+			return false
+		}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(), "At least one pod should have OOMed")
+
+		podList, err := GetOOMPods(f)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		initialPodSet := MakePodSet(podList)
+
+		ginkgo.By("Waiting to verify pods are NOT evicted (OOM took longer than 1s threshold)")
+		CheckNoPodsEvictedOOM(f, initialPodSet)
+	})
+
+	f.It("evicts pods when OOM occurs within threshold", framework.WithFeatureGate(features.PerVPAConfig), func() {
+		ginkgo.By("Setting up the Admission Controller status")
+		stopCh := make(chan struct{})
+		statusUpdater := status.NewUpdater(
+			f.ClientSet,
+			status.AdmissionControllerStatusName,
+			utils.VpaNamespace,
+			statusUpdateInterval,
+			"e2e test",
+		)
+		defer func() {
+			ginkgo.By("Deleting the Admission Controller status")
+			close(stopCh)
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
+				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		statusUpdater.Run(stopCh)
+
+		// Long threshold - OOM (~5s) < threshold → quickOOM = true → evict
+		threshold := 10 * time.Minute
+
+		ginkgo.By("Setting up VPA with very short evictAfterOOMThreshold (1 second)")
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		vpaCRD := newOOMTestVPA(f.Namespace.Name, "hamster-vpa", "hamster", containerName, threshold)
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Creating deployment that will OOM (takes >1 second to OOM)")
+		runOomingReplicationController(f.ClientSet, f.Namespace.Name, "hamster", replicas)
+
+		ginkgo.By("Waiting for pods to OOM and restart")
+		gomega.Eventually(func() bool {
+			podList, err := GetOOMPods(f)
+			if err != nil {
+				return false
+			}
+			for _, pod := range podList.Items {
+				for _, cs := range pod.Status.ContainerStatuses {
+					if cs.LastTerminationState.Terminated != nil &&
+						cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
+						framework.Logf("Pod %s container %s was OOMKilled", pod.Name, cs.Name)
+						return true
+					}
+				}
+			}
+			return false
+		}, 60*time.Second, 5*time.Second).Should(gomega.BeTrue(), "At least one pod should have OOMed")
+
+		podList, err := GetOOMPods(f)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Waiting for pods to be evicted")
+		err = WaitForPodsEvictedOOM(f, podList)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})
+
 func setupPodsForUpscalingEviction(f *framework.Framework) *apiv1.PodList {
 	return setupPodsForEviction(f, "100m", "100Mi", nil)
 }
@@ -292,4 +414,49 @@ func setupPodsForInPlace(f *framework.Framework, hamsterCPU, hamsterMemory strin
 	utils.InstallVPA(f, vpaCRD)
 
 	return podList
+}
+
+// newOOMTestVPA creates a VPA for OOM testing with memory-only recommendations.
+// Memory bounds are set so that 1Gi request is within range (no OutsideRecommendedRange eviction)
+// but target differs from request (ResourceDiff > 0, enabling eviction when quickOOM = true).
+func newOOMTestVPA(namespace, name, deploymentName, containerName string, oomThreshold time.Duration) *vpa_types.VerticalPodAutoscaler {
+	updateMode := vpa_types.UpdateModeRecreate
+	return &vpa_types.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: vpa_types.VerticalPodAutoscalerSpec{
+			TargetRef: &autoscaling.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       deploymentName,
+			},
+			UpdatePolicy: &vpa_types.PodUpdatePolicy{
+				UpdateMode:             &updateMode,
+				EvictAfterOOMThreshold: &metav1.Duration{Duration: oomThreshold},
+			},
+			ResourcePolicy: &vpa_types.PodResourcePolicy{
+				ContainerPolicies: []vpa_types.ContainerResourcePolicy{{
+					ContainerName: containerName,
+				}},
+			},
+		},
+		Status: vpa_types.VerticalPodAutoscalerStatus{
+			Recommendation: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{{
+					ContainerName: containerName,
+					Target: apiv1.ResourceList{
+						apiv1.ResourceMemory: resource.MustParse("2Gi"), // Different from 1Gi request
+					},
+					LowerBound: apiv1.ResourceList{
+						apiv1.ResourceMemory: resource.MustParse("500Mi"), // 1Gi is within [500Mi, 3Gi]
+					},
+					UpperBound: apiv1.ResourceList{
+						apiv1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+				}},
+			},
+		},
+	}
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -107,6 +107,11 @@ func parseVPA(raw []byte) (*vpa_types.VerticalPodAutoscaler, error) {
 
 // ValidateVPA checks the correctness of VPA Spec and returns an error if there is a problem.
 func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
+	// check that perVPA is on if being used
+	if err := validatePerVPAFeatureFlag(vpa); err != nil {
+		return err
+	}
+
 	if vpa.Spec.UpdatePolicy != nil {
 		mode := vpa.Spec.UpdatePolicy.UpdateMode
 		if mode == nil {
@@ -122,17 +127,13 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 		if minReplicas := vpa.Spec.UpdatePolicy.MinReplicas; minReplicas != nil && *minReplicas <= 0 {
 			return fmt.Errorf("minReplicas has to be positive, got %v", *minReplicas)
 		}
+
 	}
 
 	if vpa.Spec.ResourcePolicy != nil {
 		for _, policy := range vpa.Spec.ResourcePolicy.ContainerPolicies {
 			if policy.ContainerName == "" {
 				return fmt.Errorf("containerPolicies.ContainerName is required")
-			}
-
-			// check that perVPA is on if being used
-			if err := validatePerVPAFeatureFlag(&policy); err != nil {
-				return err
 			}
 
 			// Validate OOMBumpUpRatio
@@ -216,11 +217,20 @@ func validateMemoryResolution(val apires.Quantity) error {
 	return nil
 }
 
-func validatePerVPAFeatureFlag(policy *vpa_types.ContainerResourcePolicy) error {
+func validatePerVPAFeatureFlag(vpa *vpa_types.VerticalPodAutoscaler) error {
 	featureFlagOn := features.Enabled(features.PerVPAConfig)
-	perVPA := policy.OOMBumpUpRatio != nil || policy.OOMMinBumpUp != nil
-	if !featureFlagOn && perVPA {
-		return fmt.Errorf("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag %s is disabled", features.PerVPAConfig)
+	if !featureFlagOn && vpa.Spec.UpdatePolicy.EvictAfterOOMThreshold != nil {
+		return fmt.Errorf("EvictAfterOOMThreshold is not supported when feature flag %s is disabled", features.PerVPAConfig)
+	}
+
+	if vpa.Spec.ResourcePolicy != nil {
+		for _, policy := range vpa.Spec.ResourcePolicy.ContainerPolicies {
+			perVPA := policy.OOMBumpUpRatio != nil || policy.OOMMinBumpUp != nil
+			if !featureFlagOn && perVPA {
+				return fmt.Errorf("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag %s is disabled", features.PerVPAConfig)
+			}
+		}
+
 	}
 	return nil
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
@@ -19,10 +19,12 @@ package vpa
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -326,6 +328,33 @@ func TestValidateVPA(t *testing.T) {
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode: &validUpdateMode,
+					},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								Mode:          &validScalingMode,
+								MinAllowed: apiv1.ResourceList{
+									cpu: resource.MustParse("10"),
+								},
+								MaxAllowed: apiv1.ResourceList{
+									cpu: resource.MustParse("100"),
+								},
+								OOMBumpUpRatio: resource.NewQuantity(2, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			},
+			PerVPAConfigDisabled: false,
+		},
+		{
+			name: "per-vpa config active and used evictOOMThreshold",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode:             &validUpdateMode,
+						EvictAfterOOMThreshold: &metav1.Duration{Duration: 10 * time.Minute},
 					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -46,6 +46,8 @@ type VerticalPodAutoscalerList struct {
 // +kubebuilder:printcolumn:name="Mem",type="string",JSONPath=".status.recommendation.containerRecommendations[0].target.memory"
 // +kubebuilder:printcolumn:name="Provided",type="string",JSONPath=".status.conditions[?(@.type=='RecommendationProvided')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="MinReplicas",type="integer",JSONPath=".spec.updatePolicy.minReplicas",priority=1
+// +kubebuilder:printcolumn:name="OOMThreshold",type="string",JSONPath=".spec.updatePolicy.evictAfterOOMThreshold",priority=1
 // +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes/kubernetes/pull/63797"
 
 // VerticalPodAutoscaler is the configuration for a vertical pod
@@ -132,6 +134,7 @@ type EvictionRequirement struct {
 }
 
 // PodUpdatePolicy describes the rules on how changes are applied to the pods.
+// +kubebuilder:validation:XValidation:rule="!has(self.evictAfterOOMThreshold) || duration(self.evictAfterOOMThreshold) > duration('0s')",message="evictAfterOOMThreshold must be greater than 0"
 type PodUpdatePolicy struct {
 	// Controls when autoscaler applies changes to the pod resources.
 	// The default is 'Recreate'.
@@ -149,6 +152,15 @@ type PodUpdatePolicy struct {
 	// EvictionRequirement is specified, all of them need to be fulfilled to allow eviction.
 	// +optional
 	EvictionRequirements []*EvictionRequirement `json:"evictionRequirements,omitempty" protobuf:"bytes,3,opt,name=evictionRequirements"`
+
+	// evictAfterOOMThreshold specifies the time to wait after an OOM event before
+	// considering the pod for eviction. Pods that have OOMed in less than this threshold
+	// since start will be evicted.
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=duration
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$`
+	EvictAfterOOMThreshold *metav1.Duration `json:"evictAfterOOMThreshold,omitempty" protobuf:"bytes,4,opt,name=evictAfterOOMThreshold"`
 }
 
 // UpdateMode controls when autoscaler applies changes to the pod resources.

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1
 import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -177,6 +178,11 @@ func (in *PodUpdatePolicy) DeepCopyInto(out *PodUpdatePolicy) {
 				(*in).DeepCopyInto(*out)
 			}
 		}
+	}
+	if in.EvictAfterOOMThreshold != nil {
+		in, out := &in.EvictAfterOOMThreshold, &out.EvictAfterOOMThreshold
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 	return
 }

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -29,8 +29,14 @@ import (
 	"k8s.io/klog/v2"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
+)
+
+const (
+	// DefaultEvictAfterOOMThreshold is the default time threshold for evicting pods after OOM
+	DefaultEvictAfterOOMThreshold = 10 * time.Minute
 )
 
 var (
@@ -38,8 +44,8 @@ var (
 
 	podLifetimeUpdateThreshold = flag.Duration("in-recommendation-bounds-eviction-lifetime-threshold", time.Hour*12, "Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range")
 
-	evictAfterOOMThreshold = flag.Duration("evict-after-oom-threshold", 10*time.Minute,
-		`Evict pod that has OOMed in less than evict-after-oom-threshold since start.`)
+	evictAfterOOMThreshold = flag.Duration("evict-after-oom-threshold", DefaultEvictAfterOOMThreshold,
+		`The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start.`)
 )
 
 // UpdatePriorityCalculator is responsible for prioritizing updates on pods.
@@ -108,10 +114,11 @@ func (calc *UpdatePriorityCalculator) AddPod(pod *apiv1.Pod, now time.Time) {
 			klog.V(4).InfoS("Container with ContainerScalingModeOff. Skipping container quick OOM calculations", "containerName", cs.Name)
 			continue
 		}
+		evictOOMThreshold := calc.getEvictOOMThreshold()
 		terminationState := &cs.LastTerminationState
 		if terminationState.Terminated != nil &&
 			terminationState.Terminated.Reason == "OOMKilled" &&
-			terminationState.Terminated.FinishedAt.Sub(terminationState.Terminated.StartedAt.Time) < *evictAfterOOMThreshold {
+			terminationState.Terminated.FinishedAt.Sub(terminationState.Terminated.StartedAt.Time) < evictOOMThreshold {
 			quickOOM = true
 			klog.V(2).InfoS("Quick OOM detected in pod", "pod", klog.KObj(pod), "containerName", cs.Name)
 		}
@@ -196,6 +203,21 @@ func (calc *UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_t
 		}
 	}
 	return sb.String()
+}
+
+func (calc *UpdatePriorityCalculator) getEvictOOMThreshold() time.Duration {
+	evictOOMThreshold := *evictAfterOOMThreshold
+
+	if calc.vpa.Spec.UpdatePolicy == nil || calc.vpa.Spec.UpdatePolicy.EvictAfterOOMThreshold == nil {
+		return evictOOMThreshold
+	}
+
+	if !features.Enabled(features.PerVPAConfig) {
+		klog.V(4).InfoS("feature flag is off, falling back to default EvictAfterOOMThreshold", "flagName", features.PerVPAConfig)
+		return evictOOMThreshold
+	}
+
+	return calc.vpa.Spec.UpdatePolicy.EvictAfterOOMThreshold.Duration
 }
 
 func parseVpaObservedContainers(pod *apiv1.Pod) (bool, sets.Set[string]) {

--- a/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
@@ -33,6 +33,7 @@ type VerticalPodAutoscalerBuilder interface {
 	WithContainer(containerName string) VerticalPodAutoscalerBuilder
 	WithNamespace(namespace string) VerticalPodAutoscalerBuilder
 	WithUpdateMode(updateMode vpa_types.UpdateMode) VerticalPodAutoscalerBuilder
+	WithEvictAfterOOMThreshold(*meta.Duration) VerticalPodAutoscalerBuilder
 	WithCreationTimestamp(timestamp time.Time) VerticalPodAutoscalerBuilder
 	WithMinAllowed(containerName, cpu, memory string) VerticalPodAutoscalerBuilder
 	WithMaxAllowed(containerName, cpu, memory string) VerticalPodAutoscalerBuilder
@@ -118,6 +119,15 @@ func (b *verticalPodAutoscalerBuilder) WithUpdateMode(updateMode vpa_types.Updat
 		c.updatePolicy = &vpa_types.PodUpdatePolicy{}
 	}
 	c.updatePolicy.UpdateMode = &updateMode
+	return &c
+}
+
+func (b *verticalPodAutoscalerBuilder) WithEvictAfterOOMThreshold(threshold *meta.Duration) VerticalPodAutoscalerBuilder {
+	c := *b
+	if c.updatePolicy == nil {
+		c.updatePolicy = &vpa_types.PodUpdatePolicy{}
+	}
+	c.updatePolicy.EvictAfterOOMThreshold = threshold
 	return &c
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
evictAfterOOMThreshold is now per vpa 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[AEP]: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/8026-per-vpa-component-configuration
```
