### PR TITLE
fix(helm): add missing RBAC permissions and fix TLS certificate naming for VPA admission controller

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrole.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrole.yaml
@@ -22,6 +22,9 @@ rules:
     resources:
       - mutatingwebhookconfigurations
     verbs:
+      - create
+      - update
+      - delete
       - list
       - get
   - apiGroups:
@@ -39,6 +42,34 @@ rules:
     verbs:
       - create
       - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - replicasets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
+    verbs:
       - get
       - list
       - watch

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-tls-secret.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-tls-secret.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
 type: Opaque
 data:
-  ca.crt: {{ default $ca.Cert .Values.admissionController.tls.caCert | b64enc | quote }}
-  tls.crt: {{ default $cert.Cert .Values.admissionController.tls.cert | b64enc | quote }}
-  tls.key: {{ default $cert.Key .Values.admissionController.tls.key | b64enc | quote }}
+  caCert.pem: {{ default $ca.Cert .Values.admissionController.tls.caCert | b64enc | quote }}
+  serverCert.pem: {{ default $cert.Cert .Values.admissionController.tls.cert | b64enc | quote }}
+  serverKey.pem: {{ default $cert.Key .Values.admissionController.tls.key | b64enc | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# PR Description Template

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR fixes two critical issues in the VPA Helm chart that prevent the admission controller from functioning correctly:

1. **Missing RBAC Permissions**: The ClusterRole for the admission controller was missing several required permissions:
   - `create`, `update`, `delete` verbs for `mutatingwebhookconfigurations` (needed for self-registration)
   - Permissions to watch workload resources: `deployments`, `statefulsets`, `replicasets`, `daemonsets` (apps API group)
   - Permissions to watch batch workloads: `jobs`, `cronjobs` (batch API group)
   - Permissions to watch legacy workloads: `replicationcontrollers` (core API group)

   Without these permissions, the admission controller fails with RBAC errors and cannot watch the resources it needs to provide recommendations.

2. **TLS Certificate File Naming**: The Helm chart creates TLS certificates with standard Kubernetes secret key names (`ca.crt`, `tls.crt`, `tls.key`), but the VPA admission controller binary expects specific file names (`caCert.pem`, `serverCert.pem`, `serverKey.pem`). This mismatch causes the admission controller to fail to start with certificate file not found errors.

**Impact**: These issues cause the VPA admission controller to fail during startup, preventing VPA from functioning properly. Users experience RBAC permission denied errors and TLS certificate file not found errors in the admission controller logs.

**Environment Details:**
- Kubernetes Version: 1.32.9-eks-ecaa3a6 (EKS 1.32)
- VPA Chart Version: 0.7.0
- VPA Admission Controller Image: `registry.k8s.io/autoscaling/vpa-admission-controller:1.5.1`
- Helm Version: v3.16.1
- kubectl Version: v1.34.3

**Error Logs Observed:**

1. **RBAC Permission Errors** (before fix):
```
E1222 12:43:36.937195       1 reflector.go:205] "Failed to watch" err="failed to list *v1.StatefulSet: statefulsets.apps is forbidden: User \"system:serviceaccount:infra:vertical-pod-autoscaler-admission-controller\" cannot list resource \"statefulsets\" in API group \"apps\" at the cluster scope"
E1222 12:44:00.137421       1 reflector.go:205] "Failed to watch" err="failed to list *v1.ReplicationController: replicationcontrollers is forbidden: User \"system:serviceaccount:infra:vertical-pod-autoscaler-admission-controller\" cannot list resource \"replicationcontrollers\" in API group \"\" at the cluster scope"
E1222 12:44:07.169424       1 reflector.go:205] "Failed to watch" err="failed to list *v1.Deployment: deployments.apps is forbidden: User \"system:serviceaccount:infra:vertical-pod-autoscaler-admission-controller\" cannot list resource \"deployments\" in API group \"apps\" at the cluster scope"
E1222 12:44:18.685109       1 reflector.go:205] "Failed to watch" err="failed to list *v1.ReplicaSet: replicasets.apps is forbidden: User \"system:serviceaccount:infra:vertical-pod-autoscaler-admission-controller\" cannot list resource \"replicasets\" in API group \"apps\" at the cluster scope"
E1222 12:44:22.785352       1 reflector.go:205] "Failed to watch" err="failed to list *v1.CronJob: cronjobs.batch is forbidden: User \"system:serviceaccount:infra:vertical-pod-autoscaler-admission-controller\" cannot list resource \"cronjobs\" in API group \"batch\" at the cluster scope"
E1222 12:44:23.460402       1 reflector.go:205] "Failed to watch" err="failed to list *v1.Job: jobs.batch is forbidden: User \"system:serviceaccount:infra:vertical-pod-autoscaler-admission-controller\" cannot list resource \"jobs\" in API group \"batch\" at the cluster scope"
E1222 12:44:26.050336       1 reflector.go:205] "Failed to watch" err="failed to list *v1.DaemonSet: daemonsets.apps is forbidden: User \"system:serviceaccount:infra:vertical-pod-autoscaler-admission-controller\" cannot list resource \"daemonsets\" in API group \"apps\" at the cluster scope"
F1222 12:49:42.371263       1 config.go:190] mutatingwebhookconfigurations.admissionregistration.k8s.io is forbidden: User "system:serviceaccount:infra:vertical-pod-autoscaler-admission-controller" cannot create resource "mutatingwebhookconfigurations" in API group "admissionregistration.k8s.io" at the cluster scope
```

2. **TLS Certificate File Not Found Errors** (before fix):
```
F1222 12:46:53.059923       1 config.go:89] open /etc/tls-certs/serverCert.pem: no such file or directory
E1222 12:48:58.720778       1 certs.go:42] "Error reading certificate file" err="open /etc/tls-certs/caCert.pem: no such file or directory" file="/etc/tls-certs/caCert.pem"
```

**After applying fixes**, the admission controller starts successfully:
```
I1222 12:49:32.361011       1 certs.go:45] "Successfully read bytes from file" bytes=1224 file="/etc/tls-certs/caCert.pem"
I1222 12:50:03.393863       1 config.go:192] Self registration as MutatingWebhook succeeded.
```

#### Which issue(s) this PR fixes:
<!--
If there's an existing issue, link it here. Otherwise, you can mention:
-->
Fixes #8938

#### Special notes for your reviewer:

- The RBAC permissions added are based on the actual requirements of VPA admission controller v1.5.1
- The TLS certificate naming change aligns with what the VPA admission controller binary expects (as seen in the source code and runtime behavior)
- Both changes are backward compatible - existing installations will continue to work, but new installations will have the correct configuration
- Tested on EKS 1.32 cluster with Helm chart version 0.7.0
- Verified that after applying these fixes, the admission controller pods start successfully and the mutating webhook is registered correctly

#### Does this PR introduce a user-facing change?
```release-note
Fix VPA Helm chart admission controller RBAC permissions and TLS certificate naming. The admission controller now has the required permissions to watch workloads and self-register as a mutating webhook, and TLS certificates use the correct file names expected by the VPA binary.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```