### PR TITLE
Backport Capacity Buffers CRD scope fix to cluster-autoscaler 1.34

### DIFF
--- a/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
+++ b/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
@@ -37,7 +37,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=capacitybuffers,scope=Cluster,shortName=cb
+// +kubebuilder:resource:path=capacitybuffers,scope=Namespaced,shortName=cb
 // +kubebuilder:printcolumn:name="Strategy",type="string",JSONPath=".spec.provisioningStrategy",description="The strategy used for provisioning buffer capacity."
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="The desired number of buffer chunks, if specified."
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason",description="The readiness status of the CapacityBuffer."

--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacitybuffers.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacitybuffers.yaml
@@ -14,7 +14,7 @@ spec:
     shortNames:
     - cb
     singular: capacitybuffer
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - description: The strategy used for provisioning buffer capacity.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Backport of https://github.com/kubernetes/autoscaler/pull/8824 to cluster-autoscaler 1.34

#### Which issue(s) this PR fixes:

Fixes b/457378075

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
capacitybuffers.autoscaling.x-k8s.io scope changed from Cluster to Namespaced.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A