### PR TITLE
ci: standardize to actions/setup-go@v6 w/ go 1.25

### DIFF
--- a/.github/workflows/ca-test.yaml
+++ b/.github/workflows/ca-test.yaml
@@ -25,9 +25,9 @@ jobs:
           path: ${{ env.GOPATH }}/src/k8s.io/autoscaler
 
       - name: Set up Go
-        uses: actions/setup-go@v5.5.0
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24.0'
+          go-version: '1.25'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/cluster-autoscaler/go.sum
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -21,9 +21,9 @@ jobs:
           path: ${{ env.GOPATH }}/src/k8s.io/autoscaler
 
       - name: Set up Go
-        uses: actions/setup-go@v5.5.0
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24.0'
+          go-version: '1.25'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/cluster-autoscaler/go.sum
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum

--- a/.github/workflows/vpa-golangci-lint.yaml
+++ b/.github/workflows/vpa-golangci-lint.yaml
@@ -24,7 +24,7 @@ jobs:
           path: ${{ env.GOPATH }}/src/k8s.io/autoscaler
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.0'
+          go-version: '1.25'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/e2e/go.sum

--- a/.github/workflows/vpa-test.yaml
+++ b/.github/workflows/vpa-test.yaml
@@ -25,9 +25,9 @@ jobs:
           path: ${{ env.GOPATH }}/src/k8s.io/autoscaler
 
       - name: Set up Go
-        uses: actions/setup-go@v5.5.0
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24.0'
+          go-version: '1.25'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/e2e/go.sum


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR standardizes our GHA CI to use actions/setup-go@v6 w/ go 1.25

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
