### PR TITLE
VPA Helm chart: Add priorityClass

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -42,6 +42,7 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 | admissionController.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | admissionController.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | admissionController.podLabels | object | `{}` |  |
+| admissionController.priorityClassName | string | `nil` |  |
 | admissionController.replicas | int | `2` |  |
 | admissionController.resources | object | `{}` |  |
 | admissionController.service.annotations | object | `{}` |  |
@@ -91,6 +92,7 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 | recommender.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | recommender.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | recommender.podLabels | object | `{}` |  |
+| recommender.priorityClassName | string | `nil` |  |
 | recommender.replicas | int | `2` |  |
 | recommender.resources | object | `{}` |  |
 | recommender.serviceAccount.annotations | object | `{}` |  |
@@ -113,6 +115,7 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 | updater.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | updater.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | updater.podLabels | object | `{}` |  |
+| updater.priorityClassName | string | `nil` |  |
 | updater.replicas | int | `2` |  |
 | updater.resources | object | `{}` |  |
 | updater.serviceAccount.annotations | object | `{}` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -48,6 +48,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.admissionController.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: admission-controller
           image: {{ include "vertical-pod-autoscaler.admissionController.image" . }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
@@ -36,6 +36,9 @@ spec:
       securityContext:
         {{ toYaml . | nindent 8 | trim }}
       {{- end }}
+      {{- with .Values.recommender.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
       - name: recommender
         image: {{ include "vertical-pod-autoscaler.recommender.image" . }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -32,6 +32,9 @@ spec:
       securityContext:
         {{ toYaml . | nindent 8 | trim }}
       {{- end }}
+      {{- with .Values.updater.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: updater
           image: {{ include "vertical-pod-autoscaler.updater.image" . }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -108,6 +108,10 @@ admissionController:
     maxUnavailable:
     # maxUnavailable: 1
 
+  # name of priorityclass for scheduling
+  priorityClassName:
+  # priorityClassName : high-priority
+
 recommender:
   enabled: true
   image:
@@ -186,6 +190,10 @@ recommender:
     maxUnavailable:
     # maxUnavailable: 1
 
+  # name of priorityclass for scheduling
+  priorityClassName:
+  # priorityClassName : high-priority
+
 updater:
   enabled: true
 
@@ -250,3 +258,7 @@ updater:
     # requests:
     #   cpu: 50m
     #   memory: 200Mi
+  
+  # name of priorityclass for scheduling
+  priorityClassName:
+  # priorityClassName : high-priority


### PR DESCRIPTION
#### What type of PR is this?

<!--
/kind feature
-->

#### What this PR does / why we need it:

The current chart does not support configuring `priorityClassName`, ~~could have much tighter security settings~~ ~~and does not allow customization of security settings~~. ~~It should fit the Pod Security Standard `restricted` after this PR too~~.

#### Which issue(s) this PR fixes:
If needed, I can create issues for these

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
n/a