### PR TITLE
Deprecate Auto some more

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
@@ -90,7 +90,7 @@ func (s *AdmissionServer) addDeprecationWarnings(req *admissionv1.AdmissionReque
 	}
 
 	if vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.UpdateMode != nil &&
-		*vpa.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeAuto {
+		*vpa.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeAuto { //nolint:staticcheck
 
 		if resp.Warnings == nil {
 			resp.Warnings = []string{}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
@@ -78,37 +78,37 @@ func TestGetMatchingVpa(t *testing.T) {
 			name: "matching selector",
 			pod:  podBuilder.Get(),
 			vpas: []*vpa_types.VerticalPodAutoscaler{
-				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).WithName("auto-vpa").WithTargetRef(targetRef).Get(),
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).WithName("recreate-vpa").WithTargetRef(targetRef).Get(),
 			},
 			labelSelector:   "app = test",
 			expectedFound:   true,
-			expectedVpaName: "auto-vpa",
+			expectedVpaName: "recreate-vpa",
 		}, {
 			name: "no matching ownerRef (orphan pod)",
 			pod:  podBuilderWithoutCreator.Get(),
 			vpas: []*vpa_types.VerticalPodAutoscaler{
-				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).WithName("auto-vpa").WithTargetRef(targetRef).Get(),
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).WithName("recreate-vpa").WithTargetRef(targetRef).Get(),
 			},
 			expectedFound: false,
 		}, {
 			name: "vpa without targetRef",
 			pod:  podBuilder.Get(),
 			vpas: []*vpa_types.VerticalPodAutoscaler{
-				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).WithName("auto-vpa").Get(),
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).WithName("recreate-vpa").Get(),
 			},
 			expectedFound: false,
 		}, {
 			name: "no vpa with matching targetRef",
 			pod:  podBuilder.Get(),
 			vpas: []*vpa_types.VerticalPodAutoscaler{
-				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).WithName("auto-vpa").WithTargetRef(targetRefWithNoMatches).Get(),
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).WithName("recreate-vpa").WithTargetRef(targetRefWithNoMatches).Get(),
 			},
 			expectedFound: false,
 		}, {
 			name: "not matching selector",
 			pod:  podBuilder.Get(),
 			vpas: []*vpa_types.VerticalPodAutoscaler{
-				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).WithName("auto-vpa").WithTargetRef(targetRef).Get(),
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).WithName("recreate-vpa").WithTargetRef(targetRef).Get(),
 			},
 			labelSelector: "app = differentApp",
 			expectedFound: false,
@@ -124,11 +124,11 @@ func TestGetMatchingVpa(t *testing.T) {
 			pod:  podBuilder.Get(),
 			vpas: []*vpa_types.VerticalPodAutoscaler{
 				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeOff).WithName("off-vpa").WithTargetRef(targetRef).Get(),
-				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).WithName("auto-vpa").WithTargetRef(targetRef).Get(),
+				vpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).WithName("recreate-vpa").WithTargetRef(targetRef).Get(),
 			},
 			labelSelector:   "app = test",
 			expectedFound:   true,
