### PR TITLE
azure: Zombie Node Cleanup

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -203,7 +203,7 @@ func BuildAzure(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupD
 	} else {
 		klog.Info("Creating Azure Manager with default configuration.")
 	}
-	manager, err := CreateAzureManager(config, do)
+	manager, err := CreateAzureManager(config, do, opts.KubeClient)
 	if err != nil {
 		klog.Fatalf("Failed to create Azure Manager: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -112,6 +112,16 @@ type Config struct {
 
 	// EnableLabelPredictionsOnTemplate defines whether to enable label predictions on the template when scaling from zero
 	EnableLabelPredictionsOnTemplate bool `json:"enableLabelPredictionsOnTemplate,omitempty" yaml:"enableLabelPredictionsOnTemplate,omitempty"`
+
+	// EnableZombieCleanup defines whether to enable automatic cleanup of zombie VMSS instances
+	EnableZombieCleanup bool `json:"enableZombieCleanup,omitempty" yaml:"enableZombieCleanup,omitempty"`
+
+	// ZombieCleanupDryRun defines whether zombie cleanup should run in dry-run mode (detect but don't delete)
+	// In dry-run mode, zombies are detected and logged but NOT deleted
+	ZombieCleanupDryRun bool `json:"zombieCleanupDryRun,omitempty" yaml:"zombieCleanupDryRun,omitempty"`
+
+	// ZombieMinAgeMinutes defines the minimum age (in minutes) before an instance is considered a zombie
+	ZombieMinAgeMinutes int `json:"zombieMinAgeMinutes,omitempty" yaml:"zombieMinAgeMinutes,omitempty"`
 }
 
 // These are only here for backward compabitility. Their equivalent exists in providerazure.Config with a different name.
@@ -143,6 +153,10 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	cfg.MaxDeploymentsCount = int64(defaultMaxDeploymentsCount)
 	cfg.StrictCacheUpdates = false
 	cfg.EnableLabelPredictionsOnTemplate = true
+	// Zombie cleanup disabled by default for safety
+	cfg.EnableZombieCleanup = false
+	cfg.ZombieCleanupDryRun = true // Default to dry-run mode for extra safety
+	cfg.ZombieMinAgeMinutes = 5    // Default 5 minutes minimum age
 
 	// Config file overrides defaults
 	if configReader != nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -352,6 +352,9 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 		// This means, if it is valued by the config file, but explicitly set to 0 in the env, it will retreat to default.
 		cfg.MaxDeploymentsCount = int64(defaultMaxDeploymentsCount)
 	}
