### PR TITLE
Add safe to evict option to capacity buffers injected fake pods

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -197,7 +197,7 @@ func buildAutoscaler(ctx context.Context, debuggingSnapshotter debuggingsnapshot
 			bufferPodInjector := cbprocessor.NewCapacityBufferPodListProcessor(
 				capacitybufferClient,
 				[]string{common.ActiveProvisioningStrategy},
-				buffersPodsRegistry)
+				buffersPodsRegistry, true)
 			podListProcessor = pods.NewCombinedPodListProcessor([]pods.PodListProcessor{bufferPodInjector, podListProcessor})
 			opts.Processors.ScaleUpStatusProcessor = status.NewCombinedScaleUpStatusProcessor([]status.ScaleUpStatusProcessor{
 				cbprocessor.NewFakePodsScaleUpStatusProcessor(buffersPodsRegistry), opts.Processors.ScaleUpStatusProcessor})

--- a/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
@@ -112,7 +112,7 @@ func filterOutCapacityBuffersPod[T any](podsWrappers []T, getPod func(T) *apiv1.
 	filteredOutPodsSources := make([]T, 0)
 	for _, podsWrapper := range podsWrappers {
 		currentPod := getPod(podsWrapper)
-		if isFakeCapacityBuffersPod(currentPod) {
+		if IsFakeCapacityBuffersPod(currentPod) {
 			filteredOutPodsSources = append(filteredOutPodsSources, podsWrapper)
 		} else {
 			filteredPodsSources = append(filteredPodsSources, podsWrapper)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Capacity buffer injects fake pods into CA loop, these pods are meant to create some capacity for user workload, this change allows forcing adding safe-to-evict annotation to the pods so these fake pods are drainable and they do not block any logic requires draining them.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
