### PR TITLE
Add metric that is emitted after a successful single run of static autoscaler

### DIFF
--- a/cluster-autoscaler/loop/run.go
+++ b/cluster-autoscaler/loop/run.go
@@ -37,7 +37,9 @@ func RunAutoscalerOnce(autoscaler autoscaler, healthCheck *metrics.HealthCheck, 
 	if err != nil && err.Type() != errors.TransientError {
 		metrics.RegisterError(err)
 	} else {
-		healthCheck.UpdateLastSuccessfulRun(time.Now())
+		var successTime = time.Now()
+		healthCheck.UpdateLastSuccessfulRun(successTime)
+		metrics.UpdateLastTime(metrics.MainSuccessful, successTime)
 	}
 
 	metrics.UpdateDurationFromStart(metrics.Main, loopStart)

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -110,6 +110,7 @@ const (
 	FilterOutSchedulable       FunctionLabel = "filterOutSchedulable"
 	CloudProviderRefresh       FunctionLabel = "cloudProviderRefresh"
 	Main                       FunctionLabel = "main"
+	MainSuccessful             FunctionLabel = "mainSuccessful"
 	Poll                       FunctionLabel = "poll"
 	Reconfigure                FunctionLabel = "reconfigure"
 	Autoscaling                FunctionLabel = "autoscaling"


### PR DESCRIPTION


#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This will allow to detect situations where the loop starts and not ends (because of a health check for example).

Note that existing loop start metric is not enough because if we have autoscaler killed another autoscaler will take over role of the leader and again emit the metric of the main starting.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add new label to last_activity metric called "mainSuccessful" that is emitted after each full loop execution that finishes without errors.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
