### PR TITLE
Set all PSa labels during VPA tests

### DIFF
--- a/vertical-pod-autoscaler/e2e/integration/recommender.go
+++ b/vertical-pod-autoscaler/e2e/integration/recommender.go
@@ -35,7 +35,7 @@ import (
 
 var _ = utils.RecommenderE2eDescribe("Flags", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	var vpaClientSet vpa_clientset.Interface
 	var hamsterNamespace string

--- a/vertical-pod-autoscaler/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/e2e/v1/actuation.go
@@ -54,7 +54,7 @@ import (
 
 var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	ginkgo.It("still applies recommendations on restart when update mode is InPlaceOrRecreate", func() {
 		ginkgo.By("Setting up a hamster deployment")

--- a/vertical-pod-autoscaler/e2e/v1/admission_controller.go
+++ b/vertical-pod-autoscaler/e2e/v1/admission_controller.go
@@ -52,7 +52,7 @@ const (
 
 var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	ginkgo.BeforeEach(func() {
 		waitForVpaWebhookRegistration(f)

--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -70,7 +70,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 	// This schedules AfterEach block that needs to run after the AfterEach above and
 	// BeforeEach that needs to run before the BeforeEach below - thus the order of these matters.
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	f.Describe("with InPlaceOrRecreate update mode", framework.WithFeatureGate(features.InPlaceOrRecreate), func() {
 		ginkgo.BeforeEach(func() {
@@ -229,7 +229,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with default recommender explicitly c
 	// This schedules AfterEach block that needs to run after the AfterEach above and
 	// BeforeEach that needs to run before the BeforeEach below - thus the order of these matters.
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	ginkgo.BeforeEach(func() {
 		ns := f.Namespace.Name
@@ -299,7 +299,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with non-recognized recommender expli
 	// This schedules AfterEach block that needs to run after the AfterEach above and
 	// BeforeEach that needs to run before the BeforeEach below - thus the order of these matters.
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	ginkgo.BeforeEach(func() {
 		ns := f.Namespace.Name
@@ -360,7 +360,7 @@ var _ = FullVpaE2eDescribe("OOMing pods under VPA", func() {
 	const replicas = 3
 
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	ginkgo.BeforeEach(func() {
 		ns := f.Namespace.Name

--- a/vertical-pod-autoscaler/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1/recommender.go
@@ -132,7 +132,7 @@ func getVpaObserver(vpaClientSet vpa_clientset.Interface, namespace string) *obs
 
 var _ = utils.RecommenderE2eDescribe("Checkpoints", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	ginkgo.It("with missing VPA objects are garbage collected", func() {
 		ns := f.Namespace.Name
@@ -172,7 +172,7 @@ var _ = utils.RecommenderE2eDescribe("Checkpoints", func() {
 
 var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	ginkgo.It("serves recommendation for CronJob", func() {
 		ginkgo.By("Setting up hamster CronJob")
@@ -205,7 +205,7 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 
 var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	var (
 		vpaCRD       *vpa_types.VerticalPodAutoscaler
@@ -284,7 +284,7 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 
 var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	var (
 		vpaClientSet vpa_clientset.Interface
@@ -361,7 +361,7 @@ func getMilliCpu(resources apiv1.ResourceList) int64 {
 
 var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	var vpaClientSet vpa_clientset.Interface
 

--- a/vertical-pod-autoscaler/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/e2e/v1/updater.go
@@ -37,7 +37,7 @@ import (
 
 var _ = UpdaterE2eDescribe("Updater", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityEnforceLevel = podsecurity.LevelBaseline
+	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
 	// Sets up a lease object updated periodically to signal - requires WithSerial()
 	framework.It("evicts pods when Admission Controller status available", framework.WithSerial(), func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

During e2e tests, we see lots of this sort of warning:
> I1026 14:43:38.748445   56509 warnings.go:110] "Warning: would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"hamster\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"hamster\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"hamster\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"hamster\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"

I believe it's because the current settings set the namespace labels as such:
```
    pod-security.kubernetes.io/audit: restricted
    pod-security.kubernetes.io/enforce: baseline
    pod-security.kubernetes.io/warn: restricted
```

This change will also set audit and warn to baseline:
```
    pod-security.kubernetes.io/audit: baseline
    pod-security.kubernetes.io/enforce: baseline
    pod-security.kubernetes.io/warn: baseline
```

Meaning that the warnings that we currently see won't be created, reducing the e2e log noise.

I found a similar fix in k/k: https://github.com/kubernetes/kubernetes/pull/118280

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
