### PR TITLE
CPU startup boost: add tests

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
@@ -408,7 +408,7 @@ spec:
                                 factor:
                                   description: |-
                                     factor specifies the factor to apply to the resource request.
-                                    This field is to be used only when Type is "Factor".
+                                    This field is required when Type is "Factor".
                                   format: int32
                                   type: integer
                                 quantity:
@@ -418,7 +418,7 @@ spec:
                                   description: |-
                                     quantity specifies the absolute resource quantity to be used as the
                                     resource request and limit during the boost phase.
-                                    This field is to be used only when Type is "Quantity".
+                                    This field is required when Type is "Quantity".
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -453,7 +453,7 @@ spec:
                       factor:
                         description: |-
                           factor specifies the factor to apply to the resource request.
-                          This field is to be used only when Type is "Factor".
+                          This field is required when Type is "Factor".
                         format: int32
                         type: integer
                       quantity:
@@ -463,7 +463,7 @@ spec:
                         description: |-
                           quantity specifies the absolute resource quantity to be used as the
                           resource request and limit during the boost phase.
-                          This field is to be used only when Type is "Quantity".
+                          This field is required when Type is "Quantity".
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type:

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -408,7 +408,7 @@ spec:
                                 factor:
                                   description: |-
                                     factor specifies the factor to apply to the resource request.
-                                    This field is to be used only when Type is "Factor".
+                                    This field is required when Type is "Factor".
                                   format: int32
                                   type: integer
                                 quantity:
@@ -418,7 +418,7 @@ spec:
                                   description: |-
                                     quantity specifies the absolute resource quantity to be used as the
                                     resource request and limit during the boost phase.
-                                    This field is to be used only when Type is "Quantity".
+                                    This field is required when Type is "Quantity".
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -453,7 +453,7 @@ spec:
                       factor:
                         description: |-
                           factor specifies the factor to apply to the resource request.
-                          This field is to be used only when Type is "Factor".
+                          This field is required when Type is "Factor".
                         format: int32
                         type: integer
                       quantity:
@@ -463,7 +463,7 @@ spec:
                         description: |-
                           quantity specifies the absolute resource quantity to be used as the
                           resource request and limit during the boost phase.
-                          This field is to be used only when Type is "Quantity".
+                          This field is required when Type is "Quantity".
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       type:

