### PR TITLE
Change junit output to $ARTIFACTS

### DIFF
--- a/vertical-pod-autoscaler/hack/run-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-locally.sh
@@ -103,9 +103,9 @@ case ${SUITE} in
 
     echo " ** Running suite ${SUITE}"
     if [ ${SUITE} == recommender-externalmetrics ]; then
-       WORKSPACE=./workspace/_artifacts ${SCRIPT_ROOT}/hack/run-e2e-tests.sh recommender
+       ARTIFACTS=./workspace/_artifacts ${SCRIPT_ROOT}/hack/run-e2e-tests.sh recommender
     else
-      WORKSPACE=./workspace/_artifacts ${SCRIPT_ROOT}/hack/run-e2e-tests.sh ${SUITE}
+      ARTIFACTS=./workspace/_artifacts ${SCRIPT_ROOT}/hack/run-e2e-tests.sh ${SUITE}
     fi
     ;;
   *)

--- a/vertical-pod-autoscaler/hack/run-e2e-tests.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-tests.sh
@@ -47,7 +47,7 @@ export GO111MODULE=on
 ABSOLUTE_PATH=$(realpath "${SCRIPT_ROOT}")
 export GOBIN="${ABSOLUTE_PATH}/e2e/_output/bin"
 
-export WORKSPACE=${WORKSPACE:-/workspace/_artifacts}
+export ARTIFACTS=${ARTIFACTS:-/workspace/_artifacts}
 
 SKIP="--ginkgo.skip=\[Feature\:OffByDefault\]"
 
@@ -62,7 +62,7 @@ case ${SUITE} in
     export KUBECONFIG=$HOME/.kube/config
     pushd ${SCRIPT_ROOT}/e2e
     go install github.com/onsi/ginkgo/v2/ginkgo
-    ${GOBIN}/ginkgo build v1/ && ${GOBIN}/ginkgo --nodes=$NUMPROC --focus="\[VPA\] \[${SUITE}\]" v1/v1.test -- --report-dir=${WORKSPACE} --disable-log-dump ${SKIP}
+    ${GOBIN}/ginkgo build v1/ && ${GOBIN}/ginkgo --nodes=$NUMPROC --focus="\[VPA\] \[${SUITE}\]" v1/v1.test -- --report-dir=${ARTIFACTS} --disable-log-dump ${SKIP}
     V1_RESULT=$?
     popd
     echo v1 test result: ${V1_RESULT}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Change junit output to $ARTIFACTS
It seems that's what prow uses
Asking prow to set WORKSPACE broke the e2e tests, so I assume that env-var is already used


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
