### PR TITLE
Use v1beta1 API in CapacityBuffers code

### DIFF
--- a/cluster-autoscaler/capacitybuffer/client/client.go
+++ b/cluster-autoscaler/capacitybuffer/client/client.go
@@ -26,10 +26,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	capacitybuffer "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned"
 	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/informers/externalversions"
-	bufferslisters "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/listers/autoscaling.x-k8s.io/v1alpha1"
+	bufferslisters "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/listers/autoscaling.x-k8s.io/v1beta1"
 	"k8s.io/client-go/discovery"
 	kubernetes "k8s.io/client-go/kubernetes"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
@@ -137,8 +137,8 @@ func NewCapacityBufferClientFromClients(buffersClient capacitybuffer.Interface, 
 	stopChannel := make(chan struct{})
 
 	buffersFactory := externalversions.NewSharedInformerFactory(buffersClient, defaultResyncPeriod)
-	bufferInformer := buffersFactory.Autoscaling().V1alpha1().CapacityBuffers().Informer()
-	buffersLister := buffersFactory.Autoscaling().V1alpha1().CapacityBuffers().Lister()
+	bufferInformer := buffersFactory.Autoscaling().V1beta1().CapacityBuffers().Informer()
+	buffersLister := buffersFactory.Autoscaling().V1beta1().CapacityBuffers().Lister()
 
 	// Add indexer for PodTemplateRef
 	err := bufferInformer.AddIndexers(cache.Indexers{
@@ -276,7 +276,7 @@ func (c *CapacityBufferClient) UpdateCapacityBuffer(buffer *v1.CapacityBuffer) (
 		return nil, fmt.Errorf("Capacity buffer client is not configured for updating capacity buffer")
 	}
 
-	buffer, err := c.buffersClient.AutoscalingV1alpha1().CapacityBuffers(buffer.Namespace).UpdateStatus(context.TODO(), buffer, metav1.UpdateOptions{})
+	buffer, err := c.buffersClient.AutoscalingV1beta1().CapacityBuffers(buffer.Namespace).UpdateStatus(context.TODO(), buffer, metav1.UpdateOptions{})
 	if err == nil {
 		return buffer.DeepCopy(), nil
 	}

--- a/cluster-autoscaler/capacitybuffer/common/common.go
+++ b/cluster-autoscaler/capacitybuffer/common/common.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,7 +31,7 @@ import (
 const (
 	ActiveProvisioningStrategy    = "buffer.x-k8s.io/active-capacity"
 	CapacityBufferKind            = "CapacityBuffer"
-	CapacityBufferApiVersion      = "autoscaling.x-k8s.io/v1alpha1"
+	CapacityBufferApiVersion      = "autoscaling.x-k8s.io/v1beta1"
 	ReadyForProvisioningCondition = "ReadyForProvisioning"
 	ProvisioningCondition         = "Provisioning"
 	LimitedByQuotasCondition      = "LimitedByQuotas"

--- a/cluster-autoscaler/capacitybuffer/controller/controller.go
+++ b/cluster-autoscaler/capacitybuffer/controller/controller.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	filters "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/filters"

--- a/cluster-autoscaler/capacitybuffer/controller/resourcequotas.go
+++ b/cluster-autoscaler/capacitybuffer/controller/resourcequotas.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	podutils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"

--- a/cluster-autoscaler/capacitybuffer/controller/resourcequotas_test.go
+++ b/cluster-autoscaler/capacitybuffer/controller/resourcequotas_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"

--- a/cluster-autoscaler/capacitybuffer/filters/filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/filter.go
@@ -17,7 +17,7 @@ limitations under the License.
 package filter
 
 import (
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 )
 
 // Filter filters CapacityBuffer based on some criteria.

--- a/cluster-autoscaler/capacitybuffer/filters/filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/filter_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 )
 
 func TestCombinedAnyFilter(t *testing.T) {

--- a/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter.go
@@ -17,7 +17,7 @@ limitations under the License.
 package filter
 
 import (
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/klog/v2"
 )

--- a/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
 	fakeclient "k8s.io/client-go/kubernetes/fake"

--- a/cluster-autoscaler/capacitybuffer/filters/status_filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/status_filter.go
@@ -17,7 +17,7 @@ limitations under the License.
 package filter
 
 import (
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 )
 
 // statusFilter filters out buffers with the defined conditions

--- a/cluster-autoscaler/capacitybuffer/filters/status_filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/status_filter_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
 )

--- a/cluster-autoscaler/capacitybuffer/filters/strategy_filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/strategy_filter.go
@@ -17,7 +17,7 @@ limitations under the License.
 package filter
 
 import (
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 )
 
 // strategyFilter filters out buffers with provisioning strategies not defined in strategiesToUse

--- a/cluster-autoscaler/capacitybuffer/filters/strategy_filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/strategy_filter_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
 )
 

--- a/cluster-autoscaler/capacitybuffer/testutil/testutil.go
+++ b/cluster-autoscaler/capacitybuffer/testutil/testutil.go
@@ -19,7 +19,7 @@ package testutil
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 )
 

--- a/cluster-autoscaler/capacitybuffer/translators/pod_template_translator.go
+++ b/cluster-autoscaler/capacitybuffer/translators/pod_template_translator.go
@@ -19,7 +19,7 @@ package translator
 import (
 	"fmt"
 
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 )

--- a/cluster-autoscaler/capacitybuffer/translators/pod_template_translator_test.go
+++ b/cluster-autoscaler/capacitybuffer/translators/pod_template_translator_test.go
@@ -24,7 +24,7 @@ import (
 	fakeClient "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
 )

--- a/cluster-autoscaler/capacitybuffer/translators/resource_limits_translator.go
+++ b/cluster-autoscaler/capacitybuffer/translators/resource_limits_translator.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	api_v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	api_v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 )

--- a/cluster-autoscaler/capacitybuffer/translators/resource_limits_translator_test.go
+++ b/cluster-autoscaler/capacitybuffer/translators/resource_limits_translator_test.go
@@ -25,7 +25,7 @@ import (
 	fakeClient "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
 )

--- a/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator.go
+++ b/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator.go
@@ -24,7 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apiv1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	apiv1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	scalableobject "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/translators/scalable_objects"
 )
 