--- a/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost/README.md
+++ b/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost/README.md
@@ -159,7 +159,7 @@ type CPUStartupBoost struct {
 
 > [!IMPORTANT]
 > The boosted CPU value will be capped by
-> [`--container-recommendation-max-allowed-cpu`](https://github.com/kubernetes/autoscaler/blob/4d294562e505431d518a81e8833accc0ec99c9b8/vertical-pod-autoscaler/pkg/recommender/main.go#L122)
+> [`--max-allowed-cpu-boost`](https://github.com/kubernetes/autoscaler/blob/4b40a55bebd2ce184b289cd028969182d15f412c/vertical-pod-autoscaler/pkg/admission-controller/main.go#L86C1-L86C2)
 > flag value, if set.
 
 > [!NOTE]

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
@@ -603,6 +603,37 @@ func TestValidateVPA(t *testing.T) {
 			isCreate: true,
 		},
 		{
+			name: "top-level and container startupBoost",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					StartupBoost: &vpa_types.StartupBoost{
+						CPU: &vpa_types.GenericStartupBoost{
+							Type:   validCPUBoostTypeFactor,
+							Factor: &validCPUBoostFactor,
+						},
+					},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "loot box",
+								StartupBoost: &vpa_types.StartupBoost{
+									CPU: &vpa_types.GenericStartupBoost{
+										Type:     validCPUBoostTypeQuantity,
+										Quantity: &validCPUBoostQuantity,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isCreate: true,
+		},
+		{
 			name: "per-vpa config active and used",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -131,14 +131,14 @@ type GenericStartupBoost struct {
 	// +required
 	Type StartupBoostType `json:"type" protobuf:"bytes,1,opt,name=type"`
 	// factor specifies the factor to apply to the resource request.
-	// This field is to be used only when Type is "Factor".
+	// This field is required when Type is "Factor".
 	// +unionMember=Factor
 	// +optional
 	Factor *int32 `json:"factor,omitempty" protobuf:"bytes,2,opt,name=factor"`
 
 	// quantity specifies the absolute resource quantity to be used as the
 	// resource request and limit during the boost phase.
-	// This field is to be used only when Type is "Quantity".
+	// This field is required when Type is "Quantity".
 	// +unionMember=Quantity
 	// +optional
 	Quantity *resource.Quantity `json:"quantity,omitempty" protobuf:"bytes,3,opt,name=quantity"`

--- a/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
@@ -51,6 +51,7 @@ type VerticalPodAutoscalerBuilder interface {
 	WithOOMBumpUpRatio(ratio *resource.Quantity) VerticalPodAutoscalerBuilder
 	WithOOMMinBumpUp(minBumpUp *resource.Quantity) VerticalPodAutoscalerBuilder
 	WithCPUStartupBoost(boostType vpa_types.StartupBoostType, factor *int32, quantity *resource.Quantity, duration string) VerticalPodAutoscalerBuilder
+	WithContainerCPUStartupBoost(containerName string, boostType vpa_types.StartupBoostType, factor *int32, quantity *resource.Quantity, duration string) VerticalPodAutoscalerBuilder
 	AppendCondition(conditionType vpa_types.VerticalPodAutoscalerConditionType,
 		status core.ConditionStatus, reason, message string, lastTransitionTime time.Time) VerticalPodAutoscalerBuilder
 	AppendRecommendation(vpa_types.RecommendedContainerResources) VerticalPodAutoscalerBuilder
@@ -71,6 +72,7 @@ func VerticalPodAutoscaler() VerticalPodAutoscalerBuilder {
 		maxAllowed:              map[string]core.ResourceList{},
 		controlledValues:        map[string]*vpa_types.ContainerControlledValues{},
 		scalingMode:             map[string]*vpa_types.ContainerScalingMode{},
+		containerStartupBoost:   map[string]*vpa_types.StartupBoost{},
 	}
 }
 
@@ -85,6 +87,7 @@ type verticalPodAutoscalerBuilder struct {
 	maxAllowed              map[string]core.ResourceList
 	controlledValues        map[string]*vpa_types.ContainerControlledValues
 	scalingMode             map[string]*vpa_types.ContainerScalingMode
+	containerStartupBoost   map[string]*vpa_types.StartupBoost
 	startupBoost            *vpa_types.StartupBoost
 	recommendation          RecommendationBuilder
 	conditions              []vpa_types.VerticalPodAutoscalerCondition
@@ -260,10 +263,30 @@ func (b *verticalPodAutoscalerBuilder) WithCPUStartupBoost(boostType vpa_types.S
 	}
 	if factor != nil {
 		cpuStartupBoost.Factor = factor
-	} else {
+	}
+	if quantity != nil {
 		cpuStartupBoost.Quantity = quantity
 	}
 	c.startupBoost = &vpa_types.StartupBoost{
+		CPU: cpuStartupBoost,
+	}
+	return &c
+}
+
+func (b *verticalPodAutoscalerBuilder) WithContainerCPUStartupBoost(containerName string, boostType vpa_types.StartupBoostType, factor *int32, quantity *resource.Quantity, duration string) VerticalPodAutoscalerBuilder {
+	c := *b
+	parsedDuration, _ := time.ParseDuration(duration)
+	cpuStartupBoost := &vpa_types.GenericStartupBoost{
+		Type:     boostType,
+		Duration: &meta.Duration{Duration: parsedDuration},
+	}
+	if factor != nil {
+		cpuStartupBoost.Factor = factor
+	}
+	if quantity != nil {
+		cpuStartupBoost.Quantity = quantity
+	}
+	c.containerStartupBoost[containerName] = &vpa_types.StartupBoost{
 		CPU: cpuStartupBoost,
 	}
 	return &c
@@ -289,6 +312,7 @@ func (b *verticalPodAutoscalerBuilder) Get() *vpa_types.VerticalPodAutoscaler {
 			Mode:             &scalingModeAuto,
 			OOMBumpUpRatio:   b.oomBumpUpRatio,
 			OOMMinBumpUp:     b.oomMinBumpUp,
+			StartupBoost:     b.containerStartupBoost[containerName],
 		}
 		if scalingMode, ok := b.scalingMode[containerName]; ok {
 			containerResourcePolicy.Mode = scalingMode


### PR DESCRIPTION
This is to address comments in https://github.com/kubernetes/autoscaler/pull/8813
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