-			expectedVpaName: "auto-vpa",
+			expectedVpaName: "recreate-vpa",
 		}, {
 			name: "initial mode",
 			pod:  podBuilder.Get(),

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -171,6 +171,7 @@ const (
 	// and additionally can update them during the lifetime of the pod,
 	// using any available update method. Currently this is equivalent to
 	// Recreate.
+	//
 	// Deprecated: This value is deprecated and will be removed in a future API version.
 	// Use explicit update modes like "Recreate", "Initial", or "InPlaceOrRecreate" instead.
 	// See https://github.com/kubernetes/autoscaler/issues/8424 for more details.

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -454,7 +454,7 @@ func TestUpdatePodSelector(t *testing.T) {
 func TestAddOrUpdateVPAPolicies(t *testing.T) {
 	testVpaBuilder := test.VerticalPodAutoscaler().WithName(testVpaID.VpaName).
 		WithNamespace(testVpaID.Namespace).WithContainer(testContainerID.ContainerName)
-	updateModeAuto := vpa_types.UpdateModeAuto
+	updateModeRecreate := vpa_types.UpdateModeRecreate
 	updateModeOff := vpa_types.UpdateModeOff
 	scalingModeAuto := vpa_types.ContainerScalingModeAuto
 	scalingModeOff := vpa_types.ContainerScalingModeOff
@@ -479,7 +479,7 @@ func TestAddOrUpdateVPAPolicies(t *testing.T) {
 		}, {
 			name:   "Default scaling mode set to Off",
 			oldVpa: nil,
-			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).Get(),
+			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).Get(),
 			resourcePolicy: &vpa_types.PodResourcePolicy{
 				ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 					{
@@ -489,12 +489,12 @@ func TestAddOrUpdateVPAPolicies(t *testing.T) {
 				},
 			},
 			expectedScalingMode: &scalingModeOff,
-			expectedUpdateMode:  &updateModeAuto,
+			expectedUpdateMode:  &updateModeRecreate,
 			expectedAPIVersion:  "v1",
 		}, {
 			name:   "Explicit scaling mode set to Off",
 			oldVpa: nil,
-			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).Get(),
+			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).Get(),
 			resourcePolicy: &vpa_types.PodResourcePolicy{
 				ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 					{
@@ -504,12 +504,12 @@ func TestAddOrUpdateVPAPolicies(t *testing.T) {
 				},
 			},
 			expectedScalingMode: &scalingModeOff,
-			expectedUpdateMode:  &updateModeAuto,
+			expectedUpdateMode:  &updateModeRecreate,
 			expectedAPIVersion:  "v1",
 		}, {
 			name:   "Other container has explicit scaling mode Off",
 			oldVpa: nil,
-			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).Get(),
+			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).Get(),
 			resourcePolicy: &vpa_types.PodResourcePolicy{
 				ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 					{
@@ -519,12 +519,12 @@ func TestAddOrUpdateVPAPolicies(t *testing.T) {
 				},
 			},
 			expectedScalingMode: &scalingModeAuto,
-			expectedUpdateMode:  &updateModeAuto,
+			expectedUpdateMode:  &updateModeRecreate,
 			expectedAPIVersion:  "v1",
 		}, {
 			name:   "Scaling mode to default Off",
-			oldVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).Get(),
-			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).Get(),
+			oldVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).Get(),
+			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).Get(),
 			resourcePolicy: &vpa_types.PodResourcePolicy{
 				ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 					{
@@ -534,12 +534,12 @@ func TestAddOrUpdateVPAPolicies(t *testing.T) {
 				},
 			},
 			expectedScalingMode: &scalingModeOff,
-			expectedUpdateMode:  &updateModeAuto,
+			expectedUpdateMode:  &updateModeRecreate,
 			expectedAPIVersion:  "v1",
 		}, {
 			name:   "Scaling mode to explicit Off",
-			oldVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).Get(),
-			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).Get(),
+			oldVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).Get(),
+			newVpa: testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).Get(),
 			resourcePolicy: &vpa_types.PodResourcePolicy{
 				ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 					{
@@ -549,20 +549,20 @@ func TestAddOrUpdateVPAPolicies(t *testing.T) {
 				},
 			},
 			expectedScalingMode: &scalingModeOff,
-			expectedUpdateMode:  &updateModeAuto,
+			expectedUpdateMode:  &updateModeRecreate,
 			expectedAPIVersion:  "v1",
 		},
 		// Tests checking changes to UpdateMode.
 		{
-			name:                "UpdateMode from Off to Auto",
+			name:                "UpdateMode from Off to Recreate",
 			oldVpa:              testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeOff).Get(),
-			newVpa:              testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).Get(),
+			newVpa:              testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).Get(),
 			expectedScalingMode: &scalingModeAuto,
