### PR TITLE
Consolidate SetClusterState logic in PredicateSnapshot and small improvements

### DIFF
--- a/cluster-autoscaler/processors/customresources/csi_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/csi_processor_test.go
@@ -302,8 +302,8 @@ func TestFilterOutNodesWithUnreadyCSIResources(t *testing.T) {
 			}
 
 			clusterSnapshotStore := store.NewBasicSnapshotStore()
-			clusterSnapshotStore.SetClusterState([]*apiv1.Node{}, []*apiv1.Pod{}, nil, csiSnapshot)
 			clusterSnapshot, _, _ := testsnapshot.NewCustomTestSnapshotAndHandle(clusterSnapshotStore)
+			clusterSnapshot.SetClusterState([]*apiv1.Node{}, []*apiv1.Pod{}, nil, csiSnapshot)
 
 			autoscalingCtx := &ca_context.AutoscalingContext{CloudProvider: provider, ClusterSnapshot: clusterSnapshot}
 			processor := CSICustomResourcesProcessor{}

--- a/cluster-autoscaler/processors/customresources/dra_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/dra_processor_test.go
@@ -396,8 +396,8 @@ func TestFilterOutNodesWithUnreadyDRAResources(t *testing.T) {
 			provider.SetMachineTemplates(machineTemplates)
 			draSnapshot := drasnapshot.NewSnapshot(nil, tc.nodesSlices, nil, nil)
 			clusterSnapshotStore := store.NewBasicSnapshotStore()
-			clusterSnapshotStore.SetClusterState([]*apiv1.Node{}, []*apiv1.Pod{}, draSnapshot, nil)
 			clusterSnapshot, _, _ := testsnapshot.NewCustomTestSnapshotAndHandle(clusterSnapshotStore)
+			clusterSnapshot.SetClusterState([]*apiv1.Node{}, []*apiv1.Pod{}, draSnapshot, nil)
 
 			autoscalingCtx := &ca_context.AutoscalingContext{
 				CloudProvider:            provider,

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -24,7 +24,7 @@ import (
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
 // ClusterSnapshot is abstraction of cluster state used for predicate simulations.
@@ -88,7 +88,7 @@ type ClusterSnapshotStore interface {
 	// AddSchedulerNodeInfo adds the given schedulerframework.NodeInfo to the snapshot without checking scheduler predicates, and
 	// without taking DRA objects into account. This shouldn't be used outside the clustersnapshot pkg, use ClusterSnapshot.AddNodeInfo()
 	// instead.
-	AddSchedulerNodeInfo(nodeInfo fwk.NodeInfo) error
+	AddSchedulerNodeInfo(nodeInfo schedulerinterface.NodeInfo) error
 	// RemoveSchedulerNodeInfo removes the given schedulerframework.NodeInfo from the snapshot without taking DRA objects into account. This shouldn't
 	// be used outside the clustersnapshot pkg, use ClusterSnapshot.RemoveNodeInfo() instead.
 	RemoveSchedulerNodeInfo(nodeName string) error

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -27,11 +27,23 @@ import (
 	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
+// Forkable is an interface for objects that can be forked, reverted and committed.
+type Forkable interface {
+	// Fork creates a fork of the object state. All modifications can later be reverted to moment of forking via Revert().
+	// Use WithForkedSnapshot() helper function instead if possible.
+	Fork()
+	// Revert reverts the object state to moment of forking.
+	Revert()
+	// Commit commits changes done after forking.
+	Commit() error
+}
+
 // ClusterSnapshot is abstraction of cluster state used for predicate simulations.
 // It exposes mutation methods and can be viewed as scheduler's SharedLister.
 type ClusterSnapshot interface {
 	framework.SharedLister
 	ClusterSnapshotStore
+	Forkable
 
 	// SetClusterState resets the snapshot to an unforked state and replaces the contents of the snapshot
 	// with the provided data. scheduledPods are correlated to their Nodes based on spec.NodeName.
@@ -78,14 +90,6 @@ type ClusterSnapshot interface {
 	// CsiSnapshot returns an interface that allows accessing and modifying the CSINode objects in the snapshot.
 	CsiSnapshot() *csisnapshot.Snapshot
 
-	// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert().
-	// Use WithForkedSnapshot() helper function instead if possible.
-	Fork()
-	// Revert reverts snapshot state to moment of forking.
-	Revert()
-	// Commit commits changes done after forking.
-	Commit() error
-
 	// TODO(DRA): Move unschedulable Pods inside ClusterSnapshot (since their DRA objects are already here), refactor PodListProcessor.
 }
 
@@ -94,6 +98,7 @@ type ClusterSnapshot interface {
 // should be accessed via ClusterSnapshot.
 type ClusterSnapshotStore interface {
 	schedulerinterface.SharedLister
+	Forkable
 
 	// ForceAddPod adds the given Pod to the Node with the given nodeName inside the snapshot without checking scheduler predicates.
 	ForceAddPod(pod *apiv1.Pod, nodeName string) error
@@ -110,13 +115,6 @@ type ClusterSnapshotStore interface {
 
 	// Clear resets the snapshot to an empty, unforked state.
 	Clear()
-
-	// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert().
-	Fork()
-	// Revert reverts snapshot state to moment of forking.
-	Revert()
-	// Commit commits changes done after forking.
-	Commit() error
 }
 
 // ErrNodeNotFound means that a node wasn't found in the snapshot.

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -30,6 +30,7 @@ import (
 // ClusterSnapshot is abstraction of cluster state used for predicate simulations.
 // It exposes mutation methods and can be viewed as scheduler's SharedLister.
 type ClusterSnapshot interface {
+	framework.SharedLister
 	ClusterSnapshotStore
 
 	// SetClusterState resets the snapshot to an unforked state and replaces the contents of the snapshot
@@ -71,6 +72,20 @@ type ClusterSnapshot interface {
 	// checked against SchedulingInternalError to distinguish failing predicates from unexpected errors. Doesn't mutate the snapshot.
 	CheckPredicates(pod *apiv1.Pod, nodeName string) SchedulingError
 
+	// DraSnapshot returns an interface that allows accessing and modifying the DRA objects in the snapshot.
+	DraSnapshot() *drasnapshot.Snapshot
+
+	// CsiSnapshot returns an interface that allows accessing and modifying the CSINode objects in the snapshot.
+	CsiSnapshot() *csisnapshot.Snapshot
+
+	// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert().
+	// Use WithForkedSnapshot() helper function instead if possible.
+	Fork()
+	// Revert reverts snapshot state to moment of forking.
+	Revert()
+	// Commit commits changes done after forking.
+	Commit() error
+
 	// TODO(DRA): Move unschedulable Pods inside ClusterSnapshot (since their DRA objects are already here), refactor PodListProcessor.
 }
 
@@ -78,7 +93,7 @@ type ClusterSnapshot interface {
 // without going through scheduler predicates. ClusterSnapshotStore shouldn't be directly used outside the clustersnapshot pkg, its methods
 // should be accessed via ClusterSnapshot.
 type ClusterSnapshotStore interface {
-	framework.SharedLister
+	schedulerinterface.SharedLister
 
 	// ForceAddPod adds the given Pod to the Node with the given nodeName inside the snapshot without checking scheduler predicates.
 	ForceAddPod(pod *apiv1.Pod, nodeName string) error
@@ -93,22 +108,10 @@ type ClusterSnapshotStore interface {
 	// be used outside the clustersnapshot pkg, use ClusterSnapshot.RemoveNodeInfo() instead.
 	RemoveSchedulerNodeInfo(nodeName string) error
 
-	// SetDraSnapshot replaces the DRA snapshot in the store.
-	SetDraSnapshot(draSnapshot *drasnapshot.Snapshot)
-	// SetCsiSnapshot replaces the CSI snapshot in the store.
-	SetCsiSnapshot(csiSnapshot *csisnapshot.Snapshot)
-
-	// DraSnapshot returns an interface that allows accessing and modifying the DRA objects in the snapshot.
-	DraSnapshot() *drasnapshot.Snapshot
-
-	// CsiSnapshot returns an interface that allows accessing and modifying the CSINode objects in the snapshot.
-	CsiSnapshot() *csisnapshot.Snapshot
-
 	// Clear resets the snapshot to an empty, unforked state.
 	Clear()
 
 	// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert().
-	// Use WithForkedSnapshot() helper function instead if possible.
 	Fork()
 	// Revert reverts snapshot state to moment of forking.
 	Revert()

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	apiv1 "k8s.io/api/core/v1"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 // SchedulerPluginRunner can be used to run various phases of scheduler plugins through the scheduler framework.
@@ -50,7 +50,7 @@ func NewSchedulerPluginRunner(fwHandle *framework.Handle, snapshot clustersnapsh
 
 // RunFiltersUntilPassingNode runs the scheduler framework PreFilter phase once, and then keeps running the Filter phase for all nodes in the cluster that match the
 // opts.IsNodeAcceptable function - until a Node where the Filters pass is found. Filters are only run for matching Nodes. If no matching Node with passing Filters is found, an error is returned.
-func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts clustersnapshot.SchedulingOptions) (*apiv1.Node, *schedulerframework.CycleState, clustersnapshot.SchedulingError) {
+func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts clustersnapshot.SchedulingOptions) (*apiv1.Node, *schedulerimpl.CycleState, clustersnapshot.SchedulingError) {
 	nodeInfosList, err := p.snapshot.ListNodeInfos()
 	if err != nil {
 		return nil, nil, clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("error listing NodeInfos: %v", err))
@@ -59,7 +59,7 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 	p.fwHandle.DelegatingLister.UpdateDelegate(p.snapshot)
 	defer p.fwHandle.DelegatingLister.ResetDelegate()
 
-	state := schedulerframework.NewCycleState()
+	state := schedulerimpl.NewCycleState()
 	// Run the PreFilter phase of the framework for the Pod. This allows plugins to precompute some things (for all Nodes in the cluster at once) and
 	// save them in the CycleState. During the Filter phase, plugins can retrieve the precomputes from the CycleState and use them for answering the Filter
 	// for a given Node.
@@ -142,7 +142,7 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 }
 
 // RunFiltersOnNode runs the scheduler framework PreFilter and Filter phases to check if the given pod can be scheduled on the given node.
-func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string) (*apiv1.Node, *schedulerframework.CycleState, clustersnapshot.SchedulingError) {
+func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string) (*apiv1.Node, *schedulerimpl.CycleState, clustersnapshot.SchedulingError) {
 	nodeInfo, err := p.snapshot.GetNodeInfo(nodeName)
 	if err != nil {
 		return nil, nil, clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("error obtaining NodeInfo for name %q: %v", nodeName, err))
@@ -151,7 +151,7 @@ func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string
 	p.fwHandle.DelegatingLister.UpdateDelegate(p.snapshot)
 	defer p.fwHandle.DelegatingLister.ResetDelegate()
 
-	state := schedulerframework.NewCycleState()
+	state := schedulerimpl.NewCycleState()
 	// Run the PreFilter phase of the framework for the Pod and check the results. See the corresponding comments in RunFiltersUntilPassingNode() for more info.
 	preFilterResult, preFilterStatus, nodeFilteringPlugins := p.fwHandle.Framework.RunPreFilterPlugins(context.TODO(), state, pod)
 	if !preFilterStatus.IsSuccess() {
@@ -180,7 +180,7 @@ func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string
 }
 
 // RunReserveOnNode runs the scheduler framework Reserve phase to update the scheduler plugins state to reflect the Pod being scheduled on the Node.
-func (p *SchedulerPluginRunner) RunReserveOnNode(pod *apiv1.Pod, nodeName string, postFilterState *schedulerframework.CycleState) error {
+func (p *SchedulerPluginRunner) RunReserveOnNode(pod *apiv1.Pod, nodeName string, postFilterState *schedulerimpl.CycleState) error {
 	p.fwHandle.DelegatingLister.UpdateDelegate(p.snapshot)
 	defer p.fwHandle.DelegatingLister.ResetDelegate()
 

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
@@ -25,7 +25,7 @@ import (
 	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/dynamic-resource-allocation/resourceclaim"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 // PredicateSnapshot implements ClusterSnapshot on top of a ClusterSnapshotStore by using
@@ -52,7 +52,7 @@ func NewPredicateSnapshot(snapshotStore clustersnapshot.ClusterSnapshotStore, fw
 	return snapshot
 }
 
-// GetNodeInfo returns an internal NodeInfo wrapping the relevant schedulerframework.NodeInfo.
+// GetNodeInfo returns an internal NodeInfo wrapping the relevant schedulerimpl.NodeInfo.
 func (s *PredicateSnapshot) GetNodeInfo(nodeName string) (*framework.NodeInfo, error) {
 	schedNodeInfo, err := s.ClusterSnapshotStore.NodeInfos().Get(nodeName)
 	if err != nil {
@@ -76,7 +76,7 @@ func (s *PredicateSnapshot) GetNodeInfo(nodeName string) (*framework.NodeInfo, e
 	return wrappedNodeInfo, nil
 }
 
-// ListNodeInfos returns internal NodeInfos wrapping all schedulerframework.NodeInfos in the snapshot.
+// ListNodeInfos returns internal NodeInfos wrapping all schedulerimpl.NodeInfos in the snapshot.
 func (s *PredicateSnapshot) ListNodeInfos() ([]*framework.NodeInfo, error) {
 	schedNodeInfos, err := s.ClusterSnapshotStore.NodeInfos().List()
 	if err != nil {
@@ -260,7 +260,7 @@ func (s *PredicateSnapshot) verifyScheduledPodResourceClaims(pod *apiv1.Pod, nod
 	return nil
 }
 
-func (s *PredicateSnapshot) modifyResourceClaimsForScheduledPod(pod *apiv1.Pod, node *apiv1.Node, postFilterState *schedulerframework.CycleState) error {
+func (s *PredicateSnapshot) modifyResourceClaimsForScheduledPod(pod *apiv1.Pod, node *apiv1.Node, postFilterState *schedulerimpl.CycleState) error {
 	// We need to run the scheduler Reserve phase to allocate the appropriate ResourceClaims in the DRA snapshot. The allocations are
 	// actually computed and cached in the Filter phase, and Reserve only grabs them from the cycle state. So this should be quick, but
 	// it needs the cycle state from after running the Filter phase.

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/dynamic-resource-allocation/resourceclaim"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -40,6 +41,8 @@ type PredicateSnapshot struct {
 	draEnabled                   bool
 	enableCSINodeAwareScheduling bool
 	parallelism                  int
+	draSnapshot                  *drasnapshot.Snapshot
+	csiSnapshot                  *csisnapshot.Snapshot
 }
 
 // NewPredicateSnapshot builds a PredicateSnapshot.
@@ -49,6 +52,8 @@ func NewPredicateSnapshot(snapshotStore clustersnapshot.ClusterSnapshotStore, fw
 		draEnabled:                   draEnabled,
 		enableCSINodeAwareScheduling: enableCSINodeAwareScheduling,
 		parallelism:                  parallelism,
+		draSnapshot:                  drasnapshot.NewEmptySnapshot(),
+		csiSnapshot:                  csisnapshot.NewEmptySnapshot(),
 	}
 	// Plugin runner really only needs a framework.SharedLister for running the plugins, but it also needs to run the provided Node-matching functions
 	// which operate on *framework.NodeInfo. The only object that allows obtaining *framework.NodeInfos is PredicateSnapshot, so we have an ugly circular
@@ -92,12 +97,12 @@ func (s *PredicateSnapshot) SetClusterState(nodes []*apiv1.Node, scheduledPods [
 	if draSnapshot == nil {
 		draSnapshot = drasnapshot.NewEmptySnapshot()
 	}
-	s.ClusterSnapshotStore.SetDraSnapshot(draSnapshot)
+	s.draSnapshot = draSnapshot
 
 	if csiSnapshot == nil {
 		csiSnapshot = csisnapshot.NewEmptySnapshot()
 	}
-	s.ClusterSnapshotStore.SetCsiSnapshot(csiSnapshot)
+	s.csiSnapshot = csiSnapshot
 
 	return nil
 }
@@ -138,14 +143,14 @@ func (s *PredicateSnapshot) GetNodeInfo(nodeName string) (*framework.NodeInfo, e
 
 	wrappedNodeInfo := framework.WrapSchedulerNodeInfo(schedNodeInfo, nil, nil)
 	if s.draEnabled {
-		wrappedNodeInfo, err = s.ClusterSnapshotStore.DraSnapshot().WrapSchedulerNodeInfo(schedNodeInfo)
+		wrappedNodeInfo, err = s.draSnapshot.WrapSchedulerNodeInfo(schedNodeInfo)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if s.enableCSINodeAwareScheduling {
-		wrappedNodeInfo, err = s.ClusterSnapshotStore.CsiSnapshot().AddCSINodeInfoToNodeInfo(wrappedNodeInfo)
+		wrappedNodeInfo, err = s.csiSnapshot.AddCSINodeInfoToNodeInfo(wrappedNodeInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -165,14 +170,14 @@ func (s *PredicateSnapshot) ListNodeInfos() ([]*framework.NodeInfo, error) {
 
 		var err error
 		if s.draEnabled {
-			wrappedNodeInfo, err = s.ClusterSnapshotStore.DraSnapshot().WrapSchedulerNodeInfo(schedNodeInfo)
+			wrappedNodeInfo, err = s.draSnapshot.WrapSchedulerNodeInfo(schedNodeInfo)
 			if err != nil {
 				return nil, err
 			}
 		}
 
 		if s.enableCSINodeAwareScheduling {
-			wrappedNodeInfo, err = s.ClusterSnapshotStore.CsiSnapshot().AddCSINodeInfoToNodeInfo(wrappedNodeInfo)
+			wrappedNodeInfo, err = s.csiSnapshot.AddCSINodeInfoToNodeInfo(wrappedNodeInfo)
 			if err != nil {
 				return nil, err
 			}
@@ -187,7 +192,7 @@ func (s *PredicateSnapshot) AddNodeInfo(nodeInfo *framework.NodeInfo) error {
 	if s.draEnabled {
 		// TODO(DRA): Add transaction-like clean-up in case of errors here - don't modify the state on any errors.
 		if len(nodeInfo.LocalResourceSlices) > 0 {
-			if err := s.ClusterSnapshotStore.DraSnapshot().AddNodeResourceSlices(nodeInfo.Node().Name, nodeInfo.LocalResourceSlices); err != nil {
+			if err := s.draSnapshot.AddNodeResourceSlices(nodeInfo.Node().Name, nodeInfo.LocalResourceSlices); err != nil {
 				return fmt.Errorf("couldn't add ResourceSlices to DRA snapshot: %v", err)
 			}
 		}
@@ -206,7 +211,7 @@ func (s *PredicateSnapshot) AddNodeInfo(nodeInfo *framework.NodeInfo) error {
 
 	if s.enableCSINodeAwareScheduling {
 		if nodeInfo.CSINode != nil {
-			if err := s.ClusterSnapshotStore.CsiSnapshot().AddCSINode(nodeInfo.CSINode); err != nil {
+			if err := s.csiSnapshot.AddCSINode(nodeInfo.CSINode); err != nil {
 				return err
 			}
 		}
@@ -227,16 +232,16 @@ func (s *PredicateSnapshot) RemoveNodeInfo(nodeName string) error {
 	}
 
 	if s.draEnabled {
-		s.ClusterSnapshotStore.DraSnapshot().RemoveNodeResourceSlices(nodeName)
+		s.draSnapshot.RemoveNodeResourceSlices(nodeName)
 
 		for _, pod := range nodeInfo.Pods() {
-			s.ClusterSnapshotStore.DraSnapshot().RemovePodOwnedClaims(pod.Pod)
+			s.draSnapshot.RemovePodOwnedClaims(pod.Pod)
 		}
 	}
 	if s.enableCSINodeAwareScheduling {
 		// generally a node name is same as csi node name and hence we should be safe
 		if nodeInfo.CSINode != nil {
-			s.ClusterSnapshotStore.CsiSnapshot().RemoveCSINode(nodeName)
+			s.csiSnapshot.RemoveCSINode(nodeName)
 		}
 	}
 	return nil
@@ -308,7 +313,7 @@ func (s *PredicateSnapshot) UnschedulePod(namespace string, podName string, node
 		}
 
 		if len(foundPod.Spec.ResourceClaims) > 0 {
-			if err := s.ClusterSnapshotStore.DraSnapshot().UnreservePodClaims(foundPod); err != nil {
+			if err := s.draSnapshot.UnreservePodClaims(foundPod); err != nil {
 				return err
 			}
 		}
@@ -323,9 +328,75 @@ func (s *PredicateSnapshot) CheckPredicates(pod *apiv1.Pod, nodeName string) clu
 	return err
 }
 
+// DraSnapshot returns an interface that allows accessing and modifying the DRA objects in the snapshot.
+func (s *PredicateSnapshot) DraSnapshot() *drasnapshot.Snapshot {
+	return s.draSnapshot
+}
+
+// CsiSnapshot returns an interface that allows accessing and modifying the CSINode objects in the snapshot.
+func (s *PredicateSnapshot) CsiSnapshot() *csisnapshot.Snapshot {
+	return s.csiSnapshot
+}
+
+// Clear resets the snapshot to an empty, unforked state.
+func (s *PredicateSnapshot) Clear() {
+	s.ClusterSnapshotStore.Clear()
+	s.draSnapshot = drasnapshot.NewEmptySnapshot()
+	s.csiSnapshot = csisnapshot.NewEmptySnapshot()
+}
+
+// Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert().
+func (s *PredicateSnapshot) Fork() {
+	s.ClusterSnapshotStore.Fork()
+	s.draSnapshot.Fork()
+	s.csiSnapshot.Fork()
+}
+
+// Revert reverts snapshot state to moment of forking.
+func (s *PredicateSnapshot) Revert() {
+	s.ClusterSnapshotStore.Revert()
+	s.draSnapshot.Revert()
+	s.csiSnapshot.Revert()
+}
+
+// Commit commits changes done after forking.
+func (s *PredicateSnapshot) Commit() error {
+	if err := s.ClusterSnapshotStore.Commit(); err != nil {
+		return err
+	}
+	s.draSnapshot.Commit()
+	s.csiSnapshot.Commit()
+	return nil
+}
+
+// ResourceClaims exposes snapshot as ResourceClaimTracker
+func (s *PredicateSnapshot) ResourceClaims() schedulerinterface.ResourceClaimTracker {
+	return s.draSnapshot.ResourceClaims()
+}
+
+// ResourceSlices exposes snapshot as ResourceSliceLister.
+func (s *PredicateSnapshot) ResourceSlices() schedulerinterface.ResourceSliceLister {
+	return s.draSnapshot.ResourceSlices()
+}
+
+// DeviceClasses exposes the snapshot as DeviceClassLister.
+func (s *PredicateSnapshot) DeviceClasses() schedulerinterface.DeviceClassLister {
+	return s.draSnapshot.DeviceClasses()
+}
+
+// DeviceClassResolver exposes the snapshot as DeviceClassResolver.
+func (s *PredicateSnapshot) DeviceClassResolver() schedulerinterface.DeviceClassResolver {
+	return s.draSnapshot.DeviceClassResolver()
+}
+
+// CSINodes returns the CSI nodes snapshot.
+func (s *PredicateSnapshot) CSINodes() schedulerinterface.CSINodeLister {
+	return s.csiSnapshot.CSINodes()
+}
+
 // verifyScheduledPodResourceClaims verifies that all needed claims are tracked in the DRA snapshot, allocated, and available on the Node.
 func (s *PredicateSnapshot) verifyScheduledPodResourceClaims(pod *apiv1.Pod, node *apiv1.Node) error {
-	claims, err := s.ClusterSnapshotStore.DraSnapshot().PodClaims(pod)
+	claims, err := s.draSnapshot.PodClaims(pod)
 	if err != nil {
 		return fmt.Errorf("couldn't obtain pod %s/%s claims: %v", pod.Namespace, pod.Name, err)
 	}
@@ -347,7 +418,7 @@ func (s *PredicateSnapshot) modifyResourceClaimsForScheduledPod(pod *apiv1.Pod, 
 
 	// The pod isn't added to the ReservedFor field of the claim during the Reserve phase (it happens later, in PreBind). We can just do it
 	// manually here. It shouldn't fail, it only fails if ReservedFor is at max length already, but that is checked during the Filter phase.
-	if err := s.ClusterSnapshotStore.DraSnapshot().ReservePodClaims(pod); err != nil {
+	if err := s.draSnapshot.ReservePodClaims(pod); err != nil {
 		return fmt.Errorf("couldn't add pod %s/%s reservations to claims, this shouldn't happen: %v", pod.Namespace, pod.Name, err)
 	}
 	return nil
@@ -363,13 +434,13 @@ func (s *PredicateSnapshot) modifyResourceClaimsForNewPod(podInfo *framework.Pod
 			podOwnedClaims = append(podOwnedClaims, claim)
 		}
 	}
-	if err := s.ClusterSnapshotStore.DraSnapshot().AddClaims(podOwnedClaims); err != nil {
+	if err := s.draSnapshot.AddClaims(podOwnedClaims); err != nil {
 		return fmt.Errorf("couldn't add ResourceSlices for pod %s/%s to DRA snapshot: %v", podInfo.Namespace, podInfo.Name, err)
 	}
 
 	// The Pod-owned claims should already be reserved for the Pod after sanitization, but we need to add the reservation for the new Pod
 	// to the shared claims. This can fail if doing so would exceed the max reservation limit for a claim.
-	if err := s.ClusterSnapshotStore.DraSnapshot().ReservePodClaims(podInfo.Pod); err != nil {
+	if err := s.draSnapshot.ReservePodClaims(podInfo.Pod); err != nil {
 		return fmt.Errorf("couldn't add pod %s/%s reservations to claims, this shouldn't happen: %v", podInfo.Namespace, podInfo.Name, err)
 	}
 	return nil

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -24,8 +24,8 @@ import (
 	csisnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/csi/snapshot"
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/klog/v2"
-	fwk "k8s.io/kube-scheduler/framework"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
+	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 // BasicSnapshotStore is simple, reference implementation of ClusterSnapshotStore.
@@ -37,20 +37,20 @@ type BasicSnapshotStore struct {
 }
 
 type internalBasicSnapshotData struct {
-	nodeInfoMap        map[string]fwk.NodeInfo
+	nodeInfoMap        map[string]schedulerinterface.NodeInfo
 	pvcNamespacePodMap map[string]map[string]bool
 }
 
-func (data *internalBasicSnapshotData) listNodeInfos() []fwk.NodeInfo {
-	nodeInfoList := make([]fwk.NodeInfo, 0, len(data.nodeInfoMap))
+func (data *internalBasicSnapshotData) listNodeInfos() []schedulerinterface.NodeInfo {
+	nodeInfoList := make([]schedulerinterface.NodeInfo, 0, len(data.nodeInfoMap))
 	for _, v := range data.nodeInfoMap {
 		nodeInfoList = append(nodeInfoList, v)
 	}
 	return nodeInfoList
 }
 
-func (data *internalBasicSnapshotData) listNodeInfosThatHavePodsWithAffinityList() ([]fwk.NodeInfo, error) {
-	havePodsWithAffinityList := make([]fwk.NodeInfo, 0, len(data.nodeInfoMap))
+func (data *internalBasicSnapshotData) listNodeInfosThatHavePodsWithAffinityList() ([]schedulerinterface.NodeInfo, error) {
+	havePodsWithAffinityList := make([]schedulerinterface.NodeInfo, 0, len(data.nodeInfoMap))
 	for _, v := range data.nodeInfoMap {
 		if len(v.GetPodsWithAffinity()) > 0 {
 			havePodsWithAffinityList = append(havePodsWithAffinityList, v)
@@ -60,8 +60,8 @@ func (data *internalBasicSnapshotData) listNodeInfosThatHavePodsWithAffinityList
 	return havePodsWithAffinityList, nil
 }
 
-func (data *internalBasicSnapshotData) listNodeInfosThatHavePodsWithRequiredAntiAffinityList() ([]fwk.NodeInfo, error) {
-	havePodsWithRequiredAntiAffinityList := make([]fwk.NodeInfo, 0, len(data.nodeInfoMap))
+func (data *internalBasicSnapshotData) listNodeInfosThatHavePodsWithRequiredAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
+	havePodsWithRequiredAntiAffinityList := make([]schedulerinterface.NodeInfo, 0, len(data.nodeInfoMap))
 	for _, v := range data.nodeInfoMap {
 		if len(v.GetPodsWithRequiredAntiAffinity()) > 0 {
 			havePodsWithRequiredAntiAffinityList = append(havePodsWithRequiredAntiAffinityList, v)
@@ -71,7 +71,7 @@ func (data *internalBasicSnapshotData) listNodeInfosThatHavePodsWithRequiredAnti
 	return havePodsWithRequiredAntiAffinityList, nil
 }
 
-func (data *internalBasicSnapshotData) getNodeInfo(nodeName string) (fwk.NodeInfo, error) {
+func (data *internalBasicSnapshotData) getNodeInfo(nodeName string) (schedulerinterface.NodeInfo, error) {
 	if v, ok := data.nodeInfoMap[nodeName]; ok {
 		return v, nil
 	}
@@ -94,7 +94,7 @@ func (data *internalBasicSnapshotData) addPvcUsedByPod(pod *apiv1.Pod) {
 		if volume.PersistentVolumeClaim == nil {
 			continue
 		}
-		k := schedulerframework.GetNamespacedName(nameSpace, volume.PersistentVolumeClaim.ClaimName)
+		k := schedulerimpl.GetNamespacedName(nameSpace, volume.PersistentVolumeClaim.ClaimName)
 		_, found := data.pvcNamespacePodMap[k]
 		if !found {
 			data.pvcNamespacePodMap[k] = make(map[string]bool)
@@ -113,7 +113,7 @@ func (data *internalBasicSnapshotData) removePvcUsedByPod(pod *apiv1.Pod) {
 		if volume.PersistentVolumeClaim == nil {
 			continue
 		}
-		k := schedulerframework.GetNamespacedName(nameSpace, volume.PersistentVolumeClaim.ClaimName)
+		k := schedulerimpl.GetNamespacedName(nameSpace, volume.PersistentVolumeClaim.ClaimName)
 		if _, found := data.pvcNamespacePodMap[k]; found {
 			delete(data.pvcNamespacePodMap[k], pod.GetName())
 			if len(data.pvcNamespacePodMap[k]) == 0 {
@@ -125,13 +125,13 @@ func (data *internalBasicSnapshotData) removePvcUsedByPod(pod *apiv1.Pod) {
 
 func newInternalBasicSnapshotData() *internalBasicSnapshotData {
 	return &internalBasicSnapshotData{
-		nodeInfoMap:        make(map[string]fwk.NodeInfo),
+		nodeInfoMap:        make(map[string]schedulerinterface.NodeInfo),
 		pvcNamespacePodMap: make(map[string]map[string]bool),
 	}
 }
 
 func (data *internalBasicSnapshotData) clone() *internalBasicSnapshotData {
-	clonedNodeInfoMap := make(map[string]fwk.NodeInfo)
+	clonedNodeInfoMap := make(map[string]schedulerinterface.NodeInfo)
 	for k, v := range data.nodeInfoMap {
 		clonedNodeInfoMap[k] = v.Snapshot()
 	}
@@ -152,7 +152,7 @@ func (data *internalBasicSnapshotData) addNode(node *apiv1.Node) error {
 	if _, found := data.nodeInfoMap[node.Name]; found {
 		return fmt.Errorf("node %s already in snapshot", node.Name)
 	}
-	nodeInfo := schedulerframework.NewNodeInfo()
+	nodeInfo := schedulerimpl.NewNodeInfo()
 	nodeInfo.SetNode(node)
 	data.nodeInfoMap[node.Name] = nodeInfo
 	return nil
@@ -173,7 +173,7 @@ func (data *internalBasicSnapshotData) addPod(pod *apiv1.Pod, nodeName string) e
 	if _, found := data.nodeInfoMap[nodeName]; !found {
 		return clustersnapshot.ErrNodeNotFound
 	}
-	podInfo, _ := schedulerframework.NewPodInfo(pod)
+	podInfo, _ := schedulerimpl.NewPodInfo(pod)
 	data.nodeInfoMap[nodeName].AddPodInfo(podInfo)
 	data.addPvcUsedByPod(pod)
 	return nil
@@ -221,7 +221,7 @@ func (snapshot *BasicSnapshotStore) CsiSnapshot() *csisnapshot.Snapshot {
 }
 
 // AddSchedulerNodeInfo adds a NodeInfo.
-func (snapshot *BasicSnapshotStore) AddSchedulerNodeInfo(nodeInfo fwk.NodeInfo) error {
+func (snapshot *BasicSnapshotStore) AddSchedulerNodeInfo(nodeInfo schedulerinterface.NodeInfo) error {
 	if err := snapshot.getInternalData().addNode(nodeInfo.Node()); err != nil {
 		return err
 	}
@@ -331,57 +331,57 @@ type basicSnapshotStoreNodeLister BasicSnapshotStore
 type basicSnapshotStoreStorageLister BasicSnapshotStore
 
 // NodeInfos exposes snapshot as NodeInfoLister.
-func (snapshot *BasicSnapshotStore) NodeInfos() fwk.NodeInfoLister {
+func (snapshot *BasicSnapshotStore) NodeInfos() schedulerinterface.NodeInfoLister {
 	return (*basicSnapshotStoreNodeLister)(snapshot)
 }
 
 // StorageInfos exposes snapshot as StorageInfoLister.
-func (snapshot *BasicSnapshotStore) StorageInfos() fwk.StorageInfoLister {
+func (snapshot *BasicSnapshotStore) StorageInfos() schedulerinterface.StorageInfoLister {
 	return (*basicSnapshotStoreStorageLister)(snapshot)
 }
 
 // ResourceClaims exposes snapshot as ResourceClaimTracker
-func (snapshot *BasicSnapshotStore) ResourceClaims() fwk.ResourceClaimTracker {
+func (snapshot *BasicSnapshotStore) ResourceClaims() schedulerinterface.ResourceClaimTracker {
 	return snapshot.DraSnapshot().ResourceClaims()
 }
 
 // ResourceSlices exposes snapshot as ResourceSliceLister.
-func (snapshot *BasicSnapshotStore) ResourceSlices() fwk.ResourceSliceLister {
+func (snapshot *BasicSnapshotStore) ResourceSlices() schedulerinterface.ResourceSliceLister {
 	return snapshot.DraSnapshot().ResourceSlices()
 }
 
 // DeviceClasses exposes the snapshot as DeviceClassLister.
-func (snapshot *BasicSnapshotStore) DeviceClasses() fwk.DeviceClassLister {
+func (snapshot *BasicSnapshotStore) DeviceClasses() schedulerinterface.DeviceClassLister {
 	return snapshot.DraSnapshot().DeviceClasses()
 }
 
 // DeviceClassResolver exposes the snapshot as DeviceClassResolver.
-func (snapshot *BasicSnapshotStore) DeviceClassResolver() fwk.DeviceClassResolver {
+func (snapshot *BasicSnapshotStore) DeviceClassResolver() schedulerinterface.DeviceClassResolver {
 	return snapshot.DraSnapshot().DeviceClassResolver()
 }
 
 // CSINodes returns the CSI nodes snapshot.
-func (snapshot *BasicSnapshotStore) CSINodes() fwk.CSINodeLister {
+func (snapshot *BasicSnapshotStore) CSINodes() schedulerinterface.CSINodeLister {
 	return snapshot.csiSnapshot.CSINodes()
 }
 
 // List returns the list of nodes in the snapshot.
-func (snapshot *basicSnapshotStoreNodeLister) List() ([]fwk.NodeInfo, error) {
+func (snapshot *basicSnapshotStoreNodeLister) List() ([]schedulerinterface.NodeInfo, error) {
 	return (*BasicSnapshotStore)(snapshot).getInternalData().listNodeInfos(), nil
 }
 
 // HavePodsWithAffinityList returns the list of nodes with at least one pods with inter-pod affinity
-func (snapshot *basicSnapshotStoreNodeLister) HavePodsWithAffinityList() ([]fwk.NodeInfo, error) {
+func (snapshot *basicSnapshotStoreNodeLister) HavePodsWithAffinityList() ([]schedulerinterface.NodeInfo, error) {
 	return (*BasicSnapshotStore)(snapshot).getInternalData().listNodeInfosThatHavePodsWithAffinityList()
 }
 
 // HavePodsWithRequiredAntiAffinityList returns the list of NodeInfos of nodes with pods with required anti-affinity terms.
-func (snapshot *basicSnapshotStoreNodeLister) HavePodsWithRequiredAntiAffinityList() ([]fwk.NodeInfo, error) {
+func (snapshot *basicSnapshotStoreNodeLister) HavePodsWithRequiredAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
 	return (*BasicSnapshotStore)(snapshot).getInternalData().listNodeInfosThatHavePodsWithRequiredAntiAffinityList()
 }
 
 // Returns the NodeInfo of the given node name.
-func (snapshot *basicSnapshotStoreNodeLister) Get(nodeName string) (fwk.NodeInfo, error) {
+func (snapshot *basicSnapshotStoreNodeLister) Get(nodeName string) (schedulerinterface.NodeInfo, error) {
 	return (*BasicSnapshotStore)(snapshot).getInternalData().getNodeInfo(nodeName)
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -21,8 +21,6 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
-	csisnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/csi/snapshot"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/klog/v2"
 	schedulerinterface "k8s.io/kube-scheduler/framework"
 	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -31,9 +29,7 @@ import (
 // BasicSnapshotStore is simple, reference implementation of ClusterSnapshotStore.
 // It is inefficient. But hopefully bug-free and good for initial testing.
 type BasicSnapshotStore struct {
-	data        []*internalBasicSnapshotData
-	draSnapshot *drasnapshot.Snapshot
-	csiSnapshot *csisnapshot.Snapshot
+	data []*internalBasicSnapshotData
 }
 
 type internalBasicSnapshotData struct {
@@ -210,16 +206,6 @@ func (snapshot *BasicSnapshotStore) getInternalData() *internalBasicSnapshotData
 	return snapshot.data[len(snapshot.data)-1]
 }
 
-// DraSnapshot returns the DRA snapshot.
-func (snapshot *BasicSnapshotStore) DraSnapshot() *drasnapshot.Snapshot {
-	return snapshot.draSnapshot
-}
-
-// CsiSnapshot returns the CSI snapshot.
-func (snapshot *BasicSnapshotStore) CsiSnapshot() *csisnapshot.Snapshot {
-	return snapshot.csiSnapshot
-}
-
 // AddSchedulerNodeInfo adds a NodeInfo.
 func (snapshot *BasicSnapshotStore) AddSchedulerNodeInfo(nodeInfo schedulerinterface.NodeInfo) error {
 	if err := snapshot.getInternalData().addNode(nodeInfo.Node()); err != nil {
@@ -253,22 +239,10 @@ func (snapshot *BasicSnapshotStore) IsPVCUsedByPods(key string) bool {
 	return snapshot.getInternalData().isPVCUsedByPods(key)
 }
 
-// SetDraSnapshot replaces the DRA snapshot in the store.
-func (snapshot *BasicSnapshotStore) SetDraSnapshot(draSnapshot *drasnapshot.Snapshot) {
-	snapshot.draSnapshot = draSnapshot
-}
-
-// SetCsiSnapshot replaces the CSI snapshot in the store.
-func (snapshot *BasicSnapshotStore) SetCsiSnapshot(csiSnapshot *csisnapshot.Snapshot) {
-	snapshot.csiSnapshot = csiSnapshot
-}
-
 // Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert()
 func (snapshot *BasicSnapshotStore) Fork() {
 	forkData := snapshot.getInternalData().clone()
 	snapshot.data = append(snapshot.data, forkData)
-	snapshot.draSnapshot.Fork()
-	snapshot.csiSnapshot.Fork()
 }
 
 // Revert reverts snapshot state to moment of forking.
@@ -277,8 +251,6 @@ func (snapshot *BasicSnapshotStore) Revert() {
 		return
 	}
 	snapshot.data = snapshot.data[:len(snapshot.data)-1]
-	snapshot.draSnapshot.Revert()
-	snapshot.csiSnapshot.Revert()
 }
 
 // Commit commits changes done after forking.
@@ -288,8 +260,6 @@ func (snapshot *BasicSnapshotStore) Commit() error {
 		return nil
 	}
 	snapshot.data = append(snapshot.data[:len(snapshot.data)-2], snapshot.data[len(snapshot.data)-1])
-	snapshot.draSnapshot.Commit()
-	snapshot.csiSnapshot.Commit()
 	return nil
 }
 
@@ -297,8 +267,6 @@ func (snapshot *BasicSnapshotStore) Commit() error {
 func (snapshot *BasicSnapshotStore) Clear() {
 	baseData := newInternalBasicSnapshotData()
 	snapshot.data = []*internalBasicSnapshotData{baseData}
-	snapshot.draSnapshot = drasnapshot.NewEmptySnapshot()
-	snapshot.csiSnapshot = csisnapshot.NewEmptySnapshot()
 }
 
 // implementation of SharedLister interface
@@ -314,31 +282,6 @@ func (snapshot *BasicSnapshotStore) NodeInfos() schedulerinterface.NodeInfoListe
 // StorageInfos exposes snapshot as StorageInfoLister.
 func (snapshot *BasicSnapshotStore) StorageInfos() schedulerinterface.StorageInfoLister {
 	return (*basicSnapshotStoreStorageLister)(snapshot)
-}
-
-// ResourceClaims exposes snapshot as ResourceClaimTracker
-func (snapshot *BasicSnapshotStore) ResourceClaims() schedulerinterface.ResourceClaimTracker {
-	return snapshot.DraSnapshot().ResourceClaims()
-}
-
-// ResourceSlices exposes snapshot as ResourceSliceLister.
-func (snapshot *BasicSnapshotStore) ResourceSlices() schedulerinterface.ResourceSliceLister {
-	return snapshot.DraSnapshot().ResourceSlices()
-}
-
-// DeviceClasses exposes the snapshot as DeviceClassLister.
-func (snapshot *BasicSnapshotStore) DeviceClasses() schedulerinterface.DeviceClassLister {
-	return snapshot.DraSnapshot().DeviceClasses()
-}
-
-// DeviceClassResolver exposes the snapshot as DeviceClassResolver.
-func (snapshot *BasicSnapshotStore) DeviceClassResolver() schedulerinterface.DeviceClassResolver {
-	return snapshot.DraSnapshot().DeviceClassResolver()
-}
-
-// CSINodes returns the CSI nodes snapshot.
-func (snapshot *BasicSnapshotStore) CSINodes() schedulerinterface.CSINodeLister {
-	return snapshot.csiSnapshot.CSINodes()
 }
 
 // List returns the list of nodes in the snapshot.

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -21,8 +21,6 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
-	csisnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/csi/snapshot"
-	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/klog/v2"
 	schedulerinterface "k8s.io/kube-scheduler/framework"
 	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -52,8 +50,6 @@ import (
 // cluster autoscaler operations
 type DeltaSnapshotStore struct {
 	data        *internalDeltaSnapshotData
-	draSnapshot *drasnapshot.Snapshot
-	csiSnapshot *csisnapshot.Snapshot
 	parallelism int
 }
 
@@ -403,31 +399,6 @@ func (snapshot *DeltaSnapshotStore) StorageInfos() schedulerinterface.StorageInf
 	return (*deltaSnapshotStoreStorageLister)(snapshot)
 }
 
-// ResourceClaims exposes snapshot as ResourceClaimTracker
-func (snapshot *DeltaSnapshotStore) ResourceClaims() schedulerinterface.ResourceClaimTracker {
-	return snapshot.DraSnapshot().ResourceClaims()
-}
-
-// ResourceSlices exposes snapshot as ResourceSliceLister.
-func (snapshot *DeltaSnapshotStore) ResourceSlices() schedulerinterface.ResourceSliceLister {
-	return snapshot.DraSnapshot().ResourceSlices()
-}
-
-// DeviceClasses exposes the snapshot as DeviceClassLister.
-func (snapshot *DeltaSnapshotStore) DeviceClasses() schedulerinterface.DeviceClassLister {
-	return snapshot.DraSnapshot().DeviceClasses()
-}
-
-// DeviceClassResolver exposes the snapshot as DeviceClassResolver.
-func (snapshot *DeltaSnapshotStore) DeviceClassResolver() schedulerinterface.DeviceClassResolver {
-	return snapshot.DraSnapshot().DeviceClassResolver()
-}
-
-// CSINodes returns the CSI node lister for this snapshot.
-func (snapshot *DeltaSnapshotStore) CSINodes() schedulerinterface.CSINodeLister {
-	return snapshot.csiSnapshot.CSINodes()
-}
-
 // NewDeltaSnapshotStore creates instances of DeltaSnapshotStore.
 func NewDeltaSnapshotStore(parallelism int) *DeltaSnapshotStore {
 	snapshot := &DeltaSnapshotStore{
@@ -435,16 +406,6 @@ func NewDeltaSnapshotStore(parallelism int) *DeltaSnapshotStore {
 	}
 	snapshot.Clear()
 	return snapshot
-}
-
-// DraSnapshot returns the DRA snapshot.
-func (snapshot *DeltaSnapshotStore) DraSnapshot() *drasnapshot.Snapshot {
-	return snapshot.draSnapshot
-}
-
-// CsiSnapshot returns the CSI snapshot.
-func (snapshot *DeltaSnapshotStore) CsiSnapshot() *csisnapshot.Snapshot {
-	return snapshot.csiSnapshot
 }
 
 // AddSchedulerNodeInfo adds a NodeInfo.
@@ -480,22 +441,10 @@ func (snapshot *DeltaSnapshotStore) IsPVCUsedByPods(key string) bool {
 	return snapshot.data.isPVCUsedByPods(key)
 }
 
-// SetDraSnapshot replaces the DRA snapshot in the store.
-func (snapshot *DeltaSnapshotStore) SetDraSnapshot(draSnapshot *drasnapshot.Snapshot) {
-	snapshot.draSnapshot = draSnapshot
-}
-
-// SetCsiSnapshot replaces the CSI snapshot in the store.
-func (snapshot *DeltaSnapshotStore) SetCsiSnapshot(csiSnapshot *csisnapshot.Snapshot) {
-	snapshot.csiSnapshot = csiSnapshot
-}
-
 // Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert()
 // Time: O(1)
 func (snapshot *DeltaSnapshotStore) Fork() {
 	snapshot.data = snapshot.data.fork()
-	snapshot.draSnapshot.Fork()
-	snapshot.csiSnapshot.Fork()
 }
 
 // Revert reverts snapshot state to moment of forking.
@@ -504,8 +453,6 @@ func (snapshot *DeltaSnapshotStore) Revert() {
 	if snapshot.data.baseData != nil {
 		snapshot.data = snapshot.data.baseData
 	}
-	snapshot.draSnapshot.Revert()
-	snapshot.csiSnapshot.Revert()
 }
 
 // Commit commits changes done after forking.
@@ -516,8 +463,6 @@ func (snapshot *DeltaSnapshotStore) Commit() error {
 		return err
 	}
 	snapshot.data = newData
-	snapshot.draSnapshot.Commit()
-	snapshot.csiSnapshot.Commit()
 	return nil
 }
 
@@ -525,6 +470,4 @@ func (snapshot *DeltaSnapshotStore) Commit() error {
 // Time: O(1)
 func (snapshot *DeltaSnapshotStore) Clear() {
 	snapshot.data = newInternalDeltaSnapshotData()
-	snapshot.draSnapshot = drasnapshot.NewEmptySnapshot()
-	snapshot.csiSnapshot = csisnapshot.NewEmptySnapshot()
 }

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 func BenchmarkBuildNodeInfoList(b *testing.B) {
@@ -53,7 +53,7 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 			}
 			deltaStore.Fork()
 			for _, node := range nodes[tc.nodeCount:] {
-				schedNodeInfo := schedulerframework.NewNodeInfo()
+				schedNodeInfo := schedulerimpl.NewNodeInfo()
 				schedNodeInfo.SetNode(node)
 				if err := deltaStore.AddSchedulerNodeInfo(schedNodeInfo); err != nil {
 					assert.NoError(b, err)

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta_benchmark_test.go
@@ -48,8 +48,12 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 		b.Run(fmt.Sprintf("fork add 1000 to %d", tc.nodeCount), func(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc.nodeCount + 1000)
 			deltaStore := NewDeltaSnapshotStore(16)
-			if err := deltaStore.SetClusterState(nodes[:tc.nodeCount], nil, nil, nil); err != nil {
-				assert.NoError(b, err)
+			for _, node := range nodes[:tc.nodeCount] {
+				schedNodeInfo := schedulerimpl.NewNodeInfo()
+				schedNodeInfo.SetNode(node)
+				if err := deltaStore.AddSchedulerNodeInfo(schedNodeInfo); err != nil {
+					assert.NoError(b, err)
+				}
 			}
 			deltaStore.Fork()
 			for _, node := range nodes[tc.nodeCount:] {
@@ -70,8 +74,12 @@ func BenchmarkBuildNodeInfoList(b *testing.B) {
 		b.Run(fmt.Sprintf("base %d", tc.nodeCount), func(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc.nodeCount)
 			deltaStore := NewDeltaSnapshotStore(16)
-			if err := deltaStore.SetClusterState(nodes, nil, nil, nil); err != nil {
-				assert.NoError(b, err)
+			for _, node := range nodes {
+				schedNodeInfo := schedulerimpl.NewNodeInfo()
+				schedNodeInfo.SetNode(node)
+				if err := deltaStore.AddSchedulerNodeInfo(schedNodeInfo); err != nil {
+					assert.NoError(b, err)
+				}
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/cluster-autoscaler/simulator/csi/snapshot/csinode_lister.go
+++ b/cluster-autoscaler/simulator/csi/snapshot/csinode_lister.go
@@ -18,7 +18,7 @@ package snapshot
 
 import (
 	storagev1 "k8s.io/api/storage/v1"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
 // SnapshotCSINodeLister provides access to CSI nodes within a snapshot.
@@ -26,7 +26,7 @@ type SnapshotCSINodeLister struct {
 	snapshot *Snapshot
 }
 
-var _ fwk.CSINodeLister = SnapshotCSINodeLister{}
+var _ schedulerinterface.CSINodeLister = SnapshotCSINodeLister{}
 
 // List returns all CSI nodes in the snapshot.
 func (s SnapshotCSINodeLister) List() ([]*storagev1.CSINode, error) {

--- a/cluster-autoscaler/simulator/csi/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/csi/snapshot/snapshot.go
@@ -22,7 +22,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/common"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
 // Snapshot represents a snapshot of CSI node information for cluster simulation.
@@ -51,7 +51,7 @@ func (s *Snapshot) listCSINodes() []*storagev1.CSINode {
 }
 
 // CSINodes returns a CSI node lister for the snapshot.
-func (s *Snapshot) CSINodes() fwk.CSINodeLister {
+func (s *Snapshot) CSINodes() schedulerinterface.CSINodeLister {
 	return SnapshotCSINodeLister{snapshot: s}
 }
 

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	resourceclaim "k8s.io/dynamic-resource-allocation/resourceclaim"
 	"k8s.io/klog/v2"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
 // ResourceClaimId is a unique identifier for a ResourceClaim.
@@ -84,34 +84,34 @@ func NewEmptySnapshot() *Snapshot {
 	}
 }
 
-// ResourceClaims exposes the Snapshot as fwk.ResourceClaimTracker, in order to interact with
+// ResourceClaims exposes the Snapshot as schedulerinterface.ResourceClaimTracker, in order to interact with
 // the scheduler framework.
-func (s *Snapshot) ResourceClaims() fwk.ResourceClaimTracker {
+func (s *Snapshot) ResourceClaims() schedulerinterface.ResourceClaimTracker {
 	return snapshotClaimTracker{snapshot: s}
 }
 
-// ResourceSlices exposes the Snapshot as fwk.ResourceSliceLister, in order to interact with
+// ResourceSlices exposes the Snapshot as schedulerinterface.ResourceSliceLister, in order to interact with
 // the scheduler framework.
-func (s *Snapshot) ResourceSlices() fwk.ResourceSliceLister {
+func (s *Snapshot) ResourceSlices() schedulerinterface.ResourceSliceLister {
 	return snapshotSliceLister{snapshot: s}
 }
 
-// DeviceClasses exposes the Snapshot as fwk.DeviceClassLister, in order to interact with
+// DeviceClasses exposes the Snapshot as schedulerinterface.DeviceClassLister, in order to interact with
 // the scheduler framework.
-func (s *Snapshot) DeviceClasses() fwk.DeviceClassLister {
+func (s *Snapshot) DeviceClasses() schedulerinterface.DeviceClassLister {
 	return snapshotClassLister{snapshot: s}
 }
 
-// DeviceClassResolver exposes the Snapshot as fwk.DeviceClassResolver, in order to interact with
+// DeviceClassResolver exposes the Snapshot as schedulerinterface.DeviceClassResolver, in order to interact with
 // the scheduler framework.
-func (s *Snapshot) DeviceClassResolver() fwk.DeviceClassResolver {
+func (s *Snapshot) DeviceClassResolver() schedulerinterface.DeviceClassResolver {
 	return newSnapshotDeviceClassResolver(s)
 }
 
-// WrapSchedulerNodeInfo wraps the provided fwk.NodeInfo into an internal *framework.NodeInfo, adding
+// WrapSchedulerNodeInfo wraps the provided schedulerinterface.NodeInfo into an internal *framework.NodeInfo, adding
 // dra information. Node-local ResourceSlices are added to the NodeInfo, and all ResourceClaims referenced by each Pod
 // are added to each PodInfo. Returns an error if any of the Pods is missing a ResourceClaim.
-func (s *Snapshot) WrapSchedulerNodeInfo(schedNodeInfo fwk.NodeInfo) (*framework.NodeInfo, error) {
+func (s *Snapshot) WrapSchedulerNodeInfo(schedNodeInfo schedulerinterface.NodeInfo) (*framework.NodeInfo, error) {
 	podExtraInfos := make(map[types.UID]framework.PodExtraInfo, len(schedNodeInfo.GetPods()))
 	for _, pod := range schedNodeInfo.GetPods() {
 		podClaims, err := s.PodClaims(pod.GetPod())

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_claim_tracker_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_claim_tracker_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/dynamic-resource-allocation/structured"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
 var (
@@ -86,7 +86,7 @@ func TestSnapshotClaimTrackerList(t *testing.T) {
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
 			snapshot := NewSnapshot(tc.claims, nil, nil, nil)
-			var resourceClaimTracker fwk.ResourceClaimTracker = snapshot.ResourceClaims()
+			var resourceClaimTracker schedulerinterface.ResourceClaimTracker = snapshot.ResourceClaims()
 			claims, err := resourceClaimTracker.List()
 			if err != nil {
 				t.Fatalf("snapshotClaimTracker.List(): got unexpected error: %v", err)
@@ -132,7 +132,7 @@ func TestSnapshotClaimTrackerGet(t *testing.T) {
 				GetClaimId(claim3): claim3,
 			}
 			snapshot := NewSnapshot(claims, nil, nil, nil)
-			var resourceClaimTracker fwk.ResourceClaimTracker = snapshot.ResourceClaims()
+			var resourceClaimTracker schedulerinterface.ResourceClaimTracker = snapshot.ResourceClaims()
 
 			claim, err := resourceClaimTracker.Get(tc.claimNamespace, tc.claimName)
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
@@ -181,7 +181,7 @@ func TestSnapshotClaimTrackerListAllAllocatedDevices(t *testing.T) {
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
 			snapshot := NewSnapshot(tc.claims, nil, nil, nil)
-			var resourceClaimTracker fwk.ResourceClaimTracker = snapshot.ResourceClaims()
+			var resourceClaimTracker schedulerinterface.ResourceClaimTracker = snapshot.ResourceClaims()
 			devices, err := resourceClaimTracker.ListAllAllocatedDevices()
 			if err != nil {
 				t.Fatalf("snapshotClaimTracker.ListAllAllocatedDevices(): got unexpected error: %v", err)
@@ -225,7 +225,7 @@ func TestSnapshotClaimTrackerSignalClaimPendingAllocation(t *testing.T) {
 				GetClaimId(claim3): claim3,
 			}
 			snapshot := NewSnapshot(claims, nil, nil, nil)
-			var resourceClaimTracker fwk.ResourceClaimTracker = snapshot.ResourceClaims()
+			var resourceClaimTracker schedulerinterface.ResourceClaimTracker = snapshot.ResourceClaims()
 
 			err := resourceClaimTracker.SignalClaimPendingAllocation(tc.claimUid, tc.allocatedClaim)
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_lister_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_lister_test.go
@@ -25,7 +25,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
 var (
@@ -52,7 +52,7 @@ func TestSnapshotClassListerList(t *testing.T) {
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
 			snapshot := NewSnapshot(nil, nil, nil, tc.classes)
-			var deviceClassLister fwk.DeviceClassLister = snapshot.DeviceClasses()
+			var deviceClassLister schedulerinterface.DeviceClassLister = snapshot.DeviceClasses()
 			classes, err := deviceClassLister.List()
 			if err != nil {
 				t.Fatalf("snapshotClassLister.List(): got unexpected error: %v", err)
@@ -86,7 +86,7 @@ func TestSnapshotClassListerGet(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			classes := map[string]*resourceapi.DeviceClass{"class-1": class1, "class-2": class2, "class-3": class3}
 			snapshot := NewSnapshot(nil, nil, nil, classes)
-			var deviceClassLister fwk.DeviceClassLister = snapshot.DeviceClasses()
+			var deviceClassLister schedulerinterface.DeviceClassLister = snapshot.DeviceClasses()
 			class, err := deviceClassLister.Get(tc.className)
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("snapshotClassLister.Get(): unexpected error (-want +got): %s", diff)

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_resolver.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_resolver.go
@@ -19,7 +19,7 @@ package snapshot
 import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
 type snapshotDeviceClassResolver struct {
@@ -27,10 +27,10 @@ type snapshotDeviceClassResolver struct {
 	deviceClassMap map[v1.ResourceName]*resourceapi.DeviceClass
 }
 
-var _ fwk.DeviceClassResolver = &snapshotDeviceClassResolver{}
+var _ schedulerinterface.DeviceClassResolver = &snapshotDeviceClassResolver{}
 
 // newSnapshotDeviceClassResolver implements DeviceClassResolver for a snapshot
-func newSnapshotDeviceClassResolver(snapshot *Snapshot) fwk.DeviceClassResolver {
+func newSnapshotDeviceClassResolver(snapshot *Snapshot) schedulerinterface.DeviceClassResolver {
 	deviceClassMap := make(map[v1.ResourceName]*resourceapi.DeviceClass)
 	for _, class := range snapshot.listDeviceClasses() {
 		if class != nil {

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_slice_lister_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_slice_lister_test.go
@@ -26,7 +26,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
 func TestSnapshotSliceListerList(t *testing.T) {
@@ -78,7 +78,7 @@ func TestSnapshotSliceListerList(t *testing.T) {
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
 			snapshot := NewSnapshot(nil, tc.localSlices, tc.globalSlices, nil)
-			var resourceSliceLister fwk.ResourceSliceLister = snapshot.ResourceSlices()
+			var resourceSliceLister schedulerinterface.ResourceSliceLister = snapshot.ResourceSlices()
 			slices, err := resourceSliceLister.ListWithDeviceTaintRules()
 			if err != nil {
 				t.Fatalf("snapshotSliceLister.List(): got unexpected error: %v", err)

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_test.go
@@ -30,7 +30,7 @@ import (
 	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 var (
@@ -506,24 +506,24 @@ func TestSnapshotWrapSchedulerNodeInfo(t *testing.T) {
 	missingClaimPod := test.BuildTestPod("missingClaimPod", 1, 1, test.WithResourceClaim("ref1", "missing-claim-abc", "missing-claim"))
 	noSlicesNode := test.BuildTestNode("noSlicesNode", 1000, 1000)
 
-	noDraNodeInfo := schedulerframework.NewNodeInfo(noClaimsPod1, noClaimsPod2)
+	noDraNodeInfo := schedulerimpl.NewNodeInfo(noClaimsPod1, noClaimsPod2)
 	noDraNodeInfo.SetNode(noSlicesNode)
 
-	resourceSlicesNodeInfo := schedulerframework.NewNodeInfo(noClaimsPod1, noClaimsPod2)
+	resourceSlicesNodeInfo := schedulerimpl.NewNodeInfo(noClaimsPod1, noClaimsPod2)
 	resourceSlicesNodeInfo.SetNode(node1)
 
-	resourceClaimsNodeInfo := schedulerframework.NewNodeInfo(pod1, pod2, noClaimsPod1, noClaimsPod2)
+	resourceClaimsNodeInfo := schedulerimpl.NewNodeInfo(pod1, pod2, noClaimsPod1, noClaimsPod2)
 	resourceClaimsNodeInfo.SetNode(noSlicesNode)
 
-	fullDraNodeInfo := schedulerframework.NewNodeInfo(pod1, pod2, noClaimsPod1, noClaimsPod2)
+	fullDraNodeInfo := schedulerimpl.NewNodeInfo(pod1, pod2, noClaimsPod1, noClaimsPod2)
 	fullDraNodeInfo.SetNode(node1)
 
-	missingClaimNodeInfo := schedulerframework.NewNodeInfo(pod1, pod2, noClaimsPod1, noClaimsPod2, missingClaimPod)
+	missingClaimNodeInfo := schedulerimpl.NewNodeInfo(pod1, pod2, noClaimsPod1, noClaimsPod2, missingClaimPod)
 	missingClaimNodeInfo.SetNode(node1)
 
 	for _, tc := range []struct {
 		testName      string
-		schedNodeInfo *schedulerframework.NodeInfo
+		schedNodeInfo *schedulerimpl.NodeInfo
 		wantNodeInfo  *framework.NodeInfo
 		wantErr       error
 	}{
@@ -579,8 +579,8 @@ func TestSnapshotWrapSchedulerNodeInfo(t *testing.T) {
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("Snapshot.WrapSchedulerNodeInfo(): unexpected error (-want +got): %s", diff)
 			}
-			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmp.AllowUnexported(framework.NodeInfo{}, schedulerframework.NodeInfo{}),
-				cmpopts.IgnoreUnexported(schedulerframework.PodInfo{}),
+			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmp.AllowUnexported(framework.NodeInfo{}, schedulerimpl.NodeInfo{}),
+				cmpopts.IgnoreUnexported(schedulerimpl.PodInfo{}),
 				test.IgnoreObjectOrder[*resourceapi.ResourceClaim](), test.IgnoreObjectOrder[*resourceapi.ResourceSlice]()}
 
 			if diff := cmp.Diff(tc.wantNodeInfo, nodeInfo, cmpOpts...); diff != "" {

--- a/cluster-autoscaler/simulator/framework/delegating_shared_lister.go
+++ b/cluster-autoscaler/simulator/framework/delegating_shared_lister.go
@@ -26,14 +26,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/dynamic-resource-allocation/structured"
 	"k8s.io/klog/v2"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
 
 // SharedLister groups all interfaces that Cluster Autoscaler needs to implement for integrating with kube-scheduler.
 type SharedLister interface {
-	fwk.SharedLister
-	fwk.SharedDRAManager
-	fwk.CSIManager
+	schedulerinterface.SharedLister
+	schedulerinterface.SharedDRAManager
+	schedulerinterface.CSIManager
 }
 
 // DelegatingSchedulerSharedLister implements k8s.io/kube-scheduler/framework interfaces by passing the logic to a delegate. Delegate can be updated.
@@ -51,32 +51,32 @@ func NewDelegatingSchedulerSharedLister() *DelegatingSchedulerSharedLister {
 }
 
 // NodeInfos returns a NodeInfoLister.
-func (lister *DelegatingSchedulerSharedLister) NodeInfos() fwk.NodeInfoLister {
+func (lister *DelegatingSchedulerSharedLister) NodeInfos() schedulerinterface.NodeInfoLister {
 	return lister.delegate.NodeInfos()
 }
 
 // StorageInfos returns a StorageInfoLister
-func (lister *DelegatingSchedulerSharedLister) StorageInfos() fwk.StorageInfoLister {
+func (lister *DelegatingSchedulerSharedLister) StorageInfos() schedulerinterface.StorageInfoLister {
 	return lister.delegate.StorageInfos()
 }
 
 // ResourceClaims returns a ResourceClaimTracker.
-func (lister *DelegatingSchedulerSharedLister) ResourceClaims() fwk.ResourceClaimTracker {
+func (lister *DelegatingSchedulerSharedLister) ResourceClaims() schedulerinterface.ResourceClaimTracker {
 	return lister.delegate.ResourceClaims()
 }
 
 // ResourceSlices returns a ResourceSliceLister.
-func (lister *DelegatingSchedulerSharedLister) ResourceSlices() fwk.ResourceSliceLister {
+func (lister *DelegatingSchedulerSharedLister) ResourceSlices() schedulerinterface.ResourceSliceLister {
 	return lister.delegate.ResourceSlices()
 }
 
 // DeviceClasses returns a DeviceClassLister.
-func (lister *DelegatingSchedulerSharedLister) DeviceClasses() fwk.DeviceClassLister {
+func (lister *DelegatingSchedulerSharedLister) DeviceClasses() schedulerinterface.DeviceClassLister {
 	return lister.delegate.DeviceClasses()
 }
 
 // CSINodes returns a CSINodeLister.
-func (lister *DelegatingSchedulerSharedLister) CSINodes() fwk.CSINodeLister {
+func (lister *DelegatingSchedulerSharedLister) CSINodes() schedulerinterface.CSINodeLister {
 	return lister.delegate.CSINodes()
 }
 
@@ -86,7 +86,7 @@ func (lister *DelegatingSchedulerSharedLister) UpdateDelegate(delegate SharedLis
 }
 
 // DeviceClassResolver returns a device class resolver.
-func (lister *DelegatingSchedulerSharedLister) DeviceClassResolver() fwk.DeviceClassResolver {
+func (lister *DelegatingSchedulerSharedLister) DeviceClassResolver() schedulerinterface.DeviceClassResolver {
 	return lister.delegate.DeviceClassResolver()
 }
 
@@ -105,22 +105,22 @@ type unsetDeviceClassResolver unsetSharedLister
 type unsetCSINodeLister unsetSharedLister
 
 // List always returns an error
-func (lister *unsetNodeInfoLister) List() ([]fwk.NodeInfo, error) {
+func (lister *unsetNodeInfoLister) List() ([]schedulerinterface.NodeInfo, error) {
 	return nil, fmt.Errorf("lister not set in delegate")
 }
 
 // HavePodsWithAffinityList always returns an error
-func (lister *unsetNodeInfoLister) HavePodsWithAffinityList() ([]fwk.NodeInfo, error) {
+func (lister *unsetNodeInfoLister) HavePodsWithAffinityList() ([]schedulerinterface.NodeInfo, error) {
 	return nil, fmt.Errorf("lister not set in delegate")
 }
 
 // HavePodsWithRequiredAntiAffinityList always returns an error.
-func (lister *unsetNodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]fwk.NodeInfo, error) {
+func (lister *unsetNodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
 	return nil, fmt.Errorf("lister not set in delegate")
 }
 
 // Get always returns an error
-func (lister *unsetNodeInfoLister) Get(nodeName string) (fwk.NodeInfo, error) {
+func (lister *unsetNodeInfoLister) Get(nodeName string) (schedulerinterface.NodeInfo, error) {
 	return nil, fmt.Errorf("lister not set in delegate")
 }
 
@@ -192,32 +192,32 @@ func (u *unsetCSINodeLister) Get(name string) (*storagev1.CSINode, error) {
 }
 
 // NodeInfos returns a fake NodeInfoLister which always returns an error
-func (lister *unsetSharedLister) NodeInfos() fwk.NodeInfoLister {
+func (lister *unsetSharedLister) NodeInfos() schedulerinterface.NodeInfoLister {
 	return (*unsetNodeInfoLister)(lister)
 }
 
 // StorageInfos returns a fake StorageInfoLister which always returns an error
-func (lister *unsetSharedLister) StorageInfos() fwk.StorageInfoLister {
+func (lister *unsetSharedLister) StorageInfos() schedulerinterface.StorageInfoLister {
 	return (*unsetStorageInfoLister)(lister)
 }
 
-func (lister *unsetSharedLister) ResourceClaims() fwk.ResourceClaimTracker {
+func (lister *unsetSharedLister) ResourceClaims() schedulerinterface.ResourceClaimTracker {
 	return (*unsetResourceClaimTracker)(lister)
 }
 
-func (lister *unsetSharedLister) ResourceSlices() fwk.ResourceSliceLister {
+func (lister *unsetSharedLister) ResourceSlices() schedulerinterface.ResourceSliceLister {
 	return (*unsetResourceSliceLister)(lister)
 }
 
-func (lister *unsetSharedLister) DeviceClasses() fwk.DeviceClassLister {
+func (lister *unsetSharedLister) DeviceClasses() schedulerinterface.DeviceClassLister {
 	return (*unsetDeviceClassLister)(lister)
 }
 
-func (lister *unsetSharedLister) DeviceClassResolver() fwk.DeviceClassResolver {
+func (lister *unsetSharedLister) DeviceClassResolver() schedulerinterface.DeviceClassResolver {
 	return (*unsetDeviceClassResolver)(lister)
 }
 
-func (lister *unsetSharedLister) CSINodes() fwk.CSINodeLister {
+func (lister *unsetSharedLister) CSINodes() schedulerinterface.CSINodeLister {
 	return (*unsetCSINodeLister)(lister)
 }
 

--- a/cluster-autoscaler/simulator/framework/handle.go
+++ b/cluster-autoscaler/simulator/framework/handle.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/client-go/informers"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	schedulerconfiglatest "k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 	schedulerplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits"
 	schedulerframeworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
@@ -36,7 +36,7 @@ var (
 
 // Handle is meant for interacting with the scheduler framework.
 type Handle struct {
-	Framework        schedulerframework.Framework
+	Framework        schedulerimpl.Framework
 	DelegatingLister *DelegatingSchedulerSharedLister
 }
 

--- a/cluster-autoscaler/simulator/framework/infos.go
+++ b/cluster-autoscaler/simulator/framework/infos.go
@@ -120,7 +120,11 @@ func (n *NodeInfo) DeepCopy() *NodeInfo {
 		newSlices = append(newSlices, slice.DeepCopy())
 	}
 	// Node() can be nil, but DeepCopy() handles nil receivers gracefully.
-	return NewNodeInfo(n.Node().DeepCopy(), newSlices, newPods...)
+	ni := NewNodeInfo(n.Node().DeepCopy(), newSlices, newPods...)
+	if n.CSINode != nil {
+		ni.SetCSINode(n.CSINode.DeepCopy())
+	}
+	return ni
 }
 
 // ResourceClaims returns all ResourceClaims contained in the PodInfos in this NodeInfo. Shared claims

--- a/cluster-autoscaler/utils/scheduler/scheduler.go
+++ b/cluster-autoscaler/utils/scheduler/scheduler.go
@@ -24,7 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
-	fwk "k8s.io/kube-scheduler/framework"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 	scheduler_config "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	scheduler_scheme "k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	scheduler_validation "k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
@@ -79,7 +79,7 @@ func isHugePageResourceName(name apiv1.ResourceName) bool {
 }
 
 // ResourceToResourceList returns a resource list of the resource.
-func ResourceToResourceList(r fwk.Resource) apiv1.ResourceList {
+func ResourceToResourceList(r schedulerinterface.Resource) apiv1.ResourceList {
 	result := apiv1.ResourceList{
 		apiv1.ResourceCPU:              *resource.NewMilliQuantity(r.GetMilliCPU(), resource.DecimalSI),
 		apiv1.ResourceMemory:           *resource.NewQuantity(r.GetMemory(), resource.BinarySI),

--- a/cluster-autoscaler/utils/scheduler/scheduler_test.go
+++ b/cluster-autoscaler/utils/scheduler/scheduler_test.go
@@ -27,7 +27,7 @@ import (
 	testconfig "k8s.io/autoscaler/cluster-autoscaler/config/test"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiv1 "k8s.io/api/core/v1"
 
@@ -61,11 +61,11 @@ func TestCreateNodeNameToInfoMap(t *testing.T) {
 
 func TestResourceList(t *testing.T) {
 	tests := []struct {
-		resource *schedulerframework.Resource
+		resource *schedulerimpl.Resource
 		expected apiv1.ResourceList
 	}{
 		{
-			resource: &schedulerframework.Resource{},
+			resource: &schedulerimpl.Resource{},
 			expected: map[apiv1.ResourceName]resource.Quantity{
 				apiv1.ResourceCPU:              *resource.NewScaledQuantity(0, -3),
 				apiv1.ResourceMemory:           *resource.NewQuantity(0, resource.BinarySI),
@@ -74,7 +74,7 @@ func TestResourceList(t *testing.T) {
 			},
 		},
 		{
-			resource: &schedulerframework.Resource{
+			resource: &schedulerimpl.Resource{
 				MilliCPU:         4,
 				Memory:           2000,
 				EphemeralStorage: 5000,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
BasicSnapshotStore and DeltaSnapshotStore had separate implementations
of SetClusterState, leading to code duplication. This change moves
SetClusterState to the ClusterSnapshot interface and provides a unified
implementation in PredicateSnapshot.
This change will streamline reworking NodeInfo wrapper #9022. 

Moreover, this PR fixes CSI nodes DeepCopy and renames scheduler framework imports to improve code clarity and readability. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Relates to #9022

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
