### PR TITLE
[VPA] Enable multiple revive rules - 2

### DIFF
--- a/vertical-pod-autoscaler/.golangci.yaml
+++ b/vertical-pod-autoscaler/.golangci.yaml
@@ -16,11 +16,20 @@ linters:
         - name: bare-return
         - name: indent-error-flow
         - name: useless-fallthrough
+        - name: comment-spacings
+        - name: enforce-switch-style
+        - name: unexported-naming
 
         # Below lists the rules disabled
         - name: argument-limit
           disabled: true
         - name: unsecure-url-scheme
+          disabled: true
+        - name: confusing-naming
+          disabled: true
+        - name: flag-parameter
+          disabled: true
+        - name: max-public-structs
           disabled: true
 formatters:
   enable:

--- a/vertical-pod-autoscaler/pkg/admission-controller/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config.go
@@ -102,14 +102,14 @@ func selfRegistration(clientset kubernetes.Interface, caCert []byte, webHookDela
 			klog.Fatal(err2)
 		}
 	}
-	RegisterClientConfig := admissionregistration.WebhookClientConfig{}
+	registerClientConfig := admissionregistration.WebhookClientConfig{}
 	if !registerByURL {
-		RegisterClientConfig.Service = &admissionregistration.ServiceReference{
+		registerClientConfig.Service = &admissionregistration.ServiceReference{
 			Namespace: namespace,
 			Name:      serviceName,
 		}
 	} else {
-		RegisterClientConfig.URL = &url
+		registerClientConfig.URL = &url
 	}
 	sideEffects := admissionregistration.SideEffectClassNone
 
@@ -120,7 +120,7 @@ func selfRegistration(clientset kubernetes.Interface, caCert []byte, webHookDela
 		failurePolicy = admissionregistration.Ignore
 	}
 
-	RegisterClientConfig.CABundle = caCert
+	registerClientConfig.CABundle = caCert
 
 	var namespaceSelector metav1.LabelSelector
 	if len(ignoredNamespaces) > 0 {
@@ -177,7 +177,7 @@ func selfRegistration(clientset kubernetes.Interface, caCert []byte, webHookDela
 					},
 				},
 				FailurePolicy:     &failurePolicy,
-				ClientConfig:      RegisterClientConfig,
+				ClientConfig:      registerClientConfig,
 				SideEffects:       &sideEffects,
 				TimeoutSeconds:    &timeoutSeconds,
 				NamespaceSelector: &namespaceSelector,

--- a/vertical-pod-autoscaler/pkg/admission-controller/config_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config_test.go
@@ -53,17 +53,17 @@ func TestSelfRegistrationBase(t *testing.T) {
 	webhook := webhookConfig.Webhooks[0]
 	assert.Equal(t, "vpa.k8s.io", webhook.Name, "expected webhook name to match")
 
-	PodRule := webhook.Rules[0]
-	assert.Equal(t, []admissionregistration.OperationType{admissionregistration.Create}, PodRule.Operations, "expected operations to match")
-	assert.Equal(t, []string{""}, PodRule.APIGroups, "expected API groups to match")
-	assert.Equal(t, []string{"v1"}, PodRule.APIVersions, "expected API versions to match")
-	assert.Equal(t, []string{"pods"}, PodRule.Resources, "expected resources to match")
+	podRule := webhook.Rules[0]
+	assert.Equal(t, []admissionregistration.OperationType{admissionregistration.Create}, podRule.Operations, "expected operations to match")
+	assert.Equal(t, []string{""}, podRule.APIGroups, "expected API groups to match")
+	assert.Equal(t, []string{"v1"}, podRule.APIVersions, "expected API versions to match")
+	assert.Equal(t, []string{"pods"}, podRule.Resources, "expected resources to match")
 
-	VPARule := webhook.Rules[1]
-	assert.Equal(t, []admissionregistration.OperationType{admissionregistration.Create, admissionregistration.Update}, VPARule.Operations, "expected operations to match")
-	assert.Equal(t, []string{"autoscaling.k8s.io"}, VPARule.APIGroups, "expected API groups to match")
-	assert.Equal(t, []string{"*"}, VPARule.APIVersions, "ehook.Rulxpected API versions to match")
-	assert.Equal(t, []string{"verticalpodautoscalers"}, VPARule.Resources, "expected resources to match")
+	vpaRule := webhook.Rules[1]
+	assert.Equal(t, []admissionregistration.OperationType{admissionregistration.Create, admissionregistration.Update}, vpaRule.Operations, "expected operations to match")
+	assert.Equal(t, []string{"autoscaling.k8s.io"}, vpaRule.APIGroups, "expected API groups to match")
+	assert.Equal(t, []string{"*"}, vpaRule.APIVersions, "ehook.Rulxpected API versions to match")
+	assert.Equal(t, []string{"verticalpodautoscalers"}, vpaRule.Resources, "expected resources to match")
 
 	assert.Equal(t, admissionregistration.SideEffectClassNone, *webhook.SideEffects, "expected side effects to match")
 	assert.Equal(t, admissionregistration.Ignore, *webhook.FailurePolicy, "expected failure policy to match")
@@ -272,17 +272,17 @@ func TestSelfRegistrationWithInvalidLabels(t *testing.T) {
 	webhook := webhookConfig.Webhooks[0]
 	assert.Equal(t, "vpa.k8s.io", webhook.Name, "expected webhook name to match")
 
-	PodRule := webhook.Rules[0]
-	assert.Equal(t, []admissionregistration.OperationType{admissionregistration.Create}, PodRule.Operations, "expected operations to match")
-	assert.Equal(t, []string{""}, PodRule.APIGroups, "expected API groups to match")
-	assert.Equal(t, []string{"v1"}, PodRule.APIVersions, "expected API versions to match")
-	assert.Equal(t, []string{"pods"}, PodRule.Resources, "expected resources to match")
+	podRule := webhook.Rules[0]
+	assert.Equal(t, []admissionregistration.OperationType{admissionregistration.Create}, podRule.Operations, "expected operations to match")
+	assert.Equal(t, []string{""}, podRule.APIGroups, "expected API groups to match")
+	assert.Equal(t, []string{"v1"}, podRule.APIVersions, "expected API versions to match")
+	assert.Equal(t, []string{"pods"}, podRule.Resources, "expected resources to match")
 
-	VPARule := webhook.Rules[1]
-	assert.Equal(t, []admissionregistration.OperationType{admissionregistration.Create, admissionregistration.Update}, VPARule.Operations, "expected operations to match")
-	assert.Equal(t, []string{"autoscaling.k8s.io"}, VPARule.APIGroups, "expected API groups to match")
-	assert.Equal(t, []string{"*"}, VPARule.APIVersions, "ehook.Rulxpected API versions to match")
-	assert.Equal(t, []string{"verticalpodautoscalers"}, VPARule.Resources, "expected resources to match")
+	vpaRule := webhook.Rules[1]
+	assert.Equal(t, []admissionregistration.OperationType{admissionregistration.Create, admissionregistration.Update}, vpaRule.Operations, "expected operations to match")
+	assert.Equal(t, []string{"autoscaling.k8s.io"}, vpaRule.APIGroups, "expected API groups to match")
+	assert.Equal(t, []string{"*"}, vpaRule.APIVersions, "ehook.Rulxpected API versions to match")
+	assert.Equal(t, []string{"verticalpodautoscalers"}, vpaRule.Resources, "expected resources to match")
 
 	assert.Equal(t, admissionregistration.SideEffectClassNone, *webhook.SideEffects, "expected side effects to match")
 	assert.Equal(t, admissionregistration.Ignore, *webhook.FailurePolicy, "expected failure policy to match")

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -173,9 +173,9 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 					return fmt.Errorf("maxAllowed: %v", err)
 				}
 			}
-			ControlledValues := policy.ControlledValues
-			if mode != nil && ControlledValues != nil {
-				if *mode == vpa_types.ContainerScalingModeOff && *ControlledValues == vpa_types.ContainerControlledValuesRequestsAndLimits {
+			controlledValues := policy.ControlledValues
+			if mode != nil && controlledValues != nil {
+				if *mode == vpa_types.ContainerScalingModeOff && *controlledValues == vpa_types.ContainerControlledValuesRequestsAndLimits {
 					return fmt.Errorf("controlledValues shouldn't be specified if container scaling mode is off")
 				}
 			}

--- a/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test.go
@@ -43,7 +43,7 @@ func TestGetPodSpecsReturnsSpecs(t *testing.T) {
 	// when
 	podSpecs, err := client.GetPodSpecs()
 
-	//then
+	// then
 	assert.NoError(t, err)
 	assert.Equal(t, len(tc.podSpecs), len(podSpecs), "SpecClient returned different number of results then expected")
 	for _, podSpec := range podSpecs {

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
@@ -46,10 +46,10 @@ func TestPercentileEstimator(t *testing.T) {
 	memoryPeaksHistogram.AddSample(2e9, 1.0, anyTime)
 	memoryPeaksHistogram.AddSample(3e9, 1.0, anyTime)
 	// Create an estimator.
-	CPUPercentile := 0.2
-	MemoryPercentile := 0.5
-	cpuEstimator := NewPercentileCPUEstimator(CPUPercentile)
-	memoryEstimator := NewPercentileMemoryEstimator(MemoryPercentile)
+	cpuPercentile := 0.2
+	memoryPercentile := 0.5
+	cpuEstimator := NewPercentileCPUEstimator(cpuPercentile)
+	memoryEstimator := NewPercentileMemoryEstimator(memoryPercentile)
 	combinedEstimator := NewCombinedEstimator(cpuEstimator, memoryEstimator)
 
 	resourceEstimation := combinedEstimator.GetResourceEstimation(

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -97,6 +97,9 @@ func (container *ContainerState) observeQualityMetrics(usage ResourceAmount, isO
 		usageValue = CoresFromCPUAmount(usage)
 	case corev1.ResourceMemory:
 		usageValue = BytesFromMemoryAmount(usage)
+	default:
+		klog.V(0).InfoS("Unknown resource", "resource", resource)
+		return
 	}
 	if container.aggregator.GetLastRecommendation() == nil {
 		metrics_quality.ObserveQualityMetricsRecommendationMissing(usageValue, isOOM, resource, updateMode)

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -166,6 +166,7 @@ func resourceAmountFromFloat(amount float64) ResourceAmount {
 
 // HumanizeMemoryQuantity converts raw bytes to human-readable string using binary units (KiB, MiB, GiB, TiB) with two decimal places.
 func HumanizeMemoryQuantity(bytes int64) string {
+	//nolint:revive // local unit constants use conventional KiB/MiB/GiB/TiB names
 	const (
 		KiB = 1024
 		MiB = 1024 * KiB

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram_test.go
@@ -171,7 +171,7 @@ func TestHistogramSaveToCheckpointDropsRelativelySmallValues(t *testing.T) {
 	s, err := h.SaveToChekpoint()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 100001. /*w1+w2*/, s.TotalWeight)
+	assert.Equal(t, 100001. /* w1 + w2 */, s.TotalWeight)
 	// Bucket 1 shouldn't be there
 	assert.Len(t, s.BucketWeights, 1)
 	assert.Contains(t, s.BucketWeights, bucket2)
@@ -197,7 +197,7 @@ func TestHistogramSaveToCheckpointForMultipleValues(t *testing.T) {
 
 	s, err := h.SaveToChekpoint()
 	assert.NoError(t, err)
-	assert.Equal(t, 10051. /*w1 + w2 + w3*/, s.TotalWeight)
+	assert.Equal(t, 10051. /* w1 + w2 + w3 */, s.TotalWeight)
 	assert.Len(t, s.BucketWeights, 3)
 	assert.Equal(t, uint32(1), s.BucketWeights[bucket1])
 	assert.Equal(t, uint32(10000), s.BucketWeights[bucket2])

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -252,7 +252,7 @@ func (f *controllerFetcher) isWellKnownOrScalable(ctx context.Context, key *Cont
 		return true
 	}
 
-	//if not well known check if it supports scaling
+	// if not well known check if it supports scaling
 	groupKind, err := key.groupKind()
 	if err != nil {
 		klog.ErrorS(err, "Could not find groupKind", "object", klog.KRef(key.Namespace, key.Name))

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_eviction_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_eviction_restriction_test.go
@@ -94,7 +94,7 @@ func TestEvictionTolerance(t *testing.T) {
 	}
 
 	basicVpa := getBasicVpa()
-	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2 /*minReplicas*/, tolerance, nil, nil, nil, false)
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2 /* minReplicas */, tolerance, nil, nil, nil, false)
 	assert.NoError(t, err)
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
 	assert.NoError(t, err)

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
@@ -270,7 +270,7 @@ func TestInPlaceTooFewReplicas(t *testing.T) {
 	lipatm := map[string]time.Time{}
 
 	basicVpa := getIPORVpa()
-	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 10 /*minReplicas*/, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 10 /* minReplicas */, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
 	assert.NoError(t, err)
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
 	assert.NoError(t, err)
@@ -315,7 +315,7 @@ func TestEvictionToleranceForInPlace(t *testing.T) {
 	lipatm := map[string]time.Time{}
 
 	basicVpa := getIPORVpa()
-	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2 /*minReplicas*/, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2 /* minReplicas */, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), false)
 	assert.NoError(t, err)
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
 	assert.NoError(t, err)
@@ -373,7 +373,7 @@ func TestEvictionToleranceForInPlaceWithSkipDisruptionBudget(t *testing.T) {
 
 	basicVpa := getIPORVpa()
 	// inPlaceSkipDisruptionBudget = true
-	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2 /* minReplicas */, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), true /*inPlaceSkipDisruptionBudget*/)
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2 /* minReplicas */, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), true /* inPlaceSkipDisruptionBudget */)
 	assert.NoError(t, err)
 
 	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)

--- a/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/limit_and_request_scaling.go
@@ -79,14 +79,14 @@ func getProportionalResourceLimit(resourceName core.ResourceName, originalLimit,
 		return &result, ""
 	}
 	if resourceName == core.ResourceCPU {
-		result, capped := scaleQuantityProportionallyCPU( /*scaledQuantity=*/ originalLimit /*scaleBase=*/, originalRequest /*scaleResult=*/, recommendedRequest, noRounding)
+		result, capped := scaleQuantityProportionallyCPU( /* scaledQuantity= */ originalLimit /* scaleBase= */, originalRequest /* scaleResult= */, recommendedRequest, noRounding)
 		if !capped {
 			return result, ""
 		}
 		return result, fmt.Sprintf(
 			"%v: failed to keep limit to request ratio; capping limit to int64", resourceName)
 	}
-	result, capped := scaleQuantityProportionallyMem( /*scaledQuantity=*/ originalLimit /*scaleBase=*/, originalRequest /*scaleResult=*/, recommendedRequest, noRounding)
+	result, capped := scaleQuantityProportionallyMem( /* scaledQuantity= */ originalLimit /* scaleBase= */, originalRequest /* scaleResult= */, recommendedRequest, noRounding)
 	if !capped {
 		return result, ""
 	}
@@ -112,10 +112,10 @@ func GetBoundaryRequest(resourceName core.ResourceName, originalRequest, origina
 	// Determine which scaling function to use based on resource type.
 	var result *resource.Quantity
 	if resourceName == core.ResourceCPU {
-		result, _ = scaleQuantityProportionallyCPU(originalRequest /* scaledQuantity */, originalLimit /*scaleBase*/, boundaryLimit /*scaleResult*/, noRounding)
+		result, _ = scaleQuantityProportionallyCPU(originalRequest /* scaledQuantity */, originalLimit /* scaleBase */, boundaryLimit /* scaleResult */, noRounding)
 		return result
 	}
-	result, _ = scaleQuantityProportionallyMem(originalRequest /* scaledQuantity */, originalLimit /*scaleBase*/, boundaryLimit /*scaleResult*/, noRounding)
+	result, _ = scaleQuantityProportionallyMem(originalRequest /* scaledQuantity */, originalLimit /* scaleBase */, boundaryLimit /* scaleResult */, noRounding)
 	return result
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Enables multiple revive rules and also disabling few which might not be required.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Updates #8986

#### Special notes for your reviewer:
Continuation from this [PR](https://github.com/kubernetes/autoscaler/pull/9024).

Enables the rules as defined in golangci.yaml

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
