### PR TITLE
fix(ca): Fix pre-commit hook trigger 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,5 @@ repos:
         name: Update Cluster-Autoscaler Flags Table
         entry: bash cluster-autoscaler/hack/update-faq-flags.sh
         language: system
-        files: cluster-autoscaler/main\.go
+        files: cluster-autoscaler/config/flags/flags\.go
     repo: local

--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -975,157 +975,167 @@ However, CA does not consider "soft" constraints like `preferredDuringScheduling
 
 The following startup parameters are supported for cluster autoscaler:
 
-| Parameter                                            | Description | Default |
-|------------------------------------------------------| --- | --- |
-| `add-dir-header`                                     | If true, adds the file directory to the header of the log messages |  |
-| `address`                                            | The address to expose prometheus metrics. | ":8085" |
-| `alsologtostderr`                                    | log to standard error as well as files (no effect when -logtostderr=true) |  |
-| `async-node-groups`                                  | Whether clusterautoscaler creates and deletes node groups asynchronously. Experimental: requires cloud provider supporting async node group operations, enable at your own risk. |  |
-| `aws-use-static-instance-list`                       | Should CA fetch instance types in runtime or use a static list. AWS only |  |
-| `balance-similar-node-groups`                        | Detect similar node groups and balance the number of nodes between them |  |
-| `balancing-ignore-label`                             | Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar | [] |
-| `balancing-label`                                    | Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label. | [] |
-| `bulk-mig-instances-listing-enabled`                 | Fetch GCE mig instances in bulk instead of per mig |  |
-| `bypassed-scheduler-names`                           | Names of schedulers to bypass. If set to non-empty value, CA will not wait for pods to reach a certain age before triggering a scale-up. |  |
-| `check-capacity-batch-processing`                    | Whether to enable batch processing for check capacity requests. |  |
-| `check-capacity-processor-instance`                  | Name of the processor instance. Only ProvisioningRequests that define this name in their parameters with the key "processorInstance" will be processed by this CA instance. It only refers to check capacity ProvisioningRequests, but if not empty, best-effort atomic ProvisioningRequests processing is disabled in this instance. Not recommended: Until CA 1.35, ProvisioningRequests with this name as prefix in their class will be also processed. |  |
-| `check-capacity-provisioning-request-batch-timebox`  | Maximum time to process a batch of provisioning requests. | 10s |
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `add-dir-header` | If true, adds the file directory to the header of the log messages |  |
+| `address` | The address to expose prometheus metrics. | ":8085" |
+| `allowed-scheduler-names` | If set to non-empty value, CA will proceed only with pods targeting schedulers in the list, from the list of unschedulable and scheduler unprocessed pods |  |
+| `alsologtostderr` | log to standard error as well as files (no effect when -logtostderr=true) |  |
+| `async-node-groups` | Whether clusterautoscaler creates and deletes node groups asynchronously. Experimental: requires cloud provider supporting async node group operations, enable at your own risk. |  |
+| `aws-use-static-instance-list` | Should CA fetch instance types in runtime or use a static list. AWS only |  |
+| `balance-similar-node-groups` | Detect similar node groups and balance the number of nodes between them |  |
+| `balancing-ignore-label` | Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar | [] |
+| `balancing-label` | Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label. | [] |
+| `blocking-system-pod-distruption-timeout` | The timeout after which CA will evict non-pdb-assigned blocking system pods, applicable only when --skip-nodes-with-system-pods is set to true | 1h0m0s |
+| `bulk-mig-instances-listing-enabled` | Fetch GCE mig instances in bulk instead of per mig |  |
+| `bypassed-scheduler-names` | Names of schedulers to bypass. If set to non-empty value, CA will not wait for pods to reach a certain age before triggering a scale-up. |  |
+| `capacity-buffer-controller-enabled` | Whether to enable the default controller for capacity buffers or not |  |
+| `capacity-buffer-pod-injection-enabled` | Whether to enable pod list processor that processes ready capacity buffers and injects fake pods accordingly |  |
+| `capacity-quotas-enabled` | Whether to enable CapacityQuota CRD support. |  |
+| `check-capacity-batch-processing` | Whether to enable batch processing for check capacity requests. |  |
+| `check-capacity-processor-instance` | Name of the processor instance. Only ProvisioningRequests that define this name in their parameters with the key "processorInstance" will be processed by this CA instance. It only refers to check capacity ProvisioningRequests, but if not empty, best-effort atomic ProvisioningRequests processing is disabled in this instance. Not recommended: Until CA 1.35, ProvisioningRequests with this name as prefix in their class will be also processed. |  |
+| `check-capacity-provisioning-request-batch-timebox` | Maximum time to process a batch of provisioning requests. | 10s |
 | `check-capacity-provisioning-request-max-batch-size` | Maximum number of provisioning requests to process in a single batch. | 10 |
-| `cloud-config`                                       | The path to the cloud provider configuration file. Empty string for no configuration file. |  |
-| `cloud-provider`                                     | Cloud provider type. Available values: [aws,azure,gce,alicloud,cherryservers,cloudstack,baiducloud,magnum,digitalocean,exoscale,externalgrpc,huaweicloud,hetzner,oci,ovhcloud,clusterapi,ionoscloud,kamatera,kwok,linode,bizflycloud,brightbox,equinixmetal,vultr,tencentcloud,civo,scaleway,rancher,volcengine,utho] | "gce" |
-| `cloud-provider-gce-l7lb-src-cidrs`                  | CIDRs opened in GCE firewall for L7 LB traffic proxy & health checks | 130.211.0.0/22,35.191.0.0/16 |
-| `cloud-provider-gce-lb-src-cidrs`                    | CIDRs opened in GCE firewall for L4 LB traffic proxy & health checks | 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16 |
-| `cluster-name`                                       | Autoscaled cluster name, if available |  |
-| `cluster-snapshot-parallelism`                       | Maximum parallelism of cluster snapshot creation. | 16 |
-| `clusterapi-cloud-config-authoritative`              | Treat the cloud-config flag authoritatively (do not fallback to using kubeconfig flag). ClusterAPI only |  |
-| `cordon-node-before-terminating`                     | Should CA cordon nodes before terminating during downscale process |  |
-| `cores-total`                                        | Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. | "0:320000" |
-| `daemonset-eviction-for-empty-nodes`                 | DaemonSet pods will be gracefully terminated from empty nodes |  |
-| `daemonset-eviction-for-occupied-nodes`              | DaemonSet pods will be gracefully terminated from non-empty nodes | true |
-| `debugging-snapshot-enabled`                         | Whether the debugging snapshot of cluster autoscaler feature is enabled |  |
-| `drain-priority-config`                              | List of ',' separated pairs (priority:terminationGracePeriodSeconds) of integers separated by ':' enables priority evictor. Priority evictor groups pods into priority groups based on pod priority and evict pods in the ascending order of group priorities--max-graceful-termination-sec flag should not be set when this flag is set. Not setting this flag will use unordered evictor by default.Priority evictor reuses the concepts of drain logic in kubelet(https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown#migration-from-the-node-graceful-shutdown-feature).Eg. flag usage: '10000:20,1000:100,0:60' |  |
-| `dynamic-node-delete-delay-after-taint-enabled`      | Enables dynamic adjustment of NodeDeleteDelayAfterTaint based of the latency between CA and api-server |  |
-| `emit-per-nodegroup-metrics`                         | If true, emit per node group metrics. |  |
-| `enable-dynamic-resource-allocation`                 | Whether logic for handling DRA (Dynamic Resource Allocation) objects is enabled (Locked to true for 1.35+). |  |
-| `enable-proactive-scaleup`                           | Whether to enable/disable proactive scale-ups, defaults to false |  |
-| `enable-provisioning-requests`                       | Whether the clusterautoscaler will be handling the ProvisioningRequest CRs. |  |
-| `enforce-node-group-min-size`                        | Should CA scale up the node group to the configured min size if needed. |  |
-| `estimator`                                          | Type of resource estimator to be used in scale up. Available values: [binpacking] | "binpacking" |
-| `expander`                                           | Type of node group expander to be used in scale up. Available values: [random,most-pods,least-waste,price,priority,grpc]. Specifying multiple values separated by commas will call the expanders in succession until there is only one option remaining. Ties still existing after this process are broken randomly. | "least-waste" |
-| `expendable-pods-priority-cutoff`                    | Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable. | -10 |
-| `feature-gates`                                      | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are: |  |
-| `force-delete-unregistered-nodes`                    | Whether to enable force deletion of long unregistered nodes, regardless of the min size of the node group the belong to. |  |
-| `force-ds`                                           | Blocks scale-up of node groups too small for all suitable Daemon Sets pods. |  |
-| `frequent-loops-enabled`                             | Whether clusterautoscaler triggers new iterations more frequently when it's needed |  |
-| `gce-concurrent-refreshes`                           | Maximum number of concurrent refreshes per cloud object type. | 1 |
-| `gce-expander-ephemeral-storage-support`             | Whether scale-up takes ephemeral storage resources into account for GCE cloud provider (Deprecated, to be removed in 1.30+) | true |
-| `gce-mig-instances-min-refresh-wait-time`            | The minimum time which needs to pass before GCE MIG instances from a given MIG can be refreshed. | 5s |
-| `gpu-total`                                          | Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE. | [] |
-| `grpc-expander-cert`                                 | Path to cert used by gRPC server over TLS |  |
-| `grpc-expander-url`                                  | URL to reach gRPC expander server. |  |
-| `ignore-daemonsets-utilization`                      | Should CA ignore DaemonSet pods when calculating resource utilization for scaling down |  |
-| `ignore-mirror-pods-utilization`                     | Should CA ignore Mirror pods when calculating resource utilization for scaling down |  |
-| `ignore-taint`                                       | Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead) | [] |
-| `initial-node-group-backoff-duration`                | initialNodeGroupBackoffDuration is the duration of first backoff after a new node failed to start. | 5m0s |
-| `kube-api-content-type`                              | Content type of requests sent to apiserver. | "application/vnd.kubernetes.protobuf" |
-| `kube-client-burst`                                  | Burst value for kubernetes client. | 10 |
-| `kube-client-qps`                                    | QPS value for kubernetes client. | 5 |
-| `kubeconfig`                                         | Path to kubeconfig file with authorization and master location information. |  |
-| `kubernetes`                                         | Kubernetes master location. Leave blank for default |  |
-| `leader-elect`                                       | Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. | true |
-| `leader-elect-lease-duration`                        | The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. | 15s |
-| `leader-elect-renew-deadline`                        | The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than the lease duration. This is only applicable if leader election is enabled. | 10s |
-| `leader-elect-resource-lock`                         | The type of resource object that is used for locking during leader election. Supported options are 'leases'. | "leases" |
-| `leader-elect-resource-name`                         | The name of resource object that is used for locking during leader election. | "cluster-autoscaler" |
-| `leader-elect-resource-namespace`                    | The namespace of resource object that is used for locking during leader election. |  |
-| `leader-elect-retry-period`                          | The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. | 2s |
-| `log-backtrace-at`                                   | when logging hits line file:N, emit a stack trace | :0 |
-| `log-dir`                                            | If non-empty, write log files in this directory (no effect when -logtostderr=true) |  |
-| `log-file`                                           | If non-empty, use this log file (no effect when -logtostderr=true) |  |
-| `log-file-max-size`                                  | Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. | 1800 |
-| `log-flush-frequency`                                | Maximum number of seconds between log flushes | 5s |
-| `log-json-info-buffer-size`                          | [Alpha] In JSON format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this. |  |
-| `log-json-split-stream`                              | [Alpha] In JSON format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this. |  |
-| `log-text-info-buffer-size`                          | [Alpha] In text format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this. |  |
-| `log-text-split-stream`                              | [Alpha] In text format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this. |  |
-| `logging-format`                                     | Sets the log format. Permitted formats: "json" (gated by LoggingBetaOptions), "text". | "text" |
-| `logtostderr`                                        | log to standard error instead of files | true |
-| `max-allocatable-difference-ratio`                   | Maximum difference in allocatable resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's allocatable resource. | 0.05 |
-| `max-autoprovisioned-node-group-count`               | The maximum number of autoprovisioned groups in the cluster.This flag is deprecated and will be removed in future releases. | 15 |
-| `max-binpacking-time`                                | Maximum time spend on binpacking for a single scale-up. If binpacking is limited by this, scale-up will continue with the already calculated scale-up options. | 5m0s |
-| `max-bulk-soft-taint-count`                          | Maximum number of nodes that can be tainted/untainted PreferNoSchedule at the same time. Set to 0 to turn off such tainting. | 10 |
-| `max-bulk-soft-taint-time`                           | Maximum duration of tainting/untainting nodes as PreferNoSchedule at the same time. | 3s |
-| `max-drain-parallelism`                              | Maximum number of nodes needing drain, that can be drained and deleted in parallel. | 1 |
-| `max-empty-bulk-delete`                              | Maximum number of empty nodes that can be deleted at the same time. DEPRECATED: Use --max-scale-down-parallelism instead. | 10 |
-| `max-failing-time`                                   | Maximum time from last recorded successful autoscaler run before automatic restart | 15m0s |
-| `max-free-difference-ratio`                          | Maximum difference in free resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's free resource. | 0.05 |
-| `max-graceful-termination-sec`                       | Maximum number of seconds CA waits for pod termination when trying to scale down a node. This flag is mutually exclusion with drain-priority-config flag which allows more configuration options. | 600 |
-| `max-inactivity`                                     | Maximum time from last recorded autoscaler activity before automatic restart | 10m0s |
-| `max-node-group-backoff-duration`                    | maxNodeGroupBackoffDuration is the maximum backoff duration for a NodeGroup after new nodes failed to start. | 30m0s |
-| `max-node-provision-time`                            | The default maximum time CA waits for node to be provisioned - the value can be overridden per node group | 15m0s |
-| `max-node-startup-time`                              | The default maximum time CA waits for node to be ready from registered - the value can be overridden per node group | 15m0s |
-| `max-nodegroup-binpacking-duration`                  | Maximum time that will be spent in binpacking simulation for each NodeGroup. | 10s |
-| `max-nodes-per-scaleup`                              | Max nodes added in a single scale-up. This is intended strictly for optimizing CA algorithm latency and not a tool to rate-limit scale-up throughput. | 1000 |
-| `max-nodes-total`                                    | Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number. |  |
-| `max-pod-eviction-time`                              | Maximum time CA tries to evict a pod before giving up | 2m0s |
-| `max-scale-down-parallelism`                         | Maximum number of nodes (both empty and needing drain) that can be deleted in parallel. | 10 |
-| `max-total-unready-percentage`                       | Maximum percentage of unready nodes in the cluster. After this is exceeded, CA halts operations | 45 |
-| `memory-difference-ratio`                            | Maximum difference in memory capacity between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's memory capacity. | 0.015 |
-| `memory-total`                                       | Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. | "0:6400000" |
-| `min-replica-count`                                  | Minimum number or replicas that a replica set or replication controller should have to allow their pods deletion in scale down |  |
-| `namespace`                                          | Namespace in which cluster-autoscaler run. | "kube-system" |
-| `new-pod-scale-up-delay`                             | Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'. | 0s |
-| `node-autoprovisioning-enabled`                      | Should CA autoprovision node groups when needed.This flag is deprecated and will be removed in future releases. |  |
-| `node-delete-delay-after-taint`                      | How long to wait before deleting a node after tainting it | 5s |
-| `node-deletion-batcher-interval`                     | How long CA ScaleDown gather nodes to delete them in batch. | 0s |
-| `node-deletion-delay-timeout`                        | Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node. | 2m0s |
-| `node-group-auto-discovery`                          | of discoverer>:[<key>[=<value>]] One or more definition(s) of node group auto-discovery. A definition is expressed <name of discoverer>:[<key>[=<value>]]. The `aws`, `gce`, and `azure` cloud providers are currently supported. AWS matches by ASG tags, e.g. `asg:tag=tagKey,anotherTagKey`. GCE matches by IG name prefix, and requires you to specify min and max nodes per IG, e.g. `mig:namePrefix=pfx,min=0,max=10` Azure matches by VMSS tags, similar to AWS. And you can optionally specify a default min and max size, e.g. `label:tag=tagKey,anotherTagKey=bar,min=0,max=600`. Can be used multiple times. | [] |
-| `node-group-backoff-reset-timeout`                   | nodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset. | 3h0m0s |
-| `node-info-cache-expire-time`                        | Node Info cache expire time for each item. Default value is 10 years. | 87600h0m0s |
-| `nodes`                                              | sets min,max size and other configuration data for a node group in a format accepted by cloud provider. Can be used multiple times. Format: <min>:<max>:<other...> | [] |
-| `ok-total-unready-count`                             | Number of allowed unready nodes, irrespective of max-total-unready-percentage | 3 |
-| `one-output`                                         | If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true) |  |
-| `parallel-scale-up`                                  | Whether to allow parallel node groups scale up. Experimental: may not work on some cloud providers, enable at your own risk. |  |
-| `pod-injection-limit`                                | Limits total number of pods while injecting fake pods. If unschedulable pods already exceeds the limit, pod injection is disabled but pods are not truncated. | 5000 |
-| `profiling`                                          | Is debug/pprof endpoint enabled |  |
-| `provisioning-request-initial-backoff-time`          | Initial backoff time for ProvisioningRequest retry after failed ScaleUp. | 1m0s |
-| `provisioning-request-max-backoff-cache-size`        | Max size for ProvisioningRequest cache size used for retry backoff mechanism. | 1000 |
-| `provisioning-request-max-backoff-time`              | Max backoff time for ProvisioningRequest retry after failed ScaleUp. | 10m0s |
-| `record-duplicated-events`                           | enable duplication of similar events within a 5 minute window. |  |
-| `regional`                                           | Cluster is regional. |  |
-| `scale-down-candidates-pool-min-count`               | Minimum number of nodes that are considered as additional non empty candidatesfor scale down when some candidates from previous iteration are no longer valid.When calculating the pool size for additional candidates we takemax(#nodes * scale-down-candidates-pool-ratio, scale-down-candidates-pool-min-count). | 50 |
-| `scale-down-candidates-pool-ratio`                   | A ratio of nodes that are considered as additional non empty candidates forscale down when some candidates from previous iteration are no longer valid.Lower value means better CA responsiveness but possible slower scale down latency.Higher value can affect CA performance with big clusters (hundreds of nodes).Set to 1.0 to turn this heuristics off - CA will take all nodes as additional candidates. | 0.1 |
-| `scale-down-delay-after-add`                         | How long after scale up that scale down evaluation resumes | 10m0s |
-| `scale-down-delay-after-delete`                      | How long after node deletion that scale down evaluation resumes, defaults to scanInterval | 0s |
-| `scale-down-delay-after-failure`                     | How long after scale down failure that scale down evaluation resumes | 3m0s |
-| `scale-down-delay-type-local`                        | Should --scale-down-delay-after-* flags be applied locally per nodegroup or globally across all nodegroups |  |
-| `scale-down-enabled`                                 | Should CA scale down the cluster | true |
-| `scale-down-gpu-utilization-threshold`               | Sum of gpu requests of all pods running on the node divided by node's allocatable resource, below which a node can be considered for scale down.Utilization calculation only cares about gpu resource for accelerator node. cpu and memory utilization will be ignored. | 0.5 |
-| `scale-down-non-empty-candidates-count`              | Maximum number of non empty nodes considered in one iteration as candidates for scale down with drain.Lower value means better CA responsiveness but possible slower scale down latency.Higher value can affect CA performance with big clusters (hundreds of nodes).Set to non positive value to turn this heuristic off - CA will not limit the number of nodes it considers. | 30 |
-| `scale-down-simulation-timeout`                      | How long should we run scale down simulation. | 30s |
-| `scale-down-unneeded-time`                           | How long a node should be unneeded before it is eligible for scale down | 10m0s |
-| `scale-down-unready-enabled`                         | Should CA scale down unready nodes of the cluster | true |
-| `scale-down-unready-time`                            | How long an unready node should be unneeded before it is eligible for scale down | 20m0s |
-| `scale-down-utilization-threshold`                   | The maximum value between the sum of cpu requests and sum of memory requests of all pods running on the node divided by node's corresponding allocatable resource, below which a node can be considered for scale down | 0.5 |
-| `scale-from-unschedulable`                           | Should CA ignore a node's .spec.unschedulable field when creating a node template for considering to scale a node group. | false |
-| `scale-up-from-zero`                                 | Should CA scale up when there are 0 ready nodes. | true |
-| `scan-interval`                                      | How often cluster is reevaluated for scale up or down | 10s |
-| `scheduler-config-file`                              | scheduler-config allows changing configuration of in-tree scheduler plugins acting on PreFilter and Filter extension points |  |
-| `skip-headers`                                       | If true, avoid header prefixes in the log messages |  |
-| `skip-log-headers`                                   | If true, avoid headers when opening log files (no effect when -logtostderr=true) |  |
-| `skip-nodes-with-custom-controller-pods`             | If true cluster autoscaler will never delete nodes with pods owned by custom controllers | true |
-| `skip-nodes-with-local-storage`                      | If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath | true |
-| `skip-nodes-with-system-pods`                        | If true cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods) | true |
-| `startup-taint`                                      | Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint) | [] |
-| `startup-taint-prefix`                               | Specifies a taint key prefix. Any taint whose key starts with this prefix will be treated as a startup taint (in addition to the built-in prefixes). Can be used multiple times. | [] |
-| `status-config-map-name`                             | Status configmap name | "cluster-autoscaler-status" |
-| `status-taint`                                       | Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready | [] |
-| `stderrthreshold`                                    | logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) | 2 |
-| `unremovable-node-recheck-timeout`                   | The timeout before we check again a node that couldn't be removed before | 5m0s |
-| `user-agent`                                         | User agent used for HTTP calls. | "cluster-autoscaler" |
-| `v`                                                  | number for the log level verbosity |  |
-| `vmodule`                                            | comma-separated list of pattern=N settings for file-filtered logging (only works for text log format) |  |
-| `write-status-configmap`                             | Should CA write status information to a configmap | true |
+| `cloud-config` | The path to the cloud provider configuration file. Empty string for no configuration file. |  |
+| `cloud-provider` | Cloud provider type. Available values: [aws,azure,gce,alicloud,cherryservers,cloudstack,baiducloud,magnum,digitalocean,exoscale,externalgrpc,huaweicloud,hetzner,oci,ovhcloud,clusterapi,ionoscloud,kamatera,kwok,linode,bizflycloud,brightbox,equinixmetal,vultr,tencentcloud,civo,scaleway,rancher,volcengine,utho,coreweave] | "gce" |
+| `cloud-provider-gce-l7lb-src-cidrs` | CIDRs opened in GCE firewall for L7 LB traffic proxy & health checks | 130.211.0.0/22,35.191.0.0/16 |
+| `cloud-provider-gce-lb-src-cidrs` | CIDRs opened in GCE firewall for L4 LB traffic proxy & health checks | 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16 |
+| `cluster-name` | Autoscaled cluster name, if available |  |
+| `cluster-snapshot-parallelism` | Maximum parallelism of cluster snapshot creation. | 16 |
+| `clusterapi-cloud-config-authoritative` | Treat the cloud-config flag authoritatively (do not fallback to using kubeconfig flag). ClusterAPI only |  |
+| `cordon-node-before-terminating` | Should CA cordon nodes before terminating during downscale process | true |
+| `cores-total` | Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. | "0:320000" |
+| `daemonset-eviction-for-empty-nodes` | DaemonSet pods will be gracefully terminated from empty nodes |  |
+| `daemonset-eviction-for-occupied-nodes` | DaemonSet pods will be gracefully terminated from non-empty nodes | true |
+| `debugging-snapshot-enabled` | Whether the debugging snapshot of cluster autoscaler feature is enabled |  |
+| `drain-priority-config` | List of ',' separated pairs (priority:terminationGracePeriodSeconds) of integers separated by ':' enables priority evictor. Priority evictor groups pods into priority groups based on pod priority and evict pods in the ascending order of group priorities--max-graceful-termination-sec flag should not be set when this flag is set. Not setting this flag will use unordered evictor by default.Priority evictor reuses the concepts of drain logic in kubelet(https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown#migration-from-the-node-graceful-shutdown-feature).Eg. flag usage: '10000:20,1000:100,0:60' |  |
+| `dynamic-node-delete-delay-after-taint-enabled` | Enables dynamic adjustment of NodeDeleteDelayAfterTaint based of the latency between CA and api-server |  |
+| `emit-per-nodegroup-metrics` | If true, emit per node group metrics. |  |
+| `enable-csi-node-aware-scheduling` | Whether logic for handling CSINode objects is enabled. |  |
+| `enable-dynamic-resource-allocation` | Handle DRA (Dynamic Resource Allocation) objects, locked to true. | true |
+| `enable-proactive-scaleup` | Whether to enable/disable proactive scale-ups, defaults to false |  |
+| `enable-provisioning-requests` | Whether the clusterautoscaler will be handling the ProvisioningRequest CRs. |  |
+| `enforce-node-group-min-size` | Should CA scale up the node group to the configured min size if needed. |  |
+| `estimator` | Type of resource estimator to be used in scale up. Available values: [binpacking] | "binpacking" |
+| `expander` | Type of node group expander to be used in scale up. Available values: [random,most-pods,least-waste,price,priority,grpc]. Specifying multiple values separated by commas will call the expanders in succession until there is only one option remaining. Ties still existing after this process are broken randomly. | "least-waste" |
+| `expendable-pods-priority-cutoff` | Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable. | -10 |
+| `fastpath-binpacking-enabled` | Whether to use fastpath binpacking algorithm to optimize scale-ups. |  |
+| `feature-gates` | A set of key=value pairs that describe feature gates for alpha/experimental features. Options are: |  |
+| `force-delete-failed-nodes` | Whether to enable force deletion of failed nodes, regardless of the min size of the node group the belong to. |  |
+| `force-delete-unregistered-nodes` | Whether to enable force deletion of long unregistered nodes, regardless of the min size of the node group the belong to. |  |
+| `force-ds` | Blocks scale-up of node groups too small for all suitable Daemon Sets pods. |  |
+| `frequent-loops-enabled` | Whether clusterautoscaler triggers new iterations more frequently when it's needed | true |
+| `gce-concurrent-refreshes` | Maximum number of concurrent refreshes per cloud object type. | 1 |
+| `gce-mig-instances-min-refresh-wait-time` | The minimum time which needs to pass before GCE MIG instances from a given MIG can be refreshed. | 5s |
+| `gpu-total` | Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE. | [] |
+| `grpc-expander-cert` | Path to cert used by gRPC server over TLS |  |
+| `grpc-expander-url` | URL to reach gRPC expander server. |  |
+| `ignore-daemonsets-utilization` | Should CA ignore DaemonSet pods when calculating resource utilization for scaling down |  |
+| `ignore-mirror-pods-utilization` | Should CA ignore Mirror pods when calculating resource utilization for scaling down |  |
+| `ignore-taint` | Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead) | [] |
+| `initial-node-group-backoff-duration` | initialNodeGroupBackoffDuration is the duration of first backoff after a new node failed to start. | 5m0s |
+| `kube-api-content-type` | Content type of requests sent to apiserver. | "application/vnd.kubernetes.protobuf" |
+| `kube-client-burst` | Burst value for kubernetes client. | 10 |
+| `kube-client-qps` | QPS value for kubernetes client. | 5 |
+| `kubeconfig` | Path to kubeconfig file with authorization and master location information. |  |
+| `kubernetes` | Kubernetes master location. Leave blank for default |  |
+| `leader-elect` | Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. | true |
+| `leader-elect-lease-duration` | The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled. | 15s |
+| `leader-elect-renew-deadline` | The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than the lease duration. This is only applicable if leader election is enabled. | 10s |
+| `leader-elect-resource-lock` | The type of resource object that is used for locking during leader election. Supported options are 'leases'. | "leases" |
+| `leader-elect-resource-name` | The name of resource object that is used for locking during leader election. | "cluster-autoscaler" |
+| `leader-elect-resource-namespace` | The namespace of resource object that is used for locking during leader election. |  |
+| `leader-elect-retry-period` | The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. | 2s |
+| `log-backtrace-at` | when logging hits line file:N, emit a stack trace | :0 |
+| `log-dir` | If non-empty, write log files in this directory (no effect when -logtostderr=true) |  |
+| `log-file` | If non-empty, use this log file (no effect when -logtostderr=true) |  |
+| `log-file-max-size` | Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. | 1800 |
+| `log-flush-frequency` | Maximum number of seconds between log flushes | 5s |
+| `log-json-info-buffer-size` | [Alpha] In JSON format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this. |  |
+| `log-json-split-stream` | [Alpha] In JSON format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this. |  |
+| `log-text-info-buffer-size` | [Alpha] In text format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this. |  |
+| `log-text-split-stream` | [Alpha] In text format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this. |  |
+| `logging-format` | Sets the log format. Permitted formats: "json" (gated by LoggingBetaOptions), "text". | "text" |
+| `logtostderr` | log to standard error instead of files | true |
+| `max-allocatable-difference-ratio` | Maximum difference in allocatable resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's allocatable resource. | 0.05 |
+| `max-binpacking-time` | Maximum time spend on binpacking for a single scale-up. If binpacking is limited by this, scale-up will continue with the already calculated scale-up options. | 5m0s |
+| `max-bulk-soft-taint-count` | Maximum number of nodes that can be tainted/untainted PreferNoSchedule at the same time. Set to 0 to turn off such tainting. | 10 |
+| `max-bulk-soft-taint-time` | Maximum duration of tainting/untainting nodes as PreferNoSchedule at the same time. | 3s |
+| `max-drain-parallelism` | Maximum number of nodes needing drain, that can be drained and deleted in parallel. | 1 |
+| `max-failing-time` | Maximum time from last recorded successful autoscaler run before automatic restart | 15m0s |
+| `max-free-difference-ratio` | Maximum difference in free resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's free resource. | 0.05 |
+| `max-graceful-termination-sec` | Maximum number of seconds CA waits for pod termination when trying to scale down a node. This flag is mutually exclusion with drain-priority-config flag which allows more configuration options. | 600 |
+| `max-inactivity` | Maximum time from last recorded autoscaler activity before automatic restart | 10m0s |
+| `max-node-group-backoff-duration` | maxNodeGroupBackoffDuration is the maximum backoff duration for a NodeGroup after new nodes failed to start. | 30m0s |
+| `max-node-provision-time` | The default maximum time CA waits for node to be provisioned - the value can be overridden per node group | 15m0s |
+| `max-node-skip-eval-time-tracker-enabled` | Whether to enable the tracking of the maximum time of node being skipped during ScaleDown |  |
+| `max-node-startup-time` | The maximum time from the moment the node is registered to the time the node is ready - the value can be overridden per node group | 15m0s |
+| `max-nodegroup-binpacking-duration` | Maximum time that will be spent in binpacking simulation for each NodeGroup. | 10s |
+| `max-nodes-per-scaleup` | Max nodes added in a single scale-up. This is intended strictly for optimizing CA algorithm latency and not a tool to rate-limit scale-up throughput. | 1000 |
+| `max-nodes-total` | Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number. |  |
+| `max-pod-eviction-time` | Maximum time CA tries to evict a pod before giving up | 2m0s |
+| `max-scale-down-parallelism` | Maximum number of nodes (both empty and needing drain) that can be deleted in parallel. | 10 |
+| `max-total-unready-percentage` | Maximum percentage of unready nodes in the cluster. After this is exceeded, CA halts operations | 45 |
+| `memory-difference-ratio` | Maximum difference in memory capacity between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's memory capacity. | 0.015 |
+| `memory-total` | Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. | "0:6400000" |
+| `min-replica-count` | Minimum number or replicas that a replica set or replication controller should have to allow their pods deletion in scale down |  |
+| `namespace` | Namespace in which cluster-autoscaler run. | "kube-system" |
+| `new-pod-scale-up-delay` | Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'. | 0s |
+| `node-delete-delay-after-taint` | How long to wait before deleting a node after tainting it | 5s |
+| `node-deletion-batcher-interval` | How long CA ScaleDown gather nodes to delete them in batch. | 0s |
+| `node-deletion-candidate-ttl` | Maximum time a node can be marked as removable before the marking becomes stale. This sets the TTL of Cluster-Autoscaler's state if the Cluste-Autoscaler deployment becomes inactive | 0s |
+| `node-deletion-delay-timeout` | Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node. | 2m0s |
+| `node-group-auto-discovery` | of discoverer>:[<key>[=<value>]] One or more definition(s) of node group auto-discovery. A definition is expressed <name of discoverer>:[<key>[=<value>]]. The `aws`, `gce`, and `azure` cloud providers are currently supported. AWS matches by ASG tags, e.g. `asg:tag=tagKey,anotherTagKey`. GCE matches by IG name prefix, and requires you to specify min and max nodes per IG, e.g. `mig:namePrefix=pfx,min=0,max=10` Azure matches by VMSS tags, similar to AWS. And you can optionally specify a default min and max size, e.g. `label:tag=tagKey,anotherTagKey=bar,min=0,max=600`. Can be used multiple times. | [] |
+| `node-group-backoff-reset-timeout` | nodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset. | 3h0m0s |
+| `node-info-cache-expire-time` | Node Info cache expire time for each item. Default value is 10 years. | 87600h0m0s |
+| `node-removal-latency-tracking-enabled` | Whether to track latency from when an unneeded node is eligible for scale down until it is removed or needed again. |  |
+| `nodes` | sets min,max size and other configuration data for a node group in a format accepted by cloud provider. Can be used multiple times. Format: <min>:<max>:<other...> | [] |
+| `ok-total-unready-count` | Number of allowed unready nodes, irrespective of max-total-unready-percentage | 3 |
+| `one-output` | If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true) |  |
+| `parallel-scale-up` | Whether to allow parallel node groups scale up. Experimental: may not work on some cloud providers, enable at your own risk. |  |
+| `pod-injection-limit` | Limits total number of pods while injecting fake pods. If unschedulable pods already exceeds the limit, pod injection is disabled but pods are not truncated. | 5000 |
+| `predicate-parallelism` | Maximum parallelism of scheduler predicate checking. | 4 |
+| `profiling` | Is debug/pprof endpoint enabled |  |
+| `provisioning-request-initial-backoff-time` | Initial backoff time for ProvisioningRequest retry after failed ScaleUp. | 1m0s |
+| `provisioning-request-max-backoff-cache-size` | Max size for ProvisioningRequest cache size used for retry backoff mechanism. | 1000 |
+| `provisioning-request-max-backoff-time` | Max backoff time for ProvisioningRequest retry after failed ScaleUp. | 10m0s |
+| `record-duplicated-events` | enable duplication of similar events within a 5 minute window. |  |
+| `regional` | Cluster is regional. |  |
+| `scale-down-candidates-pool-min-count` | Minimum number of nodes that are considered as additional non empty candidatesfor scale down when some candidates from previous iteration are no longer valid.When calculating the pool size for additional candidates we takemax(#nodes * scale-down-candidates-pool-ratio, scale-down-candidates-pool-min-count). | 50 |
+| `scale-down-candidates-pool-ratio` | A ratio of nodes that are considered as additional non empty candidates forscale down when some candidates from previous iteration are no longer valid.Lower value means better CA responsiveness but possible slower scale down latency.Higher value can affect CA performance with big clusters (hundreds of nodes).Set to 1.0 to turn this heuristics off - CA will take all nodes as additional candidates. | 0.1 |
+| `scale-down-delay-after-add` | How long after scale up that scale down evaluation resumes | 10m0s |
+| `scale-down-delay-after-delete` | How long after node deletion that scale down evaluation resumes | 0s |
+| `scale-down-delay-after-failure` | How long after scale down failure that scale down evaluation resumes | 3m0s |
+| `scale-down-delay-type-local` | Should --scale-down-delay-after-* flags be applied locally per nodegroup or globally across all nodegroups |  |
+| `scale-down-enabled` | [Deprecated] Should CA scale down the cluster | true |
+| `scale-down-gpu-utilization-threshold` | Sum of gpu requests of all pods running on the node divided by node's allocatable resource, below which a node can be considered for scale down.Utilization calculation only cares about gpu resource for accelerator node. cpu and memory utilization will be ignored. | 0.5 |
+| `scale-down-non-empty-candidates-count` | Maximum number of non empty nodes considered in one iteration as candidates for scale down with drain.Lower value means better CA responsiveness but possible slower scale down latency.Higher value can affect CA performance with big clusters (hundreds of nodes).Set to non positive value to turn this heuristic off - CA will not limit the number of nodes it considers. | 30 |
+| `scale-down-simulation-timeout` | How long should we run scale down simulation. | 30s |
+| `scale-down-unneeded-time` | How long a node should be unneeded before it is eligible for scale down | 10m0s |
+| `scale-down-unready-enabled` | Should CA scale down unready nodes of the cluster | true |
+| `scale-down-unready-time` | How long an unready node should be unneeded before it is eligible for scale down | 20m0s |
+| `scale-down-utilization-threshold` | The maximum value between the sum of cpu requests and sum of memory requests of all pods running on the node divided by node's corresponding allocatable resource, below which a node can be considered for scale down | 0.5 |
+| `scale-from-unschedulable` | Specifies that the CA should ignore a node's .spec.unschedulable field in node templates when considering to scale a node group. |  |
+| `scale-up-from-zero` | Should CA scale up when there are 0 ready nodes. | true |
+| `scan-interval` | How often cluster is reevaluated for scale up or down | 10s |
+| `scheduler-config-file` | scheduler-config allows changing configuration of in-tree scheduler plugins acting on PreFilter and Filter extension points |  |
+| `skip-headers` | If true, avoid header prefixes in the log messages |  |
+| `skip-log-headers` | If true, avoid headers when opening log files (no effect when -logtostderr=true) |  |
+| `skip-nodes-with-custom-controller-pods` | If true cluster autoscaler will never delete nodes with pods owned by custom controllers | true |
+| `skip-nodes-with-local-storage` | If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath | true |
+| `skip-nodes-with-system-pods` | If true cluster autoscaler will wait for --blocking-system-pod-distruption-timeout before deleting nodes with pods from kube-system (except for DaemonSet or mirror pods) | true |
+| `startup-taint` | Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint) | [] |
+| `startup-taint-prefix` | Specifies a taint key prefix. Any taint whose key starts with this prefix will be treated as a startup taint (in addition to the built-in prefixes). Can be used multiple times. | [] |
+| `status-config-map-name` | Status configmap name | "cluster-autoscaler-status" |
+| `status-taint` | Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready | [] |
+| `stderrthreshold` | logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) | 2 |
+| `unremovable-node-recheck-timeout` | The timeout before we check again a node that couldn't be removed before | 5m0s |
+| `user-agent` | User agent used for HTTP calls. | "cluster-autoscaler" |
+| `v` | number for the log level verbosity |  |
+| `vmodule` | comma-separated list of pattern=N settings for file-filtered logging (only works for text log format) |  |
+| `write-status-configmap` | Should CA write status information to a configmap | true |
+
+
 
 # Troubleshooting
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR fixes a broken pre-commit hook and restores the usability of the `update-faq-flags` script.

Specifically:
- Fixes the pre-commit hook file matcher after `flags.go` was moved out of  `main.go`, which previously caused the hook to never trigger.
- Makes `hack/update-faq-flags.sh` work on macOS by handling the lack of  `grep -P` support.
- Makes flag table header matching more robust against whitespace-only changes.
- Fixes `awk` failures when replacing multi-line markdown tables by passing  generated content via a temporary file.

Without these changes, the flag table update hook is silently skipped and the script cannot be reliably run on non-GNU environments.

#### Special notes for your reviewer:

- `FAQ.md` was regenerated by manually running the updated script to reflect  the latest flags.
- The changes are limited to tooling and documentation generation logic and do  not affect autoscaler runtime behavior.

#### Does this PR introduce a user-facing change?
```release-note
None
```