### PR TITLE
feat: add pod-label-selectors flag to vpa updater

### DIFF
--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -164,6 +164,7 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `logtostderr` |  |  true | log to standard error instead of files  |
 | `min-replicas` | int |  2 | Minimum number of replicas to perform update  |
 | `one-output` | severity |  | If true, only write logs to their native level (vs also writing to each lower severity level; no effect when -logtostderr=true) |
+| `pod-label-selectors` | string |  | If present, the updater will only process pods matching the given label selectors. |
 | `pod-update-threshold` | float |  0.1 | Ignore updates that have priority lower than the value of this flag  |
 | `profiling` | int |  | Is debug/pprof endpoenabled |
 | `skip-headers` |  |  | If true, avoid header prefixes in the log messages |

--- a/vertical-pod-autoscaler/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/e2e/v1/updater.go
@@ -19,6 +19,8 @@ package autoscaling
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 	"k8s.io/kubernetes/test/e2e/framework"
 	podsecurity "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -205,7 +208,155 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		err := WaitForPodsUpdatedWithoutEviction(f, initialPods)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
+	framework.It("filters pods using the --pod-label-selectors flag", framework.WithSerial(), func() {
+		const (
+			testLabelKey        = "vpa-updater-test"
+			testLabelValueMatch = "enabled"
+			matchingReplicas    = 3
+			nonMatchingReplicas = 2
+		)
+		testNamespace := f.Namespace.Name
+
+		ginkgo.By("Creating pods with non-matching labels")
+		nonMatchingDeployment := utils.NewNHamstersDeployment(f, 1)
+		nonMatchingDeployment.Name = "non-matching-hamster"
+		nonMatchingDeployment.Spec.Replicas = ptr.To(int32(nonMatchingReplicas))
+		nonMatchingDeployment.Spec.Template.Labels[testLabelKey] = "disabled"
+		nonMatchingDeployment.Spec.Template.Labels["app"] = "non-matching"
+		nonMatchingDeployment.Spec.Selector.MatchLabels[testLabelKey] = "disabled"
+		nonMatchingDeployment.Spec.Selector.MatchLabels["app"] = "non-matching"
+		utils.StartDeploymentPods(f, nonMatchingDeployment)
+
+		ginkgo.By("Creating pods with matching labels")
+		matchingDeployment := utils.NewNHamstersDeployment(f, 1)
+		matchingDeployment.Name = "matching-hamster"
+		matchingDeployment.Spec.Replicas = ptr.To(int32(matchingReplicas))
+		matchingDeployment.Spec.Template.Labels[testLabelKey] = testLabelValueMatch
+		matchingDeployment.Spec.Template.Labels["app"] = "matching"
+		matchingDeployment.Spec.Selector.MatchLabels[testLabelKey] = testLabelValueMatch
+		matchingDeployment.Spec.Selector.MatchLabels["app"] = "matching"
+		utils.StartDeploymentPods(f, matchingDeployment)
+
+		ginkgo.By("Creating VPAs for both deployments")
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		nonMatchingVPA := test.VerticalPodAutoscaler().
+			WithName("non-matching-vpa").
+			WithNamespace(testNamespace).
+			WithTargetRef(&autoscaling.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       nonMatchingDeployment.Name,
+			}).
+			WithContainer(containerName).
+			WithUpdateMode(vpa_types.UpdateModeRecreate).
+			Get()
+		utils.InstallVPA(f, nonMatchingVPA)
+
+		matchingVPA := test.VerticalPodAutoscaler().
+			WithName("matching-vpa").
+			WithNamespace(testNamespace).
+			WithTargetRef(&autoscaling.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       matchingDeployment.Name,
+			}).
+			WithContainer(containerName).
+			WithUpdateMode(vpa_types.UpdateModeRecreate).
+			Get()
+		utils.InstallVPA(f, matchingVPA)
+
+		ginkgo.By("Setting up custom updater deployment with --pod-label-selectors flag")
+		// we swap the namespace to kube-system and then back to the test namespace
+		// so our custom updater deployment can use the deployed RBAC
+		originalNamespace := f.Namespace.Name
+		f.Namespace.Name = utils.UpdaterNamespace
+		deploymentName := "vpa-updater-with-pod-label-selectors"
+		updaterDeployment := utils.NewUpdaterDeployment(f, deploymentName, []string{
+			"--updater-interval=10s",
+			"--use-admission-controller-status=false",
+			fmt.Sprintf("--pod-label-selectors=%s=%s", testLabelKey, testLabelValueMatch),
+			fmt.Sprintf("--vpa-object-namespace=%s", testNamespace),
+		})
+		utils.StartDeploymentPods(f, updaterDeployment)
+		f.Namespace.Name = originalNamespace
+
+		defer func() {
+			ginkgo.By("Cleaning up custom updater deployment")
+			f.ClientSet.AppsV1().Deployments(utils.UpdaterNamespace).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
+		}()
+
+		ginkgo.By("Waiting for custom updater to report controlled pods count via metrics")
+		gomega.Eventually(func() (float64, error) {
+			return getMetricValue(f, utils.UpdaterNamespace, "vpa_updater_controlled_pods_total", map[string]string{
+				"update_mode": string(vpa_types.UpdateModeRecreate),
+			})
+		}, 2*time.Minute, 5*time.Second).Should(gomega.Equal(float64(matchingReplicas)),
+			"Custom updater should only see %d matching pods (not the %d non-matching pods)",
+			matchingReplicas, nonMatchingReplicas)
+	})
 })
+
+func getMetricValue(f *framework.Framework, namespace, metricName string, labels map[string]string) (float64, error) {
+	// Port forward to the updater pod
+	pods, err := f.ClientSet.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app=custom-vpa-updater",
+	})
+	if err != nil || len(pods.Items) == 0 {
+		return 0, fmt.Errorf("updater pod not found: %v", err)
+	}
+
+	// Use kubectl port-forward via exec in the pod
+	req := f.ClientSet.CoreV1().RESTClient().Get().
+		Namespace(namespace).
+		Resource("pods").
+		Name(pods.Items[0].Name).
+		SubResource("proxy").
+		Suffix("metrics")
+
+	result := req.Do(context.TODO())
+	body, err := result.Raw()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get metrics: %v", err)
+	}
+
+	// Parse Prometheus metrics format
+	lines := strings.Split(string(body), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, metricName) {
+			continue
+		}
+
+		// Match labels
+		if len(labels) > 0 {
+			allLabelsMatch := true
+			for k, v := range labels {
+				labelPattern := fmt.Sprintf(`%s="%s"`, k, v)
+				if !strings.Contains(line, labelPattern) {
+					allLabelsMatch = false
+					break
+				}
+			}
+			if !allLabelsMatch {
+				continue
+			}
+		}
+
+		// Extract value from end of line
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			value, err := strconv.ParseFloat(parts[len(parts)-1], 64)
+			if err == nil {
+				return value, nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("metric %s not found", metricName)
+}
 
 func setupPodsForUpscalingEviction(f *framework.Framework) *apiv1.PodList {
 	return setupPodsForEviction(f, "100m", "100Mi", nil)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Adds a `pod-label-selectors` flag to the updater to reduce the number of pods that the updater must inspect.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8773

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds `pod-label-selectors` flag to the updater.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