--- a/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator_test.go
+++ b/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator_test.go
@@ -23,7 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	buffersfake "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned/fake"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"

--- a/cluster-autoscaler/capacitybuffer/translators/translator.go
+++ b/cluster-autoscaler/capacitybuffer/translators/translator.go
@@ -17,7 +17,7 @@ limitations under the License.
 package translator
 
 import (
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 )
 
 // Translator translates the passed buffers to pod template and number of replicas

--- a/cluster-autoscaler/capacitybuffer/updater/status_updater.go
+++ b/cluster-autoscaler/capacitybuffer/updater/status_updater.go
@@ -17,7 +17,7 @@ limitations under the License.
 package updater
 
 import (
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 )
 

--- a/cluster-autoscaler/capacitybuffer/updater/status_updater_test.go
+++ b/cluster-autoscaler/capacitybuffer/updater/status_updater_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	fakeclientset "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned/fake"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 )

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/klog/v2"
 
 	apiv1 "k8s.io/api/core/v1"
-	v1alpha1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	client "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	buffersfilter "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/filters"
@@ -52,17 +52,17 @@ type CapacityBufferPodListProcessor struct {
 // capacityBuffersFakePodsRegistry a struct that keeps the status of capacity buffer
 // the fake pods generated for adding buffer event later
 type capacityBuffersFakePodsRegistry struct {
-	fakePodsUIDToBuffer map[string]*v1alpha1.CapacityBuffer
+	fakePodsUIDToBuffer map[string]*v1beta1.CapacityBuffer
 }
 
 // NewCapacityBuffersFakePodsRegistry returns a new pointer to empty capacityBuffersFakePodsRegistry
-func NewCapacityBuffersFakePodsRegistry(fakePodsToBuffers map[string]*v1alpha1.CapacityBuffer) *capacityBuffersFakePodsRegistry {
+func NewCapacityBuffersFakePodsRegistry(fakePodsToBuffers map[string]*v1beta1.CapacityBuffer) *capacityBuffersFakePodsRegistry {
 	return &capacityBuffersFakePodsRegistry{fakePodsUIDToBuffer: fakePodsToBuffers}
 }
 
 // NewDefaultCapacityBuffersFakePodsRegistry returns a new pointer to empty capacityBuffersFakePodsRegistry
 func NewDefaultCapacityBuffersFakePodsRegistry() *capacityBuffersFakePodsRegistry {
-	return &capacityBuffersFakePodsRegistry{fakePodsUIDToBuffer: map[string]*v1alpha1.CapacityBuffer{}}
+	return &capacityBuffersFakePodsRegistry{fakePodsUIDToBuffer: map[string]*v1beta1.CapacityBuffer{}}
 }
 
 // NewCapacityBufferPodListProcessor creates a new CapacityRequestPodListProcessor.
@@ -111,7 +111,7 @@ func (p *CapacityBufferPodListProcessor) Process(autoscalingCtx *ca_context.Auto
 func (p *CapacityBufferPodListProcessor) CleanUp() {
 }
 
-func (p *CapacityBufferPodListProcessor) updateCapacityBufferRegistry(fakePods []*apiv1.Pod, buffer *v1alpha1.CapacityBuffer) {
+func (p *CapacityBufferPodListProcessor) updateCapacityBufferRegistry(fakePods []*apiv1.Pod, buffer *v1beta1.CapacityBuffer) {
 	if p.buffersRegistry == nil {
 		return
 	}
@@ -124,10 +124,10 @@ func (p *CapacityBufferPodListProcessor) clearCapacityBufferRegistry() {
 	if p.buffersRegistry == nil {
 		return
 	}
-	p.buffersRegistry.fakePodsUIDToBuffer = make(map[string]*v1alpha1.CapacityBuffer, 0)
+	p.buffersRegistry.fakePodsUIDToBuffer = make(map[string]*v1beta1.CapacityBuffer, 0)
 }
 
-func (p *CapacityBufferPodListProcessor) provision(buffer *v1alpha1.CapacityBuffer) []*apiv1.Pod {
+func (p *CapacityBufferPodListProcessor) provision(buffer *v1beta1.CapacityBuffer) []*apiv1.Pod {
 	if buffer.Status.PodTemplateRef == nil || buffer.Status.Replicas == nil || *buffer.Status.Replicas == 0 {
 		return []*apiv1.Pod{}
 	}
@@ -150,8 +150,8 @@ func (p *CapacityBufferPodListProcessor) provision(buffer *v1alpha1.CapacityBuff
 	return fakePods
 }
 
-func (p *CapacityBufferPodListProcessor) filterBuffersProvStrategy(buffers []*v1alpha1.CapacityBuffer) []*v1alpha1.CapacityBuffer {
-	var filteredBuffers []*v1alpha1.CapacityBuffer
+func (p *CapacityBufferPodListProcessor) filterBuffersProvStrategy(buffers []*v1beta1.CapacityBuffer) []*v1beta1.CapacityBuffer {
+	var filteredBuffers []*v1beta1.CapacityBuffer
 	for _, buffer := range buffers {
 		if buffer.Status.ProvisioningStrategy != nil && p.provStrategies[*buffer.Status.ProvisioningStrategy] {
 			filteredBuffers = append(filteredBuffers, buffer)
@@ -160,7 +160,7 @@ func (p *CapacityBufferPodListProcessor) filterBuffersProvStrategy(buffers []*v1
 	return filteredBuffers
 }
 
-func (p *CapacityBufferPodListProcessor) updateBufferStatus(buffer *v1alpha1.CapacityBuffer) {
+func (p *CapacityBufferPodListProcessor) updateBufferStatus(buffer *v1beta1.CapacityBuffer) {
 	_, err := p.client.UpdateCapacityBuffer(buffer)
 	if err != nil {
 		klog.Errorf("Failed to update buffer status for buffer %v, error: %v", buffer.Name, err.Error())
@@ -168,7 +168,7 @@ func (p *CapacityBufferPodListProcessor) updateBufferStatus(buffer *v1alpha1.Cap
 }
 
 // makeFakePods creates podCount number of copies of the sample pod
-func makeFakePods(buffer *v1alpha1.CapacityBuffer, samplePodTemplate *apiv1.PodTemplateSpec, podCount int, forceSafeToEvictFakePods bool) ([]*apiv1.Pod, error) {
+func makeFakePods(buffer *v1beta1.CapacityBuffer, samplePodTemplate *apiv1.PodTemplateSpec, podCount int, forceSafeToEvictFakePods bool) ([]*apiv1.Pod, error) {
 	var fakePods []*apiv1.Pod
 	samplePod := pod.GetPodFromTemplate(samplePodTemplate, buffer.Namespace)
 	samplePod.Spec.NodeName = ""

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	apiv1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	apiv1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
@@ -168,7 +168,7 @@ func TestPodListProcessor(t *testing.T) {
 			assert.Equal(t, test.expectedUnschedFakePodsCount, numberOfFakePods)
 
 			for buffer, condition := range test.expectedBuffersProvCondition {
-				buffer, err := fakeBuffersClient.AutoscalingV1alpha1().CapacityBuffers(corev1.NamespaceDefault).Get(context.TODO(), buffer, metav1.GetOptions{})
+				buffer, err := fakeBuffersClient.AutoscalingV1beta1().CapacityBuffers(corev1.NamespaceDefault).Get(context.TODO(), buffer, metav1.GetOptions{})
 				assert.Equal(t, err, nil)
 				assert.Equal(t, len(buffer.Status.Conditions), 1)
 				assert.Equal(t, string(buffer.Status.Conditions[0].Type), string(condition.Type))

--- a/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
-	v1alpha1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
@@ -32,7 +32,7 @@ type FakePodsScaleUpStatusProcessor struct {
 }
 
 type bufferInfo struct {
-	buffer         *v1alpha1.CapacityBuffer
+	buffer         *v1beta1.CapacityBuffer
 	numberOfPods   int
 	reasonMessages []string
 }

--- a/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1alpha1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1"
+	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
@@ -108,13 +108,13 @@ func TestBuffersEvent(t *testing.T) {
 		NewSize:     9,
 		MaxSize:     nodeGroup1.MaxSize(),
 	}
-	buffer1 := &v1alpha1.CapacityBuffer{
+	buffer1 := &v1beta1.CapacityBuffer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "buffer_1",
 			UID:  "buffer_1",
 		},
 	}
-	buffer2 := &v1alpha1.CapacityBuffer{
+	buffer2 := &v1beta1.CapacityBuffer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "buffer_2",
 			UID:  "buffer_2",
@@ -134,7 +134,7 @@ func TestBuffersEvent(t *testing.T) {
 		expectedNotTriggeredScaleUp int
 	}{
 		"One fake pod, successful scale up": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:                  status.ScaleUpSuccessful,
 				ConsideredNodeGroups:    consideredNodeGroups,
@@ -147,7 +147,7 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 0,
 		},
 		"One fake pod, error scale up": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:                  status.ScaleUpError,
 				ConsideredNodeGroups:    consideredNodeGroups,
@@ -160,7 +160,7 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 0,
 		},
 		"One fake pod, empty scale up infos": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:                  status.ScaleUpError,
 				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{},
@@ -172,7 +172,7 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 0,
 		},
 		"One fake pod, with no node in Registry": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{}),
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{}),
 			state: &status.ScaleUpStatus{
 				Result:                  status.ScaleUpError,
 				ConsideredNodeGroups:    consideredNodeGroups,
@@ -185,7 +185,7 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 0,
 		},
 		"One fake pod, unschedulalble": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:               status.ScaleUpNoOptionsAvailable,
 				ConsideredNodeGroups: consideredNodeGroups,
@@ -203,7 +203,7 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 1,
 		},
 		"One fake pod, unschedulalble with error": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1}),
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:               status.ScaleUpError,
 				ConsideredNodeGroups: consideredNodeGroups,
@@ -221,7 +221,7 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 0,
 		},
 		"two fake pods for same buffer, one triggers scale up and the other doesn't": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{"fake-pod-1": buffer1, "fake-pod-2": buffer1}),
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1, "fake-pod-2": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:               status.ScaleUpNoOptionsAvailable,
 				ConsideredNodeGroups: consideredNodeGroups,
@@ -239,7 +239,7 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 1,
 		},
 		"multiple pods for multiple buffers with mixed conditions": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1alpha1.CapacityBuffer{
+			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{
 				"fake-pod-1": buffer1,
 				"fake-pod-2": buffer1,
 				"fake-pod-3": buffer2,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Use v1beta1 CapacityBuffers API instead of deprecated alpha

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
