### PR TITLE
Enable revive in VPA

### DIFF
--- a/vertical-pod-autoscaler/.golangci.yaml
+++ b/vertical-pod-autoscaler/.golangci.yaml
@@ -2,12 +2,17 @@ version: "2"
 linters:
   enable:
     - forbidigo
+    - revive
   settings:
     forbidigo:
       forbid:
         # Forbid use of archived package "github.com/pkg/errors". Context: https://github.com/kubernetes/autoscaler/pull/7845
         - pkg: github.com/pkg/errors
       analyze-types: true
+    revive:
+      enable-all-rules: false # Disabling all rules for now and enabling each one later
+      rules:
+        - name: increment-decrement
 formatters:
   enable:
     - goimports

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_cache_storage.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_cache_storage.go
@@ -139,7 +139,7 @@ func (cc *controllerCacheStorage) RemoveExpired() {
 	removed := 0
 	for k, v := range cc.cache {
 		if now.After(v.deleteAfter) {
-			removed += 1
+			removed++
 			delete(cc.cache, k)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:
Enables revive linter instead of using deprecated golint for VPA.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Updates #8986 

#### Special notes for your reviewer:
Currently enabling revive by disabling all the rules and enabling only `increment-decrement` rule for now (for starter). Will be enabling further rules in subsequent PRs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
