### PR TITLE
Fix startup boost workflow when limit is not set

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
@@ -246,16 +246,15 @@ func (c *resourcesUpdatesPatchCalculator) applyControlledCPUResources(container 
 		if containerResources.Limits == nil {
 			containerResources.Limits = core.ResourceList{}
 		}
-		originalLimit := container.Resources.Limits[core.ResourceCPU]
-		if originalLimit.IsZero() {
-			originalLimit = container.Resources.Requests[core.ResourceCPU]
+		newLimits, _ := vpa_api_util.GetProportionalLimit(
+			container.Resources.Limits,                           // originalLimits
+			container.Resources.Requests,                         // originalRequests
+			core.ResourceList{core.ResourceCPU: *boostedRequest}, // newRequests
+			core.ResourceList{},                                  // defaultLimit
+		)
+		if newLimit, ok := newLimits[core.ResourceCPU]; ok {
+			containerResources.Limits[core.ResourceCPU] = newLimit
 		}
-		recommendedLimit := containerResources.Limits[core.ResourceCPU]
-		boostedLimit, err := c.calculateBoostedCPU(recommendedLimit, originalLimit, startupBoostPolicy)
-		if err != nil {
-			return err
-		}
-		containerResources.Limits[core.ResourceCPU] = *boostedLimit
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

Fixes #
https://github.com/kubernetes/autoscaler/pull/8813#issuecomment-3575424670
Clarify the behaviour in the doc for what happens when limit is not specified in the pod resources  or in the recommendation.


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: (https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost#aep-7862-cpu-startup-boost)
```
