### PR TITLE
Reduce allocations in RunFiltersUntilPassingNode by removing CycleState cloning

### DIFF
--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -36,8 +37,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
-
-	apiv1 "k8s.io/api/core/v1"
 )
 
 func TestRunFiltersOnNode(t *testing.T) {
@@ -370,7 +369,7 @@ func newTestPluginRunnerAndSnapshot(schedConfig *config.KubeSchedulerConfigurati
 }
 
 func BenchmarkRunFiltersUntilPassingNode(b *testing.B) {
-	pod := BuildTestPod("p", 100, 1000)
+	pod := BuildTestPod("p", 100, 1000, WithPodHostnameAntiAffinity(map[string]string{"app": "p"}), WithLabels(map[string]string{"app": "p"}))
 	nodes := make([]*apiv1.Node, 0, 5001)
 	podsOnNodes := make(map[string][]*apiv1.Pod)
 
@@ -381,7 +380,7 @@ func BenchmarkRunFiltersUntilPassingNode(b *testing.B) {
 		// Add 10 small pods to each node
 		pods := make([]*apiv1.Pod, 0, 10)
 		for j := 0; j < 10; j++ {
-			pods = append(pods, BuildTestPod(fmt.Sprintf("p-%d-%d", i, j), 1, 1))
+			pods = append(pods, BuildTestPod(fmt.Sprintf("p-%d-%d", i, j), 1, 1, WithLabels(map[string]string{"app": "p"})))
 		}
 		podsOnNodes[nodeName] = pods
 	}

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -219,6 +219,25 @@ func WithNodeNamesAffinity(nodeNames ...string) func(*apiv1.Pod) {
 	}
 }
 
+// WithPodHostnameAntiAffinity sets pod's anti-affinity for pods matching the given labels at hostname topology level.
+func WithPodHostnameAntiAffinity(labels map[string]string) func(*apiv1.Pod) {
+	return func(pod *apiv1.Pod) {
+		if pod.Spec.Affinity == nil {
+			pod.Spec.Affinity = &apiv1.Affinity{}
+		}
+		pod.Spec.Affinity.PodAntiAffinity = &apiv1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: labels,
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		}
+	}
+}
+
 // BuildTestPodWithEphemeralStorage creates a pod with cpu, memory and ephemeral storage resources.
 func BuildTestPodWithEphemeralStorage(name string, cpu, mem, ephemeralStorage int64) *apiv1.Pod {
 	startTime := metav1.Unix(0, 0)


### PR DESCRIPTION
Avoid cloning the scheduler framework's CycleState for every node check in the filter loop. The CycleState is thread-safe and designed to be shared across parallel filter checks for the same pod scheduling cycle. This change significantly reduces memory allocations and garbage collection pressure during cluster-wide predicate checks.

Benchmarking with pod anti-affinity (intensive CycleState usage):
- Allocations: 75.3k -> 47.3k per op (~37% reduction)
- Memory: 8.4 MB -> 6.5 MB per op (~22% reduction)
- Time (parallelism-1): 13.5 ms -> 10.7 ms per op (~20% improvement)

This optimization aligns with upstream scheduler behavior where a single CycleState is shared across the parallel node filter phase:
https://github.com/kubernetes/kubernetes/blob/5467a9f9e20362304e1324143c9a4c7c17e169c0/pkg/scheduler/schedule_one.go#L664-L699

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Performance optimization.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
