### PR TITLE
Fix scale-down eligibility when utilization and threshold are zero

### DIFF
--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -154,7 +154,7 @@ func (c *Checker) unremovableReasonAndNodeUtilization(autoscalingCtx *ca_context
 		}
 	}
 
-	underutilized, err := c.isNodeBelowUtilizationThreshold(autoscalingCtx, node, nodeGroup, utilInfo)
+	underutilized, err := c.isNodeAtOrBelowUtilizationThreshold(autoscalingCtx, node, nodeGroup, utilInfo)
 	if err != nil {
 		klog.Warningf("Failed to check utilization thresholds for %s: %v", node.Name, err)
 		return simulator.UnexpectedError, nil
@@ -169,8 +169,8 @@ func (c *Checker) unremovableReasonAndNodeUtilization(autoscalingCtx *ca_context
 	return simulator.NoReason, &utilInfo
 }
 
-// isNodeBelowUtilizationThreshold determines if a given node utilization is below threshold.
-func (c *Checker) isNodeBelowUtilizationThreshold(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, utilInfo utilization.Info) (bool, error) {
+// isNodeAtOrBelowUtilizationThreshold determines if a given node utilization is at or below threshold.
+func (c *Checker) isNodeAtOrBelowUtilizationThreshold(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, utilInfo utilization.Info) (bool, error) {
 	var threshold float64
 	var err error
 	gpuConfig := autoscalingCtx.CloudProvider.GetNodeGpuConfig(node)
@@ -185,7 +185,7 @@ func (c *Checker) isNodeBelowUtilizationThreshold(autoscalingCtx *ca_context.Aut
 			return false, err
 		}
 	}
-	if utilInfo.Utilization >= threshold {
+	if utilInfo.Utilization > threshold {
 		return false, nil
 	}
 	return true, nil

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -39,15 +39,16 @@ import (
 )
 
 type testCase struct {
-	desc                        string
-	nodes                       []*apiv1.Node
-	pods                        []*apiv1.Pod
-	draSnapshot                 *drasnapshot.Snapshot
-	draEnabled                  bool
-	wantUnneeded                []string
-	wantUnremovable             []*simulator.UnremovableNode
-	scaleDownUnready            bool
-	ignoreDaemonSetsUtilization bool
+	desc                          string
+	nodes                         []*apiv1.Node
+	pods                          []*apiv1.Pod
+	draSnapshot                   *drasnapshot.Snapshot
+	draEnabled                    bool
+	wantUnneeded                  []string
+	wantUnremovable               []*simulator.UnremovableNode
+	scaleDownUnready              bool
+	ignoreDaemonSetsUtilization   bool
+	scaleDownUtilizationThreshold *float64
 }
 
 func getTestCases(ignoreDaemonSetsUtilization bool, suffix string, now time.Time) []testCase {
@@ -180,15 +181,16 @@ func getTestCases(ignoreDaemonSetsUtilization bool, suffix string, now time.Time
 	}
 
 	if ignoreDaemonSetsUtilization {
-		finalTestCases = append(testCases, testCase{
-			desc:                        "high utilization daemonsets node is filtered out",
-			nodes:                       []*apiv1.Node{regularNode},
-			pods:                        []*apiv1.Pod{smallPod, dsPod},
-			wantUnneeded:                []string{},
-			wantUnremovable:             []*simulator.UnremovableNode{{Node: regularNode, Reason: simulator.NotUnderutilized}},
-			scaleDownUnready:            true,
-			ignoreDaemonSetsUtilization: false,
-		},
+		finalTestCases = append(testCases,
+			testCase{
+				desc:                        "high utilization daemonsets node is filtered out",
+				nodes:                       []*apiv1.Node{regularNode},
+				pods:                        []*apiv1.Pod{smallPod, dsPod},
+				wantUnneeded:                []string{},
+				wantUnremovable:             []*simulator.UnremovableNode{{Node: regularNode, Reason: simulator.NotUnderutilized}},
+				scaleDownUnready:            true,
+				ignoreDaemonSetsUtilization: false,
+			},
 			testCase{
 				desc:                        "high utilization daemonsets node stays",
 				nodes:                       []*apiv1.Node{regularNode},
@@ -197,6 +199,19 @@ func getTestCases(ignoreDaemonSetsUtilization bool, suffix string, now time.Time
 				wantUnremovable:             []*simulator.UnremovableNode{},
 				scaleDownUnready:            true,
 				ignoreDaemonSetsUtilization: true,
+			},
+			testCase{
+				desc:                        "only daemonsets pods on this nodes",
+				nodes:                       []*apiv1.Node{regularNode},
+				pods:                        []*apiv1.Pod{dsPod},
+				wantUnneeded:                []string{"regular"},
+				wantUnremovable:             []*simulator.UnremovableNode{},
+				scaleDownUnready:            true,
+				ignoreDaemonSetsUtilization: true,
+				scaleDownUtilizationThreshold: func() *float64 {
+					threshold := float64(0)
+					return &threshold
+				}(),
 			})
 	}
 
@@ -210,12 +225,16 @@ func TestFilterOutUnremovable(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
+			utilizationThreshold := config.DefaultScaleDownUtilizationThreshold
+			if tc.scaleDownUtilizationThreshold != nil {
+				utilizationThreshold = *tc.scaleDownUtilizationThreshold
+			}
 			options := config.AutoscalingOptions{
 				DynamicResourceAllocationEnabled: tc.draEnabled,
 				UnremovableNodeRecheckTimeout:    5 * time.Minute,
 				ScaleDownUnreadyEnabled:          tc.scaleDownUnready,
 				NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
-					ScaleDownUtilizationThreshold:    config.DefaultScaleDownUtilizationThreshold,
+					ScaleDownUtilizationThreshold:    utilizationThreshold,
 					ScaleDownGpuUtilizationThreshold: config.DefaultScaleDownGpuUtilizationThreshold,
 					ScaleDownUnneededTime:            config.DefaultScaleDownUnneededTime,
 					ScaleDownUnreadyTime:             config.DefaultScaleDownUnreadyTime,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a corner case in scale-down eligibility.

When `--scale-down-utilization-threshold=0` is used together with `--ignore-daemonsets-utilization=true`, nodes that only run DaemonSet pods can end up with utilization == 0. The current logic treats `utilization >= threshold` (0 >= 0) as not underutilized, so the node is not considered for scale down even though it is effectively empty.

This PR changes the comparison from >= to >, so we treat utilization <= threshold as underutilized. That makes the threshold=0 case behave naturally: it effectively means “only empty (utilization 0) nodes can be removed” (ignoring DaemonSet utilization).

A test is added to cover this scenario.

#### Which issue(s) this PR fixes:

Fixes #8707

#### Special notes for your reviewer:

This only changes the equality boundary (utilization == threshold): previously it wouldn’t scale down, now it can.

#### Does this PR introduce a user-facing change?

```release-note
Fix scale-down behavior when both scale-down-utilization-threshold and node utilization are zero, so empty nodes (for example, nodes with only DaemonSet pods) can be scaled down as expected.
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE