### PR TITLE
Replace autorest/to with k8s.io/utils/ptr

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	azStorage "github.com/Azure/azure-sdk-for-go/storage"
-	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/utils/ptr"
 
 	apiv1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -521,7 +521,7 @@ func (as *AgentPool) deleteBlob(accountName, vhdContainer, vhdBlob string) error
 	}
 
 	keys := *storageKeysResult.Keys
-	client, err := azStorage.NewBasicClientOnSovereignCloud(accountName, to.String(keys[0].Value), as.manager.env)
+	client, err := azStorage.NewBasicClientOnSovereignCloud(accountName, ptr.Deref(keys[0].Value, ""), as.manager.env)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/Azure/skewer"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	providerazureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -295,11 +294,9 @@ func (m *azureCache) fetchVirtualMachines() (map[string][]compute.VirtualMachine
 		if vmPoolName == nil {
 			vmPoolName = tags[legacyAgentpoolNameTag]
 		}
-		if vmPoolName == nil {
-			continue
+		if vmPoolName != nil {
+			instances[*vmPoolName] = append(instances[*vmPoolName], instance)
 		}
-
-		instances[to.String(vmPoolName)] = append(instances[to.String(vmPoolName)], instance)
 	}
 	return instances, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache_test.go
@@ -23,9 +23,9 @@ import (
 	providerazureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"k8s.io/utils/ptr"
 )
 
 func TestFetchVMsPools(t *testing.T) {
@@ -40,7 +40,7 @@ func TestFetchVMsPools(t *testing.T) {
 	vmsPool := getTestVMsAgentPool(false)
 	vmssPoolType := armcontainerservice.AgentPoolTypeVirtualMachineScaleSets
 	vmssPool := armcontainerservice.AgentPool{
-		Name: to.StringPtr("vmsspool1"),
+		Name: ptr.To("vmsspool1"),
 		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
 			Type: &vmssPoolType,
 		},
@@ -54,7 +54,7 @@ func TestFetchVMsPools(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(vmsPoolMap))
 
-	_, ok := vmsPoolMap[to.String(vmsPool.Name)]
+	_, ok := vmsPoolMap[ptr.Deref(vmsPool.Name, "")]
 	assert.True(t, ok)
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
@@ -74,7 +74,7 @@ func newTestAzureManager(t *testing.T) *AzureManager {
 			deploymentClient: &DeploymentClientMock{
 				FakeStore: map[string]resources.DeploymentExtended{
 					"deployment": {
-						Name: to.StringPtr("deployment"),
+						Name: ptr.To("deployment"),
 						Properties: &resources.DeploymentPropertiesExtended{Template: map[string]interface{}{
 							resourcesFieldName: []interface{}{
 								map[string]interface{}{
@@ -166,7 +166,7 @@ func TestHasInstance(t *testing.T) {
 	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 	vmssType := armcontainerservice.AgentPoolTypeVirtualMachineScaleSets
 	vmssPool := armcontainerservice.AgentPool{
-		Name: to.StringPtr("test-asg"),
+		Name: ptr.To("test-asg"),
 		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
 			Type: &vmssType,
 		},
@@ -303,7 +303,7 @@ func TestMixedNodeGroups(t *testing.T) {
 
 	vmssType := armcontainerservice.AgentPoolTypeVirtualMachineScaleSets
 	vmssPool := armcontainerservice.AgentPool{
-		Name: to.StringPtr("test-asg"),
+		Name: ptr.To("test-asg"),
 		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
 			Type: &vmssType,
 		},

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -30,11 +30,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/go-autorest/autorest/date"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/utils/ptr"
 	azclient "sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
@@ -1069,9 +1069,9 @@ func TestFetchExplicitNodeGroups(t *testing.T) {
 	testAS.manager.azClient.deploymentClient = &DeploymentClientMock{
 		FakeStore: map[string]resources.DeploymentExtended{
 			"cluster-autoscaler-0001": {
-				Name: to.StringPtr("cluster-autoscaler-0001"),
+				Name: ptr.To("cluster-autoscaler-0001"),
 				Properties: &resources.DeploymentPropertiesExtended{
-					ProvisioningState: to.StringPtr("Succeeded"),
+					ProvisioningState: ptr.To("Succeeded"),
 					Timestamp:         &date.Time{Time: timeBenchMark.Add(2 * time.Minute)},
 				},
 			},

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -29,11 +29,11 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	klog "k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 )
 
 var (
@@ -209,7 +209,7 @@ func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 	// // If VMSS state is updating, return the currentSize which would've been proactively incremented or decremented by CA
 	// // unless it's -1. In that case, its better to initialize it.
 	// if scaleSet.curSize != -1 && set.VirtualMachineScaleSetProperties != nil &&
-	// 	strings.EqualFold(to.String(set.VirtualMachineScaleSetProperties.ProvisioningState), string(compute.GalleryProvisioningStateUpdating)) {
+	// 	strings.EqualFold(ptr.Deref(set.VirtualMachineScaleSetProperties.ProvisioningState, ""), string(compute.GalleryProvisioningStateUpdating)) {
 	// 	klog.V(3).Infof("VMSS %q is in updating state, returning cached size: %d", scaleSet.Name, scaleSet.curSize)
 	// 	return scaleSet.curSize, nil
 	// }
@@ -869,10 +869,10 @@ func (scaleSet *ScaleSet) cseErrors(extensions *[]compute.VirtualMachineExtensio
 	failed := false
 	if extensions != nil {
 		for _, extension := range *extensions {
-			if strings.EqualFold(to.String(extension.Name), vmssCSEExtensionName) && extension.Statuses != nil {
+			if strings.EqualFold(ptr.Deref(extension.Name, ""), vmssCSEExtensionName) && extension.Statuses != nil {
 				for _, status := range *extension.Statuses {
 					if status.Level == "Error" {
-						errs = append(errs, to.String(status.Message))
+						errs = append(errs, ptr.Deref(status.Message, ""))
 						failed = true
 					}
 				}
@@ -888,7 +888,7 @@ func (scaleSet *ScaleSet) getSKU() string {
 		klog.Errorf("Failed to get information for VMSS (%q): %v", scaleSet.Name, err)
 		return ""
 	}
-	return to.String(vmssInfo.Sku.Name)
+	return ptr.Deref(vmssInfo.Sku.Name, "")
 }
 
 func (scaleSet *ScaleSet) verifyNodeGroup(instance *azureRef, commonNgID string) error {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_instance_cache.go
@@ -23,10 +23,10 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 /*
@@ -227,7 +227,7 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *compute.VirtualMachineScaleSe
 	case string(compute.GalleryProvisioningStateFailed):
 		status.State = cloudprovider.InstanceRunning
 
-		klog.V(3).Infof("VM %s reports failed provisioning state with power state: %s, eligible for fast delete: %s", to.String(vm.ID), powerState, strconv.FormatBool(scaleSet.enableFastDeleteOnFailedProvisioning))
+		klog.V(3).Infof("VM %s reports failed provisioning state with power state: %s, eligible for fast delete: %s", ptr.Deref(vm.ID, ""), powerState, strconv.FormatBool(scaleSet.enableFastDeleteOnFailedProvisioning))
 		if scaleSet.enableFastDeleteOnFailedProvisioning {
 			// Provisioning can fail both during instance creation or after the instance is running.
 			// Per https://learn.microsoft.com/en-us/azure/virtual-machines/states-billing#provisioning-states,
@@ -253,12 +253,12 @@ func (scaleSet *ScaleSet) instanceStatusFromVM(vm *compute.VirtualMachineScaleSe
 	// Add vmssCSE Provisioning Failed Message in error info body for vmssCSE Extensions if enableDetailedCSEMessage is true
 	if scaleSet.enableDetailedCSEMessage && vm.InstanceView != nil {
 		if err, failed := scaleSet.cseErrors(vm.InstanceView.Extensions); failed {
-			klog.V(3).Infof("VM %s reports CSE failure: %v, with provisioning state %s, power state %s", to.String(vm.ID), err, to.String(vm.ProvisioningState), powerState)
+			klog.V(3).Infof("VM %s reports CSE failure: %v, with provisioning state %s, power state %s", ptr.Deref(vm.ID, ""), err, ptr.Deref(vm.ProvisioningState, ""), powerState)
 			status.State = cloudprovider.InstanceCreating
 			errorInfo := &cloudprovider.InstanceErrorInfo{
 				ErrorClass:   cloudprovider.OtherErrorClass,
 				ErrorCode:    vmssExtensionProvisioningFailed,
-				ErrorMessage: fmt.Sprintf("%s: %v", to.String(vm.Name), err),
+				ErrorMessage: fmt.Sprintf("%s: %v", ptr.Deref(vm.Name, ""), err),
 			}
 			status.ErrorInfo = errorInfo
 		}

--- a/cluster-autoscaler/cloudprovider/azure/azure_template_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_template_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 )
 
 func TestExtractLabelsFromTags(t *testing.T) {
@@ -152,10 +152,10 @@ func TestExtractTaintsFromSpecString(t *testing.T) {
 
 func TestExtractAllocatableResourcesFromScaleSet(t *testing.T) {
 	tags := map[string]*string{
-		fmt.Sprintf("%s%s", nodeResourcesTagName, "cpu"):                        to.StringPtr("100m"),
-		fmt.Sprintf("%s%s", nodeResourcesTagName, "memory"):                     to.StringPtr("100M"),
-		fmt.Sprintf("%s%s", nodeResourcesTagName, "ephemeral-storage"):          to.StringPtr("20G"),
-		fmt.Sprintf("%s%s", nodeResourcesTagName, "nvidia.com_Tesla-P100-PCIE"): to.StringPtr("4"),
+		fmt.Sprintf("%s%s", nodeResourcesTagName, "cpu"):                        ptr.To("100m"),
+		fmt.Sprintf("%s%s", nodeResourcesTagName, "memory"):                     ptr.To("100M"),
+		fmt.Sprintf("%s%s", nodeResourcesTagName, "ephemeral-storage"):          ptr.To("20G"),
+		fmt.Sprintf("%s%s", nodeResourcesTagName, "nvidia.com_Tesla-P100-PCIE"): ptr.To("4"),
 	}
 
 	labels := extractAllocatableResourcesFromScaleSet(tags)
@@ -179,7 +179,7 @@ func TestTopologyFromScaleSet(t *testing.T) {
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{OsProfile: nil}},
 		Zones:    &[]string{"1", "2", "3"},
-		Location: to.StringPtr("westus"),
+		Location: ptr.To("westus"),
 	}
 	expectedZoneValues := []string{"westus-1", "westus-2", "westus-3"}
 	template, err := buildNodeTemplateFromVMSS(testVmss, map[string]string{}, "")
@@ -206,7 +206,7 @@ func TestEmptyTopologyFromScaleSet(t *testing.T) {
 		Plan:     nil,
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{OsProfile: nil}},
-		Location: to.StringPtr("westus"),
+		Location: ptr.To("westus"),
 	}
 
 	expectedFailureDomain := "0"
@@ -242,13 +242,13 @@ func TestBuildNodeTemplateFromVMPool(t *testing.T) {
 	zone2 := "2"
 
 	vmpool := armcontainerservice.AgentPool{
-		Name: to.StringPtr(agentPoolName),
+		Name: ptr.To(agentPoolName),
 		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
 			NodeLabels: map[string]*string{
-				"existing":   to.StringPtr("label"),
-				"department": to.StringPtr("engineering"),
+				"existing":   ptr.To("label"),
+				"department": ptr.To("engineering"),
 			},
-			NodeTaints:        []*string{to.StringPtr("group=bar:NoExecute")},
+			NodeTaints:        []*string{ptr.To("group=bar:NoExecute")},
 			OSType:            &osType,
 			OSDiskType:        &osDiskType,
 			AvailabilityZones: []*string{&zone1, &zone2},
@@ -317,7 +317,7 @@ func TestBuildNodeFromTemplateWithLabelPrediction(t *testing.T) {
 			"poolName": &poolName,
 		},
 		Zones:    &[]string{"1", "2"},
-		Location: to.StringPtr("westus"),
+		Location: ptr.To("westus"),
 	}
 
 	template, err := buildNodeTemplateFromVMSS(vmss, map[string]string{}, "")
@@ -362,7 +362,7 @@ func TestBuildNodeFromTemplateWithEphemeralStorage(t *testing.T) {
 			"poolName": &poolName,
 		},
 		Zones:    &[]string{"1", "2"},
-		Location: to.StringPtr("westus"),
+		Location: ptr.To("westus"),
 	}
 
 	template, err := buildNodeTemplateFromVMSS(vmss, map[string]string{}, "")

--- a/cluster-autoscaler/cloudprovider/azure/azure_util.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_util.go
@@ -33,11 +33,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	azStorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/version"
 	klog "k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -123,7 +123,7 @@ func (util *AzUtil) DeleteBlob(accountName, vhdContainer, vhdBlob string) error 
 	}
 
 	keys := *storageKeysResult.Keys
-	client, err := azStorage.NewBasicClientOnSovereignCloud(accountName, to.String(keys[0].Value), util.manager.env)
+	client, err := azStorage.NewBasicClientOnSovereignCloud(accountName, ptr.Deref(keys[0].Value, ""), util.manager.env)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.9.24
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.13
 	github.com/Azure/go-autorest/autorest/date v0.3.0
-	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Azure/skewer v0.0.19
 	github.com/aws/aws-sdk-go v1.44.241
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -79,6 +78,7 @@ require (
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.6 // indirect
 	github.com/Azure/go-autorest/autorest/mocks v0.4.2 // indirect
+	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind deprecation

#### What this PR does / why we need it:

Replaces usages of the deprecated `github.com/Azure/go-autorest/autorest/to` package with `k8s.io/utils/ptr`.

#### Which issue(s) this PR fixes:

Refs #8145.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

