### PR TITLE
[ca] fix: undo Scale operation when a scaleUpRequest times out

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/test_cloud_provider.go
@@ -154,10 +154,14 @@ func (b *TestCloudProviderBuilder) WithNodeProcessingError(nodeNames []string) *
 // Build returns a built test cloud provider
 func (b *TestCloudProviderBuilder) Build() *TestCloudProvider {
 	p := &TestCloudProvider{
-		nodes:           make(map[string]string),
-		errNodes:        make(map[string]bool),
-		groups:          make(map[string]cloudprovider.NodeGroup),
-		resourceLimiter: cloudprovider.NewResourceLimiter(make(map[string]int64), make(map[string]int64)),
+		nodes:             make(map[string]string),
+		errNodes:          make(map[string]bool),
+		groups:            make(map[string]cloudprovider.NodeGroup),
+		onScaleUp:         func(string, int) error { return nil },
+		onScaleDown:       func(string, string) error { return nil },
+		onNodeGroupCreate: func(string) error { return nil },
+		onNodeGroupDelete: func(string) error { return nil },
+		resourceLimiter:   cloudprovider.NewResourceLimiter(make(map[string]int64), make(map[string]int64)),
 	}
 
 	for _, builder := range b.builders {

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -370,7 +370,7 @@ func (csr *ClusterStateRegistry) updateScaleRequests(currentTime time.Time) {
 			// Attempt to revert the failed scale-up by decreasing target size.
 			// This prevents cloud providers from indefinitely retrying failed provisioning attempts.
 			if scaleUpRequest.Increase > 0 {
-				klog.V(2).Infof("Reverting timed-out scale-up for node group %v by decreasing target size by %d",
+				klog.Warningf("Reverting timed-out scale-up for node group %v by decreasing target size by %d",
 					nodeGroupName, scaleUpRequest.Increase)
 				err := scaleUpRequest.NodeGroup.DecreaseTargetSize(-scaleUpRequest.Increase)
 				if err != nil {

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -366,6 +366,21 @@ func (csr *ClusterStateRegistry) updateScaleRequests(currentTime time.Time) {
 				ErrorCode:    string(metrics.Timeout),
 				ErrorMessage: fmt.Sprintf("Scale-up timed out for node group %v after %v", nodeGroupName, currentTime.Sub(scaleUpRequest.Time)),
 			}, currentTime)
+
+			// Attempt to revert the failed scale-up by decreasing target size.
+			// This prevents cloud providers from indefinitely retrying failed provisioning attempts.
+			if scaleUpRequest.Increase > 0 {
+				klog.V(2).Infof("Reverting timed-out scale-up for node group %v by decreasing target size by %d",
+					nodeGroupName, scaleUpRequest.Increase)
+				err := scaleUpRequest.NodeGroup.DecreaseTargetSize(-scaleUpRequest.Increase)
+				if err != nil {
+					klog.Warningf("Failed to revert timed-out scale-up for node group %v: %v", nodeGroupName, err)
+					csr.logRecorder.Eventf(apiv1.EventTypeWarning, "FailedToRevertScaleUp",
+						"Failed to decrease target size for group %s after scale-up timeout: %v",
+						scaleUpRequest.NodeGroup.Id(), err)
+				}
+			}
+
 			delete(csr.scaleUpRequests, nodeGroupName)
 		}
 	}

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -2123,16 +2123,21 @@ func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
-	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
-		MaxTotalUnreadyPercentage: 10,
-		OkTotalUnreadyCount:       1,
-	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+	clusterstate := newTestClusterStateRegistry(
+		provider,
+		fakeLogRecorder,
+		withMetrics(mockMetrics, provider),
+		WithConfig(ClusterStateRegistryConfig{
+			MaxTotalUnreadyPercentage: 10,
+			OkTotalUnreadyCount:       1,
+		}),
+	)
 
 	// Register scale up that started 3 minutes ago (exceeded 2 min max provision time)
 	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
 
 	// UpdateNodes should detect the timeout and call DecreaseTargetSize
-	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	err := clusterstate.UpdateNodes([]*apiv1.Node{}, now)
 	assert.NoError(t, err)
 
 	// Verify DecreaseTargetSize was called with negative delta equal to the increase
@@ -2168,16 +2173,21 @@ func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
-	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
-		MaxTotalUnreadyPercentage: 10,
-		OkTotalUnreadyCount:       1,
-	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+	clusterstate := newTestClusterStateRegistry(
+		provider,
+		fakeLogRecorder,
+		withMetrics(mockMetrics, provider),
+		WithConfig(ClusterStateRegistryConfig{
+			MaxTotalUnreadyPercentage: 10,
+			OkTotalUnreadyCount:       1,
+		}),
+	)
 
 	// Register scale up that started 3 minutes ago (exceeded 2 min max provision time)
 	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
 
 	// UpdateNodes should detect the timeout and attempt to call DecreaseTargetSize
-	err = clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{}, now)
 	assert.NoError(t, err)
 
 	// Verify DecreaseTargetSize was called even though it returned an error
@@ -2237,16 +2247,21 @@ func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
-	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
-		MaxTotalUnreadyPercentage: 10,
-		OkTotalUnreadyCount:       1,
-	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+	clusterstate := newTestClusterStateRegistry(
+		provider,
+		fakeLogRecorder,
+		withMetrics(mockMetrics, provider),
+		WithConfig(ClusterStateRegistryConfig{
+			MaxTotalUnreadyPercentage: 10,
+			OkTotalUnreadyCount:       1,
+		}),
+	)
 
 	// Register scale up requesting 4 nodes that started 3 minutes ago
 	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
 
 	// UpdateNodes should detect the timeout and revert the _entire_ recorded increase
-	err := clusterstate.UpdateNodes([]*apiv1.Node{node, node2}, nil, now)
+	err := clusterstate.UpdateNodes([]*apiv1.Node{node, node2}, now)
 	assert.NoError(t, err)
 
 	// Verify DecreaseTargetSize was called with the full original increase,

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -2121,7 +2121,7 @@ func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
-	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
@@ -2137,7 +2137,7 @@ func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
 
 	// Verify DecreaseTargetSize was called with negative delta equal to the increase
 	mockedNodeGroup.AssertCalled(t, "DecreaseTargetSize", -4)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 
 	// Verify the scale-up request was removed from the registry
 	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
@@ -2159,10 +2159,14 @@ func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
 	mockedNodeGroup.On("DecreaseTargetSize", -4).Return(fmt.Errorf("cloud provider error"))
 	provider.InsertNodeGroup(mockedNodeGroup)
 
+	// set up a fake recorder to capture events so we can assert on them later
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeRecorder := kube_record.NewFakeRecorder(10)
+	fakeLogRecorder, err := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, true, "my-cool-configmap")
+	assert.Nil(t, err)
+
 	mockMetrics := &mockMetrics{}
-	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
@@ -2173,12 +2177,31 @@ func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
 	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
 
 	// UpdateNodes should detect the timeout and attempt to call DecreaseTargetSize
-	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	err = clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
 	assert.NoError(t, err)
 
 	// Verify DecreaseTargetSize was called even though it returned an error
 	mockedNodeGroup.AssertCalled(t, "DecreaseTargetSize", -4)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
+
+	// Verify the error path was reached: DecreaseTargetSize was called exactly once
+	// and despite its error, the scale-up request was still cleaned up
+	mockedNodeGroup.AssertNumberOfCalls(t, "DecreaseTargetSize", 1)
+
+	// verify two events were recorded: one for `ScaleUpTimeOut` and one for the `FailedToRevertScaleUp` error
+	expectedErrors := []string{
+		"Warning ScaleUpTimedOut Nodes added to group ng1 failed to register within 3m0s",
+		"Warning FailedToRevertScaleUp Failed to decrease target size for group ng1 after scale-up timeout: cloud provider error",
+	}
+
+	for i := range len(expectedErrors) {
+		select {
+		case event := <-fakeRecorder.Events:
+			assert.Equal(t, expectedErrors[i], event)
+		case <-time.After(1 * time.Second):
+			t.Errorf("Expected an event but none was recorded, made it to index %d", i)
+		}
+	}
 
 	// The scale-up request should still be removed even when DecreaseTargetSize fails
 	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
@@ -2187,38 +2210,49 @@ func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
 func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
 	now := time.Now()
 
+	// Scenario: requested 4 new nodes, but only 2 came up before timeout.
+	// The revert should only decrease by the original increase (4), not by the
+	// current target size, because the code uses the recorded Increase value.
 	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	mockedNodeGroup := &mockprovider.NodeGroup{}
 	mockedNodeGroup.On("Id").Return("ng1")
-	mockedNodeGroup.On("Nodes").Return([]cloudprovider.Instance{}, nil)
+	// 2 of 4 requested nodes are now running
+	mockedNodeGroup.On("Nodes").Return([]cloudprovider.Instance{
+		{Id: "ng1_1", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning}},
+		{Id: "ng1_2", Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning}},
+	}, nil)
 	mockedNodeGroup.On("Autoprovisioned").Return(false)
