### PR TITLE
add Partial Capacity case and condition to check capacity provreqs

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -620,14 +620,26 @@ Currently, ClusterAutoscaler supports following ProvisioningClasses:
 When using this class, Cluster Autoscaler performs following actions:
 
   * __Capacity Check__: Determines if sufficient capacity exists in the cluster to fulfill the ProvisioningRequest.
+  By default, this checks whether there is capacity for the entire set of pods. However, you can configure
+  it to check for partial capacity at the PodSet level by setting the `partialCapacityCheck` parameter in the
+  ProvisioningRequest's `Parameters` field (see [Using Check Capacity Partial Capacity Check](#using-check-capacity-partial-capacity-check) for details).
 
   * __Reservation from other ProvReqs__ (if capacity is available): Reserves this capacity for the ProvisioningRequest for 10 minutes,
   preventing other ProvReqs from using it.
 
   * __Condition Updates__:
-  Adds a Accepted=True condition when ProvReq is accepted by ClusterAutoscaler and ClusterAutoscaler will check capacity for this ProvReq.
-  Adds a Provisioned=True condition to the ProvReq if capacity is available.
-  Adds a BookingExpired=True condition when the 10-minute reservation period expires.
+    * Adds a `Accepted=True` condition when ProvReq is accepted by ClusterAutoscaler and ClusterAutoscaler will check capacity for this ProvReq.
+    * Adds a `Provisioned=True` condition to the ProvReq if capacity is available:
+      * With `Reason=CapacityIsFound` when capacity exists for all pods
+      * With `Reason=PartialCapacityIsFound` when `partialCapacityCheck` is set to `"bookPartial"` and capacity is found for some but not all PodSets
+      (the message will indicate which PodSets can be scheduled, and the `schedulablePodSets` detail will contain a JSON array of their names)
+    * Adds a `Provisioned=False` condition with `Reason=PartialCapacityIsFound` when `partialCapacityCheck` is set to `"checkOnly"` and capacity is found for some but not all PodSets
+      (same message and detail as `"bookPartial"`, but capacity is not reserved)
+
+    * If capacity is not available, one of the following conditions will be added, depending on the `noRetry` Parameter:
+      * Adds a `Provisioned=False` condition with `Reason=CapacityIsNotFound` if capacity is not found and the `noRetry` parameter is not set to "true" (CA will retry by default).
+      * Adds a `Failed=True` condition with `Reason=CapacityIsNotFound` if capacity is not found and the `noRetry` parameter is set to "true" (signals that the request is terminal and will not be retried).
+    * Adds a `BookingExpired=True` condition when the 10-minute reservation period expires.
 
   Since Cluster Autoscaler version 1.33, it is possible to configure the autoscaler
   to process only subset of check capacity ProvisioningRequests and ignore the rest.
