### PR TITLE
Initialize sharedCSIManager in scheduler framework

### DIFF
--- a/cluster-autoscaler/simulator/framework/handle.go
+++ b/cluster-autoscaler/simulator/framework/handle.go
@@ -26,6 +26,7 @@ import (
 	schedulerconfiglatest "k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 	schedulerplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits"
 	schedulerframeworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	schedulermetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
 )
@@ -54,9 +55,11 @@ func NewHandle(informerFactory informers.SharedInformerFactory, schedConfig *sch
 	}
 
 	sharedLister := NewDelegatingSchedulerSharedLister()
+	sharedCSIManager := nodevolumelimits.NewCSIManager(informerFactory.Storage().V1().CSINodes().Lister())
 	opts := []schedulerframeworkruntime.Option{
 		schedulerframeworkruntime.WithInformerFactory(informerFactory),
 		schedulerframeworkruntime.WithSnapshotSharedLister(sharedLister),
+		schedulerframeworkruntime.WithSharedCSIManager(sharedCSIManager),
 	}
 	if draEnabled {
 		opts = append(opts, schedulerframeworkruntime.WithSharedDRAManager(sharedLister))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Currently sharedCSIManager is not initialized which causes panic when CA processes pods with PersistentVolumeClaims.

This change creates a sharedCSIManager in the same way it's done in kubernetes, and sets it on the scheduler framework runtime.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

