### PR TITLE
[VPA] Enable multiple revive rules - 3

### DIFF
--- a/vertical-pod-autoscaler/.golangci.yaml
+++ b/vertical-pod-autoscaler/.golangci.yaml
@@ -19,17 +19,42 @@ linters:
         - name: comment-spacings
         - name: enforce-switch-style
         - name: unexported-naming
+        - name: empty-lines
+        - name: use-errors-new
+        - name: early-return
 
         # Below lists the rules disabled
+
+        # Limits function parameter count; disabled due to generators/tests exceeding it without clarity gains.
         - name: argument-limit
           disabled: true
+
+        # Flags non-TLS (http) URLs; disabled because internal/test endpoints intentionally use http.
         - name: unsecure-url-scheme
           disabled: true
+
+        # Detects confusing/misleading identifiers which should be fine to have both exported and unexported func with same within a pkg.
         - name: confusing-naming
           disabled: true
+
+        # Discourages boolean parameters; disabled since it is mostly been followed across to take boolean values as func params.
         - name: flag-parameter
           disabled: true
+        
+        # Limits number of exported structs; disabled because API/codegen packages expose many types by design.
         - name: max-public-structs
+          disabled: true
+
+        # Requires package-level comments; disabled until comments are added across the repo.
+        - name: package-comments
+          disabled: true
+
+        # Validates struct tag keys; disabled because pb/types use inline/casttype widely and fixing needs generator bumps and broad refactors.
+        - name: struct-tag
+          disabled: true
+
+        # Flags exported funcs returning unexported types; disabled for intentional encapsulation in internal APIs.
+        - name: unexported-return
           disabled: true
 formatters:
   enable:

