### PR TITLE
VPA: Enable feature gates in dev-deploy-locally.sh

### DIFF
--- a/vertical-pod-autoscaler/hack/dev-deploy-locally.sh
+++ b/vertical-pod-autoscaler/hack/dev-deploy-locally.sh
@@ -19,6 +19,14 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 
+# Support for enabling all feature gates via environment variable
+export FEATURE_GATES=""
+
+if [ "${ENABLE_ALL_FEATURE_GATES:-}" == "true" ] ; then
+  export FEATURE_GATES='AllAlpha=true,AllBeta=true'
+  echo " ** Enabling all feature gates: ${FEATURE_GATES}"
+fi
+
 SUITE=full-vpa
 REQUIRED_COMMANDS="
 docker


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR adds support for enabling all feature gates when deploying VPA locally for development purposes. Similar to the existing `ENABLE_ALL_FEATURE_GATES` support in `run-e2e-locally.sh`, developers can now use:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8900 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE

```
