### PR TITLE
Add cloud-provider for Slicer

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -39,6 +39,7 @@ You should also take a look at the notes and "gotchas" for your specific cloud p
 * [OVHcloud](./cloudprovider/ovhcloud/README.md)
 * [Rancher](./cloudprovider/rancher/README.md)
 * [Scaleway](./cloudprovider/scaleway/README.md)
+* [Slicer](./cloudprovider/slicer/README.md)
 * [TencentCloud](./cloudprovider/tencentcloud/README.md)
 * [Utho](./cloudprovider/utho/README.md)
 * [Vultr](./cloudprovider/vultr/README.md)
@@ -242,6 +243,7 @@ Supported cloud providers:
 * OVHcloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/ovhcloud/README.md
 * Rancher https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/rancher/README.md
 * Scaleway https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/scaleway/README.md
+* Slicer https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/slicer/README.md
 * TencentCloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/tencentcloud/README.md
 * Utho https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/utho/README.md
 * Vultr https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/vultr/README.md

--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.52.1
+version: 9.52.2

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -56,7 +56,7 @@ rules:
 {{- if (eq .Values.cloudProvider "kwok") }}
     - create
 {{- end }}
-{{- if or (eq .Values.cloudProvider "kwok") (eq .Values.cloudProvider "huaweicloud") }}
+{{- if or (eq .Values.cloudProvider "kwok") (eq .Values.cloudProvider "huaweicloud") (eq .Values.cloudProvider "slicer") }}
     - delete
 {{- end }}
     - get

