### PR TITLE
Revert "feat: add evictAfterOOMThreshold per vpa (#8692)"

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
@@ -254,14 +254,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .spec.updatePolicy.minReplicas
-      name: MinReplicas
-      priority: 1
-      type: integer
-    - jsonPath: .spec.updatePolicy.evictAfterOOMThreshold
-      name: OOMThreshold
-      priority: 1
-      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -433,14 +425,6 @@ spec:
                   If not specified, all fields in the `PodUpdatePolicy` are set to their
                   default values.
                 properties:
-                  evictAfterOOMThreshold:
-                    description: |-
-                      EvictAfterOOMThreshold specifies the time to wait after an OOM event before
-                      considering the pod for eviction. Pods that have OOMed in less than this threshold
-                      since start will be evicted.
-                    format: duration
-                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                    type: string
                   evictionRequirements:
                     description: |-
                       EvictionRequirements is a list of EvictionRequirements that need to
@@ -494,10 +478,6 @@ spec:
                     - Auto
                     type: string
                 type: object
-                x-kubernetes-validations:
-                - message: evictAfterOOMThreshold must be greater than 0
-                  rule: '!has(self.evictAfterOOMThreshold) || duration(self.evictAfterOOMThreshold)
-                    > duration(''0s'')'
             required:
             - targetRef
             type: object

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -254,14 +254,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .spec.updatePolicy.minReplicas
-      name: MinReplicas
-      priority: 1
-      type: integer
-    - jsonPath: .spec.updatePolicy.evictAfterOOMThreshold
-      name: OOMThreshold
-      priority: 1
-      type: string
     name: v1
     schema:
       openAPIV3Schema:
@@ -433,14 +425,6 @@ spec:
                   If not specified, all fields in the `PodUpdatePolicy` are set to their
                   default values.
                 properties:
-                  evictAfterOOMThreshold:
-                    description: |-
-                      EvictAfterOOMThreshold specifies the time to wait after an OOM event before
-                      considering the pod for eviction. Pods that have OOMed in less than this threshold
-                      since start will be evicted.
-                    format: duration
-                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                    type: string
                   evictionRequirements:
                     description: |-
                       EvictionRequirements is a list of EvictionRequirements that need to
@@ -494,10 +478,6 @@ spec:
                     - Auto
                     type: string
                 type: object
-                x-kubernetes-validations:
-                - message: evictAfterOOMThreshold must be greater than 0
-                  rule: '!has(self.evictAfterOOMThreshold) || duration(self.evictAfterOOMThreshold)
-                    > duration(''0s'')'
             required:
             - targetRef
             type: object

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -146,7 +146,7 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `add-dir-header` |  |  | If true, adds the file directory to the header of the log messages |
 | `address` | string |  ":8943" | The address to expose Prometheus metrics.  |
 | `alsologtostderr` |  |  | log to standard error as well as files (no effect when -logtostderr=true) |
-| `evict-after-oom-threshold` |  |  10m0s | duration                              The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start.  |
+| `evict-after-oom-threshold` |  |  10m0s | duration                              Evict pod that has OOMed in less than evict-after-oom-threshold since start.  |
 | `eviction-rate-burst` | int |  1 | Burst of pods that can be evicted.  |
 | `eviction-rate-limit` | float |  | Number of pods that can be evicted per seconds. A rate limit set to 0 or -1 will disable<br>the rate limiter. (default -1) |
 | `eviction-tolerance` | float |  0.5 | Fraction of replica count that can be evicted for update, if more than one pod can be evicted.  |
@@ -181,3 +181,4 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `v,` |  | : 4 | , --v Level                                                         set the log level verbosity  (default 4) |
 | `vmodule` | moduleSpec |  | comma-separated list of pattern=N settings for file-filtered logging |
 | `vpa-object-namespace` | string |  | Specifies the namespace to search for VPA objects. Leave empty to include all namespaces. If provided, the garbage collector will only clean this namespace. |
+

