### PR TITLE
allow clusterapi provider to process managed labels

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -1494,6 +1494,7 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 
 	type testCaseConfig struct {
 		nodeLabels            map[string]string
+		managedLabels         map[string]string
 		includeNodes          bool
 		expectedErr           error
 		expectedCapacity      map[corev1.ResourceName]int64
@@ -1618,6 +1619,37 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "When the NodeGroup can scale from zero, and the scalable resource contains managed labels",
+			nodeGroupAnnotations: map[string]string{
+				memoryKey:   "2048Mi",
+				cpuKey:      "2",
+				gpuTypeKey:  gpuapis.ResourceNvidiaGPU,
+				gpuCountKey: "1",
+			},
+			config: testCaseConfig{
+				expectedErr: nil,
+				nodeLabels: map[string]string{
+					"kubernetes.io/os":   "linux",
+					"kubernetes.io/arch": "amd64",
+				},
+				managedLabels: map[string]string{
+					"node-role.kubernetes.io/test": "test",
+				},
+				expectedCapacity: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:        2,
+					corev1.ResourceMemory:     2048 * 1024 * 1024,
+					corev1.ResourcePods:       110,
+					gpuapis.ResourceNvidiaGPU: 1,
+				},
+				expectedNodeLabels: map[string]string{
+					"kubernetes.io/os":             "linux",
+					"kubernetes.io/arch":           "amd64",
+					"kubernetes.io/hostname":       "random value",
+					"node-role.kubernetes.io/test": "test",
+				},
+			},
+		},
 	}
 
 	test := func(t *testing.T, testConfig *TestConfig, config testCaseConfig) {
@@ -1704,6 +1736,7 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 					WithNamespace(testNamespace).
 					WithNodeCount(10).
 					WithAnnotations(cloudprovider.JoinStringMaps(enableScaleAnnotations, tc.nodeGroupAnnotations)).
+					WithManagedLabels(tc.config.managedLabels).
 					Build()
 				test(t, testConfig, tc.config)
 			})
@@ -1714,6 +1747,7 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 					WithNamespace(testNamespace).
 					WithNodeCount(10).
 					WithAnnotations(cloudprovider.JoinStringMaps(enableScaleAnnotations, tc.nodeGroupAnnotations)).
+					WithManagedLabels(tc.config.managedLabels).
 					Build()
 				test(t, testConfig, tc.config)
 			})

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -59,6 +59,14 @@ const (
 	scaleUpFromZeroDefaultArchEnvVar = "CAPI_SCALE_ZERO_DEFAULT_ARCH"
 	// GpuDeviceType is used if DRA device is GPU
 	GpuDeviceType = "gpu"
+
+	// Cluster API constants, copied from cluster-api/api/core/v1beta1/machine_types.go
+	// nodeRoleLabelPrefix is one of the CAPI managed Node label prefixes.
+	nodeRoleLabelPrefix = "node-role.kubernetes.io"
+	// nodeRestrictionLabelDomain is one of the CAPI managed Node label domains.
+	nodeRestrictionLabelDomain = "node-restriction.kubernetes.io"
+	// managedNodeLabelDomain is one of the CAPI managed Node label domains.
+	managedNodeLabelDomain = "node.cluster.x-k8s.io"
 )
 
 var (
@@ -406,4 +414,34 @@ func GetDefaultScaleFromZeroArchitecture() SystemArchitecture {
 		systemArchitecture = &arch
 	})
 	return *systemArchitecture
+}
+
+// getManagedNodeLabelsFromLabels returns a map of labels that will be propagated
+// to nodes based on the Cluster API metadata propagation rules.
+func getManagedNodeLabelsFromLabels(labels map[string]string) map[string]string {
+	// TODO elmiko, add a user configuration to inject a string with their `--additional-sync-machine-labels` string.
+	// ref: https://cluster-api.sigs.k8s.io/reference/api/metadata-propagation#machine
+	managedLabels := map[string]string{}
+	for key, value := range labels {
+		if isManagedLabel(key) {
+			managedLabels[key] = value
+		}
+
+	}
+
+	return managedLabels
+}
+
+func isManagedLabel(key string) bool {
+	dnsSubdomainOrName := strings.Split(key, "/")[0]
+	if dnsSubdomainOrName == nodeRoleLabelPrefix {
+		return true
+	}
+	if dnsSubdomainOrName == nodeRestrictionLabelDomain || strings.HasSuffix(dnsSubdomainOrName, "."+nodeRestrictionLabelDomain) {
+		return true
+	}
+	if dnsSubdomainOrName == managedNodeLabelDomain || strings.HasSuffix(dnsSubdomainOrName, "."+managedNodeLabelDomain) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

This change enables the provider to read the managed propagated labels from MachineSet and MachineDeployment resources when creating node templates.

#### Which issue(s) this PR fixes: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8712 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The ClusterAPI provider will now recognize labels that should be propagated from MachineDeployments and MachineSets when scaling from zero. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
