### PR TITLE
Fix incorrect StatusFilter usage in CapacityBufferPodListProcessor

### DIFF
--- a/cluster-autoscaler/capacitybuffer/common/common.go
+++ b/cluster-autoscaler/capacitybuffer/common/common.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -48,7 +49,7 @@ func SetBufferAsReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRef *
 		Reason:             "atrtibutesSetSuccessfully",
 		LastTransitionTime: metav1.Time{Time: time.Now()},
 	}
-	buffer.Status.Conditions = []metav1.Condition{readyCondition}
+	meta.SetStatusCondition(&buffer.Status.Conditions, readyCondition)
 }
 
 // SetBufferAsNotReadyForProvisioning updates the passed buffer object with the rest of the attributes and sets its condition to not ready with the passed error
@@ -69,7 +70,7 @@ func SetBufferAsNotReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRe
 		Reason:             "error",
 		LastTransitionTime: metav1.Time{Time: time.Now()},
 	}
-	buffer.Status.Conditions = []metav1.Condition{notReadyCondition}
+	meta.SetStatusCondition(&buffer.Status.Conditions, notReadyCondition)
 }
 
 func mapEmptyProvStrategyToDefault(ps *string) *string {
@@ -82,21 +83,23 @@ func mapEmptyProvStrategyToDefault(ps *string) *string {
 
 // UpdateBufferStatusToFailedProvisioing updates the status of the passed buffer and set Provisioning to false with the passes reason and message
 func UpdateBufferStatusToFailedProvisioing(buffer *v1.CapacityBuffer, reason, errorMessage string) {
-	buffer.Status.Conditions = []metav1.Condition{{
+	failedCondition := metav1.Condition{
 		Type:               ProvisioningCondition,
 		Status:             ConditionFalse,
 		Message:            errorMessage,
 		Reason:             reason,
 		LastTransitionTime: metav1.Time{Time: time.Now()},
-	}}
+	}
+	meta.SetStatusCondition(&buffer.Status.Conditions, failedCondition)
 }
 
 // UpdateBufferStatusToSuccessfullyProvisioing updates the status of the passed buffer and set Provisioning to true with the passes reason
 func UpdateBufferStatusToSuccessfullyProvisioing(buffer *v1.CapacityBuffer, reason string) {
-	buffer.Status.Conditions = []metav1.Condition{{
+	successCondition := metav1.Condition{
 		Type:               ProvisioningCondition,
 		Status:             ConditionTrue,
 		Reason:             reason,
 		LastTransitionTime: metav1.Time{Time: time.Now()},
-	}}
+	}
+	meta.SetStatusCondition(&buffer.Status.Conditions, successCondition)
 }

--- a/cluster-autoscaler/capacitybuffer/filters/status_include_filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/status_include_filter.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+)
+
+// statusIncludeFilter includes buffers with the defined conditions (opposite of statusFilter)
+type statusIncludeFilter struct {
+	conditions map[string]string
+}
+
+// NewStatusIncludeFilter creates an instance of statusIncludeFilter that includes only the buffers with conditions in passed conditions.
+func NewStatusIncludeFilter(conditionsToInclude map[string]string) *statusIncludeFilter {
+	return &statusIncludeFilter{
+		conditions: conditionsToInclude,
+	}
+}
+
+// Filter filters the passed buffers to include only those with the specified status conditions
+func (f *statusIncludeFilter) Filter(buffersToFilter []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
+	var included []*v1.CapacityBuffer
+	var excluded []*v1.CapacityBuffer
+
+	for _, buffer := range buffersToFilter {
+		if f.hasAllConditions(buffer) {
+			included = append(included, buffer)
+		} else {
+			excluded = append(excluded, buffer)
+		}
+	}
+	return included, excluded
+}
+
+// hasAllConditions checks if the buffer has all the specified conditions
+func (f *statusIncludeFilter) hasAllConditions(buffer *v1.CapacityBuffer) bool {
+	bufferConditions := buffer.Status.Conditions
+	matchCount := 0
+
+	for condType, condStatus := range f.conditions {
+		for _, condition := range bufferConditions {
+			if condition.Type == condType && string(condition.Status) == condStatus {
+				matchCount++
+				break
+			}
+		}
+	}
+
+	// All specified conditions must be present
+	return matchCount == len(f.conditions)
+}
+
+// CleanUp cleans up the filter's internal structures.
+func (f *statusIncludeFilter) CleanUp() {
+}

--- a/cluster-autoscaler/capacitybuffer/filters/status_include_filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/status_include_filter_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
+)
+
+func TestStatusIncludeFilter(t *testing.T) {
+	tests := []struct {
+		name                    string
+		conditionsToInclude     map[string]string
+		buffers                 []*v1.CapacityBuffer
+		expectedIncludedBuffers []*v1.CapacityBuffer
+		expectedExcludedBuffers []*v1.CapacityBuffer
+	}{
+		{
+			name:                "Empty conditions map, include all",
+			conditionsToInclude: map[string]string{},
+			buffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, testutil.GetConditionReady()),
+			},
+			expectedIncludedBuffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, testutil.GetConditionReady()),
+			},
+			expectedExcludedBuffers: []*v1.CapacityBuffer{},
+		},
+		{
+			name:                "One buffer, include only ready for provisioning",
+			conditionsToInclude: map[string]string{common.ReadyForProvisioningCondition: common.ConditionTrue},
+			buffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, testutil.GetConditionReady()),
+			},
+			expectedIncludedBuffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, testutil.GetConditionReady()),
+			},
+			expectedExcludedBuffers: []*v1.CapacityBuffer{},
+		},
+		{
+			name:                "Two buffers, one included",
+			conditionsToInclude: map[string]string{common.ReadyForProvisioningCondition: common.ConditionTrue},
+			buffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, testutil.GetConditionReady()),
+				getTestBufferWithCondition(testutil.AnotherPodTemplateRefName, testutil.GetConditionNotReady()),
+			},
+			expectedIncludedBuffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, testutil.GetConditionReady()),
+			},
+			expectedExcludedBuffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.AnotherPodTemplateRefName, testutil.GetConditionNotReady()),
+			},
+		},
+		{
+			name:                "Buffer with no conditions, excluded",
+			conditionsToInclude: map[string]string{common.ReadyForProvisioningCondition: common.ConditionTrue},
+			buffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, []metav1.Condition{}),
+			},
+			expectedIncludedBuffers: []*v1.CapacityBuffer{},
+			expectedExcludedBuffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, []metav1.Condition{}),
+			},
+		},
+		{
+			name: "Multiple conditions required, all must match",
+			conditionsToInclude: map[string]string{
+				common.ReadyForProvisioningCondition: common.ConditionTrue,
+				common.ProvisioningCondition:         common.ConditionTrue,
+			},
+			buffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, []metav1.Condition{
+					{Type: common.ReadyForProvisioningCondition, Status: common.ConditionTrue},
+					{Type: common.ProvisioningCondition, Status: common.ConditionTrue},
+				}),
+				getTestBufferWithCondition(testutil.AnotherPodTemplateRefName, testutil.GetConditionReady()),
+			},
+			expectedIncludedBuffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.SomePodTemplateRefName, []metav1.Condition{
+					{Type: common.ReadyForProvisioningCondition, Status: common.ConditionTrue},
+					{Type: common.ProvisioningCondition, Status: common.ConditionTrue},
+				}),
+			},
+			expectedExcludedBuffers: []*v1.CapacityBuffer{
+				getTestBufferWithCondition(testutil.AnotherPodTemplateRefName, testutil.GetConditionReady()),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			statusIncludeFilter := NewStatusIncludeFilter(test.conditionsToInclude)
+			included, excluded := statusIncludeFilter.Filter(test.buffers)
+			assert.ElementsMatch(t, test.expectedIncludedBuffers, included)
+			assert.ElementsMatch(t, test.expectedExcludedBuffers, excluded)
+		})
+	}
+}

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -42,11 +42,10 @@ const (
 // CapacityBufferPodListProcessor processes the pod lists before scale up
 // and adds buffres api virtual pods.
 type CapacityBufferPodListProcessor struct {
-	client               *client.CapacityBufferClient
-	statusFilter         buffersfilter.Filter
-	podTemplateGenFilter buffersfilter.Filter
-	provStrategies       map[string]bool
-	buffersRegistry      *capacityBuffersFakePodsRegistry
+	client          *client.CapacityBufferClient
+	statusFilter    buffersfilter.Filter
+	provStrategies  map[string]bool
+	buffersRegistry *capacityBuffersFakePodsRegistry
 }
 
 // capacityBuffersFakePodsRegistry a struct that keeps the status of capacity buffer
@@ -73,13 +72,11 @@ func NewCapacityBufferPodListProcessor(client *client.CapacityBufferClient, prov
 	}
 	return &CapacityBufferPodListProcessor{
 		client: client,
-		statusFilter: buffersfilter.NewStatusFilter(map[string]string{
+		statusFilter: buffersfilter.NewStatusIncludeFilter(map[string]string{
 			common.ReadyForProvisioningCondition: common.ConditionTrue,
-			common.ProvisioningCondition:         common.ConditionTrue,
 		}),
-		podTemplateGenFilter: buffersfilter.NewPodTemplateGenerationChangedFilter(client),
-		provStrategies:       provStrategiesMap,
-		buffersRegistry:      buffersRegistry,
+		provStrategies:  provStrategiesMap,
+		buffersRegistry: buffersRegistry,
 	}
 }
 
@@ -91,8 +88,7 @@ func (p *CapacityBufferPodListProcessor) Process(autoscalingCtx *ca_context.Auto
 		return unschedulablePods, nil
 	}
 	buffers = p.filterBuffersProvStrategy(buffers)
-	_, buffers = p.statusFilter.Filter(buffers)
-	_, buffers = p.podTemplateGenFilter.Filter(buffers)
+	buffers, _ = p.statusFilter.Filter(buffers)
 
 	totalFakePods := []*apiv1.Pod{}
 	p.clearCapacityBufferRegistry()


### PR DESCRIPTION
## What this PR does:

Fixes #8851 - Corrects filter logic in `CapacityBufferPodListProcessor` to properly select buffers ready for provisioning instead of excluding them.

## Changes:

- Add `StatusIncludeFilter` for inclusive condition filtering
- Replace `StatusFilter` with `StatusIncludeFilter` in PodListProcessor
- Improve condition updates using `meta.SetStatusCondition`
- Remove unnecessary `PodTemplateGenerationChangedFilter`

## Impact:

Before: Virtual pods were never generated for capacity buffers
After: Buffers with `ReadyForProvisioning: True` are correctly processed