@@ -722,6 +734,77 @@ spec:
             memory: 600Mi
         args: ["sleep"]
 ```
+
+#### How to use the Check Capacity Parameters
+##### Using Check Capacity Partial Capacity Check
+
+To check if there is capacity for at least some of your PodSets (rather than all or nothing),
+set the `partialCapacityCheck` parameter. This evaluates capacity at the **PodSet level** — each
+PodSet either fits entirely or not at all.
+
+Supported values:
+- `"bookPartial"`: If partial capacity is found, sets `Provisioned=True` and **reserves** the capacity for the schedulable PodSets.
+- `"checkOnly"`: If partial capacity is found, sets `Provisioned=False` and does **not** reserve capacity. The `schedulablePodSets` detail still reports which PodSets fit.
+
+1. Add the `partialCapacityCheck` parameter to your ProvisioningRequest:
+   ```yaml
+   apiVersion: autoscaling.x-k8s.io/v1
+   kind: ProvisioningRequest
+   metadata:
+     name: my-provreq
+   spec:
+     provisioningClassName: "check-capacity.autoscaling.x-k8s.io"
+     parameters:
+       partialCapacityCheck: "bookPartial"
+     podSets:
+       - podTemplateRef:
+           name: template-a
+         count: 5
+       - podTemplateRef:
+           name: template-b
+         count: 10
+   ```
+
+2. The Cluster Autoscaler will simulate scheduling each PodSet independently, in the order they
+   appear in the `PodSets` array. A PodSet is considered schedulable only if **all** of its pods fit.
+
+3. Check the condition and details for results:
+   - If `Provisioned=True` with `Reason=CapacityIsFound`, all PodSets can be scheduled.
+   - If `Reason=PartialCapacityIsFound`, the condition message will indicate which PodSets can be
+     scheduled. The `schedulablePodSets` key in `ProvisioningClassDetails` contains a JSON array
+     of the schedulable PodSet names (e.g., `["template-a"]`).
+
+**Note**: PodSets are evaluated in order. When a PodSet is schedulable, its capacity consumption is
+visible to subsequent PodSets in the simulation.
+
+##### Preventing Retries with noRetry Parameter
+
+By default, when capacity is not found, Cluster Autoscaler will retry checking capacity in subsequent iterations.
+To make a ProvisioningRequest fail immediately without retries:
+
+1. Add the `noRetry` parameter to your ProvisioningRequest:
+   ```yaml
+   apiVersion: autoscaling.x-k8s.io/v1
+   kind: ProvisioningRequest
+   metadata:
+     name: my-provreq
+   spec:
+     provisioningClassName: "check-capacity.autoscaling.x-k8s.io"
+     parameters:
+       noRetry: "true"
+     podSets:
+       - podTemplateRef:
+           name: my-template
+         count: 10
+   ```
+
+2. When capacity is not found, CA will set `Failed=True` with `Reason=CapacityIsNotFound` instead of
+   `Provisioned=False`. This signals that the request is terminal and will not be retried.
+
+**Note**: The `noRetry` and `partialCapacityCheck` parameters can be used together. When both are enabled
+and partial capacity is found, the `partialCapacityCheck` mode determines the `Provisioned` condition
+status (`"bookPartial"` → `True`, `"checkOnly"` → `False`), both with `Reason=PartialCapacityIsFound`.
+
 
 ### How can I tune Cluster Autoscaler's performance for processing ProvisioningRequests?
 

--- a/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go
+++ b/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go
@@ -87,16 +87,31 @@ type ProvisioningRequestSpec struct {
 	// ProvisioningClassName describes the different modes of provisioning the resources.
 	// Currently there is no support for 'ProvisioningClass' objects.
 	// Supported values:
-	// * check-capacity.autoscaling.x-k8s.io - check if current cluster state can fullfil this request,
+	// * check-capacity.kubernetes.io - check if current cluster state can fulfill this request,
 	//   do not reserve the capacity. Users should provide a reference to a valid PodTemplate object.
-	//   CA will check if there is enough capacity in cluster to fulfill the request and put
-	//   the answer in 'CapacityAvailable' condition.
+	//   CA will check if there is enough capacity in the cluster to fulfill the request.
+	//
+	//   Behavior:
+	//   - If all requested capacity is available: CA sets 'Provisioned' condition with Status=True
+	//     and Reason=CapacityIsFound.
+	//   - If partial capacity is available (some PodSets fit) and 'partialCapacityCheck' parameter
+	//     is set to "bookPartial": CA sets 'Provisioned' condition with Status=True and
+	//     Reason=PartialCapacityIsFound, and books capacity for the schedulable PodSets.
+	//   - If partial capacity is available and 'partialCapacityCheck' parameter is set to
+	//     "checkOnly": CA sets 'Provisioned' condition with Status=False and
+	//     Reason=PartialCapacityIsFound (capacity is not booked).
+	//   - If capacity is not available (or only partial capacity exists but 'partialCapacityCheck'
+	//     is not enabled): CA sets either 'Failed' condition with Status=True and Reason=CapacityIsNotFound
+	//     (if 'noRetry' parameter is set to "true") or 'Provisioned' condition with Status=False and
+	//     Reason=CapacityIsNotFound (will retry by default).
+	//
 	// * best-effort-atomic-scale-up.autoscaling.x-k8s.io - provision the resources in an atomic manner.
 	//   Users should provide a reference to a valid PodTemplate object.
 	//   CA will try to create the VMs in an atomic manner, clean any partially provisioned VMs
 	//   and re-try the operation in a exponential back-off manner. Users can configure the timeout
 	//   duration after which the request will fail by 'ValidUntilSeconds' key in 'Parameters'.
 	//   CA will set 'Failed=true' or 'Provisioned=true' condition according to the outcome.
+	//
 	// * ... - potential other classes that are specific to the cloud providers.
 	// 'kubernetes.io' suffix is reserved for the modes defined in Kubernetes projects.
 	//
@@ -107,8 +122,24 @@ type ProvisioningRequestSpec struct {
 	ProvisioningClassName string `json:"provisioningClassName"`
 
 	// Parameters contains all other parameters classes may require.
-	// 'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports 'ValidUntilSeconds' parameter, which should contain
-	//  a string denoting duration for which we should retry (measured since creation fo the CR).
+	//
+	// 'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports:
+	//   - 'ValidUntilSeconds': String denoting duration for which CA should retry
+	//     (measured since creation of the CR).
+	//
+	// 'check-capacity.kubernetes.io' supports:
+	//   - 'partialCapacityCheck': Enables per-PodSet capacity evaluation. Supported values:
+	//     "bookPartial" - CA sets 'Provisioned=true' with Reason=PartialCapacityIsFound when
+	//     capacity is found for some (but not all) PodSets, and books capacity for the
+	//     schedulable PodSets.
+	//     "checkOnly" - CA sets 'Provisioned=false' with Reason=PartialCapacityIsFound when
+	//     capacity is found for some PodSets, without booking capacity.
+	//     In both modes, the 'schedulablePodSets' ProvisioningClassDetails key lists which
+	//     PodSets had available capacity. Default: not set (disabled).
+	//   - 'noRetry': Set to "true" to prevent CA from retrying when capacity is not found.
+	//     When enabled, CA sets 'Failed=true' with Reason=CapacityIsNotFound instead of
+	//     'Provisioned=false'. This signals that the request is terminal and should not be
+	//     retried. Default: "false".
 	//
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"

--- a/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
@@ -91,16 +91,31 @@ type ProvisioningRequestSpec struct {
 	// ProvisioningClassName describes the different modes of provisioning the resources.
 	// Currently there is no support for 'ProvisioningClass' objects.
 	// Supported values:
-	// * check-capacity.autoscaling.x-k8s.io - check if current cluster state can fullfil this request,
+	// * check-capacity.kubernetes.io - check if current cluster state can fulfill this request,
 	//   do not reserve the capacity. Users should provide a reference to a valid PodTemplate object.
-	//   CA will check if there is enough capacity in cluster to fulfill the request and put
-	//   the answer in 'CapacityAvailable' condition.
-	// * best-effort-atomic-scale-up.autoscaling.x-k8s.io - provision the resources in an atomic manner.
+	//   CA will check if there is enough capacity in the cluster to fulfill the request.
+	//
+	//   Behavior:
+	//   - If all requested capacity is available: CA sets 'Provisioned' condition with Status=True
+	//     and Reason=CapacityIsFound.
+	//   - If partial capacity is available (some PodSets fit) and 'partialCapacityCheck' parameter
+	//     is set to "bookPartial": CA sets 'Provisioned' condition with Status=True and
+	//     Reason=PartialCapacityIsFound, and books capacity for the schedulable PodSets.
+	//   - If partial capacity is available and 'partialCapacityCheck' parameter is set to
+	//     "checkOnly": CA sets 'Provisioned' condition with Status=False and
+	//     Reason=PartialCapacityIsFound (capacity is not booked).
+	//   - If capacity is not available (or only partial capacity exists but 'partialCapacityCheck'
+	//     is not enabled): CA sets either 'Failed' condition with Status=True and Reason=CapacityIsNotFound
+	//     (if 'noRetry' parameter is set to "true") or 'Provisioned' condition with Status=False and
+	//     Reason=CapacityIsNotFound (will retry by default).
+	//
+	// * best-effort-atomic-scale-up.autoscaling.x-k8s.io  - provision the resources in an atomic manner.
 	//   Users should provide a reference to a valid PodTemplate object.
 	//   CA will try to create the VMs in an atomic manner, clean any partially provisioned VMs
 	//   and re-try the operation in a exponential back-off manner. Users can configure the timeout
 	//   duration after which the request will fail by 'ValidUntilSeconds' key in 'Parameters'.
 	//   CA will set 'Failed=true' or 'Provisioned=true' condition according to the outcome.
+	//
 	// * ... - potential other classes that are specific to the cloud providers.
 	// 'kubernetes.io' suffix is reserved for the modes defined in Kubernetes projects.
 	//
@@ -111,8 +126,24 @@ type ProvisioningRequestSpec struct {
 	ProvisioningClassName string `json:"provisioningClassName"`
 
 	// Parameters contains all other parameters classes may require.
-	// 'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports 'ValidUntilSeconds' parameter, which should contain
-	//  a string denoting duration for which we should retry (measured since creation fo the CR).
+	//
+	// 'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports:
+	//   - 'ValidUntilSeconds': String denoting duration for which CA should retry
+	//     (measured since creation of the CR).
+	//
+	// 'check-capacity.kubernetes.io' supports:
+	//   - 'partialCapacityCheck': Enables per-PodSet capacity evaluation. Supported values:
+	//     "bookPartial" - CA sets 'Provisioned=true' with Reason=PartialCapacityIsFound when
+	//     capacity is found for some (but not all) PodSets, and books capacity for the
+	//     schedulable PodSets.
+	//     "checkOnly" - CA sets 'Provisioned=false' with Reason=PartialCapacityIsFound when
+	//     capacity is found for some PodSets, without booking capacity.
+	//     In both modes, the 'schedulablePodSets' ProvisioningClassDetails key lists which
+	//     PodSets had available capacity. Default: not set (disabled).
+	//   - 'noRetry': Set to "true" to prevent CA from retrying when capacity is not found.
+	//     When enabled, CA sets 'Failed=true' with Reason=CapacityIsNotFound instead of
+	//     'Provisioned=false'. This signals that the request is terminal and should not be
+	//     retried. Default: "false".
 	//
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"

--- a/cluster-autoscaler/processors/provreq/processor.go
+++ b/cluster-autoscaler/processors/provreq/processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provreq
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -147,7 +148,7 @@ func (p *provReqProcessor) bookCapacity(autoscalingCtx *ca_context.AutoscalingCo
 		if !conditions.ShouldCapacityBeBooked(provReq, p.checkCapacityProcessorInstance) {
 			continue
 		}
-		pods, err := provreq_pods.PodsForProvisioningRequest(provReq)
+		pods, err := podsForProvReq(provReq)
 		if err != nil {
 			// ClusterAutoscaler was able to create pods before, so we shouldn't have error here.
 			// If there is an error, mark PR as invalid, because we won't be able to book capacity
@@ -168,6 +169,25 @@ func (p *provReqProcessor) bookCapacity(autoscalingCtx *ca_context.AutoscalingCo
 		return err
 	}
 	return nil
+}
+
+// podsForProvReq returns pods to book capacity for. If the ProvReq has a
+// schedulablePodSets detail, only pods for those podsets are returned.
+func podsForProvReq(provReq *provreqwrapper.ProvisioningRequest) ([]*apiv1.Pod, error) {
+	detail, ok := provReq.Status.ProvisioningClassDetails[conditions.SchedulablePodSetsDetailKey]
+	if !ok || detail == "" {
+		return provreq_pods.PodsForProvisioningRequest(provReq)
+	}
+	var podSetNames []string
+	if err := json.Unmarshal([]byte(detail), &podSetNames); err != nil {
+		klog.Errorf("failed to parse schedulablePodSets detail for ProvReq %s: %v", provReq.Name, err)
+		return provreq_pods.PodsForProvisioningRequest(provReq)
+	}
+	allowedPodSets := make(map[string]bool, len(podSetNames))
+	for _, name := range podSetNames {
+		allowedPodSets[name] = true
+	}
+	return provreq_pods.PodsForProvisioningRequestPodSets(provReq, allowedPodSets)
 }
 
 // DeleteOldProvReqs delete ProvReq that have terminal state (Provisioned/Failed == True) more than a week.

--- a/cluster-autoscaler/processors/provreq/processor_test.go
+++ b/cluster-autoscaler/processors/provreq/processor_test.go
@@ -301,3 +301,77 @@ func TestBookCapacity(t *testing.T) {
 		})
 	}
 }
+
+func TestBookCapacityPartialPodSets(t *testing.T) {
+	makeProvReq := func(name string) *provreqwrapper.ProvisioningRequest {
+		return provreqwrapper.NewProvisioningRequest(
+			&v1.ProvisioningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+				Spec: v1.ProvisioningRequestSpec{
+					ProvisioningClassName: v1.ProvisioningClassCheckCapacity,
+					PodSets: []v1.PodSet{
+						{PodTemplateRef: v1.Reference{Name: "template-0"}, Count: 3},
+						{PodTemplateRef: v1.Reference{Name: "template-1"}, Count: 2},
+					},
+				},
+				Status: v1.ProvisioningRequestStatus{Conditions: []metav1.Condition{}},
+			},
+			[]*apiv1.PodTemplate{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "template-0", Namespace: "ns"},
+					Template:   apiv1.PodTemplateSpec{Spec: apiv1.PodSpec{Containers: []apiv1.Container{{Name: "c", Image: "img"}}}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "template-1", Namespace: "ns"},
+					Template:   apiv1.PodTemplateSpec{Spec: apiv1.PodSpec{Containers: []apiv1.Container{{Name: "c", Image: "img"}}}},
+				},
+			},
+		)
+	}
+
+	testCases := []struct {
+		name               string
+		schedulablePodSets string // JSON, empty means no detail set
+		wantPodCount       int
+	}{
+		{
+			name:         "no schedulablePodSets detail books all pods",
+			wantPodCount: 5,
+		},
+		{
+			name:               "first podset only: books 3 pods",
+			schedulablePodSets: `["template-0"]`,
+			wantPodCount:       3,
+		},
+		{
+			name:               "second podset only: books 2 pods",
+			schedulablePodSets: `["template-1"]`,
+			wantPodCount:       2,
+		},
+		{
+			name:               "both podsets: books all 5 pods",
+			schedulablePodSets: `["template-0","template-1"]`,
+			wantPodCount:       5,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			pr := makeProvReq("pr")
+			conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionTrue, "", "", metav1.Now())
+			if test.schedulablePodSets != "" {
+				pr.SetProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey, v1.Detail(test.schedulablePodSets))
+			}
+
+			injector := &fakeInjector{pods: []*apiv1.Pod{}}
+			processor := &provReqProcessor{
+				now:        func() time.Time { return time.Now() },
+				client:     provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, pr),
+				maxUpdated: 20,
+				injector:   injector,
+			}
+			autoscalingCtx, _ := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, nil, nil, nil, nil, nil, nil)
+			processor.bookCapacity(&autoscalingCtx)
+			assert.Equal(t, test.wantPodCount, len(injector.pods))
+		})
+	}
+}

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -60,14 +60,14 @@ const (
 	// per-PodSet capacity evaluation. Supported values are "bookPartial" and "checkOnly".
 	// By default this is not set, and checkCapacity evaluates all pods atomically.
 	PartialCapacityCheckKey = "partialCapacityCheck"
-	// When partialCapacityCheck Parameter is set to PartialCapacityCheckBookPartial,
-	// the ProvisioningRequest condition is set to Provisioned=true if capacity is found for
-	// some of the ProvReq PodSets.
+	// PartialCapacityCheckBookPartial is a value for the partialCapacityCheck Parameter
+	// that causes the CA to set the ProvisioningRequest condition
+	// to Provisioned=true if capacity is found for some of the ProvReq PodSets.
 	PartialCapacityCheckBookPartial = "bookPartial"
-	// When partialCapacityCheck Parameter is set to PartialCapacityCheckCheckOnly,
-	// the ProvisioningRequest condition is set to Provisioned=false even if capacity is found for
-	// some of the ProvReq PodSets. If partial capacity is found, the condition message and ProvReq Details
-	// will reflect the capacity state.
+	// PartialCapacityCheckCheckOnly is a value for the partialCapacityCheck Parameter
+	// that causes the CA to set the ProvisioningRequest condition to Provisioned=false
+	// even if capacity is found for some of the ProvReq PodSets. If partial capacity
+	// is found, the condition message and ProvReq Details will reflect the capacity state.
 	PartialCapacityCheckCheckOnly = "checkOnly"
 )
 

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -17,8 +17,11 @@ limitations under the License.
 package checkcapacity
 
 import (
+	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -52,7 +55,24 @@ const (
 	// Supported values are "true" and "false" - by default ProvisioningRequests are always retried.
 	// Currently supported only for checkcapacity class.
 	NoRetryParameterKey = "noRetry"
+
+	// PartialCapacityCheckKey is a key for ProvReq's Parameters that enables
+	// per-PodSet capacity evaluation. Supported values are "bookPartial" and "checkOnly".
+	// By default this is not set, and checkCapacity evaluates all pods atomically.
+	PartialCapacityCheckKey = "partialCapacityCheck"
+	// When partialCapacityCheck Parameter is set to PartialCapacityCheckBookPartial,
+	// the ProvisioningRequest condition is set to Provisioned=true if capacity is found for
+	// some of the ProvReq PodSets.
+	PartialCapacityCheckBookPartial = "bookPartial"
+	// When partialCapacityCheck Parameter is set to PartialCapacityCheckCheckOnly,
+	// the ProvisioningRequest condition is set to Provisioned=false even if capacity is found for
+	// some of the ProvReq PodSets. If partial capacity is found, the condition message and ProvReq Details
+	// will reflect the capacity state.
+	PartialCapacityCheckCheckOnly = "checkOnly"
 )
+
+// Regex to match pod names created by PodsForProvisioningRequest.
+var podSetIndexPattern = regexp.MustCompile(`-(\d+)-(\d+)$`)
 
 type checkCapacityProvClass struct {
 	autoscalingCtx                               *ca_context.AutoscalingContext
@@ -177,32 +197,133 @@ func (o *checkCapacityProvClass) checkCapacityBatch(reqs []provreq.ProvisioningR
 func (o *checkCapacityProvClass) checkCapacity(unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) error {
 	o.autoscalingCtx.ClusterSnapshot.Fork()
 
-	// Case 1: Capacity fits.
+	partialCapacityMode, partialCapacityCheckEnabled := getPartialCapacityCheckMode(provReq)
+
+	if partialCapacityCheckEnabled {
+		// Schedule per podset using nested forks. For each podset, if all its pods fit, commit the
+		// inner fork into the outer fork so subsequent podsets see the consumed capacity. At the end,
+		// commit or revert the outer fork depending on the result and mode.
+		podsByPodSet := groupPodsByPodSet(unschedulablePods, provReq)
+		schedulablePodSets := make([]string, 0)
+
+		// PodSets are evaluated in spec order. Earlier PodSets that fit consume
+		// capacity within the simulation, which may prevent later PodSets from
+		// scheduling. In checkOnly mode the capacity is reverted after evaluation.
+		for i, podSetSpec := range provReq.Spec.PodSets {
+			pods := podsByPodSet[i]
+			if len(pods) == 0 {
+				klog.Warningf("No pods matched podset %d (%s) for ProvReq %s, treating as not schedulable", i, podSetSpec.PodTemplateRef.Name, provReq.Name)
+				continue
+			}
+			o.autoscalingCtx.ClusterSnapshot.Fork()
+			scheduled, _, err := o.schedulingSimulator.TrySchedulePods(o.autoscalingCtx.ClusterSnapshot, pods, true, clustersnapshot.SchedulingOptions{})
+			if err != nil {
+				o.autoscalingCtx.ClusterSnapshot.Revert()
+				o.autoscalingCtx.ClusterSnapshot.Revert()
+				return err
+			}
+			if len(scheduled) == len(pods) {
+				schedulablePodSets = append(schedulablePodSets, podSetSpec.PodTemplateRef.Name)
+				if commitErr := o.autoscalingCtx.ClusterSnapshot.Commit(); commitErr != nil {
+					o.autoscalingCtx.ClusterSnapshot.Revert()
+					return commitErr
+				}
+			} else {
+				o.autoscalingCtx.ClusterSnapshot.Revert()
+			}
+		}
+
+		schedulablePodSetsJSON, jsonErr := json.Marshal(schedulablePodSets)
+		if jsonErr != nil {
+			klog.Errorf("failed to marshal schedulablePodSets for ProvReq %s: %v", provReq.Name, jsonErr)
+		} else {
+			provReq.SetProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey, v1.Detail(schedulablePodSetsJSON))
+		}
+
+		// Case 1: All podsets fit.
+		if len(schedulablePodSets) == len(provReq.Spec.PodSets) {
+			combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
+			conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+			if commitErr := o.autoscalingCtx.ClusterSnapshot.Commit(); commitErr != nil {
+				o.autoscalingCtx.ClusterSnapshot.Revert()
+				return commitErr
+			}
+			return nil
+		}
+
+		// Case 2: Some podsets fit.
+		if len(schedulablePodSets) > 0 {
+			msg := fmt.Sprintf("%s. Schedulable podsets: %s", conditions.PartialCapacityIsFoundMsg, strings.Join(schedulablePodSets, ","))
+			handlePartialCapacityStatusUpdate(provReq, combinedStatus, partialCapacityMode, msg)
+			if partialCapacityMode == PartialCapacityCheckBookPartial {
+				if commitErr := o.autoscalingCtx.ClusterSnapshot.Commit(); commitErr != nil {
+					o.autoscalingCtx.ClusterSnapshot.Revert()
+					return commitErr
+				}
+			} else {
+				o.autoscalingCtx.ClusterSnapshot.Revert()
+			}
+			return nil
+		}
+
+		// Case 3: No podsets fit.
+		o.autoscalingCtx.ClusterSnapshot.Revert()
+		provReq.DeleteProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey)
+		combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable})
+		setCapacityNotFoundCondition(provReq)
+		return nil
+	}
+
+	// Non-partial path: schedule all pods at once and break on first failure.
 	scheduled, _, err := o.schedulingSimulator.TrySchedulePods(o.autoscalingCtx.ClusterSnapshot, unschedulablePods, true, clustersnapshot.SchedulingOptions{})
 	if err == nil && len(scheduled) == len(unschedulablePods) {
-		commitError := o.autoscalingCtx.ClusterSnapshot.Commit()
-		if commitError != nil {
-			o.autoscalingCtx.ClusterSnapshot.Revert()
-			return commitError
+		// Case 1: All capacity fits.
+		allPodSetNames := make([]string, 0, len(provReq.Spec.PodSets))
+		for _, ps := range provReq.Spec.PodSets {
+			allPodSetNames = append(allPodSetNames, ps.PodTemplateRef.Name)
+		}
+		schedulablePodSetsJSON, jsonErr := json.Marshal(allPodSetNames)
+		if jsonErr != nil {
+			klog.Errorf("failed to marshal schedulablePodSets for ProvReq %s: %v", provReq.Name, jsonErr)
+		} else {
+			provReq.SetProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey, v1.Detail(schedulablePodSetsJSON))
 		}
 		combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
 		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+		if commitError := o.autoscalingCtx.ClusterSnapshot.Commit(); commitError != nil {
+			o.autoscalingCtx.ClusterSnapshot.Revert()
+			return commitError
+		}
 		return nil
 	}
-	// Case 2: Capacity doesn't fit.
+
+	// Case 3: Capacity doesn't fit.
 	o.autoscalingCtx.ClusterSnapshot.Revert()
+	// Clear the detail from any previous iteration.
+	provReq.DeleteProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey)
 	combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable})
-	if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry == "true" {
-		// Failed=true condition triggers retry in Kueue. Otherwise ProvisioningRequest with Provisioned=Failed
-		// condition block capacity in Kueue even if it's in the middle of backoff waiting time.
-		conditions.AddOrUpdateCondition(provReq, v1.Failed, metav1.ConditionTrue, conditions.CapacityIsNotFoundReason, "CA could not find requested capacity", metav1.Now())
-	} else {
-		if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry != "false" {
-			klog.Errorf("Ignoring Parameter %v with invalid value: %v in ProvisioningRequest: %v. Supported values are: \"true\", \"false\"", NoRetryParameterKey, noRetry, provReq.Name)
-		}
-		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
-	}
+	setCapacityNotFoundCondition(provReq)
 	return err
+}
+
+const podNameFormatLen = 3
+
+// groupPodsByPodSet buckets pods by their podset index, extracted from the pod name.
+// Pod names are created in the format {GenerateName}{i}-{j}, where i is the podset index
+// and j is the pod index within the podset. Pods not belonging to provReq are filtered out.
+func groupPodsByPodSet(pods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest) map[int][]*apiv1.Pod {
+	groups := make(map[int][]*apiv1.Pod)
+	for _, pod := range pods {
+		if pod.Annotations[v1.ProvisioningRequestPodAnnotationKey] != provReq.Name {
+			continue
+		}
+		matches := podSetIndexPattern.FindStringSubmatch(pod.Name)
+		if len(matches) == podNameFormatLen {
+			idx, _ := strconv.Atoi(matches[1]) // safe: regex guarantees digits
+			groups[idx] = append(groups[idx], pod)
+		}
+	}
+	return groups
 }
 
 // updateRequests calls the client to update ProvisioningRequests, in parallel.
@@ -334,5 +455,51 @@ func NewCombinedStatusSet() combinedStatusSet {
 	return combinedStatusSet{
 		Result:        status.ScaleUpNotTried,
 		ScaleupErrors: make(map[*errors.AutoscalerError]bool),
+	}
+}
+
+// setCapacityNotFoundCondition sets the appropriate condition on the ProvReq when no capacity is found,
+// respecting the noRetry parameter.
+func setCapacityNotFoundCondition(provReq *provreqwrapper.ProvisioningRequest) {
+	if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry == "true" {
+		// Failed=true condition triggers retry in Kueue. Otherwise ProvisioningRequest with Provisioned=Failed
+		// condition block capacity in Kueue even if it's in the middle of backoff waiting time.
+		conditions.AddOrUpdateCondition(provReq, v1.Failed, metav1.ConditionTrue, conditions.CapacityIsNotFoundReason, "CA could not find requested capacity", metav1.Now())
+	} else {
+		if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry != "false" {
+			klog.Errorf("Ignoring Parameter %v with invalid value: %v in ProvisioningRequest: %v. Supported values are: \"true\", \"false\"", NoRetryParameterKey, noRetry, provReq.Name)
+		}
+		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
+	}
+}
+
+// handlePartialCapacityStatusUpdate handles the combineStatusSet update and ProvReq Provisioned status update for the partial capacity case
+func handlePartialCapacityStatusUpdate(provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet, provReqMode, conditionMsg string) {
+	provisionedStatus := metav1.ConditionFalse
+	scaleupStatus := status.ScaleUpSuccessful
+	if provReqMode == PartialCapacityCheckBookPartial {
+		provisionedStatus = metav1.ConditionTrue
+	}
+	combinedStatus.Add(&status.ScaleUpStatus{Result: scaleupStatus})
+	conditions.AddOrUpdateCondition(provReq, v1.Provisioned, provisionedStatus, conditions.PartialCapacityIsFoundReason, conditionMsg, metav1.Now())
+}
+
+func getPartialCapacityCheckMode(provReq *provreqwrapper.ProvisioningRequest) (string, bool) {
+	val, ok := provReq.Spec.Parameters[PartialCapacityCheckKey]
+	if !ok {
+		return "", false
+	}
+
+	switch val {
+	case PartialCapacityCheckBookPartial:
+		return PartialCapacityCheckBookPartial, true
+	case PartialCapacityCheckCheckOnly:
+		return PartialCapacityCheckCheckOnly, true
+	default:
+		klog.Errorf("Ignoring Parameter %v with invalid value: %v in ProvisioningRequest: %v. Supported values are: %v, %v",
+			PartialCapacityCheckKey, val, provReq.Name,
+			PartialCapacityCheckBookPartial, PartialCapacityCheckCheckOnly,
+		)
+		return "", false
 	}
 }

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -195,130 +195,161 @@ func (o *checkCapacityProvClass) checkCapacityBatch(reqs []provreq.ProvisioningR
 
 // checkCapacity checks if there is capacity, updates combinedStatus and Conditions. If capacity is found, it commits to the clusterSnapshot.
 func (o *checkCapacityProvClass) checkCapacity(unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) error {
-	o.autoscalingCtx.ClusterSnapshot.Fork()
+	o.autoscalingCtx.ClusterSnapshot.Fork() // outer fork
 
-	partialCapacityMode, partialCapacityCheckEnabled := getPartialCapacityCheckMode(provReq)
-
-	if partialCapacityCheckEnabled {
-		// Schedule per podset using nested forks. For each podset, if all its pods fit, commit the
-		// inner fork into the outer fork so subsequent podsets see the consumed capacity. At the end,
-		// commit or revert the outer fork depending on the result and mode.
-		podsByPodSet := groupPodsByPodSet(unschedulablePods, provReq)
-		schedulablePodSets := make([]string, 0)
-
-		// PodSets are evaluated in spec order. Earlier PodSets that fit consume
-		// capacity within the simulation, which may prevent later PodSets from
-		// scheduling. In checkOnly mode the capacity is reverted after evaluation.
-		for i, podSetSpec := range provReq.Spec.PodSets {
-			pods := podsByPodSet[i]
-			if len(pods) == 0 {
-				klog.Warningf("No pods matched podset %d (%s) for ProvReq %s, treating as not schedulable", i, podSetSpec.PodTemplateRef.Name, provReq.Name)
-				continue
-			}
-			o.autoscalingCtx.ClusterSnapshot.Fork()
-			scheduled, _, err := o.schedulingSimulator.TrySchedulePods(o.autoscalingCtx.ClusterSnapshot, pods, true, clustersnapshot.SchedulingOptions{})
-			if err != nil {
-				o.autoscalingCtx.ClusterSnapshot.Revert()
-				o.autoscalingCtx.ClusterSnapshot.Revert()
-				return err
-			}
-			if len(scheduled) == len(pods) {
-				schedulablePodSets = append(schedulablePodSets, podSetSpec.PodTemplateRef.Name)
-				if commitErr := o.autoscalingCtx.ClusterSnapshot.Commit(); commitErr != nil {
-					o.autoscalingCtx.ClusterSnapshot.Revert()
-					return commitErr
-				}
-			} else {
-				o.autoscalingCtx.ClusterSnapshot.Revert()
-			}
+	if partialCapacityMode, ok := getPartialCapacityCheckMode(provReq); ok {
+		names, counts, err := o.evaluatePartialCapacity(unschedulablePods, provReq)
+		if err != nil {
+			o.autoscalingCtx.ClusterSnapshot.Revert() // revert outer fork
+			return err
 		}
-
-		schedulablePodSetsJSON, jsonErr := json.Marshal(schedulablePodSets)
-		if jsonErr != nil {
-			klog.Errorf("failed to marshal schedulablePodSets for ProvReq %s: %v", provReq.Name, jsonErr)
-		} else {
-			provReq.SetProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey, v1.Detail(schedulablePodSetsJSON))
+		if detailErr := setSchedulableDetails(provReq, names, counts); detailErr != nil {
+			o.autoscalingCtx.ClusterSnapshot.Revert() // revert outer fork
+			return detailErr
 		}
-
-		// Case 1: All podsets fit.
-		if len(schedulablePodSets) == len(provReq.Spec.PodSets) {
-			combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
-			conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
-			if commitErr := o.autoscalingCtx.ClusterSnapshot.Commit(); commitErr != nil {
-				o.autoscalingCtx.ClusterSnapshot.Revert()
-				return commitErr
-			}
-			return nil
-		}
-
-		// Case 2: Some podsets fit.
-		if len(schedulablePodSets) > 0 {
-			msg := fmt.Sprintf("%s. Schedulable podsets: %s", conditions.PartialCapacityIsFoundMsg, strings.Join(schedulablePodSets, ","))
-			handlePartialCapacityStatusUpdate(provReq, combinedStatus, partialCapacityMode, msg)
-			if partialCapacityMode == PartialCapacityCheckBookPartial {
-				if commitErr := o.autoscalingCtx.ClusterSnapshot.Commit(); commitErr != nil {
-					o.autoscalingCtx.ClusterSnapshot.Revert()
-					return commitErr
-				}
-			} else {
-				o.autoscalingCtx.ClusterSnapshot.Revert()
-			}
-			return nil
-		}
-
-		// Case 3: No podsets fit.
-		o.autoscalingCtx.ClusterSnapshot.Revert()
-		provReq.DeleteProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey)
-		combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable})
-		setCapacityNotFoundCondition(provReq)
-		return nil
+		// resolvePartialCapacityResult commits or reverts the outer fork.
+		return o.resolvePartialCapacityResult(provReq, combinedStatus, partialCapacityMode, names)
 	}
 
 	// Non-partial path: schedule all pods at once and break on first failure.
 	scheduled, _, err := o.schedulingSimulator.TrySchedulePods(o.autoscalingCtx.ClusterSnapshot, unschedulablePods, true, clustersnapshot.SchedulingOptions{})
 	if err == nil && len(scheduled) == len(unschedulablePods) {
-		// Case 1: All capacity fits.
 		allPodSetNames := make([]string, 0, len(provReq.Spec.PodSets))
 		for _, ps := range provReq.Spec.PodSets {
 			allPodSetNames = append(allPodSetNames, ps.PodTemplateRef.Name)
 		}
-		schedulablePodSetsJSON, jsonErr := json.Marshal(allPodSetNames)
-		if jsonErr != nil {
-			klog.Errorf("failed to marshal schedulablePodSets for ProvReq %s: %v", provReq.Name, jsonErr)
-		} else {
-			provReq.SetProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey, v1.Detail(schedulablePodSetsJSON))
+		if detailErr := setSchedulableDetails(provReq, allPodSetNames, nil); detailErr != nil {
+			o.autoscalingCtx.ClusterSnapshot.Revert() // revert outer fork
+			return detailErr
 		}
 		combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
 		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
-		if commitError := o.autoscalingCtx.ClusterSnapshot.Commit(); commitError != nil {
-			o.autoscalingCtx.ClusterSnapshot.Revert()
+		if commitError := o.autoscalingCtx.ClusterSnapshot.Commit(); commitError != nil { // commit outer fork
+			o.autoscalingCtx.ClusterSnapshot.Revert() // revert outer fork
 			return commitError
 		}
 		return nil
 	}
 
-	// Case 3: Capacity doesn't fit.
-	o.autoscalingCtx.ClusterSnapshot.Revert()
-	// Clear the detail from any previous iteration.
+	// Capacity doesn't fit.
+	o.autoscalingCtx.ClusterSnapshot.Revert() // revert outer fork
+	// Clear any stale schedulablePodSets detail. Unlike the partial path
+	// (resolvePartialCapacityResult Case 3), pods are evaluated atomically here
+	// so there is no partial per-PodSet result to preserve.
 	provReq.DeleteProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey)
 	combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable})
 	setCapacityNotFoundCondition(provReq)
 	return err
 }
 
-const podNameFormatLen = 3
+// evaluatePartialCapacity schedules pods per PodSet using inner snapshot forks.
+// The caller must have already created an outer fork. This method only manages
+// inner forks (one per PodSet); the caller is responsible for the outer fork.
+func (o *checkCapacityProvClass) evaluatePartialCapacity(unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest) ([]string, map[string]int, error) {
+	podsByPodSet := groupPodsByPodSet(unschedulablePods, provReq)
+	schedulablePodSetNames := make([]string, 0, len(provReq.Spec.PodSets))
+	schedulablePodCounts := make(map[string]int, len(provReq.Spec.PodSets))
+
+	// PodSets are evaluated in spec order. Earlier PodSets that fit consume
+	// capacity within the simulation, which may prevent later PodSets from
+	// scheduling. In checkOnly mode the capacity is reverted after evaluation.
+	for i, podSetSpec := range provReq.Spec.PodSets {
+		pods := podsByPodSet[i]
+		if len(pods) == 0 {
+			klog.Warningf("No pods matched podset %d (%s) for ProvReq %s, treating as not schedulable", i, podSetSpec.PodTemplateRef.Name, provReq.Name)
+			schedulablePodCounts[podSetSpec.PodTemplateRef.Name] = 0
+			continue
+		}
+		o.autoscalingCtx.ClusterSnapshot.Fork() // inner fork: one per podset
+		scheduled, _, err := o.schedulingSimulator.TrySchedulePods(o.autoscalingCtx.ClusterSnapshot, pods, true, clustersnapshot.SchedulingOptions{})
+		if err != nil {
+			o.autoscalingCtx.ClusterSnapshot.Revert() // revert inner fork
+			return nil, nil, err
+		}
+		schedulablePodCounts[podSetSpec.PodTemplateRef.Name] = len(scheduled)
+		if len(scheduled) == len(pods) {
+			schedulablePodSetNames = append(schedulablePodSetNames, podSetSpec.PodTemplateRef.Name)
+			if commitErr := o.autoscalingCtx.ClusterSnapshot.Commit(); commitErr != nil { // commit inner fork
+				return nil, nil, commitErr
+			}
+		} else {
+			o.autoscalingCtx.ClusterSnapshot.Revert() // revert inner fork
+		}
+	}
+
+	return schedulablePodSetNames, schedulablePodCounts, nil
+}
+
+// setSchedulableDetails marshals and sets the schedulablePodSets and (optionally) schedulablePodCounts details
+// on the ProvisioningRequest. Returns an error instead of silently continuing, preventing overbooking
+// when downstream code falls back to booking all pods on marshal failure.
+func setSchedulableDetails(provReq *provreqwrapper.ProvisioningRequest, podSetNames []string, podCounts map[string]int) error {
+	schedulablePodSetsJSON, err := json.Marshal(podSetNames)
+	if err != nil {
+		return fmt.Errorf("failed to marshal schedulablePodSets for ProvReq %s: %w", provReq.Name, err)
+	}
+	provReq.SetProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey, v1.Detail(schedulablePodSetsJSON))
+
+	if podCounts != nil {
+		schedulablePodCountsJSON, err := json.Marshal(podCounts)
+		if err != nil {
+			return fmt.Errorf("failed to marshal schedulablePodCounts for ProvReq %s: %w", provReq.Name, err)
+		}
+		provReq.SetProvisioningClassDetail(conditions.SchedulablePodCountsDetailKey, v1.Detail(schedulablePodCountsJSON))
+	}
+	return nil
+}
+
+// resolvePartialCapacityResult commits or reverts the outer snapshot fork based on how many
+// PodSets were schedulable and the partialCapacityMode.
+func (o *checkCapacityProvClass) resolvePartialCapacityResult(provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet, partialCapacityMode string, schedulablePodSetNames []string) error {
+	// Case 1: All podsets fit.
+	if len(schedulablePodSetNames) == len(provReq.Spec.PodSets) {
+		combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
+		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+		if commitErr := o.autoscalingCtx.ClusterSnapshot.Commit(); commitErr != nil { // commit outer fork
+			o.autoscalingCtx.ClusterSnapshot.Revert() // revert outer fork
+			return commitErr
+		}
+		return nil
+	}
+
+	// Case 2: Some podsets fit.
+	if len(schedulablePodSetNames) > 0 {
+		handlePartialCapacityStatusUpdate(provReq, combinedStatus, partialCapacityMode)
+		if partialCapacityMode == PartialCapacityCheckBookPartial {
+			if commitErr := o.autoscalingCtx.ClusterSnapshot.Commit(); commitErr != nil { // commit outer fork
+				o.autoscalingCtx.ClusterSnapshot.Revert() // revert outer fork
+				return commitErr
+			}
+		} else {
+			o.autoscalingCtx.ClusterSnapshot.Revert() // revert outer fork
+		}
+		return nil
+	}
+
+	// Case 3: No podsets fit.
+	o.autoscalingCtx.ClusterSnapshot.Revert() // revert outer fork
+	combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpNoOptionsAvailable})
+	// Preserve schedulablePodCounts and schedulablePodSets (as []) so consumers can see
+	// per-PodSet partial counts even when nothing fully fit.
+	setCapacityNotFoundCondition(provReq)
+	return nil
+}
+
+const expectedMatchGroups = 3
 
 // groupPodsByPodSet buckets pods by their podset index, extracted from the pod name.
 // Pod names are created in the format {GenerateName}{i}-{j}, where i is the podset index
 // and j is the pod index within the podset. Pods not belonging to provReq are filtered out.
 func groupPodsByPodSet(pods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest) map[int][]*apiv1.Pod {
-	groups := make(map[int][]*apiv1.Pod)
+	groups := make(map[int][]*apiv1.Pod, len(provReq.Spec.PodSets))
 	for _, pod := range pods {
 		if pod.Annotations[v1.ProvisioningRequestPodAnnotationKey] != provReq.Name {
 			continue
 		}
 		matches := podSetIndexPattern.FindStringSubmatch(pod.Name)
-		if len(matches) == podNameFormatLen {
+		if len(matches) == expectedMatchGroups {
 			idx, _ := strconv.Atoi(matches[1]) // safe: regex guarantees digits
 			groups[idx] = append(groups[idx], pod)
 		}
@@ -474,14 +505,17 @@ func setCapacityNotFoundCondition(provReq *provreqwrapper.ProvisioningRequest) {
 }
 
 // handlePartialCapacityStatusUpdate handles the combineStatusSet update and ProvReq Provisioned status update for the partial capacity case
-func handlePartialCapacityStatusUpdate(provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet, provReqMode, conditionMsg string) {
+func handlePartialCapacityStatusUpdate(provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet, partialCapacityMode string) {
 	provisionedStatus := metav1.ConditionFalse
+	// ScaleUpSuccessful is used for both checkOnly and bookPartial modes because
+	// partial capacity was found in both cases. In checkOnly mode capacity is not
+	// actually booked, but the scale-up result still reflects that capacity exists.
 	scaleupStatus := status.ScaleUpSuccessful
-	if provReqMode == PartialCapacityCheckBookPartial {
+	if partialCapacityMode == PartialCapacityCheckBookPartial {
 		provisionedStatus = metav1.ConditionTrue
 	}
 	combinedStatus.Add(&status.ScaleUpStatus{Result: scaleupStatus})
-	conditions.AddOrUpdateCondition(provReq, v1.Provisioned, provisionedStatus, conditions.PartialCapacityIsFoundReason, conditionMsg, metav1.Now())
+	conditions.AddOrUpdateCondition(provReq, v1.Provisioned, provisionedStatus, conditions.PartialCapacityIsFoundReason, conditions.PartialCapacityIsFoundMsg, metav1.Now())
 }
 
 func getPartialCapacityCheckMode(provReq *provreqwrapper.ProvisioningRequest) (string, bool) {

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass_test.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass_test.go
@@ -231,9 +231,9 @@ func TestGroupPodsByPodSet(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty pod list",
-			pods:    []*apiv1.Pod{},
-			provReq: makeProvReq("my-pr", v1.PodSet{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 1}),
+			name:     "empty pod list",
+			pods:     []*apiv1.Pod{},
+			provReq:  makeProvReq("my-pr", v1.PodSet{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 1}),
 			expected: map[int][]string{},
 		},
 	}

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass_test.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass_test.go
@@ -21,7 +21,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqwrapper"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 )
 
@@ -126,4 +130,128 @@ func generateStatuses(n int, result status.ScaleUpResult) []*status.ScaleUpStatu
 		statuses[i] = &status.ScaleUpStatus{Result: result, ScaleUpError: scaleUpErr}
 	}
 	return statuses
+}
+
+func TestGroupPodsByPodSet(t *testing.T) {
+	makePod := func(name, prName string) *apiv1.Pod {
+		return &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Annotations: map[string]string{
+					v1.ProvisioningRequestPodAnnotationKey: prName,
+				},
+			},
+		}
+	}
+	makeProvReq := func(name string, podSets ...v1.PodSet) *provreqwrapper.ProvisioningRequest {
+		return &provreqwrapper.ProvisioningRequest{
+			ProvisioningRequest: &v1.ProvisioningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec: v1.ProvisioningRequestSpec{
+					PodSets: podSets,
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		pods     []*apiv1.Pod
+		provReq  *provreqwrapper.ProvisioningRequest
+		expected map[int][]string // podset index -> pod names
+	}{
+		{
+			name: "groups pods by podset index",
+			pods: []*apiv1.Pod{
+				makePod("my-pr-0-0", "my-pr"),
+				makePod("my-pr-0-1", "my-pr"),
+				makePod("my-pr-1-0", "my-pr"),
+			},
+			provReq: makeProvReq("my-pr",
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 2},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			),
+			expected: map[int][]string{
+				0: {"my-pr-0-0", "my-pr-0-1"},
+				1: {"my-pr-1-0"},
+			},
+		},
+		{
+			name: "filters pods from other ProvReqs",
+			pods: []*apiv1.Pod{
+				makePod("my-pr-0-0", "my-pr"),
+				makePod("other-pr-0-1", "other-pr"),
+			},
+			provReq: makeProvReq("my-pr",
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 1},
+			),
+			expected: map[int][]string{
+				0: {"my-pr-0-0"},
+			},
+		},
+		{
+			name: "ignores pods with non-matching name pattern",
+			pods: []*apiv1.Pod{
+				makePod("my-pr-0-0", "my-pr"),
+				makePod("no-index-suffix", "my-pr"),
+			},
+			provReq: makeProvReq("my-pr",
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 1},
+			),
+			expected: map[int][]string{
+				0: {"my-pr-0-0"},
+			},
+		},
+		{
+			name: "multi-digit podset indices",
+			pods: []*apiv1.Pod{
+				makePod("my-pr-0-0", "my-pr"),
+				makePod("my-pr-10-0", "my-pr"),
+				makePod("my-pr-10-1", "my-pr"),
+				makePod("my-pr-2-5", "my-pr"),
+			},
+			provReq: makeProvReq("my-pr",
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps0"}, Count: 1},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps1"}, Count: 1},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps2"}, Count: 1},
+				// podsets 3-9 have no pods
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps3"}, Count: 1},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps4"}, Count: 1},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps5"}, Count: 1},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps6"}, Count: 1},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps7"}, Count: 1},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps8"}, Count: 1},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps9"}, Count: 1},
+				v1.PodSet{PodTemplateRef: v1.Reference{Name: "ps10"}, Count: 2},
+			),
+			expected: map[int][]string{
+				0:  {"my-pr-0-0"},
+				2:  {"my-pr-2-5"},
+				10: {"my-pr-10-0", "my-pr-10-1"},
+			},
+		},
+		{
+			name:    "empty pod list",
+			pods:    []*apiv1.Pod{},
+			provReq: makeProvReq("my-pr", v1.PodSet{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 1}),
+			expected: map[int][]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := groupPodsByPodSet(tc.pods, tc.provReq)
+			resultNames := make(map[int][]string)
+			for idx, pods := range result {
+				names := make([]string, len(pods))
+				for i, p := range pods {
+					names[i] = p.Name
+				}
+				resultNames[idx] = names
+			}
+			assert.Equal(t, tc.expected, resultNames)
+		})
+	}
 }

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass_test.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass_test.go
@@ -17,16 +17,25 @@ limitations under the License.
 package checkcapacity
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/conditions"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqwrapper"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
 
 func TestCombinedStatusSet(t *testing.T) {
@@ -254,4 +263,497 @@ func TestGroupPodsByPodSet(t *testing.T) {
 			assert.Equal(t, tc.expected, resultNames)
 		})
 	}
+}
+
+func TestSetSchedulableDetails(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		podSetNames          []string
+		podCounts            map[string]int
+		wantPodSetsDetail    string
+		wantPodCountsDetail  bool
+		wantPodCountsContent string
+	}{
+		{
+			name:                 "sets both details when podCounts is non-nil",
+			podSetNames:          []string{"workers", "ps"},
+			podCounts:            map[string]int{"workers": 3, "ps": 0},
+			wantPodSetsDetail:    `["workers","ps"]`,
+			wantPodCountsDetail:  true,
+			wantPodCountsContent: `{"ps":0,"workers":3}`,
+		},
+		{
+			name:                "skips podCounts detail when nil",
+			podSetNames:         []string{"workers"},
+			podCounts:           nil,
+			wantPodSetsDetail:   `["workers"]`,
+			wantPodCountsDetail: false,
+		},
+		{
+			name:                 "empty podSetNames",
+			podSetNames:          []string{},
+			podCounts:            map[string]int{},
+			wantPodSetsDetail:    `[]`,
+			wantPodCountsDetail:  true,
+			wantPodCountsContent: `{}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provReq := makeTestProvReq("test-pr")
+
+			err := setSchedulableDetails(provReq, tc.podSetNames, tc.podCounts)
+			require.NoError(t, err)
+
+			assert.Equal(t, v1.Detail(tc.wantPodSetsDetail),
+				provReq.Status.ProvisioningClassDetails[conditions.SchedulablePodSetsDetailKey])
+
+			if tc.wantPodCountsDetail {
+				got := provReq.Status.ProvisioningClassDetails[conditions.SchedulablePodCountsDetailKey]
+				// Compare via parsed JSON to avoid map ordering issues.
+				var gotMap, wantMap map[string]int
+				require.NoError(t, json.Unmarshal([]byte(got), &gotMap))
+				require.NoError(t, json.Unmarshal([]byte(tc.wantPodCountsContent), &wantMap))
+				assert.Equal(t, wantMap, gotMap)
+			} else {
+				_, exists := provReq.Status.ProvisioningClassDetails[conditions.SchedulablePodCountsDetailKey]
+				assert.False(t, exists)
+			}
+		})
+	}
+}
+
+func TestResolvePartialCapacityResult(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		schedulablePodSetNames []string
+		totalPodSets           int
+		partialCapacityMode    string
+		wantProvisionedStatus  metav1.ConditionStatus
+		wantProvisionedReason  string
+		wantScaleUpResult      status.ScaleUpResult
+		wantSnapshotCommitted  bool
+		wantDetailsPreserved   bool
+	}{
+		{
+			name:                   "all fit / bookPartial",
+			schedulablePodSetNames: []string{"workers", "ps"},
+			totalPodSets:           2,
+			partialCapacityMode:    PartialCapacityCheckBookPartial,
+			wantProvisionedStatus:  metav1.ConditionTrue,
+			wantProvisionedReason:  conditions.CapacityIsFoundReason,
+			wantScaleUpResult:      status.ScaleUpSuccessful,
+			wantSnapshotCommitted:  true,
+		},
+		{
+			name:                   "all fit / checkOnly",
+			schedulablePodSetNames: []string{"workers", "ps"},
+			totalPodSets:           2,
+			partialCapacityMode:    PartialCapacityCheckCheckOnly,
+			wantProvisionedStatus:  metav1.ConditionTrue,
+			wantProvisionedReason:  conditions.CapacityIsFoundReason,
+			wantScaleUpResult:      status.ScaleUpSuccessful,
+			wantSnapshotCommitted:  true,
+		},
+		{
+			name:                   "some fit / bookPartial",
+			schedulablePodSetNames: []string{"workers"},
+			totalPodSets:           2,
+			partialCapacityMode:    PartialCapacityCheckBookPartial,
+			wantProvisionedStatus:  metav1.ConditionTrue,
+			wantProvisionedReason:  conditions.PartialCapacityIsFoundReason,
+			wantScaleUpResult:      status.ScaleUpSuccessful,
+			wantSnapshotCommitted:  true,
+		},
+		{
+			name:                   "some fit / checkOnly",
+			schedulablePodSetNames: []string{"workers"},
+			totalPodSets:           2,
+			partialCapacityMode:    PartialCapacityCheckCheckOnly,
+			wantProvisionedStatus:  metav1.ConditionFalse,
+			wantProvisionedReason:  conditions.PartialCapacityIsFoundReason,
+			wantScaleUpResult:      status.ScaleUpSuccessful,
+			wantSnapshotCommitted:  false,
+		},
+		{
+			name:                   "none fit / bookPartial",
+			schedulablePodSetNames: []string{},
+			totalPodSets:           2,
+			partialCapacityMode:    PartialCapacityCheckBookPartial,
+			wantProvisionedReason:  conditions.CapacityIsNotFoundReason,
+			wantScaleUpResult:      status.ScaleUpNoOptionsAvailable,
+			wantSnapshotCommitted:  false,
+			wantDetailsPreserved:   true,
+		},
+		{
+			name:                   "none fit / checkOnly",
+			schedulablePodSetNames: []string{},
+			totalPodSets:           2,
+			partialCapacityMode:    PartialCapacityCheckCheckOnly,
+			wantProvisionedReason:  conditions.CapacityIsNotFoundReason,
+			wantScaleUpResult:      status.ScaleUpNoOptionsAvailable,
+			wantSnapshotCommitted:  false,
+			wantDetailsPreserved:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+			snapshot.Fork()
+
+			provReq := makeTestProvReqWithPodSets("test-pr", tc.totalPodSets)
+			provReq.SetProvisioningClassDetail(conditions.SchedulablePodSetsDetailKey, v1.Detail(`["workers"]`))
+			provReq.SetProvisioningClassDetail(conditions.SchedulablePodCountsDetailKey, v1.Detail(`{"workers":2}`))
+
+			combinedStatus := NewCombinedStatusSet()
+			o := &checkCapacityProvClass{
+				autoscalingCtx: &ca_context.AutoscalingContext{
+					ClusterSnapshot: snapshot,
+				},
+			}
+
+			err := o.resolvePartialCapacityResult(provReq, &combinedStatus, tc.partialCapacityMode, tc.schedulablePodSetNames)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantScaleUpResult, combinedStatus.Result)
+
+			cond := findCondition(provReq, v1.Provisioned)
+			require.NotNil(t, cond, "expected Provisioned condition to be set")
+			assert.Equal(t, tc.wantProvisionedReason, cond.Reason)
+			if tc.wantProvisionedStatus != "" {
+				assert.Equal(t, tc.wantProvisionedStatus, cond.Status)
+			}
+
+			if tc.wantDetailsPreserved {
+				_, hasPodSets := provReq.Status.ProvisioningClassDetails[conditions.SchedulablePodSetsDetailKey]
+				_, hasPodCounts := provReq.Status.ProvisioningClassDetails[conditions.SchedulablePodCountsDetailKey]
+				assert.True(t, hasPodSets, "expected schedulablePodSets detail to be preserved")
+				assert.True(t, hasPodCounts, "expected schedulablePodCounts detail to be preserved")
+			}
+
+			if tc.wantSnapshotCommitted {
+				// After commit the fork is consumed; another Revert should panic or be a no-op.
+				// We just verify the method returned without error (commit succeeded).
+			} else {
+				// Snapshot was reverted inside the method; nothing extra to assert.
+			}
+		})
+	}
+}
+
+func TestEvaluatePartialCapacity(t *testing.T) {
+	now := time.Now()
+
+	testCases := []struct {
+		name                   string
+		nodeMilliCPU           int64
+		podSets                []v1.PodSet
+		podCPUs                []int64
+		wantSchedulablePodSets []string
+		wantAllSchedulable     bool
+	}{
+		{
+			name:         "all podsets fit",
+			nodeMilliCPU: 1000,
+			podSets: []v1.PodSet{
+				{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 2},
+				{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			},
+			podCPUs:                []int64{100, 100, 100},
+			wantSchedulablePodSets: []string{"workers", "ps"},
+			wantAllSchedulable:     true,
+		},
+		{
+			name:         "some podsets fit",
+			nodeMilliCPU: 250,
+			podSets: []v1.PodSet{
+				{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 2},
+				{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			},
+			podCPUs:                []int64{100, 100, 200},
+			wantSchedulablePodSets: []string{"workers"},
+		},
+		{
+			name:         "none fit",
+			nodeMilliCPU: 10,
+			podSets: []v1.PodSet{
+				{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 1},
+				{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			},
+			podCPUs:                []int64{100, 100},
+			wantSchedulablePodSets: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			node := BuildTestNode("n1", tc.nodeMilliCPU, 1000000)
+			SetNodeReadyState(node, true, now.Add(-2*time.Minute))
+
+			snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, snapshot, []*apiv1.Node{node}, []*apiv1.Pod{})
+
+			provReq := makeTestProvReqWithPodSets("test-pr", len(tc.podSets))
+			provReq.Spec.PodSets = tc.podSets
+
+			pods := buildAnnotatedPods("test-pr", tc.podSets, tc.podCPUs)
+
+			o := &checkCapacityProvClass{
+				autoscalingCtx: &ca_context.AutoscalingContext{
+					ClusterSnapshot: snapshot,
+				},
+				schedulingSimulator: scheduling.NewHintingSimulator(),
+			}
+
+			snapshot.Fork()
+			names, counts, err := o.evaluatePartialCapacity(pods, provReq)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantSchedulablePodSets, names)
+			assert.NotNil(t, counts)
+			for _, ps := range tc.podSets {
+				_, ok := counts[ps.PodTemplateRef.Name]
+				assert.True(t, ok, "expected count for podset %s", ps.PodTemplateRef.Name)
+			}
+
+			snapshot.Revert()
+		})
+	}
+}
+
+func TestCheckPartialCapacityEndToEnd(t *testing.T) {
+	now := time.Now()
+
+	testCases := []struct {
+		name                   string
+		nodeMilliCPU           int64
+		podSets                []v1.PodSet
+		podCPUs                []int64
+		partialCapacityMode    string
+		wantProvisionedReason  string
+		wantProvisionedStatus  metav1.ConditionStatus
+		wantScaleUpResult      status.ScaleUpResult
+		wantSchedulablePodSets []string
+		wantDetailPresent      bool
+	}{
+		{
+			name:         "all podsets fit / bookPartial",
+			nodeMilliCPU: 1000,
+			podSets: []v1.PodSet{
+				{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 2},
+				{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			},
+			podCPUs:                []int64{100, 100, 100},
+			partialCapacityMode:    PartialCapacityCheckBookPartial,
+			wantProvisionedReason:  conditions.CapacityIsFoundReason,
+			wantProvisionedStatus:  metav1.ConditionTrue,
+			wantScaleUpResult:      status.ScaleUpSuccessful,
+			wantSchedulablePodSets: []string{"workers", "ps"},
+			wantDetailPresent:      true,
+		},
+		{
+			name:         "all podsets fit / checkOnly",
+			nodeMilliCPU: 1000,
+			podSets: []v1.PodSet{
+				{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 2},
+				{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			},
+			podCPUs:                []int64{100, 100, 100},
+			partialCapacityMode:    PartialCapacityCheckCheckOnly,
+			wantProvisionedReason:  conditions.CapacityIsFoundReason,
+			wantProvisionedStatus:  metav1.ConditionTrue,
+			wantScaleUpResult:      status.ScaleUpSuccessful,
+			wantSchedulablePodSets: []string{"workers", "ps"},
+			wantDetailPresent:      true,
+		},
+		{
+			name:         "some podsets fit / bookPartial",
+			nodeMilliCPU: 250,
+			podSets: []v1.PodSet{
+				{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 2},
+				{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			},
+			podCPUs:                []int64{100, 100, 200},
+			partialCapacityMode:    PartialCapacityCheckBookPartial,
+			wantProvisionedReason:  conditions.PartialCapacityIsFoundReason,
+			wantProvisionedStatus:  metav1.ConditionTrue,
+			wantScaleUpResult:      status.ScaleUpSuccessful,
+			wantSchedulablePodSets: []string{"workers"},
+			wantDetailPresent:      true,
+		},
+		{
+			name:         "some podsets fit / checkOnly",
+			nodeMilliCPU: 250,
+			podSets: []v1.PodSet{
+				{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 2},
+				{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			},
+			podCPUs:                []int64{100, 100, 200},
+			partialCapacityMode:    PartialCapacityCheckCheckOnly,
+			wantProvisionedReason:  conditions.PartialCapacityIsFoundReason,
+			wantProvisionedStatus:  metav1.ConditionFalse,
+			wantScaleUpResult:      status.ScaleUpSuccessful,
+			wantSchedulablePodSets: []string{"workers"},
+			wantDetailPresent:      true,
+		},
+		{
+			name:         "none fit / bookPartial",
+			nodeMilliCPU: 10,
+			podSets: []v1.PodSet{
+				{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 1},
+				{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			},
+			podCPUs:               []int64{100, 100},
+			partialCapacityMode:   PartialCapacityCheckBookPartial,
+			wantProvisionedReason: conditions.CapacityIsNotFoundReason,
+			wantScaleUpResult:     status.ScaleUpNoOptionsAvailable,
+			// schedulablePodSets is preserved as [] so consumers can see per-PodSet counts.
+			wantSchedulablePodSets: []string{},
+			wantDetailPresent:      true,
+		},
+		{
+			name:         "none fit / checkOnly",
+			nodeMilliCPU: 10,
+			podSets: []v1.PodSet{
+				{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 1},
+				{PodTemplateRef: v1.Reference{Name: "ps"}, Count: 1},
+			},
+			podCPUs:               []int64{100, 100},
+			partialCapacityMode:   PartialCapacityCheckCheckOnly,
+			wantProvisionedReason: conditions.CapacityIsNotFoundReason,
+			wantScaleUpResult:     status.ScaleUpNoOptionsAvailable,
+			// schedulablePodSets is preserved as [] so consumers can see per-PodSet counts.
+			wantSchedulablePodSets: []string{},
+			wantDetailPresent:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			node := BuildTestNode("n1", tc.nodeMilliCPU, 1000000)
+			SetNodeReadyState(node, true, now.Add(-2*time.Minute))
+
+			snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, snapshot, []*apiv1.Node{node}, []*apiv1.Pod{})
+
+			provReq := makeTestProvReqWithPodSets("test-pr", len(tc.podSets))
+			provReq.Spec.PodSets = tc.podSets
+			provReq.Spec.Parameters = map[string]v1.Parameter{
+				PartialCapacityCheckKey: v1.Parameter(tc.partialCapacityMode),
+			}
+
+			pods := buildAnnotatedPods("test-pr", tc.podSets, tc.podCPUs)
+
+			combinedStatus := NewCombinedStatusSet()
+			o := &checkCapacityProvClass{
+				autoscalingCtx: &ca_context.AutoscalingContext{
+					ClusterSnapshot: snapshot,
+				},
+				schedulingSimulator: scheduling.NewHintingSimulator(),
+			}
+
+			err := o.checkCapacity(pods, provReq, &combinedStatus)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantScaleUpResult, combinedStatus.Result)
+
+			cond := findCondition(provReq, v1.Provisioned)
+			if cond == nil {
+				cond = findCondition(provReq, v1.Failed)
+			}
+			require.NotNil(t, cond, "expected a Provisioned or Failed condition")
+			assert.Equal(t, tc.wantProvisionedReason, cond.Reason)
+			if tc.wantProvisionedStatus != "" {
+				assert.Equal(t, tc.wantProvisionedStatus, cond.Status)
+			}
+
+			if tc.wantDetailPresent {
+				detail, ok := provReq.Status.ProvisioningClassDetails[conditions.SchedulablePodSetsDetailKey]
+				require.True(t, ok, "expected schedulablePodSets detail to be present")
+				var gotPodSets []string
+				require.NoError(t, json.Unmarshal([]byte(detail), &gotPodSets))
+				assert.Equal(t, tc.wantSchedulablePodSets, gotPodSets)
+			}
+		})
+	}
+}
+
+// --- test helpers ---
+
+func makeTestProvReq(name string) *provreqwrapper.ProvisioningRequest {
+	return &provreqwrapper.ProvisioningRequest{
+		ProvisioningRequest: &v1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: v1.ProvisioningRequestSpec{
+				PodSets: []v1.PodSet{
+					{PodTemplateRef: v1.Reference{Name: "workers"}, Count: 1},
+				},
+			},
+			Status: v1.ProvisioningRequestStatus{
+				Conditions: []metav1.Condition{},
+			},
+		},
+	}
+}
+
+func makeTestProvReqWithPodSets(name string, n int) *provreqwrapper.ProvisioningRequest {
+	podSets := make([]v1.PodSet, n)
+	for i := 0; i < n; i++ {
+		podSets[i] = v1.PodSet{
+			PodTemplateRef: v1.Reference{Name: fmt.Sprintf("podset-%d", i)},
+			Count:          1,
+		}
+	}
+	return &provreqwrapper.ProvisioningRequest{
+		ProvisioningRequest: &v1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: v1.ProvisioningRequestSpec{
+				PodSets: podSets,
+			},
+			Status: v1.ProvisioningRequestStatus{
+				Conditions: []metav1.Condition{},
+			},
+		},
+	}
+}
+
+func buildAnnotatedPods(prName string, podSets []v1.PodSet, cpus []int64) []*apiv1.Pod {
+	var pods []*apiv1.Pod
+	cpuIdx := 0
+	for i, ps := range podSets {
+		for j := int32(0); j < ps.Count; j++ {
+			cpu := int64(1)
+			if cpuIdx < len(cpus) {
+				cpu = cpus[cpuIdx]
+				cpuIdx++
+			}
+			podName := fmt.Sprintf("%s-%d-%d", prName, i, j)
+			pod := BuildTestPod(podName, cpu, 1, func(p *apiv1.Pod) {
+				p.Annotations[v1.ProvisioningRequestPodAnnotationKey] = prName
+			})
+			pods = append(pods, pod)
+		}
+	}
+	return pods
+}
+
+func findCondition(provReq *provreqwrapper.ProvisioningRequest, condType string) *metav1.Condition {
+	for i := range provReq.Status.Conditions {
+		if provReq.Status.Conditions[i].Type == condType {
+			return &provReq.Status.Conditions[i]
+		}
+	}
+	return nil
 }

