### PR TITLE
Exclude VPA from deprecated golint since it uses golangci-lint

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -37,6 +37,7 @@ excluded_packages=(
   'cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud-sdk-go'
   'cluster-autoscaler/cloudprovider/volcengine/volc-sdk-golang'
   'cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk'
+  'vertical-pod-autoscaler'
 )
 
 FIND_PACKAGES='go list ./... 2> /dev/null'


### PR DESCRIPTION
Fixes #8986

## Changes
- Add VPA to excluded packages in hack/verify-golint.sh
- VPA already uses golangci-lint with its own .golangci.yaml config

## Rationale
VPA component has migrated to golangci-lint. Excluding VPA from the deprecated golint script avoids redundant linting with the deprecated tool.