### PR TITLE
fix incorrect provisioning class names in docs

### DIFF
--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_provisioningrequests.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_provisioningrequests.yaml
@@ -61,7 +61,7 @@ spec:
                   type: string
                 description: |-
                   Parameters contains all other parameters classes may require.
-                  'atomic-scale-up.kubernetes.io' supports 'ValidUntilSeconds' parameter, which should contain
+                  'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports 'ValidUntilSeconds' parameter, which should contain
                    a string denoting duration for which we should retry (measured since creation fo the CR).
                 maxProperties: 100
                 type: object
@@ -115,11 +115,11 @@ spec:
                   ProvisioningClassName describes the different modes of provisioning the resources.
                   Currently there is no support for 'ProvisioningClass' objects.
                   Supported values:
-                  * check-capacity.kubernetes.io - check if current cluster state can fullfil this request,
+                  * check-capacity.autoscaling.x-k8s.io - check if current cluster state can fullfil this request,
                     do not reserve the capacity. Users should provide a reference to a valid PodTemplate object.
                     CA will check if there is enough capacity in cluster to fulfill the request and put
                     the answer in 'CapacityAvailable' condition.
-                  * atomic-scale-up.kubernetes.io - provision the resources in an atomic manner.
+                  * best-effort-atomic-scale-up.autoscaling.x-k8s.io - provision the resources in an atomic manner.
                     Users should provide a reference to a valid PodTemplate object.
                     CA will try to create the VMs in an atomic manner, clean any partially provisioned VMs
                     and re-try the operation in a exponential back-off manner. Users can configure the timeout
@@ -269,7 +269,7 @@ spec:
                   type: string
                 description: |-
                   Parameters contains all other parameters classes may require.
-                  'atomic-scale-up.kubernetes.io' supports 'ValidUntilSeconds' parameter, which should contain
+                  'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports 'ValidUntilSeconds' parameter, which should contain
                    a string denoting duration for which we should retry (measured since creation fo the CR).
                 maxProperties: 100
                 type: object
@@ -323,11 +323,11 @@ spec:
                   ProvisioningClassName describes the different modes of provisioning the resources.
                   Currently there is no support for 'ProvisioningClass' objects.
                   Supported values:
-                  * check-capacity.kubernetes.io - check if current cluster state can fullfil this request,
+                  * check-capacity.autoscaling.x-k8s.io - check if current cluster state can fullfil this request,
                     do not reserve the capacity. Users should provide a reference to a valid PodTemplate object.
                     CA will check if there is enough capacity in cluster to fulfill the request and put
                     the answer in 'CapacityAvailable' condition.
-                  * atomic-scale-up.kubernetes.io - provision the resources in an atomic manner.
+                  * best-effort-atomic-scale-up.autoscaling.x-k8s.io - provision the resources in an atomic manner.
                     Users should provide a reference to a valid PodTemplate object.
                     CA will try to create the VMs in an atomic manner, clean any partially provisioned VMs
                     and re-try the operation in a exponential back-off manner. Users can configure the timeout

