### PR TITLE
Make gpu_processor unready filter neutral to all GPU vendors

### DIFF
--- a/cluster-autoscaler/processors/customresources/gpu_processor.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor.go
@@ -48,9 +48,7 @@ func (p *GpuCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autosca
 		}
 
 		_, hasGpuLabel := node.Labels[autoscalingCtx.CloudProvider.GPULabel()]
-		gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[gpu.ResourceNvidiaGPU]
-		directXAllocatable, hasDirectXAllocatable := node.Status.Allocatable[gpu.ResourceDirectX]
-		if hasGpuLabel && ((!hasGpuAllocatable || gpuAllocatable.IsZero()) && (!hasDirectXAllocatable || directXAllocatable.IsZero())) {
+		if hasGpuLabel && !gpu.HasAllocatableGPUResources(node) {
 			klog.V(3).Infof("Overriding status of node %v, which seems to have unready GPU",
 				node.Name)
 			nodesWithUnreadyGpu[node.Name] = kubernetes.GetUnreadyNodeCopy(node, kubernetes.ResourceUnready)

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -123,6 +123,11 @@ func NodeHasGpu(GPULabel string, node *apiv1.Node) bool {
 		return true
 	}
 	// Check for extended resources as well
+	return HasAllocatableGPUResources(node)
+}
+
+// HasAllocatableGPUResources returns true if a given node has any allocatable vendor specific GPU resources.
+func HasAllocatableGPUResources(node *apiv1.Node) bool {
 	for _, gpuVendorResourceName := range GPUVendorResourceNames {
 		gpuAllocatable, hasGpuAllocatable := node.Status.Allocatable[gpuVendorResourceName]
 		if hasGpuAllocatable && !gpuAllocatable.IsZero() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In the function `FilterOutNodesWithUnreadyResources()` of `gpu_processor` package, the implementation is currently using hard coded way to check allocatable GPU resources one by one.

This PR is making the function `FilterOutNodesWithUnreadyResources()` neutral to all known GPU vendor's allocatable resources. In the future there is no need to add more lines in the `gpu_processor` package, all the resource detection implementation could be derived from `utils/gpu` package.

#### Which issue(s) this PR fixes:

NA

#### Special notes for your reviewer:

This is a follow-up PR for https://github.com/kubernetes/autoscaler/pull/8629

#### Does this PR introduce a user-facing change?

NONE

```release-note
Add support amd.com/gpu as allocatable GPU resources  
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
