### PR TITLE
When pod listing, filter out unschedulable and scheduler unprocessed pods not in the list of allowed schedulers

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -294,6 +294,8 @@ type AutoscalingOptions struct {
 	DynamicNodeDeleteDelayAfterTaintEnabled bool
 	// BypassedSchedulers are used to specify which schedulers to bypass their processing
 	BypassedSchedulers map[string]bool
+	// AllowedSchedulers when specified CA will proceed only with pods that are targeting allowed schedulers from unschedulable pods and unprocessed pods by BypassedSchedulers.
+	AllowedSchedulers map[string]bool
 	// ProvisioningRequestEnabled tells if CA processes ProvisioningRequest.
 	ProvisioningRequestEnabled bool
 	// AsyncNodeGroupsEnabled tells if CA creates/deletes node groups asynchronously.

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1485,7 +1485,7 @@ func TestStaticAutoscalerRunOnceWithBypassedSchedulers(t *testing.T) {
 		MaxNodesTotal:    10,
 		MaxCoresTotal:    10,
 		MaxMemoryTotal:   100000,
-		BypassedSchedulers: scheduler.GetBypassedSchedulersMap([]string{
+		BypassedSchedulers: scheduler.SchedulersMap([]string{
 			apiv1.DefaultSchedulerName,
 			bypassedScheduler,
 		}),

--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -200,6 +200,17 @@ func ArrangePodsBySchedulability(allPods []*apiv1.Pod, bypassedSchedulers map[st
 	return
 }
 
+// FilterOutPodsByScheduler is a helper method that filters out pods not in the given set of allowed schedulers.
+func FilterOutPodsByScheduler(allPods []*apiv1.Pod, allowedSchedulers map[string]bool) []*apiv1.Pod {
+	var remainingPods []*apiv1.Pod
+	for _, pod := range allPods {
+		if keep := allowedSchedulers[pod.Spec.SchedulerName]; keep {
+			remainingPods = append(remainingPods, pod)
+		}
+	}
+	return remainingPods
+}
+
 // SchedulingGatedPods is a helper method that returns all pods which has scheduling gate
 // SchedulingGated pods are not scheduled nor deleted by the implementation and are not unschedulable nor unprocessed by definition
 func SchedulingGatedPods(allPods []*apiv1.Pod) []*apiv1.Pod {

--- a/cluster-autoscaler/utils/scheduler/scheduler.go
+++ b/cluster-autoscaler/utils/scheduler/scheduler.go
@@ -126,15 +126,15 @@ func ConfigFromPath(path string) (*scheduler_config.KubeSchedulerConfiguration, 
 	return cfgObj, nil
 }
 
-// GetBypassedSchedulersMap returns a map of scheduler names that should be bypassed as keys, and values are set to true
-// Also sets "" (empty string) to true if default scheduler is bypassed
-func GetBypassedSchedulersMap(bypassedSchedulers []string) map[string]bool {
-	bypassedSchedulersMap := make(map[string]bool, len(bypassedSchedulers))
-	for _, scheduler := range bypassedSchedulers {
-		bypassedSchedulersMap[scheduler] = true
+// SchedulersMap returns a map of scheduler names as keys, and values are set to true
+// Also sets "" (empty string) to true if default scheduler is in the list
+func SchedulersMap(schedulers []string) map[string]bool {
+	schedulersMap := make(map[string]bool, len(schedulers))
+	for _, scheduler := range schedulers {
+		schedulersMap[scheduler] = true
 	}
-	if canBypass := bypassedSchedulersMap[apiv1.DefaultSchedulerName]; canBypass {
-		bypassedSchedulersMap[""] = true
+	if found := schedulersMap[apiv1.DefaultSchedulerName]; found {
+		schedulersMap[""] = true
 	}
-	return bypassedSchedulersMap
+	return schedulersMap
 }


### PR DESCRIPTION
When pod listing, filter out unschedulable and scheduler unprocessed pods not in the list of allowed schedulers.

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR introduces new command line flag where a list of schedulers can be specified. If specified, cluster autoscaler will filter out pods not belong to those schedulers at the very beginning of the CA loop. 

This feature is useful for customs CA configurations where CA does not intends to help pods targeting some custom schedulers. Specially in large clusters when there are thousands of unschedulbale pods which are not intended for CA, it adds unnecessary extra overheads and could affect CA decision making. This flag can be used as a mitigation for such cases.




#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The flag should be set to empty for general release. This flag should only be used for specific clusters which have any such needs or as a mitigation tool if applicable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
