### PR TITLE
AEP: VPA native sidecar support

### DIFF
--- a/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
+++ b/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
@@ -47,7 +47,6 @@ This functionality will be guarded by a new feature gate `NativeSidecar` to allo
 The Recommender component identifies native sidecar containers by examining init containers with `restartPolicy: Always` in the [`SpecClient`](https://github.com/kubernetes/autoscaler/blob/d9d867a15e96dc50573c59e071f84df5491c03db/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go#L53-L56). These containers are assigned the `ContainerTypeInitSidecar` type.
 
 When the `NativeSidecar` feature gate is enabled, the `ClusterFeeder` processes native sidecars similarly to standard containers:
-- They are stored in a separate `InitSidecarsContainers` map in the pod state
 - Resource usage samples are collected and aggregated for recommendations
 - Recommendations are generated using the same logic as standard containers
 ```go
@@ -67,7 +66,7 @@ for _, initContainer := range pod.InitContainers {
 }
 ```
 
-The VPA custom resource definition remains unchanged. Native sidecar recommendations are included in the `containerRecommendations` array alongside standard container recommendations, using the unique container name to identify them.
+The VPA custom resource definition remains unchanged. Native sidecar recommendations treated exactly like standard container recommendations, the unique container names allow us to identify them.
 
 ### Update / Admission
 

--- a/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
+++ b/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
@@ -1,0 +1,82 @@
+# KEP-8905: Native Sidecar Support
+
+<!-- toc -->
+- [Summary](#summary)
+   - [Goals](#goals)
+   - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+- [Design Details](#design-details)
+   - [Recommendations](#recommendations)
+   - [Update / Admission](#update--admission)
+   - [Test Plan](#test-plan)
+   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+This proposal adds support for native sidecar containers (init containers with `restartPolicy: Always`) in Vertical Pod Autoscaler.
+
+Kubernetes 1.28 introduced native sidecar containers. These are init containers that start before the main containers and continue running during the lifecycle of the Pod. VPA currently supports standard containers and regular init containers, but it should also support recommending resources for these new native sidecar containers to ensure they are right-sized.
+Addresses [issue #7229](https://github.com/kubernetes/autoscaler/issues/7229)
+
+### Goals
+
+- Allow VPA Recommender to generate resource recommendations for native sidecar containers.
+- Ensure VPA Updater and Admission Controller can apply recommendations to native sidecar containers.
+
+### Non-Goals
+
+- Support for sidecar containers in Kubernetes versions older than 1.28.
+
+## Proposal
+
+The proposal is to introduce a new feature gate `NativeSidecar` in VPA. When enabled, VPA components will recognize and handle native sidecar containers.
+
+## Design Details
+
+### Recommendations
+
+The Recommender component identifies native sidecar containers by examining init containers with `restartPolicy: Always` in the `SpecClient`. These containers are assigned the `ContainerTypeInitSidecar` type.
+
+When the `NativeSidecar` feature gate is enabled, the `ClusterFeeder` processes native sidecars similarly to standard containers:
+- They are stored in a separate `InitSidecarsContainers` map in the pod state
+- Resource usage samples are collected and aggregated for recommendations
+- Recommendations are generated using the same logic as standard containers
+
+The VPA custom resource definition remains unchanged. Native sidecar recommendations are included in the `containerRecommendations` array alongside standard container recommendations, using the unique container name to identify them.
+
+### Update / Admission
+
+Both Updater and Admission Controller components retrieve recommendations for init containers (including native sidecars) separately from standard containers using `GetContainersResourcesForPod`.
+The patch generation logic is updated to target `/spec/initContainers` for native sidecar containers, while normal containers will continue to update `/spec/containers`.
+
+### Test Plan
+
+The following test scenarios will be added to e2e tests.
+
+- Admission applies recommendations to native sidecars.
+- Updater will update sidecar container resources in-place or evict.
+- Admission will patch sidecar container resources.
+- When the feature gate `NativeSidecar` is false VPA components will not modify native sidecars.
+
+### Upgrade / Downgrade Strategy
+
+#### Upgrade
+
+On upgrade of the VPA to 1.6.0 (tentative release version), nothing will change,
+VPAs will continue to work as before.
+
+Users can use the new `NativeSidecar` by enabling the alpha Feature Gate (which defaults to disabled)
+by passing `--feature-gates=NativeSidecar=true` to the VPA components.
+
+#### Downgrade
+
+On downgrade of VPA from 1.6.0 (tentative release version), nothing will change.
+VPAs will continue to work as previously. Checkpoints may contain sidecar resource information until updated, but updater and admission will modify sidecar resources.
+
+## Alternatives
+
+### Treat as Standard Containers
+
+We could treat them as standard containers, but they are technically init containers in the Pod spec, so the patch path would be incorrect (`/spec/containers` vs `/spec/initContainers`).

--- a/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
+++ b/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
@@ -2,16 +2,19 @@
 
 <!-- toc -->
 - [Summary](#summary)
-   - [Goals](#goals)
-   - [Non-Goals](#non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
 - [Design Details](#design-details)
-   - [Recommendations](#recommendations)
-   - [Update / Admission](#update--admission)
-   - [Test Plan](#test-plan)
-   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Recommendations](#recommendations)
+  - [Update / Admission](#update--admission)
+  - [Test Plan](#test-plan)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+    - [Upgrade](#upgrade)
+    - [Downgrade](#downgrade)
 - [Implementation History](#implementation-history)
 - [Alternatives](#alternatives)
+  - [Treat as Standard Containers](#treat-as-standard-containers)
 <!-- /toc -->
 
 ## Summary
@@ -41,7 +44,7 @@ This functionality will be guarded by a new feature gate `NativeSidecar` to allo
 
 ### Recommendations
 
-The Recommender component identifies native sidecar containers by examining init containers with `restartPolicy: Always` in the `SpecClient`. These containers are assigned the `ContainerTypeInitSidecar` type.
+The Recommender component identifies native sidecar containers by examining init containers with `restartPolicy: Always` in the [`SpecClient`](https://github.com/kubernetes/autoscaler/blob/d9d867a15e96dc50573c59e071f84df5491c03db/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go#L53-L56). These containers are assigned the `ContainerTypeInitSidecar` type.
 
 When the `NativeSidecar` feature gate is enabled, the `ClusterFeeder` processes native sidecars similarly to standard containers:
 - They are stored in a separate `InitSidecarsContainers` map in the pod state

--- a/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
+++ b/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
@@ -7,6 +7,8 @@
 - [Proposal](#proposal)
 - [Design Details](#design-details)
   - [Recommendations](#recommendations)
+    - [Startup Ordering](#startup-ordering)
+    - [Pod Resource Calculations](#pod-resource-calculations)
   - [Update / Admission](#update--admission)
   - [Test Plan](#test-plan)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
@@ -21,7 +23,7 @@
 
 This proposal adds support for native sidecar containers (init containers with `restartPolicy: Always`) in Vertical Pod Autoscaler.
 
-Kubernetes 1.28 introduced native sidecar containers. These are init containers that start before the main containers and continue running during the lifecycle of the Pod. VPA currently supports standard containers, but it should also support recommending resources for these new native sidecar containers to ensure they are right-sized. Standard init containers will continue to be ignored.
+Native sidecar containers (introduced via the `SidecarContainers` feature gate) are init containers that start before the main containers and continue running during the lifecycle of the Pod. VPA currently supports standard containers, but it should also support recommending resources for these new native sidecar containers to ensure they are right-sized. Standard init containers will continue to be ignored.
 Addresses [issue #7229](https://github.com/kubernetes/autoscaler/issues/7229)
 
 ### Goals
@@ -31,7 +33,7 @@ Addresses [issue #7229](https://github.com/kubernetes/autoscaler/issues/7229)
 
 ### Non-Goals
 
-- Support for sidecar containers in Kubernetes versions older than 1.28.
+- Support for clusters where the `SidecarContainers` feature gate is not available or enabled.
 - Support for regular init containers.
 
 ## Proposal
@@ -44,7 +46,7 @@ This functionality will be guarded by a new feature gate `NativeSidecar` to allo
 
 ### Recommendations
 
-The Recommender component identifies native sidecar containers by examining init containers with `restartPolicy: Always` in the [`SpecClient`](https://github.com/kubernetes/autoscaler/blob/d9d867a15e96dc50573c59e071f84df5491c03db/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go#L53-L56). These containers are assigned the `ContainerTypeInitSidecar` type.
+The Recommender component identifies native sidecar containers by examining init containers with `restartPolicy: Always` in the [`SpecClient`](https://github.com/kubernetes/autoscaler/blob/d9d867a15e96dc50573c59e071f84df5491c03db/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go#L53-L56). These containers are assigned the `ContainerTypeNativeSidecar` type.
 
 When the `NativeSidecar` feature gate is enabled, the `ClusterFeeder` processes native sidecars similarly to standard containers:
 - Resource usage samples are collected and aggregated for recommendations
@@ -56,7 +58,7 @@ for _, container := range pod.Containers {
   }
 }
 for _, initContainer := range pod.InitContainers {
-  if features.Enabled(features.NativeSidecar) && initContainer.ContainerType == model.ContainerTypeInitSidecar {
+  if features.Enabled(features.NativeSidecar) && initContainer.ContainerType == model.ContainerTypeNativeSidecar {
     if err := feeder.clusterState.AddOrUpdateContainer(initContainer.ID, initContainer.Request, initContainer.ContainerType); err != nil {
       klog.V(4).ErrorS(err, "Failed to add initContainer", "container", initContainer.ID)
     }
@@ -66,7 +68,18 @@ for _, initContainer := range pod.InitContainers {
 }
 ```
 
-The VPA custom resource definition remains unchanged. Native sidecar recommendations treated exactly like standard container recommendations, the unique container names allow us to identify them.
+The VPA custom resource definition remains unchanged. Native sidecar recommendations are treated exactly like standard container recommendations; the unique container names allow us to identify them.
+
+#### Startup Ordering
+
+Native sidecars are defined in `initContainers` and start before regular containers. This startup ordering does not affect VPA's recommendation logic because VPA collects ongoing resource usage samples over the container's lifetime regardless of when it started. The only difference is the JSON patch path used when applying recommendations (`/spec/initContainers` vs `/spec/containers`), which is handled in the patch generation logic described below.
+
+#### Pod Resource Calculations
+
+With native sidecars, the effective pod resource request is calculated as:
+`max(max(init containers), sum(regular containers) + sum(native sidecars))`
+
+VPA generates per-container recommendations independently and does not need to account for this aggregate calculation since the scheduler handles pod-level resource accounting. However, users should be aware that increasing a native sidecar's resource request increases the pod's overall resource footprint additively (unlike regular init containers, which only matter if they exceed the sum of running containers).
 
 ### Update / Admission
 

--- a/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
+++ b/vertical-pod-autoscaler/enhancements/8905-native-sidecar-support/README.md
@@ -105,14 +105,14 @@ The following test scenarios will be added to e2e tests.
 
 #### Upgrade
 
-Upgrading to VPA 1.7.0 (tentative release version) does not change behavior by default. Existing VPAs continue to work as before.
+Upgrading to VPA 1.8.0 (tentative release version) does not change behavior by default. Existing VPAs continue to work as before.
 
 To use native sidecar support, enable the (alpha) `NativeSidecar` feature gate (disabled by default) by passing `--feature-gates=NativeSidecar=true` to all VPA components.
 When enabled, the Recommender will generate recommendations for native sidecars, and the Updater and Admission Controller will apply them.
 
 #### Downgrade
 
-If the `NativeSidecar` feature gate was never enabled, downgrading from VPA 1.7.0 (tentative release version) has no behavioral impact.
+If the `NativeSidecar` feature gate was never enabled, downgrading from VPA 1.8.0 (tentative release version) has no behavioral impact.
 
 If `NativeSidecar` was enabled before the downgrade:
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Created due to https://github.com/kubernetes/autoscaler/issues/7229

This PR adds an AEP to add support for native sidecars.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
