### PR TITLE
Protect concurrent map access in ScaleDownCandidatesDelayProcessor

### DIFF
--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaledowncandidates
 
 import (
+	"sync"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ import (
 // ScaleDownCandidatesDelayProcessor is a processor to filter out
 // nodes according to scale down delay per nodegroup
 type ScaleDownCandidatesDelayProcessor struct {
+	mu                sync.RWMutex
 	scaleUps          map[string]time.Time
 	scaleDowns        map[string]time.Time
 	scaleDownFailures map[string]time.Time
@@ -58,14 +60,21 @@ func (p *ScaleDownCandidatesDelayProcessor) GetScaleDownCandidates(autoscalingCt
 			continue
 		}
 
+		ngID := nodeGroup.Id()
 		currentTime := time.Now()
 
-		recent := func(m map[string]time.Time, d time.Duration, msg string) bool {
-			if !m[nodeGroup.Id()].IsZero() && m[nodeGroup.Id()].Add(d).After(currentTime) {
-				if !alreadyLoggedGroups[nodeGroup.Id()] {
-					klog.V(4).Infof("Skipping scale down on node group %s because it %s recently at %v",
-						nodeGroup.Id(), msg, m[nodeGroup.Id()])
-					alreadyLoggedGroups[nodeGroup.Id()] = true
+		// Read all timing data for this node group in a single critical section
+		p.mu.RLock()
+		scaleUpTime := p.scaleUps[ngID]
+		scaleDownTime := p.scaleDowns[ngID]
+		scaleDownFailureTime := p.scaleDownFailures[ngID]
+		p.mu.RUnlock()
+
+		recent := func(t time.Time, d time.Duration, msg string) bool {
+			if !t.IsZero() && t.Add(d).After(currentTime) {
+				if !alreadyLoggedGroups[ngID] {
+					klog.V(4).Infof("Skipping scale down on node group %s because it %s recently at %v", ngID, msg, t)
+					alreadyLoggedGroups[ngID] = true
 				}
 				return true
 			}
@@ -73,15 +82,15 @@ func (p *ScaleDownCandidatesDelayProcessor) GetScaleDownCandidates(autoscalingCt
 			return false
 		}
 
-		if recent(p.scaleUps, autoscalingCtx.ScaleDownDelayAfterAdd, "scaled up") {
+		if recent(scaleUpTime, autoscalingCtx.ScaleDownDelayAfterAdd, "scaled up") {
 			continue
 		}
 
-		if recent(p.scaleDowns, autoscalingCtx.ScaleDownDelayAfterDelete, "scaled down") {
+		if recent(scaleDownTime, autoscalingCtx.ScaleDownDelayAfterDelete, "scaled down") {
 			continue
 		}
 
-		if recent(p.scaleDownFailures, autoscalingCtx.ScaleDownDelayAfterFailure, "failed to scale down") {
+		if recent(scaleDownFailureTime, autoscalingCtx.ScaleDownDelayAfterFailure, "failed to scale down") {
 			continue
 		}
 
@@ -97,13 +106,17 @@ func (p *ScaleDownCandidatesDelayProcessor) CleanUp() {
 // RegisterScaleUp records when the last scale up happened for a nodegroup.
 func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup,
 	_ int, currentTime time.Time) {
+	p.mu.Lock()
 	p.scaleUps[nodeGroup.Id()] = currentTime
+	p.mu.Unlock()
 }
 
 // RegisterScaleDown records when the last scale down happened for a nodegroup.
 func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleDown(nodeGroup cloudprovider.NodeGroup,
 	nodeName string, currentTime time.Time, _ time.Time) {
+	p.mu.Lock()
 	p.scaleDowns[nodeGroup.Id()] = currentTime
+	p.mu.Unlock()
 }
 
 // RegisterFailedScaleUp records when the last scale up failed for a nodegroup.
@@ -113,7 +126,9 @@ func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleUp(_ cloudprovide
 // RegisterFailedScaleDown records failed scale-down for a nodegroup.
 func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleDown(nodeGroup cloudprovider.NodeGroup,
 	reason string, currentTime time.Time) {
+	p.mu.Lock()
 	p.scaleDownFailures[nodeGroup.Id()] = currentTime
+	p.mu.Unlock()
 }
 
 // NewScaleDownCandidatesDelayProcessor returns a new ScaleDownCandidatesDelayProcessor.


### PR DESCRIPTION
The ScaleDownCandidatesDelayProcessor uses three maps (scaleUps, scaleDowns, scaleDownFailures) that are accessed concurrently without synchronization, causing occasional "fatal error: concurrent map read and map write" panics like the one logged below:

```
I0125 23:53:49.284467      94 aws_manager.go:169] DeleteInstances was called: scheduling an ASG list refresh for next main loop evaluation
fatal error: concurrent map read and map write

goroutine 64 [running]:
internal/runtime/maps.fatal({0x6a1d287?, 0x358cfec?})
    /usr/local/go/src/runtime/panic.go:1058 +0x20
k8s.io/autoscaler/cluster-autoscaler/processors/scaledowncandidates.(*ScaleDownCandidatesDelayProcessor).GetScaleDownCandidates.func1(0x4004791290, 0x0, {0x69a3ae1, 0xb})
    /build/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go:64 +0x74
k8s.io/autoscaler/cluster-autoscaler/processors/scaledowncandidates.(*ScaleDownCandidatesDelayProcessor).GetScaleDownCandidates(0x40047a2150, 0x4000644008, {0x4041b70008, 0x3bc, 0x22f?})
    /build/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go:77 +0x2dc
k8s.io/autoscaler/cluster-autoscaler/processors/scaledowncandidates.(*combinedScaleDownCandidatesProcessor).GetScaleDownCandidates(0xad47200?, 0x4000644008, {0x40405b8008?, 0x0?, 0x0?})
    /build/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_processor.go:59 +0x6c
k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce(0x4001211860, {0x19035c?, 0x1d091a7098197?, 0xad46400?})
    /build/cluster-autoscaler/core/static_autoscaler.go:575 +0x1f20
k8s.io/autoscaler/cluster-autoscaler/loop.RunAutoscalerOnce({0xe351712f7158, 0x4001211860}, 0x4000858230, {0xad46400?, 0x39fcb2bac404?, 0xad46400?})
    /build/cluster-autoscaler/loop/run.go:36 +0x80
main.run(0x4000858230, {0x7478858, 0x400052d170})
    /build/cluster-autoscaler/main.go:324 +0x2f0
main.main.func2({0x0?, 0x0?})
    /build/cluster-autoscaler/main.go:433 +0x28
created by k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run in goroutine 1
    /go/pkg/mod/k8s.io/client-go@v0.34.2/tools/leaderelection/leaderelection.go:220 +0xe4

....

goroutine 272269381 [runnable]:
k8s.io/autoscaler/cluster-autoscaler/core/scaledown/deletiontracker.(*NodeDeletionTracker).EndDeletion(0x4004e7c550, {0x4002dd7a80, 0x34}, {0x407b582d80, 0x1d}, {{0x0?, 0x0?}, 0x404f3cbeb0?, 0x0?})
    /build/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go:99 +0x26c
k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.RegisterAndRecordSuccessfulScaleDownEvent(0x4000644008, {0x74675e0, 0x4002ec4740}, 0x40532b9808, {0x74905e0, 0x404e8f4440}, 0x0, 0x4004e7c550)
    /build/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go:227 +0x2c4
k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*NodeDeletionBatcher).deleteNodesAndRegisterStatus(0x40011df8c0, {0x40920dcd10, 0x1, 0x4090e84ba0?}, {0x4002dd7a80, 0x34}, 0x0)
    /build/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go:95 +0x118
created by k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*NodeDeletionBatcher).AddNodes in goroutine 272269380
    /build/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go:75 +0xd4

```

#### What type of PR is this?


/kind bug

/area  cluster-autoscaler

#### What this PR does / why we need it:



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Protect concurrent map access in ScaleDownCandidatesDelayProcessor
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
