### PR TITLE
[cluster-autoscaler-1.34] update hack/for-go-proj.sh

### DIFF
--- a/hack/for-go-proj.sh
+++ b/hack/for-go-proj.sh
@@ -19,58 +19,39 @@ set -o pipefail
 set -o nounset
 
 CONTRIB_ROOT="$(dirname ${BASH_SOURCE})/.."
-PROJECT_NAMES=(addon-resizer vertical-pod-autoscaler)
 
 if [[ $# -ne 1 ]]; then
-  echo "missing subcommand: [build|install|test]"
+  echo "missing subcommand: [cluster-autoscaler|vertical-pod-autoscaler|addon-resizer]"
   exit 1
 fi
 
-CMD="${1}"
+PROJECT="${1}"
 
-case "${CMD}" in
-  "build")
+case "${PROJECT}" in
+  "cluster-autoscaler")
+    pushd ${CONTRIB_ROOT}/cluster-autoscaler/
+    # TODO: #8127 - Use default analyzers set by `go test` to include `printf` analyzer.
+    # Default analyzers that go test runs according to https://github.com/golang/go/blob/52624e533fe52329da5ba6ebb9c37712048168e0/src/cmd/go/internal/test/test.go#L649
+    # This doesn't include the `printf` analyzer until cluster-autoscaler libraries are updated.
+    ANALYZERS="atomic,bool,buildtags,directive,errorsas,ifaceassert,nilfunc,slog,stringintconv,tests"
+    go test -count=1 ./... -vet="${ANALYZERS}"
+    popd
     ;;
-  "install")
+  "vertical-pod-autoscaler")
+    pushd ${CONTRIB_ROOT}/vertical-pod-autoscaler
+    go test -count=1  -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e | grep -v cluster-autoscaler/apis)
+    popd
+    pushd ${CONTRIB_ROOT}/vertical-pod-autoscaler/e2e
+    go test -run=None ./...
+    popd
     ;;
-  "test")
+  "addon-resizer")
+    pushd ${CONTRIB_ROOT}/addon-resizer
+    godep go test -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e)
+    popd
     ;;
   *)
     echo "invalid subcommand: ${CMD}"
     exit 1
     ;;
 esac
-
-for project_name in ${PROJECT_NAMES[*]}; do
-  (
-    export GO111MODULE=auto
-    project=${CONTRIB_ROOT}/${project_name}
-    echo "${CMD}ing ${project}"
-    cd "${project}"
-    case "${CMD}" in
-      "test")
-        if [[ -n $(find . -name "Godeps.json") ]]; then
-          godep go test -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e)
-        else
-          go test -count=1  -race $(go list ./... | grep -v /vendor/ | grep -v vertical-pod-autoscaler/e2e | grep -v cluster-autoscaler/apis)
-        fi
-        ;;
-      *)
-        godep go "${CMD}" ./...
-        ;;
-    esac
-  )
-done;
-
-if [ "${CMD}" = "build" ] || [ "${CMD}" == "test" ]; then
-  pushd ${CONTRIB_ROOT}/vertical-pod-autoscaler/e2e
-  go test -run=None ./...
-  popd
-  pushd ${CONTRIB_ROOT}/cluster-autoscaler/
-  # TODO: #8127 - Use default analyzers set by `go test` to include `printf` analyzer.
-  # Default analyzers that go test runs according to https://github.com/golang/go/blob/52624e533fe52329da5ba6ebb9c37712048168e0/src/cmd/go/internal/test/test.go#L649
-  # This doesn't include the `printf` analyzer until cluster-autoscaler libraries are updated.
-  ANALYZERS="atomic,bool,buildtags,directive,errorsas,ifaceassert,nilfunc,slog,stringintconv,tests"
-  go test -count=1 ./... -vet="${ANALYZERS}"
-  popd
-fi


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

One more PR that needs to go into 1.34 branch to bring in changes from https://github.com/kubernetes/autoscaler/pull/8669

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
