### PR TITLE
[cluster-autoscaler-release-1.34] Fix scale-down eligibility when utilization and threshold are zero

### DIFF
--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -154,7 +154,7 @@ func (c *Checker) unremovableReasonAndNodeUtilization(context *context.Autoscali
 		}
 	}
 
-	underutilized, err := c.isNodeBelowUtilizationThreshold(context, node, nodeGroup, utilInfo)
+	underutilized, err := c.isNodeAtOrBelowUtilizationThreshold(context, node, nodeGroup, utilInfo)
 	if err != nil {
 		klog.Warningf("Failed to check utilization thresholds for %s: %v", node.Name, err)
 		return simulator.UnexpectedError, nil
@@ -169,8 +169,8 @@ func (c *Checker) unremovableReasonAndNodeUtilization(context *context.Autoscali
 	return simulator.NoReason, &utilInfo
 }
 
-// isNodeBelowUtilizationThreshold determines if a given node utilization is below threshold.
-func (c *Checker) isNodeBelowUtilizationThreshold(context *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, utilInfo utilization.Info) (bool, error) {
+// isNodeAtOrBelowUtilizationThreshold determines if a given node utilization is at or below threshold.
+func (c *Checker) isNodeAtOrBelowUtilizationThreshold(context *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, utilInfo utilization.Info) (bool, error) {
 	var threshold float64
 	var err error
 	gpuConfig := context.CloudProvider.GetNodeGpuConfig(node)
@@ -185,7 +185,7 @@ func (c *Checker) isNodeBelowUtilizationThreshold(context *context.AutoscalingCo
 			return false, err
 		}
 	}
-	if utilInfo.Utilization >= threshold {
+	if utilInfo.Utilization > threshold {
 		return false, nil
 	}
 	return true, nil

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -39,15 +39,16 @@ import (
 )
 
 type testCase struct {
-	desc                        string
-	nodes                       []*apiv1.Node
-	pods                        []*apiv1.Pod
-	draSnapshot                 *drasnapshot.Snapshot
-	draEnabled                  bool
-	wantUnneeded                []string
-	wantUnremovable             []*simulator.UnremovableNode
-	scaleDownUnready            bool
-	ignoreDaemonSetsUtilization bool
+	desc                          string
+	nodes                         []*apiv1.Node
+	pods                          []*apiv1.Pod
+	draSnapshot                   *drasnapshot.Snapshot
+	draEnabled                    bool
+	wantUnneeded                  []string
+	wantUnremovable               []*simulator.UnremovableNode
+	scaleDownUnready              bool
+	ignoreDaemonSetsUtilization   bool
+	scaleDownUtilizationThreshold *float64
 }
 
 func getTestCases(ignoreDaemonSetsUtilization bool, suffix string, now time.Time) []testCase {
@@ -197,6 +198,19 @@ func getTestCases(ignoreDaemonSetsUtilization bool, suffix string, now time.Time
 				wantUnremovable:             []*simulator.UnremovableNode{},
 				scaleDownUnready:            true,
 				ignoreDaemonSetsUtilization: true,
+			},
+			testCase{
+				desc:                        "only daemonsets pods on this nodes",
+				nodes:                       []*apiv1.Node{regularNode},
+				pods:                        []*apiv1.Pod{dsPod},
+				wantUnneeded:                []string{"regular"},
+				wantUnremovable:             []*simulator.UnremovableNode{},
+				scaleDownUnready:            true,
+				ignoreDaemonSetsUtilization: true,
+				scaleDownUtilizationThreshold: func() *float64 {
+					threshold := float64(0)
+					return &threshold
+				}(),
 			})
 	}
 
@@ -210,12 +224,16 @@ func TestFilterOutUnremovable(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
+			utilizationThreshold := config.DefaultScaleDownUtilizationThreshold
+			if tc.scaleDownUtilizationThreshold != nil {
+				utilizationThreshold = *tc.scaleDownUtilizationThreshold
+			}
 			options := config.AutoscalingOptions{
 				DynamicResourceAllocationEnabled: tc.draEnabled,
 				UnremovableNodeRecheckTimeout:    5 * time.Minute,
 				ScaleDownUnreadyEnabled:          tc.scaleDownUnready,
 				NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
-					ScaleDownUtilizationThreshold:    config.DefaultScaleDownUtilizationThreshold,
+					ScaleDownUtilizationThreshold:    utilizationThreshold,
 					ScaleDownGpuUtilizationThreshold: config.DefaultScaleDownGpuUtilizationThreshold,
 					ScaleDownUnneededTime:            config.DefaultScaleDownUnneededTime,
 					ScaleDownUnreadyTime:             config.DefaultScaleDownUnreadyTime,


### PR DESCRIPTION
This is a manual cherry-pick of #8975

```release-note
Fix scale-down behavior when both scale-down-utilization-threshold and node utilization are zero, so empty nodes (for example, nodes with only DaemonSet pods) can be scaled down as expected.
```

Credit to @kincoy for the original fix 🙇 