### PR TITLE
Integrate resource quotas with scale up

### DIFF
--- a/cluster-autoscaler/core/options/autoscaler.go
+++ b/cluster-autoscaler/core/options/autoscaler.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/observers/loopstart"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
 	draprovider "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/provider"
@@ -57,4 +58,5 @@ type AutoscalerOptions struct {
 	DeleteOptions          options.NodeDeleteOptions
 	DrainabilityRules      rules.Rules
 	DraProvider            *draprovider.Provider
+	QuotasTrackerOptions   resourcequotas.TrackerOptions
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -47,6 +49,7 @@ type ScaleUpOrchestrator struct {
 	autoscalingCtx       *ca_context.AutoscalingContext
 	processors           *ca_processors.AutoscalingProcessors
 	resourceManager      *resource.Manager
+	quotasTrackerFactory *resourcequotas.TrackerFactory
 	clusterStateRegistry *clusterstate.ClusterStateRegistry
 	scaleUpExecutor      *scaleUpExecutor
 	estimatorBuilder     estimator.EstimatorBuilder
@@ -68,6 +71,7 @@ func (o *ScaleUpOrchestrator) Initialize(
 	clusterStateRegistry *clusterstate.ClusterStateRegistry,
 	estimatorBuilder estimator.EstimatorBuilder,
 	taintConfig taints.TaintConfig,
+	quotasTrackerFactory *resourcequotas.TrackerFactory,
 ) {
 	o.autoscalingCtx = autoscalingCtx
 	o.processors = processors
@@ -76,6 +80,7 @@ func (o *ScaleUpOrchestrator) Initialize(
 	o.taintConfig = taintConfig
 	o.resourceManager = resource.NewManager(processors.CustomResourcesProcessor)
 	o.scaleUpExecutor = newScaleUpExecutor(autoscalingCtx, processors.ScaleStateNotifier, o.processors.AsyncNodeGroupStateChecker)
+	o.quotasTrackerFactory = quotasTrackerFactory
 	o.initialized = true
 }
 
@@ -121,15 +126,15 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	// Initialise binpacking limiter.
 	o.processors.BinpackingLimiter.InitBinpacking(o.autoscalingCtx, nodeGroups)
 
-	resourcesLeft, aErr := o.resourceManager.ResourcesLeft(o.autoscalingCtx, nodeInfos, nodes)
-	if aErr != nil {
-		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, aErr.AddPrefix("could not compute total resources: "))
+	tracker, err := o.quotasTrackerFactory.NewQuotasTracker(o.autoscalingCtx, nodes)
+	if err != nil {
+		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("could not create quotas tracker: "))
 	}
 
 	now := time.Now()
 
 	// Filter out invalid node groups
-	validNodeGroups, skippedNodeGroups := o.filterValidScaleUpNodeGroups(nodeGroups, nodeInfos, resourcesLeft, len(nodes)+len(upcomingNodes), now)
+	validNodeGroups, skippedNodeGroups := o.filterValidScaleUpNodeGroups(nodeGroups, nodeInfos, tracker, len(nodes), now)
 
 	// Mark skipped node groups as processed.
 	for nodegroupID := range skippedNodeGroups {
@@ -145,7 +150,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	}
 
 	for _, nodeGroup := range validNodeGroups {
-		option := o.ComputeExpansionOption(nodeGroup, schedulablePodGroups, nodeInfos, len(nodes)+len(upcomingNodes), now, allOrNothing)
+		option := o.ComputeExpansionOption(nodeGroup, schedulablePodGroups, nodeInfos, len(nodes), now, allOrNothing)
 		o.processors.BinpackingLimiter.MarkProcessed(o.autoscalingCtx, nodeGroup.Id())
 
 		if len(option.Pods) == 0 || option.NodeCount == 0 {
@@ -189,12 +194,12 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	klog.V(1).Infof("Estimated %d nodes needed in %s", bestOption.NodeCount, bestOption.NodeGroup.Id())
 
 	// Cap new nodes to supported number of nodes in the cluster.
-	newNodes, aErr := o.GetCappedNewNodeCount(bestOption.NodeCount, len(nodes)+len(upcomingNodes))
+	newNodes, aErr := o.GetCappedNewNodeCount(bestOption.NodeCount, len(nodes))
 	if aErr != nil {
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{PodsTriggeredScaleUp: bestOption.Pods}, aErr)
 	}
 
-	newNodes, aErr = o.applyLimits(newNodes, resourcesLeft, bestOption.NodeGroup, nodeInfos)
+	newNodes, aErr = o.applyLimits(newNodes, tracker, bestOption.NodeGroup, nodeInfos)
 	if aErr != nil {
 		return status.UpdateScaleUpError(
 			&status.ScaleUpStatus{PodsTriggeredScaleUp: bestOption.Pods},
@@ -202,7 +207,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	}
 
 	if newNodes < bestOption.NodeCount {
-		klog.V(1).Infof("Only %d nodes can be added to %s due to cluster-wide limits", newNodes, bestOption.NodeGroup.Id())
+		klog.V(1).Infof("Only %d nodes can be added to %s due to resource quotas", newNodes, bestOption.NodeGroup.Id())
 		if allOrNothing {
 			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
 			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
@@ -283,14 +288,18 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	}, nil
 }
 
-func (o *ScaleUpOrchestrator) applyLimits(newNodes int, resourcesLeft resource.Limits, nodeGroup cloudprovider.NodeGroup, nodeInfos map[string]*framework.NodeInfo) (int, errors.AutoscalerError) {
+func (o *ScaleUpOrchestrator) applyLimits(newNodes int, tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfos map[string]*framework.NodeInfo) (int, errors.AutoscalerError) {
 	nodeInfo, found := nodeInfos[nodeGroup.Id()]
 	if !found {
 		// This should never happen, as we already should have retrieved nodeInfo for any considered nodegroup.
 		klog.Errorf("No node info for: %s", nodeGroup.Id())
 		return 0, errors.NewAutoscalerError(errors.CloudProviderError, "No node info for best expansion option!")
 	}
-	return o.resourceManager.ApplyLimits(o.autoscalingCtx, newNodes, resourcesLeft, nodeInfo, nodeGroup)
+	checkResult, err := tracker.CheckDelta(o.autoscalingCtx, nodeGroup, nodeInfo.Node(), newNodes)
+	if err != nil {
+		return 0, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("failed to check resource quotas: ")
+	}
+	return checkResult.AllowedDelta, nil
 }
 
 // ScaleUpToNodeGroupMinSize tries to scale up node groups that have less nodes
@@ -309,9 +318,9 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 	nodeGroups := o.autoscalingCtx.CloudProvider.NodeGroups()
 	scaleUpInfos := make([]nodegroupset.ScaleUpInfo, 0)
 
-	resourcesLeft, aErr := o.resourceManager.ResourcesLeft(o.autoscalingCtx, nodeInfos, nodes)
-	if aErr != nil {
-		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, aErr.AddPrefix("could not compute total resources: "))
+	tracker, err := o.quotasTrackerFactory.NewQuotasTracker(o.autoscalingCtx, nodes)
+	if err != nil {
+		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("could not create quotas tracker: "))
 	}
 
 	for _, ng := range nodeGroups {
@@ -342,17 +351,18 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 			continue
 		}
 
-		if skipReason := o.IsNodeGroupResourceExceeded(resourcesLeft, ng, nodeInfo, 1); skipReason != nil {
+		if skipReason := o.IsNodeGroupResourceExceeded(tracker, ng, nodeInfo, 1); skipReason != nil {
 			klog.Warningf("ScaleUpToNodeGroupMinSize: node group resource excceded: %v", skipReason)
 			continue
 		}
 
 		newNodeCount := ng.MinSize() - targetSize
-		newNodeCount, err = o.resourceManager.ApplyLimits(o.autoscalingCtx, newNodeCount, resourcesLeft, nodeInfo, ng)
+		checkResult, err := tracker.CheckDelta(o.autoscalingCtx, ng, nodeInfo.Node(), newNodeCount)
 		if err != nil {
-			klog.Warningf("ScaleUpToNodeGroupMinSize: failed to apply resource limits: %v", err)
+			klog.Warningf("ScaleUpToNodeGroupMinSize: failed to check resource quotas: %v", err)
 			continue
 		}
+		newNodeCount = checkResult.AllowedDelta
 
 		newNodeCount, err = o.GetCappedNewNodeCount(newNodeCount, targetSize)
 		if err != nil {
@@ -397,7 +407,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 	nodeGroups []cloudprovider.NodeGroup,
 	nodeInfos map[string]*framework.NodeInfo,
-	resourcesLeft resource.Limits,
+	tracker *resourcequotas.Tracker,
 	currentNodeCount int,
 	now time.Time,
 ) ([]cloudprovider.NodeGroup, map[string]status.Reasons) {
@@ -441,7 +451,7 @@ func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 			skippedNodeGroups[nodeGroup.Id()] = NotReadyReason
 			continue
 		}
-		if skipReason := o.IsNodeGroupResourceExceeded(resourcesLeft, nodeGroup, nodeInfo, numNodes); skipReason != nil {
+		if skipReason := o.IsNodeGroupResourceExceeded(tracker, nodeGroup, nodeInfo, numNodes); skipReason != nil {
 			skippedNodeGroups[nodeGroup.Id()] = skipReason
 			continue
 		}
@@ -664,31 +674,35 @@ func (o *ScaleUpOrchestrator) IsNodeGroupReadyToScaleUp(nodeGroup cloudprovider.
 }
 
 // IsNodeGroupResourceExceeded returns nil if node group resource limits are not exceeded, otherwise a reason is provided.
-func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(resourcesLeft resource.Limits, nodeGroup cloudprovider.NodeGroup, nodeInfo *framework.NodeInfo, numNodes int) status.Reasons {
-	resourcesDelta, err := o.resourceManager.DeltaForNode(o.autoscalingCtx, nodeInfo, nodeGroup)
+func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfo *framework.NodeInfo, numNodes int) status.Reasons {
+	checkResult, err := tracker.CheckDelta(o.autoscalingCtx, nodeGroup, nodeInfo.Node(), numNodes)
 	if err != nil {
-		klog.Errorf("Skipping node group %s; error getting node group resources: %v", nodeGroup.Id(), err)
+		klog.Errorf("Skipping node group %s; error checking resource quotas: %v", nodeGroup.Id(), err)
 		return NotReadyReason
 	}
 
-	for resource, delta := range resourcesDelta {
-		resourcesDelta[resource] = delta * int64(numNodes)
-	}
-
-	checkResult := resource.CheckDeltaWithinLimits(resourcesLeft, resourcesDelta)
-	if checkResult.Exceeded {
-		klog.V(4).Infof("Skipping node group %s; maximal limit exceeded for %v", nodeGroup.Id(), checkResult.ExceededResources)
-		for _, resource := range checkResult.ExceededResources {
-			switch resource {
-			case cloudprovider.ResourceNameCores:
-				metrics.RegisterSkippedScaleUpCPU()
-			case cloudprovider.ResourceNameMemory:
-				metrics.RegisterSkippedScaleUpMemory()
-			default:
-				continue
+	if checkResult.Exceeded() {
+		resources := make(sets.Set[string])
+		for _, quota := range checkResult.ExceededQuotas {
+			klog.V(4).Infof(
+				"Skipping node group %s; %q quota exceeded, resources: %v", nodeGroup.Id(), quota.ID, quota.ExceededResources,
+			)
+			for _, resource := range quota.ExceededResources {
+				if resources.Has(resource) {
+					continue
+				}
+				resources.Insert(resource)
+				switch resource {
+				case cloudprovider.ResourceNameCores:
+					metrics.RegisterSkippedScaleUpCPU()
+				case cloudprovider.ResourceNameMemory:
+					metrics.RegisterSkippedScaleUpMemory()
+				default:
+					continue
+				}
 			}
 		}
-		return NewMaxResourceLimitReached(checkResult.ExceededResources)
+		return NewMaxResourceLimitReached(checkResult.ExceededQuotas)
 	}
 	return nil
 }

--- a/cluster-autoscaler/core/scaleup/scaleup.go
+++ b/cluster-autoscaler/core/scaleup/scaleup.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -39,6 +40,7 @@ type Orchestrator interface {
 		clusterStateRegistry *clusterstate.ClusterStateRegistry,
 		estimatorBuilder estimator.EstimatorBuilder,
 		taintConfig taints.TaintConfig,
+		quotasTrackerFactory *resourcequotas.TrackerFactory,
 	)
 	// ScaleUp tries to scale the cluster up. Returns appropriate status or error if
 	// an unexpected error occurred. Assumes that all nodes in the cluster are ready

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -37,6 +37,7 @@ import (
 	processor_callbacks "k8s.io/autoscaler/cluster-autoscaler/processors/callbacks"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
@@ -118,6 +119,7 @@ type ScaleUpTestConfig struct {
 	NodeTemplateConfigs     map[string]*NodeTemplateConfig
 	EnableAutoprovisioning  bool
 	AllOrNothing            bool
+	ResourceQuotas          []resourcequotas.Quota
 }
 
 // ScaleUpTestResult represents a node groups scale up result

--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -41,6 +41,14 @@ func isVirtualKubeletNode(node *apiv1.Node) bool {
 	return node.ObjectMeta.Labels["type"] == VirtualKubeletNodeLabelValue
 }
 
+// VirtualKubeletNodeFilter excludes virtual kubelet nodes from quota tracking.
+type VirtualKubeletNodeFilter struct{}
+
+// ExcludeFromTracking returns true if the node is created by virtual kubelet.
+func (f VirtualKubeletNodeFilter) ExcludeFromTracking(node *apiv1.Node) bool {
+	return isVirtualKubeletNode(node)
+}
+
 // FilterOutNodesFromNotAutoscaledGroups return subset of input nodes for which cloud provider does not
 // return autoscaled node group.
 func FilterOutNodesFromNotAutoscaledGroups(nodes []*apiv1.Node, cloudProvider cloudprovider.CloudProvider) ([]*apiv1.Node, errors.AutoscalerError) {

--- a/cluster-autoscaler/core/utils/utils_test.go
+++ b/cluster-autoscaler/core/utils/utils_test.go
@@ -98,7 +98,7 @@ func TestGetOldestPod(t *testing.T) {
 	assert.Equal(t, p1.CreationTimestamp.Time, GetOldestCreateTime([]*apiv1.Pod{p3, p2, p1}))
 }
 
-func TestIsVirtualNode(t *testing.T) {
+func TestVirtualKubeletNodeFilter(t *testing.T) {
 	type args struct {
 		node *apiv1.Node
 	}
@@ -143,7 +143,8 @@ func TestIsVirtualNode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, isVirtualKubeletNode(tt.args.node), "isVirtualNode(%v)", tt.args.node)
+			f := VirtualKubeletNodeFilter{}
+			assert.Equalf(t, tt.want, f.ExcludeFromTracking(tt.args.node), "VirtualKubeletNodeFilter.ExcludeFromTracking(%v)", tt.args.node)
 		})
 	}
 }

--- a/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
+++ b/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
 
@@ -65,10 +66,11 @@ func (o *bestEffortAtomicProvClass) Initialize(
 	estimatorBuilder estimator.EstimatorBuilder,
 	taintConfig taints.TaintConfig,
 	injector *scheduling.HintingSimulator,
+	quotasTrackerFactory *resourcequotas.TrackerFactory,
 ) {
 	o.autoscalingCtx = autoscalingCtx
 	o.injector = injector
-	o.scaleUpOrchestrator.Initialize(autoscalingCtx, processors, clusterStateRegistry, estimatorBuilder, taintConfig)
+	o.scaleUpOrchestrator.Initialize(autoscalingCtx, processors, clusterStateRegistry, estimatorBuilder, taintConfig, quotasTrackerFactory)
 }
 
 // Provision returns success if there is, or has just been requested, sufficient capacity in the cluster for pods from ProvisioningRequest.

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/conditions"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqclient"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqwrapper"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -76,6 +77,7 @@ func (o *checkCapacityProvClass) Initialize(
 	estimatorBuilder estimator.EstimatorBuilder,
 	taintConfig taints.TaintConfig,
 	schedulingSimulator *scheduling.HintingSimulator,
+	quotasTrackerFactory *resourcequotas.TrackerFactory,
 ) {
 	o.autoscalingCtx = autoscalingCtx
 	o.schedulingSimulator = schedulingSimulator

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqclient"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	ca_errors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -39,7 +40,7 @@ type ProvisioningClass interface {
 	Provision([]*apiv1.Pod, []*apiv1.Node, []*appsv1.DaemonSet,
 		map[string]*framework.NodeInfo) (*status.ScaleUpStatus, ca_errors.AutoscalerError)
 	Initialize(*ca_context.AutoscalingContext, *ca_processors.AutoscalingProcessors, *clusterstate.ClusterStateRegistry,
-		estimator.EstimatorBuilder, taints.TaintConfig, *scheduling.HintingSimulator)
+		estimator.EstimatorBuilder, taints.TaintConfig, *scheduling.HintingSimulator, *resourcequotas.TrackerFactory)
 }
 
 // provReqOrchestrator is an orchestrator that contains orchestrators for all supported Provisioning Classes.
@@ -66,12 +67,13 @@ func (o *provReqOrchestrator) Initialize(
 	clusterStateRegistry *clusterstate.ClusterStateRegistry,
 	estimatorBuilder estimator.EstimatorBuilder,
 	taintConfig taints.TaintConfig,
+	quotasTrackerFactory *resourcequotas.TrackerFactory,
 ) {
 	o.initialized = true
 	o.autoscalingCtx = autoscalingCtx
 	o.injector = scheduling.NewHintingSimulator()
 	for _, mode := range o.provisioningClasses {
-		mode.Initialize(autoscalingCtx, processors, clusterStateRegistry, estimatorBuilder, taintConfig, o.injector)
+		mode.Initialize(autoscalingCtx, processors, clusterStateRegistry, estimatorBuilder, taintConfig, o.injector, quotasTrackerFactory)
 	}
 }
 

--- a/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -50,16 +51,10 @@ func NewWrapperOrchestrator(provReqOrchestrator scaleup.Orchestrator) *WrapperOr
 }
 
 // Initialize initializes the orchestrator object with required fields.
-func (o *WrapperOrchestrator) Initialize(
-	autoscalingCtx *ca_context.AutoscalingContext,
-	processors *ca_processors.AutoscalingProcessors,
-	clusterStateRegistry *clusterstate.ClusterStateRegistry,
-	estimatorBuilder estimator.EstimatorBuilder,
-	taintConfig taints.TaintConfig,
-) {
+func (o *WrapperOrchestrator) Initialize(autoscalingCtx *ca_context.AutoscalingContext, processors *ca_processors.AutoscalingProcessors, clusterStateRegistry *clusterstate.ClusterStateRegistry, estimatorBuilder estimator.EstimatorBuilder, taintConfig taints.TaintConfig, quotasTrackerFactory *resourcequotas.TrackerFactory) {
 	o.autoscalingCtx = autoscalingCtx
-	o.podsOrchestrator.Initialize(autoscalingCtx, processors, clusterStateRegistry, estimatorBuilder, taintConfig)
-	o.provReqOrchestrator.Initialize(autoscalingCtx, processors, clusterStateRegistry, estimatorBuilder, taintConfig)
+	o.podsOrchestrator.Initialize(autoscalingCtx, processors, clusterStateRegistry, estimatorBuilder, taintConfig, quotasTrackerFactory)
+	o.provReqOrchestrator.Initialize(autoscalingCtx, processors, clusterStateRegistry, estimatorBuilder, taintConfig, quotasTrackerFactory)
 }
 
 // ScaleUp run scaleUp function for regular pods of pods from ProvisioningRequest.

--- a/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -77,13 +78,7 @@ func (f *fakeScaleUp) ScaleUp(
 	return nil, errors.NewAutoscalerError(errors.InternalError, f.errorMsg)
 }
 
-func (f *fakeScaleUp) Initialize(
-	autoscalingCtx *ca_context.AutoscalingContext,
-	processors *ca_processors.AutoscalingProcessors,
-	clusterStateRegistry *clusterstate.ClusterStateRegistry,
-	estimatorBuilder estimator.EstimatorBuilder,
-	taintConfig taints.TaintConfig,
-) {
+func (f *fakeScaleUp) Initialize(autoscalingCtx *ca_context.AutoscalingContext, processors *ca_processors.AutoscalingProcessors, clusterStateRegistry *clusterstate.ClusterStateRegistry, estimatorBuilder estimator.EstimatorBuilder, taintConfig taints.TaintConfig, quotasTrackerFactory *resourcequotas.TrackerFactory) {
 }
 
 func (f *fakeScaleUp) ScaleUpToNodeGroupMinSize(

--- a/cluster-autoscaler/resourcequotas/cache.go
+++ b/cluster-autoscaler/resourcequotas/cache.go
@@ -77,7 +77,9 @@ func totalNodeResources(autoscalingCtx *cacontext.AutoscalingContext, crp custom
 	}
 
 	for _, resourceTarget := range resourceTargets {
-		nodeResources[resourceTarget.ResourceType] = resourceTarget.ResourceCount
+		if resourceTarget.ResourceType != "" && resourceTarget.ResourceCount > 0 {
+			nodeResources[resourceTarget.ResourceType] = resourceTarget.ResourceCount
+		}
 	}
 
 	return nodeResources, nil

--- a/cluster-autoscaler/resourcequotas/factory.go
+++ b/cluster-autoscaler/resourcequotas/factory.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
+	"k8s.io/klog/v2"
 )
 
 // TrackerFactory builds quota trackers.
@@ -63,6 +64,7 @@ func (f *TrackerFactory) NewQuotasTracker(autoscalingCtx *context.AutoscalingCon
 	}
 	var quotaStatuses []*quotaStatus
 	for _, rq := range quotas {
+		klog.V(5).Infof("Quota %q status: limits: %v, usages: %v", rq.ID(), rq.Limits(), usages[rq.ID()])
 		limitsLeft := make(resourceList)
 		limits := rq.Limits()
 		for resourceType, limit := range limits {

--- a/cluster-autoscaler/resourcequotas/testutils.go
+++ b/cluster-autoscaler/resourcequotas/testutils.go
@@ -54,20 +54,53 @@ func (f *fakeCustomResourcesProcessor) GetNodeResourceTargets(context *context.A
 func (f *fakeCustomResourcesProcessor) CleanUp() {
 }
 
-type fakeQuota struct {
-	id          string
-	appliesToFn func(*apiv1.Node) bool
-	limits      resourceList
+// FakeQuota is a simple implementation of Quota for testing.
+type FakeQuota struct {
+	Name        string
+	AppliesToFn func(*apiv1.Node) bool
+	LimitsVal   map[string]int64
 }
 
-func (f *fakeQuota) ID() string {
-	return f.id
+// ID returns the name of the quota.
+func (f *FakeQuota) ID() string {
+	return f.Name
 }
 
-func (f *fakeQuota) AppliesTo(node *apiv1.Node) bool {
-	return f.appliesToFn(node)
+// AppliesTo checks if a node applies to the quota, which is determined by the result of `AppliesToFn`.
+func (f *FakeQuota) AppliesTo(node *apiv1.Node) bool {
+	return f.AppliesToFn(node)
 }
 
-func (f *fakeQuota) Limits() map[string]int64 {
-	return f.limits
+// Limits returns the limits defined by the quota.
+func (f *FakeQuota) Limits() map[string]int64 {
+	return f.LimitsVal
+}
+
+// MatchEveryNode returns true for every passed node.
+func MatchEveryNode(_ *apiv1.Node) bool {
+	return true
+}
+
+// FakeProvider is a fake implementation of Provider for testing.
+type FakeProvider struct {
+	quotas []Quota
+	err    error
+}
+
+// Quotas returns quotas or error explicitly passed to the fake provider.
+func (f *FakeProvider) Quotas() ([]Quota, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.quotas, nil
+}
+
+// NewFakeProvider returns a new FakeProvider with hard coded quotas.
+func NewFakeProvider(quotas []Quota) *FakeProvider {
+	return &FakeProvider{quotas: quotas}
+}
+
+// NewFailingProvider returns a new FakeProvider with an error.
+func NewFailingProvider(err error) *FakeProvider {
+	return &FakeProvider{err: err}
 }

--- a/cluster-autoscaler/resourcequotas/tracker.go
+++ b/cluster-autoscaler/resourcequotas/tracker.go
@@ -32,7 +32,7 @@ type Quota interface {
 	ID() string
 	// AppliesTo returns true if the quota applies to the given node.
 	AppliesTo(node *corev1.Node) bool
-	// Limits returns the resource limits defined by the quota.
+	// Limits returns the resource LimitsVal defined by the quota.
 	Limits() map[string]int64
 }
 

--- a/cluster-autoscaler/resourcequotas/tracker_test.go
+++ b/cluster-autoscaler/resourcequotas/tracker_test.go
@@ -42,7 +42,7 @@ func TestCheckDelta(t *testing.T) {
 			name: "delta fits within limits",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 10, "memory": 1000, "nodes": 5},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -56,7 +56,7 @@ func TestCheckDelta(t *testing.T) {
 			name: "delta exceeds one resource limit",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 1, "memory": 1000, "nodes": 5},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -74,7 +74,7 @@ func TestCheckDelta(t *testing.T) {
 			name: "delta exceeds multiple resource limits",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 1, "memory": 300, "nodes": 5},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -92,11 +92,11 @@ func TestCheckDelta(t *testing.T) {
 			name: "delta exceeds multiple quotas",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 1, "memory": 2000, "nodes": 5},
 				},
 				{
-					quota:      &fakeQuota{id: "limiter2", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter2", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 10, "memory": 300, "nodes": 5},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -115,11 +115,11 @@ func TestCheckDelta(t *testing.T) {
 			name: "delta exceeds one out of multiple quotas",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 1, "memory": 2000, "nodes": 5},
 				},
 				{
-					quota:      &fakeQuota{id: "limiter2", appliesToFn: func(*apiv1.Node) bool { return false }},
+					quota:      &FakeQuota{Name: "limiter2", AppliesToFn: func(*apiv1.Node) bool { return false }},
 					limitsLeft: resourceList{"cpu": 10, "memory": 300, "nodes": 5},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -137,7 +137,7 @@ func TestCheckDelta(t *testing.T) {
 			name: "no matching quotas",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return false }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return false }},
 					limitsLeft: resourceList{"cpu": 1, "memory": 100, "nodes": 1},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -151,7 +151,7 @@ func TestCheckDelta(t *testing.T) {
 			name: "resource in limits but not in the node",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 4, "memory": 32 * units.GiB, "gpu": 2},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -165,7 +165,7 @@ func TestCheckDelta(t *testing.T) {
 			name: "resource in the node but not in the limits",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 4, "memory": 32 * units.GiB},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{NodeResourceTargets: func(node *apiv1.Node) []customresources.CustomResourceTarget {
@@ -216,7 +216,7 @@ func TestApplyDelta(t *testing.T) {
 			name: "delta applied successfully",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 10, "memory": 1000, "nodes": 5},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -233,7 +233,7 @@ func TestApplyDelta(t *testing.T) {
 			name: "partial delta calculated, nothing applied",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 3, "memory": 1000, "nodes": 5},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -253,7 +253,7 @@ func TestApplyDelta(t *testing.T) {
 			name: "delta not applied because it exceeds limits",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 1, "memory": 100, "nodes": 5},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),
@@ -273,7 +273,7 @@ func TestApplyDelta(t *testing.T) {
 			name: "applied delta results in zero limit",
 			tracker: newTracker([]*quotaStatus{
 				{
-					quota:      &fakeQuota{id: "limiter1", appliesToFn: func(*apiv1.Node) bool { return true }},
+					quota:      &FakeQuota{Name: "limiter1", AppliesToFn: func(*apiv1.Node) bool { return true }},
 					limitsLeft: resourceList{"cpu": 2, "memory": 500, "nodes": 10},
 				},
 			}, newNodeResourcesCache(&fakeCustomResourcesProcessor{})),

--- a/cluster-autoscaler/resourcequotas/usage.go
+++ b/cluster-autoscaler/resourcequotas/usage.go
@@ -29,6 +29,27 @@ type NodeFilter interface {
 	ExcludeFromTracking(node *corev1.Node) bool
 }
 
+// CombinedNodeFilter combines multiple node filters.
+type CombinedNodeFilter struct {
+	filters []NodeFilter
+}
+
+// NewCombinedNodeFilter creates a new CombinedNodeFilter.
+func NewCombinedNodeFilter(filters []NodeFilter) *CombinedNodeFilter {
+	return &CombinedNodeFilter{filters: filters}
+}
+
+// ExcludeFromTracking calls ExcludeFromTracking on all filters and returns true
+// if any of them returns true.
+func (f *CombinedNodeFilter) ExcludeFromTracking(node *corev1.Node) bool {
+	for _, filter := range f.filters {
+		if filter.ExcludeFromTracking(node) {
+			return true
+		}
+	}
+	return false
+}
+
 type usageCalculator struct {
 	nodeFilter NodeFilter
 	nodeCache  *nodeResourcesCache

--- a/cluster-autoscaler/resourcequotas/usage_test.go
+++ b/cluster-autoscaler/resourcequotas/usage_test.go
@@ -44,9 +44,9 @@ func TestCalculateUsages(t *testing.T) {
 				test.BuildTestNode("n3", 3000, 8000),
 			},
 			quotas: []Quota{
-				&fakeQuota{
-					id:          "cluster-wide",
-					appliesToFn: includeAll,
+				&FakeQuota{
+					Name:        "cluster-wide",
+					AppliesToFn: includeAll,
 				},
 			},
 			wantUsages: map[string]resourceList{
@@ -65,13 +65,13 @@ func TestCalculateUsages(t *testing.T) {
 				addLabel(test.BuildTestNode("n3", 3000, 8000), "pool", "a"),
 			},
 			quotas: []Quota{
-				&fakeQuota{
-					id:          "pool-a",
-					appliesToFn: func(node *apiv1.Node) bool { return node.Labels["pool"] == "a" },
+				&FakeQuota{
+					Name:        "pool-a",
+					AppliesToFn: func(node *apiv1.Node) bool { return node.Labels["pool"] == "a" },
 				},
-				&fakeQuota{
-					id:          "pool-b",
-					appliesToFn: func(node *apiv1.Node) bool { return node.Labels["pool"] == "b" },
+				&FakeQuota{
+					Name:        "pool-b",
+					AppliesToFn: func(node *apiv1.Node) bool { return node.Labels["pool"] == "b" },
 				},
 			},
 			wantUsages: map[string]resourceList{
@@ -95,9 +95,9 @@ func TestCalculateUsages(t *testing.T) {
 				test.BuildTestNode("n3", 3000, 8000),
 			},
 			quotas: []Quota{
-				&fakeQuota{
-					id:          "cluster-wide",
-					appliesToFn: includeAll,
+				&FakeQuota{
+					Name:        "cluster-wide",
+					AppliesToFn: includeAll,
 				},
 			},
 			nodeFilter: func(node *apiv1.Node) bool { return node.Name == "n2" },
@@ -115,9 +115,9 @@ func TestCalculateUsages(t *testing.T) {
 				test.BuildTestNode("n1", 1000, 2000),
 			},
 			quotas: []Quota{
-				&fakeQuota{
-					id:          "no-match",
-					appliesToFn: func(node *apiv1.Node) bool { return false },
+				&FakeQuota{
+					Name:        "no-match",
+					AppliesToFn: func(node *apiv1.Node) bool { return false },
 				},
 			},
 			wantUsages: map[string]resourceList{
@@ -131,9 +131,9 @@ func TestCalculateUsages(t *testing.T) {
 				test.BuildTestNode("n2", 2000, 4000),
 			},
 			quotas: []Quota{
-				&fakeQuota{
-					id:          "cluster-wide",
-					appliesToFn: includeAll,
+				&FakeQuota{
+					Name:        "cluster-wide",
+					AppliesToFn: includeAll,
 				},
 			},
 			customTargets: map[string][]customresources.CustomResourceTarget{
@@ -158,13 +158,13 @@ func TestCalculateUsages(t *testing.T) {
 				addLabel(test.BuildTestNode("n3", 3000, 8000), "pool", "a"),
 			},
 			quotas: []Quota{
-				&fakeQuota{
-					id:          "pool-a",
-					appliesToFn: func(node *apiv1.Node) bool { return node.Labels["pool"] == "a" },
+				&FakeQuota{
+					Name:        "pool-a",
+					AppliesToFn: func(node *apiv1.Node) bool { return node.Labels["pool"] == "a" },
 				},
-				&fakeQuota{
-					id:          "pool-b",
-					appliesToFn: func(node *apiv1.Node) bool { return node.Labels["pool"] == "b" },
+				&FakeQuota{
+					Name:        "pool-b",
+					AppliesToFn: func(node *apiv1.Node) bool { return node.Labels["pool"] == "b" },
 				},
 			},
 			nodeFilter: func(node *apiv1.Node) bool { return node.Name == "n3" },
@@ -210,7 +210,7 @@ func TestCalculateUsages(t *testing.T) {
 	}
 }
 
-func includeAll(node *apiv1.Node) bool {
+func includeAll(_ *apiv1.Node) bool {
 	return true
 }
 
@@ -220,4 +220,67 @@ func addLabel(node *apiv1.Node, key, value string) *apiv1.Node {
 	}
 	node.Labels[key] = value
 	return node
+}
+
+type nodeFilterFunc func(*apiv1.Node) bool
+
+func (f nodeFilterFunc) ExcludeFromTracking(node *apiv1.Node) bool { return f(node) }
+
+func TestCombinedNodeFilter(t *testing.T) {
+	alwaysExclude := nodeFilterFunc(func(n *apiv1.Node) bool { return true })
+	neverExclude := nodeFilterFunc(func(n *apiv1.Node) bool { return false })
+
+	testCases := []struct {
+		name    string
+		filters []NodeFilter
+		node    *apiv1.Node
+		exclude bool
+	}{
+		{
+			name:    "no-filters",
+			filters: []NodeFilter{},
+			node:    &apiv1.Node{},
+			exclude: false,
+		},
+		{
+			name:    "one-filter-excludes",
+			filters: []NodeFilter{alwaysExclude},
+			node:    &apiv1.Node{},
+			exclude: true,
+		},
+		{
+			name:    "one-filter-includes",
+			filters: []NodeFilter{neverExclude},
+			node:    &apiv1.Node{},
+			exclude: false,
+		},
+		{
+			name:    "multiple-filters-one-excludes",
+			filters: []NodeFilter{neverExclude, alwaysExclude},
+			node:    &apiv1.Node{},
+			exclude: true,
+		},
+		{
+			name:    "multiple-filters-none-exclude",
+			filters: []NodeFilter{neverExclude, neverExclude},
+			node:    &apiv1.Node{},
+			exclude: false,
+		},
+		{
+			name:    "multiple-filters-all-exclude",
+			filters: []NodeFilter{alwaysExclude, alwaysExclude},
+			node:    &apiv1.Node{},
+			exclude: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			combinedFilter := NewCombinedNodeFilter(tc.filters)
+			got := combinedFilter.ExcludeFromTracking(tc.node)
+			if got != tc.exclude {
+				t.Errorf("ExcludeFromTracking() = %v, want %v", got, tc.exclude)
+			}
+		})
+	}
 }


### PR DESCRIPTION

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Integrating new `resourcequotas` package with scale up orchestrator. `resourcequotas` replaces the old resource management done by `k8s.io/autoscaling/cluster-autoscaler/core/scaleup/resource` package.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/autoscaler/issues/8703

#### Special notes for your reviewer:
Please focus on possible regressions. I tested it manually on GKE and added some unit tests, but since the changes directly touch the most important CA functionality, let's ensure that we don't break anything here.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
