### PR TITLE
Migrate from archived `gopkg.in/yaml.v2` to `sigs.k8s.io/yaml`

### DIFF
--- a/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks/utils.go
+++ b/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks/utils.go
@@ -9,7 +9,8 @@ import (
 	"reflect"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
+
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud"
 )
 

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_config.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_config.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/cluster-autoscaler/clusterstate/utils/status.go
+++ b/cluster-autoscaler/clusterstate/utils/status.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/yaml.v2"
 	apiv1 "k8s.io/api/core/v1"
 	kube_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate/api"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/yaml"
 
 	klog "k8s.io/klog/v2"
 )

--- a/cluster-autoscaler/clusterstate/utils/status_test.go
+++ b/cluster-autoscaler/clusterstate/utils/status_test.go
@@ -97,7 +97,7 @@ func TestWriteStatusConfigMap(t *testing.T) {
 			Namespace:   "kube-system",
 			Annotations: map[string]string{ConfigMapLastUpdatedKey: "2023-12-21 00:00:00 +0000 UTC"},
 		},
-		Data: map[string]string{"status": "time: 2023-12-21 00:00:00 +0000 UTC\nmessage: TEST_MSG\n"},
+		Data: map[string]string{"status": "clusterWide:\n  health:\n    lastProbeTime: null\n    lastTransitionTime: null\n    nodeCounts:\n      longUnregistered: 0\n      registered:\n        notStarted: 0\n        ready: 0\n        total: 0\n        unready:\n          resourceUnready: 0\n          total: 0\n      unregistered: 0\n  scaleDown:\n    lastProbeTime: null\n    lastTransitionTime: null\n  scaleUp:\n    lastProbeTime: null\n    lastTransitionTime: null\nmessage: TEST_MSG\ntime: 2023-12-21 00:00:00 +0000 UTC\n"},
 	}
 	testCases := []struct {
 		name             string

--- a/cluster-autoscaler/clusterstate/utils/status_test.yaml
+++ b/cluster-autoscaler/clusterstate/utils/status_test.yaml
@@ -15,17 +15,17 @@ clusterWide:
           resourceUnready: 1
       longUnregistered: 1
       unregistered: 2
-    lastProbeTime: "2023-11-24T04:28:19.000048988Z"
-    lastTransitionTime: "2023-11-23T14:52:02.000011Z"
+    lastProbeTime: "2023-11-24T04:28:19Z"
+    lastTransitionTime: "2023-11-23T14:52:02Z"
   scaleUp:
     status: "NoActivity"
-    lastProbeTime: "2023-11-24T04:28:19.000048988Z"
-    lastTransitionTime: "2023-11-23T14:52:02.000011Z"
+    lastProbeTime: "2023-11-24T04:28:19Z"
+    lastTransitionTime: "2023-11-23T14:52:02Z"
   scaleDown:
     status: "NoCandidates"
     candidates: 2
-    lastProbeTime: "2023-11-24T04:28:19.000048988Z"
-    lastTransitionTime: "2023-11-23T14:52:02.000011Z"
+    lastProbeTime: "2023-11-24T04:28:19Z"
+    lastTransitionTime: "2023-11-23T14:52:02Z"
 nodeGroups:
   -
     name: "sample-node-group"
@@ -45,17 +45,17 @@ nodeGroups:
       cloudProviderTarget: 8
       minSize: 2
       maxSize: 12
-      lastProbeTime: "2023-11-24T04:28:19.000048988Z"
-      lastTransitionTime: "2023-11-23T14:52:02.000011Z"
+      lastProbeTime: "2023-11-24T04:28:19Z"
+      lastTransitionTime: "2023-11-23T14:52:02Z"
     scaleUp:
       status: "Backoff"
       backoffInfo:
         errorCode: "QUOTA_EXCEEDED"
         errorMessage: "Instance 'sample-node-group-40ce0341-t28s' creation failed: Quota 'CPUS' exceeded. Limit: 57.0 in region us-central1."
-      lastProbeTime: "2023-11-24T04:28:19.000048988Z"
-      lastTransitionTime: "2023-11-23T14:52:02.000011Z"
+      lastProbeTime: "2023-11-24T04:28:19Z"
+      lastTransitionTime: "2023-11-23T14:52:02Z"
     scaleDown:
       status: "NoCandidates"
       candidates: 2
-      lastProbeTime: "2023-11-24T04:28:19.000048988Z"
-      lastTransitionTime: "2023-11-23T14:52:02.000011Z"
+      lastProbeTime: "2023-11-24T04:28:19Z"
+      lastTransitionTime: "2023-11-23T14:52:02Z"

--- a/cluster-autoscaler/expander/priority/priority.go
+++ b/cluster-autoscaler/expander/priority/priority.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -47,7 +47,6 @@ require (
 	google.golang.org/grpc v1.72.2
 	google.golang.org/protobuf v1.36.8
 	gopkg.in/gcfg.v1 v1.2.3
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/apiserver v0.35.0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR migrates the cluster-autoscaler from the archived [gopkg.in/yaml.v2](https://github.com/go-yaml/yaml) package to the actively maintained [sigs.k8s.io/yaml](https://github.com/kubernetes-sigs/yaml) library, which is the official YAML library recommended by the Kubernetes ecosystem.

- `gopkg.in/yaml` (v2 and v3) has been archived since April 2025 and is no longer maintained
- `sigs.k8s.io/yaml` is actively maintained by the Kubernetes community and provides better integration with Kubernetes APIs
- This change aligns with Kubernetes project standards and reduces technical debt

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

The behavior change in serialization is expected and correct:

- `Zero-value structs`: Now explicitly serialized with their zero fields when the parent struct field lacks omitempty or is a value type
- `Timestamp precision`: Reduced precision is acceptable for status reporting and matches Kubernetes API conventions

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
