### PR TITLE
feat(cluster-autoscaler): add per-nodegroup unfulfilled node count metric

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -390,6 +390,7 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, nodeInfosForGr
 	csr.updateUnregisteredNodes(notRegistered)
 	csr.updateCloudProviderDeletedNodes(cloudProviderNodesRemoved)
 	csr.updateReadinessStats(currentTime)
+	csr.updateUnfulfilledNodeCountMetrics(targetSizes)
 
 	// update acceptable ranges based on requests from last loop and targetSizes
 	// updateScaleRequests relies on acceptableRanges being up to date
@@ -533,6 +534,30 @@ func (csr *ClusterStateRegistry) areThereUpcomingNodesInNodeGroup(nodeGroupName 
 		return false
 	}
 	return target > provisioned
+}
+
+func (csr *ClusterStateRegistry) updateUnfulfilledNodeCountMetrics(targetSizes map[string]int) {
+	unfulfilledNodeCount := csr.getUnfulfilledNodeCount(targetSizes)
+	metrics.UpdateNodeGroupUnfulfilledNodeCount(unfulfilledNodeCount)
+}
+
+func (csr *ClusterStateRegistry) getUnfulfilledNodeCount(targetSizes map[string]int) map[string]int {
+	result := make(map[string]int, len(targetSizes))
+	for ng, target := range targetSizes {
+		readiness, found := csr.perNodeGroupReadiness[ng]
+		actual := 0
+		if found {
+			actual = len(readiness.Registered) - len(readiness.Deleted)
+		}
+		unfulfilled := target - actual
+		if unfulfilled < 0 {
+			klog.Warningf("node group %s: registered (%d) > target (%d), %d cloud-deleted; unfulfilled=0 (possible sync delay)", ng, len(readiness.Registered), target, len(readiness.Deleted))
+			unfulfilled = 0
+		}
+		result[ng] = unfulfilled
+	}
+
+	return result
 }
 
 // IsNodeGroupRegistered returns true if the node group is registered in cluster state.

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -1706,6 +1706,66 @@ func TestHandleInstanceCreationErrors(t *testing.T) {
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 2)
 }
 
+func TestGetUnfulfilledNodeCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    map[string]int
+		readiness map[string]Readiness
+		want      map[string]int
+	}{
+		{
+			name:      "readiness missing -> actual 0",
+			target:    map[string]int{"ng1": 2},
+			readiness: map[string]Readiness{},
+			want:      map[string]int{"ng1": 2},
+		},
+		{
+			name:   "normal case registered",
+			target: map[string]int{"ng1": 10},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 10), Deleted: make([]string, 0)},
+			},
+			want: map[string]int{"ng1": 0},
+		},
+		{
+			name:   "normal case registered minus deleted",
+			target: map[string]int{"ng1": 9},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 10), Deleted: make([]string, 1)},
+			},
+			want: map[string]int{"ng1": 0},
+		},
+		{
+			name:   "negative unfulfilled clamped to 0",
+			target: map[string]int{"ng1": 5},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 10), Deleted: make([]string, 0)},
+			},
+			want: map[string]int{"ng1": 0},
+		},
+		{
+			name:   "multiple node groups mixed",
+			target: map[string]int{"ng1": 10, "ng2": 5, "ng3": 0},
+			readiness: map[string]Readiness{
+				"ng1": {Registered: make([]string, 9), Deleted: make([]string, 0)},
+				"ng2": {Registered: make([]string, 2), Deleted: make([]string, 0)},
+				"ng3": {Registered: make([]string, 0), Deleted: make([]string, 0)},
+			},
+			want: map[string]int{"ng1": 1, "ng2": 3, "ng3": 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			csr := &ClusterStateRegistry{
+				perNodeGroupReadiness: tt.readiness,
+			}
+			got := csr.getUnfulfilledNodeCount(tt.target)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 type mockMetrics struct {
 	mock.Mock
 }

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -257,3 +257,8 @@ func UpdateScaleDownNodeRemovalLatency(deleted bool, duration time.Duration) {
 func ObserveMaxNodeSkipEvalDurationSeconds(duration time.Duration) {
 	DefaultMetrics.ObserveMaxNodeSkipEvalDurationSeconds(duration)
 }
+
+// UpdateNodeGroupUnfulfilledNodeCount records the number of nodes that are not yet fulfilled by the node group.
+func UpdateNodeGroupUnfulfilledNodeCount(unfulfilledNodeCount map[string]int) {
+	DefaultMetrics.UpdateNodeGroupUnfulfilledNodeCount(unfulfilledNodeCount)
+}

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -123,20 +123,21 @@ const (
 type caMetrics struct {
 	registry metrics.KubeRegistry
 
-	clusterSafeToAutoscale *k8smetrics.Gauge
-	nodesCount             *k8smetrics.GaugeVec
-	nodeGroupsCount        *k8smetrics.GaugeVec
-	unschedulablePodsCount *k8smetrics.GaugeVec
-	maxNodesCount          *k8smetrics.Gauge
-	cpuCurrentCores        *k8smetrics.Gauge
-	cpuLimitsCores         *k8smetrics.GaugeVec
-	memoryCurrentBytes     *k8smetrics.Gauge
-	memoryLimitsBytes      *k8smetrics.GaugeVec
-	nodesGroupMinNodes     *k8smetrics.GaugeVec
-	nodesGroupMaxNodes     *k8smetrics.GaugeVec
-	nodesGroupTargetSize   *k8smetrics.GaugeVec
-	nodesGroupHealthiness  *k8smetrics.GaugeVec
-	nodeGroupBackOffStatus *k8smetrics.GaugeVec
+	clusterSafeToAutoscale         *k8smetrics.Gauge
+	nodesCount                     *k8smetrics.GaugeVec
+	nodeGroupsCount                *k8smetrics.GaugeVec
+	unschedulablePodsCount         *k8smetrics.GaugeVec
+	maxNodesCount                  *k8smetrics.Gauge
+	cpuCurrentCores                *k8smetrics.Gauge
+	cpuLimitsCores                 *k8smetrics.GaugeVec
+	memoryCurrentBytes             *k8smetrics.Gauge
+	memoryLimitsBytes              *k8smetrics.GaugeVec
+	nodesGroupMinNodes             *k8smetrics.GaugeVec
+	nodesGroupMaxNodes             *k8smetrics.GaugeVec
+	nodesGroupTargetSize           *k8smetrics.GaugeVec
+	nodesGroupUnfulfilledNodeCount *k8smetrics.GaugeVec
+	nodesGroupHealthiness          *k8smetrics.GaugeVec
+	nodeGroupBackOffStatus         *k8smetrics.GaugeVec
 
 	// Metrics related to autoscaler execution
 	lastActivity            *k8smetrics.GaugeVec
@@ -266,6 +267,14 @@ func newCaMetrics() *caMetrics {
 				Namespace: caNamespace,
 				Name:      "node_group_target_count",
 				Help:      "Target number of nodes in the node group by CA.",
+			}, []string{"node_group"},
+		),
+
+		nodesGroupUnfulfilledNodeCount: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Namespace: caNamespace,
+				Name:      "node_group_unfulfilled_node_count",
+				Help:      "Difference between node group target size and number of K8S registered nodes excluding deleted nodes(in k8s but not in cloud provider)",
 			}, []string{"node_group"},
 		),
 
@@ -556,6 +565,7 @@ func (m *caMetrics) RegisterAll(emitPerNodeGroupMetrics bool) {
 		m.mustRegister(m.nodesGroupMinNodes)
 		m.mustRegister(m.nodesGroupMaxNodes)
 		m.mustRegister(m.nodesGroupTargetSize)
+		m.mustRegister(m.nodesGroupUnfulfilledNodeCount)
 		m.mustRegister(m.nodesGroupHealthiness)
 		m.mustRegister(m.nodeGroupBackOffStatus)
 	}
@@ -680,6 +690,13 @@ func (m *caMetrics) UpdateNodeGroupMax(nodeGroup string, maxNodes int) {
 func (m *caMetrics) UpdateNodeGroupTargetSize(targetSizes map[string]int) {
 	for nodeGroup, targetSize := range targetSizes {
 		m.nodesGroupTargetSize.WithLabelValues(nodeGroup).Set(float64(targetSize))
+	}
+}
+
+// UpdateNodeGroupUnfulfilledNodeCount records the node group unfulfilled node count
+func (m *caMetrics) UpdateNodeGroupUnfulfilledNodeCount(unfulfilledNodeCount map[string]int) {
+	for nodeGroup, count := range unfulfilledNodeCount {
+		m.nodesGroupUnfulfilledNodeCount.WithLabelValues(nodeGroup).Set(float64(count))
 	}
 }
 

--- a/cluster-autoscaler/proposals/metrics.md
+++ b/cluster-autoscaler/proposals/metrics.md
@@ -21,17 +21,18 @@ All the metrics are prefixed with `cluster_autoscaler_`.
 
 ### Cluster state
 
-| Metric name | Metric type | Labels | Description |
-| ----------- | ----------- | ------ | ----------- |
-| cluster_safe_to_autoscale | Gauge | | Whether or not cluster is healthy enough for autoscaling. 1 if it is, 0 otherwise. |
-| nodes_count | Gauge | `state`=&lt;node-state&gt; | Number of nodes in cluster. |
-| unschedulable_pods_count | Gauge | | Number of unschedulable ("Pending") pods in the cluster. |
-| node_groups_count | Gauge | `node_group_type`=&lt;node-group-type&gt; | Number of node groups managed by CA. |
-| max_nodes_count | Gauge | | Maximum number of nodes in all node groups. |
-| cluster_cpu_current_cores | Gauge | | | Current number of cores in the cluster, minus deleting nodes. |
-| cpu_limits_cores | Gauge | `direction`=&lt;`minimum` or `maximum`&gt; | Minimum and maximum number of cores in the cluster. |
-| cluster_memory_current_bytes | Gauge | | Current number of bytes of memory in the cluster, minus deleting nodes. |
-| memory_limits_bytes | Gauge | `direction`=&lt;`minimum` or `maximum`&gt; | Minimum and maximum number of bytes of memory in cluster. |
+| Metric name | Metric type | Labels                                     | Description                                                                                                                            |
+| ----------- | ----------- |--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| cluster_safe_to_autoscale | Gauge |                                            | Whether or not cluster is healthy enough for autoscaling. 1 if it is, 0 otherwise.                                                     |
+| nodes_count | Gauge | `state`=&lt;node-state&gt;                 | Number of nodes in cluster.                                                                                                            |
+| unschedulable_pods_count | Gauge |                                            | Number of unschedulable ("Pending") pods in the cluster.                                                                               |
+| node_groups_count | Gauge | `node_group_type`=&lt;node-group-type&gt;  | Number of node groups managed by CA.                                                                                                   |
+| node_group_unfulfilled_node_count | Gauge | `node_group`=&lt;node-group&gt;                                            | Difference between node group target size and number of K8S registered nodes excluding deleted nodes(in k8s but not in cloud provider) |
+| max_nodes_count | Gauge |                                            | Maximum number of nodes in all node groups.                                                                                            |
+| cluster_cpu_current_cores | Gauge |                                            |                                                                                                                                        | Current number of cores in the cluster, minus deleting nodes. |
+| cpu_limits_cores | Gauge | `direction`=&lt;`minimum` or `maximum`&gt; | Minimum and maximum number of cores in the cluster.                                                                                    |
+| cluster_memory_current_bytes | Gauge |                                            | Current number of bytes of memory in the cluster, minus deleting nodes.                                                                |
+| memory_limits_bytes | Gauge | `direction`=&lt;`minimum` or `maximum`&gt; | Minimum and maximum number of bytes of memory in cluster.                                                                              |
 
 * `cluster_safe_to_autoscale` indicates whether cluster is healthy enough for autoscaling. CA stops all operations if significant number of nodes are unready (by default 33% as of CA 0.5.4).
 * `nodes_count` records the total number of nodes, labeled by node state. Possible
@@ -138,4 +139,3 @@ feature.
 | nap_enabled | Gauge | | Whether or not Node Autoprovisioning is enabled. 1 if it is, 0 otherwise. |
 | created_node_groups_total | Counter | | Number of node groups created by Node Autoprovisioning. |
 | deleted_node_groups_total | Counter | | Number of node groups deleted by Node Autoprovisioning. |
-


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
This PR adds a new per-nodegroup metric to quantify the gap between the cloud provider’s node group target size and the number of nodes currently registered in k8s (excluding nodes that have been detected as deleted on the cloud provider side but are still present in the API).

In practice, operators frequently need visibility into “how many nodes are still missing” relative to the node group’s target, even when individual nodes may be transiently unready or in startup. This metric provides a direct signal for supply shortfall (or reconciliation skew) at the node-group level and improves observability when diagnosing scale-up progress and provisioning lag.

Specifically, the metric is computed as:
- unfulfilled = targetSize - (registered - deleted)
- Negative values are clamped to 0.

The metric is updated after readiness stats are refreshed in each UpdateNodes() loop.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/7953

#### Special notes for your reviewer:
- Metric name: cluster_autoscaler_node_group_unfulfilled_node_count (gauge, labeled by node_group)
- Semantics:
  - targetSize is the cloud provider node group target size.
  - registered is the number of nodes registered in Kubernetes for the node group.
  - deleted is the subset of registered nodes that are considered removed on the cloud provider side (cloud-provider-deleted, but still present in K8S).
  - The value is clamped to >= 0 to avoid confusing negatives in dashboards/alerts.
  - Unit tests were added for getUnfulfilledNodeCount().

#### Does this PR introduce a user-facing change?
```release-note
Added a new metric `cluster_autoscaler_node_group_unfulfilled_node_count` reporting the per-node-group gap between cloud provider target size and k8s registered nodes (excluding nodes detected as deleted on the cloud provider side).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
