### PR TITLE
Enable host network for the admission controller pod

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -54,8 +54,8 @@ spec:
       {{- with .Values.admissionController.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- with .Values.admissionController.hostNetwork }}
-      hostNetwork: {{ . }}
+      {{- if .Values.admissionController.hostNetwork }}
+      hostNetwork: true
       {{- end }}
       containers:
         - name: admission-controller

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -95,8 +95,7 @@ admissionController:
   registerWebhook: false
 
   # admissionController.hostNetwork -- Enable host network for the admission controller pod. Set to true when the pod needs direct access to the host's network namespace. Note: this bypasses Kubernetes network isolation and may cause port conflicts if multiple replicas run on the same node.
-  hostNetwork:
-  # hostNetwork: true
+  hostNetwork: false
 
   certGen:
     enabled: true


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
Adds optional hostNetwork parameter to the VPA admission controller Helm chart. This allows users to enable host network mode when the admission controller pod needs direct access to the host's network namespace.

#### Which issue(s) this PR fixes:
Fixes #9143

#### Special notes for your reviewer:
The parameter is optional and not set by default, allowing Kubernetes to use its default behavior (hostNetwork: false). This follows the existing pattern used for other optional parameters like priorityClassName.

#### Does this PR introduce a user-facing change?
Added optional `hostNetwork` parameter to VPA admission controller chart for cases requiring host network access.
