### PR TITLE
refactor: make eligibility tests easier to configure per test case

### DIFF
--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -38,20 +38,103 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-type testCase struct {
-	desc                          string
-	nodes                         []*apiv1.Node
-	pods                          []*apiv1.Pod
-	draSnapshot                   *drasnapshot.Snapshot
-	draEnabled                    bool
-	wantUnneeded                  []string
-	wantUnremovable               []*simulator.UnremovableNode
-	scaleDownUnready              bool
-	ignoreDaemonSetsUtilization   bool
-	scaleDownUtilizationThreshold *float64
+type optionsPatch func(options *config.AutoscalingOptions)
+
+func defaultOptions() *config.AutoscalingOptions {
+	return &config.AutoscalingOptions{
+		DynamicResourceAllocationEnabled: false,
+		UnremovableNodeRecheckTimeout:    5 * time.Minute,
+		ScaleDownUnreadyEnabled:          true,
+		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+			ScaleDownUtilizationThreshold:    config.DefaultScaleDownUtilizationThreshold,
+			ScaleDownGpuUtilizationThreshold: config.DefaultScaleDownGpuUtilizationThreshold,
+			ScaleDownUnneededTime:            config.DefaultScaleDownUnneededTime,
+			ScaleDownUnreadyTime:             config.DefaultScaleDownUnreadyTime,
+			IgnoreDaemonSetsUtilization:      false,
+		},
+	}
 }
 