-			expectedUpdateMode:  &updateModeAuto,
+			expectedUpdateMode:  &updateModeRecreate,
 			expectedAPIVersion:  "v1",
 		}, {
-			name:                "UpdateMode from Auto to Off",
-			oldVpa:              testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeAuto).Get(),
+			name:                "UpdateMode from Recreate to Off",
+			oldVpa:              testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeRecreate).Get(),
 			newVpa:              testVpaBuilder.WithUpdateMode(vpa_types.UpdateModeOff).Get(),
 			expectedScalingMode: &scalingModeAuto,
 			expectedUpdateMode:  &updateModeOff,

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
@@ -220,7 +220,7 @@ func TestUpdateRecommendation(t *testing.T) {
 
 func TestUseAggregationIfMatching(t *testing.T) {
 	modeOff := vpa_types.UpdateModeOff
-	modeAuto := vpa_types.UpdateModeAuto
+	modeRecreate := vpa_types.UpdateModeRecreate
 	scalingModeAuto := vpa_types.ContainerScalingModeAuto
 	scalingModeOff := vpa_types.ContainerScalingModeOff
 	cases := []struct {
@@ -247,11 +247,11 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			name:                        "New matching aggregation",
 			aggregations:                []string{"test-container"},
 			vpaSelector:                 testSelectorStr,
-			updateMode:                  &modeAuto,
+			updateMode:                  &modeRecreate,
 			container:                   "second-container",
 			containerLabels:             testLabels,
 			expectedNeedsRecommendation: map[string]bool{"test-container": true, "second-container": true},
-			expectedUpdateMode:          &modeAuto,
+			expectedUpdateMode:          &modeRecreate,
 		}, {
 			name:                        "Existing matching aggregation",
 			aggregations:                []string{"test-container"},
@@ -265,7 +265,7 @@ func TestUseAggregationIfMatching(t *testing.T) {
 			name:                        "Aggregation not matching",
 			aggregations:                []string{"test-container"},
 			vpaSelector:                 testSelectorStr,
-			updateMode:                  &modeAuto,
+			updateMode:                  &modeRecreate,
 			container:                   "second-container",
 			containerLabels:             map[string]string{"different": "labels"},
 			expectedNeedsRecommendation: map[string]bool{"test-container": true},
@@ -282,11 +282,11 @@ func TestUseAggregationIfMatching(t *testing.T) {
 					},
 				},
 			},
-			updateMode:                  &modeAuto,
+			updateMode:                  &modeRecreate,
 			container:                   "second-container",
 			containerLabels:             testLabels,
 			expectedNeedsRecommendation: map[string]bool{"second-container": false, "test-container": true},
-			expectedUpdateMode:          &modeAuto,
+			expectedUpdateMode:          &modeRecreate,
 		}, {
 			name:         "New matching aggregation with default scaling mode Off",
 			aggregations: []string{"test-container"},
@@ -299,11 +299,11 @@ func TestUseAggregationIfMatching(t *testing.T) {
 					},
 				},
 			},
-			updateMode:                  &modeAuto,
+			updateMode:                  &modeRecreate,
 			container:                   "second-container",
 			containerLabels:             testLabels,
 			expectedNeedsRecommendation: map[string]bool{"second-container": false, "test-container": false},
-			expectedUpdateMode:          &modeAuto,
+			expectedUpdateMode:          &modeRecreate,
 		}, {
 			name:         "New matching aggregation with scaling mode Off with default Auto",
 			aggregations: []string{"test-container"},
@@ -320,11 +320,11 @@ func TestUseAggregationIfMatching(t *testing.T) {
 					},
 				},
 			},
-			updateMode:                  &modeAuto,
+			updateMode:                  &modeRecreate,
 			container:                   "second-container",
 			containerLabels:             testLabels,
 			expectedNeedsRecommendation: map[string]bool{"second-container": false, "test-container": true},
-			expectedUpdateMode:          &modeAuto,
+			expectedUpdateMode:          &modeRecreate,
 		}, {
 			name:         "New matching aggregation with scaling mode Auto with default Off",
 			aggregations: []string{"test-container"},
@@ -341,11 +341,11 @@ func TestUseAggregationIfMatching(t *testing.T) {
 					},
 				},
 			},
-			updateMode:                  &modeAuto,
+			updateMode:                  &modeRecreate,
 			container:                   "second-container",
 			containerLabels:             testLabels,
 			expectedNeedsRecommendation: map[string]bool{"second-container": true, "test-container": false},
