### PR TITLE
Add number of provisioned replicas of buffer chunks to the buffer

### DIFF
--- a/cluster-autoscaler/proposals/buffers.md
+++ b/cluster-autoscaler/proposals/buffers.md
@@ -338,8 +338,14 @@ type CapacityBufferStatus struct {
   //provide details about the error state.
   // +optional  
   PodTemplateRef *PodTemplateRef
+  // Number of replicas calculated by the buffer controller that autoscaler
+  // should act on.
   // +optional
   Replicas *int
+  // Number of replicas from this buffer that have provisioned capacity in the
+  // cluster that is ready to be used.
+  // +optional 
+  ReadyReplicas *int
   // +optional
   PodTemplateGeneration  *int
   Conditions             []metav1.Condition


### PR DESCRIPTION
status.

Based on the user feedback this field is needed for better observability of what is happening with the buffer.

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add a status field to the buffer proposal so that we can offer users better observability.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
