### PR TITLE
Fix capacitybuffers fake pods registry update logic

### DIFF
--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -95,6 +95,7 @@ func (p *CapacityBufferPodListProcessor) Process(autoscalingCtx *ca_context.Auto
 	_, buffers = p.podTemplateGenFilter.Filter(buffers)
 
 	totalFakePods := []*apiv1.Pod{}
+	p.clearCapacityBufferRegistry()
 	for _, buffer := range buffers {
 		fakePods := p.provision(buffer)
 		p.updateCapacityBufferRegistry(fakePods, buffer)
@@ -113,10 +114,16 @@ func (p *CapacityBufferPodListProcessor) updateCapacityBufferRegistry(fakePods [
 	if p.buffersRegistry == nil {
 		return
 	}
-	p.buffersRegistry.fakePodsUIDToBuffer = make(map[string]*v1alpha1.CapacityBuffer, len(fakePods))
 	for _, fakePod := range fakePods {
 		p.buffersRegistry.fakePodsUIDToBuffer[string(fakePod.UID)] = buffer
 	}
+}
+
+func (p *CapacityBufferPodListProcessor) clearCapacityBufferRegistry() {
+	if p.buffersRegistry == nil {
+		return
+	}
+	p.buffersRegistry.fakePodsUIDToBuffer = make(map[string]*v1alpha1.CapacityBuffer, 0)
 }
 
 func (p *CapacityBufferPodListProcessor) provision(buffer *v1alpha1.CapacityBuffer) []*apiv1.Pod {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fix Capacitybuffers pod list processor to clean the fake pods registry once and added unit tests for the registry 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
