### PR TITLE
updater: fetch pods matching VPA selectors

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
@@ -232,6 +233,7 @@ func testRunOnceBase(
 			Get()
 
 		pods[i].Labels = labels
+		pods[i].UID = types.UID(fmt.Sprintf("pod-uid-%d", i))
 
 		inplace.On("CanInPlaceUpdate", pods[i]).Return(canInPlaceUpdate)
 		if shouldInPlaceFail {
@@ -251,7 +253,7 @@ func testRunOnceBase(
 	vpaLister := &test.VerticalPodAutoscalerListerMock{}
 
 	podLister := &test.PodListerMock{}
-	podLister.On("List").Return(pods, nil)
+	podLister.On("List", selector).Return(pods, nil)
 	targetRef := &v1.CrossVersionObjectReference{
 		Kind:       rc.Kind,
 		Name:       rc.Name,
@@ -381,6 +383,7 @@ func TestRunOnceIgnoreNamespaceMatchingPods(t *testing.T) {
 			Get()
 
 		pods[i].Labels = labels
+		pods[i].UID = types.UID(fmt.Sprintf("pod-uid-%d", i))
 		eviction.On("CanEvict", pods[i]).Return(true)
 		eviction.On("Evict", pods[i], nil).Return(nil)
 	}
@@ -392,7 +395,7 @@ func TestRunOnceIgnoreNamespaceMatchingPods(t *testing.T) {
 	vpaLister := &test.VerticalPodAutoscalerListerMock{}
 
 	podLister := &test.PodListerMock{}
-	podLister.On("List").Return(pods, nil)
+	podLister.On("List", selector).Return(pods, nil)
 	targetRef := &v1.CrossVersionObjectReference{
 		Kind:       rc.Kind,
 		Name:       rc.Name,

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -156,7 +156,7 @@ func (m *PodListerMock) Pods(namespace string) v1.PodNamespaceLister {
 
 // List is a mock implementation of PodLister.List
 func (m *PodListerMock) List(selector labels.Selector) (ret []*apiv1.Pod, err error) {
-	args := m.Called()
+	args := m.Called(selector)
 	var returnArg []*apiv1.Pod
 	if args.Get(0) != nil {
 		returnArg = args.Get(0).([]*apiv1.Pod)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As discussed in #8773, The updater currently will list all pods when it attempts to find pods that are controlled by VPAs. This approach will only the pods based on the targetRef selector of the VPA object. Hence improve the performance 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8773

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