-func getTestCases(ignoreDaemonSetsUtilization bool, suffix string, now time.Time) []testCase {
+func applyOptionsPatches(opts *config.AutoscalingOptions, patches ...optionsPatch) {
+	for _, patch := range patches {
+		if patch != nil {
+			patch(opts)
+		}
+	}
+}
+
+func withIgnoreDaemonSetsUtilization(v bool) optionsPatch {
+	return func(o *config.AutoscalingOptions) {
+		o.NodeGroupDefaults.IgnoreDaemonSetsUtilization = v
+	}
+}
+
+func withScaleDownUnreadyEnabled(v bool) optionsPatch {
+	return func(o *config.AutoscalingOptions) {
+		o.ScaleDownUnreadyEnabled = v
+	}
+}
+
+func withScaleDownUtilizationThreshold(v float64) optionsPatch {
+	return func(o *config.AutoscalingOptions) {
+		o.NodeGroupDefaults.ScaleDownUtilizationThreshold = v
+	}
+}
+
+func withDRAEnabled(v bool) optionsPatch {
+	return func(o *config.AutoscalingOptions) {
+		o.DynamicResourceAllocationEnabled = v
+	}
+}
+
+type testCase struct {
+	desc        string
+	nodes       []*apiv1.Node
+	pods        []*apiv1.Pod
+	draSnapshot *drasnapshot.Snapshot
+
+	wantUnneeded    []string
+	wantUnremovable []*simulator.UnremovableNode
+
+	optsPatches []optionsPatch
+}
+
+// suite is a group of testCases that share the same default option patches.
+type suite struct {
+	name     string
+	patches  []optionsPatch
+	testCase []testCase
+}
+
+// applySuite injects suite-level patches in front of each test's patches
+// and appends the suite name to desc.
+// Patch order matters:
+//  1. suite-level patches are applied FIRST
+//     (these define the default behavior/config for the whole suite)
+//  2. test-case patches are appended AFTER suite patches
+//     (these are intended to override the suite defaults for a specific test)
+//
+// This means: if both the suite and the test case patch the same option,
+// the test-case patch wins because it runs later.
+// Example:
+//   - suite sets IgnoreDaemonSetsUtilization=true
+//   - a specific test wants IgnoreDaemonSetsUtilization=false
+//     -> put withIgnoreDaemonSetsUtilization(false) in tc.optsPatches
+//     -> it overrides the suite's default.
+func applySuite(s suite) []testCase {
+	out := make([]testCase, 0, len(s.testCase))
+	for _, tc := range s.testCase {
+		ntc := tc
+		if s.name != "" {
+			ntc.desc = ntc.desc + " " + s.name
+		}
+		ntc.optsPatches = append(append([]optionsPatch{}, s.patches...), tc.optsPatches...)
+		out = append(out, ntc)
+	}
+	return out
+}
+
+func getTestCases(now time.Time) []testCase {
 	regularNode := BuildTestNode("regular", 1000, 10)
 	SetNodeReadyState(regularNode, true, time.Time{})
 
@@ -89,158 +172,137 @@ func getTestCases(ignoreDaemonSetsUtilization bool, suffix string, now time.Time
 			Devices: []resourceapi.Device{{Name: "dev1"}},
 		},
 	}
-	testCases := []testCase{
+
+	// Base cases: run with default options.
+	baseCases := []testCase{
 		{
-			desc:             "regular node stays",
-			nodes:            []*apiv1.Node{regularNode},
-			wantUnneeded:     []string{"regular"},
-			wantUnremovable:  []*simulator.UnremovableNode{},
-			scaleDownUnready: true,
+			desc:            "regular node stays",
+			nodes:           []*apiv1.Node{regularNode},
+			wantUnneeded:    []string{"regular"},
+			wantUnremovable: []*simulator.UnremovableNode{},
 		},
 		{
-			desc:             "recently deleted node is filtered out",
-			nodes:            []*apiv1.Node{regularNode, justDeletedNode},
-			wantUnneeded:     []string{"regular"},
-			wantUnremovable:  []*simulator.UnremovableNode{{Node: justDeletedNode, Reason: simulator.CurrentlyBeingDeleted}},
-			scaleDownUnready: true,
+			desc:            "recently deleted node is filtered out",
+			nodes:           []*apiv1.Node{regularNode, justDeletedNode},
+			wantUnneeded:    []string{"regular"},
+			wantUnremovable: []*simulator.UnremovableNode{{Node: justDeletedNode, Reason: simulator.CurrentlyBeingDeleted}},
 		},
 		{
-			desc:             "marked no scale down is filtered out",
-			nodes:            []*apiv1.Node{noScaleDownNode, regularNode},
-			wantUnneeded:     []string{"regular"},
-			wantUnremovable:  []*simulator.UnremovableNode{{Node: noScaleDownNode, Reason: simulator.ScaleDownDisabledAnnotation}},
-			scaleDownUnready: true,
+			desc:            "marked no scale down is filtered out",
+			nodes:           []*apiv1.Node{noScaleDownNode, regularNode},
+			wantUnneeded:    []string{"regular"},
+			wantUnremovable: []*simulator.UnremovableNode{{Node: noScaleDownNode, Reason: simulator.ScaleDownDisabledAnnotation}},
 		},
 		{
-			desc:             "highly utilized node is filtered out",
-			nodes:            []*apiv1.Node{regularNode},
-			pods:             []*apiv1.Pod{bigPod},
-			wantUnneeded:     []string{},
-			wantUnremovable:  []*simulator.UnremovableNode{{Node: regularNode, Reason: simulator.NotUnderutilized}},
-			scaleDownUnready: true,
+			desc:            "highly utilized node is filtered out",
+			nodes:           []*apiv1.Node{regularNode},
+			pods:            []*apiv1.Pod{bigPod},
+			wantUnneeded:    []string{},
+			wantUnremovable: []*simulator.UnremovableNode{{Node: regularNode, Reason: simulator.NotUnderutilized}},
 		},
 		{
-			desc:             "underutilized node stays",
-			nodes:            []*apiv1.Node{regularNode},
-			pods:             []*apiv1.Pod{smallPod},
-			wantUnneeded:     []string{"regular"},
-			wantUnremovable:  []*simulator.UnremovableNode{},
-			scaleDownUnready: true,
+			desc:            "underutilized node stays",
+			nodes:           []*apiv1.Node{regularNode},
+			pods:            []*apiv1.Pod{smallPod},
+			wantUnneeded:    []string{"regular"},
+			wantUnremovable: []*simulator.UnremovableNode{},
 		},
 		{
-			desc:             "node is filtered out if utilization can't be calculated",
-			nodes:            []*apiv1.Node{brokenUtilNode},
-			pods:             []*apiv1.Pod{smallPod},
-			wantUnneeded:     []string{},
-			wantUnremovable:  []*simulator.UnremovableNode{{Node: brokenUtilNode, Reason: simulator.UnexpectedError}},
-			scaleDownUnready: true,
+			desc:            "node is filtered out if utilization can't be calculated",
+			nodes:           []*apiv1.Node{brokenUtilNode},
+			pods:            []*apiv1.Pod{smallPod},
+			wantUnneeded:    []string{},
+			wantUnremovable: []*simulator.UnremovableNode{{Node: brokenUtilNode, Reason: simulator.UnexpectedError}},
 		},
 		{
-			desc:             "unready node stays",
-			nodes:            []*apiv1.Node{unreadyNode},
-			wantUnneeded:     []string{"unready"},
-			wantUnremovable:  []*simulator.UnremovableNode{},
-			scaleDownUnready: true,
+			desc:            "unready node stays",
+			nodes:           []*apiv1.Node{unreadyNode},
+			wantUnneeded:    []string{"unready"},
+			wantUnremovable: []*simulator.UnremovableNode{},
 		},
 		{
-			desc:             "unready node is filtered oud when scale-down of unready is disabled",
-			nodes:            []*apiv1.Node{unreadyNode},
-			wantUnneeded:     []string{},
-			wantUnremovable:  []*simulator.UnremovableNode{{Node: unreadyNode, Reason: simulator.ScaleDownUnreadyDisabled}},
-			scaleDownUnready: false,
+			desc:            "unready node is filtered oud when scale-down of unready is disabled",
+			nodes:           []*apiv1.Node{unreadyNode},
+			wantUnneeded:    []string{},
+			wantUnremovable: []*simulator.UnremovableNode{{Node: unreadyNode, Reason: simulator.ScaleDownUnreadyDisabled}},
+			optsPatches:     []optionsPatch{withScaleDownUnreadyEnabled(false)},
 		},
 		{
-			desc:             "Node is not filtered out because of DRA issues if DRA is disabled",
-			nodes:            []*apiv1.Node{regularNode},
-			pods:             []*apiv1.Pod{smallPod},
-			draSnapshot:      drasnapshot.NewSnapshot(nil, map[string][]*resourceapi.ResourceSlice{"regular": {regularNodeIncompleteResourceSlice}}, nil, nil),
-			draEnabled:       false,
-			wantUnneeded:     []string{"regular"},
-			wantUnremovable:  []*simulator.UnremovableNode{},
-			scaleDownUnready: true,
+			desc:            "Node is not filtered out because of DRA issues if DRA is disabled",
+			nodes:           []*apiv1.Node{regularNode},
+			pods:            []*apiv1.Pod{smallPod},
+			draSnapshot:     drasnapshot.NewSnapshot(nil, map[string][]*resourceapi.ResourceSlice{"regular": {regularNodeIncompleteResourceSlice}}, nil, nil),
+			wantUnneeded:    []string{"regular"},
+			wantUnremovable: []*simulator.UnremovableNode{},
 		},
 		{
-			desc:             "Node is filtered out because of DRA issues if DRA is enabled",
-			nodes:            []*apiv1.Node{regularNode},
-			pods:             []*apiv1.Pod{smallPod},
-			draSnapshot:      drasnapshot.NewSnapshot(nil, map[string][]*resourceapi.ResourceSlice{"regular": {regularNodeIncompleteResourceSlice}}, nil, nil),
-			draEnabled:       true,
-			wantUnneeded:     []string{},
-			wantUnremovable:  []*simulator.UnremovableNode{{Node: regularNode, Reason: simulator.UnexpectedError}},
-			scaleDownUnready: true,
+			desc:            "Node is filtered out because of DRA issues if DRA is enabled",
+			nodes:           []*apiv1.Node{regularNode},
+			pods:            []*apiv1.Pod{smallPod},
+			draSnapshot:     drasnapshot.NewSnapshot(nil, map[string][]*resourceapi.ResourceSlice{"regular": {regularNodeIncompleteResourceSlice}}, nil, nil),
+			wantUnneeded:    []string{},
+			wantUnremovable: []*simulator.UnremovableNode{{Node: regularNode, Reason: simulator.UnexpectedError}},
+			optsPatches:     []optionsPatch{withDRAEnabled(true)},
 		},
 	}
 
-	finalTestCases := []testCase{}
-	for _, tc := range testCases {
-		tc.desc = tc.desc + " " + suffix
-		if ignoreDaemonSetsUtilization {
-			tc.ignoreDaemonSetsUtilization = true
-		}
-		finalTestCases = append(finalTestCases, tc)
+	// DaemonSet sensitivity cases, only run when withIgnoreDaemonSetsUtilization(true).
+	daemonsetSpecialCases := []testCase{
+		{
+			desc:            "high utilization daemonsets node stays",
+			nodes:           []*apiv1.Node{regularNode},
+			pods:            []*apiv1.Pod{smallPod, dsPod},
+			wantUnneeded:    []string{"regular"},
+			wantUnremovable: []*simulator.UnremovableNode{},
+		},
+		{
+			desc:            "high utilization daemonsets node is filtered out, when IgnoreDaemonSets is disabled",
+			nodes:           []*apiv1.Node{regularNode},
+			pods:            []*apiv1.Pod{smallPod, dsPod},
+			wantUnneeded:    []string{},
+			wantUnremovable: []*simulator.UnremovableNode{{Node: regularNode, Reason: simulator.NotUnderutilized}},
+			optsPatches:     []optionsPatch{withIgnoreDaemonSetsUtilization(false)},
+		},
+		{
+			desc:            "only daemonsets pods on this node (threshold=0)",
+			nodes:           []*apiv1.Node{regularNode},
+			pods:            []*apiv1.Pod{dsPod},
+			wantUnneeded:    []string{"regular"},
+			wantUnremovable: []*simulator.UnremovableNode{},
+			optsPatches:     []optionsPatch{withScaleDownUtilizationThreshold(0)},
+		},
 	}
 
-	if ignoreDaemonSetsUtilization {
-		finalTestCases = append(testCases,
-			testCase{
-				desc:                        "high utilization daemonsets node is filtered out",
-				nodes:                       []*apiv1.Node{regularNode},
-				pods:                        []*apiv1.Pod{smallPod, dsPod},
-				wantUnneeded:                []string{},
-				wantUnremovable:             []*simulator.UnremovableNode{{Node: regularNode, Reason: simulator.NotUnderutilized}},
-				scaleDownUnready:            true,
-				ignoreDaemonSetsUtilization: false,
-			},
-			testCase{
-				desc:                        "high utilization daemonsets node stays",
-				nodes:                       []*apiv1.Node{regularNode},
-				pods:                        []*apiv1.Pod{smallPod, dsPod},
-				wantUnneeded:                []string{"regular"},
-				wantUnremovable:             []*simulator.UnremovableNode{},
-				scaleDownUnready:            true,
-				ignoreDaemonSetsUtilization: true,
-			},
-			testCase{
-				desc:                        "only daemonsets pods on this nodes",
-				nodes:                       []*apiv1.Node{regularNode},
-				pods:                        []*apiv1.Pod{dsPod},
-				wantUnneeded:                []string{"regular"},
-				wantUnremovable:             []*simulator.UnremovableNode{},
-				scaleDownUnready:            true,
-				ignoreDaemonSetsUtilization: true,
-				scaleDownUtilizationThreshold: func() *float64 {
-					threshold := float64(0)
-					return &threshold
-				}(),
-			})
+	suites := []suite{
+		{
+			name:     "[base]",
+			patches:  nil,
+			testCase: baseCases,
+		},
+		{
+			name:     "[ignore-daemonsets=true]",
+			patches:  []optionsPatch{withIgnoreDaemonSetsUtilization(true)},
+			testCase: append(baseCases, daemonsetSpecialCases...),
+		},
 	}
 
-	return finalTestCases
+	var all []testCase
+	for _, s := range suites {
+		all = append(all, applySuite(s)...)
+	}
+
+	return all
 }
 
 func TestFilterOutUnremovable(t *testing.T) {
 	now := time.Now()
-	for _, tc := range append(getTestCases(false, "IgnoreDaemonSetUtilization=false", now),
-		getTestCases(true, "IgnoreDaemonsetUtilization=true", now)...) {
+	for _, tc := range getTestCases(now) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			utilizationThreshold := config.DefaultScaleDownUtilizationThreshold
-			if tc.scaleDownUtilizationThreshold != nil {
-				utilizationThreshold = *tc.scaleDownUtilizationThreshold
-			}
-			options := config.AutoscalingOptions{
-				DynamicResourceAllocationEnabled: tc.draEnabled,
-				UnremovableNodeRecheckTimeout:    5 * time.Minute,
-				ScaleDownUnreadyEnabled:          tc.scaleDownUnready,
-				NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
-					ScaleDownUtilizationThreshold:    utilizationThreshold,
-					ScaleDownGpuUtilizationThreshold: config.DefaultScaleDownGpuUtilizationThreshold,
-					ScaleDownUnneededTime:            config.DefaultScaleDownUnneededTime,
-					ScaleDownUnreadyTime:             config.DefaultScaleDownUnreadyTime,
-					IgnoreDaemonSetsUtilization:      tc.ignoreDaemonSetsUtilization,
-				},
-			}
+
+			options := defaultOptions()
+			applyOptionsPatches(options, tc.optsPatches...)
 			s := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults)
 			c := NewChecker(s)
 			provider := testprovider.NewTestCloudProviderBuilder().Build()
@@ -248,7 +310,7 @@ func TestFilterOutUnremovable(t *testing.T) {
 			for _, n := range tc.nodes {
 				provider.AddNode("ng1", n)
 			}
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, nil, nil, nil)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(*options, &fake.Clientset{}, nil, provider, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("Could not create autoscaling context: %v", err)
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

This PR refactors the scaledown eligibility unit tests to avoid relying on shared defaults.
Tests now construct AutoscalingOptions from a default baseline and apply per-test patches for config overrides.

No behavior change and no new test cases are included — this is a pure refactor to make it easier to add config-variant test coverage later.

#### Does this PR introduce a user-facing change?
```release-note
None
```
