### PR TITLE
Add Intel GPU cluster autoscaler support

### DIFF
--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -28,6 +28,8 @@ import (
 const (
 	// ResourceIntelGaudi is the name of the Intel Gaudi resource.
 	ResourceIntelGaudi = "habana.ai/gaudi"
+	// ResourceIntelGPU is the name of the Intel GPU resource (Xe driver).
+	ResourceIntelGPU = "gpu.intel.com/xe"
 	// ResourceAMDGPU is the name of the AMD GPU resource.
 	ResourceAMDGPU = "amd.com/gpu"
 	// ResourceNvidiaGPU is the name of the Nvidia GPU resource.
@@ -44,6 +46,7 @@ const (
 var GPUVendorResourceNames = []apiv1.ResourceName{
 	ResourceNvidiaGPU,
 	ResourceIntelGaudi,
+	ResourceIntelGPU,
 	ResourceAMDGPU,
 	ResourceDirectX,
 }


### PR DESCRIPTION
This enables the autoscaler to properly detect and handle Intel GPU nodes alongside existing NVIDIA, AMD, and DirectX GPU support.

Tested with device plugins (not DRA) on cluster api kubevirt cluster.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

Changes has been tested on on-prem cluster (cluster api + kubevirt) with two BMG 50 GPUs. Scale up/down tested, to/from zero not tested.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Cluster autoscaling now works with `gpu.intel.com/xe` resource requests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
