### PR TITLE
Enhancement/Bug Fix: Update OCI provider nodepool and error propagation and  tests

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_cloud_provider.go
@@ -161,7 +161,12 @@ func BuildOCI(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDis
 	if strings.HasPrefix(ocidType, npconsts.OciNodePoolResourceIdent) && nodepoolTagsFound == true {
 		klog.Fatalf("-nodes and -node-group-auto-discovery parameters can not be used together.")
 	} else if strings.HasPrefix(ocidType, npconsts.OciNodePoolResourceIdent) || nodepoolTagsFound == true {
-		manager, err := nodepools.CreateNodePoolManager(opts.CloudConfig, opts.NodeGroupAutoDiscovery, do, createKubeClient(opts.AutoscalingOptions))
+		manager, err := nodepools.CreateNodePoolManager(
+			opts.CloudConfig,
+			opts.NodeGroupAutoDiscovery,
+			do,
+			createKubeClient(opts.AutoscalingOptions),
+			opts.AutoscalingOptions.NodeGroupDefaults.MaxNodeProvisionTime)
 		if err != nil {
 			klog.Fatalf("Could not create OCI OKE cloud provider: %v", err)
 		}

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -87,7 +88,7 @@ type okeClient interface {
 }
 
 // CreateNodePoolManager creates an NodePoolManager that can manage autoscaling node pools
-func CreateNodePoolManager(cloudConfigPath string, nodeGroupAutoDiscoveryList []string, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, kubeClient kubernetes.Interface) (NodePoolManager, error) {
+func CreateNodePoolManager(cloudConfigPath string, nodeGroupAutoDiscoveryList []string, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, kubeClient kubernetes.Interface, maxNodeProvisionTime time.Duration) (NodePoolManager, error) {
 
 	var err error
 	var configProvider common.ConfigurationProvider
@@ -153,14 +154,16 @@ func CreateNodePoolManager(cloudConfigPath string, nodeGroupAutoDiscoveryList []
 	registeredTaintsGetter := CreateRegisteredTaintsGetter()
 
 	manager := &ociManagerImpl{
-		cfg:                    cloudConfig,
-		okeClient:              &okeClient,
-		computeClient:          &computeClient,
-		staticNodePools:        map[string]NodePool{},
-		ociShapeGetter:         ociShapeGetter,
-		ociTagsGetter:          ociTagsGetter,
-		registeredTaintsGetter: registeredTaintsGetter,
-		nodePoolCache:          newNodePoolCache(&okeClient),
+		cfg:                       cloudConfig,
+		okeClient:                 &okeClient,
+		computeClient:             &computeClient,
+		staticNodePools:           map[string]NodePool{},
+		ociShapeGetter:            ociShapeGetter,
+		ociTagsGetter:             ociTagsGetter,
+		registeredTaintsGetter:    registeredTaintsGetter,
+		nodePoolCache:             newNodePoolCache(&okeClient),
+		instanceCreationTimeCache: make(map[string]time.Time),
+		maxNodeProvisionTime:      maxNodeProvisionTime,
 	}
 
 	// auto discover nodepools from compartments with nodeGroupAutoDiscovery parameter
@@ -373,11 +376,15 @@ type ociManagerImpl struct {
 	staticNodePools        map[string]NodePool
 	nodeGroups             []nodeGroupAutoDiscovery
 
-	lastRefresh time.Time
+	lastRefresh          time.Time
+	maxNodeProvisionTime time.Duration
 
 	// caches the node pool objects received from OKE.
 	// All interactions with OKE's API should go through the cache.
 	nodePoolCache *nodePoolCache
+
+	instanceCreationTimeCache   map[string]time.Time
+	instanceCreationTimeCacheMu sync.RWMutex
 }
 
 // Refresh triggers refresh of cached resources.
@@ -555,6 +562,38 @@ func getDisplayNamePrefix(clusterId string, nodePoolId string) string {
 		"-" + shortNodePoolId
 }
 
+func (m *ociManagerImpl) exceedsMaxNodeProvisionTime(node oke.Node) bool {
+	if node.Id == nil {
+		return false
+	}
+	// If not configured, treat as disabled (no timeout enforcement).
+	if m.maxNodeProvisionTime <= 0 {
+		return false
+	}
+
+	creationTime, found := m.GetInstanceCreationTimeFromCache(*node.Id)
+
+	if !found {
+		getInstanceResponse, err := m.computeClient.GetInstance(context.Background(), core.GetInstanceRequest{
+			InstanceId: node.Id,
+		})
+		if err != nil {
+			klog.V(4).Infof("OCI node %v is not found in compute: %v", *node.Name, err)
+			return false
+		}
+
+		creationTime = getInstanceResponse.TimeCreated.Time
+		m.SetInstanceCreationTimeInCache(*getInstanceResponse.Id, creationTime)
+	}
+
+	if creationTime.Add(m.maxNodeProvisionTime).After(time.Now()) {
+		return false
+	}
+
+	// Node has exceeded the allowed startup time
+	return true
+}
+
 // GetNodePoolNodes returns NodePool nodes that are not in a terminal state.
 func (m *ociManagerImpl) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance, error) {
 	klog.V(4).Infof("getting nodes for node pool: %q", np.Id())
@@ -567,38 +606,37 @@ func (m *ociManagerImpl) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance
 
 	var instances []cloudprovider.Instance
 	for _, node := range nodePool.Nodes {
+		// Determine whether the node has exceeded MaxNodeProvisionTime
+		isTimedout := node.LifecycleState == oke.NodeLifecycleStateUpdating &&
+			m.exceedsMaxNodeProvisionTime(node)
 
-		if node.NodeError != nil {
-
-			// We should move away from the approach of determining a node error as a Out of host capacity
-			// through string comparison. An error code specifically for Out of host capacity must be set
-			// and returned in the API response.
-			errorClass := cloudprovider.OtherErrorClass
-			if *node.NodeError.Code == "LimitExceeded" ||
-				*node.NodeError.Code == "QuotaExceeded" ||
-				(*node.NodeError.Code == "InternalError" &&
-					strings.Contains(*node.NodeError.Message, "Out of host capacity")) {
-				errorClass = cloudprovider.OutOfResourcesErrorClass
+		var errorInfo *cloudprovider.InstanceErrorInfo
+		// Placeholder node (OOC or LimitExceed) is excluded, and shouldn't push to autoscaler
+		// We should not expect these nodes can register ever (refer to func expectedToRegister in clusterstate.go)
+		if node.Id != nil && *node.Id != "" {
+			if node.NodeError != nil && isTimedout {
+				errorInfo = &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OtherErrorClass,
+					ErrorCode:    *node.NodeError.Code,
+					ErrorMessage: *node.NodeError.Message,
+				}
+			} else if isTimedout {
+				// MaxNodeProvisionTime is exceeded already, but OKE does not set error on the node,
+				// return a default timeout error
+				errorInfo = &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OtherErrorClass,
+					ErrorCode:    "MaxNodeProvisionTimeExceeded",
+					ErrorMessage: "MaxNodeProvisionTimeExceeded",
+				}
 			}
-
-			instances = append(instances, cloudprovider.Instance{
-				Id: *node.Id,
-				Status: &cloudprovider.InstanceStatus{
-					State: cloudprovider.InstanceCreating,
-					ErrorInfo: &cloudprovider.InstanceErrorInfo{
-						ErrorClass:   errorClass,
-						ErrorCode:    *node.NodeError.Code,
-						ErrorMessage: *node.NodeError.Message,
-					},
-				},
-			})
-
-			continue
 		}
 
 		switch node.LifecycleState {
 		case oke.NodeLifecycleStateDeleted:
 			klog.V(4).Infof("skipping instance is in deleted state: %q", *node.Id)
+			if _, found := m.GetInstanceCreationTimeFromCache(*node.Id); found {
+				m.DeleteInstanceCreationTimeInCache(*node.Id)
+			}
 		case oke.NodeLifecycleStateDeleting:
 			instances = append(instances, cloudprovider.Instance{
 				Id: *node.Id,
@@ -606,11 +644,20 @@ func (m *ociManagerImpl) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance
 					State: cloudprovider.InstanceDeleting,
 				},
 			})
-		case oke.NodeLifecycleStateCreating, oke.NodeLifecycleStateUpdating:
+			if _, found := m.GetInstanceCreationTimeFromCache(*node.Id); found {
+				m.DeleteInstanceCreationTimeInCache(*node.Id)
+			}
+		case oke.NodeLifecycleStateCreating:
+			// Node in creating is just a placehold node. We must NOT return it. Otherwise the autoscaler core
+			// will expect that the node can register (refer to func expectedToRegister in clusterstate.go), and
+			// call deleteInstance after it reaches MaxNodeProvisionTime
+			klog.V(4).Infof("skipping placeholder node in Creating state: %v", *node.Name)
+		case oke.NodeLifecycleStateUpdating:
 			instances = append(instances, cloudprovider.Instance{
 				Id: *node.Id,
 				Status: &cloudprovider.InstanceStatus{
-					State: cloudprovider.InstanceCreating,
+					State:     cloudprovider.InstanceCreating,
+					ErrorInfo: errorInfo,
 				},
 			})
 		case oke.NodeLifecycleStateActive:
@@ -873,6 +920,25 @@ func ReasonForError(err error) metav1.StatusReason {
 		return status.Status().Reason
 	}
 	return metav1.StatusReasonUnknown
+}
+
+func (m *ociManagerImpl) GetInstanceCreationTimeFromCache(nodeId string) (time.Time, bool) {
+	m.instanceCreationTimeCacheMu.RLock()
+	defer m.instanceCreationTimeCacheMu.RUnlock()
+	creationTimestamp, found := m.instanceCreationTimeCache[nodeId]
+	return creationTimestamp, found
+}
+
+func (m *ociManagerImpl) SetInstanceCreationTimeInCache(nodeId string, creationTimestamp time.Time) {
+	m.instanceCreationTimeCacheMu.Lock()
+	defer m.instanceCreationTimeCacheMu.Unlock()
+	m.instanceCreationTimeCache[nodeId] = creationTimestamp
+}
+
+func (m *ociManagerImpl) DeleteInstanceCreationTimeInCache(nodeId string) {
+	m.instanceCreationTimeCacheMu.Lock()
+	defer m.instanceCreationTimeCacheMu.Unlock()
+	delete(m.instanceCreationTimeCache, nodeId)
 }
 
 // APIStatus allows the conversion of errors into status objects

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
@@ -214,26 +214,9 @@ func (np *nodePool) DecreaseTargetSize(delta int) error {
 		}
 	}
 	klog.V(4).Infof("DECREASE_TARGET_CHECK_VIA_COMPUTE: %v", decreaseTargetCheckViaComputeBool)
-	np.manager.InvalidateAndRefreshCache()
-	nodes, err := np.manager.GetNodePoolNodes(np)
 	if err != nil {
 		klog.V(4).Error(err, "error while performing GetNodePoolNodes call")
 		return err
-	}
-	// We do not have an OCI API that allows us to delete a node with a compute instance. So we rely on
-	// the below approach to determine the number running instance in a nodepool from the compute API and
-	//update the size of the nodepool accordingly. We should move away from this approach once we have an API
-	// to delete a specific node without a compute instance.
-	if !decreaseTargetCheckViaComputeBool {
-		for _, node := range nodes {
-			if node.Status != nil && node.Status.ErrorInfo != nil {
-				if node.Status.ErrorInfo.ErrorClass == cloudprovider.OutOfResourcesErrorClass {
-					klog.Infof("Using Compute to calculate nodepool size as nodepool may contain nodes without a compute instance.")
-					decreaseTargetCheckViaComputeBool = true
-					break
-				}
-			}
-		}
 	}
 	var nodesLen int
 	if decreaseTargetCheckViaComputeBool {
@@ -243,6 +226,21 @@ func (np *nodePool) DecreaseTargetSize(delta int) error {
 			return err
 		}
 	} else {
+		np.manager.InvalidateAndRefreshCache()
+		nodes, err := np.manager.GetNodePoolNodes(np)
+		if err != nil {
+			klog.V(4).Error(err, "error while performing GetNodePoolNodes call")
+			return err
+		}
+		nodesLen = 0
+		for _, node := range nodes {
+			// Skip OOC nodes to achieve the same effect as DECREASE_TARGET_CHECK_VIA_COMPUTE.
+			// Nodes with no backing instance (i.e., OOC or LimitExceeded) should not be counted and will be excluded from nodeLen.
+			// This ensures that the subsequent SetNodePoolSize call will delete the OOC/LimitExceeded nodes.
+			if node.Id != "" {
+				nodesLen++
+			}
+		}
 		nodesLen = len(nodes)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR improves how the OCI Provider handles node errors.

* OOC/LimitExceeded nodes (without instance IDs) and OKE InstanceCreating placeholder nodes should not be expected to register in the cluster and should be excluded from the expectedToRegister flow. (see the expectedToRegister flow in clusterstate.go), they should be handled in `fixNodeGroupSize` flow

* Nodes with instance IDs (e.g., registration timeouts & NPN errors) are handled in `deleteCreatedNodesWithErrors`.

* ErrorInfo is set when:
    * The node has an OKE NodeError and exceeds maxNodeProvisionTime.
    *  The node is Updating and exceeds maxNodeProvisionTime without an OKE error, in which case a default timeout error is applied.
    
Since DECREASE_TARGET_CHECK_VIA_COMPUTE needs to call Compute, and this is not recommended in production per our discussion offline, this PR can handle OOC/LimitExceeded nodes without using the variable and additional calls.

This behavior is consistent with the intended autoscaler core logic.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:
The change has been released in production for several months[https://bitbucket.oci.oraclecorp.com/projects/OMK/repos/autoscaler/pull-requests/6/overview] and has achieved stable scaling behavior based on the customer set timeout.
#### Does this PR introduce a user-facing change?
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