-	mockedNodeGroup.On("TargetSize").Return(3, nil) // Target is 3, started from 1, so increase was 2
+	mockedNodeGroup.On("TargetSize").Return(5, nil) // original 1 + 4 requested = target 5
 	node := BuildTestNode("ng1_1", 1000, 1000)
+	SetNodeReadyState(node, true, now.Add(-2*time.Minute))
+	node2 := BuildTestNode("ng1_2", 1000, 1000)
+	SetNodeReadyState(node2, true, now.Add(-2*time.Minute))
 	mockedNodeGroup.On("TemplateNodeInfo").Return(framework.NewTestNodeInfo(node), nil)
 	mockedNodeGroup.On("GetOptions", mock.Anything).Return(&config.NodeGroupAutoscalingOptions{}, nil)
-	mockedNodeGroup.On("DecreaseTargetSize", -2).Return(nil)
+	mockedNodeGroup.On("DecreaseTargetSize", -4).Return(nil)
 	provider.InsertNodeGroup(mockedNodeGroup)
 
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
-	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
 
-	// Register scale up with increase of 2 that started 3 minutes ago
-	clusterstate.RegisterScaleUp(mockedNodeGroup, 2, now.Add(-3*time.Minute))
+	// Register scale up requesting 4 nodes that started 3 minutes ago
+	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
 
