### PR TITLE
Fix typo in CA StaticAutoscaler test

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -786,7 +786,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	provider.AddAutoprovisionedNodeGroup("autoprovisioned-TN1", 0, 10, 0, "TN1")
 	autoprovisionedTN1 := reflect.ValueOf(provider.GetNodeGroup("autoprovisioned-TN1")).Interface().(*testprovider.TestNodeGroup)
 	assert.NotNil(t, autoprovisionedTN1)
-	provider.AddNode("ng1,", n1)
+	provider.AddNode("ng1", n1)
 	assert.NotNil(t, provider)
 
 	// Create context with mocked lister registry.


### PR DESCRIPTION
It seems that the node group id was supposed to be ng1.

The typo does strangely not cause the tests to break.

#### What type of PR is this?

/kind bug

Optionally add one or more of the following kinds if applicable:
/kind failing-test

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

This might fix the tests not actually testing the right thing.
With the typo that was previously part of the test, its setup did not actually set up the state originally intended.

Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Special notes for your reviewer:

I do not yet know why this typo did not surface earlier. I maintain a a customized fork at https://github.com/gridscale/autoscaler where the forks modifications resulted in a panic when running the autoscaler tests.

To me it looks pretty much like a typo that was not indended, given that there is also not an explicit comment that the `,` was intended to be part of this string.

Edit: I opened this as a draft PR to let the tests run. Locally they passed but I want to make sure CI passes too. I will address the automation comments next.