### PR TITLE
fix: drop remove node label and fix decrease size func

### DIFF
--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodepool.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodepool.go
@@ -187,42 +187,6 @@ func (np *CoreWeaveNodePool) SetSize(size int) error {
 	return nil
 }
 
-// MarkNodeForRemoval marks a node for removal from the node pool.
-func (np *CoreWeaveNodePool) MarkNodeForRemoval(node *apiv1.Node) error {
-	ctx, cancel := GetCoreWeaveContext()
-	defer cancel()
-	if node == nil {
-		return fmt.Errorf("node cannot be nil")
-	}
-	if node.Name == "" {
-		return fmt.Errorf("node name cannot be empty")
-	}
-	// Log the node being marked for removal
-	klog.V(4).Infof("Marking node %s for removal from node pool %s", node.Name, np.GetName())
-	// Fetch the current node object
-	currentNode, err := np.client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get node %s: %v", node.Name, err)
-	}
-	// Check if the node belongs to this node pool
-	if currentNode.Labels == nil || currentNode.Labels[coreWeaveNodePoolUID] != np.GetUID() {
-		return fmt.Errorf("node %s does not belong to node pool %s", node.Name, np.GetName())
-	}
-	// Check if the node is already marked for removal
-	if currentNode.Labels != nil && currentNode.Labels[coreWeaveRemoveNode] == "true" {
-		klog.V(4).Infof("Node %s is already marked for removal", currentNode.Name)
-		return nil // Node is already marked for removal, no action needed
-	}
-	// Set the label to indicate the node should be removed
-	currentNode.Labels[coreWeaveRemoveNode] = "true"
-	// Update the node using the client
-	_, err = np.client.CoreV1().Nodes().Update(ctx, currentNode, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to mark node %s for removal: %v", node.Name, err)
-	}
-	return nil
-}
-
 // ValidateNodes checks if the provided nodes belong to the node pool.
 func (np *CoreWeaveNodePool) ValidateNodes(nodes []*apiv1.Node) error {
 	if len(nodes) == 0 {


### PR DESCRIPTION
#### What type of PR is this?

<!--


-->
/kind bug

#### What this PR does / why we need it:

Two changes present in this PR

Dropping logic that adds the remove-node label

- The ToBeDeletedByClusterAutoscaler taint will be used as an indicator that a node should be removed from the node group. The remove-node label will only be managed by an internal controller
- The Autoscaler's usage of the remove-node label was causing conflicts with the internal controller responsible for reconciling node groups.

Taking the absolute value of delta in the DecreaseTargetSize

- This is fixing a bug in the current CoreWeave Autoscaler implementation. When DecreaseTargetSize is called delta is passed as a negative value. The CW Autoscaler currently assumes delta is positive. Taking the absolute value of delta resolves this difference

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This improves the user experience when using the CoreWeave implementation of the Cluster Autoscaler. Specifically prevents scenarios such as too many nodes getting removed and node groups being mistakenly scaled up. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
