### PR TITLE
Add new AWS provider label that needs to be ignored

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/aws_nodegroups.go
@@ -32,6 +32,7 @@ func CreateAwsNodeInfoComparator(extraIgnoredLabels []string, ratioOpts config.N
 		"k8s.amazonaws.com/eniConfig":    true, // this is a label used by the AWS CNI for custom networking.
 		"lifecycle":                      true, // this is a label used by the AWS for spot.
 		"topology.ebs.csi.aws.com/zone":  true, // this is a label used by the AWS EBS CSI driver as a target for Persistent Volume Node Affinity
+		"topology.k8s.aws/zone-id":       true, // this is a label used to determine the location of resources in an account relative to those in another one
 	}
 
 	for k, v := range BasicIgnoredLabels {

--- a/cluster-autoscaler/processors/nodegroupset/aws_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/aws_nodegroups_test.go
@@ -162,6 +162,27 @@ func TestIsAwsNodeInfoSimilar(t *testing.T) {
 			value2:         "bar",
 			removeOneLabel: true,
 		},
+		{
+			description:    "topology.k8s.aws/zone-id empty value",
+			label:          "topology.k8s.aws/zone-id",
+			value1:         "",
+			value2:         "",
+			removeOneLabel: false,
+		},
+		{
+			description:    "topology.k8s.aws/zone-id different values",
+			label:          "topology.k8s.aws/zone-id",
+			value1:         "foo",
+			value2:         "bar",
+			removeOneLabel: false,
+		},
+		{
+			description:    "topology.k8s.aws/zone-id one node labeled",
+			label:          "topology.k8s.aws/zone-id",
+			value1:         "foo",
+			value2:         "bar",
+			removeOneLabel: true,
+		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			node1.ObjectMeta.Labels[tc.label] = tc.value1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

As of [AWS EKS 1.30](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-extended.html#kubernetes-1-30), there is a new label that has been added by aws provider.  
This new label contains the zone-id and is preventing from considering nodegroups similar when they are from different availability zones

#### Which issue(s) this PR fixes:

NA / fixes occurence of following log and uneven scaling across availability zones on AWS

```
No similar node groups found
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
add topology.k8s.aws/zone-id to AWS ignore label set
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
