### PR TITLE
Fix DraCustomResourcesProcessor ignoring devices located in different resource slices.

### DIFF
--- a/cluster-autoscaler/processors/customresources/dra_processor.go
+++ b/cluster-autoscaler/processors/customresources/dra_processor.go
@@ -18,10 +18,9 @@ package customresources
 
 import (
 	apiv1 "k8s.io/api/core/v1"
-	resourceapi "k8s.io/api/resource/v1"
+	v1 "k8s.io/api/resource/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	csisnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/csi/snapshot"
@@ -59,7 +58,7 @@ func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autosca
 			continue
 		}
 
-		nodeInfo, err := getNodeInfo(autoscalingCtx, ng)
+		templateNodeInfo, err := getNodeInfo(autoscalingCtx, ng)
 		if err != nil {
 			newReadyNodes = append(newReadyNodes, node)
 			klog.Warningf("Failed to get template node info for node group %s with error: %v", ng.Id(), err)
@@ -67,7 +66,7 @@ func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autosca
 		}
 
 		nodeResourcesSlices, _ := draSnapshot.NodeResourceSlices(node.Name)
-		if isEqualResourceSlices(nodeResourcesSlices, nodeInfo.LocalResourceSlices) {
+		if areResourcePoolsReady(nodeResourcesSlices, templateNodeInfo.LocalResourceSlices) {
 			newReadyNodes = append(newReadyNodes, node)
 		} else {
 			nodesWithUnreadyDraResources[node.Name] = kubernetes.GetUnreadyNodeCopy(node, kubernetes.ResourceUnready)
@@ -94,52 +93,6 @@ func getNodeInfo(autoscalingCtx *ca_context.AutoscalingContext, ng cloudprovider
 	return ng.TemplateNodeInfo()
 }
 
-type resourceSliceSpecs struct {
-	driver string
-	pool   string
-}
-
-func isEqualResourceSlices(nodeResourcesSlices []*resourceapi.ResourceSlice, templateResourcesSlices []*resourceapi.ResourceSlice) bool {
-	tempSlicesByPools := getDevicesBySpecs(templateResourcesSlices)
-	nodeSlicesByPools := getDevicesBySpecs(nodeResourcesSlices)
-
-	for templSpecs, tempDevicesSet := range tempSlicesByPools {
-		matched := false
-		for nodeSpecs, nodeDevicesSet := range nodeSlicesByPools {
-			if templSpecs.driver == nodeSpecs.driver && nodeDevicesSet.Equal(tempDevicesSet) {
-				delete(nodeSlicesByPools, nodeSpecs)
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return false
-		}
-	}
-
-	return true
-}
-
-func getDevicesBySpecs(resourcesSlices []*resourceapi.ResourceSlice) map[resourceSliceSpecs]sets.Set[string] {
-	slicesGroupedByPoolAndDriver := make(map[resourceSliceSpecs]sets.Set[string])
-	for _, rs := range resourcesSlices {
-		rsSpecs := resourceSliceSpecs{
-			pool:   rs.Spec.Pool.Name,
-			driver: rs.Spec.Driver,
-		}
-		slicesGroupedByPoolAndDriver[rsSpecs] = getResourceSliceDevicesSet(rs)
-	}
-	return slicesGroupedByPoolAndDriver
-}
-
-func getResourceSliceDevicesSet(resourcesSlice *resourceapi.ResourceSlice) sets.Set[string] {
-	devices := sets.New[string]()
-	for _, device := range resourcesSlice.Spec.Devices {
-		devices.Insert(device.Name)
-	}
-	return devices
-}
-
 // GetNodeResourceTargets returns the resource targets for DRA resource slices, not implemented.
 func (p *DraCustomResourcesProcessor) GetNodeResourceTargets(_ *ca_context.AutoscalingContext, _ *apiv1.Node, _ cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
 	// TODO(DRA): Figure out resource limits for DRA here.
@@ -148,4 +101,66 @@ func (p *DraCustomResourcesProcessor) GetNodeResourceTargets(_ *ca_context.Autos
 
 // CleanUp cleans up processor's internal structures.
 func (p *DraCustomResourcesProcessor) CleanUp() {
+}
+
+type poolState struct {
+	count      int64
+	generation int64
+	size       int64
+}
+
+type poolSpec struct {
+	name   string
+	driver string
+}
+
+// areResourcePoolsReady returns boolean indicating whether resource slices from a real node
+// contain a minimal amount of ready resource pools as declared in the template.
+func areResourcePoolsReady(resourceSlices []*v1.ResourceSlice, templateNodeResourcesSlices []*v1.ResourceSlice) bool {
+	templatePools := getCompleteResourcePools(templateNodeResourcesSlices)
+	realPools := getCompleteResourcePools(resourceSlices)
+
+	for driver, count := range templatePools {
+		if realPools[driver] < count {
+			return false
+		}
+	}
+
+	return true
+}
+
+// getCompleteResourcePools returns a map of drivers and count of ready resource pools mapped to it.
+func getCompleteResourcePools(resourceSlices []*v1.ResourceSlice) map[string]int {
+	poolStates := make(map[poolSpec]poolState, len(resourceSlices))
+
+	for _, rs := range resourceSlices {
+		spec := poolSpec{name: rs.Spec.Pool.Name, driver: rs.Spec.Driver}
+		state, found := poolStates[spec]
+
+		// If the pool is new, or if we found a newer generation, overwrite/reset the state.
+		if !found || rs.Spec.Pool.Generation > state.generation {
+			state = poolState{
+				count:      0,
+				generation: rs.Spec.Pool.Generation,
+				size:       rs.Spec.Pool.ResourceSliceCount,
+			}
+		} else if rs.Spec.Pool.Generation < state.generation {
+			// Ignore slices from older generations
+			continue
+		}
+
+		state.count++
+		poolStates[spec] = state
+	}
+
+	// Pre-allocate map to avoid dynamic resize overhead during the loop.
+	readyPoolsByDriver := make(map[string]int, len(poolStates))
+	for spec, state := range poolStates {
+		// A pool is ready if we have seen strictly the expected number of resource slices.
+		if state.count == state.size {
+			readyPoolsByDriver[spec.driver]++
+		}
+	}
+
+	return readyPoolsByDriver
 }

--- a/cluster-autoscaler/processors/customresources/dra_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/dra_processor_test.go
@@ -18,11 +18,13 @@ package customresources
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	v1 "k8s.io/api/resource/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,304 +72,461 @@ func TestFilterOutNodesWithUnreadyDRAResources(t *testing.T) {
 		expectedNodesReadiness    map[string]bool
 		registryNodeInfos         map[string]*framework.NodeInfo
 	}{
-		"1 DRA node group all totally ready": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-					buildTestNode("node_2_Dra_Ready", true),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", createNodeResourceSlices("ng1_template", []int{1, 1})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready": createNodeResourceSlices("node_1_Dra_Ready", []int{1, 1}),
-				"node_2_Dra_Ready": createNodeResourceSlices("node_2_Dra_Ready", []int{1, 1}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready": true,
-				"node_2_Dra_Ready": true,
-			},
-		},
-		"1 DRA node group, one initially unready": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-					buildTestNode("node_2_Dra_Ready", false),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", createNodeResourceSlices("ng1_template", []int{1, 1})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready": createNodeResourceSlices("node_1_Dra_Ready", []int{1, 1}),
-				"node_2_Dra_Ready": createNodeResourceSlices("node_2_Dra_Ready", []int{1, 1}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready": true,
-				"node_2_Dra_Ready": false,
-			},
-		},
-		"1 DRA node group, one initially ready with unready reasource": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-					buildTestNode("node_2_Dra_Ready", true),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", createNodeResourceSlices("ng1_template", []int{1, 1})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready": createNodeResourceSlices("node_1_Dra_Ready", []int{1, 1}),
-				"node_2_Dra_Ready": createNodeResourceSlices("node_2_Dra_Ready", []int{1, 0}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready": true,
-				"node_2_Dra_Ready": false,
-			},
-		},
-		"1 DRA node group, one initially ready with more reasources than expected": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-					buildTestNode("node_2_Dra_Ready", true),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", createNodeResourceSlices("ng1_template", []int{1, 1})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready": createNodeResourceSlices("node_1_Dra_Ready", []int{1, 1}),
-				"node_2_Dra_Ready": createNodeResourceSlices("node_2_Dra_Ready", []int{1, 3}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready": true,
-				"node_2_Dra_Ready": false,
-			},
-		},
-		"1 DRA node group, one initially ready with no slices": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-					buildTestNode("node_2_Dra_Ready", true),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", createNodeResourceSlices("ng1_template", []int{1, 1})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready": {},
-				"node_2_Dra_Ready": createNodeResourceSlices("node_2_Dra_Ready", []int{1, 3}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready": false,
-				"node_2_Dra_Ready": false,
-			},
-		},
-		"1 DRA node group, single driver multiple pools, only one published": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", buildNodeResourceSlices("ng1_template", "driver", []int{2, 2, 2})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready": buildNodeResourceSlices("node_2_Dra_Ready", "driver", []int{2}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready": false,
-			},
-		},
-		"1 DRA node group, single driver multiple pools, more pools published including template pools": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_2_Dra_Ready", true),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", buildNodeResourceSlices("ng1_template", "driver", []int{2, 2, 2})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_2_Dra_Ready": buildNodeResourceSlices("node_2_Dra_Ready", "driver", []int{2, 2, 2, 2}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_2_Dra_Ready": true,
-			},
-		},
-		"1 DRA node group, single driver multiple pools, more pools published not including template pools": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", buildNodeResourceSlices("ng1_template", "driver", []int{2, 2, 2})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready": buildNodeResourceSlices("node_1_Dra_Ready", "driver", []int{2, 2, 1, 2}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready": false,
-			},
-		},
-		"2 node groups, one DRA with 1 reasource unready node": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-					buildTestNode("node_2_Dra_Ready", true),
-					buildTestNode("node_3_Dra_Unready", true),
-				},
-				"ng2": {
-					buildTestNode("node_4_NonDra_Ready", true),
-					buildTestNode("node_5_NonDra_Unready", false),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", createNodeResourceSlices("ng1_template", []int{2, 2})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready":   createNodeResourceSlices("node_1_Dra_Ready", []int{2, 2}),
-				"node_2_Dra_Ready":   createNodeResourceSlices("node_2_Dra_Ready", []int{2, 2}),
-				"node_3_Dra_Unready": createNodeResourceSlices("node_3_Dra_Unready", []int{2, 1}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready":      true,
-				"node_2_Dra_Ready":      true,
-				"node_3_Dra_Unready":    false,
-				"node_4_NonDra_Ready":   true,
-				"node_5_NonDra_Unready": false,
-			},
-		},
-		"2 DRA node groups, each with 1 reasource unready node": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-					buildTestNode("node_2_Dra_Ready", true),
-					buildTestNode("node_3_Dra_Unready", true),
-				},
-				"ng2": {
-					buildTestNode("node_4_Dra_Ready", true),
-					buildTestNode("node_5_Dra_Unready", true),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", createNodeResourceSlices("ng1_template", []int{2, 2})),
-				"ng2": createTemplateNodeInfo("ng2_template", createNodeResourceSlices("ng2_template", []int{3, 3})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready":   createNodeResourceSlices("node_1_Dra_Ready", []int{2, 2}),
-				"node_2_Dra_Ready":   createNodeResourceSlices("node_2_Dra_Ready", []int{2, 2}),
-				"node_3_Dra_Unready": createNodeResourceSlices("node_3_Dra_Unready", []int{2, 1}),
-				"node_4_Dra_Ready":   createNodeResourceSlices("node_4_Dra_Ready", []int{3, 3}),
-				"node_5_Dra_Unready": createNodeResourceSlices("node_5_Dra_Unready", []int{2, 1}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready":   true,
-				"node_2_Dra_Ready":   true,
-				"node_3_Dra_Unready": false,
-				"node_4_Dra_Ready":   true,
-				"node_5_Dra_Unready": false,
-			},
-		},
-		"2 DRA node group, single driver multiple pools, more pools published including template pools": {
-			nodeGroupsAllNodes: map[string][]*apiv1.Node{
-				"ng1": {
-					buildTestNode("node_1_Dra_Ready", true),
-					buildTestNode("node_2_Dra_Ready", true),
-				},
-				"ng2": {
-					buildTestNode("node_3_Dra_Ready", true),
-				},
-			},
-			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", buildNodeResourceSlices("ng1_template", "driver", []int{2, 2, 2})),
-				"ng2": createTemplateNodeInfo("ng2_template", buildNodeResourceSlices("ng2_template", "driver", []int{1, 1})),
-			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1_Dra_Ready": buildNodeResourceSlices("node_1_Dra_Ready", "driver", []int{2, 2, 2, 2}),
-				"node_2_Dra_Ready": buildNodeResourceSlices("node_2_Dra_Ready", "driver", []int{2, 2, 2}),
-				"node_3_Dra_Ready": buildNodeResourceSlices("node_3_Dra_Ready", "driver", []int{1, 1, 1}),
-			},
-			expectedNodesReadiness: map[string]bool{
-				"node_1_Dra_Ready": true,
-				"node_2_Dra_Ready": true,
-				"node_3_Dra_Ready": true,
-			},
-		},
-		"All together": {
+		"NonDraNodes_Unaffected": {
 			nodeGroupsAllNodes: map[string][]*apiv1.Node{
 				"ng1": {
 					buildTestNode("node_1", true),
-					buildTestNode("node_2", true),
-					buildTestNode("node_3", true),
-				},
-				"ng2": {
-					buildTestNode("node_4", false),
-					buildTestNode("node_5", true),
-				},
-				"ng3": {
-					buildTestNode("node_6", false),
-					buildTestNode("node_7", true),
+					buildTestNode("node_2", false),
 				},
 			},
 			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", createNodeResourceSlices("ng1_template", []int{2, 2})),
-				"ng2": createTemplateNodeInfo("ng2_template", createNodeResourceSlices("ng2_template", []int{3, 3})),
+				"ng1": createTemplateNodeInfo("ng1_template", []*v1.ResourceSlice{}),
 			},
-			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1": createNodeResourceSlices("node_1", []int{2, 2, 2}),
-				"node_2": createNodeResourceSlices("node_2", []int{1}),
-				"node_3": createNodeResourceSlices("node_3", []int{1, 2}),
-				"node_4": createNodeResourceSlices("node_4", []int{3, 3}),
-				"node_5": {},
-			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{},
 			expectedNodesReadiness: map[string]bool{
 				"node_1": true,
 				"node_2": false,
-				"node_3": false,
-				"node_4": false,
-				"node_5": false,
-				"node_6": false,
-				"node_7": true,
 			},
 		},
