### PR TITLE
Silence docker build warning about mixed case

### DIFF
--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM --platform=$BUILDPLATFORM golang:1.24 as builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When building the cluster-autoscaler container, docker emits this annoying warning:
```
#1 transferring dockerfile: 1.09kB done
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 14)
#1 DONE 0.0s
```

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

I checked all the other Dockerfiles in the autoscaler project, and this was the only one with mixed `FROM` and `AS` case.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
