### PR TITLE
[cluster-autoscaler-release-1.32] Fix scale-down eligibility when utilization and threshold are zero

### DIFF
--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -154,7 +154,7 @@ func (c *Checker) unremovableReasonAndNodeUtilization(context *context.Autoscali
 		}
 	}
 
-	underutilized, err := c.isNodeBelowUtilizationThreshold(context, node, nodeGroup, utilInfo)
+	underutilized, err := c.isNodeAtOrBelowUtilizationThreshold(context, node, nodeGroup, utilInfo)
 	if err != nil {
 		klog.Warningf("Failed to check utilization thresholds for %s: %v", node.Name, err)
 		return simulator.UnexpectedError, nil
@@ -169,8 +169,8 @@ func (c *Checker) unremovableReasonAndNodeUtilization(context *context.Autoscali
 	return simulator.NoReason, &utilInfo
 }
 
-// isNodeBelowUtilizationThreshold determines if a given node utilization is below threshold.
-func (c *Checker) isNodeBelowUtilizationThreshold(context *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, utilInfo utilization.Info) (bool, error) {
+// isNodeAtOrBelowUtilizationThreshold determines if a given node utilization is at or below threshold.
+func (c *Checker) isNodeAtOrBelowUtilizationThreshold(context *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, utilInfo utilization.Info) (bool, error) {
 	var threshold float64
 	var err error
 	gpuConfig := context.CloudProvider.GetNodeGpuConfig(node)
@@ -185,7 +185,7 @@ func (c *Checker) isNodeBelowUtilizationThreshold(context *context.AutoscalingCo
 			return false, err
 		}
 	}
-	if utilInfo.Utilization >= threshold {
+	if utilInfo.Utilization > threshold {
 		return false, nil
 	}
 	return true, nil


### PR DESCRIPTION
This is a manual cherry-pick of #8975

```release-note
Fix scale-down behavior when both scale-down-utilization-threshold and node utilization are zero, so empty nodes (for example, nodes with only DaemonSet pods) can be scaled down as expected.
```

Credit to @kincoy for the original fix 🙇 