### PR TITLE
Allow unboost even if pod replicas less than "min-replicas" flag

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
@@ -40,6 +40,7 @@ import (
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/utils"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
@@ -282,6 +283,21 @@ func TestDisruptReplicatedByController(t *testing.T) {
 			pods: []podWithExpectations{
 				{
 					pod:             generatePod().Get(),
+					canEvict:        true,
+					evictionSuccess: true,
+				},
+			},
+		},
+		{
+			name:              "Can update even a single Pod if CPU boost is in progress.",
+			replicas:          1,
+			evictionTolerance: 0.5,
+			vpa:               getBasicVpa(),
+			pods: []podWithExpectations{
+				{
+					pod: generatePod().WithAnnotations(map[string]string{
+						annotations.StartupCPUBoostAnnotation: "",
+					}).Get(),
 					canEvict:        true,
 					evictionSuccess: true,
 				},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

Existing behaviour:
Boost works for one replica
Unboost does not work with a single replica, meaning the pod stays stuck with the boosted CPU request.

After this PR the unboost will be allowed even pod replicas is less than "min-replicas" flag or minReplicas specifies per VPA.

Startup boost field has priority over any other field in vpa spec except VerticalPodAutoscalerSpec.TargetRef so this check is not needed while unboosting.
https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost#priority-of-startupboost

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: (https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost#aep-7862-cpu-startup-boost)
```

```release-note
NONE
```
