### PR TITLE
OCI provider: Remove unprovisioned nodes in error state as requested instead of returning an error

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/common/consts.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/consts.go
@@ -1,0 +1,8 @@
+package common
+
+const (
+	// InstanceStateUnfulfilled is a status indicating that the pool was unable to fulfill the operation
+	InstanceStateUnfulfilled = "Unfulfilled"
+	// InstanceIDUnfulfilled is the generic placeholder name for upcoming instances
+	InstanceIDUnfulfilled = "instance_placeholder"
+)

--- a/cluster-autoscaler/cloudprovider/oci/common/oci_ref.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_ref.go
@@ -5,11 +5,12 @@ Copyright 2021-2023 Oracle and/or its affiliates.
 package common
 
 import (
+	"strings"
+
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/instancepools/consts"
 	"k8s.io/klog/v2"
-
-	"strings"
 )
 
 // OciRef contains s reference to some entity in OCI world.
@@ -95,9 +96,9 @@ func getNodeExternalAddress(node *apiv1.Node) string {
 func getNodeInstancePoolID(node *apiv1.Node) string {
 
 	// Handle unfilled instance placeholder (instances that have yet to be created)
-	if strings.Contains(node.Name, consts.InstanceIDUnfulfilled) {
+	if strings.Contains(node.Name, InstanceIDUnfulfilled) {
 		instIndex := strings.LastIndex(node.Name, "-")
-		return strings.Replace(node.Name[:instIndex], consts.InstanceIDUnfulfilled, "", 1)
+		return strings.Replace(node.Name[:instIndex], InstanceIDUnfulfilled, "", 1)
 	}
 
 	poolIDPrefixLabel, _ := node.Labels[consts.InstancePoolIDLabelPrefix]
@@ -122,8 +123,14 @@ func getNodeInstanceID(node *apiv1.Node) string {
 	}
 
 	// Handle unfilled instance placeholder (instances that have yet to be created)
-	if strings.Contains(node.Name, consts.InstanceIDUnfulfilled) {
+	if strings.Contains(node.Name, InstanceIDUnfulfilled) {
 		return node.Name
+	} else if node.Annotations[cloudprovider.FakeNodeReasonAnnotation] == cloudprovider.FakeNodeUnregistered {
+		// Placeholder node created by CA for a node that has not registered itself yet.
+		return InstanceIDUnfulfilled
+	} else if node.Annotations[cloudprovider.FakeNodeReasonAnnotation] == cloudprovider.FakeNodeCreateError {
+		// Placeholder node created by CA for a node cannot be created because of an error.
+		return InstanceIDUnfulfilled
 	}
 
 	instancePrefixLabel, _ := node.Labels[consts.InstanceIDLabelPrefix]

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/consts/annotations.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/consts/annotations.go
@@ -5,8 +5,9 @@ Copyright 2021-2023 Oracle and/or its affiliates.
 package consts
 
 import (
-	v1 "k8s.io/api/core/v1"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -46,10 +47,6 @@ const (
 	OciInstancePoolResourceIdent = "instancepool"
 	// OciInstancePoolLaunchOp is an instance pools operation type
 	OciInstancePoolLaunchOp = "LaunchInstancesInPool"
-	// InstanceStateUnfulfilled is a status indicating that the instance pool was unable to fulfill the operation
-	InstanceStateUnfulfilled = "Unfulfilled"
-	// InstanceIDUnfulfilled is the generic placeholder name for upcoming instances
-	InstanceIDUnfulfilled = "instance_placeholder"
 
 	// OciInstancePoolIDNonPoolMember indicates a kubernetes node doesn't belong to any OCI Instance Pool.
 	OciInstancePoolIDNonPoolMember = "non_pool_member"

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
@@ -134,7 +134,7 @@ func (c *instancePoolCache) rebuild(staticInstancePools map[string]*InstancePool
 					if unrecoverableErrorMsg != "" {
 						klog.V(4).Infof("Creating placeholder instances for %s.", *getInstancePoolResp.InstancePool.DisplayName)
 						for i := len(*c.instanceSummaryCache[id]); i < *c.poolCache[id].Size; i++ {
-							c.addUnfulfilledInstanceToCache(id, fmt.Sprintf("%s%s-%d", consts.InstanceIDUnfulfilled,
+							c.addUnfulfilledInstanceToCache(id, fmt.Sprintf("%s%s-%d", ocicommon.InstanceIDUnfulfilled,
 								*getInstancePoolResp.InstancePool.Id, i), *getInstancePoolResp.InstancePool.CompartmentId,
 								fmt.Sprintf("%s-%d", *getInstancePoolResp.InstancePool.DisplayName, i))
 						}
@@ -154,7 +154,7 @@ func (c *instancePoolCache) addUnfulfilledInstanceToCache(instancePoolID, instan
 	*c.instanceSummaryCache[instancePoolID] = append(*c.instanceSummaryCache[instancePoolID], core.InstanceSummary{
 		Id:            common.String(instanceID),
 		CompartmentId: common.String(compartmentID),
-		State:         common.String(consts.InstanceStateUnfulfilled),
+		State:         common.String(ocicommon.InstanceStateUnfulfilled),
 		DisplayName:   common.String(name),
 	})
 }
@@ -171,7 +171,7 @@ func (c *instancePoolCache) removeInstance(instancePool InstancePoolNodeGroup, i
 	klog.V(4).Infof("detaching instance %s from instance-pool: %v", instanceID, instancePool.Id())
 
 	var err error
-	if strings.Contains(instanceID, consts.InstanceIDUnfulfilled) {
+	if strings.Contains(instanceID, ocicommon.InstanceIDUnfulfilled) {
 		// For an unfulfilled instance, reduce the target size of the instance pool and remove the placeholder instance from cache.
 		err = c.setSize(instancePool.Id(), *c.poolCache[instancePool.Id()].Size-1)
 	} else {
@@ -204,9 +204,9 @@ func (c *instancePoolCache) removeInstance(instancePool InstancePoolNodeGroup, i
 func (c *instancePoolCache) findInstanceByDetails(ociInstance ocicommon.OciRef) (*ocicommon.OciRef, error) {
 
 	// Unfilled instance placeholder
-	if strings.Contains(ociInstance.Name, consts.InstanceIDUnfulfilled) {
+	if strings.Contains(ociInstance.Name, ocicommon.InstanceIDUnfulfilled) {
 		instIndex := strings.LastIndex(ociInstance.Name, "-")
-		ociInstance.InstancePoolID = strings.Replace(ociInstance.Name[:instIndex], consts.InstanceIDUnfulfilled, "", 1)
+		ociInstance.InstancePoolID = strings.Replace(ociInstance.Name[:instIndex], ocicommon.InstanceIDUnfulfilled, "", 1)
 		return &ociInstance, nil
 	}
 	// Minimum amount of information we need to make a positive match
@@ -373,7 +373,7 @@ func (c *instancePoolCache) setSize(instancePoolID string, size int) error {
 		InstancePoolId: common.String(instancePoolID),
 	})
 	if err != nil {
-		klog.V(4).Infof("GetInstancePool for %s failed: %v", common.String(instancePoolID), err)
+		klog.V(4).Infof("GetInstancePool for %s failed: %v", instancePoolID, err)
 		return err
 	}
 
@@ -390,7 +390,7 @@ func (c *instancePoolCache) setSize(instancePoolID string, size int) error {
 		UpdateInstancePoolDetails: updateDetails,
 	})
 	if err != nil {
-		klog.V(4).Infof("UpdateInstancePool for %s failed: %v", common.String(instancePoolID), err)
+		klog.V(4).Infof("UpdateInstancePool for %s failed: %v", instancePoolID, err)
 		return err
 	}
 

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager.go
@@ -477,11 +477,11 @@ func (m *InstancePoolManagerImpl) GetInstancePoolNodes(ip InstancePoolNodeGroup)
 			status.State = cloudprovider.InstanceDeleting
 		case strings.ToLower(string(core.InstanceLifecycleStateStopping)):
 			status.State = cloudprovider.InstanceDeleting
-		case strings.ToLower(consts.InstanceStateUnfulfilled):
+		case strings.ToLower(ocicommon.InstanceStateUnfulfilled):
 			status.State = cloudprovider.InstanceCreating
 			status.ErrorInfo = &cloudprovider.InstanceErrorInfo{
 				ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
-				ErrorCode:    consts.InstanceStateUnfulfilled,
+				ErrorCode:    ocicommon.InstanceStateUnfulfilled,
 				ErrorMessage: "OCI cannot provision additional instances for this instance pool. Review quota and/or capacity.",
 			}
 		default:

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/cache.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sync"
 
+	ocicommon "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/common"
 	"k8s.io/klog/v2"
 
 	"github.com/pkg/errors"
@@ -70,16 +71,23 @@ func (c *nodePoolCache) rebuild(staticNodePools map[string]NodePool, maxGetNodep
 
 // removeInstance tries to remove the instance from the node pool.
 func (c *nodePoolCache) removeInstance(nodePoolID, instanceID string, nodeName string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if instanceID == "" {
 		klog.Errorf("Node %s doesn't have an instance id so it can't be deleted.", nodeName)
 		klog.Errorf("This could be due to a Compute Instance issue in OCI such as Out Of Host Capacity error. Check the instance status on OCI Console.")
 		return errors.Errorf("Node %s doesn't have an instance id so it can't be deleted.", nodeName)
+	} else if ocicommon.InstanceIDUnfulfilled == instanceID {
+		// Remove an unprovisioned instance caused by capacity or quota issues so that it does not prevent or delay the
+		// autoscaler from attempting to scale a different pool that meets the scheduling requirements.
+		size, err := c.getSize(nodePoolID)
+		if err != nil {
+			return err
+		}
+		return c.setSize(nodePoolID, size-1)
 	}
 
 	klog.Infof("Deleting instance %q from node pool %q", instanceID, nodePoolID)
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	// always try to remove the instance. This call is idempotent
 	scaleDown := true
@@ -146,7 +154,12 @@ func (c *nodePoolCache) getByInstance(instanceID string) (*oke.NodePool, error) 
 
 	for _, nodePool := range c.cache {
 		for _, node := range nodePool.Nodes {
+			// Either the IDs match or we're looking for an unfulfilled instance, and we've found a node pool with a
+			// node that cannot be created because of an error.
 			if *node.Id == instanceID {
+				return nodePool, nil
+			} else if ocicommon.InstanceIDUnfulfilled == instanceID &&
+				*node.Id == "" && oke.NodeLifecycleStateCreating == node.LifecycleState && node.NodeError != nil {
 				return nodePool, nil
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR updates the behavior of OCI's nodepool implementation of `DeleteNodes()` _when it is called with an [unfulfilled placeholder node](https://github.com/kubernetes/autoscaler/pull/4119/files) that is in an error state_. Typically is is due to capacity or quota issues. Rather than returning an error because the placeholder node has an empty instance ID, the `DeleteNodes()` request effectively cancels the failed scale-up, allowing the Cluster Autoscaler to recover more quickly and try scaling up a different node pool that meets the scheduling requirements.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

These changes are currently running in an environment where we have proactively configured multiple node-pools with different shape configurations in order to make the Cluster Autoscaler more resilient against capacity issues..

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove unprovisioned nodes from OCI provider as requested instead of returning an error.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