--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -1,5 +1,5 @@
-//go:build !gce && !aws && !azure && !kubemark && !alicloud && !magnum && !digitalocean && !clusterapi && !huaweicloud && !ionoscloud && !linode && !hetzner && !bizflycloud && !brightbox && !equinixmetal && !oci && !vultr && !tencentcloud && !scaleway && !externalgrpc && !civo && !rancher && !volcengine && !baiducloud && !cherry && !cloudstack && !exoscale && !kamatera && !ovhcloud && !kwok && !utho && !coreweave
-// +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum,!digitalocean,!clusterapi,!huaweicloud,!ionoscloud,!linode,!hetzner,!bizflycloud,!brightbox,!equinixmetal,!oci,!vultr,!tencentcloud,!scaleway,!externalgrpc,!civo,!rancher,!volcengine,!baiducloud,!cherry,!cloudstack,!exoscale,!kamatera,!ovhcloud,!kwok,!utho,!coreweave
+//go:build !gce && !aws && !azure && !kubemark && !alicloud && !magnum && !digitalocean && !clusterapi && !huaweicloud && !ionoscloud && !linode && !hetzner && !bizflycloud && !brightbox && !equinixmetal && !oci && !vultr && !tencentcloud && !scaleway && !externalgrpc && !civo && !rancher && !volcengine && !baiducloud && !cherry && !cloudstack && !exoscale && !kamatera && !ovhcloud && !kwok && !utho && !coreweave && !slicer
+// +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum,!digitalocean,!clusterapi,!huaweicloud,!ionoscloud,!linode,!hetzner,!bizflycloud,!brightbox,!equinixmetal,!oci,!vultr,!tencentcloud,!scaleway,!externalgrpc,!civo,!rancher,!volcengine,!baiducloud,!cherry,!cloudstack,!exoscale,!kamatera,!ovhcloud,!kwok,!utho,!coreweave,!slicer
 
 /*
 Copyright 2018 The Kubernetes Authors.
@@ -48,6 +48,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/ovhcloud"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/rancher"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/scaleway"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/slicer"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/tencentcloud"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/utho"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/volcengine"
@@ -89,6 +90,7 @@ var AvailableCloudProviders = []string{
 	cloudprovider.VolcengineProviderName,
 	cloudprovider.UthoProviderName,
 	cloudprovider.CoreWeaveProviderName,
+	cloudprovider.SlicerProviderName,
 }
 
 // DefaultCloudProvider is GCE.
@@ -161,6 +163,9 @@ func buildCloudProvider(opts *coreoptions.AutoscalerOptions,
 		return utho.BuildUtho(opts, do, rl)
 	case cloudprovider.CoreWeaveProviderName:
 		return coreweave.BuildCoreWeave(opts, do, rl)
+	case cloudprovider.SlicerProviderName:
+		return slicer.BuildSlicer(opts, do, rl)
 	}
+
 	return nil
 }

--- a/cluster-autoscaler/cloudprovider/builder/builder_slicer.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_slicer.go
@@ -1,0 +1,44 @@
+//go:build slicer
+// +build slicer
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/slicer"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
+	"k8s.io/client-go/informers"
+)
+
+// AvailableCloudProviders supported by the slicer cloud provider builder.
+var AvailableCloudProviders = []string{
+	cloudprovider.SlicerProviderName,
+}
+
+// DefaultCloudProvider for Slicer-only build is Slicer.
+const DefaultCloudProvider = cloudprovider.SlicerProviderName
+
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+	switch opts.CloudProviderName {
+	case cloudprovider.SlicerProviderName:
+		return slicer.BuildSlicer(opts, do, rl)
+	}
+
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -94,6 +94,8 @@ const (
 	RancherProviderName = "rancher"
 	// UthoProviderName gets the provider name of utho
 	UthoProviderName = "utho"
+	// SlicerProviderName gets the provider name of slicer
+	SlicerProviderName = "slicer"
 )
 
 // GpuConfig contains the label, type and the resource name for a GPU.

--- a/cluster-autoscaler/cloudprovider/slicer/README.md
+++ b/cluster-autoscaler/cloudprovider/slicer/README.md
@@ -17,6 +17,7 @@ The `cluster-autoscaler` with Slicer needs a configuration file to work by using
 |-----|-------|-----------|---------|
 | `global/k3s-url` | The URL of the K3s control plane API server | yes | none |
 | `global/k3s-token` | The K3s join token for adding new agent nodes | yes | none |
+| `global/ca-bundle` | Path to custom CA bundle file for Slicer API calls | no | none (uses system default CAs) |
 | `global/default-min-size` | Default minimum size of a node group (must be > 0) | no | 1 |
 | `global/default-max-size` | Default maximum size of a node group | no | 8 |
 | `nodegroup \"slicer_host_group_name\"/slicer-url` | The URL of the Slicer API server for this node group | yes | none |

--- a/cluster-autoscaler/cloudprovider/slicer/README.md
+++ b/cluster-autoscaler/cloudprovider/slicer/README.md
@@ -1,0 +1,114 @@
+## Slicer Cloud Provider for Cluster Autoscaler
+
+The cluster autoscaler for [Slicer](https://slicervm.com/) scales nodes on lightweight slicer microVMs.
+
+The architecture is as follows:
+
+* Slicer runs a K3s control plane on one virtualisation host.
+* Slicer runs all agents on one or more additional virtualisation hosts running the Slicer REST API. Starting off with zero microVMs and relying on cluster autoscaler to add new ones as Pods cannot be scheduled to the existing set of nodes.
+
+Check the documentation on [SlicerVM.com](https://docs.slicervm.com/examples/autoscaling-k3s/) for instructions on how to setup the cluster-autoscaler with with Slicer.
+
+## Configuration
+
+The `cluster-autoscaler` with Slicer needs a configuration file to work by using the `--cloud-config` parameter, it is an INI file with the following fields:
+
+| Key | Value | Mandatory | Default |
+|-----|-------|-----------|---------|
+| `global/k3s-url` | The URL of the K3s control plane API server | yes | none |
+| `global/k3s-token` | The K3s join token for adding new agent nodes | yes | none |
+| `global/default-min-size` | Default minimum size of a node group (must be > 0) | no | 1 |
+| `global/default-max-size` | Default maximum size of a node group | no | 8 |
+| `nodegroup \"slicer_host_group_name\"/slicer-url` | The URL of the Slicer API server for this node group | yes | none |
+| `nodegroup \"slicer_host_group_name\"/slicer-token` | The authentication token for the Slicer API server | yes | none |
+| `nodegroup \"slicer_host_group_name\"/min-size` | Minimum size for a specific node group | no | global/defaut-min-size |
+| `nodegroup \"slicer_host_group_name\"/max-size` | Maximum size for a specific node group | no | global/defaut-max-size |
+
+## Development
+
+Follow the instructions in the [slicer docs](https://docs.slicervm.com/examples/autoscaling-k3s/) to setup a K3S cluster and host groups for nodes.
+
+Make sure you are inside the `cluster-autoscaler` path of the [autoscaler repository](https://github.com/kubernetes/autoscaler).
+
+### Run out of cluster
+
+Start the cluster-autoscaler:
+
+```bash
+#!/bin/bash
+go run . \
+    --cloud-provider=slicer \
+    --kubeconfig $HOME/k3s-cp-kubeconfig \
+    --scale-down-enabled=true \
+    --scale-down-delay-after-add=30s \
+    --scale-down-unneeded-time=30s \
+    --expendable-pods-priority-cutoff=-10 \
+    --cloud-config="$HOME/cloud-config.ini" \
+    --v=4
+```
+
+### Run in cluster.
+
+Build and publish an image:
+
+```sh
+REGISTRY=ttl.sh/openfaasltd BUILD_TAGS=slicer TAG=dev make dev-release
+```
+
+Create a the cloud-config secret:
+
+```sh
+kubectl create secret generic cluster-autoscaler-cloud-config \
+  --from-file=cloud-config=cloud-config.ini \
+  -n kube-system
+```
+
+Create a `values.yaml` for the cluster-autoscaler chart:
+
+```yaml
+image:
+  repository: ttl.sh/openfaasltd/cluster-autoscaler-slicer-amd64
+  tag: dev
+
+cloudProvider: slicer
+
+fullnameOverride: cluster-autoscaler-slicer
+
+autoDiscovery:
+  clusterName: k3s-slicer
+
+# Mount the cluster-autoscaler-cloud-config secret
+extraVolumeSecrets:
+  cluster-autoscaler-cloud-config:
+    name: cluster-autoscaler-cloud-config
+    mountPath: /etc/slicer/
+    items:
+      - key: cloud-config
+        path: cloud-config
+
+# All your required parameters
+extraArgs:
+  cloud-config: /etc/slicer/cloud-config
+  # Standard logging
+  logtostderr: true
+  stderrthreshold: info
+  v: 4
+
+  scale-down-enabled: true
+  scale-down-delay-after-add: "30s"
+  scale-down-unneeded-time: "30s"
+  expendable-pods-priority-cutoff: -10
+```
+
+Deploy with Helm:
+
+```sh
+helm install cluster-autoscaler-slicer charts/cluster-autoscaler \
+  --namespace=kube-system \
+  --values=values.yaml
+```
+
+To test the autoscaler do one of the following:
+
+* Scale a deployment higher than can fit on the current set of control-plane nodes, then wait for the autoscaler to scale up the cluster.
+* Or, create a taint / affinity / anti-affinity rule that will prevent a pod from being scheduled to the existing set of nodes, then wait for the autoscaler to scale up the cluster.

--- a/cluster-autoscaler/cloudprovider/slicer/slicer_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/slicer/slicer_cloud_provider.go
@@ -32,6 +32,7 @@ import (
 	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 
+	"github.com/docker/go-units"
 	sdk "github.com/slicervm/sdk"
 	klog "k8s.io/klog/v2"
 )
@@ -95,7 +96,7 @@ func BuildSlicer(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroup
 		if restGroup == nil {
 			klog.Fatalf("Failed to find slicer host group with name %s", nodeGroupName)
 		}
-		klog.Infof("Slicer: Host group: Name=%s, RAMGB=%d, VCPU=%d, Arch=%s", restGroup.Name, restGroup.RamGB, restGroup.CPUs, restGroup.Arch)
+		klog.Infof("Slicer: Host group: Name=%s, RAM=%s, VCPU=%d, Arch=%s", restGroup.Name, units.BytesSize(float64(restGroup.RamBytes)), restGroup.CPUs, restGroup.Arch)
 
 		arch := restGroup.Arch
 		if len(nodeGroup.arch) > 0 {

--- a/cluster-autoscaler/cloudprovider/slicer/slicer_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/slicer/slicer_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package slicer
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -77,7 +78,8 @@ func BuildSlicer(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroup
 
 		apiClient := sdk.NewSlicerClient(nodeGroup.slicerUrl, nodeGroup.slicerToken, userAgent, httpClient)
 
-		restGroups, err := apiClient.GetHostGroups()
+		restGroups, err := apiClient.GetHostGroups(context.Background())
+
 		if err != nil {
 			klog.Fatalf("Failed to fetch node groups from %s, error: %v", nodeGroup.slicerUrl, err)
 		}
@@ -208,7 +210,7 @@ func (s *SlicerCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 				klog.V(4).Infof("Slicer: Node %s belongs to managed hostgroup %s", node.Name, hostGroupLabel)
 
 				// Also verify the node exists in the Slicer API
-				nodes, err := group.apiClient.GetHostGroupNodes(group.Id())
+				nodes, err := group.apiClient.GetHostGroupNodes(context.Background(), group.Id())
 				if err != nil {
 					klog.V(4).Infof("Slicer: Failed to get nodes for group %s: %v", group.Id(), err)
 					return true, nil // Assume it exists if we can't check

--- a/cluster-autoscaler/cloudprovider/slicer/slicer_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/slicer/slicer_cloud_provider.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slicer
+
+import (
+	"os"
+
+	kubeclient "k8s.io/client-go/kubernetes"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+
+	sdk "github.com/slicervm/sdk"
+	klog "k8s.io/klog/v2"
+)
+
+// SlicerCloudProvider implements the CloudProvider interface for slicer.
+type SlicerCloudProvider struct {
+	resourceLimiter *cloudprovider.ResourceLimiter
+	nodeGroups      []*SlicerNodeGroup
+	kubeClient      kubeclient.Interface
+}
+
+// BuildSlicer constructs a new SlicerCloudProvider.
+func BuildSlicer(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+	if opts.CloudConfig == "" {
+		klog.Fatalf("No config file provided, please specify it via the --cloud-config flag")
+	}
+
+	configFile, err := os.Open(opts.CloudConfig)
+	if err != nil {
+		klog.Fatalf("Could not open cloud provider configuration file %q, error: %v", opts.CloudConfig, err)
+	}
+	defer configFile.Close()
+
+	cfg, err := buildConfig(configFile)
+	if err != nil {
+		klog.Fatalf("Failed to parse config, error: %v", err)
+	}
+
+	klog.V(2).Infof("Slicer: K3S URL=%s", cfg.k3sURL)
+	klog.V(2).Infof("Slicer: K3S token length=%d", len(cfg.k3sToken))
+
+	groups := []*SlicerNodeGroup{}
+	for nodeGroupName, nodeGroup := range cfg.nodeGroupCfg {
+		userAgent := "cluster-autoscaler/dev"
+		// Create API client
+		apiClient := sdk.NewSlicerClient(nodeGroup.slicerUrl, nodeGroup.slicerToken, userAgent, nil)
+
+		restGroups, err := apiClient.GetHostGroups()
+		if err != nil {
+			klog.Fatalf("Failed to fetch node groups from %s, error: %v", nodeGroup.slicerUrl, err)
+		}
+
+		var restGroup *sdk.SlicerHostGroup
+		klog.Infof("Slicer: Fetched %d host groups from API", len(restGroups))
+		for _, g := range restGroups {
+			if nodeGroupName == g.Name {
+				restGroup = &g
+			}
+		}
+
+		if restGroup == nil {
+			klog.Fatalf("Failed to find slicer host group with name %s", nodeGroupName)
+		}
+		klog.Infof("Slicer: Host group: Name=%s, RAMGB=%d, VCPU=%d, Arch=%s", restGroup.Name, restGroup.RamGB, restGroup.CPUs, restGroup.Arch)
+
+		arch := restGroup.Arch
+		if len(nodeGroup.arch) > 0 {
+			arch = nodeGroup.arch
+		}
+
+		newGroup := &SlicerNodeGroup{
+			id:         nodeGroupName,
+			minSize:    nodeGroup.MinSize(),
+			maxSize:    nodeGroup.MaxSize(), // Should be adjust according to available memory and CPU on the slicer host.
+			targetSize: 1,                   // Start with 1 node (the existing one)
+			apiClient:  apiClient,
+			k3sUrl:     cfg.k3sURL,
+			k3sToken:   cfg.k3sToken,
+			arch:       arch,
+		}
+
+		groups = append(groups, newGroup)
+		klog.Infof("Slicer: Created node group with ID: %s", newGroup.Id())
+	}
+
+	provider := &SlicerCloudProvider{
+		resourceLimiter: rl,
+		nodeGroups:      groups,
+		kubeClient:      opts.KubeClient,
+	}
+
+	// Set the provider reference in each node group so they can access kubeClient
+	for _, g := range groups {
+		g.provider = provider
+		klog.V(2).Infof("Slicer: Initializing node group: %s", g.Id())
+		nodes, err := g.Nodes()
+		if err != nil {
+			klog.Errorf("Slicer: Failed to get nodes for group %s: %v", g.Id(), err)
+		} else {
+			klog.V(2).Infof("Slicer: Node group %s has %d nodes from API", g.Id(), len(nodes))
+			for i, node := range nodes {
+				klog.V(2).Infof("Slicer: API Node %d: %s", i, node.Id)
+			}
+		}
+		g.targetSize = len(nodes)
+		klog.V(2).Infof("Slicer: Set target size for group %s to %d", g.Id(), g.targetSize)
+	}
+
+	provider.nodeGroups = groups
+	return provider
+}
+
+// Name returns the name of the cloud provider.
+func (s *SlicerCloudProvider) Name() string {
+	return "slicer"
+}
+
+// NodeGroups returns all node groups configured for this cloud provider.
+func (s *SlicerCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+	result := make([]cloudprovider.NodeGroup, len(s.nodeGroups))
+	for i, g := range s.nodeGroups {
+		result[i] = g
+	}
+	return result
+}
+
+// NodeGroupForNode returns the node group for the given node, or nil if not found.
+func (s *SlicerCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	// Add more verbose logging at Info level to see what's happening
+	klog.Infof("Slicer: NodeGroupForNode called for node %s", node.Name)
+	klog.Infof("Slicer: Node labels: %v", node.Labels)
+	klog.Infof("Slicer: Number of configured node groups: %d", len(s.nodeGroups))
+
+	if len(s.nodeGroups) == 0 {
+		klog.Infof("Slicer: No node groups configured")
+		return nil, nil
+	}
+
+	// List all node group IDs for debugging
+	var groupIds []string
+	for _, group := range s.nodeGroups {
+		groupIds = append(groupIds, group.Id())
+	}
+	klog.Infof("Slicer: Available node group IDs: %v", groupIds)
+
+	// Only match nodes that have the proper slicer/hostgroup label
+	// This prevents us from claiming ownership of phantom or stale nodes
+	if hostGroupLabel, exists := node.Labels["slicer/hostgroup"]; exists {
+		klog.Infof("Slicer: Found slicer/hostgroup label: %s", hostGroupLabel)
+		for _, group := range s.nodeGroups {
+			klog.Infof("Slicer: Comparing hostgroup label '%s' with node group ID '%s'", hostGroupLabel, group.Id())
+			if group.Id() == hostGroupLabel {
+				klog.Infof("Slicer: Matched node %s to node group %s via label", node.Name, group.Id())
+				return group, nil
+			}
+		}
+		klog.Infof("Slicer: No matching node group found for hostgroup label: %s", hostGroupLabel)
+	} else {
+		klog.Infof("Slicer: Node %s missing slicer/hostgroup label - not a Slicer-managed node", node.Name)
+	}
+
+	klog.Infof("Slicer: No node group found for node %s", node.Name)
+	return nil, nil
+}
+
+// HasInstance returns whether the node has corresponding instance in cloud provider.
+func (s *SlicerCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+	klog.V(4).Infof("Slicer: Checking if node %s has instance in cloud provider", node.Name)
+
+	// Check if the node has the slicer/hostgroup label to identify if it's managed by slicer
+	if hostGroupLabel, exists := node.Labels["slicer/hostgroup"]; exists {
+		klog.V(4).Infof("Slicer: Node %s has slicer/hostgroup label: %s", node.Name, hostGroupLabel)
+		// Check if this hostgroup exists in our node groups
+		for _, group := range s.nodeGroups {
+			if group.Id() == hostGroupLabel {
+				klog.V(4).Infof("Slicer: Node %s belongs to managed hostgroup %s", node.Name, hostGroupLabel)
+
+				// Also verify the node exists in the Slicer API
+				nodes, err := group.apiClient.GetHostGroupNodes(group.Id())
+				if err != nil {
+					klog.V(4).Infof("Slicer: Failed to get nodes for group %s: %v", group.Id(), err)
+					return true, nil // Assume it exists if we can't check
+				}
+
+				// Check if the node actually exists in Slicer by comparing the slicer/hostname label
+				// Note: We should NOT compare node.Name directly with n.Hostname because:
+				// - n.Hostname comes from Slicer API (stable name like "k3s-agent-1")
+				// - node.Name comes from Kubernetes (dynamic name like "k3s-agent-1-149257af")
+				// - The mapping is done via the slicer/hostname label
+				for _, n := range nodes {
+					if slicerHostname, exists := node.Labels["slicer/hostname"]; exists && n.Hostname == slicerHostname {
+						klog.V(4).Infof("Slicer: Confirmed node %s (hostname: %s) exists in Slicer API", node.Name, slicerHostname)
+						return true, nil
+					}
+				}
+
+				klog.V(4).Infof("Slicer: Node %s has slicer label but not found in Slicer API - may have been deleted", node.Name)
+				return false, nil // Node was deleted from Slicer but still exists in K8s
+			}
+		}
+		klog.V(4).Infof("Slicer: Hostgroup %s not found in managed groups", hostGroupLabel)
+		return false, nil
+	}
+
+	// Special case: If a node has no labels at all, it's likely a stale/ghost node
+	// Don't claim ownership of such nodes to avoid confusion
+	if len(node.Labels) == 0 {
+		klog.V(4).Infof("Slicer: Node %s has no labels - treating as non-Slicer node", node.Name)
+		return false, nil
+	}
+
+	// If we get here, the node has some labels but no slicer/hostgroup label
+	// This means it's not a Slicer-managed node
+	klog.V(4).Infof("Slicer: Node %s not managed by Slicer (missing slicer/hostgroup label)", node.Name)
+	return false, nil
+}
+
+// Pricing returns pricing model for this cloud provider or error if not available.
+func (s *SlicerCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// GetAvailableMachineTypes get all machine types that can be requested from the cloud provider.
+func (s *SlicerCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// NewNodeGroup builds a theoretical node group based on the node definition provided.
+func (s *SlicerCloudProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
+func (s *SlicerCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+	return s.resourceLimiter, nil
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (s *SlicerCloudProvider) GPULabel() string {
+	return ""
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports.
+func (s *SlicerCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return nil
+}
+
+// GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have any GPUs, it returns nil.
+func (s *SlicerCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
+	return nil
+}
+
+// Cleanup cleans up open resources before the cloud provider is destroyed, i.e. go routines etc.
+func (s *SlicerCloudProvider) Cleanup() error {
+	return nil
+}
+
+// Refresh is called before every main loop and can be used to dynamically update cloud provider state.
+func (s *SlicerCloudProvider) Refresh() error {
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/slicer/slicer_config.go
+++ b/cluster-autoscaler/cloudprovider/slicer/slicer_config.go
@@ -56,6 +56,7 @@ func (ng *nodeGroupConfig) MaxSize() int {
 type slicerConfig struct {
 	k3sURL         string
 	k3sToken       string
+	caBundle       string
 	defaultMinSize int
 	defaultMaxSize int
 	nodeGroupCfg   map[string]*nodeGroupConfig
@@ -71,10 +72,16 @@ func (sc *slicerConfig) DefaultMaxSize() int {
 	return sc.defaultMaxSize
 }
 
+// CABundle returns the CA bundle path
+func (sc *slicerConfig) CABundle() string {
+	return sc.caBundle
+}
+
 // GcfgGlobalConfig is the gcfg representation of the global section in the cloud config file for slicer.
 type GcfgGlobalConfig struct {
 	K3SURL         string `gcfg:"k3s-url"`
 	K3SToken       string `gcfg:"k3s-token"`
+	CABundle       string `gcfg:"ca-bundle"`
 	DefaultMinSize string `gcfg:"default-min-size"`
 	DefaultMaxSize string `gcfg:"default-max-size"`
 }
@@ -142,6 +149,7 @@ func buildConfig(config io.Reader) (*slicerConfig, error) {
 	return &slicerConfig{
 		k3sURL:         gcfgCloudConfig.Global.K3SURL,
 		k3sToken:       gcfgCloudConfig.Global.K3SToken,
+		caBundle:       gcfgCloudConfig.Global.CABundle,
 		defaultMinSize: defaultMinSize,
 		defaultMaxSize: defaultMaxSize,
 		nodeGroupCfg:   nodeGroupCfg,

--- a/cluster-autoscaler/cloudprovider/slicer/slicer_config.go
+++ b/cluster-autoscaler/cloudprovider/slicer/slicer_config.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slicer
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"gopkg.in/gcfg.v1"
+)
+
+const (
+	// defaultMinSize is the min size of the node groups
+	// if no other value is defined for a specific node group.
+	defaultMinSize int = 0
+	// defaultMaxSize is the max size of the node groups
+	// if no other value is defined for a specific node group.
+	defaultMaxSize int = 8
+)
+
+// nodeGroupConfig is the configuration for a specific node group.
+type nodeGroupConfig struct {
+	slicerUrl   string
+	slicerToken string
+	minSize     int
+	maxSize     int
+	arch        string
+}
+
+// MinSize returns the MinSize value
+func (ng *nodeGroupConfig) MinSize() int {
+	return ng.minSize
+}
+
+// MaxSize returns the MaxSize value
+func (ng *nodeGroupConfig) MaxSize() int {
+	return ng.maxSize
+}
+
+// slicerConfig holds the configuration for the slicer provider.
+type slicerConfig struct {
+	k3sURL         string
+	k3sToken       string
+	defaultMinSize int
+	defaultMaxSize int
+	nodeGroupCfg   map[string]*nodeGroupConfig
+}
+
+// DefaultMinSize returns the DefaultMinSize value
+func (sc *slicerConfig) DefaultMinSize() int {
+	return sc.defaultMinSize
+}
+
+// DefaultMaxSize returns the DefaultMaxSize value
+func (sc *slicerConfig) DefaultMaxSize() int {
+	return sc.defaultMaxSize
+}
+
+// GcfgGlobalConfig is the gcfg representation of the global section in the cloud config file for slicer.
+type GcfgGlobalConfig struct {
+	K3SURL         string `gcfg:"k3s-url"`
+	K3SToken       string `gcfg:"k3s-token"`
+	DefaultMinSize string `gcfg:"default-min-size"`
+	DefaultMaxSize string `gcfg:"default-max-size"`
+}
+
+// GcfgNodeGroupConfig is the gcfg representation of the section in the cloud config file to change defaults for a node group.
+type GcfgNodeGroupConfig struct {
+	SlicerUrl   string `gcfg:"slicer-url"`
+	SlicerToken string `gcfg:"slicer-token"`
+	MinSize     string `gcfg:"min-size"`
+	MaxSize     string `gcfg:"max-size"`
+	Arch        string `gcfg:"arch"`
+}
+
+// gcfgCloudConfig is the gcfg representation of the cloud config file for slicer.
+type gcfgCloudConfig struct {
+	Global     GcfgGlobalConfig                `gcfg:"global"`
+	NodeGroups map[string]*GcfgNodeGroupConfig `gcfg:"nodegroup"`
+}
+
+// buildConfig creates the configuration struct for the provider.
+func buildConfig(config io.Reader) (*slicerConfig, error) {
+
+	// read the config and get the gcfg struct
+	var gcfgCloudConfig gcfgCloudConfig
+	if err := gcfg.ReadInto(&gcfgCloudConfig, config); err != nil {
+		return nil, err
+	}
+
+	// get the default min and max size as defined in the global section of the config file
+	defaultMinSize, defaultMaxSize, err := getSizeLimits(
+		gcfgCloudConfig.Global.DefaultMinSize,
+		gcfgCloudConfig.Global.DefaultMaxSize,
+		defaultMinSize,
+		defaultMaxSize)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get default size values in global section: %v", err)
+	}
+
+	// get the specific configuration of a node group
+	nodeGroupCfg := make(map[string]*nodeGroupConfig)
+	for nodeGroupName, gcfgNodeGroup := range gcfgCloudConfig.NodeGroups {
+		minSize, maxSize, err := getSizeLimits(gcfgNodeGroup.MinSize, gcfgNodeGroup.MaxSize, defaultMinSize, defaultMaxSize)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get size values for node group %q: %v", nodeGroupName, err)
+		}
+
+		ngc := &nodeGroupConfig{
+			slicerUrl:   gcfgNodeGroup.SlicerUrl,
+			slicerToken: gcfgNodeGroup.SlicerToken,
+			minSize:     minSize,
+			maxSize:     maxSize,
+		}
+		nodeGroupCfg[nodeGroupName] = ngc
+	}
+
+	// Validate required K3S configuration
+	if gcfgCloudConfig.Global.K3SURL == "" {
+		return nil, fmt.Errorf("K3S URL not configured, nodes may not be able to join the cluster")
+	}
+
+	if gcfgCloudConfig.Global.K3SToken == "" {
+		return nil, fmt.Errorf("K3S token not configured, nodes may not be able to join the cluster")
+	}
+
+	return &slicerConfig{
+		k3sURL:         gcfgCloudConfig.Global.K3SURL,
+		k3sToken:       gcfgCloudConfig.Global.K3SToken,
+		defaultMinSize: defaultMinSize,
+		defaultMaxSize: defaultMaxSize,
+		nodeGroupCfg:   nodeGroupCfg,
+	}, nil
+}
+
+// getSizeLimits takes the max, min size of a node group as strings (empty if no values are provided)
+// and default sizes, validates them and returns them as integer, or an error if such occurred
+func getSizeLimits(minStr string, maxStr string, defaultMin int, defaultMax int) (int, int, error) {
+	var err error
+	min := defaultMin
+	if len(minStr) != 0 {
+		min, err = strconv.Atoi(minStr)
+		if err != nil {
+			return 0, 0, fmt.Errorf("could not parse min size for node group: %v", err)
+		}
+	}
+
+	max := defaultMax
+	if len(maxStr) != 0 {
+		max, err = strconv.Atoi(maxStr)
+		if err != nil {
+			return 0, 0, fmt.Errorf("could not parse max size for node group: %v", err)
+		}
+	}
+
+	if min > max {
+		return 0, 0, fmt.Errorf("min size for a node group must be less than its max size (got min: %d, max: %d)",
+			min, max)
+	}
+
+	return min, max, nil
+}

--- a/cluster-autoscaler/cloudprovider/slicer/slicer_node_group.go
+++ b/cluster-autoscaler/cloudprovider/slicer/slicer_node_group.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slicer
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	sdk "github.com/slicervm/sdk"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	klog "k8s.io/klog/v2"
+)
+
+const (
+	slicerNodeGroupName = "k3s-agent"
+	slicerImportUser    = "alexellis"
+	slicerRAMGB         = 8
+	slicerCPUs          = 4
+)
+
+// SlicerNodeGroup implements cloudprovider.NodeGroup for the slicer REST API.
+type SlicerNodeGroup struct {
+	id         string
+	minSize    int
+	maxSize    int
+	provider   *SlicerCloudProvider
+	targetSize int // Track the desired target size locally
+	apiClient  *sdk.SlicerClient
+	k3sUrl     string
+	k3sToken   string
+	arch       string
+}
+
+// MaxSize returns the maximum size of the node group.
+func (g *SlicerNodeGroup) MaxSize() int { return g.maxSize }
+
+// MinSize returns the minimum size of the node group.
+func (g *SlicerNodeGroup) MinSize() int { return g.minSize }
+
+// TargetSize returns the current target size of the node group.
+func (g *SlicerNodeGroup) TargetSize() (int, error) {
+	// Return our local target size, not the actual backend count
+	return g.targetSize, nil
+}
+
+// IncreaseSize increases the size of the node group by the given delta.
+func (g *SlicerNodeGroup) IncreaseSize(delta int) error {
+	klog.V(2).Infof("Slicer: IncreaseSize called with delta=%d, current targetSize=%d", delta, g.targetSize)
+
+	if delta <= 0 {
+		return fmt.Errorf("delta must be positive")
+	}
+	if g.targetSize+delta > g.maxSize {
+		return fmt.Errorf("size increase too large: current=%d, delta=%d, max=%d", g.targetSize, delta, g.maxSize)
+	}
+
+	userdata := fmt.Sprintf(`
+#!/bin/bash
+
+HOSTNAME=$(hostname)
+
+# Populate with the join token from the master node
+export K3S_TOKEN="%s"
+
+# Join k3s agent with random node ID but label with Slicer hostname for mapping
+curl -sfL https://get.k3s.io | K3S_URL=%s sh -s - --with-node-id --node-label "slicer/hostgroup=%s" --node-label "k3sup.dev/node-type=agent" --node-label "slicer/hostname=$HOSTNAME"
+`, g.k3sToken, g.k3sUrl, g.id)
+
+	klog.V(2).Infof("Slicer: About to create %d nodes via API", delta)
+
+	// Create the nodes via API
+	for i := 0; i < delta; i++ {
+		payload := sdk.SlicerCreateNodeRequest{
+			RamGB:      slicerRAMGB,
+			CPUs:       slicerCPUs,
+			ImportUser: slicerImportUser,
+			Userdata:   userdata,
+		}
+
+		klog.V(2).Infof("Slicer: Creating node via API client")
+
+		result, err := g.apiClient.CreateNode(g.id, payload)
+		if err != nil {
+			klog.Errorf("Slicer: Failed to create node: %v", err)
+			return fmt.Errorf("failed to create node: %w", err)
+		}
+
+		klog.V(2).Infof("Slicer: Successfully created node: %s", result.Hostname)
+	}
+
+	// Update our local target size
+	g.targetSize += delta
+	klog.V(2).Infof("Slicer: Increased target size by %d to %d", delta, g.targetSize)
+	return nil
+}
+
+// AtomicIncreaseSize is not implemented.
+func (g *SlicerNodeGroup) AtomicIncreaseSize(delta int) error { return cloudprovider.ErrNotImplemented }
+
+// ForceDeleteNodes is not implemented.
+func (g *SlicerNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// DecreaseTargetSize decreases the target size of the node group by the given delta.
+func (g *SlicerNodeGroup) DecreaseTargetSize(delta int) error {
+	klog.V(2).Infof("Slicer: DecreaseTargetSize called with delta=%d, current targetSize=%d", delta, g.targetSize)
+
+	if delta >= 0 {
+		return fmt.Errorf("size decrease must be negative")
+	}
+
+	// Get actual nodes that exist
+	nodes, err := g.Nodes()
+	if err != nil {
+		return fmt.Errorf("failed to get existing nodes: %w", err)
+	}
+
+	newSize := g.targetSize + delta
+	if newSize < len(nodes) {
+		return fmt.Errorf("attempt to delete existing nodes targetSize:%d delta:%d existingNodes: %d",
+			g.targetSize, delta, len(nodes))
+	}
+
+	if newSize < g.MinSize() {
+		return fmt.Errorf("size decrease too large, desired:%d min:%d", newSize, g.MinSize())
+	}
+
+	// Update our local target size
+	g.targetSize = newSize
+	klog.V(2).Infof("Slicer: Decreased target size by %d to %d", delta, g.targetSize)
+
+	return nil
+}
+
+// DeleteNodes deletes the given nodes from the node group.
+func (g *SlicerNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+	klog.V(2).Infof("Slicer: DeleteNodes called with %d nodes", len(nodes))
+
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	for _, node := range nodes {
+		// Use the Slicer hostname from labels, not the K3s node name
+		slicerHostname := node.Name // Default to node name
+		if hostname, exists := node.Labels["slicer/hostname"]; exists {
+			slicerHostname = hostname
+		}
+
+		klog.V(2).Infof("Slicer: Deleting node - K3s name: %s, Slicer hostname: %s", node.Name, slicerHostname)
+
+		// First delete from Slicer API
+		err := g.apiClient.DeleteNode(g.id, slicerHostname)
+		if err != nil {
+			klog.Errorf("Slicer: Failed to delete node %s from Slicer API: %v", slicerHostname, err)
+			// Continue to try deleting from Kubernetes anyway
+		} else {
+			klog.V(2).Infof("Slicer: Successfully deleted node from Slicer API: %s", slicerHostname)
+		}
+
+		// Then delete from Kubernetes cluster using the actual K3s node name
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := g.provider.kubeClient.CoreV1().Nodes().Delete(ctx, node.Name, metav1.DeleteOptions{}); err != nil {
+			// Check if node was already deleted (not found error)
+			if strings.Contains(err.Error(), "not found") {
+				klog.V(2).Infof("Slicer: Node %s already deleted from Kubernetes", node.Name)
+			} else {
+				klog.Errorf("Slicer: Failed to delete node %s from Kubernetes: %v", node.Name, err)
+				return fmt.Errorf("failed to delete node from Kubernetes: %w", err)
+			}
+		} else {
+			klog.V(2).Infof("Slicer: Successfully deleted node from Kubernetes API: %s", node.Name)
+		}
+
+		g.targetSize--
+	}
+
+	return nil
+}
+
+// Id returns the unique node pool id.
+func (g *SlicerNodeGroup) Id() string { return g.id }
+
+// Debug returns a debug string for the NodeGroup.
+func (g *SlicerNodeGroup) Debug() string { return g.id }
+
+// Nodes returns a list of all nodes that belong to this node group.
+func (g *SlicerNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+	klog.V(4).Infof("Slicer: Fetching nodes for group %s", g.id)
+	nodes, err := g.apiClient.GetHostGroupNodes(g.id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch nodes: %w", err)
+	}
+
+	klog.V(4).Infof("Slicer: API returned %d nodes for group %s", len(nodes), g.id)
+
+	// Get all Kubernetes nodes to map Slicer API names to actual K8s node names
+	kubeNodes, err := g.provider.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Kubernetes nodes: %w", err)
+	}
+
+	// Create a map from Slicer hostname to Kubernetes node name
+	slicerToK8sNodeMap := make(map[string]string)
+	for _, kubeNode := range kubeNodes.Items {
+		if hostgroup, hasHostgroup := kubeNode.Labels["slicer/hostgroup"]; hasHostgroup && hostgroup == g.id {
+			if slicerHostname, hasHostname := kubeNode.Labels["slicer/hostname"]; hasHostname {
+				slicerToK8sNodeMap[slicerHostname] = kubeNode.Name
+				klog.V(4).Infof("Slicer: Mapped slicer hostname %s to K8s node %s", slicerHostname, kubeNode.Name)
+			}
+		}
+	}
+
+	instances := make([]cloudprovider.Instance, 0, len(nodes))
+	for i, n := range nodes {
+		klog.V(4).Infof("Slicer: Node %d: hostname=%s, ip=%s, created=%s", i, n.Hostname, n.IP, n.CreatedAt)
+
+		// Map Slicer API hostname to actual Kubernetes node name
+		k8sNodeName, exists := slicerToK8sNodeMap[n.Hostname]
+		if !exists {
+			klog.V(4).Infof("Slicer: No matching Kubernetes node found for Slicer hostname %s - skipping", n.Hostname)
+			continue // Skip nodes that don't have corresponding K8s nodes
+		}
+
+		klog.V(4).Infof("Slicer: Using K8s node name %s for Slicer hostname %s", k8sNodeName, n.Hostname)
+		instances = append(instances, cloudprovider.Instance{
+			Id: k8sNodeName, // Use the actual Kubernetes node name
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceRunning,
+			},
+		})
+	}
+
+	klog.V(4).Infof("Slicer: Returning %d mapped instances for group %s", len(instances), g.id)
+	return instances, nil
+}
+
+// TemplateNodeInfo returns a node template for this node group.
+func (g *SlicerNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+
+	klog.V(2).Infof("Slicer: Fetching hostgroup sizing for %s", g.id)
+
+	// Fetch hostgroup sizing
+	groups, err := g.apiClient.GetHostGroups()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch hostgroups: %w", err)
+	}
+
+	var groupInfo *sdk.SlicerHostGroup
+	for _, hg := range groups {
+		if hg.Name == g.id {
+			groupInfo = &hg
+			break
+		}
+	}
+
+	if groupInfo == nil {
+		return nil, fmt.Errorf("hostgroup %s not found", g.id)
+	}
+
+	cpu := groupInfo.CPUs
+	ramGB := groupInfo.RamGB
+	if cpu <= 0 || ramGB <= 0 {
+		return nil, fmt.Errorf("invalid cpu or ram from hostgroup: cpu=%d ramGB=%d", cpu, ramGB)
+	}
+
+	nodeName := "slicer-node-template"
+	ramQty := resource.NewQuantity(int64(ramGB)*1024*1024*1024, resource.BinarySI)
+	cpuQty := resource.NewQuantity(int64(cpu), resource.DecimalSI)
+	labels := map[string]string{
+		"kubernetes.io/arch":          g.arch,
+		"kubernetes.io/os":            "linux",
+		"kubernetes.io/instance-type": "k3s",
+		"slicer/hostgroup":            g.id,
+		"k3sup.dev/node-type":         "agent",
+		"slicer/hostname":             fmt.Sprintf("slicer-node-%d", rand.Intn(1000000)), // Random hostname for uniqueness
+	}
+
+	node := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   nodeName,
+			Labels: labels,
+		},
+		Status: apiv1.NodeStatus{
+			Capacity: apiv1.ResourceList{
+				apiv1.ResourceCPU:    *cpuQty,
+				apiv1.ResourceMemory: *ramQty,
+				apiv1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+			},
+			Allocatable: apiv1.ResourceList{
+				apiv1.ResourceCPU:    *cpuQty,
+				apiv1.ResourceMemory: *ramQty,
+				apiv1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+			},
+			Conditions: cloudprovider.BuildReadyConditions(),
+		},
+	}
+	// Defensive: check node has required fields
+	if node.Name == "" {
+		return nil, fmt.Errorf("constructed node is missing name")
+	}
+
+	nodeInfo := framework.NewNodeInfo(node, nil, &framework.PodInfo{Pod: cloudprovider.BuildKubeProxy(g.id)})
+
+	return nodeInfo, nil
+}
+
+// Exist returns true if the node group exists.
+func (g *SlicerNodeGroup) Exist() bool { return true }
+
+// Create is not implemented.
+func (g *SlicerNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// Delete is not implemented.
+func (g *SlicerNodeGroup) Delete() error { return cloudprovider.ErrNotImplemented }
+
+// Autoprovisioned returns true if the node group is autoprovisioned.
+func (g *SlicerNodeGroup) Autoprovisioned() bool { return false }
+
+// GetOptions is not implemented.
+func (g *SlicerNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -297,6 +297,13 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		return caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
 	}
 
+	targetSize, err := a.AutoscalingContext.CloudProvider.NodeGroups()[0].TargetSize()
+	if err != nil {
+		klog.Errorf("Failed to get target size: %v", err)
+	}
+
+	fmt.Printf("Target size: %d\n", targetSize)
+
 	coresTotal, memoryTotal := calculateCoresMemoryTotal(allNodes, currentTime)
 	metrics.UpdateClusterCPUCurrentCores(coresTotal)
 	metrics.UpdateClusterMemoryCurrentBytes(memoryTotal)

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
-	github.com/slicervm/sdk v0.0.5
+	github.com/slicervm/sdk v0.0.9
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
 	github.com/vburenin/ifacemaker v1.2.1

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
+	github.com/slicervm/sdk v0.0.5
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
 	github.com/vburenin/ifacemaker v1.2.1

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.241
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/digitalocean/godo v1.169.0
+	github.com/docker/go-units v0.5.0
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
@@ -27,7 +28,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
-	github.com/slicervm/sdk v0.0.9
+	github.com/slicervm/sdk v0.0.19
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
 	github.com/vburenin/ifacemaker v1.2.1
@@ -109,7 +110,6 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -361,12 +361,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/slicervm/sdk v0.0.1 h1:OqPEVbNeDnMRbq0Unc9asDEyTATkkfCrJ07NDNjlVpY=
-github.com/slicervm/sdk v0.0.1/go.mod h1:OZ7hMDRJ9OUK4d6XH/F40gfWpuEvhdbfabDJ91fGnLk=
-github.com/slicervm/sdk v0.0.2 h1:wTFTbLzviYh1VS6bBDLamqhWD840sNpLi7yZm133H3A=
-github.com/slicervm/sdk v0.0.2/go.mod h1:loZZauzbYFQ9hQI1iPkKh7FlHs8lU63y3I8fvUQ2dvc=
-github.com/slicervm/sdk v0.0.5 h1:KO1+I7R/LOzR13NkkC2pDEyNpWQNCy8cudYebmIYSSo=
-github.com/slicervm/sdk v0.0.5/go.mod h1:loZZauzbYFQ9hQI1iPkKh7FlHs8lU63y3I8fvUQ2dvc=
+github.com/slicervm/sdk v0.0.9 h1:Lro9wcit2lVBW1gA4+w5wEv54c2gpXh9IUBPCqc/w08=
+github.com/slicervm/sdk v0.0.9/go.mod h1:loZZauzbYFQ9hQI1iPkKh7FlHs8lU63y3I8fvUQ2dvc=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -361,6 +361,12 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/slicervm/sdk v0.0.1 h1:OqPEVbNeDnMRbq0Unc9asDEyTATkkfCrJ07NDNjlVpY=
+github.com/slicervm/sdk v0.0.1/go.mod h1:OZ7hMDRJ9OUK4d6XH/F40gfWpuEvhdbfabDJ91fGnLk=
+github.com/slicervm/sdk v0.0.2 h1:wTFTbLzviYh1VS6bBDLamqhWD840sNpLi7yZm133H3A=
+github.com/slicervm/sdk v0.0.2/go.mod h1:loZZauzbYFQ9hQI1iPkKh7FlHs8lU63y3I8fvUQ2dvc=
+github.com/slicervm/sdk v0.0.5 h1:KO1+I7R/LOzR13NkkC2pDEyNpWQNCy8cudYebmIYSSo=
+github.com/slicervm/sdk v0.0.5/go.mod h1:loZZauzbYFQ9hQI1iPkKh7FlHs8lU63y3I8fvUQ2dvc=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -361,8 +361,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/slicervm/sdk v0.0.9 h1:Lro9wcit2lVBW1gA4+w5wEv54c2gpXh9IUBPCqc/w08=
-github.com/slicervm/sdk v0.0.9/go.mod h1:loZZauzbYFQ9hQI1iPkKh7FlHs8lU63y3I8fvUQ2dvc=
+github.com/slicervm/sdk v0.0.19 h1:W6vjqyiEsuT0v4r5sJBDH3biePzCAUO672ok9Di9aIA=
+github.com/slicervm/sdk v0.0.19/go.mod h1:loZZauzbYFQ9hQI1iPkKh7FlHs8lU63y3I8fvUQ2dvc=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds [Slicer](https://slicervm.com/) as a new cloud provider to the Kubernetes Autoscaler. Slicer is a lightweight microVM platform. It offers a convenient, commercially supported way for running Kubernetes on Firecracker microVMs on bare-metal and on-premises infrastructure.

Integrating Slicer into the Autoscaler allows users to dynamically scale their Kubernetes clusters on bare-metal and on-premises infrastructure

Key highlights:

  * Implements the CloudProvider, NodeGroup interfaces specific to Slicer microVMs
  * Supports scale up/down using the Slicer's REST API for microVM lifecycle management

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The initial version covers scale-up and scale-down functionality.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Slicer has been added as a supported cloud provider in Kubernetes Cluster Autoscaler.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Other doc]: https://docs.slicervm.com/examples/autoscaling-k3s/
```
