### PR TITLE
Use capacity buffer namespace for injected fake pods

### DIFF
--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -163,7 +163,7 @@ func (p *CapacityBufferPodListProcessor) updateBufferStatus(buffer *v1alpha1.Cap
 // makeFakePods creates podCount number of copies of the sample pod
 func makeFakePods(buffer *v1alpha1.CapacityBuffer, samplePodTemplate *apiv1.PodTemplateSpec, podCount int) ([]*apiv1.Pod, error) {
 	var fakePods []*apiv1.Pod
-	samplePod := getPodFromTemplate(samplePodTemplate)
+	samplePod := getPodFromTemplate(samplePodTemplate, buffer.Namespace)
 	for i := 1; i <= podCount; i++ {
 		fakePod := samplePod.DeepCopy()
 		fakePod = withCapacityBufferFakePodAnnotation(fakePod)
@@ -190,7 +190,7 @@ func isFakeCapacityBuffersPod(pod *apiv1.Pod) bool {
 	return pod.Annotations[CapacityBufferFakePodAnnotationKey] == CapacityBufferFakePodAnnotationValue
 }
 
-func getPodFromTemplate(template *apiv1.PodTemplateSpec) *apiv1.Pod {
+func getPodFromTemplate(template *apiv1.PodTemplateSpec, namespace string) *apiv1.Pod {
 	desiredLabels := getPodsLabelSet(template)
 	desiredFinalizers := getPodsFinalizers(template)
 	desiredAnnotations := getPodsAnnotationSet(template)
@@ -198,7 +198,7 @@ func getPodFromTemplate(template *apiv1.PodTemplateSpec) *apiv1.Pod {
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:       desiredLabels,
-			Namespace:    template.Namespace,
+			Namespace:    namespace,
 			Annotations:  desiredAnnotations,
 			GenerateName: uuid.NewString(),
 			Finalizers:   desiredFinalizers,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:
Sets the namespace of the fake pods to the namespace as the buffer (same as the podTemplate namespace), currently they are set to podTemplateSpec namespace which will be empty, which may cause issues in CA scheduling simulations.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
