### PR TITLE
Remove node/proxy RBAC permissions from e2e test

### DIFF
--- a/vertical-pod-autoscaler/hack/e2e/prometheus.yaml
+++ b/vertical-pod-autoscaler/hack/e2e/prometheus.yaml
@@ -112,7 +112,6 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes
-  - nodes/proxy
   - services
   - endpoints
   - pods


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Related to https://kubernetes.io/docs/concepts/security/api-server-bypass-risks/#kubelet-api

The e2e tests seem to work without this permission

#### Which issue(s) this PR fixes:
Fixes #9140

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