+	if cfg.ZombieMinAgeMinutes < 1 {
+		cfg.ZombieMinAgeMinutes = 5
+	}
 	if cfg.SubscriptionID == "" {
 		metadataService, err := providerazure.NewInstanceMetadataService(imdsServerURL)
 		if err != nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -252,6 +252,15 @@ func (m *AzureManager) forceRefresh() error {
 	}
 	m.lastRefresh = time.Now()
 	klog.V(2).Infof("Refreshed Azure VM and VMSS list, next refresh after %v", m.lastRefresh.Add(m.azureCache.refreshInterval))
+
+	// Cleanup zombie nodes if enabled
+	if m.config.EnableZombieCleanup {
+		if err := m.cleanupZombieNodes(); err != nil {
+			klog.Errorf("Failed to cleanup zombie nodes: %v", err)
+			// Don't fail the refresh if zombie cleanup fails
+		}
+	}
+
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
 	kretry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog/v2"
 	providerazureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -70,6 +71,9 @@ type AzureManager struct {
 	azClient *azClient
 	env      azure.Environment
 
+	// kubeClient is the Kubernetes client used for node lookups during zombie cleanup.
+	kubeClient clientset.Interface
+
 	// azureCache is used for caching Azure resources.
 	// It keeps track of nodegroups and instances
 	// (and of which nodegroup instances belong to)
@@ -88,7 +92,7 @@ type AzureManager struct {
 }
 
 // createAzureManagerInternal allows for a custom azClient to be passed in by tests.
-func createAzureManagerInternal(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, azClient *azClient) (*AzureManager, error) {
+func createAzureManagerInternal(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, azClient *azClient, kubeClient clientset.Interface) (*AzureManager, error) {
 	cfg, err := BuildAzureConfig(configReader)
 	if err != nil {
 		return nil, err
@@ -117,6 +121,7 @@ func createAzureManagerInternal(configReader io.Reader, discoveryOpts cloudprovi
 		config:               cfg,
 		env:                  env,
 		azClient:             azClient,
+		kubeClient:           kubeClient,
 		explicitlyConfigured: make(map[string]bool),
 	}
 
@@ -165,8 +170,8 @@ func createAzureManagerInternal(configReader io.Reader, discoveryOpts cloudprovi
 }
 
 // CreateAzureManager creates Azure Manager object to work with Azure.
-func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*AzureManager, error) {
-	return createAzureManagerInternal(configReader, discoveryOpts, nil)
+func CreateAzureManager(configReader io.Reader, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, kubeClient clientset.Interface) (*AzureManager, error) {
+	return createAzureManagerInternal(configReader, discoveryOpts, nil, kubeClient)
 }
 
 func (m *AzureManager) fetchExplicitNodeGroups(specs []string) error {

--- a/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_manager_test.go
@@ -224,7 +224,7 @@ func TestCreateAzureManagerValidConfig(t *testing.T) {
 		virtualMachinesClient:         mockVMClient,
 		virtualMachineScaleSetsClient: mockVMSSClient,
 	}
-	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 
 	expectedConfig := &Config{
 		Config: providerazureconfig.Config{
@@ -279,7 +279,7 @@ func TestCreateAzureManagerLegacyConfig(t *testing.T) {
 		virtualMachinesClient:         mockVMClient,
 		virtualMachineScaleSetsClient: mockVMSSClient,
 	}
-	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgLegacy), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgLegacy), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 
 	expectedConfig := &Config{
 		Config: providerazureconfig.Config{
@@ -329,7 +329,7 @@ func TestCreateAzureManagerValidConfigForStandardVMType(t *testing.T) {
 		virtualMachinesClient:         mockVMClient,
 		virtualMachineScaleSetsClient: mockVMSSClient,
 	}
-	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForStandardVMType), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForStandardVMType), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 
 	expectedConfig := &Config{
 		Config: providerazureconfig.Config{
@@ -393,7 +393,7 @@ func TestCreateAzureManagerValidConfigForStandardVMTypeWithoutDeploymentParamete
 		loadEnv(originalEnv)
 	})
 
-	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForStandardVMTypeWithoutDeploymentParameters), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{})
+	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForStandardVMTypeWithoutDeploymentParameters), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{}, nil)
 	expectedErr := "open /var/lib/azure/azuredeploy.parameters.json: no such file or directory"
 	assert.Nil(t, manager)
 	assert.Equal(t, expectedErr, err.Error(), "return error does not match, expected: %v, actual: %v", expectedErr, err.Error())
@@ -414,7 +414,7 @@ func TestCreateAzureManagerValidConfigForVMsPool(t *testing.T) {
 		virtualMachinesClient:         mockVMClient,
 		virtualMachineScaleSetsClient: mockVMSSClient,
 	}
-	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForVMsPool), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+	manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForVMsPool), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 
 	expectedConfig := &Config{
 		Config: providerazureconfig.Config{
@@ -541,14 +541,14 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 	t.Setenv("AZURE_ENABLE_VMS_AGENT_POOLS", "true")
 
 	t.Run("environment variables correctly set", func(t *testing.T) {
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		assert.NoError(t, err)
 		assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
 	})
 
 	t.Run("invalid bool for ARM_USE_MANAGED_IDENTITY_EXTENSION", func(t *testing.T) {
 		t.Setenv("ARM_USE_MANAGED_IDENTITY_EXTENSION", "invalidbool")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr0 := "failed to parse ARM_USE_MANAGED_IDENTITY_EXTENSION \"invalidbool\": strconv.ParseBool: parsing \"invalidbool\": invalid syntax"
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr0, err.Error(), "Return err does not match, expected: %v, actual: %v", expectedErr0, err.Error())
@@ -556,7 +556,7 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 
 	t.Run("invalid int for AZURE_VMSS_CACHE_TTL", func(t *testing.T) {
 		t.Setenv("AZURE_VMSS_CACHE_TTL", "invalidint")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr := fmt.Errorf("failed to parse AZURE_VMSS_CACHE_TTL \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
@@ -564,7 +564,7 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 
 	t.Run("invalid int for AZURE_GET_VMSS_SIZE_REFRESH_PERIOD", func(t *testing.T) {
 		t.Setenv("AZURE_GET_VMSS_SIZE_REFRESH_PERIOD", "invalidint")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr := fmt.Errorf("failed to parse AZURE_GET_VMSS_SIZE_REFRESH_PERIOD \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
@@ -572,7 +572,7 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 
 	t.Run("invalid int for AZURE_MAX_DEPLOYMENT_COUNT", func(t *testing.T) {
 		t.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "invalidint")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr := fmt.Errorf("failed to parse AZURE_MAX_DEPLOYMENT_COUNT \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
@@ -580,14 +580,14 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 
 	t.Run("zero AZURE_MAX_DEPLOYMENT_COUNT will use default value", func(t *testing.T) {
 		t.Setenv("AZURE_MAX_DEPLOYMENT_COUNT", "0")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(defaultMaxDeploymentsCount), (*manager.config).MaxDeploymentsCount, "MaxDeploymentsCount does not match.")
 	})
 
 	t.Run("invalid bool for ENABLE_BACKOFF", func(t *testing.T) {
 		t.Setenv("ENABLE_BACKOFF", "invalidbool")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr := fmt.Errorf("failed to parse ENABLE_BACKOFF \"invalidbool\": strconv.ParseBool: parsing \"invalidbool\": invalid syntax")
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
@@ -595,7 +595,7 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 
 	t.Run("invalid int for BACKOFF_RETRIES", func(t *testing.T) {
 		t.Setenv("BACKOFF_RETRIES", "invalidint")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr := fmt.Errorf("failed to parse BACKOFF_RETRIES \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
@@ -603,14 +603,14 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 
 	t.Run("empty BACKOFF_RETRIES will use default value", func(t *testing.T) {
 		t.Setenv("BACKOFF_RETRIES", "")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, providerazureconsts.BackoffRetriesDefault, (*manager.config).CloudProviderBackoffRetries, "CloudProviderBackoffRetries does not match.")
 	})
 
 	t.Run("invalid float for BACKOFF_EXPONENT", func(t *testing.T) {
 		t.Setenv("BACKOFF_EXPONENT", "invalidfloat")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr := fmt.Errorf("failed to parse BACKOFF_EXPONENT \"invalidfloat\": strconv.ParseFloat: parsing \"invalidfloat\": invalid syntax")
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
@@ -618,14 +618,14 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 
 	t.Run("empty BACKOFF_EXPONENT will use default value", func(t *testing.T) {
 		t.Setenv("BACKOFF_EXPONENT", "")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, providerazureconsts.BackoffExponentDefault, (*manager.config).CloudProviderBackoffExponent, "CloudProviderBackoffExponent does not match.")
 	})
 
 	t.Run("invalid int for BACKOFF_DURATION", func(t *testing.T) {
 		t.Setenv("BACKOFF_DURATION", "invalidint")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr := fmt.Errorf("failed to parse BACKOFF_DURATION \"invalidint\": strconv.ParseInt: parsing \"invalidint\": invalid syntax")
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
@@ -633,14 +633,14 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 
 	t.Run("empty BACKOFF_DURATION will use default value", func(t *testing.T) {
 		t.Setenv("BACKOFF_DURATION", "")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, providerazureconsts.BackoffDurationDefault, (*manager.config).CloudProviderBackoffDuration, "CloudProviderBackoffDuration does not match.")
 	})
 
 	t.Run("invalid float for BACKOFF_JITTER", func(t *testing.T) {
 		t.Setenv("BACKOFF_JITTER", "invalidfloat")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr := fmt.Errorf("failed to parse BACKOFF_JITTER \"invalidfloat\": strconv.ParseFloat: parsing \"invalidfloat\": invalid syntax")
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
@@ -648,14 +648,14 @@ func TestCreateAzureManagerWithNilConfig(t *testing.T) {
 
 	t.Run("empty BACKOFF_JITTER will use default value", func(t *testing.T) {
 		t.Setenv("BACKOFF_JITTER", "")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, providerazureconsts.BackoffJitterDefault, (*manager.config).CloudProviderBackoffJitter, "CloudProviderBackoffJitter does not match.")
 	})
 
 	t.Run("invalid bool for CLOUD_PROVIDER_RATE_LIMIT", func(t *testing.T) {
 		t.Setenv("CLOUD_PROVIDER_RATE_LIMIT", "invalidbool")
-		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(nil, cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		expectedErr := fmt.Errorf("failed to parse CLOUD_PROVIDER_RATE_LIMIT \"invalidbool\": strconv.ParseBool: parsing \"invalidbool\": invalid syntax")
 		assert.Nil(t, manager)
 		assert.Equal(t, expectedErr, err, "Return err does not match, expected: %v, actual: %v", expectedErr, err)
@@ -743,7 +743,7 @@ func TestCreateAzureManagerWithEnvOverridingConfig(t *testing.T) {
 	t.Setenv("AZURE_ENABLE_FAST_DELETE_ON_FAILED_PROVISIONING", "true")
 
 	t.Run("environment variables correctly set", func(t *testing.T) {
-		manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForStandardVMType), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient)
+		manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfgForStandardVMType), cloudprovider.NodeGroupDiscoveryOptions{}, mockAzClient, nil)
 		assert.NoError(t, err)
 		assertStructsMinimallyEqual(t, *expectedConfig, *manager.config)
 	})
@@ -755,7 +755,7 @@ func TestCreateAzureManagerInvalidConfig(t *testing.T) {
 		loadEnv(originalEnv)
 	})
 
-	_, err := createAzureManagerInternal(strings.NewReader(invalidAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{})
+	_, err := createAzureManagerInternal(strings.NewReader(invalidAzureCfg), cloudprovider.NodeGroupDiscoveryOptions{}, &azClient{}, nil)
 	assert.Error(t, err, "failed to unmarshal config body")
 }
 
@@ -1130,7 +1130,7 @@ func TestVMSSNotFound(t *testing.T) {
 	// We expect the initial BuildAzure flow to pass when a NodeGroup is detected
 	// that doesn't have a corresponding VMSS in the cache.
 	t.Run("should not error when VMSS not found in cache", func(t *testing.T) {
-		manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfg), ngdo, &client)
+		manager, err := createAzureManagerInternal(strings.NewReader(validAzureCfg), ngdo, &client, nil)
 		assert.NoError(t, err)
 		// expect one nodegroup to be present
 		nodeGroups := manager.getNodeGroups()

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -1,0 +1,372 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+)
+
+type zombieInstance struct {
+	vmssName   string
+	instanceID string
+	hasK8sNode bool
+	reason     string
+}
+
+// cleanupZombieNodes detects and cleans up zombie VMSS instances that are in non-functional states.
+// A zombie instance is one that:
+// - Has failed provisioning state
+// - Has failed VM extensions
+// - Never registered in Kubernetes (age > threshold)
+// - Has unreachable taint (age > threshold)
+// - Is NotReady with a running VM (age > threshold)
+//
+// Implementation follows a hybrid approach:
+// - VMs that never registered in K8s are directly deleted
+// - VMs with K8s nodes (unreachable/NotReady) are logged only (autoscaler handles deletion)
+func (m *AzureManager) cleanupZombieNodes() error {
+	return m.cleanupZombieNodesWithContext(nil)
+}
+
+// cleanupZombieNodesWithContext is similar to cleanupZombieNodes but accepts Kubernetes nodes
+// as context to help correlate VMSS instances with K8s nodes.
+func (m *AzureManager) cleanupZombieNodesWithContext(nodes []*apiv1.Node) error {
+	ctx, cancel := getContextWithTimeout(vmssContextTimeout)
+	defer cancel()
+
+	// Get all VMSS in the resource group
+	scaleSets, err := m.azClient.virtualMachineScaleSetsClient.List(ctx, m.config.ResourceGroup)
+	if err != nil {
+		klog.Errorf("Failed to list VMSS: %v", err)
+		return fmt.Errorf("failed to list VMSS: %v", err)
+	}
+
+	// Build K8s node lookup table
+	k8sNodeMap := make(map[string]*apiv1.Node)
+	if nodes != nil {
+		for _, node := range nodes {
+			if node.Spec.ProviderID == "" {
+				continue
+			}
+			// Normalize provider ID
+			normalizedID := normalizeProviderID(node.Spec.ProviderID)
+			k8sNodeMap[normalizedID] = node
+		}
+	}
+
+	// Process each VMSS
+	zombiesByVMSS := make(map[string][]zombieInstance)
+	currentTime := time.Now()
+	minAgeDuration := time.Duration(m.config.ZombieMinAgeMinutes) * time.Minute
+
+	for _, scaleSet := range scaleSets {
+		vmssName := ptr.Deref(scaleSet.Name, "")
+		if vmssName == "" {
+			continue
+		}
+
+		// Get all VMs in this VMSS with instance view
+		vms, err := m.azClient.virtualMachineScaleSetVMsClient.List(
+			ctx,
+			m.config.ResourceGroup,
+			vmssName,
+			string(compute.InstanceViewTypesInstanceView),
+		)
+		if err != nil {
+			klog.Warningf("Failed to list VMs for VMSS %s: %v", vmssName, err)
+			continue
+		}
+
+		// Empty VMSS is normal - scale to zero
+		if len(vms) == 0 {
+			continue
+		}
+
+		// Analyze each VMSS instance for zombie status
+		for _, vm := range vms {
+			instanceID := ptr.Deref(vm.InstanceID, "")
+			if instanceID == "" {
+				continue
+			}
+
+			// Evaluate zombie conditions
+			isZombie, hasK8sNode, reason := m.evaluateZombieStatus(vm, k8sNodeMap, currentTime, minAgeDuration)
+
+			if isZombie {
+				klog.V(2).Infof("ZOMBIE DETECTED: Instance %s (VMSS: %s) - %s", instanceID, vmssName, reason)
+				zombiesByVMSS[vmssName] = append(zombiesByVMSS[vmssName], zombieInstance{
+					vmssName:   vmssName,
+					instanceID: instanceID,
+					hasK8sNode: hasK8sNode,
+					reason:     reason,
+				})
+			}
+		}
+	}
+
+	// Cleanup phase
+	totalZombies := 0
+	for _, zombies := range zombiesByVMSS {
+		totalZombies += len(zombies)
+	}
+
+	if totalZombies == 0 {
+		klog.V(4).Info("No zombies found")
+		return nil
+	}
+
+	// Separate zombies by whether they have K8s nodes
+	// Manually delete unregistered VMs, log registered ones
+	unregisteredZombies := make(map[string][]zombieInstance)
+	registeredZombieCount := 0
+
+	for vmssName, zombies := range zombiesByVMSS {
+		for _, zombie := range zombies {
+			if !zombie.hasK8sNode {
+				// Safe to delete directly - no K8s state
+				unregisteredZombies[vmssName] = append(unregisteredZombies[vmssName], zombie)
+			} else {
+				// Has K8s node - let autoscaler handle deletion
+				registeredZombieCount++
+				klog.V(2).Infof("Registered zombie node (will be handled by autoscaler): Instance %s (VMSS: %s) - %s",
+					zombie.instanceID, vmssName, zombie.reason)
+			}
+		}
+	}
+
+	unregisteredCount := totalZombies - registeredZombieCount
+
+	// Dry-run or active cleanup for unregistered zombies
+	if m.config.ZombieCleanupDryRun {
+		klog.Infof("DRY RUN: Would clean up %d unregistered zombie(s), %d registered zombies logged",
+			unregisteredCount, registeredZombieCount)
+		for vmssName, zombies := range unregisteredZombies {
+			for _, zombie := range zombies {
+				klog.V(2).Infof("Would remove: Instance %s (VMSS: %s, reason: %s)",
+					zombie.instanceID, vmssName, zombie.reason)
+			}
+		}
+		return nil
+	}
+
+	if unregisteredCount == 0 {
+		klog.V(2).Infof("No unregistered zombies to clean up (%d registered zombies will be handled by autoscaler)",
+			registeredZombieCount)
+		return nil
+	}
+
+	// Actually cleaning up unregistered zombies
+	klog.Infof("Cleaning up %d unregistered zombie(s) (%d registered zombies will be handled by autoscaler)...",
+		unregisteredCount, registeredZombieCount)
+
+	// Batch delete zombies per VMSS for efficiency
+	for vmssName, zombies := range unregisteredZombies {
+		instanceIDs := make([]string, len(zombies))
+		for i, zombie := range zombies {
+			instanceIDs[i] = zombie.instanceID
+		}
+
+		vmInstanceIDs := compute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+			InstanceIds: &instanceIDs,
+		}
+
+		klog.V(2).Infof("Deleting %d unregistered zombie instance(s) from VMSS %s: %v",
+			len(instanceIDs), vmssName, instanceIDs)
+
+		// Delete VMSS instances
+		_, err := m.azClient.virtualMachineScaleSetsClient.DeleteInstancesAsync(
+			ctx,
+			m.config.ResourceGroup,
+			vmssName,
+			vmInstanceIDs,
+			false, // forceDelete
+		)
+
+		if err != nil {
+			klog.Errorf("Failed to delete zombie instances from VMSS %s: %v", vmssName, err)
+			continue
+		}
+
+		// Log success for each zombie
+		for _, zombie := range zombies {
+			klog.V(2).Infof("Successfully cleaned zombie: Instance %s (VMSS: %s)", zombie.instanceID, vmssName)
+		}
+	}
+
+	return nil
+}
+
+// evaluateZombieStatus evaluates a VMSS VM to determine if it's a zombie
+// Returns (isZombie bool, hasK8sNode bool, reason string)
+func (m *AzureManager) evaluateZombieStatus(
+	vm compute.VirtualMachineScaleSetVM,
+	k8sNodeMap map[string]*apiv1.Node,
+	currentTime time.Time,
+	minAgeDuration time.Duration,
+) (bool, bool, string) {
+	provisioningState := ptr.Deref(vm.ProvisioningState, "")
+	powerState := ""
+	var vmssAge *time.Duration
+	if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
+		for _, status := range *vm.InstanceView.Statuses {
+			code := ptr.Deref(status.Code, "")
+
+			if strings.HasPrefix(code, "PowerState/") {
+				powerState = strings.TrimPrefix(code, "PowerState/")
+			}
+
+			if vmssAge == nil && status.Time != nil {
+				age := currentTime.Sub(status.Time.Time)
+				vmssAge = &age
+			}
+		}
+	}
+
+	// Check VM extension status
+	extensionsInstalled := false
+	extensionsFailed := false
+	if vm.InstanceView != nil && vm.InstanceView.Extensions != nil && len(*vm.InstanceView.Extensions) > 0 {
+		extensionsInstalled = true
+		for _, ext := range *vm.InstanceView.Extensions {
+			if ext.Statuses != nil {
+				for _, status := range *ext.Statuses {
+					code := ptr.Deref(status.Code, "")
+					if status.Level == compute.Error || code == "ProvisioningState/failed" {
+						extensionsFailed = true
+						break
+					}
+				}
+			}
+			if extensionsFailed {
+				break
+			}
+		}
+	}
+
+	// Find corresponding K8s node
+	var k8sNode *apiv1.Node
+	hasK8sNode := false
+	normalizedVMID := normalizeProviderID(ptr.Deref(vm.ID, ""))
+	if normalizedVMID != "" {
+		k8sNode, hasK8sNode = k8sNodeMap[normalizedVMID]
+	}
+
+	// Calculate node age if K8s node exists
+	var nodeAge *time.Duration
+	isReady := false
+	if hasK8sNode && k8sNode != nil {
+		age := currentTime.Sub(k8sNode.CreationTimestamp.Time)
+		nodeAge = &age
+
+		// Check Ready condition
+		for _, condition := range k8sNode.Status.Conditions {
+			if condition.Type == apiv1.NodeReady && condition.Status == apiv1.ConditionTrue {
+				isReady = true
+				break
+			}
+		}
+	}
+
+	// SCENARIO 1: Extensions failed or never installed
+	if !hasK8sNode && (!extensionsInstalled || extensionsFailed) {
+		if vmssAge != nil && *vmssAge > minAgeDuration {
+			if extensionsFailed {
+				return true, false, fmt.Sprintf("Extensions FAILED, age: %.0f minutes", vmssAge.Minutes())
+			}
+			return true, false, fmt.Sprintf("Extensions NOT INSTALLED (flapping zombie), age: %.0f minutes", vmssAge.Minutes())
+		} else if vmssAge == nil {
+			if extensionsFailed {
+				return true, false, "Extensions FAILED, no timestamp"
+			}
+			return true, false, "Extensions NOT INSTALLED, no timestamp"
+		}
+	}
+
+	// SCENARIO 2: Provisioning failed
+	if provisioningState == "Failed" {
+		return true, false, "Provisioning FAILED"
+	}
+
+	// SCENARIO 3: VMSS succeeded but never registered in K8s
+	if !hasK8sNode && provisioningState == "Succeeded" {
+		if vmssAge != nil && *vmssAge > minAgeDuration {
+			return true, false, fmt.Sprintf("Never registered in K8s (AllocationFailed), age: %.0f minutes", vmssAge.Minutes())
+		} else if vmssAge == nil {
+			return true, false, "Never registered in K8s (AllocationFailed), no timestamp"
+		}
+	}
+
+	// SCENARIO 4: Has K8s node but with critical issues
+	if hasK8sNode && k8sNode != nil {
+		// Sub-check 4a: Unreachable taint
+		hasUnreachableTaint := false
+		if k8sNode.Spec.Taints != nil {
+			for _, taint := range k8sNode.Spec.Taints {
+				if taint.Key == "node.kubernetes.io/unreachable" {
+					hasUnreachableTaint = true
+					break
+				}
+			}
+		}
+
+		if hasUnreachableTaint {
+			if nodeAge != nil && *nodeAge > minAgeDuration {
+				return true, true, fmt.Sprintf("Node has unreachable taint for %.0f minutes", nodeAge.Minutes())
+			}
+			// Node is too young to be considered a zombie
+			return false, true, ""
+		}
+
+		// Sub-check 4b: NotReady status (only if no unreachable taint)
+		if !isReady {
+			// Special case: Deallocated by autoscaler so healthy state
+			if powerState == "deallocated" {
+				return false, true, ""
+			}
+
+			// Problem case: VM running but node not ready
+			if powerState == "running" && nodeAge != nil && *nodeAge > minAgeDuration {
+				return true, true, fmt.Sprintf("Running VM but NotReady node for %.0f minutes", nodeAge.Minutes())
+			}
+
+			// Node is too young or not running
+			return false, true, ""
+		}
+
+		// Node is healthy
+		return false, true, ""
+	}
+
+	// Not a zombie
+	return false, false, ""
+}
+
+// normalizeProviderID normalizes Azure provider IDs for comparison
+// Removes "azure://" prefix and ensures consistent format
+func normalizeProviderID(providerID string) string {
+	normalized := strings.TrimPrefix(providerID, "azure://")
+	normalized = strings.ReplaceAll(normalized, "\\", "/")
+	normalized = strings.ToLower(normalized)
+	return normalized
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -233,28 +233,17 @@ func (m *AzureManager) evaluateZombieStatus(
 	powerState := ""
 	var vmssAge *time.Duration
 
-	// TODO: Use vm.Properties.TimeCreated for more accurate VM age detection
-	// TimeCreated is populated within ~2 seconds of VM creation, whereas status.Time can take 1-1.5 minutes.
-	// Until migrated, we use status.Time with a conservative MinAge threshold (default 5 minutes) to avoid
-	// accidentally deleting newly created VMs during the window where status.Time hasn't populated yet.
-	//
-	// The TimeCreated field is available in Track 2 SDK armcompute v5.4.0+ (Dec 2023):
-	// - CHANGELOG: https://github.com/Azure/azure-sdk-for-go/blob/d36285c8ffb8f7978c1bff5fa08974019ebab65c/sdk/resourcemanager/compute/armcompute/CHANGELOG.md#L386
-	// - VirtualMachineScaleSetVMProperties: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6#VirtualMachineScaleSetVMProperties
-	//
-	// Current approach uses InstanceView.Statuses[].Time:
-	// - Azure REST API: https://learn.microsoft.com/en-us/rest/api/compute/virtual-machine-scale-set-vms/get?view=rest-compute-2023-09-01
+	if vm.Properties != nil && vm.Properties.TimeCreated != nil {
+		age := currentTime.Sub(*vm.Properties.TimeCreated)
+		vmssAge = &age
+	}
+
 	if vm.Properties != nil && vm.Properties.InstanceView != nil && vm.Properties.InstanceView.Statuses != nil {
 		for _, status := range vm.Properties.InstanceView.Statuses {
 			code := ptr.Deref(status.Code, "")
 
 			if strings.HasPrefix(code, "PowerState/") {
 				powerState = strings.TrimPrefix(code, "PowerState/")
-			}
-
-			if vmssAge == nil && status.Time != nil {
-				age := currentTime.Sub(*status.Time)
-				vmssAge = &age
 			}
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -79,7 +79,7 @@ func (m *AzureManager) cleanupZombieNodesWithContext(nodes []*apiv1.Node) error 
 	scaleSets, err := m.azClient.virtualMachineScaleSetsClient.List(ctx, m.config.ResourceGroup)
 	if err != nil {
 		klog.Errorf("Failed to list VMSS: %v", err)
-		return fmt.Errorf("failed to list VMSS: %v", err)
+		return fmt.Errorf("failed to list VMSS: %w", err)
 	}
 
 	// Build K8s node lookup table

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -257,7 +257,7 @@ func (m *AzureManager) evaluateZombieStatus(
 			if ext.Statuses != nil {
 				for _, status := range ext.Statuses {
 					code := ptr.Deref(status.Code, "")
-					if status.Level != nil && *status.Level == armcompute.StatusLevelTypesError || code == "ProvisioningState/failed" {
+					if (status.Level != nil && *status.Level == armcompute.StatusLevelTypesError) || code == "ProvisioningState/failed" {
 						extensionsFailed = true
 						break
 					}

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -17,12 +17,14 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
@@ -35,7 +37,7 @@ type zombieInstance struct {
 }
 
 // cleanupZombieNodes detects and cleans up zombie VMSS instances that are in non-functional states.
-// A zombie instance is one that:
+// A zombie instance is one that meets any of the following conditions:
 // - Has failed provisioning state
 // - Has failed VM extensions
 // - Never registered in Kubernetes (age > threshold)
@@ -46,7 +48,23 @@ type zombieInstance struct {
 // - VMs that never registered in K8s are directly deleted
 // - VMs with K8s nodes (unreachable/NotReady) are logged only (autoscaler handles deletion)
 func (m *AzureManager) cleanupZombieNodes() error {
-	return m.cleanupZombieNodesWithContext(nil)
+	if m.kubeClient == nil {
+		klog.V(4).Info("No kubeClient available, running zombie cleanup without K8s node context")
+		return m.cleanupZombieNodesWithContext(nil)
+	}
+
+	nodeList, err := m.kubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		klog.Warningf("Failed to list K8s nodes for zombie cleanup, proceeding without K8s context: %v", err)
+		return m.cleanupZombieNodesWithContext(nil)
+	}
+
+	nodes := make([]*apiv1.Node, len(nodeList.Items))
+	for i := range nodeList.Items {
+		nodes[i] = &nodeList.Items[i]
+	}
+
+	return m.cleanupZombieNodesWithContext(nodes)
 }
 
 // cleanupZombieNodesWithContext is similar to cleanupZombieNodes but accepts Kubernetes nodes

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -404,8 +404,8 @@ func (m *AzureManager) evaluateZombieStatus(
 // normalizeProviderID normalizes Azure provider IDs for comparison
 // Removes "azure://" prefix and ensures consistent format
 func normalizeProviderID(providerID string) string {
-	normalized := strings.TrimPrefix(providerID, "azure://")
+	normalized := strings.ToLower(providerID)
+	normalized = strings.TrimPrefix(normalized, "azure://")
 	normalized = strings.ReplaceAll(normalized, "\\", "/")
-	normalized = strings.ToLower(normalized)
 	return normalized
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -212,7 +212,7 @@ func (m *AzureManager) cleanupZombieNodesWithContext(nodes []*apiv1.Node) error 
 			len(instanceIDs), vmssName, instanceIDs)
 
 		// Delete VMSS instances
-		_, err := m.azClient.vmssClientForDelete.BeginDeleteInstances(
+		poller, err := m.azClient.vmssClientForDelete.BeginDeleteInstances(
 			ctx,
 			m.config.ResourceGroup,
 			vmssName,
@@ -227,9 +227,20 @@ func (m *AzureManager) cleanupZombieNodesWithContext(nodes []*apiv1.Node) error 
 			continue
 		}
 
-		// Log success for each zombie
-		for _, zombie := range zombies {
-			klog.V(2).Infof("Successfully cleaned zombie: Instance %s (VMSS: %s)", zombie.instanceID, vmssName)
+		klog.V(2).Infof("Initiated deletion of %d zombie instance(s) from VMSS %s", len(zombies), vmssName)
+
+		// Poll for completion in background
+		if poller != nil {
+			go func(vmssName string, ids []*string) {
+				pollCtx, pollCancel := getContextWithTimeout(asyncContextTimeout)
+				defer pollCancel()
+				_, pollErr := poller.PollUntilDone(pollCtx, nil)
+				if pollErr != nil {
+					klog.Errorf("Zombie deletion polling failed for VMSS %s instances %v: %v", vmssName, ids, pollErr)
+					return
+				}
+				klog.V(2).Infof("Zombie deletion completed for VMSS %s instances %v", vmssName, ids)
+			}(vmssName, instanceIDs)
 		}
 	}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -323,7 +323,7 @@ func (m *AzureManager) evaluateZombieStatus(
 	}
 
 	// SCENARIO 1: Extensions failed or never installed
-	if !hasK8sNode && (!extensionsInstalled || extensionsFailed) {
+	if !hasK8sNode && provisioningState == "Succeeded" && (!extensionsInstalled || extensionsFailed) {
 		if vmssAge == nil {
 			klog.V(4).Infof("Skipping instance %s: no TimeCreated yet (extensions installed=%v, failed=%v)",
 				ptr.Deref(vm.InstanceID, ""), extensionsInstalled, extensionsFailed)

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -295,16 +295,16 @@ func (m *AzureManager) evaluateZombieStatus(
 
 	// SCENARIO 1: Extensions failed or never installed
 	if !hasK8sNode && (!extensionsInstalled || extensionsFailed) {
-		if vmssAge != nil && *vmssAge > minAgeDuration {
+		if vmssAge == nil {
+			klog.V(4).Infof("Skipping instance %s: no TimeCreated yet (extensions installed=%v, failed=%v)",
+				ptr.Deref(vm.InstanceID, ""), extensionsInstalled, extensionsFailed)
+			return false, false, ""
+		}
+		if *vmssAge > minAgeDuration {
 			if extensionsFailed {
 				return true, false, fmt.Sprintf("Extensions FAILED, age: %.0f minutes", vmssAge.Minutes())
 			}
 			return true, false, fmt.Sprintf("Extensions NOT INSTALLED (flapping zombie), age: %.0f minutes", vmssAge.Minutes())
-		} else if vmssAge == nil {
-			if extensionsFailed {
-				return true, false, "Extensions FAILED, no timestamp"
-			}
-			return true, false, "Extensions NOT INSTALLED, no timestamp"
 		}
 	}
 
@@ -315,10 +315,13 @@ func (m *AzureManager) evaluateZombieStatus(
 
 	// SCENARIO 3: VMSS succeeded but never registered in K8s
 	if !hasK8sNode && provisioningState == "Succeeded" {
-		if vmssAge != nil && *vmssAge > minAgeDuration {
+		if vmssAge == nil {
+			klog.V(4).Infof("Skipping instance %s: no TimeCreated yet (provisioning succeeded, not in K8s)",
+				ptr.Deref(vm.InstanceID, ""))
+			return false, false, ""
+		}
+		if *vmssAge > minAgeDuration {
 			return true, false, fmt.Sprintf("Never registered in K8s (AllocationFailed), age: %.0f minutes", vmssAge.Minutes())
-		} else if vmssAge == nil {
-			return true, false, "Never registered in K8s (AllocationFailed), no timestamp"
 		}
 	}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -53,7 +52,10 @@ func (m *AzureManager) cleanupZombieNodes() error {
 		return m.cleanupZombieNodesWithContext(nil)
 	}
 
-	nodeList, err := m.kubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	ctx, cancel := getContextWithTimeout(vmssContextTimeout)
+	defer cancel()
+
+	nodeList, err := m.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		klog.Warningf("Failed to list K8s nodes for zombie cleanup, proceeding without K8s context: %v", err)
 		return m.cleanupZombieNodesWithContext(nil)

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_cleanup.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -87,11 +87,10 @@ func (m *AzureManager) cleanupZombieNodesWithContext(nodes []*apiv1.Node) error 
 		}
 
 		// Get all VMs in this VMSS with instance view
-		vms, err := m.azClient.virtualMachineScaleSetVMsClient.List(
+		vms, err := m.azClient.virtualMachineScaleSetVMsClient.ListVMInstanceView(
 			ctx,
 			m.config.ResourceGroup,
 			vmssName,
-			string(compute.InstanceViewTypesInstanceView),
 		)
 		if err != nil {
 			klog.Warningf("Failed to list VMs for VMSS %s: %v", vmssName, err)
@@ -182,25 +181,27 @@ func (m *AzureManager) cleanupZombieNodesWithContext(nodes []*apiv1.Node) error 
 
 	// Batch delete zombies per VMSS for efficiency
 	for vmssName, zombies := range unregisteredZombies {
-		instanceIDs := make([]string, len(zombies))
+		instanceIDs := make([]*string, len(zombies))
 		for i, zombie := range zombies {
-			instanceIDs[i] = zombie.instanceID
+			instanceIDs[i] = ptr.To(zombie.instanceID)
 		}
 
-		vmInstanceIDs := compute.VirtualMachineScaleSetVMInstanceRequiredIDs{
-			InstanceIds: &instanceIDs,
+		vmInstanceIDs := armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+			InstanceIDs: instanceIDs,
 		}
 
 		klog.V(2).Infof("Deleting %d unregistered zombie instance(s) from VMSS %s: %v",
 			len(instanceIDs), vmssName, instanceIDs)
 
 		// Delete VMSS instances
-		_, err := m.azClient.virtualMachineScaleSetsClient.DeleteInstancesAsync(
+		_, err := m.azClient.vmssClientForDelete.BeginDeleteInstances(
 			ctx,
 			m.config.ResourceGroup,
 			vmssName,
 			vmInstanceIDs,
-			false, // forceDelete
+			&armcompute.VirtualMachineScaleSetsClientBeginDeleteInstancesOptions{
+				ForceDeletion: ptr.To(false),
+			},
 		)
 
 		if err != nil {
@@ -220,16 +221,31 @@ func (m *AzureManager) cleanupZombieNodesWithContext(nodes []*apiv1.Node) error 
 // evaluateZombieStatus evaluates a VMSS VM to determine if it's a zombie
 // Returns (isZombie bool, hasK8sNode bool, reason string)
 func (m *AzureManager) evaluateZombieStatus(
-	vm compute.VirtualMachineScaleSetVM,
+	vm *armcompute.VirtualMachineScaleSetVM,
 	k8sNodeMap map[string]*apiv1.Node,
 	currentTime time.Time,
 	minAgeDuration time.Duration,
 ) (bool, bool, string) {
-	provisioningState := ptr.Deref(vm.ProvisioningState, "")
+	provisioningState := ""
+	if vm.Properties != nil {
+		provisioningState = ptr.Deref(vm.Properties.ProvisioningState, "")
+	}
 	powerState := ""
 	var vmssAge *time.Duration
-	if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
-		for _, status := range *vm.InstanceView.Statuses {
+
+	// TODO: Use vm.Properties.TimeCreated for more accurate VM age detection
+	// TimeCreated is populated within ~2 seconds of VM creation, whereas status.Time can take 1-1.5 minutes.
+	// Until migrated, we use status.Time with a conservative MinAge threshold (default 5 minutes) to avoid
+	// accidentally deleting newly created VMs during the window where status.Time hasn't populated yet.
+	//
+	// The TimeCreated field is available in Track 2 SDK armcompute v5.4.0+ (Dec 2023):
+	// - CHANGELOG: https://github.com/Azure/azure-sdk-for-go/blob/d36285c8ffb8f7978c1bff5fa08974019ebab65c/sdk/resourcemanager/compute/armcompute/CHANGELOG.md#L386
+	// - VirtualMachineScaleSetVMProperties: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6#VirtualMachineScaleSetVMProperties
+	//
+	// Current approach uses InstanceView.Statuses[].Time:
+	// - Azure REST API: https://learn.microsoft.com/en-us/rest/api/compute/virtual-machine-scale-set-vms/get?view=rest-compute-2023-09-01
+	if vm.Properties != nil && vm.Properties.InstanceView != nil && vm.Properties.InstanceView.Statuses != nil {
+		for _, status := range vm.Properties.InstanceView.Statuses {
 			code := ptr.Deref(status.Code, "")
 
 			if strings.HasPrefix(code, "PowerState/") {
@@ -237,7 +253,7 @@ func (m *AzureManager) evaluateZombieStatus(
 			}
 
 			if vmssAge == nil && status.Time != nil {
-				age := currentTime.Sub(status.Time.Time)
+				age := currentTime.Sub(*status.Time)
 				vmssAge = &age
 			}
 		}
@@ -246,13 +262,13 @@ func (m *AzureManager) evaluateZombieStatus(
 	// Check VM extension status
 	extensionsInstalled := false
 	extensionsFailed := false
-	if vm.InstanceView != nil && vm.InstanceView.Extensions != nil && len(*vm.InstanceView.Extensions) > 0 {
+	if vm.Properties != nil && vm.Properties.InstanceView != nil && vm.Properties.InstanceView.Extensions != nil && len(vm.Properties.InstanceView.Extensions) > 0 {
 		extensionsInstalled = true
-		for _, ext := range *vm.InstanceView.Extensions {
+		for _, ext := range vm.Properties.InstanceView.Extensions {
 			if ext.Statuses != nil {
-				for _, status := range *ext.Statuses {
+				for _, status := range ext.Statuses {
 					code := ptr.Deref(status.Code, "")
-					if status.Level == compute.Error || code == "ProvisioningState/failed" {
+					if status.Level != nil && *status.Level == armcompute.StatusLevelTypesError || code == "ProvisioningState/failed" {
 						extensionsFailed = true
 						break
 					}

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
@@ -1,0 +1,841 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
+	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
+	providerazureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
+	providerazure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
+)
+
+func TestZombieCleanup_NoZombiesFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	healthyVMs := []compute.VirtualMachineScaleSetVM{
+		newHealthyVM(0),
+	}
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(healthyVMs, nil)
+
+	// Should not call DeleteInstancesAsync
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_DetectsFailedProvisioning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+	zombieVMs := []compute.VirtualMachineScaleSetVM{
+		newZombieVMWithFailedProvisioning(0, 10*time.Minute),
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+
+	// Verify DeleteInstancesAsync is called with correct instance IDs
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+		gomock.Any(),
+		manager.config.ResourceGroup,
+		vmssName,
+		gomock.AssignableToTypeOf(compute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
+		false,
+	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs, forceDelete bool) (*compute.VirtualMachineScaleSetsDeleteInstancesFuture, error) {
+		// Verify instance ID "0" is in the list
+		assert.NotNil(t, vmInstanceIDs.InstanceIds)
+		assert.Equal(t, 1, len(*vmInstanceIDs.InstanceIds))
+		assert.Equal(t, "0", (*vmInstanceIDs.InstanceIds)[0])
+		return nil, nil
+	})
+
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_DetectsFailedExtensions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	zombieVMs := []compute.VirtualMachineScaleSetVM{
+		newZombieVMWithFailedExtensions(0, 15*time.Minute),
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+		gomock.Any(),
+		manager.config.ResourceGroup,
+		vmssName,
+		gomock.Any(),
+		false,
+	).Return(nil, nil)
+
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_DetectsNeverRegisteredInstances(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	zombieVMs := []compute.VirtualMachineScaleSetVM{
+		newZombieVMNeverRegistered(0, 30*time.Minute),
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+		gomock.Any(),
+		manager.config.ResourceGroup,
+		vmssName,
+		gomock.Any(),
+		false,
+	).Return(nil, nil)
+
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_WithK8sNodesContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	// Create a healthy VM (succeeded provisioning, running) that will be marked unreachable
+	zombieVM := newUnreachableZombieVM(0, 10*time.Minute)
+
+	// Create a K8s node that matches this VM (unreachable)
+	nodes := []*apiv1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "node-0",
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+			},
+			Spec: apiv1.NodeSpec{
+				ProviderID: azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
+				Taints: []apiv1.Taint{
+					{
+						Key:    "node.kubernetes.io/unreachable",
+						Effect: apiv1.TaintEffectNoSchedule,
+					},
+				},
+			},
+		},
+	}
+
+	zombieVMs := []compute.VirtualMachineScaleSetVM{zombieVM}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+
+	// Should NOT call DeleteInstancesAsync because VM has a K8s node
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	err := manager.cleanupZombieNodesWithContext(nodes)
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_RespectsMinAge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 10 // 10 minute threshold
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	// VM that's only 3 minutes old (below threshold)
+	youngZombieVMs := []compute.VirtualMachineScaleSetVM{
+		newZombieVMNeverRegistered(0, 3*time.Minute),
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(youngZombieVMs, nil)
+
+	// Should NOT delete because VM is too young
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_DryRunMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = true // Dry-run enabled
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	zombieVMs := []compute.VirtualMachineScaleSetVM{
+		newZombieVMWithFailedProvisioning(0, 10*time.Minute),
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+
+	// Should NOT call DeleteInstancesAsync in dry-run mode
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_MultipleZombiesInSamePool(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	// Multiple zombie VMs
+	zombieVMs := []compute.VirtualMachineScaleSetVM{
+		newZombieVMWithFailedProvisioning(0, 10*time.Minute),
+		newZombieVMWithFailedExtensions(1, 15*time.Minute),
+		newZombieVMNeverRegistered(2, 20*time.Minute),
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+
+	// Should call DeleteInstancesAsync ONCE with all 3 instance IDs
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+		gomock.Any(),
+		manager.config.ResourceGroup,
+		vmssName,
+		gomock.AssignableToTypeOf(compute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
+		false,
+	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs, forceDelete bool) (*compute.VirtualMachineScaleSetsDeleteInstancesFuture, error) {
+		// Verify all 3 instance IDs are in the batch
+		assert.NotNil(t, vmInstanceIDs.InstanceIds)
+		assert.Equal(t, 3, len(*vmInstanceIDs.InstanceIds))
+		return nil, nil
+	})
+
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_MultipleVMSSPools(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmss1 := "vmss-pool-1"
+	vmss2 := "vmss-pool-2"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmss1)},
+		{Name: ptr.To(vmss2)},
+	}
+
+	zombieVMs1 := []compute.VirtualMachineScaleSetVM{
+		newZombieVMWithFailedProvisioning(0, 10*time.Minute),
+	}
+	zombieVMs2 := []compute.VirtualMachineScaleSetVM{
+		newZombieVMWithFailedExtensions(0, 15*time.Minute),
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmss1, gomock.Any()).Return(zombieVMs1, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmss2, gomock.Any()).Return(zombieVMs2, nil)
+
+	// Should call DeleteInstancesAsync TWICE (once per VMSS)
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, vmss1, gomock.Any(), false).Return(nil, nil)
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, vmss2, gomock.Any(), false).Return(nil, nil)
+
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_MixedZombiesAndHealthy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	// Mix of healthy and zombie VMs
+	vms := []compute.VirtualMachineScaleSetVM{
+		newHealthyVM(0), // Healthy
+		newZombieVMWithFailedProvisioning(1, 10*time.Minute), // Zombie
+		newHealthyVM(2), // Healthy
+		newZombieVMWithFailedExtensions(3, 15*time.Minute), // Zombie
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(vms, nil)
+
+	// Should delete only instances 1 and 3
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+		gomock.Any(),
+		manager.config.ResourceGroup,
+		vmssName,
+		gomock.AssignableToTypeOf(compute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
+		false,
+	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs, forceDelete bool) (*compute.VirtualMachineScaleSetsDeleteInstancesFuture, error) {
+		assert.NotNil(t, vmInstanceIDs.InstanceIds)
+		assert.Equal(t, 2, len(*vmInstanceIDs.InstanceIds))
+		// Verify only zombie instance IDs
+		instanceIDs := *vmInstanceIDs.InstanceIds
+		assert.Contains(t, instanceIDs, "1")
+		assert.Contains(t, instanceIDs, "3")
+		return nil, nil
+	})
+
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_IgnoresDeallocatedNodes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmssName := "test-vmss"
+	mockVMSSList := []compute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	// Deallocated VM (healthy autoscaler scale-down)
+	vms := []compute.VirtualMachineScaleSetVM{
+		newDeallocatedVM(0),
+	}
+
+	// Create a K8s node for this VM (NotReady but deallocated)
+	nodes := []*apiv1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "node-0",
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+			},
+			Spec: apiv1.NodeSpec{
+				ProviderID: azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
+			},
+			Status: apiv1.NodeStatus{
+				Conditions: []apiv1.NodeCondition{
+					{
+						Type:   apiv1.NodeReady,
+						Status: apiv1.ConditionFalse,
+					},
+				},
+			},
+		},
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(vms, nil)
+
+	// Should NOT delete deallocated VMs
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	err := manager.cleanupZombieNodesWithContext(nodes)
+	assert.NoError(t, err)
+}
+
+// ============================================================================
+// SCENARIO DETECTION TESTS - Demonstrating Zombie States
+// ============================================================================
+
+func TestZombieScenario_ExtensionsFailedToInstall(t *testing.T) {
+	zombieVM := newZombieVMWithFailedExtensions(0, 15*time.Minute)
+
+	hasFailedExtension := false
+	if zombieVM.InstanceView != nil && zombieVM.InstanceView.Extensions != nil {
+		for _, ext := range *zombieVM.InstanceView.Extensions {
+			if ext.Statuses != nil {
+				for _, status := range *ext.Statuses {
+					code := ptr.Deref(status.Code, "")
+					if status.Level == "Error" || code == "ProvisioningState/failed" {
+						hasFailedExtension = true
+						break
+					}
+				}
+			}
+		}
+	}
+
+	assert.True(t, hasFailedExtension,
+		"ZOMBIE DETECTED: VM has failed extensions (vmssCSE), preventing Kubernetes registration!")
+}
+
+func TestZombieScenario_ExtensionsNeverInstalled(t *testing.T) {
+	zombieVM := newZombieVMNeverRegistered(0, 20*time.Minute)
+
+	extensionsInstalled := false
+	if zombieVM.InstanceView != nil && zombieVM.InstanceView.Extensions != nil {
+		extensionsInstalled = len(*zombieVM.InstanceView.Extensions) > 0
+	}
+	vmProvisioned := ptr.Deref(zombieVM.ProvisioningState, "") == "Succeeded"
+	vmAge := 20 * time.Minute
+
+	assert.True(t, vmProvisioned && !extensionsInstalled && vmAge > 5*time.Minute,
+		"ZOMBIE DETECTED: VM provisioned successfully but extensions were NEVER INSTALLED (flapping zombie)!")
+}
+
+func TestZombieScenario_ProvisioningFailed(t *testing.T) {
+	zombieVM := newZombieVMWithFailedProvisioning(0, 10*time.Minute)
+
+	provisioningState := ptr.Deref(zombieVM.ProvisioningState, "")
+
+	assert.Equal(t, "Failed", provisioningState,
+		"ZOMBIE DETECTED: VM has ProvisioningState='%s' (should be 'Failed'), wasting quota!",
+		provisioningState)
+}
+
+func TestZombieScenario_NeverRegisteredInKubernetes(t *testing.T) {
+	zombieVM := newZombieVMNeverRegistered(0, 30*time.Minute)
+	vmProvisioned := ptr.Deref(zombieVM.ProvisioningState, "") == "Succeeded"
+	vmAge := 30 * time.Minute
+
+	// Simulated scenario: This VM never appears in `kubectl get nodes`
+	neverRegistered := true // This VM is not in K8s
+	assert.True(t, vmProvisioned && neverRegistered && vmAge > 5*time.Minute,
+		"ZOMBIE DETECTED: VM provisioned %v ago but never registered in Kubernetes (AllocationFailed)!",
+		vmAge)
+}
+
+func TestZombieScenario_NodeUnreachableTaint(t *testing.T) {
+	vm := newHealthyVM(0)
+
+	// Node has unreachable taint (common failure scenario)
+	node := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-0",
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-15 * time.Minute)},
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
+			Taints: []apiv1.Taint{
+				{
+					Key:    "node.kubernetes.io/unreachable",
+					Effect: apiv1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	// VM is running
+	vmIsRunning := false
+	if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
+		for _, status := range *vm.InstanceView.Statuses {
+			if ptr.Deref(status.Code, "") == "PowerState/running" {
+				vmIsRunning = true
+				break
+			}
+		}
+	}
+
+	// Node is tainted unreachable
+	hasUnreachableTaint := false
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "node.kubernetes.io/unreachable" {
+			hasUnreachableTaint = true
+			break
+		}
+	}
+
+	nodeAge := 15 * time.Minute
+
+	assert.True(t, vmIsRunning && hasUnreachableTaint && nodeAge > 5*time.Minute,
+		"ZOMBIE DETECTED: VM is running but node has unreachable taint for %v - pods can't schedule!",
+		nodeAge)
+}
+
+func TestZombieScenario_NodeNotReady(t *testing.T) {
+	vm := newHealthyVM(0)
+
+	// Node is NotReady for 15 minutes
+	node := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-0",
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-15 * time.Minute)},
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
+		},
+		Status: apiv1.NodeStatus{
+			Conditions: []apiv1.NodeCondition{
+				{
+					Type:               apiv1.NodeReady,
+					Status:             apiv1.ConditionFalse,
+					LastTransitionTime: metav1.Time{Time: time.Now().Add(-15 * time.Minute)},
+					Reason:             "KubeletNotReady",
+				},
+			},
+		},
+	}
+
+	// Check VM is running (not deallocated)
+	vmIsRunning := false
+	if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
+		for _, status := range *vm.InstanceView.Statuses {
+			if ptr.Deref(status.Code, "") == "PowerState/running" {
+				vmIsRunning = true
+				break
+			}
+		}
+	}
+
+	vmProvisioned := ptr.Deref(vm.ProvisioningState, "") == "Succeeded"
+
+	// Check node ready status
+	nodeReady := false
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == apiv1.NodeReady && condition.Status == apiv1.ConditionTrue {
+			nodeReady = true
+			break
+		}
+	}
+
+	notReadyDuration := 15 * time.Minute
+
+	assert.True(t, vmProvisioned && vmIsRunning && !nodeReady && notReadyDuration > 5*time.Minute,
+		"ZOMBIE DETECTED: VM running but node NotReady for %v (>5min threshold)!",
+		notReadyDuration)
+}
+
+func TestZombieScenario_DeallocatedNodesAreHealthy(t *testing.T) {
+	deallocatedVM := newDeallocatedVM(0)
+
+	// Check power state
+	isDeallocated := false
+	if deallocatedVM.InstanceView != nil && deallocatedVM.InstanceView.Statuses != nil {
+		for _, status := range *deallocatedVM.InstanceView.Statuses {
+			code := ptr.Deref(status.Code, "")
+			if code == "PowerState/deallocated" {
+				isDeallocated = true
+				break
+			}
+		}
+	}
+
+	assert.True(t, isDeallocated,
+		"Deallocated VM should have PowerState/deallocated (healthy autoscaler scale-down, NOT a zombie)")
+}
+
+func TestZombieScenario_MultipleZombiesWasteQuota(t *testing.T) {
+	// Scenario: 5 VMs in a scale set, demonstrating severe waste
+	vms := []interface{}{
+		newHealthyVM(0), // 1 healthy
+		newZombieVMWithFailedProvisioning(1, 10*time.Minute), // Zombie
+		newZombieVMWithFailedProvisioning(2, 15*time.Minute), // Zombie
+		newZombieVMWithFailedExtensions(3, 20*time.Minute),   // Zombie
+		newZombieVMNeverRegistered(4, 25*time.Minute),        // Zombie
+	}
+
+	totalVMs := len(vms)
+	zombieCount := 4
+
+	zombiePercentage := (zombieCount * 100) / totalVMs
+	assert.Equal(t, 80, zombiePercentage,
+		"ZOMBIE PROBLEM: %d out of %d VMs are zombies (%d%% waste rate) - demonstrating severe quota waste!",
+		zombieCount, totalVMs, zombiePercentage)
+}
+
+func setupMockManager(t *testing.T, ctrl *gomock.Controller) (*AzureManager, *mockvmssclient.MockInterface, *mockvmssvmclient.MockInterface) {
+	manager := newTestAzureManagerForZombieCleanup(t)
+
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+
+	manager.azClient = &azClient{
+		virtualMachineScaleSetsClient:   mockVMSSClient,
+		virtualMachineScaleSetVMsClient: mockVMSSVMClient,
+	}
+
+	return manager, mockVMSSClient, mockVMSSVMClient
+}
+
+func newTestAzureManagerForZombieCleanup(t *testing.T) *AzureManager {
+	return &AzureManager{
+		config: &Config{
+			Config: providerazure.Config{
+				ResourceGroup: "test-rg",
+				VMType:        providerazureconsts.VMTypeVMSS,
+			},
+			EnableZombieCleanup: false,
+			ZombieCleanupDryRun: false,
+			ZombieMinAgeMinutes: 10,
+		},
+	}
+}
+
+// newHealthyVM creates a healthy VMSS VM
+func newHealthyVM(instanceID int) compute.VirtualMachineScaleSetVM {
+	return compute.VirtualMachineScaleSetVM{
+		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
+		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
+		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To("Succeeded"),
+			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: ptr.To("ProvisioningState/succeeded"),
+						Time: &date.Time{Time: time.Now().Add(-2 * time.Minute)},
+					},
+					{
+						Code: ptr.To("PowerState/running"),
+						Time: &date.Time{Time: time.Now().Add(-2 * time.Minute)},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newZombieVMWithFailedProvisioning creates a VMSS VM with failed provisioning state
+func newZombieVMWithFailedProvisioning(instanceID int, age time.Duration) compute.VirtualMachineScaleSetVM {
+	return compute.VirtualMachineScaleSetVM{
+		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
+		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
+		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To("Failed"),
+			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: ptr.To("ProvisioningState/failed"),
+						Time: &date.Time{Time: time.Now().Add(-age)},
+					},
+					{
+						Code: ptr.To("PowerState/running"),
+						Time: &date.Time{Time: time.Now().Add(-age)},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newZombieVMWithFailedExtensions creates a VMSS VM with succeeded provisioning but failed extensions
+func newZombieVMWithFailedExtensions(instanceID int, age time.Duration) compute.VirtualMachineScaleSetVM {
+	return compute.VirtualMachineScaleSetVM{
+		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
+		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
+		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To("Succeeded"),
+			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: ptr.To("ProvisioningState/succeeded"),
+						Time: &date.Time{Time: time.Now().Add(-age)},
+					},
+					{
+						Code: ptr.To("PowerState/running"),
+						Time: &date.Time{Time: time.Now().Add(-age)},
+					},
+				},
+				Extensions: &[]compute.VirtualMachineExtensionInstanceView{
+					{
+						Name: ptr.To("vmssCSE"),
+						Statuses: &[]compute.InstanceViewStatus{
+							{
+								Level: compute.Error,
+								Code:  ptr.To("ProvisioningState/failed"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newZombieVMNeverRegistered creates a VMSS VM that succeeded provisioning but never registered in K8s
+func newZombieVMNeverRegistered(instanceID int, age time.Duration) compute.VirtualMachineScaleSetVM {
+	return compute.VirtualMachineScaleSetVM{
+		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
+		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
+		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To("Succeeded"),
+			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: ptr.To("ProvisioningState/succeeded"),
+						Time: &date.Time{Time: time.Now().Add(-age)},
+					},
+					{
+						Code: ptr.To("PowerState/running"),
+						Time: &date.Time{Time: time.Now().Add(-age)},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newUnreachableZombieVM creates a VM with healthy provisioning that will be paired with unreachable K8s node
+func newUnreachableZombieVM(instanceID int, age time.Duration) compute.VirtualMachineScaleSetVM {
+	return compute.VirtualMachineScaleSetVM{
+		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
+		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
+		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To("Succeeded"),
+			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: ptr.To("ProvisioningState/succeeded"),
+						Time: &date.Time{Time: time.Now().Add(-age)},
+					},
+					{
+						Code: ptr.To("PowerState/running"),
+						Time: &date.Time{Time: time.Now().Add(-age)},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newRecentVM creates a recently created VM (below age threshold)
+func newRecentVM(instanceID int) compute.VirtualMachineScaleSetVM {
+	return compute.VirtualMachineScaleSetVM{
+		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
+		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
+		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To("Succeeded"),
+			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: ptr.To("ProvisioningState/succeeded"),
+						Time: &date.Time{Time: time.Now().Add(-2 * time.Minute)}, // Less than 5 minutes
+					},
+					{
+						Code: ptr.To("PowerState/running"),
+						Time: &date.Time{Time: time.Now().Add(-2 * time.Minute)},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newDeallocatedVM creates a deallocated VM (healthy autoscaler scale-down)
+func newDeallocatedVM(instanceID int) compute.VirtualMachineScaleSetVM {
+	return compute.VirtualMachineScaleSetVM{
+		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
+		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
+		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+			ProvisioningState: ptr.To("Succeeded"),
+			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: ptr.To("ProvisioningState/succeeded"),
+					},
+					{
+						Code: ptr.To("PowerState/deallocated"),
+					},
+				},
+			},
+		},
+	}
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
@@ -668,15 +668,14 @@ func newHealthyVM(instanceID int) *armcompute.VirtualMachineScaleSetVM {
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
+			TimeCreated:       ptr.To(time.Now().Add(-2 * time.Minute)),
 			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
 				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: ptr.To(time.Now().Add(-2 * time.Minute)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: ptr.To(time.Now().Add(-2 * time.Minute)),
 					},
 				},
 			},
@@ -691,15 +690,14 @@ func newZombieVMWithFailedProvisioning(instanceID int, age time.Duration) *armco
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Failed"),
+			TimeCreated:       ptr.To(time.Now().Add(-age)),
 			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
 				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/failed"),
-						Time: ptr.To(time.Now().Add(-age)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: ptr.To(time.Now().Add(-age)),
 					},
 				},
 			},
@@ -714,15 +712,14 @@ func newZombieVMWithFailedExtensions(instanceID int, age time.Duration) *armcomp
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
+			TimeCreated:       ptr.To(time.Now().Add(-age)),
 			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
 				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: ptr.To(time.Now().Add(-age)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: ptr.To(time.Now().Add(-age)),
 					},
 				},
 				Extensions: []*armcompute.VirtualMachineExtensionInstanceView{
@@ -748,15 +745,14 @@ func newZombieVMNeverRegistered(instanceID int, age time.Duration) *armcompute.V
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
+			TimeCreated:       ptr.To(time.Now().Add(-age)),
 			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
 				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: ptr.To(time.Now().Add(-age)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: ptr.To(time.Now().Add(-age)),
 					},
 				},
 			},
@@ -771,15 +767,14 @@ func newUnreachableZombieVM(instanceID int, age time.Duration) *armcompute.Virtu
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
+			TimeCreated:       ptr.To(time.Now().Add(-age)),
 			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
 				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: ptr.To(time.Now().Add(-age)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: ptr.To(time.Now().Add(-age)),
 					},
 				},
 			},
@@ -794,15 +789,14 @@ func newRecentVM(instanceID int) *armcompute.VirtualMachineScaleSetVM {
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
+			TimeCreated:       ptr.To(time.Now().Add(-2 * time.Minute)), // Less than 5 minutes
 			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
 				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: ptr.To(time.Now().Add(-2 * time.Minute)), // Less than 5 minutes
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: ptr.To(time.Now().Add(-2 * time.Minute)),
 					},
 				},
 			},

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
@@ -510,7 +510,7 @@ func TestZombieScenario_ExtensionsFailedToInstall(t *testing.T) {
 			if ext.Statuses != nil {
 				for _, status := range ext.Statuses {
 					code := ptr.Deref(status.Code, "")
-					if *status.Level == armcompute.StatusLevelTypesError || code == "ProvisioningState/failed" {
+					if (status.Level != nil && *status.Level == armcompute.StatusLevelTypesError) || code == "ProvisioningState/failed" {
 						hasFailedExtension = true
 						break
 					}

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
@@ -402,7 +402,7 @@ func TestZombieCleanup_MultipleZombiesInSamePool(t *testing.T) {
 		vmssName,
 		gomock.AssignableToTypeOf(armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
 		gomock.Any(),
-	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, options *armcompute.VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (interface{}, error) {
+	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, options *armcompute.VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (*armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
 		// Verify all 3 instance IDs are in the batch
 		assert.NotNil(t, vmInstanceIDs.InstanceIDs)
 		assert.Equal(t, 3, len(vmInstanceIDs.InstanceIDs))
@@ -480,7 +480,7 @@ func TestZombieCleanup_MixedZombiesAndHealthy(t *testing.T) {
 		vmssName,
 		gomock.AssignableToTypeOf(armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
 		gomock.Any(),
-	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, options *armcompute.VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (interface{}, error) {
+	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, options *armcompute.VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (*armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
 		assert.NotNil(t, vmInstanceIDs.InstanceIDs)
 		assert.Equal(t, 2, len(vmInstanceIDs.InstanceIDs))
 		// Verify only zombie instance IDs
@@ -881,28 +881,6 @@ func newUnreachableZombieVM(instanceID int, age time.Duration) *armcompute.Virtu
 		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
 			TimeCreated:       ptr.To(time.Now().Add(-age)),
-			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
-				Statuses: []*armcompute.InstanceViewStatus{
-					{
-						Code: ptr.To("ProvisioningState/succeeded"),
-					},
-					{
-						Code: ptr.To("PowerState/running"),
-					},
-				},
-			},
-		},
-	}
-}
-
-// newRecentVM creates a recently created VM (below age threshold)
-func newRecentVM(instanceID int) *armcompute.VirtualMachineScaleSetVM {
-	return &armcompute.VirtualMachineScaleSetVM{
-		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
-		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
-		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-			ProvisioningState: ptr.To("Succeeded"),
-			TimeCreated:       ptr.To(time.Now().Add(-2 * time.Minute)), // Less than 5 minutes
 			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
 				Statuses: []*armcompute.InstanceViewStatus{
 					{

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
@@ -233,6 +233,72 @@ func TestZombieCleanup_RespectsMinAge(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestZombieCleanup_SkipsNilTimeCreated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient, _ := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	vmssName := "test-vmss"
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	nilTimeCreatedVMs := []*armcompute.VirtualMachineScaleSetVM{
+		// Never-registered VM with nil TimeCreated
+		{
+			ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0)),
+			InstanceID: ptr.To("0"),
+			Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+				ProvisioningState: ptr.To("Succeeded"),
+				TimeCreated:       nil,
+				InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+					Statuses: []*armcompute.InstanceViewStatus{
+						{Code: ptr.To("ProvisioningState/succeeded")},
+						{Code: ptr.To("PowerState/running")},
+					},
+				},
+			},
+		},
+		// Failed extensions VM with nil TimeCreated
+		{
+			ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 1)),
+			InstanceID: ptr.To("1"),
+			Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+				ProvisioningState: ptr.To("Succeeded"),
+				TimeCreated:       nil,
+				InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+					Statuses: []*armcompute.InstanceViewStatus{
+						{Code: ptr.To("ProvisioningState/succeeded")},
+						{Code: ptr.To("PowerState/running")},
+					},
+					Extensions: []*armcompute.VirtualMachineExtensionInstanceView{
+						{
+							Name: ptr.To("vmssCSE"),
+							Statuses: []*armcompute.InstanceViewStatus{
+								{
+									Level: ptr.To(armcompute.StatusLevelTypesError),
+									Code:  ptr.To("ProvisioningState/failed"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(nilTimeCreatedVMs, nil)
+
+	// No delete calls should be made, skip both VMs
+	err := manager.cleanupZombieNodes()
+	assert.NoError(t, err)
+}
+
 func TestZombieCleanup_DryRunMode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/mock/gomock"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetclient/mock_virtualmachinescalesetclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/mock_virtualmachinescalesetvmclient"
@@ -204,6 +205,52 @@ func TestZombieCleanup_WithK8sNodesContext(t *testing.T) {
 	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(zombieVMs, nil)
 
 	err := manager.cleanupZombieNodesWithContext(nodes)
+	assert.NoError(t, err)
+}
+
+func TestZombieCleanup_UsesKubeClientForNodeContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient, mockVMSSVMClient, _ := setupMockManager(t, ctrl)
+	manager.config.EnableZombieCleanup = true
+	manager.config.ZombieCleanupDryRun = false
+	manager.config.ZombieMinAgeMinutes = 5
+
+	// Create a K8s node with unreachable taint using the fake clientset
+	unreachableNode := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-0",
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: azurePrefix + fmt.Sprintf(fakeVirtualMachineScaleSetVMID, 0),
+			Taints: []apiv1.Taint{
+				{
+					Key:    "node.kubernetes.io/unreachable",
+					Effect: apiv1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+	manager.kubeClient = fake.NewSimpleClientset(unreachableNode)
+
+	vmssName := "test-vmss"
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
+		{Name: ptr.To(vmssName)},
+	}
+
+	// Succeeded+running VM that matches the unreachable K8s node
+	zombieVM := newUnreachableZombieVM(0, 10*time.Minute)
+
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(
+		[]*armcompute.VirtualMachineScaleSetVM{zombieVM}, nil,
+	)
+
+	// Call cleanupZombieNodes() not cleanupZombieNodesWithContext)
+	// hasK8sNode=true so the zombie is logged only, not deleted.
+	err := manager.cleanupZombieNodes()
 	assert.NoError(t, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_zombie_test.go
@@ -22,39 +22,36 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
-	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
-	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetclient/mock_virtualmachinescalesetclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetvmclient/mock_virtualmachinescalesetvmclient"
 	providerazureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
-	providerazure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
+	providerazureconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 )
 
 func TestZombieCleanup_NoZombiesFound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, _ := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	healthyVMs := []compute.VirtualMachineScaleSetVM{
+	healthyVMs := []*armcompute.VirtualMachineScaleSetVM{
 		newHealthyVM(0),
 	}
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(healthyVMs, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(healthyVMs, nil)
 
-	// Should not call DeleteInstancesAsync
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	err := manager.cleanupZombieNodes()
 	assert.NoError(t, err)
 }
@@ -63,34 +60,35 @@ func TestZombieCleanup_DetectsFailedProvisioning(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, _, mockVMSSVMClient, mockDeleteClient := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 	manager.config.ZombieMinAgeMinutes = 5
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
-	zombieVMs := []compute.VirtualMachineScaleSetVM{
+	zombieVMs := []*armcompute.VirtualMachineScaleSetVM{
 		newZombieVMWithFailedProvisioning(0, 10*time.Minute),
 	}
 
+	mockVMSSClient := manager.azClient.virtualMachineScaleSetsClient.(*mock_virtualmachinescalesetclient.MockInterface)
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(zombieVMs, nil)
 
-	// Verify DeleteInstancesAsync is called with correct instance IDs
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+	// Verify BeginDeleteInstances is called with correct instance IDs
+	mockDeleteClient.EXPECT().BeginDeleteInstances(
 		gomock.Any(),
 		manager.config.ResourceGroup,
 		vmssName,
-		gomock.AssignableToTypeOf(compute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
-		false,
-	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs, forceDelete bool) (*compute.VirtualMachineScaleSetsDeleteInstancesFuture, error) {
+		gomock.AssignableToTypeOf(armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
+		gomock.Any(),
+	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, options *armcompute.VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (*armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse, error) {
 		// Verify instance ID "0" is in the list
-		assert.NotNil(t, vmInstanceIDs.InstanceIds)
-		assert.Equal(t, 1, len(*vmInstanceIDs.InstanceIds))
-		assert.Equal(t, "0", (*vmInstanceIDs.InstanceIds)[0])
+		assert.NotNil(t, vmInstanceIDs.InstanceIDs)
+		assert.Equal(t, 1, len(vmInstanceIDs.InstanceIDs))
+		assert.Equal(t, "0", *vmInstanceIDs.InstanceIDs[0])
 		return nil, nil
 	})
 
@@ -102,29 +100,29 @@ func TestZombieCleanup_DetectsFailedExtensions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, mockDeleteClient := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 	manager.config.ZombieMinAgeMinutes = 5
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
 
-	zombieVMs := []compute.VirtualMachineScaleSetVM{
+	zombieVMs := []*armcompute.VirtualMachineScaleSetVM{
 		newZombieVMWithFailedExtensions(0, 15*time.Minute),
 	}
 
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(zombieVMs, nil)
 
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+	mockDeleteClient.EXPECT().BeginDeleteInstances(
 		gomock.Any(),
 		manager.config.ResourceGroup,
 		vmssName,
 		gomock.Any(),
-		false,
+		gomock.Any(),
 	).Return(nil, nil)
 
 	err := manager.cleanupZombieNodes()
@@ -135,29 +133,29 @@ func TestZombieCleanup_DetectsNeverRegisteredInstances(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, mockDeleteClient := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 	manager.config.ZombieMinAgeMinutes = 5
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
 
-	zombieVMs := []compute.VirtualMachineScaleSetVM{
+	zombieVMs := []*armcompute.VirtualMachineScaleSetVM{
 		newZombieVMNeverRegistered(0, 30*time.Minute),
 	}
 
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(zombieVMs, nil)
 
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+	mockDeleteClient.EXPECT().BeginDeleteInstances(
 		gomock.Any(),
 		manager.config.ResourceGroup,
 		vmssName,
 		gomock.Any(),
-		false,
+		gomock.Any(),
 	).Return(nil, nil)
 
 	err := manager.cleanupZombieNodes()
@@ -168,13 +166,13 @@ func TestZombieCleanup_WithK8sNodesContext(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, _ := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 	manager.config.ZombieMinAgeMinutes = 5
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
 
@@ -200,13 +198,10 @@ func TestZombieCleanup_WithK8sNodesContext(t *testing.T) {
 		},
 	}
 
-	zombieVMs := []compute.VirtualMachineScaleSetVM{zombieVM}
+	zombieVMs := []*armcompute.VirtualMachineScaleSetVM{zombieVM}
 
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
-
-	// Should NOT call DeleteInstancesAsync because VM has a K8s node
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(zombieVMs, nil)
 
 	err := manager.cleanupZombieNodesWithContext(nodes)
 	assert.NoError(t, err)
@@ -216,26 +211,23 @@ func TestZombieCleanup_RespectsMinAge(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, _ := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 	manager.config.ZombieMinAgeMinutes = 10 // 10 minute threshold
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
 
 	// VM that's only 3 minutes old (below threshold)
-	youngZombieVMs := []compute.VirtualMachineScaleSetVM{
+	youngZombieVMs := []*armcompute.VirtualMachineScaleSetVM{
 		newZombieVMNeverRegistered(0, 3*time.Minute),
 	}
 
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(youngZombieVMs, nil)
-
-	// Should NOT delete because VM is too young
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(youngZombieVMs, nil)
 
 	err := manager.cleanupZombieNodes()
 	assert.NoError(t, err)
@@ -245,25 +237,22 @@ func TestZombieCleanup_DryRunMode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, _ := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = true // Dry-run enabled
 	manager.config.ZombieMinAgeMinutes = 5
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
 
-	zombieVMs := []compute.VirtualMachineScaleSetVM{
+	zombieVMs := []*armcompute.VirtualMachineScaleSetVM{
 		newZombieVMWithFailedProvisioning(0, 10*time.Minute),
 	}
 
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
-
-	// Should NOT call DeleteInstancesAsync in dry-run mode
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(zombieVMs, nil)
 
 	err := manager.cleanupZombieNodes()
 	assert.NoError(t, err)
@@ -273,37 +262,37 @@ func TestZombieCleanup_MultipleZombiesInSamePool(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, mockDeleteClient := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 	manager.config.ZombieMinAgeMinutes = 5
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
 
 	// Multiple zombie VMs
-	zombieVMs := []compute.VirtualMachineScaleSetVM{
+	zombieVMs := []*armcompute.VirtualMachineScaleSetVM{
 		newZombieVMWithFailedProvisioning(0, 10*time.Minute),
 		newZombieVMWithFailedExtensions(1, 15*time.Minute),
 		newZombieVMNeverRegistered(2, 20*time.Minute),
 	}
 
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(zombieVMs, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(zombieVMs, nil)
 
-	// Should call DeleteInstancesAsync ONCE with all 3 instance IDs
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+	// Should call BeginDeleteInstances ONCE with all 3 instance IDs
+	mockDeleteClient.EXPECT().BeginDeleteInstances(
 		gomock.Any(),
 		manager.config.ResourceGroup,
 		vmssName,
-		gomock.AssignableToTypeOf(compute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
-		false,
-	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs, forceDelete bool) (*compute.VirtualMachineScaleSetsDeleteInstancesFuture, error) {
+		gomock.AssignableToTypeOf(armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
+		gomock.Any(),
+	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, options *armcompute.VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (interface{}, error) {
 		// Verify all 3 instance IDs are in the batch
-		assert.NotNil(t, vmInstanceIDs.InstanceIds)
-		assert.Equal(t, 3, len(*vmInstanceIDs.InstanceIds))
+		assert.NotNil(t, vmInstanceIDs.InstanceIDs)
+		assert.Equal(t, 3, len(vmInstanceIDs.InstanceIDs))
 		return nil, nil
 	})
 
@@ -315,32 +304,32 @@ func TestZombieCleanup_MultipleVMSSPools(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, mockDeleteClient := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 	manager.config.ZombieMinAgeMinutes = 5
 
 	vmss1 := "vmss-pool-1"
 	vmss2 := "vmss-pool-2"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmss1)},
 		{Name: ptr.To(vmss2)},
 	}
 
-	zombieVMs1 := []compute.VirtualMachineScaleSetVM{
+	zombieVMs1 := []*armcompute.VirtualMachineScaleSetVM{
 		newZombieVMWithFailedProvisioning(0, 10*time.Minute),
 	}
-	zombieVMs2 := []compute.VirtualMachineScaleSetVM{
+	zombieVMs2 := []*armcompute.VirtualMachineScaleSetVM{
 		newZombieVMWithFailedExtensions(0, 15*time.Minute),
 	}
 
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmss1, gomock.Any()).Return(zombieVMs1, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmss2, gomock.Any()).Return(zombieVMs2, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmss1).Return(zombieVMs1, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmss2).Return(zombieVMs2, nil)
 
-	// Should call DeleteInstancesAsync TWICE (once per VMSS)
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, vmss1, gomock.Any(), false).Return(nil, nil)
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, vmss2, gomock.Any(), false).Return(nil, nil)
+	// Should call BeginDeleteInstances TWICE (once per VMSS)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), manager.config.ResourceGroup, vmss1, gomock.Any(), gomock.Any()).Return(nil, nil)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), manager.config.ResourceGroup, vmss2, gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	err := manager.cleanupZombieNodes()
 	assert.NoError(t, err)
@@ -350,18 +339,18 @@ func TestZombieCleanup_MixedZombiesAndHealthy(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, mockDeleteClient := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 	manager.config.ZombieMinAgeMinutes = 5
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
 
 	// Mix of healthy and zombie VMs
-	vms := []compute.VirtualMachineScaleSetVM{
+	vms := []*armcompute.VirtualMachineScaleSetVM{
 		newHealthyVM(0), // Healthy
 		newZombieVMWithFailedProvisioning(1, 10*time.Minute), // Zombie
 		newHealthyVM(2), // Healthy
@@ -369,22 +358,25 @@ func TestZombieCleanup_MixedZombiesAndHealthy(t *testing.T) {
 	}
 
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(vms, nil)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(vms, nil)
 
 	// Should delete only instances 1 and 3
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(
+	mockDeleteClient.EXPECT().BeginDeleteInstances(
 		gomock.Any(),
 		manager.config.ResourceGroup,
 		vmssName,
-		gomock.AssignableToTypeOf(compute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
-		false,
-	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs, forceDelete bool) (*compute.VirtualMachineScaleSetsDeleteInstancesFuture, error) {
-		assert.NotNil(t, vmInstanceIDs.InstanceIds)
-		assert.Equal(t, 2, len(*vmInstanceIDs.InstanceIds))
+		gomock.AssignableToTypeOf(armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{}),
+		gomock.Any(),
+	).DoAndReturn(func(ctx context.Context, resourceGroup, vmssName string, vmInstanceIDs armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs, options *armcompute.VirtualMachineScaleSetsClientBeginDeleteInstancesOptions) (interface{}, error) {
+		assert.NotNil(t, vmInstanceIDs.InstanceIDs)
+		assert.Equal(t, 2, len(vmInstanceIDs.InstanceIDs))
 		// Verify only zombie instance IDs
-		instanceIDs := *vmInstanceIDs.InstanceIds
-		assert.Contains(t, instanceIDs, "1")
-		assert.Contains(t, instanceIDs, "3")
+		var ids []string
+		for _, id := range vmInstanceIDs.InstanceIDs {
+			ids = append(ids, *id)
+		}
+		assert.Contains(t, ids, "1")
+		assert.Contains(t, ids, "3")
 		return nil, nil
 	})
 
@@ -396,18 +388,18 @@ func TestZombieCleanup_IgnoresDeallocatedNodes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	manager, mockVMSSClient, mockVMSSVMClient := setupMockManager(t, ctrl)
+	manager, mockVMSSClient, mockVMSSVMClient, _ := setupMockManager(t, ctrl)
 	manager.config.EnableZombieCleanup = true
 	manager.config.ZombieCleanupDryRun = false
 	manager.config.ZombieMinAgeMinutes = 5
 
 	vmssName := "test-vmss"
-	mockVMSSList := []compute.VirtualMachineScaleSet{
+	mockVMSSList := []*armcompute.VirtualMachineScaleSet{
 		{Name: ptr.To(vmssName)},
 	}
 
 	// Deallocated VM (healthy autoscaler scale-down)
-	vms := []compute.VirtualMachineScaleSetVM{
+	vms := []*armcompute.VirtualMachineScaleSetVM{
 		newDeallocatedVM(0),
 	}
 
@@ -433,10 +425,7 @@ func TestZombieCleanup_IgnoresDeallocatedNodes(t *testing.T) {
 	}
 
 	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(mockVMSSList, nil)
-	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).Return(vms, nil)
-
-	// Should NOT delete deallocated VMs
-	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(vms, nil)
 
 	err := manager.cleanupZombieNodesWithContext(nodes)
 	assert.NoError(t, err)
@@ -450,12 +439,12 @@ func TestZombieScenario_ExtensionsFailedToInstall(t *testing.T) {
 	zombieVM := newZombieVMWithFailedExtensions(0, 15*time.Minute)
 
 	hasFailedExtension := false
-	if zombieVM.InstanceView != nil && zombieVM.InstanceView.Extensions != nil {
-		for _, ext := range *zombieVM.InstanceView.Extensions {
+	if zombieVM.Properties != nil && zombieVM.Properties.InstanceView != nil && zombieVM.Properties.InstanceView.Extensions != nil {
+		for _, ext := range zombieVM.Properties.InstanceView.Extensions {
 			if ext.Statuses != nil {
-				for _, status := range *ext.Statuses {
+				for _, status := range ext.Statuses {
 					code := ptr.Deref(status.Code, "")
-					if status.Level == "Error" || code == "ProvisioningState/failed" {
+					if *status.Level == armcompute.StatusLevelTypesError || code == "ProvisioningState/failed" {
 						hasFailedExtension = true
 						break
 					}
@@ -472,10 +461,10 @@ func TestZombieScenario_ExtensionsNeverInstalled(t *testing.T) {
 	zombieVM := newZombieVMNeverRegistered(0, 20*time.Minute)
 
 	extensionsInstalled := false
-	if zombieVM.InstanceView != nil && zombieVM.InstanceView.Extensions != nil {
-		extensionsInstalled = len(*zombieVM.InstanceView.Extensions) > 0
+	if zombieVM.Properties != nil && zombieVM.Properties.InstanceView != nil && zombieVM.Properties.InstanceView.Extensions != nil {
+		extensionsInstalled = len(zombieVM.Properties.InstanceView.Extensions) > 0
 	}
-	vmProvisioned := ptr.Deref(zombieVM.ProvisioningState, "") == "Succeeded"
+	vmProvisioned := ptr.Deref(zombieVM.Properties.ProvisioningState, "") == "Succeeded"
 	vmAge := 20 * time.Minute
 
 	assert.True(t, vmProvisioned && !extensionsInstalled && vmAge > 5*time.Minute,
@@ -485,7 +474,7 @@ func TestZombieScenario_ExtensionsNeverInstalled(t *testing.T) {
 func TestZombieScenario_ProvisioningFailed(t *testing.T) {
 	zombieVM := newZombieVMWithFailedProvisioning(0, 10*time.Minute)
 
-	provisioningState := ptr.Deref(zombieVM.ProvisioningState, "")
+	provisioningState := ptr.Deref(zombieVM.Properties.ProvisioningState, "")
 
 	assert.Equal(t, "Failed", provisioningState,
 		"ZOMBIE DETECTED: VM has ProvisioningState='%s' (should be 'Failed'), wasting quota!",
@@ -494,7 +483,7 @@ func TestZombieScenario_ProvisioningFailed(t *testing.T) {
 
 func TestZombieScenario_NeverRegisteredInKubernetes(t *testing.T) {
 	zombieVM := newZombieVMNeverRegistered(0, 30*time.Minute)
-	vmProvisioned := ptr.Deref(zombieVM.ProvisioningState, "") == "Succeeded"
+	vmProvisioned := ptr.Deref(zombieVM.Properties.ProvisioningState, "") == "Succeeded"
 	vmAge := 30 * time.Minute
 
 	// Simulated scenario: This VM never appears in `kubectl get nodes`
@@ -526,8 +515,8 @@ func TestZombieScenario_NodeUnreachableTaint(t *testing.T) {
 
 	// VM is running
 	vmIsRunning := false
-	if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
-		for _, status := range *vm.InstanceView.Statuses {
+	if vm.Properties != nil && vm.Properties.InstanceView != nil && vm.Properties.InstanceView.Statuses != nil {
+		for _, status := range vm.Properties.InstanceView.Statuses {
 			if ptr.Deref(status.Code, "") == "PowerState/running" {
 				vmIsRunning = true
 				break
@@ -577,8 +566,8 @@ func TestZombieScenario_NodeNotReady(t *testing.T) {
 
 	// Check VM is running (not deallocated)
 	vmIsRunning := false
-	if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
-		for _, status := range *vm.InstanceView.Statuses {
+	if vm.Properties != nil && vm.Properties.InstanceView != nil && vm.Properties.InstanceView.Statuses != nil {
+		for _, status := range vm.Properties.InstanceView.Statuses {
 			if ptr.Deref(status.Code, "") == "PowerState/running" {
 				vmIsRunning = true
 				break
@@ -586,7 +575,7 @@ func TestZombieScenario_NodeNotReady(t *testing.T) {
 		}
 	}
 
-	vmProvisioned := ptr.Deref(vm.ProvisioningState, "") == "Succeeded"
+	vmProvisioned := ptr.Deref(vm.Properties.ProvisioningState, "") == "Succeeded"
 
 	// Check node ready status
 	nodeReady := false
@@ -609,8 +598,8 @@ func TestZombieScenario_DeallocatedNodesAreHealthy(t *testing.T) {
 
 	// Check power state
 	isDeallocated := false
-	if deallocatedVM.InstanceView != nil && deallocatedVM.InstanceView.Statuses != nil {
-		for _, status := range *deallocatedVM.InstanceView.Statuses {
+	if deallocatedVM.Properties != nil && deallocatedVM.Properties.InstanceView != nil && deallocatedVM.Properties.InstanceView.Statuses != nil {
+		for _, status := range deallocatedVM.Properties.InstanceView.Statuses {
 			code := ptr.Deref(status.Code, "")
 			if code == "PowerState/deallocated" {
 				isDeallocated = true
@@ -642,24 +631,26 @@ func TestZombieScenario_MultipleZombiesWasteQuota(t *testing.T) {
 		zombieCount, totalVMs, zombiePercentage)
 }
 
-func setupMockManager(t *testing.T, ctrl *gomock.Controller) (*AzureManager, *mockvmssclient.MockInterface, *mockvmssvmclient.MockInterface) {
+func setupMockManager(t *testing.T, ctrl *gomock.Controller) (*AzureManager, *mock_virtualmachinescalesetclient.MockInterface, *mock_virtualmachinescalesetvmclient.MockInterface, *MockVMSSDeleteClient) {
 	manager := newTestAzureManagerForZombieCleanup(t)
 
-	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
-	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
 
 	manager.azClient = &azClient{
 		virtualMachineScaleSetsClient:   mockVMSSClient,
 		virtualMachineScaleSetVMsClient: mockVMSSVMClient,
+		vmssClientForDelete:             mockDeleteClient,
 	}
 
-	return manager, mockVMSSClient, mockVMSSVMClient
+	return manager, mockVMSSClient, mockVMSSVMClient, mockDeleteClient
 }
 
 func newTestAzureManagerForZombieCleanup(t *testing.T) *AzureManager {
 	return &AzureManager{
 		config: &Config{
-			Config: providerazure.Config{
+			Config: providerazureconfig.Config{
 				ResourceGroup: "test-rg",
 				VMType:        providerazureconsts.VMTypeVMSS,
 			},
@@ -671,21 +662,21 @@ func newTestAzureManagerForZombieCleanup(t *testing.T) *AzureManager {
 }
 
 // newHealthyVM creates a healthy VMSS VM
-func newHealthyVM(instanceID int) compute.VirtualMachineScaleSetVM {
-	return compute.VirtualMachineScaleSetVM{
+func newHealthyVM(instanceID int) *armcompute.VirtualMachineScaleSetVM {
+	return &armcompute.VirtualMachineScaleSetVM{
 		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
-		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
-			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
-				Statuses: &[]compute.InstanceViewStatus{
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: &date.Time{Time: time.Now().Add(-2 * time.Minute)},
+						Time: ptr.To(time.Now().Add(-2 * time.Minute)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: &date.Time{Time: time.Now().Add(-2 * time.Minute)},
+						Time: ptr.To(time.Now().Add(-2 * time.Minute)),
 					},
 				},
 			},
@@ -694,21 +685,21 @@ func newHealthyVM(instanceID int) compute.VirtualMachineScaleSetVM {
 }
 
 // newZombieVMWithFailedProvisioning creates a VMSS VM with failed provisioning state
-func newZombieVMWithFailedProvisioning(instanceID int, age time.Duration) compute.VirtualMachineScaleSetVM {
-	return compute.VirtualMachineScaleSetVM{
+func newZombieVMWithFailedProvisioning(instanceID int, age time.Duration) *armcompute.VirtualMachineScaleSetVM {
+	return &armcompute.VirtualMachineScaleSetVM{
 		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
-		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Failed"),
-			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
-				Statuses: &[]compute.InstanceViewStatus{
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/failed"),
-						Time: &date.Time{Time: time.Now().Add(-age)},
+						Time: ptr.To(time.Now().Add(-age)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: &date.Time{Time: time.Now().Add(-age)},
+						Time: ptr.To(time.Now().Add(-age)),
 					},
 				},
 			},
@@ -717,29 +708,29 @@ func newZombieVMWithFailedProvisioning(instanceID int, age time.Duration) comput
 }
 
 // newZombieVMWithFailedExtensions creates a VMSS VM with succeeded provisioning but failed extensions
-func newZombieVMWithFailedExtensions(instanceID int, age time.Duration) compute.VirtualMachineScaleSetVM {
-	return compute.VirtualMachineScaleSetVM{
+func newZombieVMWithFailedExtensions(instanceID int, age time.Duration) *armcompute.VirtualMachineScaleSetVM {
+	return &armcompute.VirtualMachineScaleSetVM{
 		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
-		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
-			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
-				Statuses: &[]compute.InstanceViewStatus{
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: &date.Time{Time: time.Now().Add(-age)},
+						Time: ptr.To(time.Now().Add(-age)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: &date.Time{Time: time.Now().Add(-age)},
+						Time: ptr.To(time.Now().Add(-age)),
 					},
 				},
-				Extensions: &[]compute.VirtualMachineExtensionInstanceView{
+				Extensions: []*armcompute.VirtualMachineExtensionInstanceView{
 					{
 						Name: ptr.To("vmssCSE"),
-						Statuses: &[]compute.InstanceViewStatus{
+						Statuses: []*armcompute.InstanceViewStatus{
 							{
-								Level: compute.Error,
+								Level: ptr.To(armcompute.StatusLevelTypesError),
 								Code:  ptr.To("ProvisioningState/failed"),
 							},
 						},
@@ -751,21 +742,21 @@ func newZombieVMWithFailedExtensions(instanceID int, age time.Duration) compute.
 }
 
 // newZombieVMNeverRegistered creates a VMSS VM that succeeded provisioning but never registered in K8s
-func newZombieVMNeverRegistered(instanceID int, age time.Duration) compute.VirtualMachineScaleSetVM {
-	return compute.VirtualMachineScaleSetVM{
+func newZombieVMNeverRegistered(instanceID int, age time.Duration) *armcompute.VirtualMachineScaleSetVM {
+	return &armcompute.VirtualMachineScaleSetVM{
 		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
-		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
-			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
-				Statuses: &[]compute.InstanceViewStatus{
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: &date.Time{Time: time.Now().Add(-age)},
+						Time: ptr.To(time.Now().Add(-age)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: &date.Time{Time: time.Now().Add(-age)},
+						Time: ptr.To(time.Now().Add(-age)),
 					},
 				},
 			},
@@ -774,21 +765,21 @@ func newZombieVMNeverRegistered(instanceID int, age time.Duration) compute.Virtu
 }
 
 // newUnreachableZombieVM creates a VM with healthy provisioning that will be paired with unreachable K8s node
-func newUnreachableZombieVM(instanceID int, age time.Duration) compute.VirtualMachineScaleSetVM {
-	return compute.VirtualMachineScaleSetVM{
+func newUnreachableZombieVM(instanceID int, age time.Duration) *armcompute.VirtualMachineScaleSetVM {
+	return &armcompute.VirtualMachineScaleSetVM{
 		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
-		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
-			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
-				Statuses: &[]compute.InstanceViewStatus{
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: &date.Time{Time: time.Now().Add(-age)},
+						Time: ptr.To(time.Now().Add(-age)),
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: &date.Time{Time: time.Now().Add(-age)},
+						Time: ptr.To(time.Now().Add(-age)),
 					},
 				},
 			},
@@ -797,21 +788,21 @@ func newUnreachableZombieVM(instanceID int, age time.Duration) compute.VirtualMa
 }
 
 // newRecentVM creates a recently created VM (below age threshold)
-func newRecentVM(instanceID int) compute.VirtualMachineScaleSetVM {
-	return compute.VirtualMachineScaleSetVM{
+func newRecentVM(instanceID int) *armcompute.VirtualMachineScaleSetVM {
+	return &armcompute.VirtualMachineScaleSetVM{
 		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
-		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
-			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
-				Statuses: &[]compute.InstanceViewStatus{
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
-						Time: &date.Time{Time: time.Now().Add(-2 * time.Minute)}, // Less than 5 minutes
+						Time: ptr.To(time.Now().Add(-2 * time.Minute)), // Less than 5 minutes
 					},
 					{
 						Code: ptr.To("PowerState/running"),
-						Time: &date.Time{Time: time.Now().Add(-2 * time.Minute)},
+						Time: ptr.To(time.Now().Add(-2 * time.Minute)),
 					},
 				},
 			},
@@ -820,14 +811,14 @@ func newRecentVM(instanceID int) compute.VirtualMachineScaleSetVM {
 }
 
 // newDeallocatedVM creates a deallocated VM (healthy autoscaler scale-down)
-func newDeallocatedVM(instanceID int) compute.VirtualMachineScaleSetVM {
-	return compute.VirtualMachineScaleSetVM{
+func newDeallocatedVM(instanceID int) *armcompute.VirtualMachineScaleSetVM {
+	return &armcompute.VirtualMachineScaleSetVM{
 		ID:         ptr.To(fmt.Sprintf(fakeVirtualMachineScaleSetVMID, instanceID)),
 		InstanceID: ptr.To(fmt.Sprintf("%d", instanceID)),
-		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 			ProvisioningState: ptr.To("Succeeded"),
-			InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
-				Statuses: &[]compute.InstanceViewStatus{
+			InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+				Statuses: []*armcompute.InstanceViewStatus{
 					{
 						Code: ptr.To("ProvisioningState/succeeded"),
 					},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
A customer had a cleanup script to cleanup "zombie nodes", non-functional Azure infra/Kubernetes nodes that are persisting in a Kubernetes cluster (and in the component state machines in cloud-provider-azure and CA). The customer has an old-fashioned script that looks for well-known "bad terminal states" of VMSS VMs and then deletes those. This PR implements that customer need into CA so that logic can be done from a point of authority.

### ****`azure_zombie_cleanup.go`** is the cleanup implementation:**
1. Check if enabled - Returns early if EnableZombieCleanup is false
2. Build K8s node lookup - Creates a map of normalized provider IDs to nodes for correlation
3. Scan all VMSS - Lists all scale sets and their VMs with instance views
4. Detect zombies - Calls evaluateZombieStatus() for each VM
5. Split by registration status:
    * Unregistered zombies (no K8s node): Safe to delete directly 
    * Registered zombies (has K8s node): Only logs and lets autoscaler handle
6. Batch delete - Groups unregistered zombies by VMSS and calls BeginDeleteInstances()

### **Key notes:**
* VMs that never registered have no K8s state so its safe to delete immediately manually
* VMs with K8s nodes (unreachable/NotReady) we can pass off to autoscaler to handle proper state deletion
* Age threshold (default 5 min) prevents deleting recently created VMs
* Feature EnableZombieCleanup config flag 
    * Dry-run mode ZombieCleanupDryRun would log what would be deleted but doesn’t actually take action
* Batch deletion reduces API calls and improves efficiency
* Inside Batch deletion poll for completion in background, matching the pattern in ScaleSet.waitForDeleteInstances
* When Cluster Autoscaler migreated to Track 2 Azure SDK we can now use `vm.TimeCreated` to populate the time within 2 seconds of VM creation versus Track 1's `status.Time` which can take 1-1.5 minutes. 
Track 1: InstanceView.Statuses https://pkg.go.dev/github.com/Azure/azure-sdk-for-go@v68.0.0+incompatible/services/compute/mgmt/2022-08-01/compute#InstanceViewStatus
Track 2: TimeCreated https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5#VirtualMachineScaleSetVMProperties
Scenario 2 where provisioning failed doesnt need to have the TimeCreated is nil check because provisioning state failed is not transient
* The first check is if extensions failed/never installed because that is the more specific scenario, but if this is the case AND provisioning failed then we should skip to the next scenario because provisioning failed is the larger issue 

### **Functions Implemented:**
`cleanupZombieNodes()`: Main entry point
`cleanupZombieNodesWithContext(nodes)`: Accepts K8s nodes for correlation
`evaluateZombieStatus(vm, k8sNodeMap, time, minAge)`: Returns (isZombie, hasK8sNode, reason)
`normalizeProviderID(providerID)`: Matches Azure IDs to K8s provider IDs
The implementation is called from `forceRefresh()` in `azure_manager.go` runs every interval of `VmssCacheTTLInSeconds` (default is 1min)

### **Tests:**
* TestZombieCleanup_NoZombiesFound - Verifies behavior when no zombies exist
* TestZombieCleanup_DetectsFailedProvisioning - Verifies Scenario 2: Provisioning failed
* TestZombieCleanup_DetectsFailedExtensions - Verifies Scenario 1: Extensions failed
* TestZombieCleanup_DetectsNeverRegisteredInstances - Verifies Scenario 3: Never registered
* TestZombieCleanup_WithK8sNodesContext - Verifies registered zombies are NOT deleted (Scenario 4a: Unreachable taint)
* TestZombieCleanup_RespectsMinAge - Verifies age threshold is respected
* TestZombieCleanup_DryRunMode - Verifies dry-run doesn't delete anything
* TestZombieCleanup_MultipleZombiesInSamePool - Verifies batch deletion
* TestZombieCleanup_MultipleVMSSPools - Verifies cleanup across multiple pools
* TestZombieCleanup_MixedZombiesAndHealthy - Verifies only zombies are deleted
* TestZombieCleanup_IgnoresDeallocatedNodes - Verifies deallocated VMs are not deleted (Scenario 4b: NotReady but deallocated)
* TestZombieCleanup_UsesKubeClientForNodeContext - Verifies kubeClient is used to fetch K8s nodes for zombie cleanup context
* TestZombieCleanup_SkipsNilTimeCreated - Verifies VMs with nil TimeCreated are skipped (not killed as zombies)

Scenario Detection Tests:
* TestZombieScenario_ExtensionsFailedToInstall - Demonstrates Scenario 1a: Extensions failed
* TestZombieScenario_ExtensionsNeverInstalled - Demonstrates Scenario 1b: Extensions never installed (flapping zombie)
* TestZombieScenario_ProvisioningFailed - Demonstrates Scenario 2: Provisioning failed
* TestZombieScenario_NeverRegisteredInKubernetes - Demonstrates Scenario 3: Never registered (AllocationFailed)
* TestZombieScenario_NodeUnreachableTaint - Demonstrates Scenario 4a: Node has unreachable taint
* TestZombieScenario_NodeNotReady - Demonstrates Scenario 4b: Node NotReady with running VM
* TestZombieScenario_DeallocatedNodesAreHealthy - Demonstrates healthy deallocated nodes are NOT zombies
* TestZombieScenario_MultipleZombiesWasteQuota - Demonstrates severe quota waste scenario

Helper Functions:
* setupMockManager - Setup mock manager with Azure clients
* newTestAzureManagerForZombieCleanup - Setup a test Azure manager with default config
* newHealthyVM - Creates a healthy VM for testing
* newZombieVMWithFailedProvisioning - Creates a VM with failed provisioning state
* newZombieVMWithFailedExtensions - Creates a VM with failed extensions
* newZombieVMNeverRegistered - Creates a VM that never registered with K8s
* newUnreachableZombieVM - Creates a VM that is running but will have unreachable taint
* newDeallocatedVM - Creates a deallocated VM (from autoscaler scale-down)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
azure: Zombie Node Cleanup
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
