### PR TITLE
fix: deprecated import of cacheddiscovery in balancer

### DIFF
--- a/balancer/main.go
+++ b/balancer/main.go
@@ -26,7 +26,7 @@ import (
 	balancerclientset "k8s.io/autoscaler/balancer/pkg/client/clientset/versioned"
 	balancerinformers "k8s.io/autoscaler/balancer/pkg/client/informers/externalversions"
 	"k8s.io/autoscaler/balancer/pkg/controller"
-	cacheddiscovery "k8s.io/client-go/discovery/cached"
+	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind deprecation

#### What this PR does / why we need it:

Fixes deprecated imports of legacy NewMemCacheClient() from cacheddiscovery "k8s.io/client-go/discovery/cached" to cacheddiscovery "k8s.io/client-go/discovery/cached/memory"

#### Which issue(s) this PR fixes:

Fixes NewMemCacheClient() import
in k8s.io/client-go/discovery/cached - NewMemCacheClient is DEPRECATED. Use memory.NewMemCacheClient directly.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
fix: deprecated import of cacheddiscovery in balancer
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Usage]: https://pkg.go.dev/k8s.io/client-go/discovery/cached
- [Usage]: https://pkg.go.dev/k8s.io/client-go/discovery/cached/memory
```

```release-note

```