-		"Fallback to NodeGroup template when registry is missing": {
+		"UnreadyNodeWithPools_NotBecomingReady": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", false),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo("ng1_template", buildResourceSlices("ng1_template", "driver", 1)),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": buildResourceSlices("node_1", "driver", 1),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": false,
+			},
+		},
+		"PoolComplete_Unaffected": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo("ng1_template", buildResourceSlices("ng1_template", "driver", 1)),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": buildResourceSlices("node_1", "driver", 1),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": true,
+			},
+		},
+		"MultipleDriversPoolsComplete_Unaffected": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					slices.Concat(
+						buildResourceSlices("ng1_template", "driver1", 5),
+						buildResourceSlices("ng1_template", "driver2", 9),
+					),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildResourceSlices("node_1", "driver1", 5),
+					buildResourceSlices("node_1", "driver2", 9),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": true,
+			},
+		},
+		"MoreReasourcePoolsAvailableThanInTemplate_Unaffected": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					slices.Concat(
+						buildResourceSlices("ng1_template", "driver1", 1),
+						buildResourceSlices("ng1_template", "driver2", 1),
+					),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildResourceSlices("node_1", "driver1", 10),
+					buildResourceSlices("node_1", "driver2", 10),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": true,
+			},
+		},
+		"IncompletePoolFromUntrackedDriver_Unaffected": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					slices.Concat(
+						buildResourceSlices("ng1_template", "driver1", 1),
+						buildResourceSlices("ng1_template", "driver2", 1),
+					),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildResourceSlices("node_1", "driver1", 10),
+					buildResourceSlices("node_1", "driver2", 10),
+					buildIncompleteResourceSlices("node_1", "driver3", 1),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": true,
+			},
+		},
+		"CompletePoolFromUntrackedDriver_Unaffected": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					slices.Concat(
+						buildResourceSlices("ng1_template", "driver1", 1),
+						buildResourceSlices("ng1_template", "driver2", 1),
+					),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildResourceSlices("node_1", "driver1", 10),
+					buildResourceSlices("node_1", "driver2", 10),
+					buildResourceSlices("node_1", "driver3", 1),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": true,
+			},
+		},
+		"ResourcePoolIncomplete_MarkedUnready": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					buildResourceSlices("ng1_template", "driver1", 1),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": buildIncompleteResourceSlices("node_1", "driver1", 1),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": false,
+			},
+		},
+		"MultipleDriversPoolsIncomplete_MarkedUnready": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					slices.Concat(
+						buildResourceSlices("ng1_template", "driver1", 5),
+						buildResourceSlices("ng1_template", "driver2", 3),
+					),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildIncompleteResourceSlices("node_1", "driver1", 5),
+					buildIncompleteResourceSlices("node_1", "driver2", 3),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": false,
+			},
+		},
+		"OneDriverPoolIncomplete_MarkedUnready": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					slices.Concat(
+						buildResourceSlices("ng1_template", "driver1", 5),
+						buildResourceSlices("ng1_template", "driver2", 3),
+					),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildResourceSlices("node_1", "driver1", 5),
+					buildIncompleteResourceSlices("node_1", "driver2", 3),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": false,
+			},
+		},
+		"ResourcePoolBothGenerationsNotReady_MarkedUnready": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					buildResourceSlices("ng1_template", "driver1", 1),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildResourcePoolWithSplitGeneration("node_1", "driver1", 1, map[int]int{1: 1, 2: 1}),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": false,
+			},
+		},
+		"ResourcePoolOldGenerationReady_MarkedUnready": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					buildResourceSlices("ng1_template", "driver1", 1),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildResourcePoolWithSplitGeneration("node_1", "driver1", 1, map[int]int{1: 0, 2: 1}),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": false,
+			},
+		},
+		"ResourcePoolNewGenerationComplete_Unaffected": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					buildResourceSlices("ng1_template", "driver1", 1),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildResourcePoolWithSplitGeneration("node_1", "driver1", 1, map[int]int{1: 1, 2: 0}),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": true,
+			},
+		},
+		"ResourcePoolBothGenerationsReady_Unaffected": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					buildResourceSlices("ng1_template", "driver1", 1),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": slices.Concat(
+					buildResourcePoolWithSplitGeneration("node_1", "driver1", 1, map[int]int{1: 0, 2: 0}),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": true,
+			},
+		},
+		"MissingResourcePool_MarkedUnready": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo(
+					"ng1_template",
+					buildResourceSlices("ng1_template", "driver1", 5),
+				),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": false,
+			},
+		},
+		"FallBackToNodeGroupTemplateWhenRegistryIsMissing": {
 			nodeGroupsAllNodes: map[string][]*apiv1.Node{
 				"ng1": {
 					buildTestNode("node_1", true),
 				},
 			},
 			nodeGroupsTemplatesSlices: map[string][]*resourceapi.ResourceSlice{
-				"ng1": createNodeResourceSlices("ng1_template", []int{1, 1}),
+				"ng1": buildResourceSlices("ng1_template", "driver", 1),
 			},
 			registryNodeInfos: map[string]*framework.NodeInfo{},
 			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1": createNodeResourceSlices("node_1", []int{1}),
+				"node_1": buildResourceSlices("node_1", "driver", 1),
 			},
 			expectedNodesReadiness: map[string]bool{
-				"node_1": false,
+				"node_1": true,
 			},
 		},
