### PR TITLE
Add api-reviewers and api-approvers to the VPA API directory

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,33 @@
 aliases:
+  api-approvers:
+    - deads2k
+    - msau42
+    - smarterclayton
+    - thockin
+    - liggitt
+  api-reviewers:
+    - andrewsykim
+    - smarterclayton
+    - thockin
+    - liggitt
+    - wojtek-t
+    - deads2k
+    - yujuhong
+    - derekwaynecarr
+    - mikedanese
+    - sttts
+    - dchen1107
+    - saad-ali
+    - luxas
+    - janetkuo
+    - justinsb
+    - pwittrock
+    - tallclair
+    - mwielgus
+    - soltysh
+    - jsafrane
+    - dims
+    - cici37
   sig-autoscaling-leads:
     - adrianmoisey
     - gjtempleton

--- a/vertical-pod-autoscaler/pkg/apis/OWNERS
+++ b/vertical-pod-autoscaler/pkg/apis/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
+approvers:
+  - api-approvers
+reviewers:
+  - api-reviewers
+
+labels:
+  - kind/api-change


### PR DESCRIPTION
As per
https://github.com/kubernetes/community/blob/master/sig-architecture/api-review-process.md#mandatory

> Kubernetes-style API that uses a *.k8s.io or *.kubernetes.io name, e.g. "storage.k8s.io".

Since the VPA uses autoscaling.k8s.io, we should get API review for any API changes we make.

#### What type of PR is this?

/kind cleanup
/kind documentation

```release-note
NONE
```

cc @soltysh 
