### PR TITLE
Implement graceful degradation mechanism for unschedulable pods

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -378,6 +378,10 @@ type AutoscalingOptions struct {
 	CapacityQuotasEnabled             bool
 	// ScaleUpSimulationForSkippedNodeGroupsEnabled is used to enable/disable the scaleUpSimulation for the skipped node groups
 	ScaleUpSimulationForSkippedNodeGroupsEnabled bool
+	// PendingPodsBatchingTimeout is the maximum time spends when running scheduling simulations when preparing the batch of pods passed to scale up logic. This timeout is used in core filter-out pod list processor.
+	PendingPodsBatchingTimeout time.Duration
+	// GracefulDegradationEnabled tells if graceful degradation for unschedulable pods is enabled.
+	GracefulDegradationEnabled bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -245,6 +245,8 @@ var (
 	maxNodeSkipEvalTimeTrackerEnabled            = flag.Bool("max-node-skip-eval-time-tracker-enabled", false, "Whether to enable the tracking of the maximum time of node being skipped during ScaleDown")
 	capacityQuotasEnabled                        = flag.Bool("capacity-quotas-enabled", false, "Whether to enable CapacityQuota CRD support.")
 	scaleUpSimulationForSkippedNodeGroupsEnabled = flag.Bool("scaleup-simulation-for-skipped-node-groups-enabled", false, "Whether to enable the scale up simulation for skipped node groups.")
+	pendingPodsBatchingTimeout                   = flag.Duration("pending-pods-batching-timeout", 4*time.Minute, "The maximum time spends when running scheduling simulations when preparing the batch of pods passed to scale up logic. This timeout is used in core filter-out pod list processor.")
+	enableGracefulDegradation                    = flag.Bool("enable-graceful-degradation", false, "Enables graceful degradation for unschedulable pods. When enabled, scheduling simulations during filter out pod list processor will be stopped after a timeout(specified by scheduling-simulation-timeout) and CA will proceed with a sub set of pods.")
 
 	// Deprecated flags
 	ignoreTaintsFlag           = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
@@ -464,6 +466,8 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MaxNodeSkipEvalTimeTrackerEnabled:            *maxNodeSkipEvalTimeTrackerEnabled,
 		CapacityQuotasEnabled:                        *capacityQuotasEnabled,
 		ScaleUpSimulationForSkippedNodeGroupsEnabled: *scaleUpSimulationForSkippedNodeGroupsEnabled,
+		PendingPodsBatchingTimeout:                   *pendingPodsBatchingTimeout,
+		GracefulDegradationEnabled:                   *enableGracefulDegradation,
 	}
 }
 

--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -77,6 +77,9 @@ type AutoscalingContext struct {
 	TemplateNodeInfoRegistry TemplateNodeInfoRegistry
 	// CsiProvider is the provider for CSI node aware scheduling.
 	CsiProvider *csinodeprovider.Provider
+	// GracefulDegradationLoopCount counts the number of subsequent CA loops where graceful degradation is active.
+	// GracefulDegradationLoopCount > 0 iff Cluster Autoscaler is running in a degraded mode.
+	GracefulDegradationLoopCount int
 }
 
 // TemplateNodeInfoRegistry is the interface for getting template node infos.

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable.go
@@ -17,6 +17,8 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
+	"fmt"
 	"sort"
 	"time"
 
