### PR TITLE
Fix update of uneeded threshold

### DIFF
--- a/cluster-autoscaler/core/scaledown/unneeded/nodes.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes.go
@@ -136,12 +136,12 @@ func (n *Nodes) updateInternalState(autoscalingCtx *ca_context.AutoscalingContex
 
 		val, found := n.byName[name]
 		if found {
-			updated[name] = &node{
-				ntbr:                     nn,
-				since:                    val.since,
-				removalThreshold:         val.removalThreshold,
-				thresholdRetrievalFailed: val.thresholdRetrievalFailed,
+			newNodeState := &node{
+				ntbr:  nn,
+				since: val.since,
 			}
+			n.lookupAndSetRemovalThreshold(newNodeState, autoscalingCtx.CloudProvider)
+			updated[name] = newNodeState
 		} else {
 			updated[name] = n.newNode(nn, timestampGetter, ts, autoscalingCtx.CloudProvider)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the update of the unneeded nodes list to refresh unneeded/unready threshold every time

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```release-note
NONE
```