-		"Registry preferred over NodeGroup template": {
+		"RegistryPreferredOverNodeGroupTemplate": {
 			nodeGroupsAllNodes: map[string][]*apiv1.Node{
 				"ng1": {
 					buildTestNode("node_1", true),
 				},
 			},
 			nodeGroupsTemplatesSlices: map[string][]*resourceapi.ResourceSlice{
-				"ng1": createNodeResourceSlices("ng1_template", []int{1, 1}),
+				"ng1": buildResourceSlices("ng1_template", "driver", 10),
 			},
 			registryNodeInfos: map[string]*framework.NodeInfo{
-				"ng1": createTemplateNodeInfo("ng1_template", createNodeResourceSlices("ng1_template", []int{9, 9})),
+				"ng1": createTemplateNodeInfo("ng1_template", buildResourceSlices("ng1_template", "driver", 9)),
 			},
 			nodesSlices: map[string][]*resourceapi.ResourceSlice{
-				"node_1": createNodeResourceSlices("node_1", []int{1, 1}),
+				"node_1": buildResourceSlices("node_1", "driver", 9),
 			},
 			expectedNodesReadiness: map[string]bool{
-				"node_1": false,
+				"node_1": true,
+			},
+		},
+		"MultipleNodeGroups_AllNodesReady": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+					buildTestNode("node_11", true),
+				},
+				"ng2": {
+					buildTestNode("node_2", true),
+					buildTestNode("node_22", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo("ng1_template", buildResourceSlices("ng1_template", "driver", 1)),
+				"ng2": createTemplateNodeInfo("ng2_template", buildResourceSlices("ng2_template", "driver", 1)),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1":  buildResourceSlices("node_1", "driver", 1),
+				"node_11": buildResourceSlices("node_11", "driver", 2),
+				"node_2":  buildResourceSlices("node_2", "driver", 1),
+				"node_22": buildResourceSlices("node_22", "driver", 2),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1":  true,
+				"node_11": true,
+				"node_2":  true,
+				"node_22": true,
+			},
+		},
+		"MultipleNodeGroups_OneNodeResourcePoolUnready": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"ng1": {
+					buildTestNode("node_1", true),
+				},
+				"ng2": {
+					buildTestNode("node_2", true),
+				},
+				"ng3": {
+					buildTestNode("node_3", true),
+				},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"ng1": createTemplateNodeInfo("ng1_template", buildResourceSlices("ng1_template", "driver", 1)),
+				"ng2": createTemplateNodeInfo("ng2_template", buildResourceSlices("ng2_template", "driver", 1)),
+				"ng3": createTemplateNodeInfo("ng3_template", buildResourceSlices("ng3_template", "driver", 1)),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"node_1": buildResourceSlices("node_1", "driver", 1),
+				"node_2": buildResourceSlices("node_2", "driver", 1),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"node_1": true,
+				"node_2": true,
+				"node_3": false,
+			},
+		},
+		"AllInOne": {
+			nodeGroupsAllNodes: map[string][]*apiv1.Node{
+				"unready_ng":              {buildTestNode("unready", false)},
+				"split_generation_ng":     {buildTestNode("split_generation", true)},
+				"pools_ready_ng":          {buildTestNode("pools_ready", true)},
+				"pool_incomplete_ng":      {buildTestNode("pool_incomplete", true)},
+				"missing_pool_ng":         {buildTestNode("missing_pool", true)},
+				"multiple_drivers_ng":     {buildTestNode("multiple_drivers", true)},
+				"extra_resource_pools_ng": {buildTestNode("extra_resource_pools", true)},
+			},
+			registryNodeInfos: map[string]*framework.NodeInfo{
+				"unready_ng":          createTemplateNodeInfo("unready_ng_template", buildResourceSlices("unready_ng_template", "driver", 1)),
+				"split_generation_ng": createTemplateNodeInfo("split_generation_ng_template", buildResourceSlices("split_generation_ng_template", "driver", 1)),
+				"pools_ready_ng":      createTemplateNodeInfo("pools_ready_ng_template", buildResourceSlices("pools_ready_ng_template", "driver", 1)),
+				"pool_incomplete_ng":  createTemplateNodeInfo("pool_incomplete_ng_template", buildResourceSlices("pool_incomplete_ng_template", "driver", 1)),
+				"missing_pool_ng":     createTemplateNodeInfo("missing_pool_ng_template", buildResourceSlices("missing_pool_ng_template", "driver", 1)),
+				"multiple_drivers_ng": createTemplateNodeInfo("multiple_drivers_ng_template", slices.Concat(
+					buildResourceSlices("multiple_drivers_ng_template", "driver", 1),
+					buildResourceSlices("multiple_drivers_ng_template", "other_driver", 1),
+				)),
+				"extra_resource_pools_ng": createTemplateNodeInfo("extra_resource_pools_ng_template", buildResourceSlices("extra_resource_pools_ng_template", "driver", 1)),
+			},
+			nodesSlices: map[string][]*resourceapi.ResourceSlice{
+				"unready":          buildResourceSlices("unready", "driver", 1),
+				"split_generation": buildResourcePoolWithSplitGeneration("split_generation", "driver", 1, map[int]int{1: 1, 2: 7}),
+				"pools_ready":      buildResourceSlices("pools_ready", "driver", 1),
+				"pool_incomplete":  buildIncompleteResourceSlices("pool_incomplete", "driver", 1),
+				"multiple_drivers": slices.Concat(
+					buildResourceSlices("multiple_drivers", "driver", 1),
+					buildResourceSlices("multiple_drivers", "other_driver", 1),
+				),
+				"extra_resource_pools": slices.Concat(
+					buildResourceSlices("extra_resource_pools", "driver", 1),
+					buildResourceSlices("extra_resource_pools", "other_driver", 1),
+				),
+			},
+			expectedNodesReadiness: map[string]bool{
+				"unready":              false,
+				"split_generation":     false,
+				"pools_ready":          true,
+				"pool_incomplete":      false,
+				"missing_pool":         false,
+				"multiple_drivers":     true,
+				"extra_resource_pools": true,
 			},
 		},
 	}