--- a/cluster-autoscaler/provisioningrequest/conditions/conditions.go
+++ b/cluster-autoscaler/provisioningrequest/conditions/conditions.go
@@ -36,6 +36,11 @@ const (
 	CapacityIsFoundReason = "CapacityIsFound"
 	// CapacityIsFoundMsg is added when capacity was found in the cluster.
 	CapacityIsFoundMsg = "Capacity is found in the cluster"
+	// PartialCapacityIsFoundReason is added when capacity was found in the cluster for some but not all pods.
+	// Only used in check-capacity class when partialCapacityCheck parameter is set to "bookPartial" or "checkOnly".
+	PartialCapacityIsFoundReason = "PartialCapacityIsFound"
+	// PartialCapacityIsFoundMsg is added when partial capacity was found in the cluster.
+	PartialCapacityIsFoundMsg = "Partial capacity is found in the cluster"
 	// CapacityIsProvisionedReason is added when capacity was requested successfully.
 	CapacityIsProvisionedReason = "CapacityIsProvisioned"
 	// CapacityIsProvisionedMsg is added when capacity was requested successfully.
@@ -56,6 +61,9 @@ const (
 	ExpiredReason = "Expired"
 	// ExpiredMsg is added if ProvisioningRequest is expired.
 	ExpiredMsg = "ProvisioningRequest is expired"
+	// SchedulablePodSetsDetailKey is the ProvisioningClassDetails key indicating
+	// which PodSets CA found capacity for.
+	SchedulablePodSetsDetailKey = "schedulablePodSets"
 )
 
 // ShouldCapacityBeBooked returns whether capacity should be booked.

--- a/cluster-autoscaler/provisioningrequest/conditions/conditions.go
+++ b/cluster-autoscaler/provisioningrequest/conditions/conditions.go
@@ -64,6 +64,10 @@ const (
 	// SchedulablePodSetsDetailKey is the ProvisioningClassDetails key indicating
 	// which PodSets CA found capacity for.
 	SchedulablePodSetsDetailKey = "schedulablePodSets"
+	// SchedulablePodCountsDetailKey is the ProvisioningClassDetails key indicating
+	// the number of scheduled pods per PodSet. Each PodSet is evaluated independently;
+	// counts are not additive across PodSets that did not fully fit.
+	SchedulablePodCountsDetailKey = "schedulablePodCounts"
 )
 
 // ShouldCapacityBeBooked returns whether capacity should be booked.

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
@@ -73,7 +74,7 @@ func TestScaleUp(t *testing.T) {
 	// Active check capacity requests.
 	newCheckCapacityCpuProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "newCheckCapacityCpuProvReq",
+			Name:     "new-check-capacity-cpu-provreq",
 			CPU:      "5m",
 			Memory:   "5",
 			PodCount: int32(100),
@@ -82,7 +83,7 @@ func TestScaleUp(t *testing.T) {
 
 	anotherCheckCapacityCpuProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "anotherCheckCapacityCpuProvReq",
+			Name:     "another-check-capacity-cpu-provreq",
 			CPU:      "5m",
 			Memory:   "5",
 			PodCount: int32(100),
@@ -91,7 +92,7 @@ func TestScaleUp(t *testing.T) {
 
 	newCheckCapacityMemProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "newCheckCapacityMemProvReq",
+			Name:     "new-check-capacity-mem-provreq",
 			CPU:      "1m",
 			Memory:   "100",
 			PodCount: int32(100),
@@ -99,7 +100,7 @@ func TestScaleUp(t *testing.T) {
 		})
 	impossibleCheckCapacityReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "impossibleCheckCapacityRequest",
+			Name:     "impossible-check-capacity-request",
 			CPU:      "1m",
 			Memory:   "1",
 			PodCount: int32(5001),
@@ -108,17 +109,105 @@ func TestScaleUp(t *testing.T) {
 
 	anotherImpossibleCheckCapacityReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "anotherImpossibleCheckCapacityRequest",
+			Name:     "another-impossible-check-capacity-request",
 			CPU:      "1m",
 			Memory:   "1",
 			PodCount: int32(5001),
 			Class:    v1.ProvisioningClassCheckCapacity,
 		})
 
+	// Partial capacity check requests.
+	// Total cluster capacity: 100 CPU nodes (10 bytes each) + 100 memory nodes (1000 bytes each) = 101,000 bytes
+	// Request 300 pods * 400 bytes = 120,000 bytes, which exceeds capacity
+	// Expected: ~252 pods can fit (101,000 / 400)
+	partialCapacityProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "partial-capacity-provreq",
+			CPU:      "1m",
+			Memory:   "400",
+			PodCount: int32(300),
+			Class:    v1.ProvisioningClassCheckCapacity,
+		})
+
+	// Another partial capacity request for batch testing
+	// Request 280 pods * 400 bytes = 112,000 bytes
+	// Expected: ~252 pods can fit (101,000 / 400)
+	anotherPartialCapacityProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "another-partial-capacity-provreq",
+			CPU:      "1m",
+			Memory:   "400",
+			PodCount: int32(280),
+			Class:    v1.ProvisioningClassCheckCapacity,
+		})
+
+	// Check capacity request that fits completely, even with partialCapacityCheck enabled
+	completeCapacityProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "complete-capacity-provreq",
+			CPU:      "5m",
+			Memory:   "5",
+			PodCount: int32(50),
+			Class:    v1.ProvisioningClassCheckCapacity,
+		})
+
+	// Check capacity request that has 0 pods that can fit
+	impossibleResourceRequest := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
+		provreqwrapper.TestProvReqOptions{
+			Name:     "impossible-resource-request",
+			CPU:      "101m", // More than any single node has (100m max)
+			Memory:   "1001", // More than any single node has (1000 max)
+			PodCount: int32(5),
+			Class:    v1.ProvisioningClassCheckCapacity,
+		})
+
+	// Multi-PodSet ProvReq: first PodSet (small pods) fits, second PodSet (impossible pods) doesn't.
+	// Used to test checkOnly vs bookPartial divergence, which only occurs with multiple PodSets.
+	multiPodSetProvReq := provreqwrapper.NewProvisioningRequest(
+		&v1.ProvisioningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: "multi-podset-provreq", Namespace: "default",
+				CreationTimestamp: metav1.NewTime(time.Now())},
+			Spec: v1.ProvisioningRequestSpec{
+				ProvisioningClassName: v1.ProvisioningClassCheckCapacity,
+				PodSets: []v1.PodSet{
+					{PodTemplateRef: v1.Reference{Name: "small-template"}, Count: 10},
+					{PodTemplateRef: v1.Reference{Name: "large-template"}, Count: 5},
+				},
+			},
+			Status: v1.ProvisioningRequestStatus{Conditions: []metav1.Condition{}},
+		},
+		[]*apiv1.PodTemplate{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "small-template", Namespace: "default"},
+				Template: apiv1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test-app"}},
+					Spec: apiv1.PodSpec{Containers: []apiv1.Container{
+						{Name: "c", Image: "img", Resources: apiv1.ResourceRequirements{
+							Requests: apiv1.ResourceList{apiv1.ResourceCPU: resource.MustParse("5m"), apiv1.ResourceMemory: resource.MustParse("5")},
+							Limits:   apiv1.ResourceList{apiv1.ResourceCPU: resource.MustParse("5m"), apiv1.ResourceMemory: resource.MustParse("5")},
+						}},
+					}},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "large-template", Namespace: "default"},
+				Template: apiv1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test-app"}},
+					Spec: apiv1.PodSpec{Containers: []apiv1.Container{
+						{Name: "c", Image: "img", Resources: apiv1.ResourceRequirements{
+							Requests: apiv1.ResourceList{apiv1.ResourceCPU: resource.MustParse("101m"), apiv1.ResourceMemory: resource.MustParse("1001")},
+							Limits:   apiv1.ResourceList{apiv1.ResourceCPU: resource.MustParse("101m"), apiv1.ResourceMemory: resource.MustParse("1001")},
+						}},
+					}},
+				},
+			},
+		},
+	)
+
 	// Active atomic scale up requests.
 	atomicScaleUpProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "atomicScaleUpProvReq",