-	// UpdateNodes should detect the timeout and call DecreaseTargetSize with the increase amount
-	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	// UpdateNodes should detect the timeout and revert the _entire_ recorded increase
+	err := clusterstate.UpdateNodes([]*apiv1.Node{node, node2}, nil, now)
 	assert.NoError(t, err)
 
-	// Verify DecreaseTargetSize was called with negative delta equal to the increase
-	mockedNodeGroup.AssertCalled(t, "DecreaseTargetSize", -2)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+	// Verify DecreaseTargetSize was called with the full original increase,
+	// even though 2 nodes came up out of the 4
+	mockedNodeGroup.AssertCalled(t, "DecreaseTargetSize", -4)
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 
 	// Verify the scale-up request was removed
 	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -572,7 +572,9 @@ func TestExpiredScaleUp(t *testing.T) {
 	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
 	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider := testprovider.NewTestCloudProviderBuilder().
+		WithOnScaleUp(func(nodeGroup string, delta int) error { return nil }).
+		Build()
 	provider.AddNodeGroup("ng1", 1, 10, 5)
 	provider.AddNode("ng1", ng1_1)
 	assert.NotNil(t, provider)
@@ -951,7 +953,9 @@ func TestScaleUpBackoff(t *testing.T) {
 	ng1_3 := BuildTestNode("ng1-3", 1000, 1000)
 	SetNodeReadyState(ng1_3, true, now.Add(-time.Minute))
 
-	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider := testprovider.NewTestCloudProviderBuilder().
+		WithOnScaleUp(func(nodeGroup string, delta int) error { return nil }).
+		Build()
 	provider.AddNodeGroup("ng1", 1, 10, 4)
 	ng1 := provider.GetNodeGroup("ng1")
 	provider.AddNode("ng1", ng1_1)
@@ -1007,6 +1011,9 @@ func TestScaleUpBackoff(t *testing.T) {
 	assert.True(t, clusterstate.IsClusterHealthy())
 	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
 	assert.Equal(t, NodeGroupScalingSafety{SafeToScale: true, Healthy: true}, clusterstate.NodeGroupScaleUpSafety(ng1, now))
+
+	// Reset target size (it was decreased when the previous scale-up timed out and was reverted)
+	ng1.(*testprovider.TestNodeGroup).SetTargetSize(4)
 
 	// Another failed scale up should cause longer backoff
 	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 1, now.Add(-121*time.Second))
@@ -2094,4 +2101,125 @@ func withMetrics(m *mockMetrics, cloudProvider cloudprovider.CloudProvider) Opti
 func newTestClusterStateRegistry(cloudProvider cloudprovider.CloudProvider, logRecorder *utils.LogEventRecorder, opts ...Option) *ClusterStateRegistry {
 	nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute})
 	return NewNotifiedClusterStateRegistry(cloudProvider, logRecorder, newBackoff(), nodeGroupConfigProcessor, &emptyTemplateNodeInfoRegistry{}, opts...)
+}
+
+func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
+	now := time.Now()
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	mockedNodeGroup := &mockprovider.NodeGroup{}
+	mockedNodeGroup.On("Id").Return("ng1")
+	mockedNodeGroup.On("Nodes").Return([]cloudprovider.Instance{}, nil)
+	mockedNodeGroup.On("Autoprovisioned").Return(false)
+	mockedNodeGroup.On("TargetSize").Return(5, nil)
+	node := BuildTestNode("ng1_1", 1000, 1000)
+	mockedNodeGroup.On("TemplateNodeInfo").Return(framework.NewTestNodeInfo(node), nil)
+	mockedNodeGroup.On("GetOptions", mock.Anything).Return(&config.NodeGroupAutoscalingOptions{}, nil)
+	mockedNodeGroup.On("DecreaseTargetSize", -4).Return(nil)
+	provider.InsertNodeGroup(mockedNodeGroup)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	mockMetrics := &mockMetrics{}
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
+		MaxTotalUnreadyPercentage: 10,
+		OkTotalUnreadyCount:       1,
+	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+
+	// Register scale up that started 3 minutes ago (exceeded 2 min max provision time)
+	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
+
+	// UpdateNodes should detect the timeout and call DecreaseTargetSize
+	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
+
+	// Verify DecreaseTargetSize was called with negative delta equal to the increase
+	mockedNodeGroup.AssertCalled(t, "DecreaseTargetSize", -4)
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+
+	// Verify the scale-up request was removed from the registry
+	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
+}
+
+func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
+	now := time.Now()
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	mockedNodeGroup := &mockprovider.NodeGroup{}
+	mockedNodeGroup.On("Id").Return("ng1")
+	mockedNodeGroup.On("Nodes").Return([]cloudprovider.Instance{}, nil)
+	mockedNodeGroup.On("Autoprovisioned").Return(false)
+	mockedNodeGroup.On("TargetSize").Return(5, nil)
+	node := BuildTestNode("ng1_1", 1000, 1000)
+	mockedNodeGroup.On("TemplateNodeInfo").Return(framework.NewTestNodeInfo(node), nil)
+	mockedNodeGroup.On("GetOptions", mock.Anything).Return(&config.NodeGroupAutoscalingOptions{}, nil)
+	// Simulate an error when trying to decrease target size
+	mockedNodeGroup.On("DecreaseTargetSize", -4).Return(fmt.Errorf("cloud provider error"))
+	provider.InsertNodeGroup(mockedNodeGroup)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	mockMetrics := &mockMetrics{}
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
+		MaxTotalUnreadyPercentage: 10,
+		OkTotalUnreadyCount:       1,
+	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+
+	// Register scale up that started 3 minutes ago (exceeded 2 min max provision time)
+	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
+
+	// UpdateNodes should detect the timeout and attempt to call DecreaseTargetSize
+	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
+
+	// Verify DecreaseTargetSize was called even though it returned an error
+	mockedNodeGroup.AssertCalled(t, "DecreaseTargetSize", -4)
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+
+	// The scale-up request should still be removed even when DecreaseTargetSize fails
+	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
+}
+
+func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
+	now := time.Now()
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	mockedNodeGroup := &mockprovider.NodeGroup{}
+	mockedNodeGroup.On("Id").Return("ng1")
+	mockedNodeGroup.On("Nodes").Return([]cloudprovider.Instance{}, nil)
+	mockedNodeGroup.On("Autoprovisioned").Return(false)
+	mockedNodeGroup.On("TargetSize").Return(3, nil) // Target is 3, started from 1, so increase was 2
+	node := BuildTestNode("ng1_1", 1000, 1000)
+	mockedNodeGroup.On("TemplateNodeInfo").Return(framework.NewTestNodeInfo(node), nil)
+	mockedNodeGroup.On("GetOptions", mock.Anything).Return(&config.NodeGroupAutoscalingOptions{}, nil)
+	mockedNodeGroup.On("DecreaseTargetSize", -2).Return(nil)
+	provider.InsertNodeGroup(mockedNodeGroup)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	mockMetrics := &mockMetrics{}
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
+		MaxTotalUnreadyPercentage: 10,
+		OkTotalUnreadyCount:       1,
+	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+
+	// Register scale up with increase of 2 that started 3 minutes ago
+	clusterstate.RegisterScaleUp(mockedNodeGroup, 2, now.Add(-3*time.Minute))
+
+	// UpdateNodes should detect the timeout and call DecreaseTargetSize with the increase amount
+	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
+
+	// Verify DecreaseTargetSize was called with negative delta equal to the increase
+	mockedNodeGroup.AssertCalled(t, "DecreaseTargetSize", -2)
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+
+	// Verify the scale-up request was removed
+	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR modifies the cluster-autoscaler to automatically revert (decrease) the target size of a node group when a scale-up request times out. 

