### PR TITLE
[VPA][Revive] Enable multiple rules - 1

### DIFF
--- a/vertical-pod-autoscaler/.golangci.yaml
+++ b/vertical-pod-autoscaler/.golangci.yaml
@@ -13,6 +13,15 @@ linters:
       enable-all-rules: false # Disabling all rules for now and enabling each one later
       rules:
         - name: increment-decrement
+        - name: bare-return
+        - name: indent-error-flow
+        - name: useless-fallthrough
+
+        # Below lists the rules disabled
+        - name: argument-limit
+          disabled: true
+        - name: unsecure-url-scheme
+          disabled: true
 formatters:
   enable:
     - goimports

--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -55,9 +55,7 @@ func configTLS(cfg certsConfig, minTlsVersion, ciphers string, stop <-chan struc
 	}
 
 	switch minTlsVersion {
-	case "":
-		fallthrough
-	case "tls1_2":
+	case "", "tls1_2":
 		tlsVersion = tls.VersionTLS12
 	case "tls1_3":
 		tlsVersion = tls.VersionTLS13

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -163,7 +163,20 @@ func main() {
 	ignoredNamespaces := strings.Split(commonFlags.IgnoredVpaObjectNamespaces, ",")
 	go func() {
 		if *registerWebhook {
-			selfRegistration(kubeClient, readFile(*certsConfiguration.clientCaFile), webHookDelay, namespace, *serviceName, url, *registerByURL, int32(*webhookTimeout), commonFlags.VpaObjectNamespace, ignoredNamespaces, *webHookFailurePolicy, *webhookLabels)
+			selfRegistration(
+				kubeClient,
+				readFile(*certsConfiguration.clientCaFile),
+				webHookDelay,
+				namespace,
+				*serviceName,
+				url,
+				*registerByURL,
+				int32(*webhookTimeout),
+				commonFlags.VpaObjectNamespace,
+				ignoredNamespaces,
+				*webHookFailurePolicy,
+				*webhookLabels,
+			)
 		}
 		// Start status updates after the webhook is initialized.
 		statusUpdater.Run(stopCh)

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -153,13 +153,15 @@ func ResourceAmountMax(amount1, amount2 ResourceAmount) ResourceAmount {
 }
 
 func resourceAmountFromFloat(amount float64) ResourceAmount {
-	if amount < 0 {
-		return ResourceAmount(0)
-	} else if amount > float64(MaxResourceAmount) {
+	if amount > float64(MaxResourceAmount) {
 		return MaxResourceAmount
-	} else {
-		return ResourceAmount(amount)
 	}
+
+	if amount < 0 {
+		amount = 0
+	}
+
+	return ResourceAmount(amount)
 }
 
 // HumanizeMemoryQuantity converts raw bytes to human-readable string using binary units (KiB, MiB, GiB, TiB) with two decimal places.

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -56,7 +56,7 @@ func patchVpaStatus(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName st
 	bytes, err := json.Marshal(patches)
 	if err != nil {
 		klog.ErrorS(err, "Cannot marshal VPA status patches", "patches", patches)
-		return
+		return nil, err
 	}
 
 	return vpaClient.Patch(context.TODO(), vpaName, types.JSONPatchType, bytes, meta.PatchOptions{}, "status")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Enable multiple revive rules in VPA

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Updates #8986 

#### Special notes for your reviewer:
Continuation from the previous Revive linter enable: https://github.com/kubernetes/autoscaler/pull/9007

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

Below are the list of rules enabled:
        - name: argument-limit
        - name: bare-return
        - name: indent-error-flow
        - name: unsecure-url-scheme
        - name: useless-fallthrough


Here are the list of issues fixed as part of enabling the above rules

<img width="1289" height="614" alt="image" src="https://github.com/user-attachments/assets/b8276abf-7c0b-40b4-bd70-3658123bec52" />



#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