+			Name:     "atomic-scale-up-provreq",
 			CPU:      "5m",
 			Memory:   "5",
 			PodCount: int32(5),
@@ -126,7 +215,7 @@ func TestScaleUp(t *testing.T) {
 		})
 	largeAtomicScaleUpProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "largeAtomicScaleUpProvReq",
+			Name:     "large-atomic-scale-up-provreq",
 			CPU:      "1m",
 			Memory:   "100",
 			PodCount: int32(100),
@@ -134,7 +223,7 @@ func TestScaleUp(t *testing.T) {
 		})
 	impossibleAtomicScaleUpReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "impossibleAtomicScaleUpRequest",
+			Name:     "impossible-atomic-scale-up-request",
 			CPU:      "1m",
 			Memory:   "1",
 			PodCount: int32(5001),
@@ -142,7 +231,7 @@ func TestScaleUp(t *testing.T) {
 		})
 	possibleAtomicScaleUpReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "possibleAtomicScaleUpReq",
+			Name:     "possible-atomic-scale-up-req",
 			CPU:      "100m",
 			Memory:   "1",
 			PodCount: int32(120),
@@ -150,7 +239,7 @@ func TestScaleUp(t *testing.T) {
 		})
 	autoprovisioningAtomicScaleUpReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "autoprovisioningAtomicScaleUpReq",
