### PR TITLE
Remove unused gitlab-registry imagePullSecret from Hetzner example manifest

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/examples/cluster-autoscaler-run-on-master.yaml
+++ b/cluster-autoscaler/cloudprovider/hetzner/examples/cluster-autoscaler-run-on-master.yaml
@@ -183,8 +183,6 @@ spec:
               mountPath: /etc/ssl/certs/ca-certificates.crt
               readOnly: true
           imagePullPolicy: "Always"
-      imagePullSecrets:
-        - name: gitlab-registry
       volumes:
         - name: ssl-certs
           hostPath:


### PR DESCRIPTION
Removes unused `gitlab-registry` imagePullSecret from the Hetzner example manifest.

Fixes https://github.com/kubernetes/autoscaler/issues/8976

```release-note
NONE
```
