### PR TITLE
Reconfigure VPA conditions to be true/false

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -64,7 +64,7 @@ var (
 	empty                               = ""
 	unsupportedConditionTextFromFetcher = "Cannot read targetRef. Reason: targetRef not defined"
 	unsupportedConditionNoExtraText     = "Cannot read targetRef"
-	unsupportedConditionNoTargetRef     = "Cannot read targetRef"
+	unsupportedConditionNoTargetRef     = "targetRef cannot be empty"
 	unsupportedConditionMudaMudaMuda    = "Error checking if target taxonomy.doestar/doseph-doestar is a topmost well-known or scalable controller: muda muda muda"
 	unsupportedTargetRefHasParent       = "The target stardust.dodokind/dotaro has a parent controller but it should point to a topmost well-known or scalable controller"
 )
@@ -184,7 +184,7 @@ func TestLoadVPAs(t *testing.T) {
 			selector:                  parseLabelSelector("app = test"),
 			fetchSelectorError:        nil,
 			expectedSelector:          labels.Nothing(),
-			expectedConfigUnsupported: nil,
+			expectedConfigUnsupported: &unsupportedConditionNoTargetRef,
 			expectedConfigDeprecated:  nil,
 			expectedVpaFetch:          true,
 		},
@@ -198,7 +198,7 @@ func TestLoadVPAs(t *testing.T) {
 				Name:       name1,
 				APIVersion: apiVersion,
 			},
-			expectedConfigUnsupported: &unsupportedConditionNoTargetRef,
+			expectedConfigUnsupported: &unsupportedConditionNoExtraText,
 			expectedVpaFetch:          true,
 		},
 		{
@@ -385,20 +385,25 @@ func TestLoadVPAs(t *testing.T) {
 				assert.Nil(t, storedVpa.PodSelector)
 			}
 
+			assert.Contains(t, storedVpa.Conditions, vpa_types.ConfigDeprecated)
+			// Unused code path...
 			if tc.expectedConfigDeprecated != nil {
-				assert.Contains(t, storedVpa.Conditions, vpa_types.ConfigDeprecated)
+				assert.Equal(t, v1.ConditionTrue, storedVpa.Conditions[vpa_types.ConfigDeprecated].Status)
 				assert.Equal(t, *tc.expectedConfigDeprecated, storedVpa.Conditions[vpa_types.ConfigDeprecated].Message)
 			} else {
-				assert.NotContains(t, storedVpa.Conditions, vpa_types.ConfigDeprecated)
+				assert.Equal(t, v1.ConditionFalse, storedVpa.Conditions[vpa_types.ConfigDeprecated].Status)
+				assert.NotEmpty(t, storedVpa.Conditions[vpa_types.ConfigDeprecated].Message)
 			}
 
 			if tc.expectedConfigUnsupported != nil {
 				assert.Contains(t, storedVpa.Conditions, vpa_types.ConfigUnsupported)
+				assert.Equal(t, v1.ConditionTrue, storedVpa.Conditions[vpa_types.ConfigUnsupported].Status)
 				assert.Equal(t, *tc.expectedConfigUnsupported, storedVpa.Conditions[vpa_types.ConfigUnsupported].Message)
 			} else {
-				assert.NotContains(t, storedVpa.Conditions, vpa_types.ConfigUnsupported)
+				assert.Contains(t, storedVpa.Conditions, vpa_types.ConfigUnsupported)
+				assert.Equal(t, v1.ConditionFalse, storedVpa.Conditions[vpa_types.ConfigUnsupported].Status)
+				assert.NotEmpty(t, storedVpa.Conditions[vpa_types.ConfigUnsupported].Message)
 			}
-
 		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -257,7 +257,7 @@ func (vpa *Vpa) UpdateConditions(podsMatched bool) {
 	reason := ""
 	msg := ""
 	if podsMatched {
-		delete(vpa.Conditions, vpa_types.NoPodsMatched)
+		vpa.Conditions.Set(vpa_types.NoPodsMatched, false, "Cleared", "Matching pods detected")
 	} else {
 		reason = "NoPodsMatched"
 		msg = "No pods match this VPA object"

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
@@ -65,8 +65,13 @@ func TestUpdateConditions(t *testing.T) {
 					Reason:  "",
 					Message: "",
 				},
+				{
+					Type:    vpa_types.NoPodsMatched,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Cleared",
+					Message: "Matching pods detected",
+				},
 			},
-			expectedAbsent: []vpa_types.VerticalPodAutoscalerConditionType{vpa_types.NoPodsMatched},
 		}, {
 			name:              "Has recommendation but no pods matched",
 			podsMatched:       false,
@@ -95,8 +100,13 @@ func TestUpdateConditions(t *testing.T) {
 					Reason:  "",
 					Message: "",
 				},
+				{
+					Type:    vpa_types.NoPodsMatched,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Cleared",
+					Message: "Matching pods detected",
+				},
 			},
-			expectedAbsent: []vpa_types.VerticalPodAutoscalerConditionType{vpa_types.NoPodsMatched},
 		}, {
 			name:              "No recommendation no pods matched",
 			podsMatched:       false,


### PR DESCRIPTION
Rather than deleting them and recreating them

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

First part of [AEP-8898](https://github.com/kubernetes/autoscaler/pull/8898)
Rather than deleting/creating condition as per the [recommendation](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Persist VPA resource conditions, rather than deleting and creating them
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [AEP]: https://github.com/kubernetes/autoscaler/pull/8898
```
