### PR TITLE
Fix race condition in eligibility_test.go

### DIFF
--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -314,7 +314,7 @@ func TestFilterOutUnremovable(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Could not create autoscaling context: %v", err)
 			}
-			if err := autoscalingCtx.ClusterSnapshot.SetClusterState(tc.nodes, tc.pods, tc.draSnapshot, nil); err != nil {
+			if err := autoscalingCtx.ClusterSnapshot.SetClusterState(tc.nodes, tc.pods, drasnapshot.CloneTestSnapshot(tc.draSnapshot), nil); err != nil {
 				t.Fatalf("Could not SetClusterState: %v", err)
 			}
 			unremovableNodes := unremovable.NewNodes()

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/test_utils.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/test_utils.go
@@ -25,6 +25,10 @@ import (
 // CloneTestSnapshot creates a deep copy of the provided Snapshot.
 // This function is intended for testing purposes only.
 func CloneTestSnapshot(snapshot *Snapshot) *Snapshot {
+	if snapshot == nil {
+		return nil
+	}
+
 	cloneString := func(s string) string { return s }
 	cloneResourceClaimId := func(rc ResourceClaimId) ResourceClaimId { return rc }
 	cloneDeviceClass := func(dc *resourceapi.DeviceClass) *resourceapi.DeviceClass { return dc.DeepCopy() }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

This PR fixes a race condition in a test. This issue is not visible with the current CI setup. I'm planning on fixing it in another PR.

#### Which issue(s) this PR fixes:
Flaky test: TestFilterOutUnremovable

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