-			expectedUpdateMode:          &modeAuto,
+			expectedUpdateMode:          &modeRecreate,
 		},
 	}
 	for _, tc := range cases {

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -53,8 +53,9 @@ import (
 
 // logDeprecationWarnings logs deprecation warnings for VPAs using deprecated modes
 func logDeprecationWarnings(vpa *vpa_types.VerticalPodAutoscaler) {
-	if vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.UpdateMode != nil &&
-		*vpa.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeAuto {
+	if vpa.Spec.UpdatePolicy != nil &&
+		vpa.Spec.UpdatePolicy.UpdateMode != nil &&
+		*vpa.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeAuto { //nolint:staticcheck
 
 		klog.InfoS("VPA uses deprecated UpdateMode 'Auto'. This mode is deprecated and will be removed in a future API version. Please use explicit update modes like 'Recreate', 'Initial', or 'InPlaceOrRecreate'",
 			"vpa", klog.KObj(vpa), "issue", "https://github.com/kubernetes/autoscaler/issues/8424")
@@ -178,7 +179,8 @@ func (u *updater) RunOnce(ctx context.Context) {
 		logDeprecationWarnings(vpa)
 
 		if vpa_api_util.GetUpdateMode(vpa) != vpa_types.UpdateModeRecreate &&
-			vpa_api_util.GetUpdateMode(vpa) != vpa_types.UpdateModeAuto && vpa_api_util.GetUpdateMode(vpa) != vpa_types.UpdateModeInPlaceOrRecreate {
+			vpa_api_util.GetUpdateMode(vpa) != vpa_types.UpdateModeAuto && //nolint:staticcheck
+			vpa_api_util.GetUpdateMode(vpa) != vpa_types.UpdateModeInPlaceOrRecreate {
 			klog.V(3).InfoS("Skipping VPA object because its mode is not  \"InPlaceOrRecreate\", \"Recreate\" or \"Auto\"", "vpa", klog.KObj(vpa))
 			continue
 		}

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -65,7 +65,7 @@ func TestRunOnce_Mode(t *testing.T) {
 	}{
 		{
 			name:                  "with Auto mode",
-			updateMode:            vpa_types.UpdateModeAuto,
+			updateMode:            vpa_types.UpdateModeAuto, //nolint:staticcheck
 			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 5,
@@ -177,7 +177,7 @@ func TestRunOnce_Status(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testRunOnceBase(
 				t,
-				vpa_types.UpdateModeAuto,
+				vpa_types.UpdateModeRecreate,
 				false,
 				tc.statusValidator,
 				tc.expectFetchCalls,
@@ -514,7 +514,7 @@ func TestLogDeprecationWarnings(t *testing.T) {
 	}{
 		{
 			name:             "Auto mode should trigger deprecation warning logic",
-			updateMode:       &[]vpa_types.UpdateMode{vpa_types.UpdateModeAuto}[0],
+			updateMode:       &[]vpa_types.UpdateMode{vpa_types.UpdateModeAuto}[0], //nolint:staticcheck
 			shouldLogWarning: true,
 		},
 		{
@@ -557,7 +557,7 @@ func TestLogDeprecationWarnings(t *testing.T) {
 
 			shouldLogWarning := vpa.Spec.UpdatePolicy != nil &&
 				vpa.Spec.UpdatePolicy.UpdateMode != nil &&
-				*vpa.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeAuto
+				*vpa.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeAuto //nolint:staticcheck
 
 			assert.Equal(t, tc.shouldLogWarning, shouldLogWarning,
 				"Expected shouldLogWarning=%v for test case %s", tc.shouldLogWarning, tc.name)

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender.go
@@ -168,7 +168,7 @@ func NewObjectCounter() *ObjectCounter {
 
 // Add updates the helper state to include the given VPA object
 func (oc *ObjectCounter) Add(vpa *model.Vpa) {
-	mode := vpa_types.UpdateModeAuto
+	mode := vpa_types.UpdateModeRecreate
 	if vpa.UpdateMode != nil && string(*vpa.UpdateMode) != "" {
 		mode = *vpa.UpdateMode
 	}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
@@ -32,7 +32,7 @@ func TestObjectCounter(t *testing.T) {
 	updateModeOff := vpa_types.UpdateModeOff
 	updateModeInitial := vpa_types.UpdateModeInitial
 	updateModeRecreate := vpa_types.UpdateModeRecreate
-	updateModeAuto := vpa_types.UpdateModeAuto
+	updateModeAuto := vpa_types.UpdateModeAuto //nolint:staticcheck
 	updateModeInPlaceOrRecreate := vpa_types.UpdateModeInPlaceOrRecreate
 	// We verify that other update modes are handled correctly as validation
 	// may not happen if there are issues with the admission controller.
@@ -51,7 +51,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -62,7 +62,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1beta1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1beta1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -73,7 +73,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1beta2,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1beta2,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -84,7 +84,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -96,7 +96,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -180,7 +180,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -194,7 +194,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -208,7 +208,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=true,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1,has_recommendation=true,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -220,7 +220,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -236,7 +236,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=false,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1,has_recommendation=false,matches_pods=false,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -248,7 +248,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
 			},
 		},
 		{
@@ -264,7 +264,7 @@ func TestObjectCounter(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=true,update_mode=Auto,": 1,
+				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=true,update_mode=Recreate,": 1,
 			},
 		},
 	}
@@ -339,7 +339,7 @@ func TestObjectCounterResetsAllUpdateModes(t *testing.T) {
 	updatesModes := []vpa_types.UpdateMode{
 		vpa_types.UpdateModeOff,
 		vpa_types.UpdateModeInitial,
-		vpa_types.UpdateModeAuto,
+		vpa_types.UpdateModeAuto, //nolint:staticcheck
 		vpa_types.UpdateModeRecreate,
 		vpa_types.UpdateModeInPlaceOrRecreate,
 	}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -37,7 +37,7 @@ func TestAddEvictedPod(t *testing.T) {
 		{
 			desc:         "VPA size 5, mode Auto",
 			vpaSize:      5,
-			mode:         vpa_types.UpdateModeAuto,
+			mode:         vpa_types.UpdateModeAuto, //nolint:staticcheck
 			log2:         "2",
 			vpaName:      "vpa-5",
 			vpaNamespace: "vpa-ns-5",
@@ -208,24 +208,24 @@ func TestUpdateModeAndSizeBasedGauge(t *testing.T) {
 			iterations: []iteration{
 				{
 					additions: []addition{
-						{1, vpa_types.UpdateModeAuto, 5},
+						{1, vpa_types.UpdateModeRecreate, 5},
 						{2, vpa_types.UpdateModeOff, 10},
-						{2, vpa_types.UpdateModeAuto, 2},
-						{2, vpa_types.UpdateModeAuto, 7},
+						{2, vpa_types.UpdateModeRecreate, 2},
+						{2, vpa_types.UpdateModeRecreate, 7},
 					},
 					expectations: []expectation{
-						{[]string{"0" /* log2(1) */, "Auto"}, 5},
-						{[]string{"1" /* log2(2) */, "Auto"}, 9},
+						{[]string{"0" /* log2(1) */, "Recreate"}, 5},
+						{[]string{"1" /* log2(2) */, "Recreate"}, 9},
 						{[]string{"1" /* log2(2) */, "Off"}, 10},
 					},
 				},
 				{
 					additions: []addition{
-						{2, vpa_types.UpdateModeAuto, 2},
-						{2, vpa_types.UpdateModeAuto, 3},
+						{2, vpa_types.UpdateModeRecreate, 2},
+						{2, vpa_types.UpdateModeRecreate, 3},
 					},
 					expectations: []expectation{
-						{[]string{"1" /* log2(2) */, "Auto"}, 5},
+						{[]string{"1" /* log2(2) */, "Recreate"}, 5},
 					},
 				},
 			},
@@ -238,11 +238,11 @@ func TestUpdateModeAndSizeBasedGauge(t *testing.T) {
 			iterations: []iteration{
 				{
 					additions: []addition{
-						{4, vpa_types.UpdateModeAuto, 3},
+						{4, vpa_types.UpdateModeInitial, 3},
 						{1, vpa_types.UpdateModeRecreate, 8},
 					},
 					expectations: []expectation{
-						{[]string{"2" /* log2(4) */, "Auto"}, 3},
+						{[]string{"2" /* log2(4) */, "Initial"}, 3},
 						{[]string{"0" /* log2(1) */, "Recreate"}, 8},
 					},
 				},
@@ -267,11 +267,11 @@ func TestUpdateModeAndSizeBasedGauge(t *testing.T) {
 				{
 					additions: []addition{
 						{1, vpa_types.UpdateModeOff, 1},
-						{2, vpa_types.UpdateModeAuto, 1},
+						{2, vpa_types.UpdateModeRecreate, 1},
 					},
 					expectations: []expectation{
 						{[]string{"0" /* log2(1) */, "Off"}, 1},
-						{[]string{"1" /* log2(2) */, "Auto"}, 1},
+						{[]string{"1" /* log2(2) */, "Recreate"}, 1},
 					},
 				},
 				{
@@ -292,19 +292,19 @@ func TestUpdateModeAndSizeBasedGauge(t *testing.T) {
 			iterations: []iteration{
 				{
 					additions: []addition{
-						{1, vpa_types.UpdateModeAuto, 2},
-						{1, vpa_types.UpdateModeAuto, 3},
+						{1, vpa_types.UpdateModeRecreate, 2},
+						{1, vpa_types.UpdateModeRecreate, 3},
 					},
 					expectations: []expectation{
-						{[]string{"0" /* log2(1) */, "Auto"}, 5},
+						{[]string{"0" /* log2(1) */, "Recreate"}, 5},
 					},
 				},
 				{
 					additions: []addition{
-						{1, vpa_types.UpdateModeAuto, 5},
+						{1, vpa_types.UpdateModeRecreate, 5},
 					},
 					expectations: []expectation{
-						{[]string{"0" /* log2(1) */, "Auto"}, 5},
+						{[]string{"0" /* log2(1) */, "Recreate"}, 5},
 					},
 				},
 			},

--- a/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_vpa.go
@@ -200,7 +200,7 @@ func (b *verticalPodAutoscalerBuilder) WithGroupVersion(gv meta.GroupVersion) Ve
 }
 
 func (b *verticalPodAutoscalerBuilder) WithEvictionRequirements(evictionRequirements []*vpa_types.EvictionRequirement) VerticalPodAutoscalerBuilder {
-	updateModeAuto := vpa_types.UpdateModeAuto
+	updateModeAuto := vpa_types.UpdateModeRecreate
 	c := *b
 	if c.updatePolicy == nil {
 		c.updatePolicy = &vpa_types.PodUpdatePolicy{UpdateMode: &updateModeAuto}
@@ -210,7 +210,7 @@ func (b *verticalPodAutoscalerBuilder) WithEvictionRequirements(evictionRequirem
 }
 
 func (b *verticalPodAutoscalerBuilder) WithMinReplicas(minReplicas *int32) VerticalPodAutoscalerBuilder {
-	updateModeAuto := vpa_types.UpdateModeAuto
+	updateModeAuto := vpa_types.UpdateModeRecreate
 	c := *b
 	if c.updatePolicy == nil {
 		c.updatePolicy = &vpa_types.PodUpdatePolicy{UpdateMode: &updateModeAuto}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -234,10 +234,10 @@ func FindParentControllerForPod(ctx context.Context, pod *core.Pod, ctrlFetcher 
 }
 
 // GetUpdateMode returns the updatePolicy.updateMode for a given VPA.
-// If the mode is not specified it returns the default (UpdateModeAuto).
+// If the mode is not specified it returns the default (UpdateModeRecreate).
 func GetUpdateMode(vpa *vpa_types.VerticalPodAutoscaler) vpa_types.UpdateMode {
 	if vpa.Spec.UpdatePolicy == nil || vpa.Spec.UpdatePolicy.UpdateMode == nil || *vpa.Spec.UpdatePolicy.UpdateMode == "" {
-		return vpa_types.UpdateModeAuto
+		return vpa_types.UpdateModeRecreate
 	}
 	return *vpa.Spec.UpdatePolicy.UpdateMode
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Follow up to:
- https://github.com/kubernetes/autoscaler/pull/8426
- https://github.com/kubernetes/autoscaler/pull/8899

If updatePolicy isn't set, then this code causes the VPA to be set to "auto" mode.
Since auto is deprecated, we would prefer Recreate.

Also, for IDEs to mark something as deprecated, the comment block needs a newline above it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Correctly mark the VPA UpdateMode "Auto" as deprecated, that was deprecated in VPA 1.5
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
