### PR TITLE
update builder Dockerfile to go 1.25

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24.0
+FROM golang:1.25.0
 
 ENV GOPATH /gopath/
 ENV PATH $GOPATH/bin:$PATH


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

builder Dockerfile needs to be in sync with the version of go in CA to avoid errors like this:

```
docker build --network=default -t autoscaling-builder ../builder
[+] Building 0.8s (9/9) FINISHED                                                                                                                                                                                                    docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                0.0s
 => => transferring dockerfile: 891B                                                                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/golang:1.24.0                                                                                                                                                                                    0.8s
 => [internal] load .dockerignore                                                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                                                     0.0s
 => [1/5] FROM docker.io/library/golang:1.24.0@sha256:3f7444391c51a11a039bf0359ee81cc64e663c17d787ad0e637a4de1a3f62a71                                                                                                                              0.0s
 => CACHED [2/5] RUN apt-get update && apt-get --yes install libseccomp-dev                                                                                                                                                                         0.0s
 => CACHED [3/5] RUN go version                                                                                                                                                                                                                     0.0s
 => CACHED [4/5] RUN go install github.com/tools/godep@latest                                                                                                                                                                                       0.0s
 => CACHED [5/5] RUN godep version                                                                                                                                                                                                                  0.0s
 => exporting to image                                                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                                                             0.0s
 => => writing image sha256:b12ab89e28ee22476e7a17f018e989de83d62a2ab61435e8b1d078f178af4298                                                                                                                                                        0.0s
 => => naming to docker.io/library/autoscaling-builder                                                                                                                                                                                              0.0s

 3 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 17)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 18)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 19)

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/gv0wf29wrz5g7wutnic4i7xsh
rm -f cluster-autoscaler-amd64
docker run  -v `pwd`:/gopath/src/k8s.io/autoscaler/cluster-autoscaler/:Z autoscaling-builder:latest \
		bash -c 'cd /gopath/src/k8s.io/autoscaler/cluster-autoscaler && BUILD_TAGS= LDFLAGS="-s" make build-arch-amd64'
rm -f cluster-autoscaler-amd64
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o cluster-autoscaler-amd64 --ldflags="-s" 
go: go.mod requires go >= 1.25.0 (running go 1.24.0; GOTOOLCHAIN=local)
make: *** [Makefile:48: build-arch-amd64] Error 1
make: *** [build-in-docker-arch-amd64] Error 2
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
