### PR TITLE
Implement loop aware function duration tracking.

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -283,6 +283,9 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	a.DebuggingSnapshotter.StartDataCollection()
 	defer a.DebuggingSnapshotter.Flush()
 
+	// Flush aggregated function durations at the end of the loop.
+	defer metrics.FlushAggregatedDurations()
+
 	podLister := a.AllPodLister()
 	autoscalingCtx := a.AutoscalingContext
 

--- a/cluster-autoscaler/metrics/duration_counter.go
+++ b/cluster-autoscaler/metrics/duration_counter.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+const DurationCountersCapacity = 128
+
+// DurationCounter is a thread-safe counter for durations. It is used to
+// count the total duration of operations with the same key under assumption
+// that the number of keys is small is for the most part unchanging.
+type DurationCounter struct {
+	counters [DurationCountersCapacity]atomic.Int64
+	counterLabels [DurationCountersCapacity]string
+	entriesRegistered atomic.Int64
+}
+
+// NewDurationCounter creates a new DurationCounter.
+func NewDurationCounter() *DurationCounter {
+	return &DurationCounter{
+		counters: [DurationCountersCapacity]atomic.Int64{},
+	}
+}
+
+// RegisterLabel registers a label for a given key.
+func (dc *DurationCounter) RegisterLabel(key int, label string) {
+	dc.counterLabels[key] = label
+	dc.entriesRegistered.Add(1)
+}
+
+// Increment increments the counter for the given key by the given duration.
+func (dc *DurationCounter) Increment(key int, duration time.Duration) {
+	dc.counters[key].Add(int64(duration))
+}
+
+// Snapshot returns a snapshot of the current counters, may be inaccurate
+// if the counter is getting incremented concurrently.
+func (dc *DurationCounter) Snapshot() map[string]time.Duration {
+	result := make(map[string]time.Duration, dc.entriesRegistered.Load())
+	for i := range dc.counters {
+		label := dc.counterLabels[i]
+		counter := dc.counters[i].Load()
+
+		// Do not store entries with zero values as it indicates that
+		// the key was never incremented during this iteration of the counter
+		// or wasn't registered at all
+		if counter == 0 {
+			continue
+		}
+
+		if label == "" {
+			klog.Warningf("DurationCounter: counter %d is incremented, while label is not registered", i)
+			continue
+		}
+
+		result[label] = time.Duration(counter)
+	}
+
+	return result
+}
+
+// Reset resets the counters without removing the keys.
+func (dc *DurationCounter) Reset() {
+	for i := range dc.counters {
+		dc.counters[i].Store(0)
+	}
+}

