### PR TITLE
feat: VPA InPlace updateMode

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
@@ -596,6 +596,7 @@ spec:
                     - Initial
                     - Recreate
                     - InPlaceOrRecreate
+                    - InPlace
                     - Auto
                     type: string
                 type: object

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -596,6 +596,7 @@ spec:
                     - Initial
                     - Recreate
                     - InPlaceOrRecreate
+                    - InPlace
                     - Auto
                     type: string
                 type: object

--- a/vertical-pod-autoscaler/docs/api.md
+++ b/vertical-pod-autoscaler/docs/api.md
@@ -160,7 +160,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `updateMode` _[UpdateMode](#updatemode)_ | Controls when autoscaler applies changes to the pod resources.<br />The default is 'Recreate'. |  | Enum: [Off Initial Recreate InPlaceOrRecreate Auto] <br />Optional: \{\} <br /> |
+| `updateMode` _[UpdateMode](#updatemode)_ | Controls when autoscaler applies changes to the pod resources.<br />The default is 'Recreate'. |  | Enum: [Off Initial Recreate InPlaceOrRecreate InPlace Auto] <br />Optional: \{\} <br /> |
 | `minReplicas` _integer_ | Minimal number of replicas which need to be alive for Updater to attempt<br />pod eviction (pending other checks like PDB). Only positive values are<br />allowed. Overrides global '--min-replicas' flag. |  | Optional: \{\} <br /> |
 | `evictionRequirements` _[EvictionRequirement](#evictionrequirement) array_ | EvictionRequirements is a list of EvictionRequirements that need to<br />evaluate to true in order for a Pod to be evicted. If more than one<br />EvictionRequirement is specified, all of them need to be fulfilled to allow eviction. |  | Optional: \{\} <br /> |
 | `evictAfterOOMSeconds` _integer_ | evictAfterOOMSeconds specifies the time in seconds to wait after an OOM event before<br />considering the pod for eviction. Pods that have OOMed in less than this time<br />since start will be evicted. |  | Minimum: 1 <br />Optional: \{\} <br /> |
@@ -249,7 +249,7 @@ _Underlying type:_ _string_
 UpdateMode controls when autoscaler applies changes to the pod resources.
 
 _Validation:_
-- Enum: [Off Initial Recreate InPlaceOrRecreate Auto]
+- Enum: [Off Initial Recreate InPlaceOrRecreate InPlace Auto]
 
 _Appears in:_
 - [PodUpdatePolicy](#podupdatepolicy)
@@ -261,6 +261,7 @@ _Appears in:_
 | `Recreate` | UpdateModeRecreate means that autoscaler assigns resources on pod<br />creation and additionally can update them during the lifetime of the<br />pod by deleting and recreating the pod.<br /> |
 | `Auto` | UpdateModeAuto means that autoscaler assigns resources on pod creation<br />and additionally can update them during the lifetime of the pod,<br />using any available update method. Currently this is equivalent to<br />Recreate.<br />Deprecated: This value is deprecated and will be removed in a future API version.<br />Use explicit update modes like "Recreate", "Initial", or "InPlaceOrRecreate" instead.<br />See https://github.com/kubernetes/autoscaler/issues/8424 for more details.<br /> |
 | `InPlaceOrRecreate` | UpdateModeInPlaceOrRecreate means that autoscaler tries to assign resources in-place.<br />If this is not possible (e.g., resizing takes too long or is infeasible), it falls back to the<br />"Recreate" update mode.<br />Requires VPA level feature gate "InPlaceOrRecreate" to be enabled<br />on the admission and updater pods.<br />Requires cluster feature gate "InPlacePodVerticalScaling" to be enabled.<br /> |
+| `InPlace` | UpdateModeInPlace means that autoscaler will only attempt to update pods in-place<br />and will never evict them. If in-place update fails, autoscaler will rely on<br />Kubelet's automatic retry mechanism.<br />Requires VPA level feature gate "InPlace" to be enabled<br />on the admission and updater pods<br />Requires cluster feature gate "InPlacePodVerticalScaling" to be enabled.<br /> |
 
 
 #### VerticalPodAutoscaler

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -21,7 +21,7 @@ This document is auto-generated from the flag definitions in the VPA admission-c
 | `alsologtostderr` |  |  | log to standard error as well as files (no effect when -logtostderr=true) |
 | `alsologtostderrthreshold` | severity |  | logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true) |
 | `client-ca-file` | string |  "/etc/tls-certs/caCert.pem" | Path to CA PEM file.  |
-| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>CPUStartupBoost=true\|false (ALPHA - default=false)<br>PerVPAConfig=true\|false (ALPHA - default=false) |
+| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>CPUStartupBoost=true\|false (ALPHA - default=false)<br>InPlace=true\|false (ALPHA - default=false)<br>PerVPAConfig=true\|false (ALPHA - default=false) |
 | `ignored-vpa-object-namespaces` | string |  | A comma-separated list of namespaces to ignore when searching for VPA objects. Leave empty to avoid ignoring any namespaces. These namespaces will not be cleaned by the garbage collector. |
 | `kube-api-burst` | float |  100 | QPS burst limit when making requests to Kubernetes apiserver  |
 | `kube-api-qps` | float |  50 | QPS limit when making requests to Kubernetes apiserver  |
@@ -78,7 +78,7 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `cpu-integer-post-processor-enabled` |  |  | Enable the cpu-integer recommendation post processor. The post processor will round up CPU recommendations to a whole CPU for pods which were opted in by setting an appropriate label on VPA object (experimental) |
 | `external-metrics-cpu-metric` | string |  | ALPHA.  Metric to use with external metrics provider for CPU usage. |
 | `external-metrics-memory-metric` | string |  | ALPHA.  Metric to use with external metrics provider for memory usage. |
-| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>CPUStartupBoost=true\|false (ALPHA - default=false)<br>PerVPAConfig=true\|false (ALPHA - default=false) |
+| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>CPUStartupBoost=true\|false (ALPHA - default=false)<br>InPlace=true\|false (ALPHA - default=false)<br>PerVPAConfig=true\|false (ALPHA - default=false) |
 | `history-cpu-metric` | string |  "container_cpu_usage_seconds_total" | Name of the metric to use for CPU history when querying Prometheus.  |
 | `history-length` | string |  "8d" | How much time back prometheus have to be queried to get historical metrics  |
 | `history-memory-metric` | string |  "container_memory_working_set_bytes" | Name of the metric to use for memory history when querying Prometheus  |
@@ -158,7 +158,7 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `eviction-rate-burst` | int |  1 | Burst of pods that can be evicted.  |
 | `eviction-rate-limit` | float |  -1 | Number of pods that can be evicted per seconds. A rate limit set to 0 or -1 will disable the rate limiter.  |
 | `eviction-tolerance` | float |  0.5 | Fraction of replica count that can be evicted for update, if more than one pod can be evicted.  |
-| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>CPUStartupBoost=true\|false (ALPHA - default=false)<br>PerVPAConfig=true\|false (ALPHA - default=false) |
+| `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>CPUStartupBoost=true\|false (ALPHA - default=false)<br>InPlace=true\|false (ALPHA - default=false)<br>PerVPAConfig=true\|false (ALPHA - default=false) |
 | `ignored-vpa-object-namespaces` | string |  | A comma-separated list of namespaces to ignore when searching for VPA objects. Leave empty to avoid ignoring any namespaces. These namespaces will not be cleaned by the garbage collector. |
 | `in-place-skip-disruption-budget` |  |  | [ALPHA] If true, VPA updater skips disruption budget checks for in-place pod updates when all containers have NotRequired resize policy (or no policy defined) for both CPU and memory resources. Disruption budgets are still respected when any container has RestartContainer resize policy for any resource. |
 | `in-recommendation-bounds-eviction-lifetime-threshold` |  |  12h0m0s | duration   Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range  |
@@ -190,4 +190,3 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `v,` |  | : 4 | , --v Level                                                         set the log level verbosity  (default 4) |
 | `vmodule` | moduleSpec |  | comma-separated list of pattern=N settings for file-filtered logging |
 | `vpa-object-namespace` | string |  | Specifies the namespace to search for VPA objects. Leave empty to include all namespaces. If provided, the garbage collector will only clean this namespace. |
-

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation.go
@@ -33,6 +33,7 @@ type VPAValidationOptions struct {
 	AllowCPUStartupBoost   bool
 	AllowInPlaceOrRecreate bool
 	AllowPerVPAConfig      bool
+	AllowInPlace           bool
 }
 
 func getValidationOptionsForVPA(oldObj *vpa_types.VerticalPodAutoscaler) VPAValidationOptions {
@@ -41,6 +42,7 @@ func getValidationOptionsForVPA(oldObj *vpa_types.VerticalPodAutoscaler) VPAVali
 		AllowCPUStartupBoost:   allowCPUBoost(oldObj),
 		AllowInPlaceOrRecreate: features.Enabled(features.InPlaceOrRecreate),
 		AllowPerVPAConfig:      allowPerVPAConfig(oldObj),
+		AllowInPlace:           allowInPlace(oldObj),
 	}
 
 	return opts
@@ -93,6 +95,22 @@ func allowPerVPAConfig(oldObj *vpa_types.VerticalPodAutoscaler) bool {
 	return false
 }
 
+func allowInPlace(oldObj *vpa_types.VerticalPodAutoscaler) bool {
+	if features.Enabled(features.InPlace) {
+		return true
+	}
+
+	if oldObj == nil {
+		return false
+	}
+
+	if oldObj.Spec.UpdatePolicy != nil && oldObj.Spec.UpdatePolicy.UpdateMode != nil && *oldObj.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeInPlace {
+		return true
+	}
+
+	return false
+}
+
 func validateVPA(vpa *vpa_types.VerticalPodAutoscaler, opts VPAValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateVPASpec(&vpa.Spec, field.NewPath("spec"), opts)...)
@@ -139,6 +157,10 @@ func validateVPASpecUpdatePolicy(updatePolicy *vpa_types.PodUpdatePolicy, fldPat
 
 		if *mode == vpa_types.UpdateModeInPlaceOrRecreate && !opts.AllowInPlaceOrRecreate {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("updateMode"), fmt.Sprintf("in order to use UpdateMode %s, you must enable feature gate %s in the admission-controller args", vpa_types.UpdateModeInPlaceOrRecreate, features.InPlaceOrRecreate)))
+		}
+
+		if *mode == vpa_types.UpdateModeInPlace && !opts.AllowInPlace {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("updateMode"), fmt.Sprintf("in order to use UpdateMode %s, you must enable feature gate %s in the admission-controller args", vpa_types.UpdateModeInPlace, features.InPlace)))
 		}
 	}
 	if minReplicas := updatePolicy.MinReplicas; minReplicas != nil && *minReplicas <= 0 {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation_test.go
@@ -256,6 +256,7 @@ func TestValidateVPA(t *testing.T) {
 	scalingModeOff := vpa_types.ContainerScalingModeOff
 	controlledValuesRequestsAndLimits := vpa_types.ContainerControlledValuesRequestsAndLimits
 	inPlaceOrRecreateUpdateMode := vpa_types.UpdateModeInPlaceOrRecreate
+	inPlaceUpdateMode := vpa_types.UpdateModeInPlace
 	badCPUBoostFactor := int32(0)
 	validCPUBoostFactor := int32(2)
 	badCPUBoostQuantity := resource.MustParse("187500u")
@@ -306,7 +307,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: errors.New("spec.updatePolicy.updateMode: Unsupported value: \"bad\": supported values: \"InPlaceOrRecreate\", \"Initial\", \"Off\", \"Recreate\""),
+			expectError: errors.New("spec.updatePolicy.updateMode: Unsupported value: \"bad\": supported values: \"InPlace\", \"InPlaceOrRecreate\", \"Initial\", \"Off\", \"Recreate\""),
 		},
 		{
 			name: "creating VPA with InPlaceOrRecreate update mode not allowed by disabled feature gate",
@@ -1087,6 +1088,70 @@ func TestValidateVPA(t *testing.T) {
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowPerVPAConfig: false},
 			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].oomMinBumpUp: Forbidden: not supported when feature flag PerVPAConfig is disabled"),
+		},
+		{
+			name: "creating VPA with InPlace update mode not allowed by disabled feature gate",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode: &inPlaceUpdateMode,
+					},
+				},
+			},
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowInPlace: false},
+			expectError: fmt.Errorf("spec.updatePolicy.updateMode: Forbidden: in order to use UpdateMode %s, you must enable feature gate %s in the admission-controller args", vpa_types.UpdateModeInPlace, features.InPlace),
+		},
+		{
+			name: "InPlace update mode with minReplicas",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode:  &inPlaceUpdateMode,
+						MinReplicas: &validMinReplicas,
+					},
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+				},
+			},
+			opts: VPAValidationOptions{IsVPACreate: true, AllowInPlace: true},
+		},
+		{
+			name: "InPlace update mode with complete resource policy",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode:  &inPlaceUpdateMode,
+						MinReplicas: &validMinReplicas,
+					},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "test-container",
+								Mode:          &validScalingMode,
+								MinAllowed: corev1.ResourceList{
+									cpu:    resource.MustParse("10m"),
+									memory: resource.MustParse("100Mi"),
+								},
+								MaxAllowed: corev1.ResourceList{
+									cpu:    resource.MustParse("1000m"),
+									memory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			opts: VPAValidationOptions{IsVPACreate: true, AllowInPlace: true},
 		},
 	}
 	for _, tc := range tests {

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/helpers.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/helpers.go
@@ -26,6 +26,7 @@ func GetUpdateModes() map[UpdateMode]any {
 		UpdateModeRecreate:          nil,
 		UpdateModeAuto:              nil,
 		UpdateModeInPlaceOrRecreate: nil,
+		UpdateModeInPlace:           nil,
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -214,7 +214,7 @@ type PodUpdatePolicy struct {
 }
 
 // UpdateMode controls when autoscaler applies changes to the pod resources.
-// +kubebuilder:validation:Enum=Off;Initial;Recreate;InPlaceOrRecreate;Auto
+// +kubebuilder:validation:Enum=Off;Initial;Recreate;InPlaceOrRecreate;InPlace;Auto
 type UpdateMode string
 
 const (
@@ -245,6 +245,13 @@ const (
 	// on the admission and updater pods.
 	// Requires cluster feature gate "InPlacePodVerticalScaling" to be enabled.
 	UpdateModeInPlaceOrRecreate UpdateMode = "InPlaceOrRecreate"
+	// UpdateModeInPlace means that autoscaler will only attempt to update pods in-place
+	// and will never evict them. If in-place update fails, autoscaler will rely on
+	// Kubelet's automatic retry mechanism.
+	// Requires VPA level feature gate "InPlace" to be enabled
+	// on the admission and updater pods
+	// Requires cluster feature gate "InPlacePodVerticalScaling" to be enabled.
+	UpdateModeInPlace UpdateMode = "InPlace"
 )
 
 // PodResourcePolicy controls how autoscaler computes the recommended resources
@@ -341,7 +348,6 @@ type VerticalPodAutoscalerStatus struct {
 	// autoscaler for the controlled pods.
 	// +optional
 	Recommendation *RecommendedPodResources `json:"recommendation,omitempty" protobuf:"bytes,1,opt,name=recommendation"`
-
 	// Conditions is the set of conditions required for this autoscaler to scale its target,
 	// and indicates whether or not those conditions are met.
 	// +optional

--- a/vertical-pod-autoscaler/pkg/features/features.go
+++ b/vertical-pod-autoscaler/pkg/features/features.go
@@ -64,6 +64,13 @@ const (
 	// optimization strategies to be applied to different workloads within the
 	// same cluster.
 	PerVPAConfig featuregate.Feature = "PerVPAConfig"
+
+	// alpha: v1.7.0
+	// components: admission-controller, updater
+
+	// InPlace enables the InPlace update mode to be used.
+	// Requires KEP-1287 InPlacePodVerticalScaling feature-gate to be enabled on the cluster.
+	InPlace featuregate.Feature = "InPlace"
 )
 
 // MutableFeatureGate is a mutable, versioned, global FeatureGate.

--- a/vertical-pod-autoscaler/pkg/features/versioned_features.go
+++ b/vertical-pod-autoscaler/pkg/features/versioned_features.go
@@ -35,6 +35,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("1.5"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.6"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
+	InPlace: {
+		{Version: version.MustParse("1.7"), Default: false, PreRelease: featuregate.Alpha},
+	},
 	PerVPAConfig: {
 		{Version: version.MustParse("1.5"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/set"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -82,6 +84,7 @@ type updater struct {
 	statusValidator              status.Validator
 	controllerFetcher            controllerfetcher.ControllerFetcher
 	ignoredNamespaces            []string
+	infeasibleAttempts           map[types.UID]*vpa_types.RecommendedPodResources
 	defaultUpdateThreshold       float64
 	podLifetimeUpdateThreshold   time.Duration
 	evictAfterOOMThreshold       time.Duration
@@ -142,6 +145,7 @@ func NewUpdater(
 			status.AdmissionControllerStatusName,
 			statusNamespace,
 		),
+		infeasibleAttempts:         make(map[types.UID]*vpa_types.RecommendedPodResources),
 		ignoredNamespaces:          ignoredNamespaces,
 		defaultUpdateThreshold:     defaultUpdateThreshold,
 		podLifetimeUpdateThreshold: podLifetimeUpdateThreshold,
@@ -157,11 +161,11 @@ func (u *updater) RunOnce(ctx context.Context) {
 	if u.useAdmissionControllerStatus {
 		isValid, err := u.statusValidator.IsStatusValid(ctx, status.AdmissionControllerStatusTimeout)
 		if err != nil {
-			klog.ErrorS(err, "Error getting Admission Controller status. Skipping eviction loop")
+			klog.ErrorS(err, "Error getting Admission Controller status. Skipping update loop")
 			return
 		}
 		if !isValid {
-			klog.V(0).InfoS("Admission Controller status is not valid. Skipping eviction loop", "timeout", status.AdmissionControllerStatusTimeout)
+			klog.V(0).InfoS("Admission Controller status is not valid. Skipping update loop", "timeout", status.AdmissionControllerStatusTimeout)
 			return
 		}
 	}
@@ -175,8 +179,9 @@ func (u *updater) RunOnce(ctx context.Context) {
 
 	vpas := make([]*vpa_api_util.VpaWithSelector, 0)
 
-	inPlaceFeatureEnable := features.Enabled(features.InPlaceOrRecreate)
-
+	inPlaceOrRecreateFeatureEnabled := features.Enabled(features.InPlaceOrRecreate)
+	inPlaceFeatureEnabled := features.Enabled(features.InPlace)
+	cpuStartupBoostFeatureEnabled := features.Enabled(features.CPUStartupBoost)
 	for _, vpa := range vpaList {
 		if slices.Contains(u.ignoredNamespaces, vpa.Namespace) {
 			klog.V(3).InfoS("Skipping VPA object in ignored namespace", "vpa", klog.KObj(vpa), "namespace", vpa.Namespace)
@@ -189,8 +194,9 @@ func (u *updater) RunOnce(ctx context.Context) {
 		if updateMode != vpa_types.UpdateModeRecreate &&
 			updateMode != vpa_types.UpdateModeAuto && //nolint:staticcheck
 			updateMode != vpa_types.UpdateModeInPlaceOrRecreate &&
+			updateMode != vpa_types.UpdateModeInPlace &&
 			vpa.Spec.StartupBoost == nil {
-			klog.V(3).InfoS("Skipping VPA object because its mode is not  \"InPlaceOrRecreate\", \"Recreate\" or \"Auto\" and it doesn't have startupBoost configured", "vpa", klog.KObj(vpa))
+			klog.V(3).InfoS("Skipping VPA object because its mode is not  \"InPlaceOrRecreate\", \"InPlace\", \"Recreate\" or \"Auto\" and it doesn't have startupBoost configured", "vpa", klog.KObj(vpa))
 			continue
 		}
 		selector, err := u.selectorFetcher.Fetch(ctx, vpa)
@@ -222,11 +228,18 @@ func (u *updater) RunOnce(ctx context.Context) {
 	allLivePods := filterDeletedPods(podsList)
 
 	controlledPods := make(map[*vpa_types.VerticalPodAutoscaler][]*corev1.Pod)
+	livePodUIDs := set.New[types.UID]()
 	for _, pod := range allLivePods {
+		livePodUIDs.Insert(pod.UID)
 		controllingVPA := vpa_api_util.GetControllingVPAForPod(ctx, pod, vpas, u.controllerFetcher)
 		if controllingVPA != nil {
 			controlledPods[controllingVPA.Vpa] = append(controlledPods[controllingVPA.Vpa], pod)
 		}
+	}
+
+	// Clean up stale infeasible attempts for pods that no longer exist
+	if len(u.infeasibleAttempts) > 0 {
+		u.cleanupStaleInfeasibleAttempts(livePodUIDs)
 	}
 	timer.ObserveStep("FilterPods")
 
@@ -255,7 +268,6 @@ func (u *updater) RunOnce(ctx context.Context) {
 	defer vpasWithInPlaceUpdatablePodsCounter.Observe()
 	defer vpasWithInPlaceUpdatedPodsCounter.Observe()
 
-	cpuStartupBoostEnabled := features.Enabled(features.CPUStartupBoost)
 	for vpa, livePods := range controlledPods {
 		vpaSize := len(livePods)
 		updateMode := vpa_api_util.GetUpdateMode(vpa)
@@ -271,7 +283,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 		podsToUnboost := make([]*corev1.Pod, 0)
 		withInPlaceUpdated := false
 
-		if cpuStartupBoostEnabled && vpa.Spec.StartupBoost != nil {
+		if cpuStartupBoostFeatureEnabled && vpa.Spec.StartupBoost != nil {
 			// First, handle unboosting for pods that have finished their startup period.
 			for _, pod := range livePods {
 				if vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
@@ -319,8 +331,8 @@ func (u *updater) RunOnce(ctx context.Context) {
 		withInPlaceUpdatable := false
 		withEvictable := false
 
-		if updateMode == vpa_types.UpdateModeInPlaceOrRecreate && inPlaceFeatureEnable {
-			podsForInPlace = u.getPodsUpdateOrder(filterNonInPlaceUpdatablePods(podsAvailableForUpdate, inPlaceLimiter), vpa)
+		if (updateMode == vpa_types.UpdateModeInPlaceOrRecreate && inPlaceOrRecreateFeatureEnabled) || (updateMode == vpa_types.UpdateModeInPlace && inPlaceFeatureEnabled) {
+			podsForInPlace = u.getPodsUpdateOrder(filterNonInPlaceUpdatablePods(podsAvailableForUpdate, inPlaceLimiter, vpa, u.infeasibleAttempts), vpa)
 			inPlaceUpdatablePodsCounter.Add(vpaSize, len(podsForInPlace))
 			if len(podsForInPlace) > 0 {
 				withInPlaceUpdatable = true
@@ -328,7 +340,11 @@ func (u *updater) RunOnce(ctx context.Context) {
 		} else {
 			// If the feature gate is not enabled but update mode is InPlaceOrRecreate, updater will always fallback to eviction.
 			if updateMode == vpa_types.UpdateModeInPlaceOrRecreate {
-				klog.InfoS("Warning: feature gate is not enabled for this updateMode", "featuregate", features.InPlaceOrRecreate, "updateMode", vpa_types.UpdateModeInPlaceOrRecreate)
+				klog.InfoS("Warning: feature gate is not enabled for this updateMode", "featuregate", features.InPlaceOrRecreate, "updateMode", updateMode)
+				// If the feature gate is not enabled but update mode is InPlace, updater will do nothing.
+			} else if updateMode == vpa_types.UpdateModeInPlace {
+				klog.InfoS("Warning: feature gate is not enabled for this updateMode", "featuregate", features.InPlace, "updateMode", updateMode)
+				continue
 			}
 			podsForEviction = u.getPodsUpdateOrder(filterNonEvictablePods(podsAvailableForUpdate, evictionLimiter), vpa)
 			evictablePodsCounter.Add(vpaSize, updateMode, len(podsForEviction))
@@ -340,15 +356,45 @@ func (u *updater) RunOnce(ctx context.Context) {
 		withEvicted := false
 
 		for _, pod := range podsForInPlace {
-			decision := inPlaceLimiter.CanInPlaceUpdate(pod)
+			decision := inPlaceLimiter.CanInPlaceUpdate(pod, vpa, u.infeasibleAttempts)
 
-			if decision == utils.InPlaceDeferred {
-				klog.V(0).InfoS("In-place update deferred", "pod", klog.KObj(pod))
-				continue
-			} else if decision == utils.InPlaceEvict {
+			switch decision {
+			case utils.InPlaceDeferred:
+				// this can be happening for both InPlace and InPlaceOrRecreate
+				if updateMode == vpa_types.UpdateModeInPlaceOrRecreate {
+					klog.V(0).InfoS("In-place update deferred", "pod", klog.KObj(pod))
+					continue
+				}
+				// Pod passed priority calculator, meaning recommendations differ from spec.
+				// Retry the in-place update implicitly by ignoring until the next loop.
+				klog.V(2).InfoS("In-place update deferred", "pod", klog.KObj(pod))
+			case utils.InPlaceEvict:
+				// This should only happen for InPlaceOrRecreate mode
 				podsForEviction = append(podsForEviction, pod)
 				continue
+
+			case utils.InPlaceInfeasibleCached:
+				// this can only be happening for InPlace mode
+				klog.V(2).InfoS("In-place update infeasible, no resource is lower in new recommendation, skipping pod", "pod", klog.KObj(pod))
+				continue
+
+			case utils.InPlaceInfeasible:
+				// This should only happen for InPlace mode
+				// Status is Infeasible, but recommendation has changed
+				// (or first infeasible attempt)
+				// Retry in-place update (no backoff for alpha)
+				// this status should only be returned with InPlace update mode (InPlaceOrRecreate will return InPlaceEvict in case of infeasible state)
+				// Fall through to attempt in-place update
+				klog.V(2).InfoS("In-place update infeasible, retrying with new recommendation", "pod", klog.KObj(pod))
+				u.recordInfeasibleAttempt(pod, vpa)
+			case utils.InPlaceApproved:
+				klog.V(2).InfoS("In-place update approved", "pod", klog.KObj(pod))
+				// Proceed with in-place update
+			default:
+				klog.ErrorS(nil, "Unexpected in-place update decision, skipping pod", "decision", decision, "pod", klog.KObj(pod))
+				continue
 			}
+
 			err = u.inPlaceRateLimiter.Wait(ctx)
 			if err != nil {
 				klog.V(0).InfoS("In-place rate limiter wait failed for in-place resize", "error", err)
@@ -357,8 +403,28 @@ func (u *updater) RunOnce(ctx context.Context) {
 			}
 			err := inPlaceLimiter.InPlaceUpdate(pod, vpa, u.eventRecorder)
 			if err != nil {
+				reason := "InPlaceUpdateError"
+				// For InPlace mode, don't evict pods even if we get an error
+				if updateMode == vpa_types.UpdateModeInPlace {
+					// TODO: check for an admission plugin error because of OS and node capacity checks
+					// Check if it's an infeasibility error
+					// infeasible patches are rejected at API server level (soon),
+					// so spec.resources remains unchanged. We must track the attempted
+					// recommendation to prevent infinite retry loops.
+					// This work is still in progress (https://github.com/kubernetes/kubernetes/pull/136043)
+					// Currently isInfeasibleError return false
+					if isInfeasibleError(err) {
+						// TODO: this will be changed when we know how errors shoule be look like
+						// depends on https://github.com/kubernetes/kubernetes/pull/136043
+						reason = "InPlaceUpdateInfeasible"
+						u.recordInfeasibleAttempt(pod, vpa)
+					}
+					klog.V(0).InfoS("In-place resize failed", "error", err, "pod", klog.KObj(pod), "reason", reason)
+					metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, reason)
+					continue
+				}
 				klog.V(0).InfoS("In-place resize failed, falling back to eviction", "error", err, "pod", klog.KObj(pod))
-				metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, "InPlaceUpdateError")
+				metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, reason)
 				podsForEviction = append(podsForEviction, pod)
 				continue
 			}
@@ -403,6 +469,20 @@ func (u *updater) RunOnce(ctx context.Context) {
 	timer.ObserveStep("EvictPods")
 }
 
+func (u *updater) cleanupStaleInfeasibleAttempts(livePodUIDs set.Set[types.UID]) {
+	for podID := range u.infeasibleAttempts {
+		if !livePodUIDs.Has(podID) {
+			delete(u.infeasibleAttempts, podID)
+		}
+	}
+}
+
+// recordInfeasibleAttempt stores the recommendation that failed as infeasible
+func (u *updater) recordInfeasibleAttempt(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) {
+	u.infeasibleAttempts[pod.UID] = vpa.Status.Recommendation
+	klog.V(2).InfoS("Recorded infeasible attempt, will retry when recommendation changes", "pod", klog.KObj(pod))
+}
+
 func getRateLimiter(rateLimit float64, rateLimitBurst int) *rate.Limiter {
 	var rateLimiter *rate.Limiter
 	if rateLimit <= 0 {
@@ -430,7 +510,7 @@ func (u *updater) getPodsUpdateOrder(pods []*corev1.Pod, vpa *vpa_types.Vertical
 		u.priorityProcessor)
 
 	for _, pod := range pods {
-		priorityCalculator.AddPod(pod, time.Now())
+		priorityCalculator.AddPod(pod, time.Now(), u.infeasibleAttempts)
 	}
 
 	return priorityCalculator.GetSortedPods(u.evictionAdmission)
@@ -446,9 +526,30 @@ func filterPods(pods []*corev1.Pod, predicate func(*corev1.Pod) bool) []*corev1.
 	return result
 }
 
-func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restriction.PodsInPlaceRestriction) []*corev1.Pod {
+func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restriction.PodsInPlaceRestriction, vpa *vpa_types.VerticalPodAutoscaler, infeasibleAttempts map[types.UID]*vpa_types.RecommendedPodResources) []*corev1.Pod {
 	return filterPods(pods, func(pod *corev1.Pod) bool {
-		return inplaceRestriction.CanInPlaceUpdate(pod) != utils.InPlaceDeferred
+		updateMode := *vpa.Spec.UpdatePolicy.UpdateMode
+		decision := inplaceRestriction.CanInPlaceUpdate(pod, vpa, infeasibleAttempts)
+		switch decision {
+		case utils.InPlaceApproved:
+			return true
+		case utils.InPlaceInfeasible:
+			// For InPlace mode, include infeasible pods to retry (no backoff for alpha)
+			return updateMode == vpa_types.UpdateModeInPlace
+		case utils.InPlaceEvict:
+			// For InPlaceOrRecreate, include so they can be redirected to eviction in the loop
+			return updateMode == vpa_types.UpdateModeInPlaceOrRecreate
+		case utils.InPlaceDeferred:
+			// For InPlace mode, include deferred pods so we can check if recommendation
+			// changed and apply a new patch while a previous update is in progress
+			return updateMode == vpa_types.UpdateModeInPlace
+		case utils.InPlaceInfeasibleCached:
+			// Cached infeasibility means we've already determined this pod cannot be
+			// updated in-place and cached the result to avoid redundant checks
+			return false
+		default:
+			return false
+		}
 	})
 }
 
@@ -492,4 +593,12 @@ func newEventRecorder(kubeClient kube_client.Interface) record.EventRecorder {
 	}
 
 	return eventBroadcaster.NewRecorder(vpascheme, corev1.EventSource{Component: "vpa-updater"})
+}
+
+// isInfeasibleError checks if an error indicates the resize is infeasible.
+// Infeasible error detection at the admission controller level is still in progress
+// (https://github.com/kubernetes/kubernetes/pull/136043).
+// This is just a placeholder until that work lands and we know the exact error format.
+func isInfeasibleError(err error) bool {
+	return false
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -32,8 +32,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/set"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
@@ -640,6 +642,44 @@ func TestLogDeprecationWarnings(t *testing.T) {
 		})
 	}
 }
+
+func TestInfeasibleAttempts(t *testing.T) {
+	containerName := "container1"
+	pod1 := test.Pod().WithName("pod1").WithUID("pod1").AddContainer(test.Container().WithName(containerName).Get()).Get()
+	pod2 := test.Pod().WithName("pod2").WithUID("pod2").AddContainer(test.Container().WithName(containerName).Get()).Get()
+
+	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).Get()
+
+	// Initialize updater with required fields for these functions
+	u := &updater{
+		recommendationProcessor: &test.FakeRecommendationProcessor{},
+		infeasibleAttempts:      make(map[types.UID]*vpa_types.RecommendedPodResources),
+	}
+
+	t.Run("recordInfeasibleAttempt stores recommendation", func(t *testing.T) {
+		u.recordInfeasibleAttempt(pod1, vpa)
+		u.recordInfeasibleAttempt(pod2, vpa)
+		assert.Len(t, u.infeasibleAttempts, 2)
+		assert.Contains(t, u.infeasibleAttempts, pod1.UID)
+		assert.Contains(t, u.infeasibleAttempts, pod2.UID)
+	})
+
+	t.Run("cleanupStaleInfeasibleAttempts removes old pods", func(t *testing.T) {
+		// Only pod1 is "live" now
+		livePodUIDs := set.New(pod1.UID)
+		u.cleanupStaleInfeasibleAttempts(livePodUIDs)
+		// pod1 should stay, pod2 should be deleted
+		assert.Len(t, u.infeasibleAttempts, 1)
+		assert.Contains(t, u.infeasibleAttempts, pod1.UID)
+		assert.NotContains(t, u.infeasibleAttempts, pod2.UID)
+	})
+
+	t.Run("cleanupStaleInfeasibleAttempts clears all if none live", func(t *testing.T) {
+		u.cleanupStaleInfeasibleAttempts(set.New[types.UID]())
+		assert.Empty(t, u.infeasibleAttempts)
+	})
+}
+
 func TestRunOnce_AutoUnboostThenEvict(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlaceOrRecreate, true)
 

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
@@ -71,11 +72,28 @@ func NewUpdatePriorityCalculator(vpa *vpa_types.VerticalPodAutoscaler,
 }
 
 // AddPod adds pod to the UpdatePriorityCalculator.
-func (calc *UpdatePriorityCalculator) AddPod(pod *corev1.Pod, now time.Time) {
+// AddPod adds pod to the UpdatePriorityCalculator. The caller must hold the lock protecting the calculator.
+func (calc *UpdatePriorityCalculator) AddPod(pod *corev1.Pod, now time.Time, infeasibleAttempts map[types.UID]*vpa_types.RecommendedPodResources) {
 	processedRecommendation, _, err := calc.recommendationProcessor.Apply(calc.vpa, pod)
 	if err != nil {
 		klog.V(2).ErrorS(err, "Cannot process recommendation for pod", "pod", klog.KObj(pod))
 		return
+	}
+
+	// Check if this recommendation was already tried and failed as infeasible
+	// only for InPlace update mode
+	if vpa_api_util.GetUpdateMode(calc.vpa) == vpa_types.UpdateModeInPlace {
+		if lastAttempt, exists := infeasibleAttempts[pod.UID]; exists {
+			// Only retry if the new recommendation has at least one resource lower than the last attempt
+			if !hasLowerResourceRecommendation(lastAttempt, processedRecommendation) {
+				klog.V(4).InfoS("Skipping pod, recommendation not lower than last infeasible attempt",
+					"pod", klog.KObj(pod))
+				return
+			}
+			// Recommendation has lower resource, will retry
+			klog.V(4).InfoS("Recommendation changed since last infeasible attempt, will retry",
+				"pod", klog.KObj(pod))
+		}
 	}
 
 	hasObservedContainers, vpaContainerSet := parseVpaObservedContainers(pod)
@@ -221,6 +239,42 @@ func parseVpaObservedContainers(pod *corev1.Pod) (bool, sets.Set[string]) {
 		}
 	}
 	return hasObservedContainers, vpaContainerSet
+}
+
+// hasLowerResourceRecommendation checks if the new recommendation has any resource
+// (CPU or Memory) that is lower than the last recommendation. This is used to determine
+// if a previously infeasible update attempt should be retried.
+func hasLowerResourceRecommendation(lastAttempt, newRecommendation *vpa_types.RecommendedPodResources) bool {
+	if lastAttempt == nil || newRecommendation == nil {
+		return false
+	}
+
+	// Create a map of container names to their recommendations for easier lookup
+	lastAttemptMap := make(map[string]*vpa_types.RecommendedContainerResources)
+	for i := range lastAttempt.ContainerRecommendations {
+		cr := &lastAttempt.ContainerRecommendations[i]
+		lastAttemptMap[cr.ContainerName] = cr
+	}
+
+	// Check if any resource in the new recommendation is lower than the last attempt
+	for i := range newRecommendation.ContainerRecommendations {
+		newCR := &newRecommendation.ContainerRecommendations[i]
+		lastCR, exists := lastAttemptMap[newCR.ContainerName]
+		if !exists {
+			continue
+		}
+
+		// Compare target resources
+		for resourceName, newTarget := range newCR.Target {
+			if lastTarget, exists := lastCR.Target[resourceName]; exists {
+				if newTarget.Cmp(lastTarget) < 0 {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }
 
 type prioritizedPod struct {

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
@@ -61,10 +62,10 @@ func TestSortPriority(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(vpa, updateconfig, &test.FakeRecommendationProcessor{}, priorityProcessor)
 
 	timestampNow := pod1.Status.StartTime.Add(time.Hour * 24)
-	calculator.AddPod(pod1, timestampNow)
-	calculator.AddPod(pod2, timestampNow)
-	calculator.AddPod(pod3, timestampNow)
-	calculator.AddPod(pod4, timestampNow)
+	calculator.AddPod(pod1, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
+	calculator.AddPod(pod2, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
+	calculator.AddPod(pod3, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
+	calculator.AddPod(pod4, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 
 	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*corev1.Pod{pod3, pod1, pod4, pod2}, result, "Wrong priority order")
@@ -85,9 +86,9 @@ func TestSortPriorityResourcesDecrease(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(vpa, updateconfig, &test.FakeRecommendationProcessor{}, priorityProcessor)
 
 	timestampNow := pod1.Status.StartTime.Add(time.Hour * 24)
-	calculator.AddPod(pod1, timestampNow)
-	calculator.AddPod(pod2, timestampNow)
-	calculator.AddPod(pod3, timestampNow)
+	calculator.AddPod(pod1, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
+	calculator.AddPod(pod2, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
+	calculator.AddPod(pod3, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 
 	// Expect the following order:
 	// 1. pod1 - wants to grow by 1 unit.
@@ -108,7 +109,7 @@ func TestUpdateNotRequired(t *testing.T) {
 		priorityProcessor)
 
 	timestampNow := pod1.Status.StartTime.Add(time.Hour * 24)
-	calculator.AddPod(pod1, timestampNow)
+	calculator.AddPod(pod1, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 
 	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*corev1.Pod{}, result, "Pod should not be updated")
@@ -130,7 +131,7 @@ func TestUseProcessor(t *testing.T) {
 		vpa, updateconfig, recommendationProcessor, priorityProcessor)
 
 	timestampNow := pod1.Status.StartTime.Add(time.Hour * 24)
-	calculator.AddPod(pod1, timestampNow)
+	calculator.AddPod(pod1, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 
 	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*corev1.Pod{}, result, "Pod should not be updated")
@@ -165,7 +166,7 @@ func TestUpdateLonglivedPods(t *testing.T) {
 	// Pretend that the test pods started 13 hours ago.
 	timestampNow := pods[0].Status.StartTime.Add(time.Hour * 13)
 	for i := range 3 {
-		calculator.AddPod(pods[i], timestampNow)
+		calculator.AddPod(pods[i], timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 	}
 	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*corev1.Pod{pods[1], pods[2]}, result, "Exactly POD2 and POD3 should be updated")
@@ -201,7 +202,7 @@ func TestUpdateShortlivedPods(t *testing.T) {
 	// Pretend that the test pods started 11 hours ago.
 	timestampNow := pods[0].Status.StartTime.Add(time.Hour * 11)
 	for i := range 3 {
-		calculator.AddPod(pods[i], timestampNow)
+		calculator.AddPod(pods[i], timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 	}
 	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*corev1.Pod{pods[2]}, result, "Only POD3 should be updated")
@@ -240,7 +241,7 @@ func TestUpdatePodWithQuickOOM(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(
 		vpa, updateconfig, &test.FakeRecommendationProcessor{}, priorityProcessor)
 
-	calculator.AddPod(pod, timestampNow)
+	calculator.AddPod(pod, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*corev1.Pod{pod}, result, "Pod should be updated")
 }
@@ -278,7 +279,7 @@ func TestDontUpdatePodWithQuickOOMNoResourceChange(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(
 		vpa, updateconfig, &test.FakeRecommendationProcessor{}, priorityProcessor)
 
-	calculator.AddPod(pod, timestampNow)
+	calculator.AddPod(pod, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*corev1.Pod{}, result, "Pod should not be updated")
 }
@@ -314,7 +315,7 @@ func TestDontUpdatePodWithOOMAfterLongRun(t *testing.T) {
 	calculator := NewUpdatePriorityCalculator(
 		vpa, updateconfig, &test.FakeRecommendationProcessor{}, priorityProcessor)
 
-	calculator.AddPod(pod, timestampNow)
+	calculator.AddPod(pod, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 	result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 	assert.Exactly(t, []*corev1.Pod{}, result, "Pod shouldn't be updated")
 }
@@ -376,7 +377,7 @@ func TestQuickOOM_VpaOvservedContainers(t *testing.T) {
 			calculator := NewUpdatePriorityCalculator(
 				vpa, updateconfig, &test.FakeRecommendationProcessor{}, priorityProcessor)
 
-			calculator.AddPod(pod, timestampNow)
+			calculator.AddPod(pod, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 			result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 			isUpdate := len(result) != 0
 			assert.Equal(t, tc.want, isUpdate)
@@ -467,7 +468,7 @@ func TestQuickOOM_ContainerResourcePolicy(t *testing.T) {
 			calculator := NewUpdatePriorityCalculator(
 				vpa, updateconfig, &test.FakeRecommendationProcessor{}, priorityProcessor)
 
-			calculator.AddPod(pod, timestampNow)
+			calculator.AddPod(pod, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 			result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
 			isUpdate := len(result) != 0
 			assert.Equal(t, tc.want, isUpdate)
@@ -508,10 +509,10 @@ func TestAdmission(t *testing.T) {
 		&test.FakeRecommendationProcessor{}, priorityProcessor)
 
 	timestampNow := pod1.Status.StartTime.Add(time.Hour * 24)
-	calculator.AddPod(pod1, timestampNow)
-	calculator.AddPod(pod2, timestampNow)
-	calculator.AddPod(pod3, timestampNow)
-	calculator.AddPod(pod4, timestampNow)
+	calculator.AddPod(pod1, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
+	calculator.AddPod(pod2, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
+	calculator.AddPod(pod3, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
+	calculator.AddPod(pod4, timestampNow, make(map[types.UID]*vpa_types.RecommendedPodResources))
 
 	result := calculator.GetSortedPods(&pod1Admission{})
 	assert.Exactly(t, []*corev1.Pod{pod1}, result, "Wrong priority order")
@@ -646,6 +647,189 @@ func TestAddPodLogs(t *testing.T) {
 
 			actualLog := calculator.GetProcessedRecommendationTargets(tc.givenRec)
 			assert.Equal(t, tc.expectedLog, actualLog)
+		})
+	}
+}
+
+func TestHasLowerResourceRecommendation(t *testing.T) {
+	testCases := []struct {
+		name              string
+		lastAttempt       *vpa_types.RecommendedPodResources
+		newRecommendation *vpa_types.RecommendedPodResources
+		expected          bool
+	}{
+		{
+			name:              "both nil",
+			lastAttempt:       nil,
+			newRecommendation: nil,
+			expected:          false,
+		},
+		{
+			name:              "lastAttempt nil",
+			lastAttempt:       nil,
+			newRecommendation: test.Recommendation().WithContainer(containerName).WithTarget("100m", "").Get(),
+			expected:          false,
+		},
+		{
+			name:              "newRecommendation nil",
+			lastAttempt:       test.Recommendation().WithContainer(containerName).WithTarget("100m", "").Get(),
+			newRecommendation: nil,
+			expected:          false,
+		},
+		{
+			name:              "new CPU is lower",
+			lastAttempt:       test.Recommendation().WithContainer(containerName).WithTarget("200m", "").Get(),
+			newRecommendation: test.Recommendation().WithContainer(containerName).WithTarget("100m", "").Get(),
+			expected:          true,
+		},
+		{
+			name:              "new memory is lower",
+			lastAttempt:       test.Recommendation().WithContainer(containerName).WithTarget("", "512Mi").Get(),
+			newRecommendation: test.Recommendation().WithContainer(containerName).WithTarget("", "256Mi").Get(),
+			expected:          true,
+		},
+		{
+			name:              "new resources are higher",
+			lastAttempt:       test.Recommendation().WithContainer(containerName).WithTarget("100m", "256Mi").Get(),
+			newRecommendation: test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			expected:          false,
+		},
+		{
+			name:              "equal resources",
+			lastAttempt:       test.Recommendation().WithContainer(containerName).WithTarget("100m", "256Mi").Get(),
+			newRecommendation: test.Recommendation().WithContainer(containerName).WithTarget("100m", "256Mi").Get(),
+			expected:          false,
+		},
+		{
+			name:              "container not in lastAttempt",
+			lastAttempt:       test.Recommendation().WithContainer(containerName).WithTarget("100m", "").Get(),
+			newRecommendation: test.Recommendation().WithContainer("other-container").WithTarget("50m", "").Get(),
+			expected:          false,
+		},
+		{
+			name:              "one resource lower one higher",
+			lastAttempt:       test.Recommendation().WithContainer(containerName).WithTarget("200m", "256Mi").Get(),
+			newRecommendation: test.Recommendation().WithContainer(containerName).WithTarget("100m", "512Mi").Get(),
+			expected:          true,
+		},
+		{
+			name:              "cpu higher memory lower",
+			lastAttempt:       test.Recommendation().WithContainer(containerName).WithTarget("100m", "512Mi").Get(),
+			newRecommendation: test.Recommendation().WithContainer(containerName).WithTarget("200m", "256Mi").Get(),
+			expected:          true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasLowerResourceRecommendation(tc.lastAttempt, tc.newRecommendation)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestAddPodWithInfeasibleAttempts(t *testing.T) {
+	testCases := []struct {
+		name            string
+		updateMode      vpa_types.UpdateMode
+		lastAttempt     *vpa_types.RecommendedPodResources
+		currentRecommen *vpa_types.RecommendedPodResources
+		shouldAddPod    bool
+	}{
+		{
+			name:            "InPlace mode: no previous infeasible attempt",
+			updateMode:      vpa_types.UpdateModeInPlace,
+			lastAttempt:     nil,
+			currentRecommen: test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			shouldAddPod:    true,
+		},
+		{
+			name:            "InPlace mode: same recommendation as last infeasible attempt",
+			updateMode:      vpa_types.UpdateModeInPlace,
+			lastAttempt:     test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			currentRecommen: test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			shouldAddPod:    false,
+		},
+		{
+			name:            "InPlace mode: higher recommendation than last infeasible attempt",
+			updateMode:      vpa_types.UpdateModeInPlace,
+			lastAttempt:     test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			currentRecommen: test.Recommendation().WithContainer(containerName).WithTarget("300m", "1Gi").Get(),
+			shouldAddPod:    false,
+		},
+		{
+			name:            "InPlace mode: lower CPU than last infeasible attempt",
+			updateMode:      vpa_types.UpdateModeInPlace,
+			lastAttempt:     test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			currentRecommen: test.Recommendation().WithContainer(containerName).WithTarget("100m", "512Mi").Get(),
+			shouldAddPod:    true,
+		},
+		{
+			name:            "InPlace mode: lower memory than last infeasible attempt",
+			updateMode:      vpa_types.UpdateModeInPlace,
+			lastAttempt:     test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			currentRecommen: test.Recommendation().WithContainer(containerName).WithTarget("200m", "256Mi").Get(),
+			shouldAddPod:    true,
+		},
+		{
+			name:            "InPlace mode: one resource lower, one higher",
+			updateMode:      vpa_types.UpdateModeInPlace,
+			lastAttempt:     test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			currentRecommen: test.Recommendation().WithContainer(containerName).WithTarget("100m", "1Gi").Get(),
+			shouldAddPod:    true,
+		},
+		{
+			name:            "Recreate mode: same recommendation as last infeasible attempt",
+			updateMode:      vpa_types.UpdateModeRecreate,
+			lastAttempt:     test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			currentRecommen: test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			shouldAddPod:    true,
+		},
+		{
+			name:            "Auto mode: same recommendation as last infeasible attempt",
+			updateMode:      vpa_types.UpdateModeAuto, //nolint:staticcheck
+			lastAttempt:     test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			currentRecommen: test.Recommendation().WithContainer(containerName).WithTarget("200m", "512Mi").Get(),
+			shouldAddPod:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := test.Pod().WithName("POD1").
+				AddContainer(test.Container().WithName(containerName).
+					WithCPURequest(resource.MustParse("100m")).
+					WithMemRequest(resource.MustParse("128Mi")).Get()).Get()
+
+			vpa := test.VerticalPodAutoscaler().
+				WithContainer(containerName).
+				WithTarget("200m", "512Mi").
+				WithUpdateMode(tc.updateMode).Get()
+
+			priorityProcessor := NewFakeProcessor(map[string]PodPriority{
+				"POD1": {OutsideRecommendedRange: true, ScaleUp: true, ResourceDiff: 1.0},
+			})
+
+			recommendationProcessor := &test.RecommendationProcessorMock{}
+			recommendationProcessor.On("Apply").Return(tc.currentRecommen, nil)
+
+			calculator := NewUpdatePriorityCalculator(vpa, updateconfig, recommendationProcessor, priorityProcessor)
+
+			infeasibleAttempts := make(map[types.UID]*vpa_types.RecommendedPodResources)
+			if tc.lastAttempt != nil {
+				infeasibleAttempts[pod.UID] = tc.lastAttempt
+			}
+
+			timestampNow := pod.Status.StartTime.Add(time.Hour * 24)
+			calculator.AddPod(pod, timestampNow, infeasibleAttempts)
+
+			result := calculator.GetSortedPods(NewDefaultPodEvictionAdmission())
+			if tc.shouldAddPod {
+				assert.Len(t, result, 1, "Pod should be added to update queue")
+				assert.Equal(t, pod, result[0])
+			} else {
+				assert.Len(t, result, 0, "Pod should not be added to update queue")
+			}
 		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -36,6 +36,7 @@ import (
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/utils"
+	resourcehelpers "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/resources"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
@@ -51,14 +52,24 @@ const (
 )
 
 // PodsInPlaceRestriction controls pods in-place updates. It ensures that we will not update too
-// many pods from one replica set. For replica set will allow to update one pod or more if
+// many pods from one replica set. For a replica set, it will allow updating one pod or more if
 // inPlaceToleranceFraction is configured.
 type PodsInPlaceRestriction interface {
-	// InPlaceUpdate attempts to actuate the in-place resize.
-	// Returns error if client returned error.
+	// InPlaceUpdate attempts to actuate the in-place resize for the given pod.
+	// Returns error if the client operation fails.
 	InPlaceUpdate(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler, eventRecorder record.EventRecorder) error
-	// CanInPlaceUpdate checks if pod can be safely updated in-place. If not, it will return a decision to potentially evict the pod.
-	CanInPlaceUpdate(pod *corev1.Pod) utils.InPlaceDecision
+
+	// CanInPlaceUpdate checks if a pod can be safely updated in-place.
+	// Returns:
+	//   - InPlaceApproved: The pod can be updated in-place immediately.
+	//   - InPlaceDeferred: The update should be deferred (e.g., pod is pending, already updating, or group is not disruptable).
+	//   - InPlaceEvict: The pod should be evicted instead of updated in-place.
+	//   - InPlaceInfeasible: The in-place update is infeasible (node can't accommodate it or error occurred). Will only retry when recommendation changes.
+	//
+	// The updateMode parameter affects the decision:
+	//   - UpdateModeInPlace: Waits indefinitely for in-progress updates.
+	//   - UpdateModeInPlaceOrRecreate: May return InPlaceEvict if the pod update exceeds the timeout threshold.
+	CanInPlaceUpdate(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler, infeasibleAttempts map[k8stypes.UID]*vpa_types.RecommendedPodResources) utils.InPlaceDecision
 	// CanUnboost checks if a pod can be safely unboosted.
 	CanUnboost(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) bool
 }
@@ -75,37 +86,111 @@ type PodsInPlaceRestrictionImpl struct {
 }
 
 // CanInPlaceUpdate checks if pod can be safely updated
-func (ip *PodsInPlaceRestrictionImpl) CanInPlaceUpdate(pod *corev1.Pod) utils.InPlaceDecision {
-	if !features.Enabled(features.InPlaceOrRecreate) {
+func (ip *PodsInPlaceRestrictionImpl) CanInPlaceUpdate(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler, infeasibleAttempts map[k8stypes.UID]*vpa_types.RecommendedPodResources) utils.InPlaceDecision {
+	// Use default mode when update mode is nil
+	updateMode := vpa_types.UpdateModeRecreate
+	if (vpa.Spec.UpdatePolicy != nil) && (vpa.Spec.UpdatePolicy.UpdateMode != nil) {
+		updateMode = *vpa.Spec.UpdatePolicy.UpdateMode
+	}
+
+	switch updateMode {
+	case vpa_types.UpdateModeInPlaceOrRecreate:
+		if !features.Enabled(features.InPlaceOrRecreate) {
+			return utils.InPlaceEvict
+		}
+	case vpa_types.UpdateModeInPlace:
+		if !features.Enabled(features.InPlace) {
+			return utils.InPlaceDeferred
+		}
+	default:
 		return utils.InPlaceEvict
 	}
 
 	cr, present := ip.podToReplicaCreatorMap[getPodID(pod)]
-	if present {
-		singleGroupStats, present := ip.creatorToSingleGroupStatsMap[cr]
-		if pod.Status.Phase == corev1.PodPending {
-			return utils.InPlaceDeferred
-		}
-		if present {
-			if isInPlaceUpdating(pod) {
-				canEvict := CanEvictInPlacingPod(pod, singleGroupStats, ip.lastInPlaceAttemptTimeMap, ip.clock)
-				if canEvict {
-					return utils.InPlaceEvict
-				}
-				return utils.InPlaceDeferred
-			}
-			if ip.inPlaceSkipDisruptionBudget {
-				if utils.IsNonDisruptiveResize(pod) {
-					klog.V(4).InfoS("in-place-skip-disruption-budget enabled, skipping disruption budget check for in-place update")
-					return utils.InPlaceApproved
-				}
-				klog.V(4).InfoS("in-place-skip-disruption-budget enabled, but pod has RestartContainer resize policy", "pod", klog.KObj(pod))
-			}
-			if singleGroupStats.isPodDisruptable() {
-				return utils.InPlaceApproved
-			}
+	if !present {
+		klog.V(4).InfoS("Can't in-place update pod, but not falling back to eviction. Waiting for next loop", "pod", klog.KObj(pod))
+		return utils.InPlaceDeferred
+	}
+
+	if pod.Status.Phase == corev1.PodPending {
+		return utils.InPlaceDeferred
+	}
+
+	singleGroupStats, present := ip.creatorToSingleGroupStatsMap[cr]
+	if !present {
+		klog.V(4).InfoS("Can't in-place update pod, but not falling back to eviction. Waiting for next loop", "pod", klog.KObj(pod))
+		return utils.InPlaceDeferred
+	}
+
+	if vpa.Status.Recommendation == nil {
+		klog.V(4).InfoS("Can't in-place update pod, no recommendation available yet. Waiting for next loop", "pod", klog.KObj(pod))
+		return utils.InPlaceDeferred
+	}
+
+	recommendation := vpa.Status.Recommendation
+
+	// if the update mode is inPlace we want to check the map for previous Infeasible attempts
+	if updateMode == vpa_types.UpdateModeInPlace && infeasibleAttempts != nil {
+		lastAttempt, exist := infeasibleAttempts[pod.UID]
+		if exist && !resourcehelpers.RecommendationHasLowerResource(lastAttempt, recommendation) {
+			klog.V(2).InfoS("In-place update infeasible, no resource is lower in new recommendation, skipping pod", "pod", klog.KObj(pod))
+			return utils.InPlaceInfeasibleCached
 		}
 	}
+
+	resizeStatus := getResizeStatus(pod)
+
+	// pod is in place updaing
+	// utils.ResizeStatusNone means that  there is no container that is inPodResizePending or PodResizeInProgress state
+	if resizeStatus != utils.ResizeStatusNone {
+		// For InPlace mode: wait for all non-terminal statuses, never evict.
+		// Infeasible attempts are tracked and only retried when recommendation changes.
+		if updateMode == vpa_types.UpdateModeInPlace {
+			switch resizeStatus {
+			case utils.ResizeStatusInfeasible:
+				// Infeasible means node can't accommodate the resize.
+				// Store spec.resources and wait for recommendation to change before retrying.
+				klog.V(4).InfoS("In-place update infeasible", "pod", klog.KObj(pod))
+				return utils.InPlaceInfeasible
+			case utils.ResizeStatusDeferred:
+				// Deferred means kubelet is waiting to apply the resize.
+				// Do nothing, wait for kubelet to proceed.
+				klog.V(4).InfoS("In-place update deferred by kubelet, waiting", "pod", klog.KObj(pod))
+				return utils.InPlaceDeferred
+			case utils.ResizeStatusInProgress:
+				// Resize is actively being applied, wait for completion.
+				klog.V(4).InfoS("In-place update in progress, waiting for completion", "pod", klog.KObj(pod))
+				return utils.InPlaceDeferred
+			case utils.ResizeStatusError:
+				// Error during resize, will retry if recommendation changes.
+				klog.V(4).ErrorS(nil, "In-place update error, will retry if recommendation changes", "pod", klog.KObj(pod))
+				return utils.InPlaceInfeasible
+			default:
+				klog.V(4).InfoS("In-place update status unknown, waiting", "pod", klog.KObj(pod), "status", resizeStatus)
+				return utils.InPlaceDeferred
+			}
+		}
+
+		// For InPlaceOrRecreate mode, check timeout
+		canEvict := CanEvictInPlacingPod(pod, singleGroupStats, ip.lastInPlaceAttemptTimeMap, ip.clock)
+		if canEvict {
+			return utils.InPlaceEvict
+		}
+		return utils.InPlaceDeferred
+	}
+
+	if ip.inPlaceSkipDisruptionBudget {
+		if utils.IsNonDisruptiveResize(pod) {
+			klog.V(4).InfoS("in-place-skip-disruption-budget enabled, skipping disruption budget check for in-place update")
+			return utils.InPlaceApproved
+		}
+		klog.V(4).InfoS("in-place-skip-disruption-budget enabled, but pod has RestartContainer resize policy", "pod", klog.KObj(pod))
+	}
+
+	if singleGroupStats.isPodDisruptable() {
+		return utils.InPlaceApproved
+	}
+
 	klog.V(4).InfoS("Can't in-place update pod, but not falling back to eviction. Waiting for next loop", "pod", klog.KObj(pod))
 	return utils.InPlaceDeferred
 }
@@ -113,6 +198,9 @@ func (ip *PodsInPlaceRestrictionImpl) CanInPlaceUpdate(pod *corev1.Pod) utils.In
 // CanUnboost checks if a pod can be safely unboosted.
 func (ip *PodsInPlaceRestrictionImpl) CanUnboost(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) bool {
 	if !features.Enabled(features.CPUStartupBoost) {
+		return false
+	}
+	if pod.Status.Phase == corev1.PodPending {
 		return false
 	}
 	durationPassed := vpa_api_util.IsPodReadyAndStartupBoostDurationPassed(pod, vpa)
@@ -125,9 +213,6 @@ func (ip *PodsInPlaceRestrictionImpl) CanUnboost(pod *corev1.Pod, vpa *vpa_types
 	cr, present := ip.podToReplicaCreatorMap[getPodID(pod)]
 	if present {
 		singleGroupStats, present := ip.creatorToSingleGroupStatsMap[cr]
-		if pod.Status.Phase == corev1.PodPending {
-			return false
-		}
 		if present {
 			if isInPlaceUpdating(pod) {
 				return false

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
@@ -23,12 +23,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	baseclocktest "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/utils"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
@@ -41,10 +45,17 @@ type CanInPlaceUpdateTestParams struct {
 	evictionTolerance       float64
 	lastInPlaceAttempt      time.Time
 	expectedInPlaceDecision utils.InPlaceDecision
+	vpa                     *vpa_types.VerticalPodAutoscaler
+	clockTime               *time.Time
+	minReplicas             int
+	infeasibleAttempts      map[types.UID]*vpa_types.RecommendedPodResources
+	vpaForCreatorMaps       *vpa_types.VerticalPodAutoscaler
+	alsoTestInPlaceUpdate   bool
 }
 
 func TestCanInPlaceUpdate(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlaceOrRecreate, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlace, true)
 
 	rc := corev1.ReplicationController{
 		ObjectMeta: metav1.ObjectMeta{
@@ -64,6 +75,68 @@ func TestCanInPlaceUpdate(t *testing.T) {
 	// NOTE: the pod we are checking for CanInPlaceUpdate will always be the first one for these tests
 	whichPodIdxForCanInPlaceUpdate := 0
 
+	// Recommendations for infeasible caching tests
+	rec1000m1Gi := &vpa_types.RecommendedPodResources{
+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+			{
+				ContainerName: "test-container",
+				Target: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1000m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+	rec2000m2Gi := &vpa_types.RecommendedPodResources{
+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+			{
+				ContainerName: "test-container",
+				Target: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2000m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	rec1000m2Gi := &vpa_types.RecommendedPodResources{
+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+			{
+				ContainerName: "test-container",
+				Target: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1000m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+
+	ipVpaWithRec := func(rec *vpa_types.RecommendedPodResources) *vpa_types.VerticalPodAutoscaler {
+		v := getIPVpa()
+		v.Status.Recommendation = rec
+		return v
+	}
+	iporVpaWithRec := func(rec *vpa_types.RecommendedPodResources) *vpa_types.VerticalPodAutoscaler {
+		v := getIPORVpa()
+		v.Status.Recommendation = rec
+		return v
+	}
+
+	podWithUID := func(uid string) *corev1.Pod {
+		return test.Pod().
+			WithName("test-pod").
+			WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+			WithUID(types.UID(uid)).
+			Get()
+	}
+
+	// Pods for infeasible caching test cases (each needs a unique UID)
+	icPodSameRec := podWithUID("test-uid-same-rec")
+	icPodLowerRec := podWithUID("test-uid-lower-rec")
+	icPodHigherRec := podWithUID("test-uid-higher-rec")
+	icPodNoHistory := podWithUID("test-uid-no-history")
+	icPodIPOR := podWithUID("test-uid-ipor")
+	icPodNoCurrentRec := podWithUID("test-uid-no-current-rec")
+
 	testCases := []CanInPlaceUpdateTestParams{
 		{
 			name: "CanInPlaceUpdate=InPlaceApproved - (half of 3)",
@@ -76,6 +149,7 @@ func TestCanInPlaceUpdate(t *testing.T) {
 			evictionTolerance:       0.5,
 			lastInPlaceAttempt:      time.Time{},
 			expectedInPlaceDecision: utils.InPlaceApproved,
+			vpa:                     getIPORVpa(),
 		},
 		{
 			name: "CanInPlaceUpdate=InPlaceDeferred - no pods can be in-placed, one missing",
@@ -87,6 +161,7 @@ func TestCanInPlaceUpdate(t *testing.T) {
 			evictionTolerance:       0.5,
 			lastInPlaceAttempt:      time.Time{},
 			expectedInPlaceDecision: utils.InPlaceDeferred,
+			vpa:                     getIPORVpa(),
 		},
 		{
 			name: "CanInPlaceUpdate=InPlaceApproved - small tolerance, all running",
@@ -99,6 +174,7 @@ func TestCanInPlaceUpdate(t *testing.T) {
 			evictionTolerance:       0.1,
 			lastInPlaceAttempt:      time.Time{},
 			expectedInPlaceDecision: utils.InPlaceApproved,
+			vpa:                     getIPORVpa(),
 		},
 		{
 			name: "CanInPlaceUpdate=InPlaceApproved - small tolerance, one missing",
@@ -110,6 +186,7 @@ func TestCanInPlaceUpdate(t *testing.T) {
 			evictionTolerance:       0.5,
 			lastInPlaceAttempt:      time.Time{},
 			expectedInPlaceDecision: utils.InPlaceDeferred,
+			vpa:                     getIPORVpa(),
 		},
 		{
 			name: "CanInPlaceUpdate=InPlaceDeferred - resize Deferred, conditions not met to fallback",
@@ -128,6 +205,7 @@ func TestCanInPlaceUpdate(t *testing.T) {
 			evictionTolerance:       0.5,
 			lastInPlaceAttempt:      time.UnixMilli(3600000), // 1 hour from epoch
 			expectedInPlaceDecision: utils.InPlaceDeferred,
+			vpa:                     getIPORVpa(),
 		},
 		{
 			name: ("CanInPlaceUpdate=InPlaceEvict - resize inProgress for more too long"),
@@ -145,6 +223,7 @@ func TestCanInPlaceUpdate(t *testing.T) {
 			evictionTolerance:       0.5,
 			lastInPlaceAttempt:      time.UnixMilli(0), // epoch (too long ago...)
 			expectedInPlaceDecision: utils.InPlaceEvict,
+			vpa:                     getIPORVpa(),
 		},
 		{
 			name: "CanInPlaceUpdate=InPlaceDeferred - resize InProgress, conditions not met to fallback",
@@ -162,6 +241,7 @@ func TestCanInPlaceUpdate(t *testing.T) {
 			evictionTolerance:       0.5,
 			lastInPlaceAttempt:      time.UnixMilli(3600000), // 1 hour from epoch
 			expectedInPlaceDecision: utils.InPlaceDeferred,
+			vpa:                     getIPORVpa(),
 		},
 		{
 			name: "CanInPlaceUpdate=InPlaceEvict - infeasible",
@@ -180,6 +260,213 @@ func TestCanInPlaceUpdate(t *testing.T) {
 			evictionTolerance:       0.5,
 			lastInPlaceAttempt:      time.Time{},
 			expectedInPlaceDecision: utils.InPlaceEvict,
+			vpa:                     getIPORVpa(),
+		},
+		{
+			name: "InPlace - CanInPlaceUpdate=InPlaceApproved - all pods running",
+			pods: []*corev1.Pod{
+				generatePod().Get(),
+				generatePod().Get(),
+				generatePod().Get(),
+			},
+			replicas:                3,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceApproved,
+			vpa:                     getIPVpa(),
+		},
+		{
+			name: "InPlace - CanInPlaceUpdate=InPlaceDeferred - resize InProgress, waits indefinitely (no timeout)",
+			pods: []*corev1.Pod{
+				generatePod().WithPodConditions([]corev1.PodCondition{
+					{
+						Type:   corev1.PodResizeInProgress,
+						Status: corev1.ConditionTrue,
+					},
+				}).Get(),
+				generatePod().Get(),
+				generatePod().Get(),
+			},
+			replicas:                3,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.UnixMilli(0), // epoch (too long ago...)
+			expectedInPlaceDecision: utils.InPlaceDeferred,
+			vpa:                     getIPVpa(),
+		},
+		{
+			name: "InPlace - CanInPlaceUpdate=InPlaceDeferred - no update policy for vpa",
+			pods: []*corev1.Pod{
+				generatePod().WithPodConditions([]corev1.PodCondition{
+					{
+						Type:   corev1.PodResizeInProgress,
+						Status: corev1.ConditionTrue,
+					},
+				}).Get(),
+				generatePod().Get(),
+				generatePod().Get(),
+			},
+			replicas:                3,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.UnixMilli(0), // epoch (too long ago...)
+			expectedInPlaceDecision: utils.InPlaceEvict,
+			vpa:                     getBasicVpa(),
+		},
+		{
+			name: "InPlace mode - waits indefinitely for in-progress updates",
+			pods: []*corev1.Pod{
+				test.Pod().WithName("wait-1").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+					WithPodConditions([]corev1.PodCondition{
+						{Type: corev1.PodResizeInProgress, Status: corev1.ConditionTrue},
+					}).Get(),
+				test.Pod().WithName("wait-2").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+				test.Pod().WithName("wait-3").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+			},
+			replicas:                3,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.UnixMilli(0),
+			expectedInPlaceDecision: utils.InPlaceDeferred,
+			vpa:                     getIPVpa(),
+			clockTime:               ptr.To(time.UnixMilli(7200000)),
+			vpaForCreatorMaps:       getIPVpa(),
+		},
+		{
+			name: "InPlace mode - infeasible returns InPlaceInfeasible",
+			pods: []*corev1.Pod{
+				test.Pod().WithName("infeasible-1").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+					WithPodConditions([]corev1.PodCondition{
+						{Type: corev1.PodResizePending, Status: corev1.ConditionTrue, Reason: corev1.PodReasonInfeasible},
+					}).Get(),
+				test.Pod().WithName("infeasible-2").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+				test.Pod().WithName("infeasible-3").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+			},
+			replicas:                3,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceInfeasible,
+			vpa:                     getIPVpa(),
+			clockTime:               ptr.To(time.Time{}),
+			vpaForCreatorMaps:       getIPVpa(),
+		},
+		{
+			name: "InPlace mode - deferred pod with changed recommendations retries",
+			pods: []*corev1.Pod{
+				test.Pod().WithName("deferred-retry-1").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+					WithPodConditions([]corev1.PodCondition{
+						{Type: corev1.PodResizePending, Status: corev1.ConditionTrue, Reason: corev1.PodReasonDeferred},
+					}).Get(),
+				test.Pod().WithName("deferred-retry-2").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+				test.Pod().WithName("deferred-retry-3").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+			},
+			replicas:                3,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceDeferred,
+			vpa:                     getIPVpa(),
+			clockTime:               ptr.To(time.Time{}),
+			vpaForCreatorMaps:       getIPVpa(),
+			alsoTestInPlaceUpdate:   true,
+		},
+		{
+			name: "InPlaceOrRecreate mode - deferred pod with changed recommendations retries",
+			pods: []*corev1.Pod{
+				test.Pod().WithName("deferred-ipor-1").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+					WithPodConditions([]corev1.PodCondition{
+						{Type: corev1.PodResizePending, Status: corev1.ConditionTrue, Reason: corev1.PodReasonDeferred},
+					}).Get(),
+				test.Pod().WithName("deferred-ipor-2").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+				test.Pod().WithName("deferred-ipor-3").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+			},
+			replicas:                3,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceDeferred,
+			vpa:                     getIPORVpa(),
+			clockTime:               ptr.To(time.Time{}),
+			alsoTestInPlaceUpdate:   true,
+		},
+		{
+			name:                    "InfeasibleCaching - same recommendation returns cached",
+			pods:                    []*corev1.Pod{icPodSameRec},
+			replicas:                1,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceInfeasibleCached,
+			vpa:                     ipVpaWithRec(rec1000m1Gi),
+			clockTime:               ptr.To(time.Time{}),
+			minReplicas:             1,
+			vpaForCreatorMaps:       getIPVpa(),
+			infeasibleAttempts: map[types.UID]*vpa_types.RecommendedPodResources{
+				icPodSameRec.UID: rec1000m1Gi,
+			},
+		},
+		{
+			name:                    "InfeasibleCaching - lower recommendation allows retry",
+			pods:                    []*corev1.Pod{icPodLowerRec},
+			replicas:                1,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceApproved,
+			vpa:                     ipVpaWithRec(rec1000m2Gi),
+			clockTime:               ptr.To(time.Time{}),
+			minReplicas:             1,
+			vpaForCreatorMaps:       getIPVpa(),
+			infeasibleAttempts: map[types.UID]*vpa_types.RecommendedPodResources{
+				icPodLowerRec.UID: rec2000m2Gi,
+			},
+		},
+		{
+			name:                    "InfeasibleCaching - higher recommendation returns cached",
+			pods:                    []*corev1.Pod{icPodHigherRec},
+			replicas:                1,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceInfeasibleCached,
+			vpa:                     ipVpaWithRec(rec2000m2Gi),
+			clockTime:               ptr.To(time.Time{}),
+			minReplicas:             1,
+			vpaForCreatorMaps:       getIPVpa(),
+			infeasibleAttempts: map[types.UID]*vpa_types.RecommendedPodResources{
+				icPodHigherRec.UID: rec1000m1Gi,
+			},
+		},
+		{
+			name:                    "InfeasibleCaching - no history proceeds normally",
+			pods:                    []*corev1.Pod{icPodNoHistory},
+			replicas:                1,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceApproved,
+			vpa:                     ipVpaWithRec(rec1000m1Gi),
+			clockTime:               ptr.To(time.Time{}),
+			minReplicas:             1,
+			vpaForCreatorMaps:       getIPVpa(),
+		},
+		{
+			name:                    "InfeasibleCaching - InPlaceOrRecreate ignores cache",
+			pods:                    []*corev1.Pod{icPodIPOR},
+			replicas:                1,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceApproved,
+			vpa:                     iporVpaWithRec(rec1000m1Gi),
+			clockTime:               ptr.To(time.Time{}),
+			minReplicas:             1,
+			vpaForCreatorMaps:       getIPORVpa(),
+			infeasibleAttempts: map[types.UID]*vpa_types.RecommendedPodResources{
+				icPodIPOR.UID: rec1000m1Gi,
+			},
+		},
+		{
+			name:                    "InfeasibleCaching - no current recommendation defers",
+			pods:                    []*corev1.Pod{icPodNoCurrentRec},
+			replicas:                1,
+			evictionTolerance:       0.5,
+			lastInPlaceAttempt:      time.Time{},
+			expectedInPlaceDecision: utils.InPlaceDeferred,
+			vpa:                     ipVpaWithRec(nil),
+			clockTime:               ptr.To(time.Time{}),
+			minReplicas:             1,
+			vpaForCreatorMaps:       getIPVpa(),
 		},
 	}
 	for _, tc := range testCases {
@@ -190,17 +477,37 @@ func TestCanInPlaceUpdate(t *testing.T) {
 
 			selectedPod := tc.pods[whichPodIdxForCanInPlaceUpdate]
 
-			clock := baseclocktest.NewFakeClock(time.UnixMilli(3600001)) // 1 hour from epoch + 1 millis
+			clockTime := time.UnixMilli(3600001) // default: 1 hour from epoch + 1 millis
+			if tc.clockTime != nil {
+				clockTime = *tc.clockTime
+			}
+			clock := baseclocktest.NewFakeClock(clockTime)
 			lipatm := map[string]time.Time{getPodID(selectedPod): tc.lastInPlaceAttempt}
 
-			factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tc.evictionTolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
+			minReplicas := 2
+			if tc.minReplicas > 0 {
+				minReplicas = tc.minReplicas
+			}
+
+			factory, err := getRestrictionFactory(&rc, nil, nil, nil, minReplicas, tc.evictionTolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
 			assert.NoError(t, err)
-			creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(tc.pods, getIPORVpa())
+
+			vpaForCreatorMaps := getIPORVpa()
+			if tc.vpaForCreatorMaps != nil {
+				vpaForCreatorMaps = tc.vpaForCreatorMaps
+			}
+
+			creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(tc.pods, vpaForCreatorMaps)
 			assert.NoError(t, err)
 			inPlace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
-			result := inPlace.CanInPlaceUpdate(selectedPod)
+			result := inPlace.CanInPlaceUpdate(selectedPod, tc.vpa, tc.infeasibleAttempts)
 			assert.Equal(t, tc.expectedInPlaceDecision, result)
+
+			if tc.alsoTestInPlaceUpdate {
+				err := inPlace.InPlaceUpdate(selectedPod, tc.vpa, test.FakeEventRecorder())
+				assert.NoError(t, err)
+			}
 		})
 	}
 }
@@ -239,7 +546,7 @@ func TestInPlaceDisabledFeatureGate(t *testing.T) {
 	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
 	for _, pod := range pods {
-		assert.Equal(t, utils.InPlaceEvict, inplace.CanInPlaceUpdate(pod))
+		assert.Equal(t, utils.InPlaceEvict, inplace.CanInPlaceUpdate(pod, basicVpa, nil))
 	}
 }
 
@@ -279,7 +586,7 @@ func TestInPlaceTooFewReplicas(t *testing.T) {
 	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
 	for _, pod := range pods {
-		assert.Equal(t, utils.InPlaceDeferred, inplace.CanInPlaceUpdate(pod))
+		assert.Equal(t, utils.InPlaceDeferred, inplace.CanInPlaceUpdate(pod, basicVpa, nil))
 	}
 
 	for _, pod := range pods {
@@ -324,7 +631,7 @@ func TestEvictionToleranceForInPlace(t *testing.T) {
 	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
 	for _, pod := range pods {
-		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod))
+		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod, basicVpa, nil))
 	}
 
 	for _, pod := range pods[:4] {
@@ -376,12 +683,11 @@ func TestEvictionToleranceForInPlaceWithSkipDisruptionBudget(t *testing.T) {
 
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
 	assert.NoError(t, err)
-
 	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
 	// All in-place updates should be approved
 	for _, pod := range pods {
-		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod))
+		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod, basicVpa, nil))
 	}
 
 	// And all updates should succeed without being blocked by eviction tolerance
@@ -441,7 +747,7 @@ func TestEvictionToleranceForInPlaceWithSkipDisruptionBudgetWithLessThanMinimumP
 
 	// All in-place updates should be approved
 	for _, pod := range pods {
-		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod))
+		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod, basicVpa, nil))
 	}
 
 	// And all in-place updates should succeed without being blocked by eviction tolerance, but eviction
@@ -589,7 +895,7 @@ func TestInPlaceSkipDisruptionBudgetWithResizePolicy(t *testing.T) {
 
 			successCount := 0
 			for _, pod := range pods {
-				decision := inplace.CanInPlaceUpdate(pod)
+				decision := inplace.CanInPlaceUpdate(pod, basicVpa, nil)
 				if decision != utils.InPlaceApproved {
 					continue
 				}
@@ -629,21 +935,21 @@ func TestInPlaceAtLeastOne(t *testing.T) {
 		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get()
 	}
 
-	basicVpa := getBasicVpa()
+	inPlaceOrRecreateVPA := getIPORVpa()
 	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc(), false)
 	assert.NoError(t, err)
-	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
+	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, inPlaceOrRecreateVPA)
 	assert.NoError(t, err)
 	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
 	for _, pod := range pods[:1] {
-		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod))
-		err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
+		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod, inPlaceOrRecreateVPA, nil))
+		err := inplace.InPlaceUpdate(pod, inPlaceOrRecreateVPA, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should in-place update with no error")
 	}
 	for _, pod := range pods[1:] {
-		assert.Equal(t, utils.InPlaceDeferred, inplace.CanInPlaceUpdate(pod))
-		err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
+		assert.Equal(t, utils.InPlaceDeferred, inplace.CanInPlaceUpdate(pod, inPlaceOrRecreateVPA, nil))
+		err := inplace.InPlaceUpdate(pod, inPlaceOrRecreateVPA, test.FakeEventRecorder())
 		assert.Nil(t, err, "Error should not be expected")
 	}
 }
@@ -673,16 +979,16 @@ func TestInPlaceUpdate_EventEmission(t *testing.T) {
 		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get()
 	}
 
-	basicVpa := getBasicVpa()
+	inPlaceOrRecreateVPA := getIPORVpa()
 	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc(), false)
 	assert.NoError(t, err)
-	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
+	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, inPlaceOrRecreateVPA)
 	assert.NoError(t, err)
 	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
 	eventRecorder := record.NewFakeRecorder(10)
 
-	err = inplace.InPlaceUpdate(pods[0], basicVpa, eventRecorder)
+	err = inplace.InPlaceUpdate(pods[0], inPlaceOrRecreateVPA, eventRecorder)
 	assert.NoError(t, err)
 
 	select {
@@ -691,4 +997,326 @@ func TestInPlaceUpdate_EventEmission(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		assert.Fail(t, "timeout waiting for event")
 	}
+}
+
+func TestInPlaceModeDisabledFeatureGate(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlace, false)
+
+	replicas := int32(5)
+	livePods := 5
+	tolerance := 1.0
+
+	rc := corev1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ReplicationController",
+		},
+		Spec: corev1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	pods := make([]*corev1.Pod, livePods)
+	for i := range pods {
+		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get()
+	}
+
+	inPlaceVpa := getIPVpa()
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc(), false)
+	assert.NoError(t, err)
+	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, inPlaceVpa)
+	assert.NoError(t, err)
+	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+	for _, pod := range pods {
+		assert.Equal(t, utils.InPlaceDeferred, inplace.CanInPlaceUpdate(pod, inPlaceVpa, nil),
+			"InPlace mode should return InPlaceDeferred when feature gate is disabled")
+	}
+}
+
+func TestInPlaceModeAtLeastOne(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlace, true)
+
+	replicas := int32(5)
+	livePods := 5
+	tolerance := 0.1 // Very small tolerance, but at least one should be allowed
+
+	rc := corev1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ReplicationController",
+		},
+		Spec: corev1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	pods := make([]*corev1.Pod, livePods)
+	for i := range pods {
+		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get()
+	}
+
+	inPlaceVpa := getIPVpa()
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc(), false)
+	assert.NoError(t, err)
+	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, inPlaceVpa)
+	assert.NoError(t, err)
+	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+	for _, pod := range pods {
+		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod, inPlaceVpa, nil))
+	}
+
+	for _, pod := range pods {
+		err := inplace.InPlaceUpdate(pod, inPlaceVpa, test.FakeEventRecorder())
+		assert.NoError(t, err, "Should in-place update at least one pod even with small tolerance")
+	}
+}
+
+func TestInPlaceModeResizeStatuses(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlace, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlaceOrRecreate, true)
+
+	replicas := int32(3)
+	tolerance := 0.5
+
+	rc := corev1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ReplicationController",
+		},
+		Spec: corev1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	testCases := []struct {
+		name               string
+		podConditions      []corev1.PodCondition
+		updateMode         vpa_types.UpdateMode
+		expectedDecision   utils.InPlaceDecision
+		lastInPlaceAttempt time.Time
+		clockTime          time.Time
+	}{
+		// InPlace mode tests
+		{
+			name: "InPlace mode - ResizeStatusDeferred returns InPlaceDeferred",
+			podConditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodResizePending,
+					Status: corev1.ConditionTrue,
+					Reason: corev1.PodReasonDeferred,
+				},
+			},
+			updateMode:         vpa_types.UpdateModeInPlace,
+			expectedDecision:   utils.InPlaceDeferred,
+			lastInPlaceAttempt: time.UnixMilli(0),
+			clockTime:          time.UnixMilli(3600000),
+		},
+		{
+			name: "InPlace mode - ResizeStatusInfeasible returns InPlaceInfeasible",
+			podConditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodResizePending,
+					Status: corev1.ConditionTrue,
+					Reason: corev1.PodReasonInfeasible,
+				},
+			},
+			updateMode:         vpa_types.UpdateModeInPlace,
+			expectedDecision:   utils.InPlaceInfeasible,
+			lastInPlaceAttempt: time.UnixMilli(0),
+			clockTime:          time.UnixMilli(3600000),
+		},
+		{
+			name: "InPlace mode - ResizeStatusInProgress returns InPlaceDeferred",
+			podConditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodResizeInProgress,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			updateMode:         vpa_types.UpdateModeInPlace,
+			expectedDecision:   utils.InPlaceDeferred,
+			lastInPlaceAttempt: time.UnixMilli(0),
+			clockTime:          time.UnixMilli(3600000),
+		},
+		{
+			name: "InPlace mode - ResizeStatusError returns InPlaceInfeasible (retry)",
+			podConditions: []corev1.PodCondition{
+				{
+					Type:    corev1.PodResizeInProgress,
+					Status:  corev1.ConditionTrue,
+					Reason:  corev1.PodReasonError,
+					Message: "some error",
+				},
+			},
+			updateMode:         vpa_types.UpdateModeInPlace,
+			expectedDecision:   utils.InPlaceInfeasible,
+			lastInPlaceAttempt: time.UnixMilli(0),
+			clockTime:          time.UnixMilli(3600000),
+		},
+		// InPlaceOrRecreate mode tests - same conditions, different behavior
+		{
+			name: "InPlaceOrRecreate mode - ResizeStatusDeferred within timeout returns InPlaceDeferred",
+			podConditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodResizePending,
+					Status: corev1.ConditionTrue,
+					Reason: corev1.PodReasonDeferred,
+				},
+			},
+			updateMode:         vpa_types.UpdateModeInPlaceOrRecreate,
+			expectedDecision:   utils.InPlaceDeferred,
+			lastInPlaceAttempt: time.UnixMilli(3600000), // 1 hour from epoch
+			clockTime:          time.UnixMilli(3600001), // just 1ms later
+		},
+		{
+			name: "InPlaceOrRecreate mode - ResizeStatusDeferred past timeout returns InPlaceEvict",
+			podConditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodResizePending,
+					Status: corev1.ConditionTrue,
+					Reason: corev1.PodReasonDeferred,
+				},
+			},
+			updateMode:         vpa_types.UpdateModeInPlaceOrRecreate,
+			expectedDecision:   utils.InPlaceEvict,
+			lastInPlaceAttempt: time.UnixMilli(0),                                          // epoch
+			clockTime:          time.UnixMilli(int64(10 * time.Minute / time.Millisecond)), // 10 minutes later (past 5 min timeout)
+		},
+		{
+			name: "InPlaceOrRecreate mode - ResizeStatusInfeasible returns InPlaceEvict",
+			podConditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodResizePending,
+					Status: corev1.ConditionTrue,
+					Reason: corev1.PodReasonInfeasible,
+				},
+			},
+			updateMode:         vpa_types.UpdateModeInPlaceOrRecreate,
+			expectedDecision:   utils.InPlaceEvict,
+			lastInPlaceAttempt: time.UnixMilli(0),
+			clockTime:          time.UnixMilli(3600000),
+		},
+		{
+			name: "InPlaceOrRecreate mode - ResizeStatusInProgress within timeout returns InPlaceDeferred",
+			podConditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodResizeInProgress,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			updateMode:         vpa_types.UpdateModeInPlaceOrRecreate,
+			expectedDecision:   utils.InPlaceDeferred,
+			lastInPlaceAttempt: time.UnixMilli(3600000),
+			clockTime:          time.UnixMilli(3600001),
+		},
+		{
+			name: "InPlaceOrRecreate mode - ResizeStatusInProgress past timeout returns InPlaceEvict",
+			podConditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodResizeInProgress,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			updateMode:         vpa_types.UpdateModeInPlaceOrRecreate,
+			expectedDecision:   utils.InPlaceEvict,
+			lastInPlaceAttempt: time.UnixMilli(0),                                       // epoch
+			clockTime:          time.UnixMilli(int64(2 * time.Hour / time.Millisecond)), // 2 hours later (past 1 hour timeout)
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := test.Pod().WithName("test-pod").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+				WithPodConditions(tc.podConditions).Get()
+			pods := []*corev1.Pod{
+				pod,
+				test.Pod().WithName("test-pod-2").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+				test.Pod().WithName("test-pod-3").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+			}
+
+			clock := baseclocktest.NewFakeClock(tc.clockTime)
+			lipatm := map[string]time.Time{getPodID(pod): tc.lastInPlaceAttempt}
+
+			var vpa *vpa_types.VerticalPodAutoscaler
+			if tc.updateMode == vpa_types.UpdateModeInPlace {
+				vpa = getIPVpa()
+			} else {
+				vpa = getIPORVpa()
+			}
+
+			factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
+			assert.NoError(t, err)
+			creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, vpa)
+			assert.NoError(t, err)
+			inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+			result := inplace.CanInPlaceUpdate(pod, vpa, nil)
+			assert.Equal(t, tc.expectedDecision, result)
+		})
+	}
+}
+
+func TestInPlaceModeAllowsRetryForInfeasible(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlace, true)
+
+	replicas := int32(3)
+	tolerance := 0.5
+
+	rc := corev1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ReplicationController",
+		},
+		Spec: corev1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	// Pod with infeasible resize status
+	pod := test.Pod().WithName("test-pod").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+		WithPodConditions([]corev1.PodCondition{
+			{
+				Type:   corev1.PodResizePending,
+				Status: corev1.ConditionTrue,
+				Reason: corev1.PodReasonInfeasible,
+			},
+		}).Get()
+	pods := []*corev1.Pod{
+		pod,
+		test.Pod().WithName("test-pod-2").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+		test.Pod().WithName("test-pod-3").WithCreator(&rc.ObjectMeta, &rc.TypeMeta).Get(),
+	}
+
+	clock := baseclocktest.NewFakeClock(time.Time{})
+	lipatm := map[string]time.Time{}
+
+	vpa := getIPVpa()
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
+	assert.NoError(t, err)
+	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, vpa)
+	assert.NoError(t, err)
+	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+	// CanInPlaceUpdate should return InPlaceInfeasible
+	decision := inplace.CanInPlaceUpdate(pod, vpa, nil)
+	assert.Equal(t, utils.InPlaceInfeasible, decision,
+		"InPlace mode should return InPlaceInfeasible for infeasible pods")
+
+	// InPlaceUpdate should succeed for InPlaceInfeasible decision in InPlace mode
+	err = inplace.InPlaceUpdate(pod, vpa, test.FakeEventRecorder())
+	assert.NoError(t, err, "InPlace mode should allow retry for infeasible pods")
 }

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory.go
@@ -32,6 +32,7 @@ import (
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/utils"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
@@ -323,4 +324,37 @@ func isInPlaceUpdating(podToCheck *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// getResizeStatus returns the current resize status of a pod based on its conditions.
+// This is used to determine the appropriate action for pods undergoing in-place updates.
+func getResizeStatus(pod *corev1.Pod) utils.ResizeStatus {
+	if !isInPlaceUpdating(pod) {
+		return utils.ResizeStatusNone
+	}
+
+	resizePendingCondition, ok := utils.GetPodCondition(pod, corev1.PodResizePending)
+	if ok {
+		switch resizePendingCondition.Reason {
+		case corev1.PodReasonDeferred:
+			return utils.ResizeStatusDeferred
+		case corev1.PodReasonInfeasible:
+			return utils.ResizeStatusInfeasible
+		default:
+			return utils.ResizeStatusUnknown
+		}
+	}
+
+	resizeInProgressCondition, ok := utils.GetPodCondition(pod, corev1.PodResizeInProgress)
+	if ok {
+		if resizeInProgressCondition.Reason == "" && resizeInProgressCondition.Message == "" {
+			return utils.ResizeStatusInProgress
+		}
+		if resizeInProgressCondition.Reason == corev1.PodReasonError {
+			return utils.ResizeStatusError
+		}
+	}
+
+	// Pod is in-place updating but no specific condition found
+	return utils.ResizeStatusUnknown
 }

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
@@ -63,6 +63,14 @@ func getIPORVpa() *vpa_types.VerticalPodAutoscaler {
 	return vpa
 }
 
+func getIPVpa() *vpa_types.VerticalPodAutoscaler {
+	vpa := getBasicVpa()
+	vpa.Spec.UpdatePolicy = &vpa_types.PodUpdatePolicy{
+		UpdateMode: ptr.To(vpa_types.UpdateModeInPlace),
+	}
+	return vpa
+}
+
 func TestDisruptReplicatedByController(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlaceOrRecreate, true)
 
@@ -524,7 +532,7 @@ func TestDisruptReplicatedByController(t *testing.T) {
 			updateMode := vpa_api_util.GetUpdateMode(testCase.vpa)
 			for i, p := range testCase.pods {
 				if updateMode == vpa_types.UpdateModeInPlaceOrRecreate {
-					assert.Equalf(t, p.canInPlaceUpdate, inplace.CanInPlaceUpdate(p.pod), "unexpected CanInPlaceUpdate result for pod-%v %#v", testCase.name, i, p.pod)
+					assert.Equalf(t, p.canInPlaceUpdate, inplace.CanInPlaceUpdate(p.pod, testCase.vpa, nil), "unexpected CanInPlaceUpdate result for pod-%v %#v", testCase.name, i, p.pod)
 				} else {
 					assert.Equalf(t, p.canEvict, eviction.CanEvict(p.pod), "unexpected CanEvict result for pod-%v %#v", i, p.pod)
 				}
@@ -791,5 +799,173 @@ func NewFakeCalculatorWithInPlacePatches() patch.Calculator {
 func GetFakeCalculatorsWithFakeResourceCalc() []patch.Calculator {
 	return []patch.Calculator{
 		NewFakeCalculatorWithInPlacePatches(),
+	}
+}
+
+func TestGetResizeStatus(t *testing.T) {
+	testCases := []struct {
+		name           string
+		pod            *corev1.Pod
+		expectedStatus utils.ResizeStatus
+	}{
+		{
+			name:           "pod not in-place updating - no resize status",
+			pod:            test.Pod().WithName("test-pod").Get(),
+			expectedStatus: utils.ResizeStatusNone,
+		},
+		{
+			name: "PodResizePending with Deferred reason",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:   corev1.PodResizePending,
+						Status: corev1.ConditionTrue,
+						Reason: corev1.PodReasonDeferred,
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusDeferred,
+		},
+		{
+			name: "PodResizePending with Infeasible reason",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:    corev1.PodResizePending,
+						Status:  corev1.ConditionTrue,
+						Reason:  corev1.PodReasonInfeasible,
+						Message: "Insufficient cpu",
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusInfeasible,
+		},
+		{
+			name: "PodResizePending with unknown reason",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:   corev1.PodResizePending,
+						Status: corev1.ConditionTrue,
+						Reason: "SomeOtherReason",
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusUnknown,
+		},
+		{
+			name: "PodResizePending with empty reason",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:   corev1.PodResizePending,
+						Status: corev1.ConditionTrue,
+						Reason: "",
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusUnknown,
+		},
+		{
+			name: "PodResizeInProgress with empty reason and message",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:    corev1.PodResizeInProgress,
+						Status:  corev1.ConditionTrue,
+						Reason:  "",
+						Message: "",
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusInProgress,
+		},
+		{
+			name: "PodResizeInProgress with Error reason",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:    corev1.PodResizeInProgress,
+						Status:  corev1.ConditionTrue,
+						Reason:  corev1.PodReasonError,
+						Message: "Failed to resize container",
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusError,
+		},
+		{
+			name: "PodResizeInProgress with unknown reason",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:    corev1.PodResizeInProgress,
+						Status:  corev1.ConditionTrue,
+						Reason:  "SomeOtherReason",
+						Message: "some message",
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusUnknown,
+		},
+		{
+			name: "PodResizeInProgress with message but no reason",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:    corev1.PodResizeInProgress,
+						Status:  corev1.ConditionTrue,
+						Reason:  "",
+						Message: "some message",
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusUnknown,
+		},
+		{
+			name: "pod with unrelated condition only",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusNone,
+		},
+		{
+			name: "both PodResizePending and PodResizeInProgress - PodResizePending takes precedence",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:   corev1.PodResizePending,
+						Status: corev1.ConditionTrue,
+						Reason: corev1.PodReasonDeferred,
+					},
+					{
+						Type:   corev1.PodResizeInProgress,
+						Status: corev1.ConditionTrue,
+						Reason: "",
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusDeferred,
+		},
+		{
+			name: "PodResizePending Infeasible takes precedence over PodResizeInProgress Error",
+			pod: test.Pod().WithName("test-pod").
+				WithPodConditions([]corev1.PodCondition{
+					{
+						Type:   corev1.PodResizePending,
+						Status: corev1.ConditionTrue,
+						Reason: corev1.PodReasonInfeasible,
+					},
+					{
+						Type:    corev1.PodResizeInProgress,
+						Status:  corev1.ConditionTrue,
+						Reason:  corev1.PodReasonError,
+						Message: "Error message",
+					},
+				}).Get(),
+			expectedStatus: utils.ResizeStatusInfeasible,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getResizeStatus(tc.pod)
+			assert.Equal(t, tc.expectedStatus, result)
+		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/updater/utils/types.go
+++ b/vertical-pod-autoscaler/pkg/updater/utils/types.go
@@ -19,6 +19,9 @@ package utils
 // InPlaceDecision is the type of decision that can be made for a pod.
 type InPlaceDecision string
 
+// ResizeStatus is the status of resize api call.
+type ResizeStatus string
+
 const (
 	// InPlaceApproved means we can in-place update the pod.
 	InPlaceApproved InPlaceDecision = "InPlaceApproved"
@@ -26,4 +29,20 @@ const (
 	InPlaceDeferred InPlaceDecision = "InPlaceDeferred"
 	// InPlaceEvict means we will attempt to evict the pod.
 	InPlaceEvict InPlaceDecision = "InPlaceEvict"
+	// InPlaceInfeasible means we can't in-place update the pod right now but we want to retry
+	InPlaceInfeasible InPlaceDecision = "InPlaceInfeasible"
+	// InPlaceInfeasibleCached indicates a cached infeasibility status, avoiding repeated feasibility checks
+	InPlaceInfeasibleCached InPlaceDecision = "InPlaceInfeasibleCached"
+	// ResizeStatusDeferred indicates the resize is deferred by kubelet
+	ResizeStatusDeferred ResizeStatus = "ResizeDeferred"
+	// ResizeStatusInfeasible indicates the resize cannot be performed (e.g., insufficient node resources)
+	ResizeStatusInfeasible ResizeStatus = "ResizeInfeasible"
+	// ResizeStatusInProgress indicates the resize is currently being applied
+	ResizeStatusInProgress ResizeStatus = "ResizeInProgress"
+	// ResizeStatusError indicates an error occurred during resize
+	ResizeStatusError ResizeStatus = "ResizeError"
+	// ResizeStatusUnknown indicates an unknown resize status
+	ResizeStatusUnknown ResizeStatus = "ResizeUnknown"
+	// ResizeStatusNone indicates no resize operation is pending
+	ResizeStatusNone ResizeStatus = "ResizeNone"
 )

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	metrics_resources "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/resources"
 )
 
@@ -107,4 +108,35 @@ func initContainerStatusFor(initContainerName string, pod *corev1.Pod) *corev1.C
 		}
 	}
 	return nil
+}
+
+// RecommendationHasLowerResource returns true if recommendation b has at least one
+// resource target lower than a for any matching container. This is used for infeasible
+// retry logic: we don't know which resource causes infeasibility, so any reduction
+// is worth retrying.
+func RecommendationHasLowerResource(a, b *vpa_types.RecommendedPodResources) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	for _, aRec := range a.ContainerRecommendations {
+		for _, bRec := range b.ContainerRecommendations {
+			if aRec.ContainerName == bRec.ContainerName {
+				if HasLowerResource(aRec.Target, bRec.Target) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// HasLowerResource returns true if any resource in b is lower than the
+// corresponding resource in a.
+func HasLowerResource(a, b corev1.ResourceList) bool {
+	for key, aVal := range a {
+		if bVal, exists := b[key]; exists && bVal.Cmp(aVal) < 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 )
 
@@ -340,6 +341,141 @@ func TestInitContainerRequestsAndLimits(t *testing.T) {
 			gotRequests, gotLimits := InitContainerRequestsAndLimits(tc.initContainerName, tc.pod)
 			assert.Equal(t, tc.wantRequests, gotRequests, "requests don't match")
 			assert.Equal(t, tc.wantLimits, gotLimits, "limits don't match")
+		})
+	}
+}
+
+func TestHasLowerResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        corev1.ResourceList
+		b        corev1.ResourceList
+		expected bool
+	}{
+		{"Both empty", corev1.ResourceList{}, corev1.ResourceList{}, false},
+		{"Identical resources", corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}, corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}, false},
+		{"b has lower CPU", corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}, corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}, true},
+		{"b has lower memory", corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		}, corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}, true},
+		{"b has higher resources", corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}, corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		}, false},
+		{"b missing key from a", corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}, corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("50m"),
+		}, true},
+		{"b has extra key not in a", corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("100m"),
+		}, corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasLowerResource(tt.a, tt.b); got != tt.expected {
+				t.Errorf("HasLowerResource() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRecommendationHasLowerResource(t *testing.T) {
+	containerHigh := vpa_types.RecommendedContainerResources{
+		ContainerName: "app",
+		Target: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	containerLowCPU := vpa_types.RecommendedContainerResources{
+		ContainerName: "app",
+		Target: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	containerSame := vpa_types.RecommendedContainerResources{
+		ContainerName: "app",
+		Target: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	containerDiffName := vpa_types.RecommendedContainerResources{
+		ContainerName: "sidecar",
+		Target: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("50m"),
+		},
+	}
+
+	tests := []struct {
+		name     string
+		a        *vpa_types.RecommendedPodResources
+		b        *vpa_types.RecommendedPodResources
+		expected bool
+	}{
+		{"Both nil", nil, nil, false},
+		{"One nil", &vpa_types.RecommendedPodResources{}, nil, false},
+		{"Both empty lists",
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{}},
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{}},
+			false,
+		},
+		{"Same recommendations",
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{containerHigh}},
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{containerSame}},
+			false,
+		},
+		{"b has lower CPU for matching container",
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{containerHigh}},
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{containerLowCPU}},
+			true,
+		},
+		{"No matching container names",
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{containerHigh}},
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{containerDiffName}},
+			false,
+		},
+		{"Multiple containers one has lower resource",
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{containerHigh, containerDiffName}},
+			&vpa_types.RecommendedPodResources{ContainerRecommendations: []vpa_types.RecommendedContainerResources{containerLowCPU, containerDiffName}},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RecommendationHasLowerResource(tt.a, tt.b); got != tt.expected {
+				t.Errorf("RecommendationHasLowerResource() = %v, want %v", got, tt.expected)
+			}
 		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/test/test_pod.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_pod.go
@@ -19,11 +19,13 @@ package test
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // PodBuilder helps building pods for tests.
 type PodBuilder interface {
 	WithName(name string) PodBuilder
+	WithUID(types.UID) PodBuilder
 	AddContainer(container corev1.Container) PodBuilder
 	AddInitContainer(initContainer corev1.Container) PodBuilder
 	AddContainerStatus(containerStatus corev1.ContainerStatus) PodBuilder
@@ -47,6 +49,7 @@ func Pod() PodBuilder {
 
 type podBuilderImpl struct {
 	name                  string
+	uid                   types.UID
 	containers            []corev1.Container
 	initContainers        []corev1.Container
 	creatorObjectMeta     *metav1.ObjectMeta
@@ -75,6 +78,12 @@ func (pb *podBuilderImpl) WithAnnotations(annotations map[string]string) PodBuil
 func (pb *podBuilderImpl) WithName(name string) PodBuilder {
 	r := *pb
 	r.name = name
+	return &r
+}
+
+func (pb *podBuilderImpl) WithUID(uid types.UID) PodBuilder {
+	r := *pb
+	r.uid = uid
 	return &r
 }
 
@@ -152,6 +161,10 @@ func (pb *podBuilderImpl) Get() *corev1.Pod {
 
 	if pb.annotations != nil {
 		pod.Annotations = pb.annotations
+	}
+
+	if pb.uid != "" {
+		pod.UID = pb.uid
 	}
 
 	if pb.creatorObjectMeta != nil && pb.creatorTypeMeta != nil {

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
@@ -134,7 +135,7 @@ func (m *PodsInPlaceRestrictionMock) InPlaceUpdate(pod *corev1.Pod, vpa *vpa_typ
 }
 
 // CanInPlaceUpdate is a mock implementation of PodsInPlaceRestriction.CanInPlaceUpdate
-func (m *PodsInPlaceRestrictionMock) CanInPlaceUpdate(pod *corev1.Pod) utils.InPlaceDecision {
+func (m *PodsInPlaceRestrictionMock) CanInPlaceUpdate(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler, infeasibleAttempts map[types.UID]*vpa_types.RecommendedPodResources) utils.InPlaceDecision {
 	args := m.Called(pod)
 	return args.Get(0).(utils.InPlaceDecision)
 }

--- a/vertical-pod-autoscaler/test/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/common.go
@@ -473,11 +473,16 @@ func WaitForPodsUpdatedWithoutEviction(f *framework.Framework, initialPods *apiv
 		}
 		resourcesHaveDiffered := false
 		podMissing := false
+		podEvicted := false
 		for _, initialPod := range initialPods.Items {
 			found := false
 			for _, pod := range podList.Items {
 				if initialPod.Name == pod.Name {
 					found = true
+					if initialPod.UID != pod.UID {
+						framework.Logf("%s: UID changed from %v to %v, pod was evicted and recreated", pod.Name, initialPod.UID, pod.UID)
+						podEvicted = true
+					}
 					for num, container := range pod.Status.ContainerStatuses {
 						for resourceName, resourceLimit := range container.Resources.Limits {
 							initialResourceLimit := initialPod.Status.ContainerStatuses[num].Resources.Limits[resourceName]
@@ -500,7 +505,7 @@ func WaitForPodsUpdatedWithoutEviction(f *framework.Framework, initialPods *apiv
 				podMissing = true
 			}
 		}
-		if podMissing {
+		if podMissing || podEvicted {
 			return true, fmt.Errorf("a pod was erroneously evicted")
 		}
 		if resourcesHaveDiffered {

--- a/vertical-pod-autoscaler/test/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/updater.go
@@ -66,7 +66,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		}()
 		statusUpdater.Run(stopCh)
 
-		podList := setupPodsForUpscalingEviction(f)
+		podList := setupPodsForUpscalingEviction(f, vpa_types.UpdateModeRecreate)
 
 		ginkgo.By("Waiting for pods to be evicted")
 		err := WaitForPodsEvicted(f, podList)
@@ -97,7 +97,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		}()
 		statusUpdater.Run(stopCh)
 
-		podList := setupPodsForDownscalingEviction(f, nil)
+		podList := setupPodsForDownscalingEviction(f, nil, vpa_types.UpdateModeRecreate)
 
 		ginkgo.By("Waiting for pods to be evicted")
 		err := WaitForPodsEvicted(f, podList)
@@ -132,14 +132,14 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 				ChangeRequirement: vpa_types.TargetHigherThanRequests,
 			},
 		}
-		podList := setupPodsForDownscalingEviction(f, er)
+		podList := setupPodsForDownscalingEviction(f, er, vpa_types.UpdateModeRecreate)
 
 		ginkgo.By(fmt.Sprintf("Waiting for pods to be evicted, hoping it won't happen, sleep for %s", VpaEvictionTimeout.String()))
 		CheckNoPodsEvicted(f, MakePodSet(podList))
 	})
 	// FIXME todo(adrianmoisey): This test seems to be flaky after running in parallel, unsure why, see if it's possible to fix
 	framework.It("doesn't evict pods when Admission Controller status unavailable", framework.WithSerial(), func() {
-		podList := setupPodsForUpscalingEviction(f)
+		podList := setupPodsForUpscalingEviction(f, vpa_types.UpdateModeInPlaceOrRecreate)
 
 		ginkgo.By(fmt.Sprintf("Waiting for pods to be evicted, hoping it won't happen, sleep for %s", VpaEvictionTimeout.String()))
 		CheckNoPodsEvicted(f, MakePodSet(podList))
@@ -169,7 +169,7 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		}()
 		statusUpdater.Run(stopCh)
 
-		podList := setupPodsForUpscalingInPlace(f)
+		podList := setupPodsForUpscalingInPlace(f, vpa_types.UpdateModeInPlaceOrRecreate)
 		initialPods := podList.DeepCopy()
 
 		ginkgo.By("Waiting for pods to be in-place updated")
@@ -201,14 +201,150 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 		}()
 		statusUpdater.Run(stopCh)
 
-		podList := setupPodsForDownscalingInPlace(f, nil)
+		podList := setupPodsForDownscalingInPlace(f, nil, vpa_types.UpdateModeInPlaceOrRecreate)
 		initialPods := podList.DeepCopy()
 
 		ginkgo.By("Waiting for pods to be in-place downscaled")
 		err := WaitForPodsUpdatedWithoutEviction(f, initialPods)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
+	// Sets up a lease object updated periodically to signal - requires WithSerial()
+	framework.It("In-place updates pods with InPlace mode when update succeeds", framework.WithSerial(), framework.WithFeatureGate(features.InPlace), func() {
+		const statusUpdateInterval = 10 * time.Second
+
+		ginkgo.By("Setting up the Admission Controller status")
+		stopCh := make(chan struct{})
+		statusUpdater := status.NewUpdater(
+			f.ClientSet,
+			status.AdmissionControllerStatusName,
+			utils.VpaNamespace,
+			statusUpdateInterval,
+			"e2e test",
+		)
+		defer func() {
+			// Schedule a cleanup of the Admission Controller status.
+			// Status is created outside the test namespace.
+			ginkgo.By("Deleting the Admission Controller status")
+			close(stopCh)
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
+				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		statusUpdater.Run(stopCh)
+
+		podList := setupPodsForUpscalingInPlace(f, vpa_types.UpdateModeInPlace)
+		initialPods := podList.DeepCopy()
+
+		ginkgo.By("Waiting for pods to be in-place updated with InPlace mode")
+		err := WaitForPodsUpdatedWithoutEviction(f, initialPods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	framework.It("does not evicts pods for downscaling with InPlace mode", framework.WithSerial(), func() {
+		const statusUpdateInterval = 10 * time.Second
+
+		ginkgo.By("Setting up the Admission Controller status")
+		stopCh := make(chan struct{})
+		statusUpdater := status.NewUpdater(
+			f.ClientSet,
+			status.AdmissionControllerStatusName,
+			utils.VpaNamespace,
+			statusUpdateInterval,
+			"e2e test",
+		)
+		defer func() {
+			// Schedule a cleanup of the Admission Controller status.
+			// Status is created outside the test namespace.
+			ginkgo.By("Deleting the Admission Controller status")
+			close(stopCh)
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
+				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		statusUpdater.Run(stopCh)
+
+		podList := setupPodsForDownscalingEviction(f, nil, vpa_types.UpdateModeInPlace)
+
+		ginkgo.By(fmt.Sprintf("Waiting for pods to be evicted, hoping it won't happen, sleep for %s", VpaEvictionTimeout.String()))
+		CheckNoPodsEvicted(f, MakePodSet(podList))
+	})
+
+	framework.It("InPlace mode retries when recommendations change", framework.WithSerial(), framework.WithFeatureGate(features.InPlace), func() {
+		const statusUpdateInterval = 10 * time.Second
+
+		ginkgo.By("Setting up the Admission Controller status")
+		stopCh := make(chan struct{})
+		statusUpdater := status.NewUpdater(
+			f.ClientSet,
+			status.AdmissionControllerStatusName,
+			utils.VpaNamespace,
+			statusUpdateInterval,
+			"e2e test",
+		)
+		defer func() {
+			ginkgo.By("Deleting the Admission Controller status")
+			close(stopCh)
+			err := f.ClientSet.CoordinationV1().Leases(utils.VpaNamespace).
+				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		statusUpdater.Run(stopCh)
+
+		// Set up pods with initial recommendation (100m -> 200m)
+		podList := setupPodsForUpscalingInPlace(f, vpa_types.UpdateModeInPlace)
+		initialPods := podList.DeepCopy()
+
+		ginkgo.By("Waiting for initial in-place update")
+		err := WaitForPodsUpdatedWithoutEviction(f, initialPods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Recording current pod state after first update")
+		podListAfterFirstUpdate, err := GetHamsterPods(f)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		podsAfterFirstUpdate := podListAfterFirstUpdate.DeepCopy()
+
+		ginkgo.By("Updating VPA with new recommendations (300m)")
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		vpaClientSet := utils.GetVpaClientSet(f)
+
+		vpaCRD, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalers(f.Namespace.Name).
+			Get(context.TODO(), "hamster-vpa", metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		vpaCRD.Status.Recommendation = &vpa_types.RecommendedPodResources{
+			ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: containerName,
+					Target: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("300m"),
+						apiv1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+					LowerBound: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("300m"),
+						apiv1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+					UpperBound: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("300m"),
+						apiv1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+				},
+			},
+		}
+
+		_, err = vpaClientSet.AutoscalingV1().VerticalPodAutoscalers(f.Namespace.Name).
+			UpdateStatus(context.TODO(), vpaCRD, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Waiting for pods to be updated again with new recommendations")
+		err = WaitForPodsUpdatedWithoutEviction(f, podsAfterFirstUpdate)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
 })
+
+func setupPodsForUpscalingEviction(f *framework.Framework, updateMode vpa_types.UpdateMode) *apiv1.PodList {
+	return setupPodsForEviction(f, "100m", "100Mi", nil, updateMode)
+}
 
 var _ = UpdaterE2eDescribe("Updater with PerVPAConfig", func() {
 	const replicas = 3
@@ -410,15 +546,11 @@ func setupPodsForCPUBoost(f *framework.Framework, hamsterCPU, hamsterMemory stri
 	return podList
 }
 
-func setupPodsForUpscalingEviction(f *framework.Framework) *apiv1.PodList {
-	return setupPodsForEviction(f, "100m", "100Mi", nil)
+func setupPodsForDownscalingEviction(f *framework.Framework, er []*vpa_types.EvictionRequirement, updateMode vpa_types.UpdateMode) *apiv1.PodList {
+	return setupPodsForEviction(f, "500m", "500Mi", er, updateMode)
 }
 
-func setupPodsForDownscalingEviction(f *framework.Framework, er []*vpa_types.EvictionRequirement) *apiv1.PodList {
-	return setupPodsForEviction(f, "500m", "500Mi", er)
-}
-
-func setupPodsForEviction(f *framework.Framework, hamsterCPU, hamsterMemory string, er []*vpa_types.EvictionRequirement) *apiv1.PodList {
+func setupPodsForEviction(f *framework.Framework, hamsterCPU, hamsterMemory string, er []*vpa_types.EvictionRequirement, updateMode vpa_types.UpdateMode) *apiv1.PodList {
 	controller := &autoscaling.CrossVersionObjectReference{
 		APIVersion: "apps/v1",
 		Kind:       "Deployment",
@@ -435,7 +567,7 @@ func setupPodsForEviction(f *framework.Framework, hamsterCPU, hamsterMemory stri
 		WithName("hamster-vpa").
 		WithNamespace(f.Namespace.Name).
 		WithTargetRef(controller).
-		WithUpdateMode(vpa_types.UpdateModeRecreate).
+		WithUpdateMode(updateMode).
 		WithEvictionRequirements(er).
 		WithContainer(containerName).
 		AppendRecommendation(
@@ -452,15 +584,15 @@ func setupPodsForEviction(f *framework.Framework, hamsterCPU, hamsterMemory stri
 	return podList
 }
 
-func setupPodsForUpscalingInPlace(f *framework.Framework) *apiv1.PodList {
-	return setupPodsForInPlace(f, "100m", "100Mi", nil, true)
+func setupPodsForUpscalingInPlace(f *framework.Framework, updateMode vpa_types.UpdateMode) *apiv1.PodList {
+	return setupPodsForInPlace(f, "100m", "100Mi", nil, true, updateMode)
 }
 
-func setupPodsForDownscalingInPlace(f *framework.Framework, er []*vpa_types.EvictionRequirement) *apiv1.PodList {
-	return setupPodsForInPlace(f, "500m", "500Mi", er, true)
+func setupPodsForDownscalingInPlace(f *framework.Framework, er []*vpa_types.EvictionRequirement, updateMode vpa_types.UpdateMode) *apiv1.PodList {
+	return setupPodsForInPlace(f, "500m", "500Mi", er, true, updateMode)
 }
 
-func setupPodsForInPlace(f *framework.Framework, hamsterCPU, hamsterMemory string, er []*vpa_types.EvictionRequirement, withRecommendation bool) *apiv1.PodList {
+func setupPodsForInPlace(f *framework.Framework, hamsterCPU, hamsterMemory string, er []*vpa_types.EvictionRequirement, withRecommendation bool, updateMode vpa_types.UpdateMode) *apiv1.PodList {
 	controller := &autoscaling.CrossVersionObjectReference{
 		APIVersion: "apps/v1",
 		Kind:       "Deployment",
@@ -477,7 +609,7 @@ func setupPodsForInPlace(f *framework.Framework, hamsterCPU, hamsterMemory strin
 		WithName("hamster-vpa").
 		WithNamespace(f.Namespace.Name).
 		WithTargetRef(controller).
-		WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
+		WithUpdateMode(updateMode).
 		WithEvictionRequirements(er).
 		WithContainer(containerName)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 VPA InPlace updateMode support.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8720

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The VPA support InPlace update mode. VPA will not evict any pods and only try to resize pods inplace.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
AEP: https://github.com/kubernetes/autoscaler/pull/8818
```
