### PR TITLE
cluster-autoscaler/chart: add more annotations and allow selector ove…

### DIFF
--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.54.1
+version: 9.55.0

--- a/cluster-autoscaler/charts/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/charts/cluster-autoscaler/README.md
@@ -339,7 +339,7 @@ rbac:
 
 ### Azure - Using azure workload identity
 
-You can use the project [Azure workload identity](https://github.com/Azure/azure-workload-identity), to automatically configure the correct setup for your pods to used federated identity with Azure.
+You can use the project [Azure workload identity](https://github.com/Azure/azure-workload-identity), to automatically configure the correct setup for your pods to use federated identity with Azure.
 
 You can also set the correct settings yourself instead of relying on this project.
 
@@ -463,6 +463,7 @@ vpa:
 | containerSecurityContext | object | `{}` | [Security context for container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | customArgs | list | `[]` | Additional custom container arguments. Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler parameters and their default values. List of arguments as strings. |
 | deployment.annotations | object | `{}` | Annotations to add to the Deployment object. |
+| deployment.selector | object | `{}` | Labels for Deployment `spec.selector.matchLabels`. |
 | dnsConfig | object | `{}` | [Pod's DNS Config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) |
 | dnsPolicy | string | `"ClusterFirst"` | Defaults to `ClusterFirst`. Valid values are: `ClusterFirstWithHostNet`, `ClusterFirst`, `Default` or `None`. If autoscaler does not depend on cluster DNS, recommended to set this to `Default`. |
 | envFromConfigMap | string | `""` | ConfigMap name to use as envFrom. |
@@ -490,7 +491,9 @@ vpa:
 | nameOverride | string | `""` | String to partially override `cluster-autoscaler.fullname` template (will maintain the release name) |
 | nodeSelector | object | `{}` | Node labels for pod assignment. Ref: https://kubernetes.io/docs/user-guide/node-selection/. |
 | podAnnotations | object | `{}` | Annotations to add to each pod. |
-| podDisruptionBudget | object | `{"maxUnavailable":1}` | Pod disruption budget. |
+| podDisruptionBudget | object | `{"annotations":{},"maxUnavailable":1,"selector":{}}` | Pod disruption budget. |
+| podDisruptionBudget.annotations | object | `{}` | Annotations to add to the PodDisruptionBudget. |
+| podDisruptionBudget.selector | object | `{}` | Override labels for PodDisruptionBudget `spec.selector.matchLabels`. |
 | podLabels | object | `{}` | Labels to add to each pod. |
 | priorityClassName | string | `"system-cluster-critical"` | priorityClassName |
 | priorityConfigMapAnnotations | object | `{}` | Annotations to add to `cluster-autoscaler-priority-expander` ConfigMap. |
@@ -500,6 +503,7 @@ vpa:
 | prometheusRule.namespace | string | `"monitoring"` | Namespace which Prometheus is running in. |
 | prometheusRule.rules | list | `[]` | Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule). |
 | rbac.additionalRules | list | `[]` | Additional rules for role/clusterrole |
+| rbac.annotations | object | `{}` | Additional annotations to add to RBAC resources (Role/RoleBinding/ClusterRole/ClusterRoleBinding). |
 | rbac.clusterScoped | bool | `true` | if set to false will only provision RBAC to alter resources in the current namespace. Most useful for Cluster-API |
 | rbac.create | bool | `true` | If `true`, create and use RBAC resources. |
 | rbac.pspEnabled | bool | `false` | If `true`, creates and uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled. Must be used with `rbac.create` set to `true`. |
@@ -520,6 +524,7 @@ vpa:
 | service.loadBalancerIP | string | `""` | IP address to assign to load balancer (if supported). |
 | service.loadBalancerSourceRanges | list | `[]` | List of IP CIDRs allowed access to load balancer (if supported). |
 | service.portName | string | `"http"` | Name for service port. |
+| service.selector | object | `{}` | Override labels for Service `spec.selector`. |
 | service.servicePort | int | `8085` | Service port to expose. |
 | service.type | string | `"ClusterIP"` | Type of service to create. |
 | serviceMonitor.annotations | object | `{}` | Annotations to add to service monitor |
@@ -534,7 +539,7 @@ vpa:
 | topologySpreadConstraints | list | `[]` | You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. (requires Kubernetes >= 1.19). |
 | updateStrategy | object | `{}` | [Deployment update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
 | vpa | object | `{"containerPolicy":{},"enabled":false,"recommender":"default","updateMode":"Auto"}` | Configure a VerticalPodAutoscaler for the cluster-autoscaler Deployment. |
-| vpa.containerPolicy | object | `{}` | [ContainerResourcePolicy](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L159). The containerName is always et to the deployment's container name. This value is required if VPA is enabled. |
+| vpa.containerPolicy | object | `{}` | [ContainerResourcePolicy](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L159). The containerName is always set to the deployment's container name. This value is required if VPA is enabled. |
 | vpa.enabled | bool | `false` | If true, creates a VerticalPodAutoscaler. |
 | vpa.recommender | string | `"default"` | Name of the VPA recommender that will provide recommendations for vertical scaling. |
 | vpa.updateMode | string | `"Auto"` | [UpdateMode](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L124) |

--- a/cluster-autoscaler/charts/cluster-autoscaler/README.md.gotmpl
+++ b/cluster-autoscaler/charts/cluster-autoscaler/README.md.gotmpl
@@ -339,7 +339,7 @@ rbac:
 
 ### Azure - Using azure workload identity
 
-You can use the project [Azure workload identity](https://github.com/Azure/azure-workload-identity), to automatically configure the correct setup for your pods to used federated identity with Azure.
+You can use the project [Azure workload identity](https://github.com/Azure/azure-workload-identity), to automatically configure the correct setup for your pods to use federated identity with Azure.
 
 You can also set the correct settings yourself instead of relying on this project.
 

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -2,6 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- with .Values.rbac.annotations }}
+  annotations:
+  {{- range $k, $v := . }}
+    {{- printf "%s: %s" (tpl $k $) (tpl $v $) | nindent 4 }}
+  {{- end }}
+{{- end }}
   labels:
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/clusterrolebinding.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/clusterrolebinding.yaml
@@ -2,6 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+{{- with .Values.rbac.annotations }}
+  annotations:
+  {{- range $k, $v := . }}
+    {{- printf "%s: %s" (tpl $k $) (tpl $v $) | nindent 4 }}
+  {{- end }}
+{{- end }}
   labels:
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/deployment.yaml
@@ -14,10 +14,14 @@ spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
+{{- if .Values.deployment.selector }}
+{{ toYaml .Values.deployment.selector | indent 6 }}
+{{- else }}
 {{ include "cluster-autoscaler.instance-name" . | indent 6 }}
     {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 6 }}
     {{- end }}
+{{- end }}
 {{- if .Values.updateStrategy }}
   strategy:
     {{ toYaml .Values.updateStrategy | nindent 4 | trim }}

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/pdb.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/pdb.yaml
@@ -4,6 +4,10 @@
 {{- end }}apiVersion: {{ template "podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
+{{- if .Values.podDisruptionBudget.annotations }}
+  annotations:
+{{ toYaml .Values.podDisruptionBudget.annotations | indent 4 }}
+{{- end }}
   labels:
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
@@ -11,6 +15,9 @@ metadata:
 spec:
   selector:
     matchLabels:
+{{- if .Values.podDisruptionBudget.selector }}
+{{ toYaml .Values.podDisruptionBudget.selector | indent 6 }}
+{{- else }}
 {{ include "cluster-autoscaler.instance-name" . | indent 6 }}
   {{- if and .Values.podDisruptionBudget.minAvailable (not .Values.podDisruptionBudget.maxUnavailable) }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
@@ -19,3 +26,4 @@ spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}
+{{- end }}

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/role.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/role.yaml
@@ -2,6 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+{{- with .Values.rbac.annotations }}
+  annotations:
+  {{- range $k, $v := . }}
+    {{- printf "%s: %s" (tpl $k $) (tpl $v $) | nindent 4 }}
+  {{- end }}
+{{- end }}
   labels:
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/rolebinding.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/rolebinding.yaml
@@ -2,6 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+{{- with .Values.rbac.annotations }}
+  annotations:
+  {{- range $k, $v := . }}
+    {{- printf "%s: %s" (tpl $k $) (tpl $v $) | nindent 4 }}
+  {{- end }}
+{{- end }}
   labels:
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/service.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/service.yaml
@@ -34,6 +34,10 @@ spec:
       targetPort: 8085
       name: {{ .Values.service.portName }}
   selector:
+{{- if .Values.service.selector }}
+{{ toYaml .Values.service.selector | indent 4 }}
+{{- else }}
 {{ include "cluster-autoscaler.instance-name" . | indent 4 }}
+{{- end }}
   type: "{{ .Values.service.type }}"
 {{- end }}

--- a/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
@@ -170,6 +170,8 @@ containerSecurityContext: {}
 deployment:
   # deployment.annotations -- Annotations to add to the Deployment object.
   annotations: {}
+  # deployment.selector -- Labels for Deployment `spec.selector.matchLabels`.
+  selector: {}
 
 # dnsConfig -- [Pod's DNS Config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config)
 dnsConfig: {}
@@ -333,6 +335,10 @@ podAnnotations: {}
 
 # podDisruptionBudget -- Pod disruption budget.
 podDisruptionBudget:
+  # podDisruptionBudget.annotations -- Annotations to add to the PodDisruptionBudget.
+  annotations: {}
+  # podDisruptionBudget.selector -- Override labels for PodDisruptionBudget `spec.selector.matchLabels`.
+  selector: {}
   maxUnavailable: 1
   # minAvailable: 2
 
@@ -370,6 +376,8 @@ rbac:
   pspEnabled: false
   # rbac.clusterScoped -- if set to false will only provision RBAC to alter resources in the current namespace. Most useful for Cluster-API
   clusterScoped: true
+  # rbac.annotations -- Additional annotations to add to RBAC resources (Role/RoleBinding/ClusterRole/ClusterRoleBinding).
+  annotations: {}
   serviceAccount:
     # rbac.serviceAccount.annotations -- Additional Service Account annotations.
     annotations: {}
@@ -423,6 +431,9 @@ service:
   labels: {}
   # service.externalIPs -- List of IP addresses at which the service is available. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips.
   externalIPs: []
+
+  # service.selector -- Override labels for Service `spec.selector`.
+  selector: {}
 
   # service.clusterIP -- IP address to assign to service
   clusterIP: ""
@@ -487,7 +498,7 @@ vpa:
   enabled: false
   # vpa.updateMode -- [UpdateMode](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L124)
   updateMode: "Auto"
-  # vpa.containerPolicy -- [ContainerResourcePolicy](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L159). The containerName is always et to the deployment's container name. This value is required if VPA is enabled.
+  # vpa.containerPolicy -- [ContainerResourcePolicy](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler/v0.13.0/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L159). The containerName is always set to the deployment's container name. This value is required if VPA is enabled.
   containerPolicy: {}
   # vpa.recommender -- Name of the VPA recommender that will provide recommendations for vertical scaling.
   recommender: default


### PR DESCRIPTION
…rrides

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds new Helm chart values to improve integration with clusters that require:
- Custom annotations on RBAC and PDB resources to integrate with cluster policy/ownership tooling, avoiding post-render patches.
- Overriding selector on Service/PDB/Deployment to support non-standard label/selector setups. This improves compatibility with managed Kubernetes distributions and non-standard deployments (e.g. managed
add-ons such as AWS EKS), which may use different/externally-managed labels and selectors and may require
additional metadata on resources.

#### Special notes for your reviewer:
The changes are backward compatible and new options are opt-in to override the default behaviors.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Helm chart: allow applying custom annotations to all resources and overriding selector on deployment/service/pdb resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Usage]: Chart README (values documentation updated)

```