### PR TITLE
add noisy workloads for vpa benchmark

### DIFF
--- a/vertical-pod-autoscaler/benchmark/README.md
+++ b/vertical-pod-autoscaler/benchmark/README.md
@@ -74,7 +74,8 @@ The benchmark program (`main.go`) assumes the cluster is already set up with VPA
    - Scales down VPA components
    - Cleans up previous benchmark resources
    - Creates ReplicaSets with fake pods assigned directly to KWOK node (bypasses scheduler)
-   - Creates VPAs targeting those ReplicaSets
+   - Creates noise ReplicaSets (if `--noise-ratio` > 0) — these are not managed by any VPA
+   - Creates VPAs targeting managed ReplicaSets only
    - Scales up recommender, waits for recommendations
    - Scales up updater, waits for its loop to complete
    - Scrapes `vpa_updater_execution_latency_seconds_sum` metrics
@@ -109,6 +110,8 @@ Ideally the benchmark would be done on the same machine (or a similar one), with
 | xlarge  | 500  | 500         | 1000 |
 | xxlarge | 1000 | 1000        | 2000 |
 
+When `--noise-percentage=P` is set, each profile also creates `P%` additional noise ReplicaSets (not managed by any VPA). For example, `--profile=medium --noise-percentage=50` creates 100 managed RS (200 pods) + 50 noise RS (100 pods) = 300 total pods.
+
 ## Flags
 
 | Flag | Default | Description |
@@ -117,6 +120,7 @@ Ideally the benchmark would be done on the same machine (or a similar one), with
 | `--runs` | 1 | Iterations per profile. This is used for averaging multiple runs. |
 | `--output` | "" | Path to output file for results table (CSV format). Output will always be printed to stdout. |
 | `--kubeconfig` | "" | Path to kubeconfig. Required if not using KUBECONFIG env var or ~/.kube/config. |
+| `--noise-percentage` | 0% | Percentage of additional noise (unmanaged) ReplicaSets relative to managed ReplicaSets. Set to 0% for no noise. Noise pods increase `FilterPods` and `ListPods` costs without adding VPAs. |
 
 ## Metrics Collected
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a new flag for "noise" pods for the VPA benchmark.
Test it by running:

```bash
./benchmark/hack/full-benchmark.sh --profile=small --output=results.csv --noise-percentage=50
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
