### PR TITLE
Fix buffer validation message

### DIFF
--- a/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1/types.go
@@ -98,7 +98,7 @@ type ResourceList map[ResourceName]resource.Quantity
 
 // CapacityBufferSpec defines the desired state of CapacityBuffer.
 // +kubebuilder:validation:XValidation:rule="!has(self.podTemplateRef) || has(self.replicas) || has(self.limits)",message="If X is set, replicas or limits must also be set"
-// +kubebuilder:validation:XValidation:rule="!(has(self.podTemplateRef) && has(self.scalableRef))",message="You must define both PodTemplateRef and ScalableRef"
+// +kubebuilder:validation:XValidation:rule="!(has(self.podTemplateRef) && has(self.scalableRef))",message="You must define either PodTemplateRef or ScalableRef, but not both"
 type CapacityBufferSpec struct {
 	// ProvisioningStrategy defines how the buffer is utilized.
 	// "buffer.x-k8s.io/active-capacity" is the default strategy, where the buffer actively scales up the cluster by creating placeholder pods.

--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacitybuffers.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacitybuffers.yaml
@@ -373,7 +373,8 @@ spec:
             x-kubernetes-validations:
             - message: If X is set, replicas or limits must also be set
               rule: '!has(self.podTemplateRef) || has(self.replicas) || has(self.limits)'
-            - message: You must define both PodTemplateRef and ScalableRef
+            - message: You must define either PodTemplateRef or ScalableRef, but not
+                both
               rule: '!(has(self.podTemplateRef) && has(self.scalableRef))'
           status:
             description: Status represents the current state of the buffer and its


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
This PR fixes a misleading validation message returned by a validation rule checking that PodTemplateRef and ScalableRef in the CapacityBuffer spec are not set together.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed misleading validation message returned when PodTemplateRef and ScalableRef are set together in CapacityBuffer's spec.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
