### PR TITLE
Enable noduration and nobools kube-api-linter rule for VPA

### DIFF
--- a/vertical-pod-autoscaler/hack/tools/kube-api-linter/.golangci-kal.yml
+++ b/vertical-pod-autoscaler/hack/tools/kube-api-linter/.golangci-kal.yml
@@ -21,7 +21,7 @@ linters:
               #- "integers" # Ensure only int32 and int64 are used for integers.
               #- "jsontags" # Ensure every field has a json tag.
               #- "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
-              #- "nobools" # Bools do not evolve over time, should use enums instead.
+              - "nobools" # Bools do not evolve over time, should use enums instead.
               - "nodurations" # Prevents usage of `Duration` types.
               #- "nofloats" # Ensure floats are not used.
               #- "nomaps" # Ensure maps are not used.

--- a/vertical-pod-autoscaler/hack/tools/kube-api-linter/.golangci-kal.yml
+++ b/vertical-pod-autoscaler/hack/tools/kube-api-linter/.golangci-kal.yml
@@ -22,7 +22,7 @@ linters:
               #- "jsontags" # Ensure every field has a json tag.
               #- "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
               #- "nobools" # Bools do not evolve over time, should use enums instead.
-              #- "nodurations" # Prevents usage of `Duration` types.
+              - "nodurations" # Prevents usage of `Duration` types.
               #- "nofloats" # Ensure floats are not used.
               #- "nomaps" # Ensure maps are not used.
               #- "nonullable" # Ensure that types and fields do not have the nullable marker.

--- a/vertical-pod-autoscaler/hack/verify-kube-api-linter.sh
+++ b/vertical-pod-autoscaler/hack/verify-kube-api-linter.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Based on this comment: https://github.com/kubernetes/autoscaler/pull/9141#discussion_r2742887757
This feels like a straight up non controversial rule we should apply, since we have kube-api-linter ready, figured I'd enable the rule

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