Currently, when a scale-up fails due to infrastructure provider capacity limits (e.g., CAPI infrastructure provider cannot provision new nodes), the autoscaler removes the scale-up request from tracking and puts the node group in backoff, but it does **not** decrease the target size back to its original value. This causes the infrastructure provider to indefinitely retry provisioning the failed nodes, even after the workload that triggered the scale-up has disappeared. Manual intervention is required to scale the cluster back down.

With this fix, when a scale-up request times out:
1. The autoscaler calls `DecreaseTargetSize()` on the node group to revert the increase
2. If the decrease fails, a warning is logged and an event is emitted
3. The scale-up request is then removed from tracking as before

This allows clusters running close to infrastructure capacity to automatically recover from failed scale-ups without manual intervention.

#### Which issue(s) this PR fixes:

Fixes #9120

#### Special notes for your reviewer:

- The `DecreaseTargetSize` method is called with a negative value equal to the original `Increase` from the scale-up request
- Error handling is in place - if the decrease fails, we log a warning and emit an event, but still proceed with removing the scale-up request and applying backoff
- Existing tests were updated to include `WithOnScaleUp` handler since the test provider now needs to handle the decrease operation
- Three new test cases were added:
  - `TestExpiredScaleUpRevertsTargetSize` - verifies target size is decreased on timeout
  - `TestExpiredScaleUpRevertsTargetSizeHandlesError` - verifies graceful handling when decrease fails
  - `TestExpiredScaleUpRevertsPartialIncrease` - verifies correct decrease amount for partial increases

#### Does this PR introduce a user-facing change?

```release-note
Cluster-autoscaler now automatically reverts the target size of a node group when a scale-up request times out. This prevents cloud providers from indefinitely retrying failed node provisioning attempts after infrastructure capacity limits are hit.
```