+			Name:     "autoprovisioning-atomic-scale-up-req",
 			CPU:      "100m",
 			Memory:   "100",
 			PodCount: int32(5),
@@ -161,7 +250,7 @@ func TestScaleUp(t *testing.T) {
 	// Books 20 out of 100 high-memory nodes.
 	bookedCapacityProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "bookedCapacityProvReq",
+			Name:     "booked-capacity-provreq",
 			CPU:      "1m",
 			Memory:   "200",
 			PodCount: int32(100),
@@ -172,7 +261,7 @@ func TestScaleUp(t *testing.T) {
 	// Expired provisioning request - should be ignored.
 	expiredProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "expiredProvReq",
+			Name:     "expired-provreq",
 			CPU:      "1m",
 			Memory:   "200",
 			PodCount: int32(100),
@@ -183,7 +272,7 @@ func TestScaleUp(t *testing.T) {
 	// Unsupported provisioning request - should be ignored.
 	unsupportedProvReq := provreqwrapper.BuildValidTestProvisioningRequestFromOptions(
 		provreqwrapper.TestProvReqOptions{
-			Name:     "unsupportedProvReq",
+			Name:     "unsupported-provreq",
 			CPU:      "1",
 			Memory:   "1",
 			PodCount: int32(5),
@@ -401,6 +490,117 @@ func TestScaleUp(t *testing.T) {
 			batchTimebox:        5 * time.Minute,
 			numProvisionedFalse: 2,
 		},
+		// Partial capacity check tests (non-batch)
+		{
+			name: "partial capacity check enabled, some pods fit",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				partialCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckBookPartial}),
+			},
+			provReqToScaleUp: partialCapacityProvReq,
+			// Single PodSet where not all pods fit → podset not schedulable → NoOptionsAvailable
+			scaleUpResult: status.ScaleUpNoOptionsAvailable,
+		},
+		{
+			name: "partial capacity check enabled, all pods fit",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				completeCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckBookPartial}),
+			},
+			provReqToScaleUp: completeCapacityProvReq,
+			scaleUpResult:    status.ScaleUpSuccessful,
+		},
+		{
+			name: "partial capacity check disabled, partial capacity available but returns not available",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				partialCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{}),
+			},
+			provReqToScaleUp: partialCapacityProvReq,
+			scaleUpResult:    status.ScaleUpNoOptionsAvailable,
+		},
+		{
+			name: "partial capacity check with noRetry parameter, some pods fit",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				partialCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckBookPartial, "noRetry": "true"}),
+			},
+			provReqToScaleUp: partialCapacityProvReq,
+			// Single PodSet where not all pods fit → noRetry triggers Failed=true
+			scaleUpResult: status.ScaleUpNoOptionsAvailable,
+			numFailedTrue: 1,
+		},
+		{
+			name: "partial capacity check enabled, zero pods fit due to resource constraints",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				impossibleResourceRequest.CopyWithParameters(map[string]v1.Parameter{checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckBookPartial}),
+			},
+			provReqToScaleUp: impossibleResourceRequest,
+			scaleUpResult:    status.ScaleUpNoOptionsAvailable,
+		},
+		{
+			name: "partial capacity check param value invalid, use default behavior despite partial capacity existing",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				partialCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{checkcapacity.PartialCapacityCheckKey: "invalid-value"}),
+			},
+			provReqToScaleUp: partialCapacityProvReq,
+			// Returns NoOptionsAvailable since partial capacity check is not enabled
+			scaleUpResult: status.ScaleUpNoOptionsAvailable,
+		},
+		// Batch processing with partial capacity check
+		{
+			name: "batch processing with partial capacity check, first request gets partial, second gets none",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				// First request: 300 pods, single PodSet, not all fit → not schedulable
+				partialCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckBookPartial}),
+				// Second request: 280 pods, single PodSet, not all fit → not schedulable
+				anotherPartialCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckBookPartial}),
+			},
+			provReqToScaleUp:    partialCapacityProvReq,
+			scaleUpResult:       status.ScaleUpNoOptionsAvailable,
+			batchProcessing:     true,
+			maxBatchSize:        3,
+			batchTimebox:        5 * time.Minute,
+			numProvisionedTrue:  0, // Neither single-PodSet request fully fits
+			numProvisionedFalse: 2, // Both get Provisioned=False
+		},
+		{
+			name: "batch processing with mixed partial capacity check settings",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				// Single PodSet, not all fit → NoOptionsAvailable, Provisioned=False
+				partialCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckBookPartial}),
+				// No partial check, not all fit → NoOptionsAvailable, Provisioned=False
+				anotherPartialCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{}),
+				// Single PodSet, all 50 pods fit → Successful, Provisioned=True
+				completeCapacityProvReq.CopyWithParameters(map[string]v1.Parameter{checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckBookPartial}),
+			},
+			provReqToScaleUp:    partialCapacityProvReq,
+			scaleUpResult:       status.ScaleUpSuccessful,
+			batchProcessing:     true,
+			maxBatchSize:        3,
+			batchTimebox:        5 * time.Minute,
+			numProvisionedTrue:  1,
+			numProvisionedFalse: 2,
+		},
+		// Multi-PodSet checkOnly vs bookPartial tests
+		{
+			name: "checkOnly mode, multi-PodSet, partial capacity reports Provisioned=false",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				multiPodSetProvReq.CopyWithParameters(map[string]v1.Parameter{
+					checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckCheckOnly,
+				}),
+			},
+			provReqToScaleUp:    multiPodSetProvReq,
+			scaleUpResult:       status.ScaleUpSuccessful,
+			numProvisionedFalse: 1, // checkOnly: partial capacity found but not booked
+		},
+		{
+			name: "bookPartial mode, multi-PodSet, partial capacity reports Provisioned=true",
+			provReqs: []*provreqwrapper.ProvisioningRequest{
+				multiPodSetProvReq.CopyWithParameters(map[string]v1.Parameter{
+					checkcapacity.PartialCapacityCheckKey: checkcapacity.PartialCapacityCheckBookPartial,
+				}),
+			},
+			provReqToScaleUp:   multiPodSetProvReq,
+			scaleUpResult:      status.ScaleUpSuccessful,
+			numProvisionedTrue: 1, // bookPartial: partial capacity found and booked
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -446,8 +646,7 @@ func TestScaleUp(t *testing.T) {
 				assert.Equal(t, len(tc.provReqs), len(provReqsAfterScaleUp))
 				assert.Equal(t, tc.numFailedTrue, NumProvisioningRequestsWithCondition(provReqsAfterScaleUp, v1.Failed, metav1.ConditionTrue))
 
-				if tc.batchProcessing {
-					// Since batch processing returns aggregated result, we need to check the number of provisioned requests which have the provisioned condition.
+				if tc.batchProcessing || tc.numProvisionedTrue > 0 || tc.numProvisionedFalse > 0 {
 					assert.Equal(t, tc.numProvisionedTrue, NumProvisioningRequestsWithCondition(provReqsAfterScaleUp, v1.Provisioned, metav1.ConditionTrue))
 					assert.Equal(t, tc.numProvisionedFalse, NumProvisioningRequestsWithCondition(provReqsAfterScaleUp, v1.Provisioned, metav1.ConditionFalse))
 				}

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -18,6 +18,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -39,6 +40,7 @@ import (
 	processorstest "k8s.io/autoscaler/cluster-autoscaler/processors/test"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/besteffortatomic"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/checkcapacity"
+	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/conditions"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/pods"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqclient"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqwrapper"
@@ -292,6 +294,7 @@ func TestScaleUp(t *testing.T) {
 		numProvisionedTrue  int
 		numProvisionedFalse int
 		numFailedTrue       int
+		wantPodCounts       map[string]int
 	}{
 		{
 			name:          "no ProvisioningRequests",
@@ -589,6 +592,7 @@ func TestScaleUp(t *testing.T) {
 			provReqToScaleUp:    multiPodSetProvReq,
 			scaleUpResult:       status.ScaleUpSuccessful,
 			numProvisionedFalse: 1, // checkOnly: partial capacity found but not booked
+			wantPodCounts:       map[string]int{"small-template": 10, "large-template": 0},
 		},
 		{
 			name: "bookPartial mode, multi-PodSet, partial capacity reports Provisioned=true",
@@ -600,6 +604,7 @@ func TestScaleUp(t *testing.T) {
 			provReqToScaleUp:   multiPodSetProvReq,
 			scaleUpResult:      status.ScaleUpSuccessful,
 			numProvisionedTrue: 1, // bookPartial: partial capacity found and booked
+			wantPodCounts:      map[string]int{"small-template": 10, "large-template": 0},
 		},
 	}
 	for _, tc := range testCases {
@@ -649,6 +654,13 @@ func TestScaleUp(t *testing.T) {
 				if tc.batchProcessing || tc.numProvisionedTrue > 0 || tc.numProvisionedFalse > 0 {
 					assert.Equal(t, tc.numProvisionedTrue, NumProvisioningRequestsWithCondition(provReqsAfterScaleUp, v1.Provisioned, metav1.ConditionTrue))
 					assert.Equal(t, tc.numProvisionedFalse, NumProvisioningRequestsWithCondition(provReqsAfterScaleUp, v1.Provisioned, metav1.ConditionFalse))
+				}
+				if tc.wantPodCounts != nil {
+					detail, ok := provReqsAfterScaleUp[0].Status.ProvisioningClassDetails[conditions.SchedulablePodCountsDetailKey]
+					assert.True(t, ok, "expected schedulablePodCounts detail to be set")
+					var gotPodCounts map[string]int
+					assert.NoError(t, json.Unmarshal([]byte(detail), &gotPodCounts))
+					assert.Equal(t, tc.wantPodCounts, gotPodCounts)
 				}
 			} else {
 				assert.Error(t, err)

--- a/cluster-autoscaler/provisioningrequest/pods/pods.go
+++ b/cluster-autoscaler/provisioningrequest/pods/pods.go
@@ -39,6 +39,13 @@ const (
 // PodsForProvisioningRequest returns a list of pods for which Provisioning
 // Request needs to provision resources.
 func PodsForProvisioningRequest(pr *provreqwrapper.ProvisioningRequest) ([]*corev1.Pod, error) {
+	return PodsForProvisioningRequestPodSets(pr, nil)
+}
+
+// PodsForProvisioningRequestPodSets is like PodsForProvisioningRequest but only
+// generates pods for PodSets whose PodTemplateRef.Name is in allowedPodSets.
+// If allowedPodSets is nil, all PodSets are included.
+func PodsForProvisioningRequestPodSets(pr *provreqwrapper.ProvisioningRequest, allowedPodSets map[string]bool) ([]*corev1.Pod, error) {
 	if pr == nil {
 		return nil, nil
 	}
@@ -48,6 +55,9 @@ func PodsForProvisioningRequest(pr *provreqwrapper.ProvisioningRequest) ([]*core
 	}
 	pods := make([]*corev1.Pod, 0)
 	for i, podSet := range podSets {
+		if allowedPodSets != nil && !allowedPodSets[pr.Spec.PodSets[i].PodTemplateRef.Name] {
+			continue
+		}
 		for j := 0; j < int(podSet.Count); j++ {
 			pod, err := controller.GetPodFromTemplate(&podSet.PodTemplate, pr.ProvisioningRequest, ownerReference(pr))
 			if err != nil {

--- a/cluster-autoscaler/provisioningrequest/pods/pods_test.go
+++ b/cluster-autoscaler/provisioningrequest/pods/pods_test.go
@@ -351,3 +351,76 @@ func TestPodsForProvisioningRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestPodsForProvisioningRequestPodSets(t *testing.T) {
+	pr := &v1.ProvisioningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr-name",
+			Namespace: "test-namespace",
+		},
+		Spec: v1.ProvisioningRequestSpec{
+			PodSets: []v1.PodSet{
+				{Count: 2, PodTemplateRef: v1.Reference{Name: "template-1"}},
+				{Count: 3, PodTemplateRef: v1.Reference{Name: "template-2"}},
+			},
+			ProvisioningClassName: testProvisioningClassName,
+		},
+	}
+	podTemplates := []*corev1.PodTemplate{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "template-1", Namespace: "test-namespace"},
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c1", Image: "img1"}},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "template-2", Namespace: "test-namespace"},
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c2", Image: "img2"}},
+			}},
+		},
+	}
+	wrapped := provreqwrapper.NewProvisioningRequest(pr, podTemplates)
+
+	tests := []struct {
+		desc          string
+		allowedPodSets map[string]bool
+		wantNames     []string
+	}{
+		{
+			desc:          "nil allowedPodSets returns all pods",
+			allowedPodSets: nil,
+			wantNames:     []string{"test-pr-name-0-0", "test-pr-name-0-1", "test-pr-name-1-0", "test-pr-name-1-1", "test-pr-name-1-2"},
+		},
+		{
+			desc:          "only first podset allowed",
+			allowedPodSets: map[string]bool{"template-1": true},
+			wantNames:     []string{"test-pr-name-0-0", "test-pr-name-0-1"},
+		},
+		{
+			desc:          "only second podset allowed, index preserved in pod name",
+			allowedPodSets: map[string]bool{"template-2": true},
+			wantNames:     []string{"test-pr-name-1-0", "test-pr-name-1-1", "test-pr-name-1-2"},
+		},
+		{
+			desc:          "empty allowedPodSets returns no pods",
+			allowedPodSets: map[string]bool{},
+			wantNames:     []string{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := PodsForProvisioningRequestPodSets(wrapped, tc.allowedPodSets)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gotNames := make([]string, len(got))
+			for i, p := range got {
+				gotNames[i] = p.Name
+			}
+			if diff := cmp.Diff(tc.wantNames, gotNames); diff != "" {
+				t.Errorf("unexpected pod names (-want +got): %v", diff)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/provisioningrequest/pods/pods_test.go
+++ b/cluster-autoscaler/provisioningrequest/pods/pods_test.go
@@ -383,29 +383,29 @@ func TestPodsForProvisioningRequestPodSets(t *testing.T) {
 	wrapped := provreqwrapper.NewProvisioningRequest(pr, podTemplates)
 
 	tests := []struct {
-		desc          string
+		desc           string
 		allowedPodSets map[string]bool
-		wantNames     []string
+		wantNames      []string
 	}{
 		{
-			desc:          "nil allowedPodSets returns all pods",
+			desc:           "nil allowedPodSets returns all pods",
 			allowedPodSets: nil,
-			wantNames:     []string{"test-pr-name-0-0", "test-pr-name-0-1", "test-pr-name-1-0", "test-pr-name-1-1", "test-pr-name-1-2"},
+			wantNames:      []string{"test-pr-name-0-0", "test-pr-name-0-1", "test-pr-name-1-0", "test-pr-name-1-1", "test-pr-name-1-2"},
 		},
 		{
-			desc:          "only first podset allowed",
+			desc:           "only first podset allowed",
 			allowedPodSets: map[string]bool{"template-1": true},
-			wantNames:     []string{"test-pr-name-0-0", "test-pr-name-0-1"},
+			wantNames:      []string{"test-pr-name-0-0", "test-pr-name-0-1"},
 		},
 		{
-			desc:          "only second podset allowed, index preserved in pod name",
+			desc:           "only second podset allowed, index preserved in pod name",
 			allowedPodSets: map[string]bool{"template-2": true},
-			wantNames:     []string{"test-pr-name-1-0", "test-pr-name-1-1", "test-pr-name-1-2"},
+			wantNames:      []string{"test-pr-name-1-0", "test-pr-name-1-1", "test-pr-name-1-2"},
 		},
 		{
-			desc:          "empty allowedPodSets returns no pods",
+			desc:           "empty allowedPodSets returns no pods",
 			allowedPodSets: map[string]bool{},
-			wantNames:     []string{},
+			wantNames:      []string{},
 		},
 	}
 	for _, tc := range tests {

--- a/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
+++ b/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
@@ -22,7 +22,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 )
 
 // ProvisioningRequest wrapper representation of the ProvisioningRequest
@@ -50,6 +50,20 @@ func NewProvisioningRequest(pr *v1.ProvisioningRequest, podTemplates []*apiv1.Po
 // SetConditions of the Provisioning Request.
 func (pr *ProvisioningRequest) SetConditions(conditions []metav1.Condition) {
 	pr.Status.Conditions = conditions
+}
+
+// SetProvisioningClassDetail set the key entry to the given value for the ProvisiongRequest Details.
+func (pr *ProvisioningRequest) SetProvisioningClassDetail(key string, value v1.Detail) {
+	if pr.Status.ProvisioningClassDetails == nil {
+		pr.Status.ProvisioningClassDetails = make(map[string]v1.Detail)
+	}
+
+	pr.Status.ProvisioningClassDetails[key] = value
+}
+
+// DeleteProvisioningClassDetail deletes the given key entry for the ProvisiongRequest Details.
+func (pr *ProvisioningRequest) DeleteProvisioningClassDetail(key string) {
+	delete(pr.Status.ProvisioningClassDetails, key)
 }
 
 // PodSets of the Provisioning Request.

--- a/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper_test.go
+++ b/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper_test.go
@@ -139,4 +139,18 @@ func TestProvisioningRequestWrapper(t *testing.T) {
 	podSets, err := wrappedBetaPRMissingPodTemplates.PodSets()
 	assert.Nil(t, podSets)
 	assert.EqualError(t, err, "missing pod templates, 1 pod templates were referenced, 1 templates were missing: name-pod-template-beta")
+
+	// Set a detail and check the value.
+	wrappedBetaPR.SetProvisioningClassDetail("key", "value")
+	assert.Equal(t, v1.Detail("value"), wrappedBetaPR.Status.ProvisioningClassDetails["key"])
+
+	// Delete the detail and check it is removed.
+	wrappedBetaPR.DeleteProvisioningClassDetail("key")
+	_, exists := wrappedBetaPR.Status.ProvisioningClassDetails["key"]
+	assert.False(t, exists)
+
+	// Set a detail on a PR with nil ProvisioningClassDetails and check the value.
+	wrappedBetaPR.Status.ProvisioningClassDetails = nil
+	wrappedBetaPR.SetProvisioningClassDetail("key", "value")
+	assert.Equal(t, v1.Detail("value"), wrappedBetaPR.Status.ProvisioningClassDetails["key"])
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds a Partial Capacity condition  for the Capacity Check Provisioning Request scheduling simulations. 

Users will be able to add a Parameter to their ProvisioningRequest to indicate that they would like to see if their pod set is at least partially schedulable. Previously, the the ProvReq conditions would only show a whether or not all the pods are scheduable via the simulation.

This PR also introduces sorting of the ProvReq pods so that the partial capacity will be deterministic. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This adds a Partial Capacity condition for the Capacity Check Provisioning Request scheduling simulations. Users will be able to see if there is capacity for some of their requested pod set.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
