### PR TITLE
Exclude capacity buffers fake pods from pods to evict

### DIFF
--- a/cluster-autoscaler/core/scaledown/actuation/drain.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain.go
@@ -27,6 +27,7 @@ import (
 	kube_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	capacitybufferpodlister "k8s.io/autoscaler/cluster-autoscaler/processors/capacitybuffer"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
@@ -278,6 +279,8 @@ func podsToEvict(nodeInfo *framework.NodeInfo, evictDsByDefault bool) (dsPods, n
 		if pod_util.IsMirrorPod(podInfo.Pod) {
 			continue
 		} else if fake.IsFake(podInfo.Pod) {
+			continue
+		} else if capacitybufferpodlister.IsFakeCapacityBuffersPod(podInfo.Pod) {
 			continue
 		} else if pod_util.IsDaemonSetPod(podInfo.Pod) {
 			dsPods = append(dsPods, podInfo.Pod)

--- a/cluster-autoscaler/core/scaledown/actuation/drain_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
+	capacitybufferpodlister "k8s.io/autoscaler/cluster-autoscaler/processors/capacitybuffer"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
 	simulator_fake "k8s.io/autoscaler/cluster-autoscaler/simulator/fake"
@@ -689,6 +690,11 @@ func TestPodsToEvict(t *testing.T) {
 			wantDsPods:    []*apiv1.Pod{},
 			wantNonDsPods: []*apiv1.Pod{},
 		},
+		"capacity buffers fake pods are never returned": {
+			pods:          []*apiv1.Pod{capacitybufferFakePod("pod-1"), capacitybufferFakePod("pod-2")},
+			wantDsPods:    []*apiv1.Pod{},
+			wantNonDsPods: []*apiv1.Pod{},
+		},
 		"non-DS pods are correctly returned": {
 			pods:          []*apiv1.Pod{regularPod("pod-1"), regularPod("pod-2")},
 			wantDsPods:    []*apiv1.Pod{},
@@ -774,6 +780,17 @@ func mirrorPod(name string) *apiv1.Pod {
 
 func fakePod(name string) *apiv1.Pod {
 	return simulator_fake.WithFakePodAnnotation(regularPod(name))
+}
+
+func capacitybufferFakePod(name string) *apiv1.Pod {
+	return &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				capacitybufferpodlister.CapacityBufferFakePodAnnotationKey: capacitybufferpodlister.CapacityBufferFakePodAnnotationValue,
+			},
+		},
+	}
 }
 
 func dsPod(name string, evictable bool) *apiv1.Pod {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Capacity buffers creates fake/virtual pods to be injected into CA loop, on draining the nodes we need to get the pods to be evicted from the running node, this PR excludes capacity buffers fake pods from this list of pods as the pods are already not bounded to the node and they don't need to be evicted.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
