### PR TITLE
feat(chart): VPA Updater leaderElection

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -97,9 +97,15 @@ The Vertical Pod Autoscaler (VPA) automatically adjusts the CPU and memory resou
 | updater.image.pullPolicy | string | `"IfNotPresent"` |  |
 | updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` |  |
 | updater.image.tag | string | `nil` |  |
+| updater.leaderElection.enabled | string | `nil` |  |
+| updater.leaderElection.leaseDuration | string | `"15s"` |  |
+| updater.leaderElection.renewDeadline | string | `"10s"` |  |
+| updater.leaderElection.resourceName | string | `"vpa-updater-lease"` |  |
+| updater.leaderElection.resourceNamespace | string | `""` |  |
+| updater.leaderElection.retryPeriod | string | `"2s"` |  |
 | updater.podAnnotations | object | `{}` |  |
 | updater.podLabels | object | `{}` |  |
-| updater.replicas | int | `1` |  |
+| updater.replicas | int | `2` |  |
 | updater.serviceAccount.annotations | object | `{}` |  |
 | updater.serviceAccount.create | bool | `true` |  |
 | updater.serviceAccount.labels | object | `{}` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
@@ -96,6 +96,16 @@ app.kubernetes.io/component: updater
 {{- printf "%s:%s" .Values.updater.image.repository (default .Chart.AppVersion .Values.updater.image.tag) }}
 {{- end }}
 
+{{- define "vertical-pod-autoscaler.updater.leaderElectionEnabled" -}}
+{{- if and (eq .Values.updater.leaderElection.enabled nil) (gt (int .Values.updater.replicas) 1) -}}
+true
+{{- else if .Values.updater.leaderElection.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Create the name of the namespace to use

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -40,6 +40,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          args:
+          - --v=4
+          - --stderrthreshold=info
+          {{- if eq (include "vertical-pod-autoscaler.updater.leaderElectionEnabled" .) "true" }}
+          - --leader-elect=true
+          - --leader-elect-resource-namespace={{ .Values.updater.leaderElection.resourceNamespace | default .Release.Namespace }}
+          - --leader-elect-resource-name={{ .Values.updater.leaderElection.resourceName }}
+          - --leader-elect-lease-duration={{ .Values.updater.leaderElection.leaseDuration }}
+          - --leader-elect-renew-deadline={{ .Values.updater.leaderElection.renewDeadline }}
+          - --leader-elect-retry-period={{ .Values.updater.leaderElection.retryPeriod }}
+          {{- end }}
           ports:
             - name: prometheus
               containerPort: 8943

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-role.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-role.yaml
@@ -1,4 +1,5 @@
-{{- if and (.Values.updater.enabled) .Values.updater.serviceAccount.create -}}
+{{- if and .Values.updater.enabled .Values.rbac.create -}}
+{{- if eq (include "vertical-pod-autoscaler.updater.leaderElectionEnabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -6,13 +7,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
-  {{- with .Values.updater.serviceAccount.labels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.updater.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 rules:
   - apiGroups:
       - "coordination.k8s.io"
@@ -23,11 +17,12 @@ rules:
   - apiGroups:
       - "coordination.k8s.io"
     resourceNames:
-      - vpa-updater
+      - {{ .Values.updater.leaderElection.resourceName }}
     resources:
       - leases
     verbs:
       - get
       - watch
       - update
+{{- end -}}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-rolebinding.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-rolebinding.yaml
@@ -1,4 +1,5 @@
-{{- if and (.Values.updater.enabled) .Values.rbac.create -}}
+{{- if and .Values.updater.enabled .Values.rbac.create -}}
+{{- if eq (include "vertical-pod-autoscaler.updater.leaderElectionEnabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -12,4 +13,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -191,7 +191,7 @@ updater:
     pullPolicy: IfNotPresent
 
   # Number of Updater replicas to create.
-  replicas: 1
+  replicas: 2
 
   # Labels to add to the Updater pod.
   podLabels: {}
@@ -205,3 +205,19 @@ updater:
     labels: {}
     # Annotations to add to the Updater service account.
     annotations: {}
+  
+  # Leader election configuration for the Updater.
+  # When running multiple replicas, leader election ensures only one instance is actively processing.
+  leaderElection:
+    # Enable leader election. If not set (null), automatically enabled when replicas > 1
+    enabled:
+    # Namespace for the lease resource. Defaults to Release.Namespace if not set.
+    resourceNamespace: ""
+    # Name of the lease resource.
+    resourceName: vpa-updater-lease
+    # Duration that non-leader candidates will wait after observing a leadership renewal.
+    leaseDuration: 15s
+    # Interval between attempts by the acting master to renew a leadership slot.
+    renewDeadline: 10s
+    # Duration the clients should wait between attempting acquisition and renewal of a leadership.
+    retryPeriod: 2s


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
- Helm chart support `leaderElection` for VPA Updater
- Update `updater-role` to only create when `leaderElection.enabled`. The role name and its permissions clearly states that it belongs to `leaderElection` instead of `serviceAccount`.

#### Which issue(s) this PR fixes:
Relates https://github.com/kubernetes/autoscaler/issues/8587

#### Special notes for your reviewer:
Quick test using
```console
helm upgrade --install vpa ./vertical-pod-autoscaler/charts/vertical-pod-autoscaler/ \
  -n vpa --create-namespace
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
