### PR TITLE
fix(capacitybuffer): correct spelling mistakes in function names and messages

### DIFF
--- a/cluster-autoscaler/capacitybuffer/common/common.go
+++ b/cluster-autoscaler/capacitybuffer/common/common.go
@@ -45,7 +45,7 @@ func SetBufferAsReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRef *
 		Type:               ReadyForProvisioningCondition,
 		Status:             ConditionTrue,
 		Message:            "ready",
-		Reason:             "atrtibutesSetSuccessfully",
+		Reason:             "attributesSetSuccessfully",
 		LastTransitionTime: metav1.Time{Time: time.Now()},
 	}
 	buffer.Status.Conditions = []metav1.Condition{readyCondition}
@@ -53,7 +53,7 @@ func SetBufferAsReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRef *
 
 // SetBufferAsNotReadyForProvisioning updates the passed buffer object with the rest of the attributes and sets its condition to not ready with the passed error
 func SetBufferAsNotReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRef *v1.LocalObjectRef, podTemplateGeneration *int64, replicas *int32, provStrategy *string, err error) {
-	errorMessage := "Buffer not ready for provisioing"
+	errorMessage := "Buffer not ready for provisioning"
 	if err != nil {
 		errorMessage = err.Error()
 	}
@@ -80,8 +80,8 @@ func mapEmptyProvStrategyToDefault(ps *string) *string {
 	return ps
 }
 
-// UpdateBufferStatusToFailedProvisioing updates the status of the passed buffer and set Provisioning to false with the passes reason and message
-func UpdateBufferStatusToFailedProvisioing(buffer *v1.CapacityBuffer, reason, errorMessage string) {
+// UpdateBufferStatusToFailedProvisioning updates the status of the passed buffer and set Provisioning to false with the passed reason and message
+func UpdateBufferStatusToFailedProvisioning(buffer *v1.CapacityBuffer, reason, errorMessage string) {
 	buffer.Status.Conditions = []metav1.Condition{{
 		Type:               ProvisioningCondition,
 		Status:             ConditionFalse,
@@ -91,8 +91,8 @@ func UpdateBufferStatusToFailedProvisioing(buffer *v1.CapacityBuffer, reason, er
 	}}
 }
 
-// UpdateBufferStatusToSuccessfullyProvisioing updates the status of the passed buffer and set Provisioning to true with the passes reason
-func UpdateBufferStatusToSuccessfullyProvisioing(buffer *v1.CapacityBuffer, reason string) {
+// UpdateBufferStatusToSuccessfullyProvisioning updates the status of the passed buffer and set Provisioning to true with the passed reason
+func UpdateBufferStatusToSuccessfullyProvisioning(buffer *v1.CapacityBuffer, reason string) {
 	buffer.Status.Conditions = []metav1.Condition{{
 		Type:               ProvisioningCondition,
 		Status:             ConditionTrue,

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -134,17 +134,17 @@ func (p *CapacityBufferPodListProcessor) provision(buffer *v1alpha1.CapacityBuff
 	replicas := buffer.Status.Replicas
 	podTemplate, err := p.client.GetPodTemplate(buffer.Namespace, podTemplateName)
 	if err != nil {
-		common.UpdateBufferStatusToFailedProvisioing(buffer, "FailedToGetPodTemplate", fmt.Sprintf("failed to get pod template with error: %v", err.Error()))
+		common.UpdateBufferStatusToFailedProvisioning(buffer, "FailedToGetPodTemplate", fmt.Sprintf("failed to get pod template with error: %v", err.Error()))
 		p.updateBufferStatus(buffer)
 		return []*apiv1.Pod{}
 	}
 	fakePods, err := makeFakePods(buffer, &podTemplate.Template, int(*replicas))
 	if err != nil {
-		common.UpdateBufferStatusToFailedProvisioing(buffer, "FailedToMakeFakePods", fmt.Sprintf("failed to create fake pods with error: %v", err.Error()))
+		common.UpdateBufferStatusToFailedProvisioning(buffer, "FailedToMakeFakePods", fmt.Sprintf("failed to create fake pods with error: %v", err.Error()))
 		p.updateBufferStatus(buffer)
 		return []*apiv1.Pod{}
 	}
-	common.UpdateBufferStatusToSuccessfullyProvisioing(buffer, "FakePodsInjected")
+	common.UpdateBufferStatusToSuccessfullyProvisioning(buffer, "FakePodsInjected")
 	p.updateBufferStatus(buffer)
 	return fakePods
 }


### PR DESCRIPTION
Fixes spelling mistakes in CapacityBuffer common package:
- `atrtibutesSetSuccessfully` → `attributesSetSuccessfully`
- `provisioing` → `provisioning`
- `passes` → `passed`

Updated function names and all call sites. No functional changes.