### PR TITLE
Fix helm chart github actions

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -56,6 +56,7 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: vertical-pod-autoscaler/charts
+          skip_existing: true
 name: Release Charts
 on:
   push:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,13 +35,15 @@ jobs:
         run: git fetch --prune --unshallow
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
-      - name: Run chart-testing (lint)
-        run: ct lint --chart-dirs cluster-autoscaler/charts vertical-pod-autoscaler/charts --target-branch ${{ github.event.pull_request.base.ref }}
+      - name: Run chart-testing for CA (lint)
+        run: ct lint --chart-dirs cluster-autoscaler/charts --target-branch ${{ github.event.pull_request.base.ref }}
+      - name: Run chart-testing for VPA (lint)
+        run: ct lint --chart-dirs vertical-pod-autoscaler/charts --target-branch ${{ github.event.pull_request.base.ref }} --check-version-increment=false
       # Only build a kind cluster if there are chart changes to test.
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --chart-dirs cluster-autoscaler/charts vertical-pod-autoscaler/charts --target-branch ${{ github.event.pull_request.base.ref }})
+          changed=$(ct list-changed --chart-dirs cluster-autoscaler/charts,vertical-pod-autoscaler/charts --target-branch ${{ github.event.pull_request.base.ref }})
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
@@ -50,7 +52,7 @@ jobs:
         uses: helm/kind-action@v1.12.0
       - if: steps.list-changed.outputs.changed == 'true'
         name: Run chart-testing (install)
-        run: ct install --chart-dirs cluster-autoscaler/charts vertical-pod-autoscaler/charts --target-branch ${{ github.event.pull_request.base.ref }}
+        run: ct install --chart-dirs cluster-autoscaler/charts,vertical-pod-autoscaler/charts --target-branch ${{ github.event.pull_request.base.ref }}
   helm-docs-validate:
     if: ${{ needs.changes.outputs.charts == 'true' }}
     name: Helm Docs


### PR DESCRIPTION

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

1. Add `--check-version-increment=false` to VPA linting - we don't require a release on every change
2. Fix use of `--chart-dirs` in `ct`, it requires a comma separated list
3. Add `skip_existing` to VPA release - we don't require a release on every change, if the tag exists, the job shouldn't fail

Some context: https://github.com/kubernetes/autoscaler/pull/8600#discussion_r2400136177

Also, master is currently failing:
https://github.com/kubernetes/autoscaler/actions/runs/20692530866/job/59402663740
And chart-testing is failing silently: https://github.com/kubernetes/autoscaler/actions/runs/20614954935/job/59205842965

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @jackfrancis @omerap12 
