### PR TITLE
VPA: Allow e2e tests to reference a custom namespace

### DIFF
--- a/vertical-pod-autoscaler/e2e/integration/recommender.go
+++ b/vertical-pod-autoscaler/e2e/integration/recommender.go
@@ -46,7 +46,7 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		f.ClientSet.AppsV1().Deployments(utils.RecommenderNamespace).Delete(context.TODO(), utils.RecommenderDeploymentName, metav1.DeleteOptions{})
+		f.ClientSet.AppsV1().Deployments(utils.VpaNamespace).Delete(context.TODO(), utils.RecommenderDeploymentName, metav1.DeleteOptions{})
 	})
 
 	ginkgo.It("starts recommender with --vpa-object-namespace parameter", func() {
@@ -54,7 +54,7 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 		ignoredNamespace, err := f.CreateNamespace(context.TODO(), "ignored-namespace", nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		f.Namespace.Name = utils.RecommenderNamespace
+		f.Namespace.Name = utils.VpaNamespace
 		vpaDeployment := utils.NewVPADeployment(f, []string{
 			"--recommender-interval=10s",
 			fmt.Sprintf("--vpa-object-namespace=%s", hamsterNamespace),
@@ -69,7 +69,7 @@ var _ = utils.RecommenderE2eDescribe("Flags", func() {
 		ignoredNamespace, err := f.CreateNamespace(context.TODO(), "ignored-namespace", nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		f.Namespace.Name = utils.RecommenderNamespace
+		f.Namespace.Name = utils.VpaNamespace
 		vpaDeployment := utils.NewVPADeployment(f, []string{
 			"--recommender-interval=10s",
 			fmt.Sprintf("--ignored-vpa-object-namespaces=%s", ignoredNamespace.Name),

--- a/vertical-pod-autoscaler/e2e/utils/common.go
+++ b/vertical-pod-autoscaler/e2e/utils/common.go
@@ -57,14 +57,14 @@ const (
 )
 
 var (
-	// RecommenderNamespace is namespace to deploy VPA recommender.
+	// VpaNamespace is namespace to deploy VPA components.
 	// Can be overridden via VPA_NAMESPACE environment variable.
-	RecommenderNamespace = "kube-system"
+	VpaNamespace = "kube-system"
 )
 
 func init() {
 	if ns := os.Getenv("VPA_NAMESPACE"); ns != "" {
-		RecommenderNamespace = ns
+		VpaNamespace = ns
 	}
 }
 

--- a/vertical-pod-autoscaler/e2e/utils/webhook.go
+++ b/vertical-pod-autoscaler/e2e/utils/webhook.go
@@ -219,7 +219,7 @@ func waitWebhookConfigurationReady(f *framework.Framework) error {
 func CreateAuthReaderRoleBinding(f *framework.Framework, namespace string) {
 	ginkgo.By("Create role binding to let webhook read extension-apiserver-authentication")
 	client := f.ClientSet
-	_, err := client.RbacV1().RoleBindings(RecommenderNamespace).Create(context.TODO(), &rbacv1.RoleBinding{
+	_, err := client.RbacV1().RoleBindings(VpaNamespace).Create(context.TODO(), &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: roleBindingName,
 			Annotations: map[string]string{
@@ -382,5 +382,5 @@ func CleanWebhookTest(client clientset.Interface, namespaceName string) {
 	_ = client.CoreV1().Services(namespaceName).Delete(context.TODO(), WebhookServiceName, metav1.DeleteOptions{})
 	_ = client.AppsV1().Deployments(namespaceName).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
 	_ = client.CoreV1().Secrets(namespaceName).Delete(context.TODO(), WebhookServiceName, metav1.DeleteOptions{})
-	_ = client.RbacV1().RoleBindings(RecommenderNamespace).Delete(context.TODO(), roleBindingName, metav1.DeleteOptions{})
+	_ = client.RbacV1().RoleBindings(VpaNamespace).Delete(context.TODO(), roleBindingName, metav1.DeleteOptions{})
 }

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -55,18 +54,6 @@ const (
 	// pod, if there are no mechanisms blocking it.
 	VpaInPlaceTimeout = 2 * time.Minute
 )
-
-var (
-	// VpaNamespace is the namespace that holds the all the VPA components.
-	// Can be overridden via VPA_NAMESPACE environment variable.
-	VpaNamespace = "kube-system"
-)
-
-func init() {
-	if ns := os.Getenv("VPA_NAMESPACE"); ns != "" {
-		VpaNamespace = ns
-	}
-}
 
 // UpdaterE2eDescribe describes a VPA updater e2e test.
 func UpdaterE2eDescribe(name string, args ...interface{}) bool {

--- a/vertical-pod-autoscaler/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1/recommender.go
@@ -480,7 +480,7 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 })
 
 func deleteRecommender(c clientset.Interface) error {
-	namespace := VpaNamespace
+	namespace := utils.VpaNamespace
 	listOptions := metav1.ListOptions{}
 	podList, err := c.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
 	if err != nil {

--- a/vertical-pod-autoscaler/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/e2e/v1/updater.go
@@ -48,7 +48,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		statusUpdater := status.NewUpdater(
 			f.ClientSet,
 			status.AdmissionControllerStatusName,
-			status.AdmissionControllerStatusNamespace,
+			utils.VpaNamespace,
 			statusUpdateInterval,
 			"e2e test",
 		)
@@ -57,7 +57,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 			// Status is created outside the test namespace.
 			ginkgo.By("Deleting the Admission Controller status")
 			close(stopCh)
-			err := f.ClientSet.CoordinationV1().Leases(status.AdmissionControllerStatusNamespace).
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
 				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -79,7 +79,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		statusUpdater := status.NewUpdater(
 			f.ClientSet,
 			status.AdmissionControllerStatusName,
-			status.AdmissionControllerStatusNamespace,
+			utils.VpaNamespace,
 			statusUpdateInterval,
 			"e2e test",
 		)
@@ -88,7 +88,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 			// Status is created outside the test namespace.
 			ginkgo.By("Deleting the Admission Controller status")
 			close(stopCh)
-			err := f.ClientSet.CoordinationV1().Leases(status.AdmissionControllerStatusNamespace).
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
 				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -109,7 +109,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		statusUpdater := status.NewUpdater(
 			f.ClientSet,
 			status.AdmissionControllerStatusName,
-			status.AdmissionControllerStatusNamespace,
+			utils.VpaNamespace,
 			statusUpdateInterval,
 			"e2e test",
 		)
@@ -118,7 +118,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 			// Status is created outside the test namespace.
 			ginkgo.By("Deleting the Admission Controller status")
 			close(stopCh)
-			err := f.ClientSet.CoordinationV1().Leases(status.AdmissionControllerStatusNamespace).
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
 				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -151,7 +151,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		statusUpdater := status.NewUpdater(
 			f.ClientSet,
 			status.AdmissionControllerStatusName,
-			status.AdmissionControllerStatusNamespace,
+			utils.VpaNamespace,
 			statusUpdateInterval,
 			"e2e test",
 		)
@@ -160,7 +160,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 			// Status is created outside the test namespace.
 			ginkgo.By("Deleting the Admission Controller status")
 			close(stopCh)
-			err := f.ClientSet.CoordinationV1().Leases(status.AdmissionControllerStatusNamespace).
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
 				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -183,7 +183,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		statusUpdater := status.NewUpdater(
 			f.ClientSet,
 			status.AdmissionControllerStatusName,
-			status.AdmissionControllerStatusNamespace,
+			utils.VpaNamespace,
 			statusUpdateInterval,
 			"e2e test",
 		)
@@ -192,7 +192,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 			// Status is created outside the test namespace.
 			ginkgo.By("Deleting the Admission Controller status")
 			close(stopCh)
-			err := f.ClientSet.CoordinationV1().Leases(status.AdmissionControllerStatusNamespace).
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
 				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it:
Enables VPA e2e tests to use a custom namespace via the `VPA_NAMESPACE` environment variable, while maintaining backward compatibility with the default `kube-system` namespace.
This makes the e2e tests consistent with the VPA components' ability to run in custom namespaces, as mentioned in issue #8752.

## Which issue(s) this PR fixes:
Fixes #8752

## Special notes for your reviewer:
This implementation follows the same pattern as PR #7654, using environment variables with sensible defaults to enable custom configurations without breaking existing tests.

The changes are minimal and only affect e2e test code:
- Made `VpaNamespace` (e2e/v1/common.go) configurable via `VPA_NAMESPACE` env var
- Made `RecommenderNamespace` (e2e/utils/common.go) configurable via `VPA_NAMESPACE` env var
- Replaced hardcoded `kube-system` strings in `deleteRecommender()` function
- Replaced hardcoded `kube-system` strings in webhook RoleBinding operations

All unit tests pass with race detection enabled.

## Does this PR introduce a user-facing change?
```release-note
NONE