@@ -29,6 +31,10 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	klog "k8s.io/klog/v2"
+)
+
+const (
+	requestor = "filter-out-pod-list-processor"
 )
 
 type filterOutSchedulablePodListProcessor struct {
@@ -65,7 +71,7 @@ func (p *filterOutSchedulablePodListProcessor) Process(autoscalingCtx *ca_contex
 	klog.V(4).Infof("Filtering out schedulables")
 	filterOutSchedulableStart := time.Now()
 
-	unschedulablePodsToHelp, err := p.filterOutSchedulableByPacking(unschedulablePods, autoscalingCtx.ClusterSnapshot)
+	unschedulablePodsToHelp, err := p.filterOutSchedulableByPacking(autoscalingCtx, unschedulablePods, autoscalingCtx.ClusterSnapshot)
 
 	if err != nil {
 		return nil, err
@@ -94,32 +100,51 @@ func (p *filterOutSchedulablePodListProcessor) CleanUp() {
 // unschedulable can be scheduled on free capacity on existing nodes by trying to pack the pods. It
 // tries to pack the higher priority pods first. It takes into account pods that are bound to node
 // and will be scheduled after lower priority pod preemption.
-func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(unschedulableCandidates []*apiv1.Pod, clusterSnapshot clustersnapshot.ClusterSnapshot) ([]*apiv1.Pod, error) {
+func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(autoscalingCtx *ca_context.AutoscalingContext, unschedulableCandidates []*apiv1.Pod, clusterSnapshot clustersnapshot.ClusterSnapshot) ([]*apiv1.Pod, error) {
 	// Sort unschedulable pods by importance
 	sort.Slice(unschedulableCandidates, func(i, j int) bool {
 		return corev1helpers.PodPriority(unschedulableCandidates[i]) > corev1helpers.PodPriority(unschedulableCandidates[j])
 	})
 
-	statuses, overflowingControllerCount, err := p.schedulingSimulator.TrySchedulePods(clusterSnapshot, unschedulableCandidates, false, clustersnapshot.SchedulingOptions{IsNodeAcceptable: p.nodeFilter})
+	var cancel context.CancelFunc
+	ctx := context.WithValue(context.Background(), scheduling.SimulationRequestorName, requestor)
+	if autoscalingCtx.GracefulDegradationEnabled {
+		ctx, cancel = context.WithTimeout(ctx, autoscalingCtx.PendingPodsBatchingTimeout)
+		defer cancel()
+	}
+
+	schedulingResult, err := p.schedulingSimulator.TrySchedulePods(ctx, clusterSnapshot, unschedulableCandidates, false, clustersnapshot.SchedulingOptions{IsNodeAcceptable: p.nodeFilter})
+
+	manageGracefulDegradation(autoscalingCtx, schedulingResult)
+
 	if err != nil {
 		return nil, err
 	}
 
 	scheduledPods := make(map[types.UID]bool)
-	for _, status := range statuses {
+	for _, status := range schedulingResult.Statuses {
 		scheduledPods[status.Pod.UID] = true
+	}
+
+	unprocessedPodsMap := make(map[types.UID]bool)
+	for _, pod := range schedulingResult.UnprocessedPods {
+		unprocessedPodsMap[pod.UID] = true
 	}
 
 	// Pods that remain unschedulable
 	var unschedulablePods []*apiv1.Pod
 	for _, pod := range unschedulableCandidates {
-		if !scheduledPods[pod.UID] {
+		if !scheduledPods[pod.UID] && !unprocessedPodsMap[pod.UID] {
 			unschedulablePods = append(unschedulablePods, pod)
 		}
 	}
 
-	metrics.UpdateOverflowingControllers(overflowingControllerCount)
-	klog.V(4).Infof("%v pods marked as unschedulable can be scheduled.", len(unschedulableCandidates)-len(unschedulablePods))
+	metrics.UpdateOverflowingControllers(schedulingResult.OverflowingControllerCount)
+	skippedPodCountMsg := ""
+	if len(schedulingResult.UnprocessedPods) > 0 {
+		skippedPodCountMsg = fmt.Sprintf(" %v pods were skipped due to exceeding pending pod batching timeout.", len(schedulingResult.UnprocessedPods))
+	}
+	klog.V(4).Infof("%v pods marked as unschedulable can be scheduled.%s", len(unschedulableCandidates)-len(unschedulablePods)-len(schedulingResult.UnprocessedPods), skippedPodCountMsg)
 
 	p.schedulingSimulator.DropOldHints()
 	return unschedulablePods, nil
@@ -137,4 +162,25 @@ func findSchedulablePods(allUnschedulablePods, podsStillUnschedulable []*apiv1.P
 		}
 	}
 	return schedulablePods
+}
+
+func manageGracefulDegradation(autoscalingCtx *ca_context.AutoscalingContext, schedulingResult scheduling.Result) {
+	metrics.UpdateSkippedPodsCount(len(schedulingResult.UnprocessedPods), requestor)
+
+	if !autoscalingCtx.GracefulDegradationEnabled {
+		return
+	}
+
+	if len(schedulingResult.UnprocessedPods) > 0 {
+		if autoscalingCtx.GracefulDegradationLoopCount == 0 {
+			autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "GracefulDegradationStarted", "Autoscaler is unable to handle the large amount of unschedulable pods. Consider reducing the rate of adding new pods, so autoscaler could auto recover.")
+		}
+		autoscalingCtx.GracefulDegradationLoopCount += 1
+		return
+	}
+
+	if autoscalingCtx.GracefulDegradationLoopCount > 0 {
+		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "GracefulDegradationStopped", "Autoscaler exited from GracefulDegradationMode and works normally.")
+	}
+	autoscalingCtx.GracefulDegradationLoopCount = 0
 }

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
@@ -30,6 +33,8 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestFilterOutSchedulable(t *testing.T) {
@@ -191,7 +196,7 @@ func TestFilterOutSchedulable(t *testing.T) {
 			clusterSnapshot.Fork()
 
 			processor := NewFilterOutSchedulablePodListProcessor(tc.nodeFilter)
-			unschedulablePods, err := processor.filterOutSchedulableByPacking(tc.unschedulableCandidates, clusterSnapshot)
+			unschedulablePods, err := processor.filterOutSchedulableByPacking(&ca_context.AutoscalingContext{}, tc.unschedulableCandidates, clusterSnapshot)
 
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, unschedulablePods, tc.expectedUnscheduledPods, "unschedulable pods differ")
@@ -288,7 +293,7 @@ func BenchmarkFilterOutSchedulable(b *testing.B) {
 
 				for i := 0; i < b.N; i++ {
 					processor := NewFilterOutSchedulablePodListProcessor(scheduling.ScheduleAnywhere)
-					if stillPending, err := processor.filterOutSchedulableByPacking(pendingPods, clusterSnapshot); err != nil {
+					if stillPending, err := processor.filterOutSchedulableByPacking(&ca_context.AutoscalingContext{}, pendingPods, clusterSnapshot); err != nil {
 						assert.NoError(b, err)
 					} else if len(stillPending) < tc.pendingPods {
 						assert.Equal(b, len(stillPending), tc.pendingPods)
@@ -309,4 +314,120 @@ func buildPriorityTestPod(name string, cpu, mem int64, priority int32) *apiv1.Po
 	pod := BuildTestPod(name, cpu, mem)
 	pod.Spec.Priority = &priority
 	return pod
+}
+
+func TestFilterOutSchedulable_GracefulDegradation(t *testing.T) {
+	node := buildReadyTestNode("node", 2000, 100)
+
+	testCases := []struct {
+		desc                       string
+		unschedulableCandidates    []*apiv1.Pod
+		expectedUnscheduled        []*apiv1.Pod
+		expectedScheduled          []*apiv1.Pod
+		initialModeActive          bool
+		initialLoopCount           int
+		expectedModeActive         bool
+		expectedLoopCount          int
+		simulationTimeout          time.Duration
+		gracefulDegradationEnabled bool
+	}{
+		{
+			desc: "graceful degradation enabled, negative timeout",
+			unschedulableCandidates: []*apiv1.Pod{
+				BuildTestPod("pod1", 500, 10),
+				BuildTestPod("pod2", 500, 10),
+			},
+			expectedUnscheduled:        []*apiv1.Pod{},
+			expectedScheduled:          []*apiv1.Pod{},
+			initialModeActive:          false,
+			initialLoopCount:           0,
+			expectedModeActive:         true,
+			expectedLoopCount:          1,
+			simulationTimeout:          -1 * time.Minute,
+			gracefulDegradationEnabled: true,
+		},
+		{
+			desc: "degradation enabled, zero timeout",
+			unschedulableCandidates: []*apiv1.Pod{
+				BuildTestPod("pod1", 500, 10),
+			},
+			expectedUnscheduled:        []*apiv1.Pod{},
+			expectedScheduled:          []*apiv1.Pod{},
+			initialModeActive:          false,
+			initialLoopCount:           1,
+			expectedModeActive:         true,
+			expectedLoopCount:          2,
+			simulationTimeout:          0,
+			gracefulDegradationEnabled: true,
+		},
+		{
+			desc: "degradation enabled, normal operation",
+			unschedulableCandidates: []*apiv1.Pod{
+				BuildTestPod("pod1", 500, 10),
+			},
+			expectedUnscheduled: []*apiv1.Pod{},
+			expectedScheduled: []*apiv1.Pod{
+				BuildTestPod("pod1", 500, 10),
+			},
+			initialModeActive:          true,
+			initialLoopCount:           5,
+			expectedModeActive:         false,
+			expectedLoopCount:          0,
+			simulationTimeout:          4 * time.Minute,
+			gracefulDegradationEnabled: true,
+		},
+		{
+			desc: "degradation disabled, negative timeout",
+			unschedulableCandidates: []*apiv1.Pod{
+				BuildTestPod("pod1", 500, 10),
+			},
+			expectedUnscheduled: []*apiv1.Pod{},
+			expectedScheduled: []*apiv1.Pod{
+				BuildTestPod("pod1", 500, 10),
+			},
+			initialModeActive:          false,
+			initialLoopCount:           0,
+			expectedModeActive:         false,
+			expectedLoopCount:          0,
+			simulationTimeout:          -1 * time.Minute,
+			gracefulDegradationEnabled: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			clusterSnapshot := testsnapshot.NewTestSnapshotOrDie(t)
+			err := clusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node, []*apiv1.Pod{}...))
+			assert.NoError(t, err)
+			clusterSnapshot.Fork()
+
+			ctx := context.Background()
+			opts := config.AutoscalingOptions{PendingPodsBatchingTimeout: tc.simulationTimeout}
+			fakeClientSet := fake.NewSimpleClientset()
+			fakeInformerFactory := informers.NewSharedInformerFactory(fakeClientSet, 0)
+			kubeClients := ca_context.NewAutoscalingKubeClients(ctx, opts, fakeClientSet, fakeInformerFactory)
+
+			autoscalingCtx := ca_context.NewAutoscalingContext(opts, nil, clusterSnapshot, kubeClients, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			autoscalingCtx.GracefulDegradationEnabled = tc.gracefulDegradationEnabled
+			autoscalingCtx.GracefulDegradationLoopCount = tc.initialLoopCount
+
+			processor := NewFilterOutSchedulablePodListProcessor(func(*framework.NodeInfo) bool { return true })
+			unschedulablePods, err := processor.filterOutSchedulableByPacking(autoscalingCtx, tc.unschedulableCandidates, clusterSnapshot)
+
+			assert.NoError(t, err, "filterOutSchedulableByPacking() should not return an error")
+			assert.ElementsMatch(t, tc.expectedUnscheduled, unschedulablePods, "Unexpected unscheduled pods")
+
+			nodeInfos, err := clusterSnapshot.ListNodeInfos()
+			assert.NoError(t, err)
+			var scheduledPods []*apiv1.Pod
+			for _, nodeInfo := range nodeInfos {
+				for _, podInfo := range nodeInfo.Pods() {
+					scheduledPods = append(scheduledPods, podInfo.Pod)
+				}
+			}
+			assert.ElementsMatch(t, tc.expectedScheduled, scheduledPods, "Unexpected scheduled pods")
+
+			assert.Equal(t, tc.expectedLoopCount, autoscalingCtx.GracefulDegradationLoopCount, "Unexpected GracefulDegradationLoopCount")
+		})
+	}
 }

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -17,6 +17,7 @@ limitations under the License.
 package planner
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -271,12 +272,13 @@ func (p *Planner) injectPods(pods []*apiv1.Pod) error {
 	pods = pod_util.ClearPodNodeNames(pods)
 	// Note: We're using ScheduleAnywhere, but the pods won't schedule back
 	// on the drained nodes due to taints.
-	statuses, _, err := p.actuationInjector.TrySchedulePods(p.autoscalingCtx.ClusterSnapshot, pods, true, clustersnapshot.SchedulingOptions{IsNodeAcceptable: scheduling.ScheduleAnywhere})
+	schedulingResult, err := p.actuationInjector.TrySchedulePods(context.Background(), p.autoscalingCtx.ClusterSnapshot, pods, true, clustersnapshot.SchedulingOptions{IsNodeAcceptable: scheduling.ScheduleAnywhere})
+
 	if err != nil {
 		return fmt.Errorf("cannot scale down, an unexpected error occurred: %v", err)
 	}
-	if len(statuses) != len(pods) {
-		return fmt.Errorf("can reschedule only %d out of %d pods from ongoing deletions", len(statuses), len(pods))
+	if len(schedulingResult.Statuses) != len(pods) {
+		return fmt.Errorf("can reschedule only %d out of %d pods from ongoing deletions", len(schedulingResult.Statuses), len(pods))
 	}
 	return nil
 }

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -82,6 +82,15 @@ const (
 	// The idea is that nodes with GPU are very expensive and we're ready to sacrifice
 	// a bit more latency to wait for more pods and make a more informed scale-up decision.
 	unschedulablePodWithGpuTimeBuffer = 30 * time.Second
+	// Number of autoscaler loops in a graceful degradation cycle.
+	// When autoscaler is unable to handle a large number of pending pods, when attempting to
+	// run scheduling simulations, autoscaler enters to a graceful degradation mode.
+	// When graceful degradation mode is active, autoscaler does scale ups and scale downs in
+	// alternative loops so scale down is not starved because of scale ups. Sometimes
+	// scale up could be blocked due to scale down as well. When graceful degradation
+	// mode is active every 4th loop is dedicated for scale down and the other loops
+	// are dedicated for scale up.
+	gracefulDegradationCycle = 4
 )
 
 // StaticAutoscaler is an autoscaler which has all the core functionality of a CA but without the reconfiguration feature
@@ -536,46 +545,14 @@ func (a *StaticAutoscaler) RunOnce(ctx context.Context, currentTime time.Time) c
 	// finally, filter out pods that are too "young" to safely be considered for a scale-up (delay is configurable)
 	unschedulablePodsToHelp = a.filterOutYoungPods(unschedulablePodsToHelp, currentTime)
 
-	shouldScaleUp := true
-
-	if len(unschedulablePodsToHelp) == 0 {
-		scaleUpStatus.Result = status.ScaleUpNotNeeded
-		klog.V(1).Info("No unschedulable pods")
-		shouldScaleUp = false
-	} else if a.MaxNodesTotal > 0 && len(readyNodes) >= a.MaxNodesTotal {
-		scaleUpStatus.Result = status.ScaleUpLimitedByMaxNodesTotal
-		klog.Warningf("Max total nodes in cluster reached: %v. Current number of ready nodes: %v", a.MaxNodesTotal, len(readyNodes))
-		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "MaxNodesTotalReached",
-			"Max total nodes in cluster reached: %v", autoscalingCtx.MaxNodesTotal)
-		shouldScaleUp = false
-
-		noScaleUpInfoForPods := []status.NoScaleUpInfo{}
-		for _, pod := range unschedulablePodsToHelp {
-			noScaleUpInfo := status.NoScaleUpInfo{
-				Pod: pod,
-			}
-			noScaleUpInfoForPods = append(noScaleUpInfoForPods, noScaleUpInfo)
-		}
-		scaleUpStatus.PodsRemainUnschedulable = noScaleUpInfoForPods
-	} else if len(a.BypassedSchedulers) == 0 && allPodsAreNew(unschedulablePodsToHelp, currentTime) {
-		// The assumption here is that these pods have been created very recently and probably there
-		// is more pods to come. In theory we could check the newest pod time but then if pod were created
-		// slowly but at the pace of 1 every 2 seconds then no scale up would be triggered for long time.
-		// We also want to skip a real scale down (just like if the pods were handled).
-		// This logic only makes sense if CA is not trying to react quickly
-		// by bypassing scheduler marking pods as unschedulable.
-		a.processorCallbacks.DisableScaleDownForLoop()
-		scaleUpStatus.Result = status.ScaleUpInCooldown
-		klog.V(1).Info("Unschedulable pods are very new, waiting one iteration for more")
-		shouldScaleUp = false
-	}
+	shouldScaleUp, scaleUpStatus := a.shouldScaleUp(unschedulablePodsToHelp, scaleUpStatus, readyNodes, currentTime)
 
 	if err := ctx.Err(); err != nil {
 		klog.V(0).Infof("Skipping scale-up/scale-down, context cancelled: %v", err)
 		return nil
 	}
 
-	if shouldScaleUp || a.processors.ScaleUpEnforcer.ShouldForceScaleUp(unschedulablePodsToHelp) {
+	if shouldScaleUp {
 		scaleUpTriggered = true
 		nodes := make([]*apiv1.Node, len(allNodeInfos))
 		for i, nodeInfo := range allNodeInfos {
@@ -606,7 +583,7 @@ func (a *StaticAutoscaler) RunOnce(ctx context.Context, currentTime time.Time) c
 		}
 	}
 
-	if a.ScaleDownEnabled {
+	if a.shouldScaleDown() {
 		if typedErr = a.scaleDown(currentTime, allNodes, scaleDownActuationStatus, scaleDownStatus); typedErr != nil {
 			return typedErr
 		}
@@ -626,6 +603,50 @@ func (a *StaticAutoscaler) RunOnce(ctx context.Context, currentTime time.Time) c
 	}
 
 	return nil
+}
+
+func (a *StaticAutoscaler) shouldScaleUp(unschedulablePodsToHelp []*apiv1.Pod, scaleUpStatus *status.ScaleUpStatus, readyNodes []*apiv1.Node, currentTime time.Time) (bool, *status.ScaleUpStatus) {
+	shouldScaleUp := true
+	if len(unschedulablePodsToHelp) == 0 {
+		scaleUpStatus.Result = status.ScaleUpNotNeeded
+		klog.V(1).Info("No unschedulable pods")
+		shouldScaleUp = false
+	} else if a.MaxNodesTotal > 0 && len(readyNodes) >= a.MaxNodesTotal {
+		scaleUpStatus.Result = status.ScaleUpLimitedByMaxNodesTotal
+		klog.Warningf("Max total nodes in cluster reached: %v. Current number of ready nodes: %v", a.MaxNodesTotal, len(readyNodes))
+		a.LogRecorder.Eventf(apiv1.EventTypeWarning, "MaxNodesTotalReached",
+			"Max total nodes in cluster reached: %v", a.MaxNodesTotal)
+		shouldScaleUp = false
+
+		noScaleUpInfoForPods := []status.NoScaleUpInfo{}
+		for _, pod := range unschedulablePodsToHelp {
+			noScaleUpInfo := status.NoScaleUpInfo{
+				Pod: pod,
+			}
+			noScaleUpInfoForPods = append(noScaleUpInfoForPods, noScaleUpInfo)
+		}
+		scaleUpStatus.PodsRemainUnschedulable = noScaleUpInfoForPods
+	} else if len(a.BypassedSchedulers) == 0 && allPodsAreNew(unschedulablePodsToHelp, currentTime) {
+		// The assumption here is that these pods have been created very recently and probably there
+		// is more pods to come. In theory, we could check the newest pod time but then if pod were created
+		// slowly but at the pace of 1 every 2 seconds then no scale up would be triggered for long time.
+		// We also want to skip a real scale down (just like if the pods were handled).
+		// This logic only makes sense if CA is not trying to react quickly
+		// by bypassing scheduler marking pods as unschedulable.
+		a.processorCallbacks.DisableScaleDownForLoop()
+		scaleUpStatus.Result = status.ScaleUpInCooldown
+		klog.V(1).Info("Unschedulable pods are very new, waiting one iteration for more")
+		shouldScaleUp = false
+	}
+
+	shouldScaleUp = shouldScaleUp || a.processors.ScaleUpEnforcer.ShouldForceScaleUp(unschedulablePodsToHelp)
+
+	if a.GracefulDegradationEnabled && a.GracefulDegradationLoopCount > 0 && a.GracefulDegradationLoopCount%gracefulDegradationCycle == 0 {
+		shouldScaleUp = false
+		scaleUpStatus.Result = status.ScaleUpInCooldown
+	}
+
+	return shouldScaleUp, scaleUpStatus
 }
 
 // instrumentedScaleUp handles a single ScaleUp orchestrator call with metrics and status reporting.
@@ -752,6 +773,7 @@ func (a *StaticAutoscaler) updateSoftDeletionTaints(allNodes []*apiv1.Node) {
 }
 
 func (a *StaticAutoscaler) scaleDown(currentTime time.Time, allNodes []*apiv1.Node, scaleDownActuationStatus scaledown.ActuationStatus, scaleDownStatus *scaledownstatus.ScaleDownStatus) caerrors.AutoscalerError {
+
 	unneededStart := time.Now()
 
 	klog.V(4).Infof("Calculating unneeded nodes")
@@ -1409,4 +1431,12 @@ func listPods(podLister kube_util.PodLister, bypassedSchedulers, allowedSchedule
 			initialPodCount, len(podsBySchedulability.Scheduled), len(podsBySchedulability.NominatedNode), len(podsBySchedulability.Unschedulable), len(podsBySchedulability.Unprocessed), ignored, ignoredDueToDisallowed)
 	}
 	return
+}
+
+func (a *StaticAutoscaler) shouldScaleDown() bool {
+	if !a.ScaleDownEnabled {
+		return false
+	}
+	// When GracefulDegradationMode is active, autoscaler does scale down only on every 4th(gracefulDegradationCycle th) loop.
+	return !(a.AutoscalingContext.GracefulDegradationEnabled && a.AutoscalingContext.GracefulDegradationLoopCount > 0 && a.AutoscalingContext.GracefulDegradationLoopCount%gracefulDegradationCycle != 0)
 }

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -3917,3 +3917,99 @@ func TestStaticAutoscalerScaleDownCustomQuota(t *testing.T) {
 		assert.Equal(t, simulator.MinimalResourceLimitExceeded, unremovableNode.Reason)
 	}
 }
+
+func TestShouldScaleDown(t *testing.T) {
+	now := time.Now()
+	underutilizedNode := BuildTestNode("underutilized-node", 1000, 1000)
+	SetNodeReadyState(underutilizedNode, true, now)
+
+	testCases := []struct {
+		name                         string
+		scaleDownEnabled             bool
+		gracefulDegradationEnabled   bool
+		gracefulDegradationLoopCount int
+		wantScaleDownAttempt         bool
+	}{
+		{
+			name:                 "scale down disabled",
+			wantScaleDownAttempt: false,
+		},
+		{
+			name:                       "scale down enabled, gracefulDegradation disabled",
+			scaleDownEnabled:           true,
+			gracefulDegradationEnabled: false,
+			wantScaleDownAttempt:       true,
+		},
+		{
+			name:                         "scale down enabled, gracefulDegradation enabled, graceful degradation not active",
+			scaleDownEnabled:             true,
+			gracefulDegradationEnabled:   true,
+			gracefulDegradationLoopCount: 0,
+			wantScaleDownAttempt:         true,
+		},
+		{
+			name:                         "scale down enabled, gracefulDegradation enabled, graceful degradation active, not a scale down loop",
+			scaleDownEnabled:             true,
+			gracefulDegradationEnabled:   true,
+			gracefulDegradationLoopCount: 5,
+			wantScaleDownAttempt:         false,
+		},
+		{
+			name:                         "scale down enabled, gracefulDegradation enabled, graceful degradation active, scale down loop",
+			scaleDownEnabled:             true,
+			gracefulDegradationEnabled:   true,
+			gracefulDegradationLoopCount: 8,
+			wantScaleDownAttempt:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mocks := newCommonMocks()
+			setupConfig := &autoscalerSetupConfig{
+				autoscalingOptions: config.AutoscalingOptions{
+					ScaleDownEnabled:           tc.scaleDownEnabled,
+					GracefulDegradationEnabled: tc.gracefulDegradationEnabled,
+					NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+						ScaleDownUnneededTime:         0 * time.Second,
+						ScaleDownUtilizationThreshold: 0.5,
+					},
+					MaxNodesTotal: 10,
+				},
+				nodeGroups: []*nodeGroup{{
+					name:     "ng1",
+					min:      0,
+					max:      10,
+					nodes:    []*apiv1.Node{underutilizedNode},
+					template: framework.NewTestNodeInfo(BuildTestNode("template-node", 1000, 1000)),
+				}},
+				nodeStateUpdateTime: now,
+				mocks:               mocks,
+				nodesDeleted:        make(chan bool, 1),
+			}
+
+			autoscaler, err := setupAutoscaler(setupConfig)
+			assert.NoError(t, err)
+			autoscaler.GracefulDegradationLoopCount = tc.gracefulDegradationLoopCount
+			autoscaler.initialized = true
+
+			mocks.allPodLister.On("List").Return([]*apiv1.Pod{}, nil)
+			mocks.daemonSetLister.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil)
+			mocks.podDisruptionBudgetLister.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil)
+			mocks.readyNodeLister.SetNodes([]*apiv1.Node{underutilizedNode})
+			mocks.allNodeLister.SetNodes([]*apiv1.Node{underutilizedNode})
+
+			mocks.onScaleDown.On("ScaleDown", "ng1", underutilizedNode.Name).Return(nil).Maybe()
+
+			err = autoscaler.RunOnce(context.Background(), now.Add(2*time.Minute))
+			assert.NoError(t, err)
+
+			if tc.wantScaleDownAttempt {
+				waitForDeleteToFinish(t, setupConfig.nodesDeleted)
+				mocks.onScaleDown.AssertCalled(t, "ScaleDown", "ng1", underutilizedNode.Name)
+			} else {
+				mocks.onScaleDown.AssertNotCalled(t, "ScaleDown", "ng1", underutilizedNode.Name)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -257,3 +257,8 @@ func UpdateScaleDownNodeRemovalLatency(deleted bool, delayReason string, duratio
 func ObserveMaxNodeSkipEvalDurationSeconds(duration time.Duration) {
 	DefaultMetrics.ObserveMaxNodeSkipEvalDurationSeconds(duration)
 }
+
+// UpdateSkippedPodsCount records the number of pods skipped when doing scheduling simulations.
+func UpdateSkippedPodsCount(podsCount int, label string) {
+	DefaultMetrics.UpdateSkippedPodsCount(podsCount, label)
+}

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -158,6 +158,7 @@ type caMetrics struct {
 	nodesGroupTargetSize   *k8smetrics.GaugeVec
 	nodesGroupHealthiness  *k8smetrics.GaugeVec
 	nodeGroupBackOffStatus *k8smetrics.GaugeVec
+	skippedPodsCounts      *k8smetrics.GaugeVec
 
 	// Metrics related to autoscaler execution
 	lastActivity            *k8smetrics.GaugeVec
@@ -538,6 +539,14 @@ func newCaMetrics() *caMetrics {
 				Help:      "Count of resource mismatches between ready nodes and node templates",
 			}, []string{"driver", "mismatch_type"},
 		),
+
+		skippedPodsCounts: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Namespace: caNamespace,
+				Name:      "skipped_pods_count",
+				Help:      "Number of pods where scheduling simulation was skipped.",
+			}, []string{"requestor"},
+		),
 	}
 }
 
@@ -555,6 +564,7 @@ func (m *caMetrics) RegisterAll(emitPerNodeGroupMetrics bool) {
 	m.mustRegister(m.nodesCount)
 	m.mustRegister(m.nodeGroupsCount)
 	m.mustRegister(m.unschedulablePodsCount)
+	m.mustRegister(m.skippedPodsCounts)
 	m.mustRegister(m.maxNodesCount)
 	m.mustRegister(m.cpuCurrentCores)
 	m.mustRegister(m.cpuLimitsCores)
@@ -920,4 +930,9 @@ func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, delayReason 
 // If a node is skipped multiple times consecutively, we store only the earliest timestamp.
 func (m *caMetrics) ObserveMaxNodeSkipEvalDurationSeconds(duration time.Duration) {
 	m.maxNodeSkipEvalDurationSeconds.Set(duration.Seconds())
+}
+
+// UpdateSkippedPodsCount records the number of pods skipped when doing scheduling simulations.
+func (m *caMetrics) UpdateSkippedPodsCount(podsCount int, label string) {
+	m.skippedPodsCounts.WithLabelValues(label).Set(float64(podsCount))
 }

--- a/cluster-autoscaler/processors/provreq/processor.go
+++ b/cluster-autoscaler/processors/provreq/processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provreq
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -45,7 +46,7 @@ const (
 )
 
 type injector interface {
-	TrySchedulePods(clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) ([]scheduling.Status, int, error)
+	TrySchedulePods(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) (scheduling.Result, error)
 }
 
 type provReqProcessor struct {
@@ -185,7 +186,7 @@ func (p *provReqProcessor) bookCapacity(autoscalingCtx *ca_context.AutoscalingCo
 		return nil
 	}
 	// Scheduling the pods to reserve capacity for provisioning request.
-	if _, _, err = p.injector.TrySchedulePods(autoscalingCtx.ClusterSnapshot, podsToCreate, false, clustersnapshot.SchedulingOptions{}); err != nil {
+	if _, err = p.injector.TrySchedulePods(context.Background(), autoscalingCtx.ClusterSnapshot, podsToCreate, false, clustersnapshot.SchedulingOptions{}); err != nil {
 		return err
 	}
 	return nil

--- a/cluster-autoscaler/processors/provreq/processor_test.go
+++ b/cluster-autoscaler/processors/provreq/processor_test.go
@@ -234,9 +234,9 @@ type fakeInjector struct {
 	pods []*apiv1.Pod
 }
 
-func (f *fakeInjector) TrySchedulePods(clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) ([]scheduling.Status, int, error) {
+func (f *fakeInjector) TrySchedulePods(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) (scheduling.Result, error) {
 	f.pods = pods
-	return nil, 0, nil
+	return scheduling.Result{}, nil
 }
 
 func TestBookCapacity(t *testing.T) {

--- a/cluster-autoscaler/processors/test/common.go
+++ b/cluster-autoscaler/processors/test/common.go
@@ -17,6 +17,8 @@ limitations under the License.
 package test
 
 import (
+	"time"
+
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/podlistprocessor"
@@ -41,6 +43,10 @@ import (
 func NewTestProcessors(options config.AutoscalingOptions) (*processors.AutoscalingProcessors, ca_context.TemplateNodeInfoRegistry) {
 	templateNodeInfoProvider := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false)
 	templateNodeInfoRegistry := nodeinfosprovider.NewTemplateNodeInfoRegistry(templateNodeInfoProvider)
+	if options.PendingPodsBatchingTimeout == 0 {
+		// This disables graceful degradation in tests if not set explicitly.
+		options.PendingPodsBatchingTimeout = 24 * time.Hour
+	}
 
 	return &processors.AutoscalingProcessors{
 		PodListProcessor:       podlistprocessor.NewDefaultPodListProcessor(scheduling.ScheduleAnywhere),

--- a/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
+++ b/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
@@ -17,6 +17,8 @@ limitations under the License.
 package besteffortatomic
 
 import (
+	"context"
+
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,13 +140,13 @@ func (o *bestEffortAtomicProvClass) Provision(
 }
 
 func (o *bestEffortAtomicProvClass) filterOutSchedulable(pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
-	statuses, _, err := o.injector.TrySchedulePods(o.autoscalingCtx.ClusterSnapshot, pods, false, clustersnapshot.SchedulingOptions{})
+	schedulingResult, err := o.injector.TrySchedulePods(context.Background(), o.autoscalingCtx.ClusterSnapshot, pods, false, clustersnapshot.SchedulingOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	scheduledPods := make(map[types.UID]bool)
-	for _, status := range statuses {
+	for _, status := range schedulingResult.Statuses {
 		scheduledPods[status.Pod.UID] = true
 	}
 

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -17,6 +17,7 @@ limitations under the License.
 package checkcapacity
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -178,8 +179,8 @@ func (o *checkCapacityProvClass) checkCapacity(unschedulablePods []*apiv1.Pod, p
 	o.autoscalingCtx.ClusterSnapshot.Fork()
 
 	// Case 1: Capacity fits.
-	scheduled, _, err := o.schedulingSimulator.TrySchedulePods(o.autoscalingCtx.ClusterSnapshot, unschedulablePods, true, clustersnapshot.SchedulingOptions{})
-	if err == nil && len(scheduled) == len(unschedulablePods) {
+	schedulingResult, err := o.schedulingSimulator.TrySchedulePods(context.Background(), o.autoscalingCtx.ClusterSnapshot, unschedulablePods, true, clustersnapshot.SchedulingOptions{})
+	if err == nil && len(schedulingResult.Statuses) == len(unschedulablePods) {
 		commitError := o.autoscalingCtx.ClusterSnapshot.Commit()
 		if commitError != nil {
 			o.autoscalingCtx.ClusterSnapshot.Revert()

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -259,12 +260,12 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
 		newpods = append(newpods, &newpod)
 	}
 
-	statuses, _, err := r.schedulingSimulator.TrySchedulePods(r.clusterSnapshot, newpods, true, clustersnapshot.SchedulingOptions{IsNodeAcceptable: isCandidateNode})
+	schedulingResult, err := r.schedulingSimulator.TrySchedulePods(context.Background(), r.clusterSnapshot, newpods, true, clustersnapshot.SchedulingOptions{IsNodeAcceptable: isCandidateNode})
 	if err != nil {
 		return err
 	}
-	if len(statuses) != len(newpods) {
-		return fmt.Errorf("can reschedule only %d out of %d pods", len(statuses), len(newpods))
+	if len(schedulingResult.Statuses) != len(newpods) {
+		return fmt.Errorf("can reschedule only %d out of %d pods", len(schedulingResult.Statuses), len(newpods))
 	}
 
 	// After successful scheduling simulation, remove the tainted ghost node so that

--- a/cluster-autoscaler/simulator/scheduling/hinting_simulator.go
+++ b/cluster-autoscaler/simulator/scheduling/hinting_simulator.go
@@ -17,11 +17,22 @@ limitations under the License.
 package scheduling
 
 import (
+	"context"
+	"errors"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/klogx"
+	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 
 	apiv1 "k8s.io/api/core/v1"
+)
+
+const (
+	// SimulationRequestorName is the key for simulation requestor.
+	SimulationRequestorName = "requestor"
 )
 
 // Status contains information about pods scheduled by the HintingSimulator
@@ -42,42 +53,117 @@ func NewHintingSimulator() *HintingSimulator {
 	}
 }
 
+// Result contains the results after scheduling simulations.
+type Result struct {
+	Statuses                   []Status
+	UnprocessedPods            []*apiv1.Pod
+	OverflowingControllerCount int
+}
+
 // TrySchedulePods attempts to schedule provided pods on any acceptable nodes.
 // Each node is considered acceptable iff isNodeAcceptable() returns true.
-// Returns a list of scheduled pods with assigned pods and the count of overflowing
-// controllers, or an error if an unexpected error occurs.
+// Returns a Result object consisting list of scheduled pods with assigned pods,
+// a list of unprocessed pods from simulations due to exceeding the context deadline
+// and the count of overflowing controllers, or an error if an unexpected error occurs.
 // If the breakOnFailure is set to true, the function will stop scheduling attempts
 // after the first scheduling attempt that fails. This is useful if all provided
 // pods need to be scheduled.
 // Note: this function does not fork clusterSnapshot: this has to be done by the caller.
-func (s *HintingSimulator) TrySchedulePods(clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) ([]Status, int, error) {
+// Simulations may stop early if the context deadline has passed.
+func (s *HintingSimulator) TrySchedulePods(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) (Result, error) {
 	similarPods := NewSimilarPodsScheduling()
 
 	var statuses []Status
 	loggingQuota := klogx.PodsLoggingQuota()
+	unschedulablePods := make(map[types.UID]bool)
+
+	for _, podGroup := range groupByPriority(pods) {
+		podsWithoutHints, groupStatuses, err := s.tryScheduleWithHints(ctx, clusterSnapshot, podGroup, opts, loggingQuota)
+		statuses = append(statuses, groupStatuses...)
+		if err != nil {
+			return handleContextError(ctx, pods, unschedulablePods, statuses, similarPods, loggingQuota, err)
+		}
+
+		unschedulablePods, groupStatuses, err = s.tryScheduleWithoutHints(ctx, clusterSnapshot, podsWithoutHints, unschedulablePods, similarPods, breakOnFailure, opts, loggingQuota)
+		statuses = append(statuses, groupStatuses...)
+		if err != nil {
+			return handleContextError(ctx, pods, unschedulablePods, statuses, similarPods, loggingQuota, err)
+		}
+	}
+
+	klogx.V(4).Over(loggingQuota).Infof("There were also %v other logs from HintingSimulator.TrySchedulePods func that were capped.", -loggingQuota.Left())
+	return newResult(pods, unschedulablePods, statuses, similarPods), nil
+}
+
+func (s *HintingSimulator) tryScheduleWithHints(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, opts clustersnapshot.SchedulingOptions, loggingQuota *klogx.Quota) ([]*apiv1.Pod, []Status, error) {
+	var podsWithoutHints []*apiv1.Pod
+	var statuses []Status
 	for _, pod := range pods {
+		if err := ctx.Err(); err != nil {
+			return podsWithoutHints, statuses, err
+		}
+
 		klogx.V(5).UpTo(loggingQuota).Infof("Looking for place for %s/%s", pod.Namespace, pod.Name)
 		nodeName, err := s.tryScheduleUsingHints(clusterSnapshot, pod, opts.IsNodeAcceptable)
 		if err != nil {
-			return nil, 0, err
+			return podsWithoutHints, statuses, err
 		}
 
 		if nodeName == "" {
-			nodeName, err = s.trySchedule(similarPods, clusterSnapshot, pod, loggingQuota, opts)
-			if err != nil {
-				return nil, 0, err
-			}
+			podsWithoutHints = append(podsWithoutHints, pod)
+			continue
+		}
+
+		klogx.V(4).UpTo(loggingQuota).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, nodeName)
+		statuses = append(statuses, Status{Pod: pod, NodeName: nodeName})
+	}
+	return podsWithoutHints, statuses, nil
+}
+
+func (s *HintingSimulator) tryScheduleWithoutHints(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, unschedulablePods map[types.UID]bool, similarPods *SimilarPodsScheduling, breakOnFailure bool, opts clustersnapshot.SchedulingOptions, loggingQuota *klogx.Quota) (map[types.UID]bool, []Status, error) {
+	var statuses []Status
+	for _, pod := range pods {
+		if err := ctx.Err(); err != nil {
+			return unschedulablePods, statuses, err
+		}
+
+		nodeName, err := s.trySchedule(similarPods, clusterSnapshot, pod, loggingQuota, opts)
+		if err != nil {
+			return unschedulablePods, statuses, err
 		}
 
 		if nodeName != "" {
 			klogx.V(4).UpTo(loggingQuota).Infof("Pod %s/%s can be moved to %s", pod.Namespace, pod.Name, nodeName)
 			statuses = append(statuses, Status{Pod: pod, NodeName: nodeName})
-		} else if breakOnFailure {
-			break
+			continue
 		}
+
+		if breakOnFailure {
+			unschedulablePods[pod.UID] = true
+			klogx.V(4).Over(loggingQuota).Infof("There were also %v other logs from HintingSimulator.TrySchedulePods func that were capped.", -loggingQuota.Left())
+			return unschedulablePods, statuses, nil
+		}
+
+		unschedulablePods[pod.UID] = true
 	}
-	klogx.V(4).Over(loggingQuota).Infof("There were also %v other logs from HintingSimulator.TrySchedulePods func that were capped.", -loggingQuota.Left())
-	return statuses, similarPods.OverflowingControllerCount(), nil
+	return unschedulablePods, statuses, nil
+}
+
+func handleContextError(ctx context.Context, pods []*apiv1.Pod, unschedulablePods map[types.UID]bool, statuses []Status, similarPods *SimilarPodsScheduling, loggingQuota *klogx.Quota, err error) (Result, error) {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		requestor, found := ctx.Value(SimulationRequestorName).(string)
+		if !found {
+			klogx.V(4).Infof("Scheduling simulation requestor not found from context.")
+			requestor = "NOT FOUND"
+		}
+
+		unprocessedPodsCount := len(pods) - len(statuses) - len(unschedulablePods)
+		klogx.V(4).Infof("Scheduling simulation aborted early due to %v. Requestor: %s, Simulated %d pods. %d pods were unprocessed", err, requestor, len(statuses), unprocessedPodsCount)
+		klogx.V(4).Over(loggingQuota).Infof("There were also %v other logs from HintingSimulator.TrySchedulePods func that were capped.", -loggingQuota.Left())
+
+		return newResult(pods, unschedulablePods, statuses, similarPods), nil
+	}
+	return Result{}, err
 }
 
 // tryScheduleUsingHints tries to schedule the provided Pod in the provided clusterSnapshot using hints. If the pod is scheduled, the name of its Node is returned. If the
@@ -141,4 +227,43 @@ func (s *HintingSimulator) DropOldHints() {
 // ScheduleAnywhere can be passed to TrySchedulePods when there are no extra restrictions on nodes to consider.
 func ScheduleAnywhere(_ *framework.NodeInfo) bool {
 	return true
+}
+
+// groupByPriority groups pods by their priority and returns a slice of pod slices, ordered from highest to lowest priority.
+func groupByPriority(pods []*apiv1.Pod) [][]*apiv1.Pod {
+	podGroups := make(map[int32][]*apiv1.Pod)
+	for _, pod := range pods {
+		priority := corev1helpers.PodPriority(pod)
+		podGroups[priority] = append(podGroups[priority], pod)
+	}
+
+	var priorities []int
+	for p := range podGroups {
+		priorities = append(priorities, int(p))
+	}
+
+	sort.Slice(priorities, func(i, j int) bool {
+		return priorities[i] > priorities[j]
+	})
+
+	var result [][]*apiv1.Pod
+	for _, p := range priorities {
+		result = append(result, podGroups[int32(p)])
+	}
+	return result
+}
+
+func newResult(allPods []*apiv1.Pod, unschedulablePodMap map[types.UID]bool, statuses []Status, similarPods *SimilarPodsScheduling) Result {
+	processedPodMap := make(map[types.UID]bool)
+	var unprocessedPods []*apiv1.Pod
+	for _, status := range statuses {
+		processedPodMap[status.Pod.UID] = true
+	}
+
+	for _, pod := range allPods {
+		if !processedPodMap[pod.UID] && !unschedulablePodMap[pod.UID] {
+			unprocessedPods = append(unprocessedPods, pod)
+		}
+	}
+	return Result{statuses, unprocessedPods, similarPods.OverflowingControllerCount()}
 }

--- a/cluster-autoscaler/simulator/scheduling/hinting_simulator_test.go
+++ b/cluster-autoscaler/simulator/scheduling/hinting_simulator_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package scheduling
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
@@ -39,6 +41,7 @@ func TestTrySchedulePods(t *testing.T) {
 		acceptableNodes func(*framework.NodeInfo) bool
 		wantStatuses    []Status
 		wantErr         bool
+		contextDeadline time.Duration
 	}{
 		{
 			desc: "two new pods, two nodes",
@@ -149,6 +152,86 @@ func TestTrySchedulePods(t *testing.T) {
 				{Pod: BuildTestPod("p2", 500, 500000), NodeName: "n1"},
 			},
 		},
+		{
+			desc: "hinted pods are prioritized",
+			nodes: []*apiv1.Node{
+				buildReadyNode("n1", 1000, 2000000),
+			},
+			newPods: []*apiv1.Pod{
+				BuildTestPod("p1-high", 1100, 1000000, WithPodPriority(100)),
+				BuildTestPod("p2-low-not-hinted", 800, 1000000, WithPodPriority(10)),
+				BuildTestPod("p2-low-hinted", 800, 1000000, WithPodPriority(10)),
+			},
+			hints: map[*apiv1.Pod]string{
+				BuildTestPod("p2-low-hinted", 800, 1000000, WithPodPriority(10)): "n1",
+			},
+			acceptableNodes: ScheduleAnywhere,
+			wantStatuses: []Status{
+				{Pod: BuildTestPod("p2-low-hinted", 800, 1000000, WithPodPriority(10)), NodeName: "n1"},
+			},
+		},
+		{
+			desc: "higher priority pods are prioritized",
+			nodes: []*apiv1.Node{
+				buildReadyNode("n1", 1000, 2000000),
+				buildReadyNode("n2", 1000, 2000000),
+				buildReadyNode("n3", 1500, 2000000),
+			},
+			newPods: []*apiv1.Pod{
+				BuildTestPod("p1-low", 800, 1000000),
+				BuildTestPod("p2-high", 800, 1000000, WithPodPriority(100)),
+				BuildTestPod("p3-highest", 1100, 1000000, WithPodPriority(1000)),
+			},
+			hints: map[*apiv1.Pod]string{
+				BuildTestPod("p1-low", 800, 1000000):                             "n1",
+				BuildTestPod("p2-high", 800, 1000000, WithPodPriority(100)):      "n1",
+				BuildTestPod("p3-highest", 1100, 1000000, WithPodPriority(1000)): "n1",
+			},
+			acceptableNodes: ScheduleAnywhere,
+			wantStatuses: []Status{
+				{Pod: BuildTestPod("p3-highest", 1100, 1000000, WithPodPriority(1000)), NodeName: "n3"},
+				{Pod: BuildTestPod("p2-high", 800, 1000000, WithPodPriority(100)), NodeName: "n1"},
+				{Pod: BuildTestPod("p1-low", 800, 1000000), NodeName: "n2"},
+			},
+		},
+		{
+			desc: "first schedule pods with working hints and next schedule pods without hints for the remaining capacity while preserving the input pod order",
+			nodes: []*apiv1.Node{
+				buildReadyNode("n1", 2100, 4000000),
+			},
+			newPods: []*apiv1.Pod{
+				BuildTestPod("p1", 500, 1000000),
+				BuildTestPod("p2", 500, 1000000),
+				BuildTestPod("p3", 500, 1000000),
+				BuildTestPod("p4", 500, 1000000),
+				BuildTestPod("p5", 500, 1000000),
+				BuildTestPod("p6", 500, 1000000),
+			},
+			hints: map[*apiv1.Pod]string{
+				BuildTestPod("p2", 500, 1000000): "n1",
+				BuildTestPod("p5", 500, 1000000): "n1",
+				BuildTestPod("p6", 500, 1000000): "n2",
+			},
+			acceptableNodes: ScheduleAnywhere,
+			wantStatuses: []Status{
+				{Pod: BuildTestPod("p2", 500, 1000000), NodeName: "n1"},
+				{Pod: BuildTestPod("p5", 500, 1000000), NodeName: "n1"},
+				{Pod: BuildTestPod("p1", 500, 1000000), NodeName: "n1"},
+				{Pod: BuildTestPod("p3", 500, 1000000), NodeName: "n1"},
+			},
+		},
+		{
+			desc: "no simulations when context exceeded",
+			nodes: []*apiv1.Node{
+				buildReadyNode("n1", 1000, 2000000),
+			},
+			newPods: []*apiv1.Pod{
+				BuildTestPod("p1", 800, 500000),
+			},
+			acceptableNodes: ScheduleAnywhere,
+			wantStatuses:    nil,
+			contextDeadline: -2 * time.Minute,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -163,14 +246,21 @@ func TestTrySchedulePods(t *testing.T) {
 				s.hints.Set(HintKeyFromPod(pod), nodeName)
 			}
 
-			statuses, _, err := s.TrySchedulePods(clusterSnapshot, tc.newPods, false, clustersnapshot.SchedulingOptions{IsNodeAcceptable: tc.acceptableNodes})
+			ctx := context.Background()
+			var cancel context.CancelFunc
+			if tc.contextDeadline.Abs() > 0 {
+				ctx, cancel = context.WithTimeout(ctx, tc.contextDeadline)
+				defer cancel()
+			}
+
+			schedulingResult, err := s.TrySchedulePods(ctx, clusterSnapshot, tc.newPods, false, clustersnapshot.SchedulingOptions{IsNodeAcceptable: tc.acceptableNodes})
 			if tc.wantErr {
 				assert.Error(t, err)
 				return
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tc.wantStatuses, statuses)
+			assert.Equal(t, tc.wantStatuses, schedulingResult.Statuses)
 
 			numScheduled := countPods(t, clusterSnapshot)
 			assert.Equal(t, len(tc.pods)+len(tc.wantStatuses), numScheduled)
@@ -250,9 +340,9 @@ func TestPodSchedulesOnHintedNode(t *testing.T) {
 				s.hints.Set(HintKeyFromPod(pod), n)
 				expectedStatuses = append(expectedStatuses, Status{Pod: pod, NodeName: n})
 			}
-			statuses, _, err := s.TrySchedulePods(clusterSnapshot, pods, false, clustersnapshot.SchedulingOptions{})
+			schedulingResult, err := s.TrySchedulePods(context.Background(), clusterSnapshot, pods, false, clustersnapshot.SchedulingOptions{})
 			assert.NoError(t, err)
-			assert.Equal(t, expectedStatuses, statuses)
+			assert.Equal(t, expectedStatuses, schedulingResult.Statuses)
 
 			for p, hinted := range tc.podNodes {
 				actual := nodeNameForPod(t, clusterSnapshot, p)
@@ -302,5 +392,93 @@ func nodeNameForPod(t *testing.T, clusterSnapshot clustersnapshot.ClusterSnapsho
 func singleNodeOk(nodeName string) func(*framework.NodeInfo) bool {
 	return func(nodeInfo *framework.NodeInfo) bool {
 		return nodeName == nodeInfo.Node().Name
+	}
+}
+
+func TestNewResult(t *testing.T) {
+	p1 := BuildTestPod("p1", 100, 1000)
+	p2 := BuildTestPod("p2", 100, 1000)
+	p3 := BuildTestPod("p3", 100, 1000)
+	p4 := BuildTestPod("p4", 100, 1000)
+
+	testCases := []struct {
+		desc                 string
+		allPods              []*apiv1.Pod
+		unschedulablePodMap  map[types.UID]bool
+		statuses             []Status
+		similarPodScheduling *SimilarPodsScheduling
+		want                 Result
+	}{
+		{
+			desc:                 "empty inputs",
+			allPods:              []*apiv1.Pod{},
+			unschedulablePodMap:  map[types.UID]bool{},
+			statuses:             []Status{},
+			similarPodScheduling: &SimilarPodsScheduling{},
+			want:                 Result{[]Status{}, nil, 0},
+		},
+		{
+			desc:                 "no overlap",
+			allPods:              []*apiv1.Pod{p1, p2},
+			unschedulablePodMap:  map[types.UID]bool{p3.UID: true},
+			statuses:             []Status{{Pod: p4}},
+			similarPodScheduling: &SimilarPodsScheduling{},
+			want:                 Result{[]Status{{Pod: p4}}, []*apiv1.Pod{p1, p2}, 0},
+		},
+		{
+			desc:                 "overlap with unschedulablePodMap",
+			allPods:              []*apiv1.Pod{p1, p2, p3},
+			unschedulablePodMap:  map[types.UID]bool{p2.UID: true, p3.UID: true},
+			statuses:             []Status{},
+			similarPodScheduling: &SimilarPodsScheduling{},
+			want:                 Result{[]Status{}, []*apiv1.Pod{p1}, 0},
+		},
+		{
+			desc:                 "overlap with statuses",
+			allPods:              []*apiv1.Pod{p1, p2, p3},
+			unschedulablePodMap:  map[types.UID]bool{},
+			statuses:             []Status{{Pod: p1}, {Pod: p3}},
+			similarPodScheduling: &SimilarPodsScheduling{},
+			want:                 Result{[]Status{{Pod: p1}, {Pod: p3}}, []*apiv1.Pod{p2}, 0},
+		},
+		{
+			desc:                 "overlap with both",
+			allPods:              []*apiv1.Pod{p1, p2, p3, p4},
+			unschedulablePodMap:  map[types.UID]bool{p2.UID: true},
+			statuses:             []Status{{Pod: p4}},
+			similarPodScheduling: &SimilarPodsScheduling{},
+			want:                 Result{[]Status{{Pod: p4}}, []*apiv1.Pod{p1, p3}, 0},
+		},
+		{
+			desc:                 "pods in maps but not in allPods",
+			allPods:              []*apiv1.Pod{p1},
+			unschedulablePodMap:  map[types.UID]bool{p2.UID: true},
+			statuses:             []Status{{Pod: p3}},
+			similarPodScheduling: &SimilarPodsScheduling{},
+			want:                 Result{[]Status{{Pod: p3}}, []*apiv1.Pod{p1}, 0},
+		},
+		{
+			desc:                 "all pods are either schedulable or unschedulable",
+			allPods:              []*apiv1.Pod{p1, p2, p3, p4},
+			unschedulablePodMap:  map[types.UID]bool{p1.UID: true, p2.UID: true, p3.UID: true},
+			statuses:             []Status{{Pod: p4}},
+			similarPodScheduling: &SimilarPodsScheduling{},
+			want:                 Result{[]Status{{Pod: p4}}, nil, 0},
+		},
+		{
+			desc:                 "some pods are unprocessed",
+			allPods:              []*apiv1.Pod{p1, p2, p3, p4},
+			unschedulablePodMap:  map[types.UID]bool{p1.UID: true, p2.UID: true},
+			statuses:             []Status{{Pod: p4}},
+			similarPodScheduling: &SimilarPodsScheduling{overflowingControllers: map[string]bool{"c1": true, "c2": true}},
+			want:                 Result{[]Status{{Pod: p4}}, []*apiv1.Pod{p3}, 2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := newResult(tc.allPods, tc.unschedulablePodMap, tc.statuses, tc.similarPodScheduling)
+			assert.Equal(t, tc.want, got)
+		})
 	}
 }

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -238,6 +238,13 @@ func WithPodHostnameAntiAffinity(labels map[string]string) func(*apiv1.Pod) {
 	}
 }
 
+// WithPodPriority sets the priority of the pod.
+func WithPodPriority(priority int32) func(*apiv1.Pod) {
+	return func(pod *apiv1.Pod) {
+		pod.Spec.Priority = &priority
+	}
+}
+
 // BuildTestPodWithEphemeralStorage creates a pod with cpu, memory and ephemeral storage resources.
 func BuildTestPodWithEphemeralStorage(name string, cpu, mem, ephemeralStorage int64) *apiv1.Pod {
 	startTime := metav1.Unix(0, 0)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When there are thousands of unschedulable pods CA could spend minutes executing pod scheduling simulations. During this period of time CA does not updates the lastActivity timestamp which is used for health checks. So after some minutes kubelet will kill the CA assuming it is not working/trapped in a deadlock. This could happen in a cycle and CA will not do any useful work. This is very possible in large clusters with tens of thousands of nodes since scheduling simulations is proportional to # of unschedulable pods and # of nodes.

So instead of trying to process all the unschedulable pods it would be beneficial to proceed with a subset of unschedulable pods although it could be suboptimal.
This PR adds a timeout to scheduling simulations and CA will proceed to next steps after stoping the scheduling simulations after timeout.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
If there are thousands of unschedulable pods CA might make suboptimal decisions.


<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CA might proceed with suboptimal decision if CA is hitting its scalability limits(large number of unschedulable pods).

Graceful degradation is configured and enabled with `--pending-pods-batching-timeout` and `--enable-graceful-degradation`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
