### PR TITLE
fix: vertical-pod-autoscaler helm chart updater extraArgs indentation 

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrole.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrole.yaml
@@ -6,40 +6,40 @@ metadata:
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - configmaps
-  - nodes
-  - limitranges
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  verbs:
-  - list
-  - get
-- apiGroups:
-  - autoscaling.k8s.io
-  resources:
-  - verticalpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - update
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - nodes
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - update
+      - get
+      - list
+      - watch
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrolebinding.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrolebinding.yaml
@@ -10,7 +10,7 @@ roleRef:
   kind: ClusterRole
   name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
 subjects:
-- kind: ServiceAccount
-  name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -61,10 +61,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
-          - --v=4
-          - --stderrthreshold=info
+            - --v=4
+            - --stderrthreshold=info
           {{- with .Values.admissionController.extraArgs }}
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - containerPort: 8000
@@ -98,5 +98,5 @@ spec:
             {{ toYaml . | nindent 12 | trim }}
           {{- end }}
       volumes:
-        {{- toYaml .Values.admissionController.volumes | nindent 12 }}
+        {{- toYaml .Values.admissionController.volumes | nindent 8 }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-clusterrolebindings.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-clusterrolebindings.yaml
@@ -11,9 +11,9 @@ roleRef:
   kind: ClusterRole
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-metrics-reader
 subjects:
-- kind: ServiceAccount
-  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -26,9 +26,9 @@ roleRef:
   kind: ClusterRole
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-actor
 subjects:
-- kind: ServiceAccount
-  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -41,9 +41,9 @@ roleRef:
   kind: ClusterRole
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-status-actor
 subjects:
-- kind: ServiceAccount
-  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -56,9 +56,9 @@ roleRef:
   kind: ClusterRole
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-checkpoint-actor
 subjects:
-- kind: ServiceAccount
-  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -71,8 +71,8 @@ roleRef:
   kind: ClusterRole
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-target-reader
 subjects:
-- kind: ServiceAccount
-  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end -}}
 

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-clusterroles.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-clusterroles.yaml
@@ -7,13 +7,13 @@ metadata:
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - "metrics.k8s.io"
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - "metrics.k8s.io"
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -22,44 +22,44 @@ metadata:
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - limitranges
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - patch
-  - update
-- apiGroups:
-  - "poc.autoscaling.k8s.io"
-  resources:
-  - verticalpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "autoscaling.k8s.io"
-  resources:
-  - verticalpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - "poc.autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -68,13 +68,13 @@ metadata:
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - "autoscaling.k8s.io"
-  resources:
-  - verticalpodautoscalers/status
-  verbs:
-  - get
-  - patch
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers/status
+    verbs:
+      - get
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -83,35 +83,35 @@ metadata:
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - "poc.autoscaling.k8s.io"
-  resources:
-  - verticalpodautoscalercheckpoints
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - delete
-- apiGroups:
-  - "autoscaling.k8s.io"
-  resources:
-  - verticalpodautoscalercheckpoints
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - "poc.autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalercheckpoints
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalercheckpoints
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -120,39 +120,39 @@ metadata:
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*/scale'
-  verbs:
-  - get
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - replicationcontrollers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
@@ -37,63 +37,63 @@ spec:
         {{ toYaml . | nindent 8 | trim }}
       {{- end }}
       containers:
