### PR TITLE
Return nil for missing provider ID instead of error for huawei provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
@@ -119,7 +119,7 @@ func (hcp *huaweicloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudpr
 	instanceID := node.Spec.ProviderID
 	if len(instanceID) == 0 {
 		klog.Warningf("Node %v has no providerId", node.Name)
-		return nil, fmt.Errorf("provider id missing from node: %s", node.Name)
+		return nil, nil
 	}
 
 	return hcp.cloudServiceManager.GetAsgForInstance(instanceID)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

There is no issue at present. Maybe fewer people use it, but I think this problem is very important.

#### Special notes for your reviewer:

Currently, when a node lacks a providerId, the huaweicloud provider
returns an error, causing the entire TemplateNodeInfoProvider.Process()
to fail. This prevents the cluster autoscaler from functioning even when
other nodes have valid providerIds.

This change makes the huaweicloud provider consistent with the alicloud
provider by returning (nil, nil) instead of an error when a node has no
providerId. This allows the autoscaler to skip such nodes and continue
processing other nodes normally.

This is a common scenario when:
- Nodes are added before Cloud Controller Manager is deployed
- Manual nodes exist alongside cloud-managed nodes
- During cluster migration or upgrades

##### Before this change:

```go
if len(instanceID) == 0 {
    klog.Warningf("Node %v has no providerId", node.Name)
    return nil, fmt.Errorf("provider id missing from node: %s", node.Name)  // Returns error
}
```

**Impact**: If **any** node in the cluster lacks a providerId, the entire CA stops working.

##### After this change:

```go
if len(instanceID) == 0 {
    klog.Warningf("Node %v has no providerId, skipping", node.Name)
    return nil, nil  // Returns nil, nil (skip the node)
}
```

#### Does this PR introduce a user-facing change?

```release-note
`huawei-cloud-provider`: Nodes without providerId are skipped (with a warning), and CA continues to work normally for other nodes.
```

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
