### PR TITLE
Replace Sprintf with string concatenation in gce_url.go

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_url.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url.go
@@ -82,8 +82,7 @@ func GenerateInstanceUrl(domainUrl string, ref GceRef) string {
 	if domainUrl == "" {
 		domainUrl = defaultDomainUrl
 	}
-	instanceUrlTemplate := domainUrl + projectsSubstring + "%s/zones/%s/instances/%s"
-	return fmt.Sprintf(instanceUrlTemplate, ref.Project, ref.Zone, ref.Name)
+	return domainUrl + projectsSubstring + ref.Project + "/zones/" + ref.Zone + "/instances/" + ref.Name
 }
 
 // GenerateMigUrl generates url for instance.
@@ -91,8 +90,7 @@ func GenerateMigUrl(domainUrl string, ref GceRef) string {
 	if domainUrl == "" {
 		domainUrl = defaultDomainUrl
 	}
-	migUrlTemplate := domainUrl + projectsSubstring + "%s/zones/%s/instanceGroups/%s"
-	return fmt.Sprintf(migUrlTemplate, ref.Project, ref.Zone, ref.Name)
+	return domainUrl + projectsSubstring + ref.Project + "/zones/" + ref.Zone + "/instanceGroups/" + ref.Name
 }
 
 // IsInstanceTemplateRegional determines whether or not an instance template is regional based on the url
@@ -116,13 +114,13 @@ func InstanceTemplateNameFromUrl(instanceTemplateLink string) (InstanceTemplateN
 }
 
 func parseGceUrl(prefix, url, expectedResource string) (project string, zone string, name string, err error) {
-	reg := regexp.MustCompile(fmt.Sprintf("%sprojects/.*/zones/.*/%s/.*", prefix, expectedResource))
+	reg := regexp.MustCompile(prefix + "projects/.*/zones/.*/" + expectedResource + "/.*")
 	errMsg := fmt.Errorf("wrong url: expected format %sprojects/<project-id>/zones/<zone>/%s/<name>, got %s", prefix, expectedResource, url)
 	if !reg.MatchString(url) {
 		return "", "", "", errMsg
 	}
 
-	subMatches := regexp.MustCompile(fmt.Sprintf("%sprojects/(.*)/zones/(.*)/%s/(.*)", prefix, expectedResource)).FindStringSubmatch(url)
+	subMatches := regexp.MustCompile(prefix + "projects/(.*)/zones/(.*)/" + expectedResource + "/(.*)").FindStringSubmatch(url)
 	project = subMatches[1]
 	zone = subMatches[2]
 	name = subMatches[3]


### PR DESCRIPTION
This change improves performance and reduces allocations in GCE URL generation and parsing functions.

Benchmark results:
BenchmarkGenerateInstanceUrl: 294.8 ns/op -> 73.4 ns/op
BenchmarkGenerateMigUrl: 296.5 ns/op -> 73.7 ns/op
Allocations: 5 allocs/op -> 1 allocs/op

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[GCE] Minor performance improvement
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