-      - name: recommender
-        image: {{ include "vertical-pod-autoscaler.recommender.image" . }}
-        imagePullPolicy: {{ .Values.recommender.image.pullPolicy }}
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        {{- with .Values.recommender.extraEnv }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        args:
-        - --v=4
-        - --stderrthreshold=info
-        {{- /* Smart auto-enable: if enabled is null, auto-enable when replicas > 1 */ -}}
-        {{- $leaderElectionEnabled := .Values.recommender.leaderElection.enabled }}
-        {{- if eq $leaderElectionEnabled nil }}
-          {{- $leaderElectionEnabled = gt (int .Values.recommender.replicas) 1 }}
-        {{- end }}
-        {{- if $leaderElectionEnabled }}
-        - --leader-elect=true
-        - --leader-elect-resource-namespace={{ .Values.recommender.leaderElection.resourceNamespace | default .Release.Namespace }}
-        - --leader-elect-resource-name={{ .Values.recommender.leaderElection.resourceName }}
-        - --leader-elect-lease-duration={{ .Values.recommender.leaderElection.leaseDuration }}
-        - --leader-elect-renew-deadline={{ .Values.recommender.leaderElection.renewDeadline }}
-        - --leader-elect-retry-period={{ .Values.recommender.leaderElection.retryPeriod }}
-        {{- end }}
-        {{- with .Values.recommender.extraArgs }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        ports:
-        - name: prometheus
-          containerPort: 8942
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /health-check
-            port: prometheus
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          failureThreshold: 3
-        readinessProbe:
-          httpGet:
-            path: /health-check
-            port: prometheus
-            scheme: HTTP
-          periodSeconds: 10
-          failureThreshold: 3
-        {{- with .Values.recommender.resources }}
-        resources:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.containerSecurityContext }}
-        securityContext:
-          {{ toYaml . | nindent 10 | trim }}
-        {{- end }}
+        - name: recommender
+          image: {{ include "vertical-pod-autoscaler.recommender.image" . }}
+          imagePullPolicy: {{ .Values.recommender.image.pullPolicy }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{- with .Values.recommender.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - --v=4
+            - --stderrthreshold=info
+            {{- /* Smart auto-enable: if enabled is null, auto-enable when replicas > 1 */ -}}
+            {{- $leaderElectionEnabled := .Values.recommender.leaderElection.enabled }}
+            {{- if eq $leaderElectionEnabled nil }}
+              {{- $leaderElectionEnabled = gt (int .Values.recommender.replicas) 1 }}
+            {{- end }}
+            {{- if $leaderElectionEnabled }}
+            - --leader-elect=true
+            - --leader-elect-resource-namespace={{ .Values.recommender.leaderElection.resourceNamespace | default .Release.Namespace }}
+            - --leader-elect-resource-name={{ .Values.recommender.leaderElection.resourceName }}
+            - --leader-elect-lease-duration={{ .Values.recommender.leaderElection.leaseDuration }}
+            - --leader-elect-renew-deadline={{ .Values.recommender.leaderElection.renewDeadline }}
+            - --leader-elect-retry-period={{ .Values.recommender.leaderElection.retryPeriod }}
+            {{- end }}
+          {{- with .Values.recommender.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: prometheus
+              containerPort: 8942
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: prometheus
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health-check
+              port: prometheus
+              scheme: HTTP
+            periodSeconds: 10
+            failureThreshold: 3
+          {{- with .Values.recommender.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{ toYaml . | nindent 12 | trim }}
+          {{- end }}
       {{- with .Values.recommender.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-leader-election-rbac.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-leader-election-rbac.yaml
@@ -14,22 +14,22 @@ metadata:
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - "coordination.k8s.io"
-  resources:
-  - leases
-  verbs:
-  - create
-- apiGroups:
-  - "coordination.k8s.io"
-  resourceNames:
-  - {{ .Values.recommender.leaderElection.resourceName }}
-  resources:
-  - leases
-  verbs:
-  - get
-  - watch
-  - update
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - "coordination.k8s.io"
+    resourceNames:
+      - {{ .Values.recommender.leaderElection.resourceName }}
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -43,8 +43,8 @@ roleRef:
   kind: Role
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}-leader-locking
 subjects:
-- kind: ServiceAccount
-  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end -}}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -42,16 +42,16 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           args:
-          - --v=4
-          - --stderrthreshold=info
-          {{- if eq (include "vertical-pod-autoscaler.updater.leaderElectionEnabled" .) "true" }}
-          - --leader-elect=true
-          - --leader-elect-resource-namespace={{ .Values.updater.leaderElection.resourceNamespace | default .Release.Namespace }}
-          - --leader-elect-resource-name={{ .Values.updater.leaderElection.resourceName }}
-          - --leader-elect-lease-duration={{ .Values.updater.leaderElection.leaseDuration }}
-          - --leader-elect-renew-deadline={{ .Values.updater.leaderElection.renewDeadline }}
-          - --leader-elect-retry-period={{ .Values.updater.leaderElection.retryPeriod }}
-          {{- end }}
+            - --v=4
+            - --stderrthreshold=info
+            {{- if eq (include "vertical-pod-autoscaler.updater.leaderElectionEnabled" .) "true" }}
+            - --leader-elect=true
+            - --leader-elect-resource-namespace={{ .Values.updater.leaderElection.resourceNamespace | default .Release.Namespace }}
+            - --leader-elect-resource-name={{ .Values.updater.leaderElection.resourceName }}
+            - --leader-elect-lease-duration={{ .Values.updater.leaderElection.leaseDuration }}
+            - --leader-elect-renew-deadline={{ .Values.updater.leaderElection.renewDeadline }}
+            - --leader-elect-retry-period={{ .Values.updater.leaderElection.retryPeriod }}
+            {{- end }}
           {{- with .Values.updater.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #8942

#### Special notes for your reviewer:

It's the same issue/fix as in https://github.com/kubernetes/autoscaler/pull/8937 just for another component.

#### Does this PR introduce a user-facing change?

```release-note
Fixes indentation in vertical-pod-austoscaler helm chart for updater container extraArgs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
