### PR TITLE
fix(vpa-chart): fix admission controller deployment and permissions

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrole.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrole.yaml
@@ -24,6 +24,9 @@ rules:
   verbs:
   - list
   - get
+  - create
+  - delete
+  - patch
 - apiGroups:
   - autoscaling.k8s.io
   resources:

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -62,6 +62,9 @@ spec:
           args:
           - --v=4
           - --stderrthreshold=info
+          - --client-ca-file=/etc/tls-certs/ca.crt
+          - --tls-cert-file=/etc/tls-certs/tls.crt
+          - --tls-private-key=/etc/tls-certs/tls.key
           {{- with .Values.admissionController.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix the admission controller deployment by:
- Setting correct TLS resources paths in the app arguments
- Fixing ClusterRole needed for handling admissionregistration.k8s.io/mutatingwebhookconfigurations

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
