### PR TITLE
bugfix: successfully scale up 0-sized pool

### DIFF
--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
@@ -19,7 +19,6 @@ package scaleway
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"math"
 	"os"
@@ -322,10 +321,15 @@ func (scw *scalewayCloudProvider) NodePrice(node *apiv1.Node, startTime time.Tim
 		if _, ok := ng.nodes[node.Spec.ProviderID]; ok {
 			nodeGroup = ng
 		}
+		// necessary for simulated node with 0-sized pool
+		if ng.pool.ID == node.Spec.ProviderID {
+			nodeGroup = ng
+		}
 	}
 
 	if nodeGroup == nil {
-		return 0.0, fmt.Errorf("node group not found for node %s", node.Spec.ProviderID)
+		klog.Warningf("node group not found for node %s", node.Spec.ProviderID)
+		return 0.0, nil
 	}
 
 	d := endTime.Sub(startTime)

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider_test.go
@@ -548,7 +548,7 @@ func TestScalewayCloudProvider_NodePrice(t *testing.T) {
 		endTime := startTime.Add(1 * time.Hour)
 
 		price, err := provider.NodePrice(k8sNode, startTime, endTime)
-		assert.Error(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 0.0, price)
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
it fixes a bug where scaleway 0-sized pool could not scale up, simulated node would not be linked to corresponding nodeGroup and no price would be attached

also, to avoid blocking scale-up, NodePrice doesn't return an error anymore if nodeType is not found. Only a logging warning is emitted and a price of 0 is returned.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
none
