### PR TITLE
Enable host network for the admission controller pod

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -54,6 +54,9 @@ spec:
       {{- with .Values.admissionController.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.admissionController.hostNetwork }}
+      hostNetwork: {{ . }}
+      {{- end }}
       containers:
         - name: admission-controller
           image: {{ include "vertical-pod-autoscaler.admissionController.image" . }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -94,6 +94,10 @@ admissionController:
   # admissionController.registerWebhook -- Whether to register webhook via the application itself or via Helm. Set to false when using Helm-managed webhook. Security issue: granting delete on mutatingwebhookconfigurations is a potential security risk as it allows the admission controller to remove any webhook configurations.
   registerWebhook: false
 
+  # admissionController.hostNetwork -- Enable host network for the admission controller pod. Set to true when the pod needs direct access to the host's network namespace. Note: this bypasses Kubernetes network isolation and may cause port conflicts if multiple replicas run on the same node.
+  hostNetwork:
+  # hostNetwork: true
+
   certGen:
     enabled: true
     image:


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
Adds optional `hostNetwork` parameter to the VPA admission controller Helm chart. This allows users to enable host network mode when the admission controller pod needs direct access to the host's network namespace.

#### Which issue(s) this PR fixes:
Fixes #9143

#### Special notes for your reviewer:
The parameter is optional and not set by default, allowing Kubernetes to use its default behavior (hostNetwork: false). This follows the existing pattern used for other optional parameters like `priorityClassName`.

#### Does this PR introduce a user-facing change?
```release-note
Added optional `hostNetwork` parameter to VPA admission controller chart for cases requiring host network access.