--- a/cluster-autoscaler/metrics/duration_counter_test.go
+++ b/cluster-autoscaler/metrics/duration_counter_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDurationCounter(t *testing.T) {
+	dc := NewDurationCounter()
+	assert.NotNil(t, dc)
+}
+
+func TestDurationCounter_Increment(t *testing.T) {
+	dc := NewDurationCounter()
+
+	dc.RegisterLabel(1, "key1")
+	dc.RegisterLabel(2, "key2")
+
+	// Test single increment
+	dc.Increment(1, 5*time.Second)
+	snapshot := dc.Snapshot()
+	assert.Equal(t, 5*time.Second, snapshot["key1"])
+	assert.Equal(t, 1, len(snapshot))
+
+	// Test multiple increments same key
+	dc.Increment(1, 3*time.Second)
+	snapshot = dc.Snapshot()
+	assert.Equal(t, 8*time.Second, snapshot["key1"])
+	assert.Equal(t, 1, len(snapshot))
+
+	// Test new key
+	dc.Increment(2, 10*time.Second)
+	snapshot = dc.Snapshot()
+	assert.Equal(t, 8*time.Second, snapshot["key1"])
+	assert.Equal(t, 10*time.Second, snapshot["key2"])
+	assert.Equal(t, 2, len(snapshot))
+
+	// Test unregistered key
+	dc.Increment(3, 15*time.Second)
+	snapshot = dc.Snapshot()
+	assert.Equal(t, 8*time.Second, snapshot["key1"])
+	assert.Equal(t, 10*time.Second, snapshot["key2"])
+	assert.Equal(t, 2, len(snapshot))
+}
+
+func TestDurationCounter_Snapshot(t *testing.T) {
+	dc := NewDurationCounter()
+	dc.RegisterLabel(1, "key1")
+	dc.RegisterLabel(2, "key2")
+	dc.Increment(1, 1*time.Second)
+	dc.Increment(2, 2*time.Second)
+
+	snapshot := dc.Snapshot()
+	assert.Equal(t, 1*time.Second, snapshot["key1"])
+	assert.Equal(t, 2*time.Second, snapshot["key2"])
+
+	dc.Reset()
+	snapshot = dc.Snapshot()
+	assert.Empty(t, snapshot)
+
+	dc.Increment(2, 1*time.Second)
+	snapshot = dc.Snapshot()
+	assert.Equal(t, 1*time.Second, snapshot["key2"])
+}
+
+func TestDurationCounter_Reset(t *testing.T) {
+	dc := NewDurationCounter()
+	dc.RegisterLabel(1, "key1")
+	dc.RegisterLabel(2, "key2")
+	dc.Increment(1, 10*time.Second)
+	dc.Increment(2, 20*time.Second)
+
+	dc.Reset()
+	snapshot := dc.Snapshot()
+	assert.Empty(t, snapshot)
+
+	// Ensure keys can be reused after reset
+	dc.Increment(1, 5*time.Second)
+	snapshot = dc.Snapshot()
+	assert.Equal(t, 5*time.Second, snapshot["key1"])
+}
+
+func TestDurationCounter_RaceCondition(t *testing.T) {
+	dc := NewDurationCounter()
+	var wg sync.WaitGroup
+	routines := 100
+	iterations := 1000
+
+	// Register all the keys
+	dc.RegisterLabel(0, "key_concurrent")
+	for i := 1; i < DurationCountersCapacity; i++ {
+		dc.RegisterLabel(i, fmt.Sprintf("key_%d", i))
+	}
+
+	// Concurrent increments on the same key
+	wg.Add(routines)
+	for i := 0; i < routines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				dc.Increment(0, 1*time.Nanosecond)
+			}
+		}()
+	}
+
+	// Concurrent increments on different keys
+	wg.Add(routines)
+	for i := 0; i < routines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < DurationCountersCapacity - 1; j++ {
+				key := (j + 1) % DurationCountersCapacity
+				dc.Increment(key, 1*time.Nanosecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	snapshot := dc.Snapshot()
+
+	// Verify same key total
+	expectedDuration := time.Duration(routines*iterations) * time.Nanosecond
+	assert.Equal(t, expectedDuration, snapshot["key_concurrent"])
+
+	// Verify different keys
+	for i := 1; i < DurationCountersCapacity; i++ {
+		key := fmt.Sprintf("key_%d", i)
+		expected := time.Duration(routines) * time.Nanosecond
+		assert.Equal(t, expected, snapshot[key])
+	}
+}
+
+func BenchmarkDurationCounter_SingleCounter(b *testing.B) {
+	dc := NewDurationCounter()
+	dc.RegisterLabel(0, "key")
+	for b.Loop() {
+		dc.Increment(0, 1*time.Nanosecond)
+	}
+}
+
+func BenchmarkDurationCounter_StaticSetOfKeys(b *testing.B) {
+	dc := NewDurationCounter()
+	for i := 0; i < DurationCountersCapacity; i++ {
+		dc.RegisterLabel(i, fmt.Sprintf("key_%d", i))
+	}
+	for i := 0; i < b.N; i++ {
+		dc.Increment(i%DurationCountersCapacity, 1*time.Nanosecond)
+	}
+}
+
+func BenchmarkDurationCounter_StaticSetOfKeys_TimeSince(b *testing.B) {
+	dc := NewDurationCounter()
+	for i := 0; i < DurationCountersCapacity; i++ {
+		dc.RegisterLabel(i, fmt.Sprintf("key_%d", i))
+	}
+	for i := 0; i < b.N; i++ {
+		start := time.Now()
+		dc.Increment(i%DurationCountersCapacity, time.Since(start))
+	}
+}

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -49,6 +49,31 @@ func UpdateDuration(label FunctionLabel, duration time.Duration) {
 	DefaultMetrics.UpdateDuration(label, duration)
 }
 
+// UpdateDurationAggregated records the duration of the step identified by the
+// label key. The choice of using int as a key is to avoid the overhead of
+// hashing strings and to enforce zero collisions.
+//
+// Warning: if the label key is not registered, it will be ignored when flushing the
+// aggregated durations.
+func UpdateDurationAggregated(labelKey FunctionLabelKey, duration time.Duration) {
+	DefaultMetrics.UpdateDurationAggregated(labelKey, duration)
+}
+
+// UpdateDurationAggregatedFromStart records the duration of the step identified by the
+// label key using start time.
+//
+// Warning: if the label key is not registered, it will be ignored when flushing the
+// aggregated durations.
+func UpdateDurationAggregatedFromStart(labelKey FunctionLabelKey, start time.Time) {
+	DefaultMetrics.UpdateDurationAggregatedFromStart(labelKey, start)
+}
+
+// FlushAggregatedDurations records aggregated durations of the steps tracked
+// by UpdateDuration, resets the tracker and updates the metric.
+func FlushAggregatedDurations() {
+	DefaultMetrics.FlushAggregatedDurations()
+}
+
 // UpdateLastTime records the time the step identified by the label was started
 func UpdateLastTime(label FunctionLabel, now time.Time) {
 	DefaultMetrics.UpdateLastTime(label, now)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Current function_duration_seconds metric tracks per function invocations and while it's feasible to approximate the amount of work autoscaler performed per loop - it's close to impossible to do that precisely. The new metric (function_aggregated_duration_seconds) satisfies exactly this purpose by exposing aggregated function durations collected throughout the loop and flushes them only at the end of it

The performance impact on the autoscaler should be very small especially because the implementation is highly specialized for the use case of static amount of keys (function labels) being tracked by the counter and those do not grow without extending the source code and recompiling the binary. This instrumentation shouldn't be used in the hot loops in and the performance impact should be measured before adding it

Note that in benchmarks duration calculation takes a major part of the workload while the store itself is almost free

```
goos: linux
goarch: amd64
pkg: k8s.io/autoscaler/cluster-autoscaler/metrics
cpu: AMD EPYC 7B12
BenchmarkDurationCounter_SingleCounter-24                       463768752                2.592 ns/op           0 B/op          0 allocs/op
BenchmarkDurationCounter_StaticSetOfKeys-24                     477213328                2.508 ns/op           0 B/op          0 allocs/op
BenchmarkDurationCounter_StaticSetOfKeys_TimeSince-24           13188592                92.34 ns/op            0 B/op          0 allocs/op
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