@@ -415,43 +575,69 @@ func TestFilterOutNodesWithUnreadyDRAResources(t *testing.T) {
 			assert.True(t, len(newAllNodes) == len(initialAllNodes), "Total number of nodes should not change")
 			for _, node := range newAllNodes {
 				gotReadiness := getNodeReadiness(node)
-				assert.Equal(t, tc.expectedNodesReadiness[node.Name], gotReadiness)
-				assert.Equal(t, gotReadiness, readyNodes[node.Name])
+				assert.Equal(t, tc.expectedNodesReadiness[node.Name], gotReadiness, "Node %v readiness doesn't match expected readiness %v != %v", node.Name, gotReadiness, tc.expectedNodesReadiness[node.Name])
+				assert.Equal(t, gotReadiness, readyNodes[node.Name], "Node %v is marked as ready, but not categorized as one", node.Name)
 			}
-
 		})
 	}
-
 }
 
 func createTemplateNodeInfo(nodeName string, slices []*resourceapi.ResourceSlice) *framework.NodeInfo {
 	return framework.NewNodeInfo(buildTestNode(nodeName, true), slices)
 }
 
-func createNodeResourceSlices(nodeName string, numberOfDevicesInSlices []int) []*resourceapi.ResourceSlice {
-	return buildNodeResourceSlices(nodeName, "", numberOfDevicesInSlices)
-}
-
-func buildNodeResourceSlices(nodeName, driverName string, numberOfDevicesInSlices []int) []*resourceapi.ResourceSlice {
-	numberOfSlices := len(numberOfDevicesInSlices)
-	resourceSlices := []*resourceapi.ResourceSlice{}
-	for sliceIndex := range numberOfSlices {
-		devices := []resourceapi.Device{}
-		for deviceIndex := range numberOfDevicesInSlices[sliceIndex] {
-			devices = append(devices, resourceapi.Device{Name: fmt.Sprintf("%d_%d", sliceIndex, deviceIndex)})
-		}
-		if driverName == "" {
-			driverName = fmt.Sprintf("driver_%d", sliceIndex)
+// buildResourceSlices builds a slice of resource slices with the given node name, driver name and number of ready pools.
+// All resource pools are referencing a single generation and target one resource slice count to be counted as complete pool.
+func buildResourceSlices(nodeName, driverName string, readyPoolsCount int) []*resourceapi.ResourceSlice {
+	resourceSlices := make([]*resourceapi.ResourceSlice, readyPoolsCount)
+	for i := 0; i < readyPoolsCount; i++ {
+		pool := resourceapi.ResourcePool{
+			Name:               fmt.Sprintf("%s_pool_%d", nodeName, i),
+			ResourceSliceCount: 1,
+			Generation:         1,
 		}
 		spec := resourceapi.ResourceSliceSpec{
 			NodeName: &nodeName,
 			Driver:   driverName,
-			Pool:     resourceapi.ResourcePool{Name: fmt.Sprintf("%s_pool_%d", nodeName, sliceIndex)},
-			Devices:  devices,
+			Pool:     pool,
+			Devices:  []resourceapi.Device{{Name: fmt.Sprintf("%d_%d", i, 0)}},
 		}
-		resourceSlices = append(resourceSlices, &resourceapi.ResourceSlice{ObjectMeta: metav1.ObjectMeta{Name: nodeName}, Spec: spec})
+		resourceSlices[i] = &resourceapi.ResourceSlice{ObjectMeta: metav1.ObjectMeta{Name: nodeName}, Spec: spec}
 	}
 	return resourceSlices
+}
+
+func buildIncompleteResourceSlices(nodeName, driverName string, poolsCount int) []*resourceapi.ResourceSlice {
+	rs := buildResourceSlices(nodeName, driverName, poolsCount)
+	for i := range rs {
+		rs[i].Spec.Pool.ResourceSliceCount = 2
+		rs[i].Spec.Pool.Name = fmt.Sprintf("%s_incomplete_pool_%d", nodeName, i)
+	}
+	return rs
+}
+
+// buildResourcePoolWithSplitGeneration builds a list of resource slices for the requested resource pool
+// The resource pool is split across multiple generations with different number of missing resource slices.
+// If the number of missing resource slices is 0, the resource slice is considered complete.
+// Resource slices are presented in random order depending on the map iteration order, it may lead to
+// test flakiness, but results in a better test coverage without any additional complexity.
+func buildResourcePoolWithSplitGeneration(nodeName, driverName string, id int, slicesMissingPerGeneration map[int]int) []*resourceapi.ResourceSlice {
+	rs := make([]*resourceapi.ResourceSlice, 0, len(slicesMissingPerGeneration))
+	for generation, countMissing := range slicesMissingPerGeneration {
+		rs = append(rs, &resourceapi.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			Spec: resourceapi.ResourceSliceSpec{
+				Driver: driverName,
+				Pool: resourceapi.ResourcePool{
+					Name:               fmt.Sprintf("%s_split_pool_%d", nodeName, id),
+					ResourceSliceCount: int64(countMissing + 1),
+					Generation:         int64(generation),
+				},
+			},
+		})
+	}
+
+	return rs
 }
 
 func buildTestNode(nodeName string, ready bool) *apiv1.Node {
@@ -467,4 +653,467 @@ func getNodeReadiness(node *apiv1.Node) bool {
 		}
 	}
 	return false
+}
+
+func TestGetCompleteResourcePools(t *testing.T) {
+	tests := map[string]struct {
+		slices   []*v1.ResourceSlice
+		expected map[string]int
+	}{
+		"EmptySlices": {
+			slices:   []*v1.ResourceSlice{},
+			expected: map[string]int{},
+		},
+		"SingleSlice": {
+			slices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			expected: map[string]int{"driver": 1},
+		},
+		"MultipleSlicesSamePool": {
+			slices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 2,
+							Generation:         1,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 2,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			expected: map[string]int{"driver": 1},
+		},
+		"MultipleSlicesDifferentPools": {
+			slices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_2",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			expected: map[string]int{"driver": 2},
+		},
+		"MultipleSlicesDifferentDrivers": {
+			slices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver2",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			expected: map[string]int{"driver1": 1, "driver2": 1},
+		},
+		"MultipleSlicesDifferentDriversSamePool_NotCompatible": {
+			slices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 2,
+							Generation:         1,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver2",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 2,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			expected: map[string]int{},
+		},
+		"PoolWithMultipleGenerations": {
+			slices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 2,
+							Generation:         2,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 2,
+							Generation:         2,
+						},
+					},
+				},
+			},
+			expected: map[string]int{"driver": 1},
+		},
+		"PoolWithMultipleGenerationsDifferentDrivers": {
+			slices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 2,
+							Generation:         1,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 2,
+							Generation:         2,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver2",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_1",
+							ResourceSliceCount: 2,
+							Generation:         2,
+						},
+					},
+				},
+			},
+			expected: map[string]int{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := getCompleteResourcePools(test.slices)
+			if diff := cmp.Diff(test.expected, result); diff != "" {
+				t.Errorf("getCompleteResourcePools(): unexpected result (-want +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestAreResourcePoolsReady(t *testing.T) {
+	tests := map[string]struct {
+		realSlices     []*v1.ResourceSlice
+		templateSlices []*v1.ResourceSlice
+		expected       bool
+	}{
+		"EmptyTemplatesAndRealSlices": {
+			realSlices:     []*v1.ResourceSlice{},
+			templateSlices: []*v1.ResourceSlice{},
+			expected:       true,
+		},
+		"EmptyTemplatesWithRealSlices": {
+			realSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_real",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			templateSlices: []*v1.ResourceSlice{},
+			expected:       true,
+		},
+		"TemplateRequiresOneRealHasOne": {
+			realSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_real",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			templateSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_template",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		"TemplateRequiresOneRealHasNone": {
+			realSlices: []*v1.ResourceSlice{},
+			templateSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_template",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"TemplateRequiresOneRealHasTwo": {
+			realSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_real_1",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_real_2",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			templateSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_template",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		"TemplateRequiresMultipleDriversRealMatches": {
+			realSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool:   resourceapi.ResourcePool{Name: "real_1", ResourceSliceCount: 1, Generation: 1},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver2",
+						Pool:   resourceapi.ResourcePool{Name: "real_2", ResourceSliceCount: 1, Generation: 1},
+					},
+				},
+			},
+			templateSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool:   resourceapi.ResourcePool{Name: "tpl_1", ResourceSliceCount: 1, Generation: 1},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver2",
+						Pool:   resourceapi.ResourcePool{Name: "tpl_2", ResourceSliceCount: 1, Generation: 1},
+					},
+				},
+			},
+			expected: true,
+		},
+		"TemplateRequiresMultipleDriversRealMissingOne": {
+			realSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool:   resourceapi.ResourcePool{Name: "real_1", ResourceSliceCount: 1, Generation: 1},
+					},
+				},
+			},
+			templateSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool:   resourceapi.ResourcePool{Name: "tpl_1", ResourceSliceCount: 1, Generation: 1},
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver2",
+						Pool:   resourceapi.ResourcePool{Name: "tpl_2", ResourceSliceCount: 1, Generation: 1},
+					},
+				},
+			},
+			expected: false,
+		},
+		"RealHasIncompletePool": {
+			realSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_real",
+							ResourceSliceCount: 2,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			templateSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool_template",
+							ResourceSliceCount: 1,
+							Generation:         1,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := areResourcePoolsReady(test.realSlices, test.templateSlices)
+			if result != test.expected {
+				t.Errorf("areResourcePoolsReady(): unexpected result, got %v, want %v", result, test.expected)
+			}
+		})
+	}
+}
+
+func BenchmarkGetCompleteResourcePools(b *testing.B) {
+	slices := []*v1.ResourceSlice{
+		{
+			Spec: v1.ResourceSliceSpec{
+				Pool: resourceapi.ResourcePool{
+					Name:               "pool_1",
+					ResourceSliceCount: 1,
+					Generation:         2,
+				},
+			},
+		},
+		{
+			Spec: v1.ResourceSliceSpec{
+				Pool: resourceapi.ResourcePool{
+					Name:               "pool_1",
+					ResourceSliceCount: 2,
+					Generation:         1,
+				},
+			},
+		},
+		{
+			Spec: v1.ResourceSliceSpec{
+				Pool: resourceapi.ResourcePool{
+					Name:               "pool_1",
+					ResourceSliceCount: 2,
+					Generation:         1,
+				},
+			},
+		},
+		{
+			Spec: v1.ResourceSliceSpec{
+				Pool: resourceapi.ResourcePool{
+					Name:               "pool_1",
+					ResourceSliceCount: 2,
+					Generation:         2,
+				},
+			},
+		},
+	}
+
+	for b.Loop() {
+		getCompleteResourcePools(slices)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This change resolves an issue with comparing DRA resource pools where devices are grouped in the multiple resource slices instead of a single one, current logic simply overwrites the assignment which causes non deterministic behaviour depending on the order of resource slices presentation. New logic instead relies on resource pool completion instead of comparing device names, previously vendors needed to provide all the devices which cloud provider builds as a template node or one acquired from the sanitized real node for autoscaler to treat node as ready. While in the new implementation we only require that count of ready resource pools is at least the same as in template pool

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug with DRA node readiness processor not considering devices from multiple resource slices
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
