### PR TITLE
VPA: Skip minReplicas check when in-place-skip-disruption-budget is enabled

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_eviction_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_eviction_restriction.go
@@ -61,6 +61,10 @@ func (e *PodsEvictionRestrictionImpl) CanEvict(pod *apiv1.Pod) bool {
 			return true
 		}
 		if present {
+			if singleGroupStats.belowMinReplicas {
+				klog.V(2).InfoS("Cannot evict pod, group is below minReplicas", "pod", klog.KObj(pod))
+				return false
+			}
 			if isInPlaceUpdating(pod) {
 				return CanEvictInPlacingPod(pod, singleGroupStats, e.lastInPlaceAttemptTimeMap, e.clock)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a user specifies --in-place-skip-disruption-budget, also skip the min replicas check.
This was missed in https://github.com/kubernetes/autoscaler/pull/8987

#### Which issue(s) this PR fixes:
Fixes #9157

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
