### PR TITLE
VPA: allow in-place updates below minReplicas for InPlaceOrRecreate, block eviction

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_eviction_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_eviction_restriction.go
@@ -57,6 +57,10 @@ func (e *PodsEvictionRestrictionImpl) CanEvict(pod *apiv1.Pod) bool {
 	cr, present := e.podToReplicaCreatorMap[getPodID(pod)]
 	if present {
 		singleGroupStats, present := e.creatorToSingleGroupStatsMap[cr]
+		if present && singleGroupStats.belowMinReplicas {
+			klog.V(2).InfoS("Skipping eviction: replica group below minReplicas (in-place update may still be used)", "pod", klog.KObj(pod), "creator", cr.Name)
+			return false
+		}
 		if pod.Status.Phase == apiv1.PodPending {
 			return true
 		}

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
@@ -368,15 +368,15 @@ func TestDisruptReplicatedByController(t *testing.T) {
 			},
 		},
 		{
-			name:              "Cannot in-place a single Pod under default settings.",
+			name:              "Can in-place a single Pod under default settings (belowMinReplicas allows in-place, blocks eviction).",
 			replicas:          1,
 			evictionTolerance: 0.5,
 			vpa:               getIPORVpa(),
 			pods: []podWithExpectations{
 				{
 					pod:                  generatePod().Get(),
-					canInPlaceUpdate:     utils.InPlaceDeferred,
-					inPlaceUpdateSuccess: false,
+					canInPlaceUpdate:     utils.InPlaceApproved,
+					inPlaceUpdateSuccess: true,
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When a replica group has fewer live pods than `minReplicas` (e.g. one pod with default `--min-replicas=2`), the VPA updater used to skip it entirely in `GetCreatorMaps` (`if actual < required { continue }`). As a result, with `updateMode: InPlaceOrRecreate`, such groups (single replica or small sets) could never get recommendations applied: no in-place, and we also do not want to evict.

This change:

1. **Includes below-minReplicas groups in the maps** with a new `belowMinReplicas` flag in `singleGroupStats`.
2. **Blocks eviction** when `belowMinReplicas` is set: `PodsEvictionRestrictionImpl.CanEvict()` returns `false` and logs, so fallback to recreate does not run.
3. **Leaves in-place unchanged** with respect to minReplicas: `PodsInPlaceRestriction` does not check `belowMinReplicas`, so in-place resize is still allowed for these groups.

Result: with **InPlaceOrRecreate**, groups below minReplicas can receive VPA recommendations **only via in-place resize**. If in-place is not possible (e.g. Infeasible), we do nothing and log instead of evicting.

Users with one or few replicas and InPlaceOrRecreate can now get VPA resource updates via in-place resize without lowering minReplicas or increasing replica count. Eviction/recreate remains forbidden when below minReplicas, so availability is preserved.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9157
https://github.com/kubernetes/autoscaler/issues/9157
#### Special notes for your reviewer:
Unit tests in `pkg/updater/restriction/` cover: in-place allowed for singleton below minReplicas, tolerance limit in one loop, and fallback to eviction blocked when below minReplicas (`TestFallbackToRecreateBlockedWhenBelowMinReplicas`).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
VPA (InPlaceOrRecreate): in-place resize is now allowed when the replica group has fewer pods than minReplicas; eviction/recreate remains blocked in that case so single-replica and small replica sets can receive recommendations without being evicted.

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
