### PR TITLE
Add skip-reschedule annotation to skip rescheduling simulation

### DIFF
--- a/cluster-autoscaler/simulator/drainability/rules/rules.go
+++ b/cluster-autoscaler/simulator/drainability/rules/rules.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/replicacount"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/replicated"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/safetoevict"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/skipreschedule"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/system"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/terminal"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
@@ -55,6 +56,7 @@ func Default(deleteOptions options.NodeDeleteOptions) Rules {
 		skip bool
 	}{
 		{rule: mirror.New()},
+		{rule: skipreschedule.New()},
 		{rule: longterminating.New()},
 		{rule: replicacount.New(deleteOptions.MinReplicaCount), skip: !deleteOptions.SkipNodesWithCustomControllerPods},
 

--- a/cluster-autoscaler/simulator/drainability/rules/skipreschedule/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/skipreschedule/rule.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package skipreschedule
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+)
+
+const (
+	// SkipRescheduleAnnotationKey is an annotation that indicates the pod should be
+	// skipped during rescheduling simulation. Pods with this annotation:
+	// - Are evictable (can be terminated during scale-down)
+	// - Receive SkipDrain status (not simulated for rescheduling to other nodes)
+	// - Are NOT included in template nodes (unlike daemonset-pod annotation)
+	//
+	// Use case: Ephemeral pods that don't need to survive node deletion and don't
+	// need destination simulation. The pod will simply be terminated when the node
+	// is removed.
+	SkipRescheduleAnnotationKey = "cluster-autoscaler.kubernetes.io/skip-reschedule"
+)
+
+// Rule is a drainability rule on how to handle pods that should skip rescheduling simulation.
+type Rule struct{}
+
+// New creates a new Rule.
+func New() *Rule {
+	return &Rule{}
+}
+
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "SkipReschedule"
+}
+
+// Drainable decides what to do with skip-reschedule pods on node drain.
+// Pods with the skip-reschedule annotation will receive SkipDrain status,
+// meaning they won't block drain and won't be simulated for rescheduling.
+func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod, _ *framework.NodeInfo) drainability.Status {
+	if HasSkipRescheduleAnnotation(pod) {
+		return drainability.NewSkipStatus()
+	}
+	return drainability.NewUndefinedStatus()
+}
+
+// HasSkipRescheduleAnnotation returns true if the pod has the skip-reschedule annotation set to "true".
+func HasSkipRescheduleAnnotation(pod *apiv1.Pod) bool {
+	return pod.Annotations[SkipRescheduleAnnotationKey] == "true"
+}

--- a/cluster-autoscaler/simulator/drainability/rules/skipreschedule/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/skipreschedule/rule_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package skipreschedule
+
+import (
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
+)
+
+func TestDrainable(t *testing.T) {
+	testCases := []struct {
+		name    string
+		pod     *apiv1.Pod
+		wantOut drainability.OutcomeType
+	}{
+		{
+			name: "pod with skip-reschedule annotation",
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						SkipRescheduleAnnotationKey: "true",
+					},
+				},
+			},
+			wantOut: drainability.SkipDrain,
+		},
+		{
+			name: "pod with skip-reschedule annotation set to false",
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						SkipRescheduleAnnotationKey: "false",
+					},
+				},
+			},
+			wantOut: drainability.UndefinedOutcome,
+		},
+		{
+			name: "pod without skip-reschedule annotation",
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+				},
+			},
+			wantOut: drainability.UndefinedOutcome,
+		},
+		{
+			name: "pod with other annotations but not skip-reschedule",
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						"some-other-annotation": "value",
+					},
+				},
+			},
+			wantOut: drainability.UndefinedOutcome,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rule := New()
+			got := rule.Drainable(nil, tc.pod, nil)
+			if got.Outcome != tc.wantOut {
+				t.Errorf("Drainable() = %v, want %v", got.Outcome, tc.wantOut)
+			}
+		})
+	}
+}
+
+func TestHasSkipRescheduleAnnotation(t *testing.T) {
+	testCases := []struct {
+		name string
+		pod  *apiv1.Pod
+		want bool
+	}{
+		{
+			name: "has annotation set to true",
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						SkipRescheduleAnnotationKey: "true",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "has annotation set to false",
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						SkipRescheduleAnnotationKey: "false",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no annotations",
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			want: false,
+		},
+		{
+			name: "nil annotations",
+			pod: &apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := HasSkipRescheduleAnnotation(tc.pod)
+			if got != tc.want {
+				t.Errorf("HasSkipRescheduleAnnotation() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a new drainability rule that checks for the annotation cluster-autoscaler.kubernetes.io/skip-reschedule: "true"

Pods with this annotation will:
- Be evictable (can be terminated during scale-down)
- Receive SkipDrain status (not simulated for rescheduling)
- NOT be included in template nodes (unlike daemonset-pod annotation)

Use case: Ephemeral pods that don't need to survive node deletion and don't need destination simulation. The pod will simply be terminated when the node is removed.

This differs from the daemonset-pod annotation which causes pods to be included in template nodes, potentially breaking pod anti-affinity rules during scale-up evaluation.

Ref: https://github.com/kubernetes/autoscaler/issues/9110

/kind feature

```release-note
Add skip-reschedule annotation to skip rescheduling simulation
```