--- a/vertical-pod-autoscaler/e2e/utils/common.go
+++ b/vertical-pod-autoscaler/e2e/utils/common.go
@@ -81,9 +81,6 @@ var RecommenderLabels = map[string]string{"app": "vpa-recommender"}
 // HamsterLabels are labels of hamster app
 var HamsterLabels = map[string]string{"app": "hamster"}
 
-// OOMLabels are labels for OOM test pods
-var OOMLabels = map[string]string{"app": "oom-test"}
-
 // SIGDescribe adds sig-autoscaling tag to test description.
 // Takes args that are passed to ginkgo.Describe.
 func SIGDescribe(scenario, name string, args ...any) bool {

--- a/vertical-pod-autoscaler/e2e/v1/admission_controller.go
+++ b/vertical-pod-autoscaler/e2e/v1/admission_controller.go
@@ -956,6 +956,32 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
 				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: oomBumpUpRatio must be greater than or equal to 1.0, got -1",
 			},
 			{
+				name: "Invalid oomBumpUpRatio (string value)",
+				vpaJSON: `{
+            "apiVersion": "autoscaling.k8s.io/v1",
+            "kind": "VerticalPodAutoscaler",
+            "metadata": {"name": "oom-test-vpa"},
+            "spec": {
+                "targetRef": {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "name": "oom-test"
+                },
+                "updatePolicy": {
+                    "updateMode": "Auto"
+                },
+                "resourcePolicy": {
+                    "containerPolicies": [{
+                        "containerName": "*",
+                        "oomBumpUpRatio": "not-a-number",
+                        "oomMinBumpUp": 104857600
+                    }]
+                }
+            }
+        }`,
+				expectedErr: "admission webhook \"vpa\\.k8s\\.io\" denied the request: quantities must match the regular expression",
+			},
+			{
 				name: "Invalid oomBumpUpRatio (less than 1)",
 				vpaJSON: `{
             "apiVersion": "autoscaling.k8s.io/v1",
@@ -1006,32 +1032,6 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
             }
         }`,
 				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: oomMinBumpUp must be greater than or equal to 0, got -1 bytes",
-			},
-			{
-				name: "Invalid oomBumpUpRatio (string value)",
-				vpaJSON: `{
-            "apiVersion": "autoscaling.k8s.io/v1",
-            "kind": "VerticalPodAutoscaler",
-            "metadata": {"name": "oom-test-vpa"},
-            "spec": {
-                "targetRef": {
-                    "apiVersion": "apps/v1",
-                    "kind": "Deployment",
-                    "name": "oom-test"
-                },
-                "updatePolicy": {
-                    "updateMode": "Auto"
-                },
-                "resourcePolicy": {
-                    "containerPolicies": [{
-                        "containerName": "*",
-                        "oomBumpUpRatio": "not-a-number",
-                        "oomMinBumpUp": 104857600
-                    }]
-                }
-            }
-        }`,
-				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: quantities must match the regular expression",
 			},
 		}
 		for _, tc := range testCases {

--- a/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/e2e/v1/autoscaling_utils.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/e2e/utils"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
@@ -441,7 +440,6 @@ func runOomingReplicationController(c clientset.Interface, ns, name string, repl
 		Namespace:   ns,
 		Timeout:     timeoutRC,
 		Replicas:    replicas,
-		Labels:      utils.OOMLabels,
 		Annotations: make(map[string]string),
 		MemRequest:  1024 * 1024 * 1024,
 		MemLimit:    1024 * 1024 * 1024,

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
@@ -19,12 +19,10 @@ package vpa
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -328,33 +326,6 @@ func TestValidateVPA(t *testing.T) {
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode: &validUpdateMode,
-					},
-					ResourcePolicy: &vpa_types.PodResourcePolicy{
-						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
-							{
-								ContainerName: "loot box",
-								Mode:          &validScalingMode,
-								MinAllowed: apiv1.ResourceList{
-									cpu: resource.MustParse("10"),
-								},
-								MaxAllowed: apiv1.ResourceList{
-									cpu: resource.MustParse("100"),
-								},
-								OOMBumpUpRatio: resource.NewQuantity(2, resource.DecimalSI),
-							},
-						},
-					},
-				},
-			},
-			PerVPAConfigDisabled: false,
-		},
-		{
-			name: "per-vpa config active and used evictOOMThreshold",
-			vpa: vpa_types.VerticalPodAutoscaler{
-				Spec: vpa_types.VerticalPodAutoscalerSpec{
-					UpdatePolicy: &vpa_types.PodUpdatePolicy{
-						UpdateMode:             &validUpdateMode,
-						EvictAfterOOMThreshold: &metav1.Duration{Duration: 10 * time.Minute},
 					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -46,8 +46,6 @@ type VerticalPodAutoscalerList struct {
 // +kubebuilder:printcolumn:name="Mem",type="string",JSONPath=".status.recommendation.containerRecommendations[0].target.memory"
 // +kubebuilder:printcolumn:name="Provided",type="string",JSONPath=".status.conditions[?(@.type=='RecommendationProvided')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="MinReplicas",type="integer",JSONPath=".spec.updatePolicy.minReplicas",priority=1
-// +kubebuilder:printcolumn:name="OOMThreshold",type="string",JSONPath=".spec.updatePolicy.evictAfterOOMThreshold",priority=1
 // +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes/kubernetes/pull/63797"
 
 // VerticalPodAutoscaler is the configuration for a vertical pod
@@ -134,7 +132,6 @@ type EvictionRequirement struct {
 }
 
 // PodUpdatePolicy describes the rules on how changes are applied to the pods.
-// +kubebuilder:validation:XValidation:rule="!has(self.evictAfterOOMThreshold) || duration(self.evictAfterOOMThreshold) > duration('0s')",message="evictAfterOOMThreshold must be greater than 0"
 type PodUpdatePolicy struct {
 	// Controls when autoscaler applies changes to the pod resources.
 	// The default is 'Recreate'.
@@ -152,15 +149,6 @@ type PodUpdatePolicy struct {
 	// EvictionRequirement is specified, all of them need to be fulfilled to allow eviction.
 	// +optional
 	EvictionRequirements []*EvictionRequirement `json:"evictionRequirements,omitempty" protobuf:"bytes,3,opt,name=evictionRequirements"`
-
-	// evictAfterOOMThreshold specifies the time to wait after an OOM event before
-	// considering the pod for eviction. Pods that have OOMed in less than this threshold
-	// since start will be evicted.
-	// +optional
-	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Format=duration
-	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$`
-	EvictAfterOOMThreshold *metav1.Duration `json:"evictAfterOOMThreshold,omitempty" protobuf:"bytes,4,opt,name=evictAfterOOMThreshold"`
 }
 
 // UpdateMode controls when autoscaler applies changes to the pod resources.

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -24,7 +24,6 @@ package v1
 import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -178,11 +177,6 @@ func (in *PodUpdatePolicy) DeepCopyInto(out *PodUpdatePolicy) {
 				(*in).DeepCopyInto(*out)
 			}
 		}
-	}
-	if in.EvictAfterOOMThreshold != nil {
-		in, out := &in.EvictAfterOOMThreshold, &out.EvictAfterOOMThreshold
-		*out = new(metav1.Duration)
-		**out = **in
 	}
 	return
 }

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -29,14 +29,8 @@ import (
 	"k8s.io/klog/v2"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-)
-
-const (
-	// DefaultEvictAfterOOMThreshold is the default time threshold for evicting pods after OOM
-	DefaultEvictAfterOOMThreshold = 10 * time.Minute
 )
 
 var (
@@ -44,8 +38,8 @@ var (
 
 	podLifetimeUpdateThreshold = flag.Duration("in-recommendation-bounds-eviction-lifetime-threshold", time.Hour*12, "Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range")
 
-	evictAfterOOMThreshold = flag.Duration("evict-after-oom-threshold", DefaultEvictAfterOOMThreshold,
-		`The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start.`)
+	evictAfterOOMThreshold = flag.Duration("evict-after-oom-threshold", 10*time.Minute,
+		`Evict pod that has OOMed in less than evict-after-oom-threshold since start.`)
 )
 
 // UpdatePriorityCalculator is responsible for prioritizing updates on pods.
@@ -114,11 +108,10 @@ func (calc *UpdatePriorityCalculator) AddPod(pod *apiv1.Pod, now time.Time) {
 			klog.V(4).InfoS("Container with ContainerScalingModeOff. Skipping container quick OOM calculations", "containerName", cs.Name)
 			continue
 		}
-		evictOOMThreshold := calc.getEvictOOMThreshold()
 		terminationState := &cs.LastTerminationState
 		if terminationState.Terminated != nil &&
 			terminationState.Terminated.Reason == "OOMKilled" &&
-			terminationState.Terminated.FinishedAt.Sub(terminationState.Terminated.StartedAt.Time) < evictOOMThreshold {
+			terminationState.Terminated.FinishedAt.Sub(terminationState.Terminated.StartedAt.Time) < *evictAfterOOMThreshold {
 			quickOOM = true
 			klog.V(2).InfoS("Quick OOM detected in pod", "pod", klog.KObj(pod), "containerName", cs.Name)
 		}
@@ -203,21 +196,6 @@ func (calc *UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_t
 		}
 	}
 	return sb.String()
-}
-
-func (calc *UpdatePriorityCalculator) getEvictOOMThreshold() time.Duration {
-	evictOOMThreshold := *evictAfterOOMThreshold
-
-	if calc.vpa.Spec.UpdatePolicy == nil || calc.vpa.Spec.UpdatePolicy.EvictAfterOOMThreshold == nil {
-		return evictOOMThreshold
-	}
-
-	if !features.Enabled(features.PerVPAConfig) {
-		klog.V(4).InfoS("feature flag is off, falling back to default EvictAfterOOMThreshold", "flagName", features.PerVPAConfig)
-		return evictOOMThreshold
-	}
-
-	return calc.vpa.Spec.UpdatePolicy.EvictAfterOOMThreshold.Duration
 }
 
 func parseVpaObservedContainers(pod *apiv1.Pod) (bool, sets.Set[string]) {

--- a/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
@@ -33,7 +33,6 @@ type VerticalPodAutoscalerBuilder interface {
 	WithContainer(containerName string) VerticalPodAutoscalerBuilder
 	WithNamespace(namespace string) VerticalPodAutoscalerBuilder
 	WithUpdateMode(updateMode vpa_types.UpdateMode) VerticalPodAutoscalerBuilder
-	WithEvictAfterOOMThreshold(*meta.Duration) VerticalPodAutoscalerBuilder
 	WithCreationTimestamp(timestamp time.Time) VerticalPodAutoscalerBuilder
 	WithMinAllowed(containerName, cpu, memory string) VerticalPodAutoscalerBuilder
 	WithMaxAllowed(containerName, cpu, memory string) VerticalPodAutoscalerBuilder
@@ -119,15 +118,6 @@ func (b *verticalPodAutoscalerBuilder) WithUpdateMode(updateMode vpa_types.Updat
 		c.updatePolicy = &vpa_types.PodUpdatePolicy{}
 	}
 	c.updatePolicy.UpdateMode = &updateMode
-	return &c
-}
-
-func (b *verticalPodAutoscalerBuilder) WithEvictAfterOOMThreshold(threshold *meta.Duration) VerticalPodAutoscalerBuilder {
-	c := *b
-	if c.updatePolicy == nil {
-		c.updatePolicy = &vpa_types.PodUpdatePolicy{}
-	}
-	c.updatePolicy.EvictAfterOOMThreshold = threshold
 	return &c
 }
 


### PR DESCRIPTION
This reverts commit 075153779691ef7a831ee0b3fcb35b17fb4d4c96.

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We accidentally merged #8692 before passing the api review. this commit revert that change. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
