### PR TITLE
[cluster-autoscaler-release-1.32] GOARCH as --build-arg for docker buildx

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -68,7 +68,8 @@ dev-release-arch-%: build-arch-% make-image-arch-% push-image-arch-%
 make-image: make-image-arch-$(GOARCH)
 
 make-image-arch-%:
-	GOOS=$(GOOS) GOARCH=$* docker buildx build --pull --platform linux/$* \
+	GOOS=$(GOOS) docker buildx build --pull --platform linux/$* \
+		--build-arg "GOARCH=$*" \
 		-t ${IMAGE}-$*:${TAG} \
 		-f Dockerfile .
 	@echo "Image ${TAG}${FOR_PROVIDER}-$* completed"
@@ -78,12 +79,15 @@ push-image: push-image-arch-$(GOARCH)
 push-image-arch-%:
 	./push_image.sh ${IMAGE}-$*:${TAG}
 
+push-release-image-arch-%:
+	docker push ${IMAGE}-$*:${TAG}
+
 push-manifest:
 	docker manifest create ${IMAGE}:${TAG} \
 	    $(addprefix $(REGISTRY)/cluster-autoscaler$(PROVIDER)-, $(addsuffix :$(TAG), $(ALL_ARCH)))
 	docker manifest push --purge ${IMAGE}:${TAG}
 
-execute-release: $(addprefix make-image-arch-,$(ALL_ARCH)) $(addprefix push-image-arch-,$(ALL_ARCH)) push-manifest
+execute-release: $(addprefix make-image-arch-,$(ALL_ARCH)) $(addprefix push-release-image-arch-,$(ALL_ARCH)) push-manifest
 	@echo "Release ${TAG}${FOR_PROVIDER} completed"
 
 clean: clean-arch-$(GOARCH)

--- a/cluster-autoscaler/cloudbuild.yaml
+++ b/cluster-autoscaler/cloudbuild.yaml
@@ -1,60 +1,15 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 3600s
 options:
-  machineType: E2_HIGHCPU_32
-timeout: 10800s
-
-substitutions:
-  { "_TAG": "dev" }
-
+  # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+  # or any new substitutions added in the future.
+  substitution_option: ALLOW_LOOSE
 steps:
-- name: gcr.io/cloud-builders/git
-  id: git-clone
-  entrypoint: bash
-  args:
-  - "-c"
-  - |
-    set -ex
-    mkdir -p /workspace/src/k8s.io
-    cd /workspace/src/k8s.io
-    git clone https://github.com/kubernetes/autoscaler.git
-
-- name: gcr.io/cloud-builders/docker
-  id: build-build-container
-  entrypoint: bash
-  dir: "/workspace/src/k8s.io/autoscaler/cluster-autoscaler"
-  args:
-  - "-c"
-  - |
-    set -e
-    docker build -t autoscaling-builder ../builder
-
-- name: autoscaling-builder
-  id: run-tests
-  entrypoint: godep
-  dir: "/workspace/src/k8s.io/autoscaler/cluster-autoscaler"
-  env:
-  - "GOPATH=/workspace/"
-  args: ["go", "test", "./..."]
-
-- name: autoscaling-builder
-  id: run-build
-  entrypoint: godep
-  dir: "/workspace/src/k8s.io/autoscaler/cluster-autoscaler"
-  env:
-  - "GOPATH=/workspace/"
-  - "GOOS=linux"
-  args: ["go", "build", "-o", "cluster-autoscaler"]
-  waitFor: build-build-container
-
-- name: gcr.io/cloud-builders/docker
-  id: build-container
-  entrypoint: bash
-  dir: "/workspace/src/k8s.io/autoscaler/cluster-autoscaler"
-  args:
-  - "-c"
-  - |
-    set -e
-    docker build -t gcr.io/k8s-image-staging/cluster-autoscaler:${_TAG} .
-  waitFor: ["run-tests", "run-build"]
-
-images:
-  - "gcr.io/k8s-image-staging/cluster-autoscaler:${_TAG}"
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest"
+    entrypoint: make
+    env:
+      - TAG=$_GIT_TAG
+    args:
+      - execute-release
+substitutions:
+  _GIT_TAG: "0.0.0" # default value, this is substituted at build time


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR brings in the changes from https://github.com/kubernetes/autoscaler/pull/8066 to the 1.32 branch in response to observed mimatched architecture compliation

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9226

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
