### PR TITLE
fix(capacitybuffer): correct spelling mistakes in function names and messages

### DIFF
--- a/cluster-autoscaler/capacitybuffer/common/common.go
+++ b/cluster-autoscaler/capacitybuffer/common/common.go
@@ -45,15 +45,14 @@ func SetBufferAsReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRef *
 		Type:               ReadyForProvisioningCondition,
 		Status:             ConditionTrue,
 		Message:            "ready",
-		Reason:             "atrtibutesSetSuccessfully",
+		Reason:             "attributesSetSuccessfully",
 		LastTransitionTime: metav1.Time{Time: time.Now()},
 	}
 	buffer.Status.Conditions = []metav1.Condition{readyCondition}
 }
 
 // SetBufferAsNotReadyForProvisioning updates the passed buffer object with the rest of the attributes and sets its condition to not ready with the passed error
-func SetBufferAsNotReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRef *v1.LocalObjectRef, podTemplateGeneration *int64, replicas *int32, provStrategy *string, err error) {
-	errorMessage := "Buffer not ready for provisioing"
+func SetBufferAsNotReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRef *v1.LocalObjectRef, podTemplateGeneration *int64, replicas *int32, provStrategy *string, err error) {	errorMessage := "Buffer not ready for provisioning"
 	if err != nil {
 		errorMessage = err.Error()
 	}
@@ -80,8 +79,8 @@ func mapEmptyProvStrategyToDefault(ps *string) *string {
 	return ps
 }
 
-// UpdateBufferStatusToFailedProvisioing updates the status of the passed buffer and set Provisioning to false with the passes reason and message
-func UpdateBufferStatusToFailedProvisioing(buffer *v1.CapacityBuffer, reason, errorMessage string) {
+// UpdateBufferStatusToFailedProvisioning updates the status of the passed buffer and set Provisioning to false with the passed reason and message
+func UpdateBufferStatusToFailedProvisioning(buffer *v1.CapacityBuffer, reason, errorMessage string) {
 	buffer.Status.Conditions = []metav1.Condition{{
 		Type:               ProvisioningCondition,
 		Status:             ConditionFalse,
@@ -91,8 +90,8 @@ func UpdateBufferStatusToFailedProvisioing(buffer *v1.CapacityBuffer, reason, er
 	}}
 }
 
-// UpdateBufferStatusToSuccessfullyProvisioing updates the status of the passed buffer and set Provisioning to true with the passes reason
-func UpdateBufferStatusToSuccessfullyProvisioing(buffer *v1.CapacityBuffer, reason string) {
+// UpdateBufferStatusToSuccessfullyProvisioning updates the status of the passed buffer and set Provisioning to true with the passed reason
+func UpdateBufferStatusToSuccessfullyProvisioning(buffer *v1.CapacityBuffer, reason string) {
 	buffer.Status.Conditions = []metav1.Condition{{
 		Type:               ProvisioningCondition,
 		Status:             ConditionTrue,

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -140,11 +140,11 @@ func (p *CapacityBufferPodListProcessor) provision(buffer *v1alpha1.CapacityBuff
 	}
 	fakePods, err := makeFakePods(buffer, &podTemplate.Template, int(*replicas))
 	if err != nil {
-		common.UpdateBufferStatusToFailedProvisioing(buffer, "FailedToMakeFakePods", fmt.Sprintf("failed to create fake pods with error: %v", err.Error()))
+		common.UpdateBufferStatusToFailedProvisioning(buffer, "FailedToMakeFakePods", fmt.Sprintf("failed to create fake pods with error: %v", err.Error()))
 		p.updateBufferStatus(buffer)
 		return []*apiv1.Pod{}
 	}
-	common.UpdateBufferStatusToSuccessfullyProvisioing(buffer, "FakePodsInjected")
+	common.UpdateBufferStatusToSuccessfullyProvisioning(buffer, "FakePodsInjected")
 	p.updateBufferStatus(buffer)
 	return fakePods
 }


### PR DESCRIPTION
## Summary
Fixed spelling mistakes in the Capacity Buffer feature code.

## Changes
- `atrtibutesSetSuccessfully` → `attributesSetSuccessfully`
- `provisioing` → `provisioning`
- Function name corrections:
  - `UpdateBufferStatusToFailedProvisioing` → `UpdateBufferStatusToFailedProvisioning`
  - `UpdateBufferStatusToSuccessfullyProvisioing` → `UpdateBufferStatusToSuccessfullyProvisioning`
- Comment correction: `passes` → `passed`

## Affected Files
- `cluster-autoscaler/capacitybuffer/common/common.go`
- `cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go`

No functional changes, purely spelling corrections.