### PR TITLE
Add CapacityBuffers status fields to the printed columns for beta api

### DIFF
--- a/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
+++ b/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
@@ -38,12 +38,12 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=capacitybuffers,scope=Namespaced,shortName=cb
-// +kubebuilder:printcolumn:name="Strategy",type="string",JSONPath=".status.provisioningStrategy",description="The strategy used."
-// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="The actual number of buffer chunks."
+// +kubebuilder:printcolumn:name="Strategy",type="string",JSONPath=".spec.provisioningStrategy",description="The strategy to be used."
 // +kubebuilder:printcolumn:name="PodTemplate",type="string",JSONPath=".status.podTemplateRef.name",description="The name of the PodTemplate used."
-// +kubebuilder:printcolumn:name="Conditions",type="string",JSONPath=".status.conditions[*].type",description="List of all condition types."
-// +kubebuilder:printcolumn:name="ConditionsTime",type="string",JSONPath=".status.conditions[*].lastTransitionTime",description="List of all condition timestamps."
-// +kubebuilder:printcolumn:name="ConditionsMessages",type="string",JSONPath=".status.conditions[*].message",description="List of all condition messages."
+// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="The actual number of buffer chunks."
+// +kubebuilder:printcolumn:name="ConditionsType",type="string",JSONPath=".status.conditions[*].type",description="List of all condition types."
+// +kubebuilder:printcolumn:name="ConditionsStatus",type="string",JSONPath=".status.conditions[*].status",description="List of all condition statuses."
+// +kubebuilder:printcolumn:name="ConditionsReason",type="string",JSONPath=".status.conditions[*].reason",description="List of all condition reasons."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the CapacityBuffer."
 // +versionName=v1alpha1
 // +kubebuilder:deprecatedversion

--- a/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1/types.go
@@ -38,9 +38,12 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=capacitybuffers,scope=Namespaced,shortName=cb
-// +kubebuilder:printcolumn:name="Strategy",type="string",JSONPath=".spec.provisioningStrategy",description="The strategy used for provisioning buffer capacity."
-// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="The desired number of buffer chunks, if specified."
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason",description="The readiness status of the CapacityBuffer."
+// +kubebuilder:printcolumn:name="Strategy",type="string",JSONPath=".spec.provisioningStrategy",description="The strategy to be used."
+// +kubebuilder:printcolumn:name="PodTemplate",type="string",JSONPath=".status.podTemplateRef.name",description="The name of the PodTemplate used."
+// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="The actual number of buffer chunks."
+// +kubebuilder:printcolumn:name="ConditionsType",type="string",JSONPath=".status.conditions[*].type",description="List of all condition types."
+// +kubebuilder:printcolumn:name="ConditionsStatus",type="string",JSONPath=".status.conditions[*].status",description="List of all condition statuses."
+// +kubebuilder:printcolumn:name="ConditionsReason",type="string",JSONPath=".status.conditions[*].reason",description="List of all condition reasons."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the CapacityBuffer."
 // +versionName=v1beta1
 // +kubebuilder:storageversion

--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacitybuffers.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacitybuffers.yaml
@@ -17,29 +17,29 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The strategy used.
-      jsonPath: .status.provisioningStrategy
+    - description: The strategy to be used.
+      jsonPath: .spec.provisioningStrategy
       name: Strategy
+      type: string
+    - description: The name of the PodTemplate used.
+      jsonPath: .status.podTemplateRef.name
+      name: PodTemplate
       type: string
     - description: The actual number of buffer chunks.
       jsonPath: .status.replicas
       name: Replicas
       type: integer
-    - description: The name of the PodTemplate used.
-      jsonPath: .status.podTemplateRef.name
-      name: PodTemplate
-      type: string
     - description: List of all condition types.
       jsonPath: .status.conditions[*].type
-      name: Conditions
+      name: ConditionsType
       type: string
-    - description: List of all condition timestamps.
-      jsonPath: .status.conditions[*].lastTransitionTime
-      name: ConditionsTime
+    - description: List of all condition statuses.
+      jsonPath: .status.conditions[*].status
+      name: ConditionsStatus
       type: string
-    - description: List of all condition messages.
-      jsonPath: .status.conditions[*].message
-      name: ConditionsMessages
+    - description: List of all condition reasons.
+      jsonPath: .status.conditions[*].reason
+      name: ConditionsReason
       type: string
     - description: The age of the CapacityBuffer.
       jsonPath: .metadata.creationTimestamp
@@ -261,17 +261,29 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - description: The strategy used for provisioning buffer capacity.
+    - description: The strategy to be used.
       jsonPath: .spec.provisioningStrategy
       name: Strategy
       type: string
-    - description: The desired number of buffer chunks, if specified.
-      jsonPath: .spec.replicas
+    - description: The name of the PodTemplate used.
+      jsonPath: .status.podTemplateRef.name
+      name: PodTemplate
+      type: string
+    - description: The actual number of buffer chunks.
+      jsonPath: .status.replicas
       name: Replicas
       type: integer
-    - description: The readiness status of the CapacityBuffer.
-      jsonPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Status
+    - description: List of all condition types.
+      jsonPath: .status.conditions[*].type
+      name: ConditionsType
+      type: string
+    - description: List of all condition statuses.
+      jsonPath: .status.conditions[*].status
+      name: ConditionsStatus
+      type: string
+    - description: List of all condition reasons.
+      jsonPath: .status.conditions[*].reason
+      name: ConditionsReason
       type: string
     - description: The age of the CapacityBuffer.
       jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Adds Capacity buffers conditions types and values to the printed columns in beta and alpha APIs.
also updated the provisioningStrategy to be viewed from the specs and to view the condition `status` and the condition `reason` instead of `message` as the message usually long with much details to view in printcolumns, the user will be able to see the conditions types updates and for more details about a condition message the user should describe the buffers object.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add status conditions types and values to CapacityBuffers PrinterColumns for alpha and beta APIs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

