### PR TITLE
Backport to 1.34: Making CapacityBuffer ProvisioningStrategy a string (not enum)

### DIFF
--- a/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
+++ b/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
@@ -100,7 +100,6 @@ type ResourceList map[ResourceName]resource.Quantity
 type CapacityBufferSpec struct {
 	// ProvisioningStrategy defines how the buffer is utilized.
 	// "buffer.x-k8s.io/active-capacity" is the default strategy, where the buffer actively scales up the cluster by creating placeholder pods.
-	// +kubebuilder:validation:Enum=buffer.x-k8s.io/active-capacity
 	// +kubebuilder:default="buffer.x-k8s.io/active-capacity"
 	// +optional
 	ProvisioningStrategy *string `json:"provisioningStrategy,omitempty" protobuf:"bytes,1,opt,name=provisioningStrategy"`

--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacitybuffers.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacitybuffers.yaml
@@ -102,8 +102,6 @@ spec:
                 description: |-
                   ProvisioningStrategy defines how the buffer is utilized.
                   "buffer.x-k8s.io/active-capacity" is the default strategy, where the buffer actively scales up the cluster by creating placeholder pods.
-                enum:
-                - buffer.x-k8s.io/active-capacity
                 type: string
               replicas:
                 description: |-


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Backport #8832 to cluster-autoscaler 1.34

#### Which issue(s) this PR fixes:
Different providers can have their own custom provisioning strategies. This field cannot be constrained by known in advance enum values.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Make CapacityBuffer ProvisioningStrategy a string
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