--- a/vertical-pod-autoscaler/pkg/admission-controller/certs.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/certs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -127,17 +128,17 @@ func (cr *certReloader) reloadWebhookCA() error {
 	client := cr.mutatingWebhookClient
 	if client == nil {
 		// this should never happen as we don't watch the file if mutatingWebhookClient is nil
-		return fmt.Errorf("webhook client is not set")
+		return errors.New("webhook client is not set")
 	}
 	webhook, err := client.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 	if webhook == nil {
-		return fmt.Errorf("webhook not found")
+		return errors.New("webhook not found")
 	}
 	if len(webhook.Webhooks) == 0 {
-		return fmt.Errorf("webhook configuration has no webhooks")
+		return errors.New("webhook configuration has no webhooks")
 	}
 	currentBundle := webhook.Webhooks[0].ClientConfig.CABundle[:]
 	base64CurrentBundle := base64.StdEncoding.EncodeToString(currentBundle)

--- a/vertical-pod-autoscaler/pkg/admission-controller/certs_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/certs_test.go
@@ -260,7 +260,6 @@ func TestChangedCAReloader(t *testing.T) {
 
 	oldCAEncodedString := base64.StdEncoding.EncodeToString(oldWebhookCABundle)
 	for !patchCalled.Load() {
-
 		time.Sleep(1 * time.Second)
 	}
 	newWebhookConfig, err := webhookConfigInterface.Get(context.TODO(), webhookConfigName, metav1.GetOptions{})

--- a/vertical-pod-autoscaler/pkg/admission-controller/config_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestSelfRegistrationBase(t *testing.T) {
-
 	testClientSet := fake.NewClientset()
 	caCert := []byte("fake")
 	webHookDelay := 0 * time.Second
@@ -72,7 +71,6 @@ func TestSelfRegistrationBase(t *testing.T) {
 }
 
 func TestSelfRegistrationWithURL(t *testing.T) {
-
 	testClientSet := fake.NewClientset()
 	caCert := []byte("fake")
 	webHookDelay := 0 * time.Second
@@ -100,7 +98,6 @@ func TestSelfRegistrationWithURL(t *testing.T) {
 }
 
 func TestSelfRegistrationWithOutURL(t *testing.T) {
-
 	testClientSet := fake.NewClientset()
 	caCert := []byte("fake")
 	webHookDelay := 0 * time.Second
@@ -130,7 +127,6 @@ func TestSelfRegistrationWithOutURL(t *testing.T) {
 }
 
 func TestSelfRegistrationWithIgnoredNamespaces(t *testing.T) {
-
 	testClientSet := fake.NewClientset()
 	caCert := []byte("fake")
 	webHookDelay := 0 * time.Second
@@ -161,7 +157,6 @@ func TestSelfRegistrationWithIgnoredNamespaces(t *testing.T) {
 }
 
 func TestSelfRegistrationWithSelectedNamespaces(t *testing.T) {
-
 	testClientSet := fake.NewClientset()
 	caCert := []byte("fake")
 	webHookDelay := 0 * time.Second
@@ -193,7 +188,6 @@ func TestSelfRegistrationWithSelectedNamespaces(t *testing.T) {
 }
 
 func TestSelfRegistrationWithFailurePolicy(t *testing.T) {
-
 	testClientSet := fake.NewClientset()
 	caCert := []byte("fake")
 	webHookDelay := 0 * time.Second
@@ -220,7 +214,6 @@ func TestSelfRegistrationWithFailurePolicy(t *testing.T) {
 }
 
 func TestSelfRegistrationWithOutFailurePolicy(t *testing.T) {
-
 	testClientSet := fake.NewClientset()
 	caCert := []byte("fake")
 	webHookDelay := 0 * time.Second
@@ -247,7 +240,6 @@ func TestSelfRegistrationWithOutFailurePolicy(t *testing.T) {
 }
 
 func TestSelfRegistrationWithInvalidLabels(t *testing.T) {
-
 	testClientSet := fake.NewClientset()
 	caCert := []byte("fake")
 	webHookDelay := 0 * time.Second

--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
@@ -91,7 +91,6 @@ func (s *AdmissionServer) addDeprecationWarnings(req *admissionv1.AdmissionReque
 
 	if vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.UpdateMode != nil &&
 		*vpa.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeAuto { //nolint:staticcheck
-
 		if resp.Warnings == nil {
 			resp.Warnings = []string{}
 		}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler.go
@@ -19,7 +19,7 @@ package pod
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +67,7 @@ func (h *resourceHandler) DisallowIncorrectObjects() bool {
 // GetPatches builds patches for Pod in given admission request.
 func (h *resourceHandler) GetPatches(ctx context.Context, ar *admissionv1.AdmissionRequest) ([]resource_admission.PatchRecord, error) {
 	if ar.Resource.Version != "v1" {
-		return nil, fmt.Errorf("only v1 Pods are supported")
+		return nil, errors.New("only v1 Pods are supported")
 	}
 	raw, namespace := ar.Object.Raw, ar.Namespace
 	pod := corev1.Pod{}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler_test.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -91,15 +92,15 @@ func TestGetPatches(t *testing.T) {
 			namespace:            "default",
 			vpa:                  testVpa,
 			podPreProcessorError: nil,
-			expectError:          fmt.Errorf("unexpected end of JSON input"),
+			expectError:          errors.New("unexpected end of JSON input"),
 		},
 		{
 			name:                 "invalid pod",
 			podJson:              []byte("{}"),
 			namespace:            "default",
 			vpa:                  testVpa,
-			podPreProcessorError: fmt.Errorf("bad pod"),
-			expectError:          fmt.Errorf("bad pod"),
+			podPreProcessorError: errors.New("bad pod"),
+			expectError:          errors.New("bad pod"),
 		},
 		{
 			name:                 "no vpa found",
@@ -116,10 +117,10 @@ func TestGetPatches(t *testing.T) {
 			namespace: "test",
 			vpa:       testVpa,
 			calculators: []patch.Calculator{&fakePatchCalculator{
-				[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+				[]resource_admission.PatchRecord{}, errors.New("Can't calculate this"),
 			}},
 			podPreProcessorError: nil,
-			expectError:          fmt.Errorf("Can't calculate this"),
+			expectError:          errors.New("Can't calculate this"),
 			expectPatches:        []resource_admission.PatchRecord{},
 		},
 		{
@@ -132,10 +133,10 @@ func TestGetPatches(t *testing.T) {
 					testPatchRecord,
 				}, nil},
 				&fakePatchCalculator{
-					[]resource_admission.PatchRecord{}, fmt.Errorf("Can't calculate this"),
+					[]resource_admission.PatchRecord{}, errors.New("Can't calculate this"),
 				}},
 			podPreProcessorError: nil,
-			expectError:          fmt.Errorf("Can't calculate this"),
+			expectError:          errors.New("Can't calculate this"),
 			expectPatches:        []resource_admission.PatchRecord{},
 		},
 		{

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package recommendation
 
 import (
-	"fmt"
+	"errors"
 	"math"
 	"testing"
 
@@ -269,9 +269,9 @@ func TestUpdateResourceRequests(t *testing.T) {
 			name:              "limit range calculation error",
 			pod:               initialized,
 			vpa:               vpa,
-			limitRangeCalcErr: fmt.Errorf("oh no"),
+			limitRangeCalcErr: errors.New("oh no"),
 			expectedAction:    false,
-			expectedError:     fmt.Errorf("error getting containerLimitRange: oh no"),
+			expectedError:     errors.New("error getting containerLimitRange: oh no"),
 		},
 		{
 			name:             "proportional limit from default",
@@ -354,9 +354,7 @@ func TestUpdateResourceRequests(t *testing.T) {
 					assert.NoError(t, err)
 				}
 			}
-
 		})
-
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -19,6 +19,7 @@ package vpa
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	v1 "k8s.io/api/admission/v1"
@@ -110,7 +111,7 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 	if vpa.Spec.UpdatePolicy != nil {
 		mode := vpa.Spec.UpdatePolicy.UpdateMode
 		if mode == nil {
-			return fmt.Errorf("updateMode is required if UpdatePolicy is used")
+			return errors.New("updateMode is required if UpdatePolicy is used")
 		}
 		if _, found := vpa_types.GetUpdateModes()[*mode]; !found {
 			return fmt.Errorf("unexpected UpdateMode value %s", *mode)
@@ -127,7 +128,7 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 	if vpa.Spec.ResourcePolicy != nil {
 		for _, policy := range vpa.Spec.ResourcePolicy.ContainerPolicies {
 			if policy.ContainerName == "" {
-				return fmt.Errorf("containerPolicies.ContainerName is required")
+				return errors.New("containerPolicies.ContainerName is required")
 			}
 
 			// check that perVPA is on if being used
@@ -175,18 +176,18 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 			controlledValues := policy.ControlledValues
 			if mode != nil && controlledValues != nil {
 				if *mode == vpa_types.ContainerScalingModeOff && *controlledValues == vpa_types.ContainerControlledValuesRequestsAndLimits {
-					return fmt.Errorf("controlledValues shouldn't be specified if container scaling mode is off")
+					return errors.New("controlledValues shouldn't be specified if container scaling mode is off")
 				}
 			}
 		}
 	}
 
 	if isCreate && vpa.Spec.TargetRef == nil {
-		return fmt.Errorf("targetRef is required. If you're using v1beta1 version of the API, please migrate to v1")
+		return errors.New("targetRef is required. If you're using v1beta1 version of the API, please migrate to v1")
 	}
 
 	if len(vpa.Spec.Recommenders) > 1 {
-		return fmt.Errorf("the current version of VPA object shouldn't specify more than one recommenders")
+		return errors.New("the current version of VPA object shouldn't specify more than one recommenders")
 	}
 
 	return nil

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vpa
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -62,7 +63,7 @@ func TestValidateVPA(t *testing.T) {
 			name:        "empty create",
 			vpa:         vpa_types.VerticalPodAutoscaler{},
 			isCreate:    true,
-			expectError: fmt.Errorf("targetRef is required. If you're using v1beta1 version of the API, please migrate to v1"),
+			expectError: errors.New("targetRef is required. If you're using v1beta1 version of the API, please migrate to v1"),
 		},
 		{
 			name: "no update mode",
@@ -71,7 +72,7 @@ func TestValidateVPA(t *testing.T) {
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{},
 				},
 			},
-			expectError: fmt.Errorf("updateMode is required if UpdatePolicy is used"),
+			expectError: errors.New("updateMode is required if UpdatePolicy is used"),
 		},
 		{
 			name: "bad update mode",
@@ -82,7 +83,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("unexpected UpdateMode value bad"),
+			expectError: errors.New("unexpected UpdateMode value bad"),
 		},
 		{
 			name: "creating VPA with InPlaceOrRecreate update mode not allowed by disabled feature gate",
@@ -130,7 +131,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("minReplicas has to be positive, got 0"),
+			expectError: errors.New("minReplicas has to be positive, got 0"),
 		},
 		{
 			name: "no policy name",
@@ -141,7 +142,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("containerPolicies.ContainerName is required"),
+			expectError: errors.New("containerPolicies.ContainerName is required"),
 		},
 		{
 			name: "invalid scaling mode",
@@ -157,7 +158,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("unexpected Mode value bad"),
+			expectError: errors.New("unexpected Mode value bad"),
 		},
 		{
 			name: "more than one recommender",
@@ -172,7 +173,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("the current version of VPA object shouldn't specify more than one recommenders"),
+			expectError: errors.New("the current version of VPA object shouldn't specify more than one recommenders"),
 		},
 		{
 			name: "bad limits",
@@ -193,7 +194,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("max resource for cpu is lower than min"),
+			expectError: errors.New("max resource for cpu is lower than min"),
 		},
 		{
 			name: "bad minAllowed cpu value",
@@ -294,7 +295,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("controlledValues shouldn't be specified if container scaling mode is off"),
+			expectError: errors.New("controlledValues shouldn't be specified if container scaling mode is off"),
 		},
 		{
 			name: "all valid",
@@ -372,7 +373,7 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			PerVPAConfigDisabled: true,
-			expectError:          fmt.Errorf("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag PerVPAConfig is disabled"),
+			expectError:          errors.New("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag PerVPAConfig is disabled"),
 		},
 	}
 	for _, tc := range tests {

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
@@ -106,7 +106,6 @@ func TestMergeContainerStateForCheckpointDropsRecentMemoryPeak(t *testing.T) {
 }
 
 func TestIsFetchingHistory(t *testing.T) {
-
 	testCases := []struct {
 		vpa               model.Vpa
 		isFetchingHistory bool
@@ -147,7 +146,6 @@ func TestIsFetchingHistory(t *testing.T) {
 }
 
 func TestGetVpasToCheckpointSorts(t *testing.T) {
-
 	time1 := time.Unix(10000, 0)
 	time2 := time.Unix(20000, 0)
 
@@ -178,7 +176,6 @@ func TestGetVpasToCheckpointSorts(t *testing.T) {
 	assert.Equal(t, genVpaID(0), result[0].ID)
 	assert.Equal(t, genVpaID(1), result[1].ID)
 	assert.Equal(t, genVpaID(2), result[2].ID)
-
 }
 
 func TestStoreCheckpointsMakesProgressEvenForCancelledContext(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -492,7 +492,6 @@ func (feeder *clusterStateFeeder) LoadPods() {
 		for _, initContainer := range pod.InitContainers {
 			podInitContainers := feeder.clusterState.Pods()[pod.ID].InitContainers
 			feeder.clusterState.Pods()[pod.ID].InitContainers = append(podInitContainers, initContainer.ID.ContainerName)
-
 		}
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -18,6 +18,7 @@ package input
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -122,7 +123,6 @@ func (cs *fakeClusterState) StateMapSize() int {
 }
 
 func TestLoadVPAs(t *testing.T) {
-
 	type testCase struct {
 		name                                string
 		selector                            labels.Selector
@@ -142,7 +142,7 @@ func TestLoadVPAs(t *testing.T) {
 		{
 			name:                      "no selector",
 			selector:                  nil,
-			fetchSelectorError:        fmt.Errorf("targetRef not defined"),
+			fetchSelectorError:        errors.New("targetRef not defined"),
 			expectedSelector:          labels.Nothing(),
 			expectedConfigUnsupported: &unsupportedConditionTextFromFetcher,
 			expectedConfigDeprecated:  nil,
@@ -234,7 +234,7 @@ func TestLoadVPAs(t *testing.T) {
 			},
 			expectedConfigUnsupported:           &unsupportedConditionMudaMudaMuda,
 			expectedVpaFetch:                    true,
-			findTopMostWellKnownOrScalableError: fmt.Errorf("muda muda muda"),
+			findTopMostWellKnownOrScalableError: errors.New("muda muda muda"),
 		},
 		{
 			name:               "top-level target ref",
@@ -331,7 +331,6 @@ func TestLoadVPAs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -398,7 +397,6 @@ func TestLoadVPAs(t *testing.T) {
 			} else {
 				assert.NotContains(t, storedVpa.Conditions, vpa_types.ConfigUnsupported)
 			}
-
 		})
 	}
 }
@@ -484,7 +482,6 @@ func TestClusterStateFeeder_LoadPods_ContainerTracking(t *testing.T) {
 	assert.Equal(t, len(feeder.clusterState.Pods()[podWithInitContainersID].InitContainers), 2)
 	assert.Equal(t, len(feeder.clusterState.Pods()[podWithoutInitContainersID].Containers), 2)
 	assert.Equal(t, len(feeder.clusterState.Pods()[podWithoutInitContainersID].InitContainers), 0)
-
 }
 
 func TestClusterStateFeeder_LoadPods_MemorySaverMode(t *testing.T) {
@@ -794,7 +791,6 @@ func TestFilterVPAs(t *testing.T) {
 }
 
 func TestFilterVPAsIgnoreNamespaces(t *testing.T) {
-
 	vpa1 := &vpa_types.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "namespace1",

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -18,7 +18,7 @@ package history
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -177,7 +177,7 @@ func TestPrometheusError(t *testing.T) {
 		prometheusClient: &mockClient,
 	}
 	mockClient.On("QueryRange", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("v1.Range")).Return().Times(2).Return(
-		nil, fmt.Errorf("bla"))
+		nil, errors.New("bla"))
 	_, err := historyProvider.GetClusterHistory()
 	assert.NotNil(t, err)
 }
@@ -410,6 +410,5 @@ func TestPrometheusAuth(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, capturedRequest.Header.Get("Authorization"), "Basic cHJvbV91c2VyOnByb21fcGFzc3dvcmQ=") // "prom_user:prom_password"
-
 	})
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -134,13 +134,11 @@ func (s *externalMetricsClient) List(ctx context.Context, namespace string, opts
 					}
 					containerMetrics[ctrName][resourceName] = val.Value
 				}
-
 			}
 			for cname, res := range containerMetrics {
 				podMets.Containers = append(podMets.Containers, v1beta1.ContainerMetrics{Name: cname, Usage: res})
 			}
 			result.Items = append(result.Items, podMets)
-
 		}
 	}
 	return &result, nil

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
@@ -151,7 +151,6 @@ func (o *observer) OnUpdate(oldObj, newObj any) {
 		if containerStatus.RestartCount > 0 &&
 			containerStatus.LastTerminationState.Terminated != nil &&
 			containerStatus.LastTerminationState.Terminated.Reason == "OOMKilled" {
-
 			oldStatus := findStatus(containerStatus.Name, oldPod.Status.ContainerStatuses)
 			if oldStatus != nil && containerStatus.RestartCount > oldStatus.RestartCount {
 				oldSpec := findSpec(containerStatus.Name, oldPod.Spec.Containers)

--- a/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go
@@ -133,7 +133,6 @@ func calculateRequestedResources(pod *v1.Pod, container v1.Container, isInitCont
 		model.ResourceCPU:    model.ResourceAmount(cpuMillicores),
 		model.ResourceMemory: model.ResourceAmount(memoryBytes),
 	}
-
 }
 
 func podID(pod *v1.Pod) model.PodID {

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
@@ -162,7 +162,6 @@ func TestConfidenceMultiplierNoHistory(t *testing.T) {
 // Verifies that the MarginEstimator adds margin to the originally
 // estimated resources.
 func TestMarginEstimator(t *testing.T) {
-
 	// Use 10% margin on top of the recommended resources.
 	marginFraction := 0.1
 	baseCPUEstimator := NewConstCPUEstimator(model.CPUAmountFromCores(3.14))
@@ -190,5 +189,4 @@ func TestMinResourcesEstimator(t *testing.T) {
 	memoryEstimator := WithMemoryMinResource(minMemory, constMemoryEstimator)
 	memoryEstimation := memoryEstimator.GetMemoryEstimation(s)
 	assert.Equal(t, 4e8, model.BytesFromMemoryAmount(memoryEstimation))
-
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -249,7 +250,7 @@ func (cluster *clusterState) AddSample(sample *ContainerUsageSampleWithKey) erro
 		return NewKeyError(sample.Container)
 	}
 	if !containerState.AddSample(&sample.ContainerUsageSample) {
-		return fmt.Errorf("sample discarded (invalid or out of order)")
+		return errors.New("sample discarded (invalid or out of order)")
 	}
 	return nil
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -215,7 +216,7 @@ func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory 
 		Resource:     ResourceMemory,
 	}
 	if !container.addMemorySample(&oomMemorySample, true) {
-		return fmt.Errorf("adding OOM sample failed")
+		return errors.New("adding OOM sample failed")
 	}
 	return nil
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
@@ -191,7 +192,7 @@ func HumanizeMemoryQuantity(bytes int64) string {
 // RoundUpToScale rounds the value to the nearest multiple of scale, rounding up
 func RoundUpToScale(value ResourceAmount, scale int) (ResourceAmount, error) {
 	if scale <= 0 {
-		return value, fmt.Errorf("scale must be greater than zero")
+		return value, errors.New("scale must be greater than zero")
 	}
 	scale64 := int64(scale)
 	roundedValue := int64(math.Ceil(float64(value)/float64(scale64))) * scale64

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -268,7 +268,6 @@ func (vpa *Vpa) UpdateConditions(podsMatched bool) {
 	} else {
 		vpa.Conditions.Set(vpa_types.RecommendationProvided, false, reason, msg)
 	}
-
 }
 
 // AsStatus returns this objects equivalent of VPA Status. UpdateConditions

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
@@ -34,7 +34,6 @@ var (
 )
 
 func TestMergeAggregateContainerState(t *testing.T) {
-
 	containersInitialAggregateState := ContainerNameToAggregateStateMap{}
 	containersInitialAggregateState["test"] = NewAggregateContainerState()
 	vpa := NewVpa(VpaID{}, nil, anyTime)

--- a/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
@@ -42,7 +42,6 @@ var _ RecommendationPostProcessor = &IntegerCPUPostProcessor{}
 // Process apply the capping post-processing to the recommendation.
 // For this post processor the CPU value is rounded up to an integer
 func (p *IntegerCPUPostProcessor) Process(vpa *vpa_types.VerticalPodAutoscaler, recommendation *vpa_types.RecommendedPodResources) *vpa_types.RecommendedPodResources {
-
 	amendedRecommendation := recommendation.DeepCopy()
 
 	for key, value := range vpa.Annotations {

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -248,7 +249,7 @@ func (h *histogram) SaveToChekpoint() (*vpa_types.HistogramCheckpoint, error) {
 
 func (h *histogram) LoadFromCheckpoint(checkpoint *vpa_types.HistogramCheckpoint) error {
 	if checkpoint == nil {
-		return fmt.Errorf("cannot load from empty checkpoint")
+		return errors.New("cannot load from empty checkpoint")
 	}
 	if checkpoint.TotalWeight < 0.0 {
 		return fmt.Errorf("cannot load checkpoint with negative weight %v", checkpoint.TotalWeight)

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_cache_storage_test.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_cache_storage_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controllerfetcher
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -85,7 +85,7 @@ func TestControllerCache_InsertAndRefresh(t *testing.T) {
 	assert.Equal(t, getScale(), val)
 	assert.Nil(t, err)
 
-	c.Refresh(key.namespace, key.groupResource, key.name, nil, fmt.Errorf("err"))
+	c.Refresh(key.namespace, key.groupResource, key.name, nil, errors.New("err"))
 	present, val, err = c.Get(key.namespace, key.groupResource, key.name)
 	assert.True(t, present)
 	assert.Nil(t, val)
@@ -105,7 +105,7 @@ func TestControllerCache_InsertExistingKey(t *testing.T) {
 	assert.Nil(t, err)
 
 	// We might overwrite old values or keep them, either way should be fine.
-	c.Insert(key.namespace, key.groupResource, key.name, nil, fmt.Errorf("err"))
+	c.Insert(key.namespace, key.groupResource, key.name, nil, errors.New("err"))
 	present, _, _ = c.Get(key.namespace, key.groupResource, key.name)
 	assert.True(t, present)
 }

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher.go
@@ -190,7 +190,7 @@ func getParentOfWellKnownController(informer cache.SharedIndexInformer, controll
 		return getOwnerController(apiObj.OwnerReferences, namespace), nil
 	}
 
-	return nil, fmt.Errorf("don't know how to read owner controller")
+	return nil, errors.New("don't know how to read owner controller")
 }
 
 func (f *controllerFetcher) getParentOfController(ctx context.Context, controllerKey ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
@@ -335,7 +335,7 @@ func (f *controllerFetcher) FindTopMostWellKnownOrScalable(ctx context.Context, 
 
 		_, alreadyVisited := visited[*owner]
 		if alreadyVisited {
-			return nil, fmt.Errorf("cycle detected in ownership chain")
+			return nil, errors.New("cycle detected in ownership chain")
 		}
 		visited[*key] = true
 

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
@@ -18,6 +18,7 @@ package controllerfetcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -84,7 +85,6 @@ func simpleControllerFetcher() *controllerFetcher {
 
 	// resource that can scale
 	scaleNamespacer.AddReactor("get", "iCanScale", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-
 		ret = &autoscalingv1.Scale{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "Scaler",
@@ -312,7 +312,7 @@ func TestControllerFetcher(t *testing.T) {
 				},
 			}},
 			expectedKey:   nil,
-			expectedError: fmt.Errorf("cycle detected in ownership chain"),
+			expectedError: errors.New("cycle detected in ownership chain"),
 		},
 		{
 			name: "deployment, parent with no scale subresource",

--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -18,6 +18,7 @@ package target
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -109,7 +110,7 @@ type vpaTargetSelectorFetcher struct {
 
 func (f *vpaTargetSelectorFetcher) Fetch(ctx context.Context, vpa *vpa_types.VerticalPodAutoscaler) (labels.Selector, error) {
 	if vpa.Spec.TargetRef == nil {
-		return nil, fmt.Errorf("targetRef not defined. If this is a v1beta1 object, switch to v1")
+		return nil, errors.New("targetRef not defined. If this is a v1beta1 object, switch to v1")
 	}
 	kind := wellKnownController(vpa.Spec.TargetRef.Kind)
 	informer, exists := f.informersMap[kind]
@@ -160,7 +161,7 @@ func getLabelSelector(informer cache.SharedIndexInformer, kind, namespace, name 
 	case (*corev1.ReplicationController):
 		return metav1.LabelSelectorAsSelector(metav1.SetAsLabelSelector(apiObj.Spec.Selector))
 	}
-	return nil, fmt.Errorf("don't know how to read label selector")
+	return nil, errors.New("don't know how to read label selector")
 }
 
 func (f *vpaTargetSelectorFetcher) getLabelSelectorFromResource(

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -56,7 +56,6 @@ func logDeprecationWarnings(vpa *vpa_types.VerticalPodAutoscaler) {
 	if vpa.Spec.UpdatePolicy != nil &&
 		vpa.Spec.UpdatePolicy.UpdateMode != nil &&
 		*vpa.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeAuto { //nolint:staticcheck
-
 		klog.InfoS("VPA uses deprecated UpdateMode 'Auto'. This mode is deprecated and will be removed in a future API version. Please use explicit update modes like 'Recreate', 'Initial', or 'InPlaceOrRecreate'",
 			"vpa", klog.KObj(vpa), "issue", "https://github.com/kubernetes/autoscaler/issues/8424")
 	}

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -18,7 +18,7 @@ package logic
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -235,7 +235,7 @@ func testRunOnceBase(
 
 		inplace.On("CanInPlaceUpdate", pods[i]).Return(canInPlaceUpdate)
 		if shouldInPlaceFail {
-			inplace.On("InPlaceUpdate", pods[i], nil).Return(fmt.Errorf("in-place update failed"))
+			inplace.On("InPlaceUpdate", pods[i], nil).Return(errors.New("in-place update failed"))
 		} else {
 			inplace.On("InPlaceUpdate", pods[i], nil).Return(nil)
 		}

--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission_test.go
@@ -356,7 +356,6 @@ func TestAdmitForSingleContainer(t *testing.T) {
 
 		assert.Equal(t, false, sdpea.Admit(pod, recommendation))
 	})
-
 }
 
 func TestAdmitForMultipleContainer(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -474,7 +474,6 @@ func (p *pod1Admission) Admit(pod *apiv1.Pod, recommendation *vpa_types.Recommen
 func (p *pod1Admission) CleanUp() {}
 
 func TestAdmission(t *testing.T) {
-
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("2")).Get()).Get()
 	pod2 := test.Pod().WithName("POD2").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("4")).Get()).Get()
 	pod3 := test.Pod().WithName("POD3").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).Get()).Get()
@@ -552,7 +551,6 @@ func TestLessPodPriority(t *testing.T) {
 			assert.Equal(t, !tc.isLess, tc.other.Less(tc.prio))
 		})
 	}
-
 }
 
 func TestAddPodLogs(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_eviction_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_eviction_restriction_test.go
@@ -250,7 +250,6 @@ func TestEvictEmitEvent(t *testing.T) {
 
 			if p.canEvict {
 				mockRecorder.AssertNumberOfCalls(t, "Event", 2)
-
 			} else {
 				mockRecorder.AssertNumberOfCalls(t, "Event", 0)
 			}

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -19,6 +19,7 @@ package restriction
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -136,32 +137,33 @@ func (ip *PodsInPlaceRestrictionImpl) InPlaceUpdate(podToUpdate *apiv1.Pod, vpa 
 			annotationPatches = append(annotationPatches, p...)
 		}
 	}
-	if len(resizePatches) > 0 {
-		patch, err := json.Marshal(resizePatches)
+
+	if len(resizePatches) == 0 {
+		return errors.New("no resource patches were calculated to apply")
+	}
+
+	patch, err := json.Marshal(resizePatches)
+	if err != nil {
+		return err
+	}
+
+	res, err := ip.client.CoreV1().Pods(podToUpdate.Namespace).Patch(context.TODO(), podToUpdate.Name, k8stypes.JSONPatchType, patch, metav1.PatchOptions{}, "resize")
+	if err != nil {
+		return err
+	}
+	klog.V(4).InfoS("In-place patched pod /resize subresource using patches", "pod", klog.KObj(res), "patches", string(patch))
+
+	if len(annotationPatches) > 0 {
+		patch, err := json.Marshal(annotationPatches)
 		if err != nil {
 			return err
 		}
-
-		res, err := ip.client.CoreV1().Pods(podToUpdate.Namespace).Patch(context.TODO(), podToUpdate.Name, k8stypes.JSONPatchType, patch, metav1.PatchOptions{}, "resize")
+		res, err = ip.client.CoreV1().Pods(podToUpdate.Namespace).Patch(context.TODO(), podToUpdate.Name, k8stypes.JSONPatchType, patch, metav1.PatchOptions{})
 		if err != nil {
-			return err
+			klog.V(4).ErrorS(err, "Failed to patch pod annotations", "pod", klog.KObj(res), "patches", string(patch))
+		} else {
+			klog.V(4).InfoS("Patched pod annotations", "pod", klog.KObj(res), "patches", string(patch))
 		}
-		klog.V(4).InfoS("In-place patched pod /resize subresource using patches", "pod", klog.KObj(res), "patches", string(patch))
-
-		if len(annotationPatches) > 0 {
-			patch, err := json.Marshal(annotationPatches)
-			if err != nil {
-				return err
-			}
-			res, err = ip.client.CoreV1().Pods(podToUpdate.Namespace).Patch(context.TODO(), podToUpdate.Name, k8stypes.JSONPatchType, patch, metav1.PatchOptions{})
-			if err != nil {
-				klog.V(4).ErrorS(err, "Failed to patch pod annotations", "pod", klog.KObj(res), "patches", string(patch))
-			} else {
-				klog.V(4).InfoS("Patched pod annotations", "pod", klog.KObj(res), "patches", string(patch))
-			}
-		}
-	} else {
-		return fmt.Errorf("no resource patches were calculated to apply")
 	}
 
 	eventRecorder.Event(podToUpdate, apiv1.EventTypeNormal, "InPlaceResizedByVPA", "Pod was resized in place by VPA Updater.")

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package restriction
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -122,7 +123,7 @@ func (f *PodsRestrictionFactoryImpl) getReplicaCount(creator podReplicaCreator) 
 		}
 		rc, ok := rcObj.(*apiv1.ReplicationController)
 		if !ok {
-			return 0, fmt.Errorf("failed to parse Replication Controller")
+			return 0, errors.New("failed to parse Replication Controller")
 		}
 		if rc.Spec.Replicas == nil || *rc.Spec.Replicas == 0 {
 			return 0, fmt.Errorf("replication controller %s/%s has no replicas config", creator.Namespace, creator.Name)
@@ -138,7 +139,7 @@ func (f *PodsRestrictionFactoryImpl) getReplicaCount(creator podReplicaCreator) 
 		}
 		rs, ok := rsObj.(*appsv1.ReplicaSet)
 		if !ok {
-			return 0, fmt.Errorf("failed to parse Replicaset")
+			return 0, errors.New("failed to parse Replicaset")
 		}
 		if rs.Spec.Replicas == nil || *rs.Spec.Replicas == 0 {
 			return 0, fmt.Errorf("replica set %s/%s has no replicas config", creator.Namespace, creator.Name)
@@ -154,7 +155,7 @@ func (f *PodsRestrictionFactoryImpl) getReplicaCount(creator podReplicaCreator) 
 		}
 		ss, ok := ssObj.(*appsv1.StatefulSet)
 		if !ok {
-			return 0, fmt.Errorf("failed to parse StatefulSet")
+			return 0, errors.New("failed to parse StatefulSet")
 		}
 		if ss.Spec.Replicas == nil || *ss.Spec.Replicas == 0 {
 			return 0, fmt.Errorf("stateful set %s/%s has no replicas config", creator.Namespace, creator.Name)
@@ -170,7 +171,7 @@ func (f *PodsRestrictionFactoryImpl) getReplicaCount(creator podReplicaCreator) 
 		}
 		ds, ok := dsObj.(*appsv1.DaemonSet)
 		if !ok {
-			return 0, fmt.Errorf("failed to parse DaemonSet")
+			return 0, errors.New("failed to parse DaemonSet")
 		}
 		if ds.Status.NumberReady == 0 {
 			return 0, fmt.Errorf("daemon set %s/%s has no number ready pods", creator.Namespace, creator.Name)
@@ -242,7 +243,6 @@ func (f *PodsRestrictionFactoryImpl) GetCreatorMaps(pods []*apiv1.Pod, vpa *vpa_
 		}
 		singleGroup.running = len(replicas) - singleGroup.pending
 		creatorToSingleGroupStatsMap[creator] = singleGroup
-
 	}
 	return creatorToSingleGroupStatsMap, podToReplicaCreatorMap, nil
 }

--- a/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
+++ b/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package limitrange
 
 import (
+	"errors"
 	"fmt"
 
 	core "k8s.io/api/core/v1"
@@ -51,7 +52,7 @@ type limitsChecker struct {
 // NewLimitsRangeCalculator returns a limitsChecker or an error it encountered when attempting to create it.
 func NewLimitsRangeCalculator(f informers.SharedInformerFactory) (*limitsChecker, error) {
 	if f == nil {
-		return nil, fmt.Errorf("NewLimitsRangeCalculator requires a SharedInformerFactory but got nil")
+		return nil, errors.New("NewLimitsRangeCalculator requires a SharedInformerFactory but got nil")
 	}
 	limitRangeLister := f.Core().V1().LimitRanges().Lister()
 	return &limitsChecker{limitRangeLister}, nil

--- a/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator_test.go
@@ -149,6 +149,5 @@ func TestGetContainerLimitRangeItem(t *testing.T) {
 				assert.Equal(t, tc.expectedLimits, limitRange)
 			}
 		})
-
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -449,7 +449,6 @@ func TestSizeBasedGauge(t *testing.T) {
 						t.Errorf("Unexpected value for metric %s with labels %v: got %v, want %v", tc.metricName, expected.labels, val, expected.value)
 					}
 				}
-
 			}
 		})
 	}

--- a/vertical-pod-autoscaler/pkg/utils/status/status_object_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/status/status_object_test.go
@@ -18,6 +18,7 @@ package status
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"syscall"
 	"testing"
@@ -50,7 +51,7 @@ func TestUpdateStatus(t *testing.T) {
 					return true, &apicoordinationv1.Lease{}, nil
 				}
 
-				return true, nil, fmt.Errorf("unsupported action")
+				return true, nil, errors.New("unsupported action")
 			},
 			wantErr: false,
 		},
@@ -69,7 +70,7 @@ func TestUpdateStatus(t *testing.T) {
 						}
 					}
 
-					return true, nil, fmt.Errorf("unsupported action")
+					return true, nil, errors.New("unsupported action")
 				}
 			}(),
 			wantErr: false,
@@ -90,7 +91,7 @@ func TestUpdateStatus(t *testing.T) {
 						}
 					}
 
-					return true, nil, fmt.Errorf("unsupported action")
+					return true, nil, errors.New("unsupported action")
 				}
 			}(),
 			wantErr: false,
@@ -111,7 +112,7 @@ func TestUpdateStatus(t *testing.T) {
 						}
 					}
 
-					return true, nil, fmt.Errorf("unsupported action")
+					return true, nil, errors.New("unsupported action")
 				}
 			}(),
 			wantErr: false,
@@ -122,7 +123,7 @@ func TestUpdateStatus(t *testing.T) {
 				if action.GetResource().Resource == "leases" {
 					return true, nil, apierrors.NewNotFound(schema.GroupResource{}, leaseName)
 				}
-				return true, nil, fmt.Errorf("unsupported action")
+				return true, nil, errors.New("unsupported action")
 			},
 			wantErr: true,
 		},
@@ -157,7 +158,7 @@ func TestGetStatus(t *testing.T) {
 					return true, &apicoordinationv1.Lease{}, nil
 				}
 
-				return true, nil, fmt.Errorf("unsupported action")
+				return true, nil, errors.New("unsupported action")
 			},
 			wantErr: false,
 		},
@@ -176,7 +177,7 @@ func TestGetStatus(t *testing.T) {
 						}
 					}
 
-					return true, nil, fmt.Errorf("unsupported action")
+					return true, nil, errors.New("unsupported action")
 				}
 			}(),
 			wantErr: false,
@@ -190,13 +191,13 @@ func TestGetStatus(t *testing.T) {
 						i++
 						switch i {
 						case 1:
-							return true, nil, fmt.Errorf("non-retryable error")
+							return true, nil, errors.New("non-retryable error")
 						default:
 							return true, &apicoordinationv1.Lease{}, nil
 						}
 					}
 
-					return true, nil, fmt.Errorf("unsupported action")
+					return true, nil, errors.New("unsupported action")
 				}
 			}(),
 			wantErr: true,

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/stretchr/testify/mock"
@@ -166,7 +166,7 @@ func (m *PodListerMock) List(selector labels.Selector) (ret []*apiv1.Pod, err er
 
 // Get is not implemented for this mock
 func (m *PodListerMock) Get(name string) (*apiv1.Pod, error) {
-	return nil, fmt.Errorf("unimplemented")
+	return nil, errors.New("unimplemented")
 }
 
 // VerticalPodAutoscalerListerMock is a mock of VerticalPodAutoscalerLister or
@@ -197,7 +197,7 @@ func (m *VerticalPodAutoscalerListerMock) VerticalPodAutoscalers(namespace strin
 
 // Get is not implemented for this mock
 func (m *VerticalPodAutoscalerListerMock) Get(name string) (*vpa_types.VerticalPodAutoscaler, error) {
-	return nil, fmt.Errorf("unimplemented")
+	return nil, errors.New("unimplemented")
 }
 
 // VerticalPodAutoscalerCheckPointListerMock is a mock of VerticalPodAutoscalerCheckPointLister
@@ -227,7 +227,7 @@ func (m *VerticalPodAutoscalerCheckPointListerMock) VerticalPodAutoscalerCheckpo
 
 // Get is not implemented for this mock
 func (m *VerticalPodAutoscalerCheckPointListerMock) Get(name string) (*vpa_types.VerticalPodAutoscalerCheckpoint, error) {
-	return nil, fmt.Errorf("unimplemented")
+	return nil, errors.New("unimplemented")
 }
 
 // VerticalPodAutoscalerV1Beta1ListerMock is a mock of VerticalPodAutoscalerLister or
@@ -258,7 +258,7 @@ func (m *VerticalPodAutoscalerV1Beta1ListerMock) VerticalPodAutoscalers(namespac
 
 // Get is not implemented for this mock
 func (m *VerticalPodAutoscalerV1Beta1ListerMock) Get(name string) (*vpa_types_v1beta1.VerticalPodAutoscaler, error) {
-	return nil, fmt.Errorf("unimplemented")
+	return nil, errors.New("unimplemented")
 }
 
 // RecommendationProcessorMock is mock implementation of RecommendationProcessor

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -169,7 +169,6 @@ func Stronger(a, b *vpa_types.VerticalPodAutoscaler) bool {
 
 // GetControllingVPAForPod chooses the earliest created VPA from the input list that matches the given Pod.
 func GetControllingVPAForPod(ctx context.Context, pod *core.Pod, vpas []*VpaWithSelector, ctrlFetcher controllerfetcher.ControllerFetcher) *VpaWithSelector {
-
 	parentController, err := FindParentControllerForPod(ctx, pod, ctrlFetcher)
 	if err != nil {
 		klog.ErrorS(err, "Failed to get parent controller for pod", "pod", klog.KObj(pod))

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -17,6 +17,7 @@ limitations under the License.
 package api
 
 import (
+	"errors"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -59,10 +60,10 @@ func (c *cappingRecommendationProcessor) Apply(
 	// TODO: Annotate if request enforced by maintaining proportion with limit and allowed limit range is in conflict with policy.
 
 	if vpa == nil {
-		return nil, nil, fmt.Errorf("cannot process nil vpa")
+		return nil, nil, errors.New("cannot process nil vpa")
 	}
 	if pod == nil {
-		return nil, nil, fmt.Errorf("cannot process nil pod")
+		return nil, nil, errors.New("cannot process nil pod")
 	}
 
 	policy := vpa.Spec.ResourcePolicy

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -193,7 +193,6 @@ func TestRecommendationToLimitCapping(t *testing.T) {
 			}
 
 			assert.Equal(t, tc.expectedUpperBound, res.ContainerRecommendations[0].UpperBound)
-
 		})
 	}
 }
@@ -305,7 +304,6 @@ func TestApply(t *testing.T) {
 	pod := test.Pod().WithName("pod1").AddContainer(test.Container().WithName(containerName).Get()).Get()
 
 	for _, testCase := range applyTestCases {
-
 		vpa := test.VerticalPodAutoscaler().WithContainer(containerName).Get()
 		vpa.Spec.ResourcePolicy = testCase.Policy
 		vpa.Status.Recommendation = testCase.PodRecommendation

--- a/vertical-pod-autoscaler/pkg/utils/vpa/sequential_processor.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/sequential_processor.go
@@ -17,7 +17,7 @@ limitations under the License.
 package api
 
 import (
-	"fmt"
+	"errors"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -37,9 +37,8 @@ type sequentialRecommendationProcessor struct {
 func (p *sequentialRecommendationProcessor) Apply(
 	vpa *vpa_types.VerticalPodAutoscaler,
 	pod *v1.Pod) (*vpa_types.RecommendedPodResources, ContainerToAnnotationsMap, error) {
-
 	if vpa == nil {
-		return nil, nil, fmt.Errorf("cannot process nil vpa")
+		return nil, nil, errors.New("cannot process nil vpa")
 	}
 	if vpa.Status.Recommendation == nil {
 		return nil, nil, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Enables multiple revive rules and also disabling few which might not be required.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Updates #8986

#### Special notes for your reviewer:
Continuation from this [PR](https://github.com/kubernetes/autoscaler/pull/9039).

Enables the rules as defined in golangci.yaml

Below are the revive linter rules enabled as part of this PR
        - name: empty-lines
        - name: use-errors-new
        - name: early-return

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
