### PR TITLE
Add FetchMigActualSize method to GCE

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -43,6 +43,11 @@ func (m *gceManagerMock) GetMigSize(mig Mig) (int64, error) {
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *gceManagerMock) GetMigActualSize(migRef GceRef) (int64, error) {
+	args := m.Called(mig)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func (m *gceManagerMock) SetMigSize(mig Mig, size int64) error {
 	args := m.Called(mig, size)
 	return args.Error(0)

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -92,6 +92,8 @@ type GceManager interface {
 	GetResourceLimiter() (*cloudprovider.ResourceLimiter, error)
 	// GetMigSize gets MIG size.
 	GetMigSize(mig Mig) (int64, error)
+	// GetMigActualSize returns actual size for given MIG ref
+	GetMigActualSize(migRef GceRef) (int64, error)
 	// GetMigOptions returns MIG's NodeGroupAutoscalingOptions
 	GetMigOptions(mig Mig, defaults config.NodeGroupAutoscalingOptions) *config.NodeGroupAutoscalingOptions
 
@@ -241,9 +243,13 @@ func (m *gceManagerImpl) registerMig(mig Mig) bool {
 	return changed
 }
 
-// GetMigSize gets MIG size.
+// GetMigSize gets MIG target size.
 func (m *gceManagerImpl) GetMigSize(mig Mig) (int64, error) {
 	return m.migInfoProvider.GetMigTargetSize(mig.GceRef())
+}
+
+func (m *gceManagerImpl) GetMigActualSize(migRef GceRef) (int64, error) {
+	return m.GceService.FetchMigActualSize(migRef)
 }
 
 // SetMigSize sets MIG size.

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -43,6 +43,8 @@ type MigInfoProvider interface {
 	RegenerateMigInstancesCache() error
 	// GetMigTargetSize returns target size for given MIG ref
 	GetMigTargetSize(migRef GceRef) (int64, error)
+	// GetMigActualSize returns current number of instances in a given MIG
+	GetMigActualSize(migRef GceRef) (int64, error)
 	// GetMigBasename returns basename for given MIG ref
 	GetMigBasename(migRef GceRef) (string, error)
 	// GetMigInstanceTemplateName returns instance template name for given MIG ref
@@ -354,6 +356,10 @@ func (c *cachingMigInfoProvider) GetMigTargetSize(migRef GceRef) (int64, error) 
 	}
 	c.cache.SetMigTargetSize(migRef, targetSize)
 	return targetSize, nil
+}
+
+func (c *cachingMigInfoProvider) GetMigActualSize(migRef GceRef) (int64, error) {
+	return c.gceClient.FetchMigActualSize(migRef)
 }
 
 func (c *cachingMigInfoProvider) GetMigBasename(migRef GceRef) (string, error) {

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -112,6 +112,7 @@ type mockAutoscalingGceClient struct {
 	fetchMigs                        func(string) ([]*gce.InstanceGroupManager, error)
 	fetchAllInstances                func(project, zone string, filter string) ([]GceInstance, error)
 	fetchMigTargetSize               func(GceRef) (int64, error)
+	fetchMigActualSize               func(GceRef) (int64, error)
 	fetchMigBasename                 func(GceRef) (string, error)
 	fetchMigInstances                func(GceRef) ([]GceInstance, error)
 	fetchMigTemplateName             func(GceRef) (InstanceTemplateName, error)
@@ -138,6 +139,9 @@ func (client *mockAutoscalingGceClient) FetchAllInstances(project, zone string, 
 
 func (client *mockAutoscalingGceClient) FetchMigTargetSize(migRef GceRef) (int64, error) {
 	return client.fetchMigTargetSize(migRef)
+}
+func (client *mockAutoscalingGceClient) FetchMigActualSize(migRef GceRef) (int64, error) {
+	return client.fetchMigActualSize(migRef)
 }
 
 func (client *mockAutoscalingGceClient) FetchMigBasename(migRef GceRef) (string, error) {


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
This change adds a way to get the actual size of a node group without listing its instances. `ListManagedInstances` is an expensive API call and if we only need the number of nodes we can use `nodeGroups.get`.


#### Does this PR introduce a user-facing change?

```release-note
None
```


