### PR TITLE
Implement OCI Node force delete functions

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
@@ -70,9 +70,9 @@ func (ip *InstancePoolNodeGroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
-// deleteNodesInternal performs the actual node deletion logic, converting nodes to OCI refs
+// deleteNodes performs the actual node deletion logic, converting nodes to OCI refs
 // and deleting them. It does not check min size constraints.
-func (ip *InstancePoolNodeGroup) deleteNodesInternal(nodes []*apiv1.Node) error {
+func (ip *InstancePoolNodeGroup) deleteNodes(nodes []*apiv1.Node) error {
 	refs := make([]common.OciRef, 0, len(nodes))
 	for _, node := range nodes {
 		belongs, err := ip.Belongs(node)
@@ -110,7 +110,7 @@ func (ip *InstancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
-	return ip.deleteNodesInternal(nodes)
+	return ip.deleteNodes(nodes)
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
@@ -119,7 +119,7 @@ func (ip *InstancePoolNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 
 	klog.Infof("ForceDeleteNodes called with %d node(s) (ignoring min size constraint)", len(nodes))
 
-	return ip.deleteNodesInternal(nodes)
+	return ip.deleteNodes(nodes)
 }
 
 // DecreaseTargetSize decreases the target size of the instance-pool based node group. This function

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
@@ -25,12 +25,10 @@ import (
 	ocicommon "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/common"
 )
 
-var (
-	// This mutex guarantees that multiple node pool actions aren't happening at the same time
-	// Note that the actual wait for nodes to come up or delete is asynchronous.
-	// This mutex is only around the api operations.
-	nodePoolDeleteMutex sync.Mutex
-)
+// This mutex guarantees that multiple node pool actions aren't happening at the same time
+// Note that the actual wait for nodes to come up or delete is asynchronous.
+// This mutex is only around the api operations.
+var nodePoolDeleteMutex sync.Mutex
 
 // NodePool implements the NodeGroup interface via an OCI Node Pool
 type NodePool interface {
@@ -124,9 +122,9 @@ func (np *nodePool) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
-// deleteNodesInternal performs the actual node deletion logic, converting nodes to OCI refs
+// deleteNodes performs the actual node deletion logic, converting nodes to OCI refs
 // and deleting them. It does not check min size constraints.
-func (np *nodePool) deleteNodesInternal(nodes []*apiv1.Node) error {
+func (np *nodePool) deleteNodes(nodes []*apiv1.Node) error {
 	refs := make([]ocicommon.OciRef, 0, len(nodes))
 
 	// even though the nodes param is an array, in reality, nodes only contains a single node
@@ -186,7 +184,7 @@ func (np *nodePool) DeleteNodes(nodes []*apiv1.Node) (err error) {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
-	return np.deleteNodesInternal(nodes)
+	return np.deleteNodes(nodes)
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
@@ -201,7 +199,7 @@ func (np *nodePool) ForceDeleteNodes(nodes []*apiv1.Node) error {
 
 	klog.Infof("ForceDeleteNodes called with %d nodes (ignoring min size constraint)", len(nodes))
 
-	return np.deleteNodesInternal(nodes)
+	return np.deleteNodes(nodes)
 }
 
 // DecreaseTargetSize decreases the target size of the node group. This function
@@ -239,7 +237,7 @@ func (np *nodePool) DecreaseTargetSize(delta int) error {
 	}
 	// We do not have an OCI API that allows us to delete a node with a compute instance. So we rely on
 	// the below approach to determine the number running instance in a nodepool from the compute API and
-	//update the size of the nodepool accordingly. We should move away from this approach once we have an API
+	// update the size of the nodepool accordingly. We should move away from this approach once we have an API
 	// to delete a specific node without a compute instance.
 	if !decreaseTargetCheckViaComputeBool {
 		for _, node := range nodes {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

When the `--force-delete-unregistered-nodes` argument is enabled, it is unable to delete unresponsive Nodes when the NodePool is at the min number of nodes under cloud providers that do not have the `ForceDeleteNodes` function implemented. When this happens in OCI, the autoscaler becomes stuck in an error state: `could not extract taints from the nodepool: invalid taint spec: , name part must be non-empty`. This PR implements `ForceDeleteNodes` function in order to allow the `--force-delete-unregistered-nodes` argument to work as intended under OCI.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
```release-note
OCI: implement ForceDelete
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE