### PR TITLE
Optimize EmptySorting by caching isNodeEmpty result

### DIFF
--- a/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting_benchmark_test.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting_benchmark_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package emptycandidates
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func BenchmarkEmptySorting(b *testing.B) {
+	nodeCount := 5000
+	nodeInfos := make(map[string]*framework.NodeInfo)
+	nodes := make([]*apiv1.Node, 0, nodeCount)
+
+	for i := 0; i < nodeCount; i++ {
+		name := fmt.Sprintf("node-%d", i)
+		node := BuildTestNode(name, 1000, 1000)
+		nodes = append(nodes, node)
+		// Every other node is non-empty
+		if i%2 == 0 {
+			pod := BuildTestPod(fmt.Sprintf("pod-%d", i), 100, 100)
+			nodeInfos[name] = framework.NewTestNodeInfo(node, pod)
+		} else {
+			nodeInfos[name] = framework.NewTestNodeInfo(node)
+		}
+	}
+
+	niGetter := &testNodeInfoGetter{m: nodeInfos}
+	deleteOptions := options.NodeDeleteOptions{
+		SkipNodesWithSystemPods:           true,
+		SkipNodesWithLocalStorage:         true,
+		SkipNodesWithCustomControllerPods: true,
+	}
+	p := NewEmptySortingProcessor(niGetter, deleteOptions, nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.ResetState()
+		nodesCopy := make([]*apiv1.Node, len(nodes))
+		copy(nodesCopy, nodes)
+
+		sort.SliceStable(nodesCopy, func(i, j int) bool {
+			return p.ScaleDownEarlierThan(nodesCopy[i], nodesCopy[j])
+		})
+	}
+}

--- a/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting_test.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting_test.go
@@ -62,10 +62,7 @@ func TestScaleDownEarlierThan(t *testing.T) {
 		SkipNodesWithLocalStorage:         true,
 		SkipNodesWithCustomControllerPods: true,
 	}
-	p := EmptySorting{
-		nodeInfoGetter: &niGetter,
-		deleteOptions:  deleteOptions,
-	}
+	p := NewEmptySortingProcessor(&niGetter, deleteOptions, nil)
 
 	tests := []struct {
 		name        string

--- a/cluster-autoscaler/processors/scaledowncandidates/previouscandidates/previous_candidates_sorting.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/previouscandidates/previous_candidates_sorting.go
@@ -50,6 +50,9 @@ func (p *PreviousCandidates) ScaleDownEarlierThan(node1, node2 *apiv1.Node) bool
 	return false
 }
 
+// ResetState resets internal state before every sorting.
+func (p *PreviousCandidates) ResetState() {}
+
 func (p *PreviousCandidates) isPreviousCandidate(node *apiv1.Node) bool {
 	return p.candidates[node.Name]
 }

--- a/cluster-autoscaler/processors/scaledowncandidates/sorting_processor.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/sorting_processor.go
@@ -26,6 +26,8 @@ import (
 type CandidatesComparer interface {
 	// ScaleDownEarlierThan return true if node1 should be scaled down earlier than node2.
 	ScaleDownEarlierThan(node1, node2 *apiv1.Node) bool
+	// ResetState resets internal state before every sorting.
+	ResetState()
 }
 
 // NodeSorter struct contain the list of nodes and the list of processors that should be applied for sorting.
@@ -38,6 +40,9 @@ type NodeSorter struct {
 func (n *NodeSorter) Sort() []*apiv1.Node {
 	if len(n.processors) == 0 {
 		return n.nodes
+	}
+	for _, p := range n.processors {
+		p.ResetState()
 	}
 	sort.Sort(n)
 	return n.nodes

--- a/cluster-autoscaler/processors/scaledowncandidates/sorting_processor_test.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/sorting_processor_test.go
@@ -36,6 +36,8 @@ func (p *scoreProcessor) ScaleDownEarlierThan(node1, node2 *apiv1.Node) bool {
 	return p.scores[idx1] > p.scores[idx2]
 }
 
+func (p *scoreProcessor) ResetState() {}
+
 func TestSort(t *testing.T) {
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
This change optimizes the EmptySorting scale down candidate processor by implementing a caching mechanism for the isNodeEmpty check.

Summary of changes:
1.  Extended CandidatesComparer interface with ResetState() method to allow clearing caches before each sorting pass.
2.  Updated NodeSorter.Sort() to invoke ResetState() on all processors.
3.  Implemented caching in EmptySorting, ensuring simulator.GetPodsToMove is called at most once per node during a sorting cycle.
4.  Added no-op ResetState() to other CandidatesComparer implementations.

Benchmark results for sorting 5000 nodes with EmptySorting:
- Before: 26,403,629 ns/op (~26.4 ms)
- After: 5,120,497 ns/op (~5.1 ms)

Performance improvement: ~5x.

Testing: Added micro benchmark BenchmarkEmptySorting and updated existing unit tests.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Minor performance improvement reducing loop time in large clusters.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
