### PR TITLE
feat(chart): VPA Updater PodDisruptionBudget

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -4,7 +4,7 @@ WARNING: This chart is currently under development and is not ready for producti
 
 Automatically adjust resources for your workloads
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
 
@@ -107,6 +107,9 @@ The Vertical Pod Autoscaler (VPA) automatically adjusts the CPU and memory resou
 | updater.leaderElection.resourceNamespace | string | `""` |  |
 | updater.leaderElection.retryPeriod | string | `"2s"` |  |
 | updater.podAnnotations | object | `{}` |  |
+| updater.podDisruptionBudget.enabled | bool | `true` |  |
+| updater.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
+| updater.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | updater.podLabels | object | `{}` |  |
 | updater.replicas | int | `2` |  |
 | updater.serviceAccount.annotations | object | `{}` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-pdb.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.updater.enabled .Values.updater.podDisruptionBudget.enabled -}}
+{{- if and .Values.updater.podDisruptionBudget.minAvailable .Values.updater.podDisruptionBudget.maxUnavailable }}
+    {{- fail "Only one of updater.podDisruptionBudget.minAvailable or updater.podDisruptionBudget.maxUnavailable should be set." }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vertical-pod-autoscaler.updater.selectorLabels" . | nindent 6 }}
+  {{- if .Values.updater.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.updater.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.updater.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.updater.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -227,3 +227,13 @@ updater:
     renewDeadline: 10s
     # Duration the clients should wait between attempting acquisition and renewal of a leadership.
     retryPeriod: 2s
+
+  # PodDisruptionBudget for the Updater.
+  podDisruptionBudget:
+    enabled: true
+    # -- (int or string) Minimum number/percentage of pods that must be available after the eviction.
+    # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
+    minAvailable: 1
+    # -- (int or string) Maximum number/percentage of pods that can be unavailable after the eviction.
+    # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
+    maxUnavailable:


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Helm chart support PodDisruptionBudget for VPA Updater

#### Which issue(s) this PR fixes:
Relates #8587

#### Special notes for your reviewer:
Quick test using
```console
helm upgrade --install vpa ./vertical-pod-autoscaler/charts/vertical-pod-autoscaler/ \
  -n vpa --create-namespace
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
