### PR TITLE
List managed instances

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -181,6 +181,15 @@ func (gc *GceCache) GetMigInstancesUpdateTime(migRef GceRef) (time.Time, bool) {
 	return timestamp, found
 }
 
+// IsMigInstancesCacheEmpty returns true if instances cache for the given MIG is empty.
+func (gc *GceCache) IsMigInstancesCacheEmpty(migRef GceRef) bool {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	_, found := gc.instances[migRef]
+	return !found
+}
+
 // GetMigForInstance returns the cached MIG for instance GceRef
 func (gc *GceCache) GetMigForInstance(instanceRef GceRef) (GceRef, bool) {
 	gc.cacheMutex.Lock()

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -686,13 +686,15 @@ func TestGetMigForInstance(t *testing.T) {
 
 	setupTestDefaultPool(g, false)
 	g.cache.InvalidateAllMigBasenames()
+	g.cache.InvalidateAllInstancesToMig()
+	g.cache.InvalidateAllMigInstances()
 
 	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers").Return(
 		buildListInstanceGroupManagersResponse(
 			buildListInstanceGroupManagersResponsePart(defaultPoolMigName, zoneB, 7),
 			buildListInstanceGroupManagersResponsePart(extraPoolMigName, zoneB, 8),
 		)).Once()
-	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers/gke-cluster-1-default-pool/listManagedInstances").Return(buildFourRunningInstancesOnDefaultMigManagedInstancesResponse(zoneB)).Twice()
+	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers/gke-cluster-1-default-pool/listManagedInstances").Return(buildFourRunningInstancesOnDefaultMigManagedInstancesResponse(zoneB)).Once()
 	gceRef1 := GceRef{
 		Project: projectId,
 		Zone:    zoneB,

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -110,6 +110,7 @@ func (c *cachingMigInfoProvider) GetMigInstances(migRef GceRef) ([]GceInstance, 
 		return instances, nil
 	}
 
+	// MIG is not in the cache.
 	err := c.fillMigInstances(migRef)
 	if err != nil {
 		return nil, err
@@ -133,16 +134,24 @@ func (c *cachingMigInfoProvider) GetMigForInstance(instanceRef GceRef) (Mig, err
 		return nil, nil
 	}
 
+	// Cache is cleared every loop.
+	// If it's not empty, it's been refreshed this loop, and we don't want to refresh it again.
+	if !c.cache.IsMigInstancesCacheEmpty(mig.GceRef()) {
+		c.cache.MarkInstanceMigUnknown(instanceRef)
+		return nil, nil
+	}
+
 	err = c.fillMigInstances(mig.GceRef())
 	if err != nil {
 		return nil, err
 	}
-
+	// Check in the cache again after it's been refilled
 	mig, found, err = c.getCachedMigForInstance(instanceRef)
 	if !found {
 		c.cache.MarkInstanceMigUnknown(instanceRef)
 	}
 	return mig, err
+
 }
 
 func (c *cachingMigInfoProvider) getCachedMigForInstance(instanceRef GceRef) (Mig, bool, error) {

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -1562,7 +1562,7 @@ func TestGetMigMachineType(t *testing.T) {
 	}
 }
 
-func TestMultipleGetMigInstanceCallsLimited(t *testing.T) {
+func TestMultipleFillMigInstancesCallsLimited(t *testing.T) {
 	mig := &gceMig{
 		gceRef: GceRef{
 			Project: "project",
@@ -1570,16 +1570,6 @@ func TestMultipleGetMigInstanceCallsLimited(t *testing.T) {
 			Name:    "base-instance-name",
 		},
 	}
-	instance := GceInstance{
-		Instance: cloudprovider.Instance{Id: "gce://project/zone/base-instance-name-abcd"}, NumericId: 1111,
-	}
-	instanceRef, err := GceRefFromProviderId(instance.Id)
-	assert.Nil(t, err)
-	instance2 := GceInstance{
-		Instance: cloudprovider.Instance{Id: "gce://project/zone/base-instance-name-abcd2"}, NumericId: 222,
-	}
-	instanceRef2, err := GceRefFromProviderId(instance2.Id)
-	assert.Nil(t, err)
 	now := time.Now()
 	for name, tc := range map[string]struct {
 		refreshRateDuration              time.Duration
@@ -1628,10 +1618,10 @@ func TestMultipleGetMigInstanceCallsLimited(t *testing.T) {
 				timeProvider:                   ft,
 			}
 			ft.now = tc.firstCallTime
-			_, err = provider.GetMigForInstance(instanceRef)
+			err := provider.fillMigInstances(mig.GceRef())
 			assert.NoError(t, err)
 			ft.now = tc.secondCallTime
-			_, err = provider.GetMigForInstance(instanceRef2)
+			err = provider.fillMigInstances(mig.GceRef())
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedCallsToFetchMigInstances, callCounter[mig.GceRef()])
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

This PR includes a chage that is needed to reduce the number of `ListManagedInstances `calls from GCE provider.
It prevents MigInfoProvider from refreshing cache multiple times per loop when calling `getMigForInstance`. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[GCE] Reduced number of listManagedInstances API calls during cluster scale down.
```
