### PR TITLE
Add --in-place-skip-disruption-budget flag

### DIFF
--- a/vertical-pod-autoscaler/docs/features.md
+++ b/vertical-pod-autoscaler/docs/features.md
@@ -10,6 +10,8 @@
 - [In-Place Updates (<code>InPlaceOrRecreate</code>)](#in-place-updates-inplaceorrecreate)
   - [Usage](#usage)
   - [Behavior](#behavior)
+  - [Skipping Disruption Budget for Non-Disruptive Updates](#skipping-disruption-budget-for-non-disruptive-updates)
+    - [When Disruption Budgets Are Still Respected](#when-disruption-budgets-are-still-respected)
   - [Requirements:](#requirements)
   - [Configuration](#configuration)
   - [Limitations](#limitations)
@@ -89,7 +91,7 @@ To enable this feature, set the `--round-memory-bytes` flag when running the VPA
 
 ## In-Place Updates (`InPlaceOrRecreate`)
 
-> [!WARNING] 
+> [!WARNING]
 > FEATURE STATE: VPA v1.4.0 [alpha]
 > FEATURE STATE: VPA v1.5.0 [beta]
 
@@ -123,6 +125,19 @@ Important Notes
 
 * Memory Limit Downscaling: In the beta version, memory limit downscaling is not supported for pods with resizePolicy: PreferNoRestart. In such cases, VPA will fall back to pod recreation.
 
+### Skipping Disruption Budget for Non-Disruptive Updates
+
+By default, VPA respects disruption budgets (eviction tolerance, min replicas) even for in-place updates. However, when an in-place update doesn't require container restarts, it's truly non-disruptive and these checks may be unnecessarily restrictive.
+
+The `--in-place-skip-disruption-budget` flag (default: `false`) allows VPA to skip disruption budget checks for in-place updates when all containers in the pod have `NotRequired` resize policy for both CPU and memory or no resize policy is defined.
+
+#### When Disruption Budgets Are Still Respected
+
+Even with this flag enabled, disruption budgets are enforced when:
+* Any container has `RestartContainer` resize policy for any resource
+* The update would result in pod eviction/recreation (fallback scenarios)
+
+
 ### Requirements:
 
 * Kubernetes 1.33+ with `InPlacePodVerticalScaling` feature gate enabled
@@ -134,7 +149,7 @@ Enable the feature by setting the following flags in VPA components ( for both u
 
 ```bash
 --feature-gates=InPlaceOrRecreate=true
-``` 
+```
 
 ### Limitations
 

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -152,6 +152,7 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `eviction-tolerance` | float |  0.5 | Fraction of replica count that can be evicted for update, if more than one pod can be evicted.  |
 | `feature-gates` | mapStringBool |  | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:<br>AllAlpha=true\|false (ALPHA - default=false)<br>AllBeta=true\|false (BETA - default=false)<br>InPlaceOrRecreate=true\|false (BETA - default=true)<br>PerVPAConfig=true\|false (ALPHA - default=false) |
 | `ignored-vpa-object-namespaces` | string |  | A comma-separated list of namespaces to ignore when searching for VPA objects. Leave empty to avoid ignoring any namespaces. These namespaces will not be cleaned by the garbage collector. |
+| `in-place-skip-disruption-budget` |  |  | [ALPHA] If true, VPA updater skips disruption budget checks for in-place pod updates when all containers have NotRequired resize policy (or no policy defined) for both CPU and memory resources. Disruption budgets are still respected when any container has RestartContainer resize policy for any resource. |
 | `in-recommendation-bounds-eviction-lifetime-threshold` |  |  12h0m0s | duration   Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range  |
 | `kube-api-burst` | float |  100 | QPS burst limit when making requests to Kubernetes apiserver  |
 | `kube-api-qps` | float |  50 | QPS limit when making requests to Kubernetes apiserver  |
@@ -180,4 +181,3 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `v,` |  | : 4 | , --v Level                                                         set the log level verbosity  (default 4) |
 | `vmodule` | moduleSpec |  | comma-separated list of pattern=N settings for file-filtered logging |
 | `vpa-object-namespace` | string |  | Specifies the namespace to search for VPA objects. Leave empty to include all namespaces. If provided, the garbage collector will only clean this namespace. |
-

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -93,6 +93,7 @@ func NewUpdater(
 	evictionRateBurst int,
 	evictionToleranceFraction float64,
 	useAdmissionControllerStatus bool,
+	inPlaceSkipDisruptionBudget bool,
 	statusNamespace string,
 	recommendationProcessor vpa_api_util.RecommendationProcessor,
 	evictionAdmission priority.PodEvictionAdmission,
@@ -111,6 +112,7 @@ func NewUpdater(
 		minReplicasForEviction,
 		evictionToleranceFraction,
 		patchCalculators,
+		inPlaceSkipDisruptionBudget,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create restriction factory: %v", err)

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -75,6 +75,13 @@ var (
 	useAdmissionControllerStatus = flag.Bool("use-admission-controller-status", true,
 		"If true, updater will only evict pods when admission controller status is valid.")
 
+	inPlaceSkipDisruptionBudget = flag.Bool(
+		"in-place-skip-disruption-budget",
+		false,
+		"[ALPHA] If true, VPA updater skips disruption budget checks for in-place pod updates when all containers have NotRequired resize policy (or no policy defined) for both CPU and memory resources. "+
+			"Disruption budgets are still respected when any container has RestartContainer resize policy for any resource.",
+	)
+
 	namespace = os.Getenv("NAMESPACE")
 )
 
@@ -217,6 +224,7 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		*evictionRateBurst,
 		*evictionToleranceFraction,
 		*useAdmissionControllerStatus,
+		*inPlaceSkipDisruptionBudget,
 		admissionControllerStatusNamespace,
 		vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator),
 		priority.NewScalingDirectionPodEvictionAdmission(),

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
@@ -192,7 +192,7 @@ func TestCanInPlaceUpdate(t *testing.T) {
 			clock := baseclocktest.NewFakeClock(time.UnixMilli(3600001)) // 1 hour from epoch + 1 millis
 			lipatm := map[string]time.Time{getPodID(selectedPod): tc.lastInPlaceAttempt}
 
-			factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tc.evictionTolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc())
+			factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tc.evictionTolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
 			assert.NoError(t, err)
 			creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(tc.pods, getIPORVpa())
 			assert.NoError(t, err)
@@ -230,7 +230,7 @@ func TestInPlaceDisabledFeatureGate(t *testing.T) {
 	}
 
 	basicVpa := getBasicVpa()
-	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc())
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc(), false)
 	assert.NoError(t, err)
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
 	assert.NoError(t, err)
@@ -270,7 +270,7 @@ func TestInPlaceTooFewReplicas(t *testing.T) {
 	lipatm := map[string]time.Time{}
 
 	basicVpa := getIPORVpa()
-	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 10 /*minReplicas*/, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc())
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 10 /*minReplicas*/, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
 	assert.NoError(t, err)
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
 	assert.NoError(t, err)
@@ -315,7 +315,7 @@ func TestEvictionToleranceForInPlace(t *testing.T) {
 	lipatm := map[string]time.Time{}
 
 	basicVpa := getIPORVpa()
-	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2 /*minReplicas*/, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc())
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2 /*minReplicas*/, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
 	assert.NoError(t, err)
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
 	assert.NoError(t, err)
@@ -332,6 +332,206 @@ func TestEvictionToleranceForInPlace(t *testing.T) {
 	for _, pod := range pods[4:] {
 		err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
 		assert.Error(t, err, "Error expected")
+	}
+}
+
+func TestEvictionToleranceForInPlaceWithSkipDisruptionBudget(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(
+		t,
+		features.MutableFeatureGate,
+		features.InPlaceOrRecreate,
+		true,
+	)
+
+	replicas := int32(5)
+	livePods := 5
+	tolerance := 0.8
+
+	rc := apiv1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ReplicationController",
+		},
+		Spec: apiv1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	pods := make([]*apiv1.Pod, livePods)
+	for i := range pods {
+		pods[i] = test.Pod().
+			WithName(getTestPodName(i)).
+			WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+			Get()
+	}
+
+	clock := baseclocktest.NewFakeClock(time.Time{})
+	lipatm := map[string]time.Time{}
+
+	basicVpa := getIPORVpa()
+	// inPlaceSkipDisruptionBudget = true
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2 /* minReplicas */, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), true /*inPlaceSkipDisruptionBudget*/)
+	assert.NoError(t, err)
+
+	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
+	assert.NoError(t, err)
+
+	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+	// All in-place updates should be approved
+	for _, pod := range pods {
+		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod))
+	}
+
+	// And all updates should succeed without being blocked by eviction tolerance
+	for _, pod := range pods {
+		err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
+		assert.NoError(t, err)
+	}
+}
+
+func TestInPlaceSkipDisruptionBudgetWithResizePolicy(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlaceOrRecreate, true)
+
+	replicas := int32(5)
+	livePods := 5
+	tolerance := 0.1 // Very low tolerance - would normally block most updates
+
+	rc := apiv1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ReplicationController",
+		},
+		Spec: apiv1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	testCases := []struct {
+		name                        string
+		podBuilder                  test.PodBuilder
+		inPlaceSkipDisruptionBudget bool
+		expectedUpdateSuccesses     int
+	}{
+		{
+			name: "NotRequired policy with flag enabled - should skip disruption budget",
+			podBuilder: test.Pod().WithCreator(&rc.ObjectMeta, &rc.TypeMeta).AddContainer(
+				test.Container().WithName("container1").WithContainerResizePolicy([]apiv1.ContainerResizePolicy{
+					{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+					{ResourceName: apiv1.ResourceMemory, RestartPolicy: apiv1.NotRequired},
+				}).Get()),
+			inPlaceSkipDisruptionBudget: true,
+			expectedUpdateSuccesses:     5,
+		},
+		{
+			name: "RestartContainer policy with flag enabled - should respect disruption budget",
+			podBuilder: test.Pod().WithCreator(&rc.ObjectMeta, &rc.TypeMeta).AddContainer(
+				test.Container().WithName("container1").WithContainerResizePolicy([]apiv1.ContainerResizePolicy{
+					{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+					{ResourceName: apiv1.ResourceMemory, RestartPolicy: apiv1.NotRequired},
+				}).Get()),
+			inPlaceSkipDisruptionBudget: false,
+			expectedUpdateSuccesses:     1, // Still respects budget because of RestartContainer
+		},
+		{
+			name: "Only RestartContainer policy with flag enabled - should respect disruption budget",
+			podBuilder: test.Pod().WithCreator(&rc.ObjectMeta, &rc.TypeMeta).AddContainer(
+				test.Container().WithName("container1").WithContainerResizePolicy([]apiv1.ContainerResizePolicy{
+					{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.RestartContainer},
+				}).Get()),
+			inPlaceSkipDisruptionBudget: true,
+			expectedUpdateSuccesses:     1,
+		},
+		{
+			name:                        "No resize policy with flag enabled - should skip disruption budget (K8s default is NotRequired)",
+			podBuilder:                  test.Pod().WithCreator(&rc.ObjectMeta, &rc.TypeMeta).AddContainer(test.Container().WithName("container1").Get()),
+			inPlaceSkipDisruptionBudget: true,
+			expectedUpdateSuccesses:     5,
+		},
+		{
+			name:                        "No resize policy with flag disabled - should respect disruption budget",
+			podBuilder:                  test.Pod().WithCreator(&rc.ObjectMeta, &rc.TypeMeta).AddContainer(test.Container().WithName("container1").Get()),
+			inPlaceSkipDisruptionBudget: false,
+			expectedUpdateSuccesses:     1,
+		},
+		{
+			name: "Multiple containers - all NotRequired - should skip disruption budget",
+			podBuilder: test.Pod().WithCreator(&rc.ObjectMeta, &rc.TypeMeta).AddContainer(
+				test.Container().WithName("container1").WithContainerResizePolicy([]apiv1.ContainerResizePolicy{
+					{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+					{ResourceName: apiv1.ResourceMemory, RestartPolicy: apiv1.NotRequired},
+				}).Get(),
+			).AddContainer(
+				test.Container().WithName("container2").WithContainerResizePolicy([]apiv1.ContainerResizePolicy{
+					{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+					{ResourceName: apiv1.ResourceMemory, RestartPolicy: apiv1.NotRequired},
+				}).Get()),
+			inPlaceSkipDisruptionBudget: true,
+			expectedUpdateSuccesses:     5,
+		},
+		{
+			name: "Multiple containers - one NotRequired, one RestartContainer - should respect disruption budget",
+			podBuilder: test.Pod().WithCreator(&rc.ObjectMeta, &rc.TypeMeta).AddContainer(
+				test.Container().WithName("container1").WithContainerResizePolicy([]apiv1.ContainerResizePolicy{
+					{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+					{ResourceName: apiv1.ResourceMemory, RestartPolicy: apiv1.NotRequired},
+				}).Get(),
+			).AddContainer(
+				test.Container().WithName("container2").WithContainerResizePolicy([]apiv1.ContainerResizePolicy{
+					{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.RestartContainer},
+					{ResourceName: apiv1.ResourceMemory, RestartPolicy: apiv1.RestartContainer},
+				}).Get()),
+			inPlaceSkipDisruptionBudget: true,
+			expectedUpdateSuccesses:     1, // Respects budget because container2 has RestartContainer
+		},
+		{
+			name: "Multiple containers - one with policy, one without - should skip disruption budget",
+			podBuilder: test.Pod().WithCreator(&rc.ObjectMeta, &rc.TypeMeta).AddContainer(
+				test.Container().WithName("container1").WithContainerResizePolicy([]apiv1.ContainerResizePolicy{
+					{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+				}).Get(),
+			).AddContainer(
+				test.Container().WithName("container2").Get()),
+			inPlaceSkipDisruptionBudget: true,
+			expectedUpdateSuccesses:     5,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pods := make([]*apiv1.Pod, livePods)
+			for index := range livePods {
+				pods[index] = tc.podBuilder.WithName(getTestPodName(index)).Get()
+			}
+
+			clock := baseclocktest.NewFakeClock(time.Time{})
+			lipatm := map[string]time.Time{}
+
+			basicVpa := getIPORVpa()
+			factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), tc.inPlaceSkipDisruptionBudget)
+			assert.NoError(t, err)
+
+			creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
+			assert.NoError(t, err)
+
+			inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+			successCount := 0
+			for _, pod := range pods {
+				err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
+				if err == nil {
+					successCount++
+				}
+			}
+			assert.Equal(t, tc.expectedUpdateSuccesses, successCount,
+				"Expected %d successful updates but got %d", tc.expectedUpdateSuccesses, successCount)
+		})
 	}
 }
 
@@ -361,7 +561,7 @@ func TestInPlaceAtLeastOne(t *testing.T) {
 	}
 
 	basicVpa := getBasicVpa()
-	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc())
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc(), false)
 	assert.NoError(t, err)
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
 	assert.NoError(t, err)
@@ -407,7 +607,7 @@ func TestInPlaceUpdate_EventEmission(t *testing.T) {
 	}
 
 	basicVpa := getBasicVpa()
-	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc())
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, nil, nil, GetFakeCalculatorsWithFakeResourceCalc(), false)
 	assert.NoError(t, err)
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
 	assert.NoError(t, err)

--- a/vertical-pod-autoscaler/pkg/updater/utils/pod.go
+++ b/vertical-pod-autoscaler/pkg/updater/utils/pod.go
@@ -1,0 +1,48 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// GetPodCondition will get Pod's condition.
+func GetPodCondition(pod *apiv1.Pod, conditionType apiv1.PodConditionType) (apiv1.PodCondition, bool) {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == conditionType {
+			return cond, true
+		}
+	}
+	return apiv1.PodCondition{}, false
+}
+
+// IsNonDisruptiveResize checks if all containers in the pod have NotRequired
+// resize policy for the resources being resized. If any container requires
+// restart for any resource, returns false.
+func IsNonDisruptiveResize(pod *apiv1.Pod) bool {
+	for _, container := range pod.Spec.Containers {
+		for _, policy := range container.ResizePolicy {
+			// If any resource has RestartContainer policy, it's disruptive
+			if policy.RestartPolicy == apiv1.RestartContainer {
+				return false
+			}
+		}
+	}
+	// TODO(omerap12): do we want to check here for InitContainers/InitContainers+restartPolicy Always/
+	// Also check init containers if they can be resized
+	return true
+}

--- a/vertical-pod-autoscaler/pkg/updater/utils/pod_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/utils/pod_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func TestIsNonDisruptiveResize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pod      *apiv1.Pod
+		expected bool
+	}{
+		{
+			name: "No resize policy - defaults to NotRequired",
+			pod: &apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "container1"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "All NotRequired",
+			pod: &apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name: "container1",
+							ResizePolicy: []apiv1.ContainerResizePolicy{
+								{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+								{ResourceName: apiv1.ResourceMemory, RestartPolicy: apiv1.NotRequired},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "One RestartContainer",
+			pod: &apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name: "container1",
+							ResizePolicy: []apiv1.ContainerResizePolicy{
+								{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+								{ResourceName: apiv1.ResourceMemory, RestartPolicy: apiv1.RestartContainer},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Multiple containers - one with RestartContainer",
+			pod: &apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name: "container1",
+							ResizePolicy: []apiv1.ContainerResizePolicy{
+								{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+							},
+						},
+						{
+							Name: "container2",
+							ResizePolicy: []apiv1.ContainerResizePolicy{
+								{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.RestartContainer},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Multiple containers - all NotRequired",
+			pod: &apiv1.Pod{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name: "container1",
+							ResizePolicy: []apiv1.ContainerResizePolicy{
+								{ResourceName: apiv1.ResourceCPU, RestartPolicy: apiv1.NotRequired},
+							},
+						},
+						{
+							Name: "container2",
+							ResizePolicy: []apiv1.ContainerResizePolicy{
+								{ResourceName: apiv1.ResourceMemory, RestartPolicy: apiv1.NotRequired},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsNonDisruptiveResize(tc.pod)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/updater/utils/types.go
+++ b/vertical-pod-autoscaler/pkg/updater/utils/types.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package utils
 
-import (
-	apiv1 "k8s.io/api/core/v1"
-)
-
 // InPlaceDecision is the type of decision that can be made for a pod.
 type InPlaceDecision string
 
@@ -31,13 +27,3 @@ const (
 	// InPlaceEvict means we will attempt to evict the pod.
 	InPlaceEvict InPlaceDecision = "InPlaceEvict"
 )
-
-// GetPodCondition will get Pod's condition.
-func GetPodCondition(pod *apiv1.Pod, conditionType apiv1.PodConditionType) (apiv1.PodCondition, bool) {
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == conditionType {
-			return cond, true
-		}
-	}
-	return apiv1.PodCondition{}, false
-}

--- a/vertical-pod-autoscaler/pkg/utils/test/test_container.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_container.go
@@ -22,11 +22,12 @@ import (
 )
 
 type containerBuilder struct {
-	name       string
-	cpuRequest *resource.Quantity
-	memRequest *resource.Quantity
-	cpuLimit   *resource.Quantity
-	memLimit   *resource.Quantity
+	name         string
+	cpuRequest   *resource.Quantity
+	memRequest   *resource.Quantity
+	cpuLimit     *resource.Quantity
+	memLimit     *resource.Quantity
+	resizePolicy []apiv1.ContainerResizePolicy
 }
 
 // Container returns object that helps build containers for tests.
@@ -64,6 +65,12 @@ func (cb *containerBuilder) WithMemLimit(memLimit resource.Quantity) *containerB
 	return &r
 }
 
+func (cb *containerBuilder) WithContainerResizePolicy(resizePolicy []apiv1.ContainerResizePolicy) *containerBuilder {
+	r := *cb
+	r.resizePolicy = resizePolicy
+	return &r
+}
+
 func (cb *containerBuilder) Get() apiv1.Container {
 	container := apiv1.Container{
 		Name: cb.name,
@@ -83,6 +90,9 @@ func (cb *containerBuilder) Get() apiv1.Container {
 	}
 	if cb.memLimit != nil {
 		container.Resources.Limits[apiv1.ResourceMemory] = *cb.memLimit
+	}
+	if cb.resizePolicy != nil {
+		container.ResizePolicy = cb.resizePolicy
 	}
 	return container
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds `--in-place-skip-disruption-budget` flag that skips disruption budget checks for in-place pod updates when all containers have NotRequired resize policy. This allows non-disruptive in-place updates to proceed without being throttled by eviction tolerance, while still respecting disruption budgets for RestartContainer resize policy.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8980 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds --in-place-skip-disruption-budget flag that skips disruption budget checks for in-place pod updates when all containers have NotRequired resize policy
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