--- a/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go
+++ b/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go
@@ -87,11 +87,11 @@ type ProvisioningRequestSpec struct {
 	// ProvisioningClassName describes the different modes of provisioning the resources.
 	// Currently there is no support for 'ProvisioningClass' objects.
 	// Supported values:
-	// * check-capacity.kubernetes.io - check if current cluster state can fullfil this request,
+	// * check-capacity.autoscaling.x-k8s.io - check if current cluster state can fullfil this request,
 	//   do not reserve the capacity. Users should provide a reference to a valid PodTemplate object.
 	//   CA will check if there is enough capacity in cluster to fulfill the request and put
 	//   the answer in 'CapacityAvailable' condition.
-	// * atomic-scale-up.kubernetes.io - provision the resources in an atomic manner.
+	// * best-effort-atomic-scale-up.autoscaling.x-k8s.io - provision the resources in an atomic manner.
 	//   Users should provide a reference to a valid PodTemplate object.
 	//   CA will try to create the VMs in an atomic manner, clean any partially provisioned VMs
 	//   and re-try the operation in a exponential back-off manner. Users can configure the timeout
@@ -107,7 +107,7 @@ type ProvisioningRequestSpec struct {
 	ProvisioningClassName string `json:"provisioningClassName"`
 
 	// Parameters contains all other parameters classes may require.
-	// 'atomic-scale-up.kubernetes.io' supports 'ValidUntilSeconds' parameter, which should contain
+	// 'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports 'ValidUntilSeconds' parameter, which should contain
 	//  a string denoting duration for which we should retry (measured since creation fo the CR).
 	//
 	// +optional

--- a/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go
@@ -91,11 +91,11 @@ type ProvisioningRequestSpec struct {
 	// ProvisioningClassName describes the different modes of provisioning the resources.
 	// Currently there is no support for 'ProvisioningClass' objects.
 	// Supported values:
-	// * check-capacity.kubernetes.io - check if current cluster state can fullfil this request,
+	// * check-capacity.autoscaling.x-k8s.io - check if current cluster state can fullfil this request,
 	//   do not reserve the capacity. Users should provide a reference to a valid PodTemplate object.
 	//   CA will check if there is enough capacity in cluster to fulfill the request and put
 	//   the answer in 'CapacityAvailable' condition.
-	// * atomic-scale-up.kubernetes.io - provision the resources in an atomic manner.
+	// * best-effort-atomic-scale-up.autoscaling.x-k8s.io - provision the resources in an atomic manner.
 	//   Users should provide a reference to a valid PodTemplate object.
 	//   CA will try to create the VMs in an atomic manner, clean any partially provisioned VMs
 	//   and re-try the operation in a exponential back-off manner. Users can configure the timeout
@@ -111,7 +111,7 @@ type ProvisioningRequestSpec struct {
 	ProvisioningClassName string `json:"provisioningClassName"`
 
 	// Parameters contains all other parameters classes may require.
-	// 'atomic-scale-up.kubernetes.io' supports 'ValidUntilSeconds' parameter, which should contain
+	// 'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports 'ValidUntilSeconds' parameter, which should contain
 	//  a string denoting duration for which we should retry (measured since creation fo the CR).
 	//
 	// +optional

--- a/cluster-autoscaler/apis/provisioningrequest/client/applyconfiguration/autoscaling.x-k8s.io/v1/provisioningrequestspec.go
+++ b/cluster-autoscaler/apis/provisioningrequest/client/applyconfiguration/autoscaling.x-k8s.io/v1/provisioningrequestspec.go
@@ -34,11 +34,11 @@ type ProvisioningRequestSpecApplyConfiguration struct {
 	// ProvisioningClassName describes the different modes of provisioning the resources.
 	// Currently there is no support for 'ProvisioningClass' objects.
 	// Supported values:
-	// * check-capacity.kubernetes.io - check if current cluster state can fullfil this request,
+	// * check-capacity.autoscaling.x-k8s.io - check if current cluster state can fullfil this request,
 	// do not reserve the capacity. Users should provide a reference to a valid PodTemplate object.
 	// CA will check if there is enough capacity in cluster to fulfill the request and put
 	// the answer in 'CapacityAvailable' condition.
-	// * atomic-scale-up.kubernetes.io - provision the resources in an atomic manner.
+	// * best-effort-atomic-scale-up.autoscaling.x-k8s.io - provision the resources in an atomic manner.
 	// Users should provide a reference to a valid PodTemplate object.
 	// CA will try to create the VMs in an atomic manner, clean any partially provisioned VMs
 	// and re-try the operation in a exponential back-off manner. Users can configure the timeout
@@ -48,7 +48,7 @@ type ProvisioningRequestSpecApplyConfiguration struct {
 	// 'kubernetes.io' suffix is reserved for the modes defined in Kubernetes projects.
 	ProvisioningClassName *string `json:"provisioningClassName,omitempty"`
 	// Parameters contains all other parameters classes may require.
-	// 'atomic-scale-up.kubernetes.io' supports 'ValidUntilSeconds' parameter, which should contain
+	// 'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports 'ValidUntilSeconds' parameter, which should contain
 	// a string denoting duration for which we should retry (measured since creation fo the CR).
 	Parameters map[string]autoscalingxk8siov1.Parameter `json:"parameters,omitempty"`
 }

--- a/cluster-autoscaler/apis/provisioningrequest/client/applyconfiguration/autoscaling.x-k8s.io/v1beta1/provisioningrequestspec.go
+++ b/cluster-autoscaler/apis/provisioningrequest/client/applyconfiguration/autoscaling.x-k8s.io/v1beta1/provisioningrequestspec.go
@@ -34,11 +34,11 @@ type ProvisioningRequestSpecApplyConfiguration struct {
 	// ProvisioningClassName describes the different modes of provisioning the resources.
 	// Currently there is no support for 'ProvisioningClass' objects.
 	// Supported values:
-	// * check-capacity.kubernetes.io - check if current cluster state can fullfil this request,
+	// * check-capacity.autoscaling.x-k8s.io - check if current cluster state can fullfil this request,
 	// do not reserve the capacity. Users should provide a reference to a valid PodTemplate object.
 	// CA will check if there is enough capacity in cluster to fulfill the request and put
 	// the answer in 'CapacityAvailable' condition.
-	// * atomic-scale-up.kubernetes.io - provision the resources in an atomic manner.
+	// * best-effort-atomic-scale-up.autoscaling.x-k8s.io - provision the resources in an atomic manner.
 	// Users should provide a reference to a valid PodTemplate object.
 	// CA will try to create the VMs in an atomic manner, clean any partially provisioned VMs
 	// and re-try the operation in a exponential back-off manner. Users can configure the timeout
@@ -48,7 +48,7 @@ type ProvisioningRequestSpecApplyConfiguration struct {
 	// 'kubernetes.io' suffix is reserved for the modes defined in Kubernetes projects.
 	ProvisioningClassName *string `json:"provisioningClassName,omitempty"`
 	// Parameters contains all other parameters classes may require.
-	// 'atomic-scale-up.kubernetes.io' supports 'ValidUntilSeconds' parameter, which should contain
+	// 'best-effort-atomic-scale-up.autoscaling.x-k8s.io' supports 'ValidUntilSeconds' parameter, which should contain
 	// a string denoting duration for which we should retry (measured since creation fo the CR).
 	Parameters map[string]autoscalingxk8siov1beta1.Parameter `json:"parameters,omitempty"`
 }

--- a/cluster-autoscaler/proposals/provisioning-request.md
+++ b/cluster-autoscaler/proposals/provisioning-request.md
@@ -88,9 +88,9 @@ type ProvisioningRequestSpec struct {
 
 	// ProvisioningClass describes the different modes of provisioning the resources.
 	// Supported values:
-	// * check-capacity.kubernetes.io - check if current cluster state can fullfil this request,
+	// * check-capacity.autoscaling.x-k8s.io - check if current cluster state can fullfil this request,
 	//   do not reserve the capacity.
-	// * atomic-scale-up.kubernetes.io - provision the resources in an atomic manner
+	// * best-effort-atomic-scale-up.autoscaling.x-k8s.io - provision the resources in an atomic manner
     // * ... - potential other classes that are specific to the cloud providers
 	//
 	// +kubebuilder:validation:Required
@@ -152,18 +152,18 @@ type ProvisioningRequestStatus struct {
 
 ### Provisioning Classes
 
-#### check-capacity.kubernetes.io class
+#### check-capacity.autoscaling.x-k8s.io class
 
-The `check-capacity.kubernetes.io` is one-off check to verify that the in the cluster
+The `check-capacity.autoscaling.x-k8s.io` is one-off check to verify that the in the cluster
 there is enough capacity to provision given set of pods.
 
 Note: If two of such objects are created around the same time, CA will consider
 them independently and place no guards for the capacity.
 Also the capacity is not reserved in any manner so it may be scaled-down.
 
-#### atomic-scale-up.kubernetes.io class
+#### best-effort-atomic-scale-up.autoscaling.x-k8s.io class
 
-The `atomic-scale-up.kubernetes.io` aims to provision the resources required for the
+The `best-effort-atomic-scale-up.autoscaling.x-k8s.io` aims to provision the resources required for the
 specified pods in an atomic way. The proposed logic is to:
 1. Try to provision required VMs in one loop.
 2. If it failed, remove the partially provisioned VMs and back-off.
@@ -191,7 +191,7 @@ annotations:
 Previous prosoal included annotations with prefix `cluster-autoscaler.kubernetes.io`
 but were deprecated as part of API reivew.
 
-If those are provided for the pods that consume the ProvReq with `check-capacity.kubernetes.io` class,
+If those are provided for the pods that consume the ProvReq with `check-capacity.autoscaling.x-k8s.io` class,
 the CA will not provision the capacity, even if it was needed (as some other pods might have been
 scheduled on it) and will result in visibility events passed to the ProvReq and pods.
 If those are not passed the CA will behave normally and just provision the capacity if it needed.
@@ -281,9 +281,9 @@ loop. This will require changes in multiple parts of CA:
 The following e2e test scenarios will be created to check whether ProvReq
 handling works as expected:
 
-1.  A new ProvReq with `check-capacity.kubernetes.io` provisioning class is created, CA
+1.  A new ProvReq with `check-capacity.autoscaling.x-k8s.io` provisioning class is created, CA
     checks if there is enough capacity in cluster to provision specified pods.
-2.  A new ProvReq with `atomic-scale-up.kubernetes.io` provisioning class is created, CA
+2.  A new ProvReq with `best-effort-atomic-scale-up.autoscaling.x-k8s.io` provisioning class is created, CA
     picks an appropriate node group scales it up atomically.
 3.  A new atomic ProvReq is created for which a NAP needs to provision a new
     node group. NAP creates it CA scales it atomically.
@@ -311,7 +311,7 @@ which follows the same approach as
 [StorageClass object](https://kubernetes.io/docs/concepts/storage/storage-classes/).
 Such approach would allow administrators of the cluster to introduce a list of allowed
 ProvisioningClasses. Such CRD can also contain a pre set configuration, i.e.
-administrators may set that `atomic-scale-up.kubernetes.io` would retry up to `2h`.
+administrators may set that `best-effort-atomic-scale-up.autoscaling.x-k8s.io` would retry up to `2h`.
 
 Possible CRD definition:
 ```go


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

This change updates the docs and code docs to indicate the current names for the provisioning classes used by the ProvisioningClass resource. This change also updates the generated CRD manifest.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
