### PR TITLE
Mark slow e2e tests as slow

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/e2e/v1/actuation.go
@@ -208,7 +208,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 	})
 
 	// Consumes the entire node's CPU, causing other pods to be pending - requires WithSerial()
-	framework.It("falls back to evicting pods when resize is Deferred and more than 5 minute has elapsed since last in-place update when update mode is InPlaceOrRecreate", framework.WithSerial(), func() {
+	framework.It("falls back to evicting pods when resize is Deferred and more than 5 minute has elapsed since last in-place update when update mode is InPlaceOrRecreate", framework.WithSerial(), framework.WithSlow(), func() {
 		ginkgo.By("Setting up a hamster deployment")
 		replicas := int32(2)
 		SetupHamsterDeployment(f, "100m", "100Mi", replicas)
@@ -438,7 +438,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 				Name:       tc.name,
 			})
 		})
-		ginkgo.It("by default does not evict pods in a 1-Pod "+tc.kind, func() {
+		f.It("by default does not evict pods in a 1-Pod "+tc.kind, framework.WithSlow(), func() {
 			testDoesNotEvictSingletonPodByDefault(f, &autoscaling.CrossVersionObjectReference{
 				APIVersion: tc.apiVersion,
 				Kind:       tc.kind,
@@ -667,7 +667,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 		CheckNoPodsEvicted(f, MakePodSet(podList))
 	})
 
-	ginkgo.It("does not act on injected sidecars", func() {
+	f.It("does not act on injected sidecars", framework.WithSlow(), func() {
 		const (
 			agnhostImage  = "registry.k8s.io/e2e-test-images/agnhost:2.40"
 			sidecarParam  = "--sidecar-image=registry.k8s.io/pause:3.1"

--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -341,7 +341,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with non-recognized recommender expli
 
 	})
 
-	ginkgo.It("deployment not updated by non-recognized recommender", func() {
+	f.It("deployment not updated by non-recognized recommender", framework.WithSlow(), func() {
 		err := waitForResourceRequestInRangeInPods(
 			f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
 			ParseQuantityOrDie(minimalCPULowerBound), ParseQuantityOrDie(minimalCPUUpperBound))

--- a/vertical-pod-autoscaler/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1/recommender.go
@@ -134,7 +134,7 @@ var _ = utils.RecommenderE2eDescribe("Checkpoints", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
 	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
-	ginkgo.It("with missing VPA objects are garbage collected", func() {
+	f.It("with missing VPA objects are garbage collected", framework.WithSlow(), func() {
 		ns := f.Namespace.Name
 		vpaClientSet := utils.GetVpaClientSet(f)
 
@@ -174,7 +174,7 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
 	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
-	ginkgo.It("serves recommendation for CronJob", func() {
+	f.It("serves recommendation for CronJob", framework.WithSlow(), func() {
 		ginkgo.By("Setting up hamster CronJob")
 		SetupHamsterCronJob(f, "*/5 * * * *", "100m", "100Mi", utils.DefaultHamsterReplicas)
 
@@ -242,7 +242,7 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 	})
 
 	// FIXME todo(adrianmoisey): This test seems to be flaky after running in parallel, unsure why, see if it's possible to fix
-	framework.It("doesn't drop lower/upper after recommender's restart", framework.WithSerial(), func() {
+	f.It("doesn't drop lower/upper after recommender's restart", framework.WithSerial(), framework.WithSlow(), func() {
 
 		o := getVpaObserver(vpaClientSet, f.Namespace.Name)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The reason for this change is two fold:
1. Mark the slow tests as slow, so we know which ones to work on to speed up
2. When we can use the work that Patrick did in https://github.com/kubernetes/kubernetes/pull/134881, the slow tests will run first, allowing for faster (in theory) overall run time of tests

To determine with tests need to be marked as slow, I looked at each junit file and picked the outliers, see: 
[actuation.xml.html](https://github.com/user-attachments/files/23292279/actuation.xml.html)
[admission-controller.xml.html](https://github.com/user-attachments/files/23292280/admission-controller.xml.html)
[full-vpa.xml.html](https://github.com/user-attachments/files/23292281/full-vpa.xml.html)
[recommender.xml.html](https://github.com/user-attachments/files/23292298/recommender.xml.html)
[updater.xml.html](https://github.com/user-attachments/files/23292299/updater.xml.html)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


