### PR TITLE
Remove Docker build warnings

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -14,9 +14,9 @@
 
 FROM golang:1.24.0
 
-ENV GOPATH /gopath/
-ENV PATH $GOPATH/bin:$PATH
-ENV GO111MODULE auto
+ENV GOPATH=/gopath/
+ENV PATH=$GOPATH/bin:$PATH
+ENV GO111MODULE=auto
 
 RUN apt-get update && apt-get --yes install libseccomp-dev
 RUN go version


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When building an image, for example when you run `make test-in-docker`.
Docker prints warnings:
```
make test-in-docker
rm -f cluster-autoscaler-amd64
docker build --network=default -t autoscaling-builder ../builder
[+] Building 0.6s (9/9) FINISHED                                                                                                                                                 docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                             0.0s
 => => transferring dockerfile: 891B                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/golang:1.24.0                                                                                                                                 0.5s
 => [internal] load .dockerignore                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                  0.0s
 => [1/5] FROM docker.io/library/golang:1.24.0@sha256:3f7444391c51a11a039bf0359ee81cc64e663c17d787ad0e637a4de1a3f62a71                                                                           0.0s
 => CACHED [2/5] RUN apt-get update && apt-get --yes install libseccomp-dev                                                                                                                      0.0s
 => CACHED [3/5] RUN go version                                                                                                                                                                  0.0s
 => CACHED [4/5] RUN go install github.com/tools/godep@latest                                                                                                                                    0.0s
 => CACHED [5/5] RUN godep version                                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                           0.0s
 => => exporting layers                                                                                                                                                                          0.0s
 => => writing image sha256:10eadd62e605aabb6ccfa63d0035bcf8f3078553cec842e8e3c15612b3fa552e                                                                                                     0.0s
 => => naming to docker.io/library/autoscaling-builder                                                                                                                                           0.0s

 3 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 17)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 18)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 19)
```


P.S. Similar warnings were removed earlier in PR: #7457


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
