### PR TITLE
Optimize cluster-autoscaler release build process

### DIFF
--- a/cluster-autoscaler/.dockerignore
+++ b/cluster-autoscaler/.dockerignore
@@ -1,0 +1,24 @@
+# Ignore git and GitHub folders
+.git
+.github
+
+# Ignore Go binaries and build artifacts
+cluster-autoscaler-*
+
+# Ignore test files
+*_test.go
+e2e/
+
+# Ignore documentation and other non-build files
+*.md
+LICENSE
+OWNERS
+OWNERS_ALIASES
+CONTRIBUTING.md
+SECURITY_CONTACTS
+code-of-conduct.md
+cloudbuild.yaml
+Makefile
+push_image.sh
+update_toc.py
+*.txt

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -15,13 +15,24 @@ FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 WORKDIR /workspace
 
+# Copy go.mod and go.sum files first to cache dependencies
+COPY go.mod go.sum ./
+COPY apis/go.mod apis/go.sum ./apis/
+
+# Download dependencies
+RUN go mod download
+
+# Copy the rest of the source code
 COPY . .
 
 ARG GOARCH
 ARG LDFLAGS_FLAG
 ARG TAGS_FLAG
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o cluster-autoscaler-$GOARCH $LDFLAGS_FLAG $TAGS_FLAG
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux go build -o cluster-autoscaler-$GOARCH $LDFLAGS_FLAG $TAGS_FLAG
+
 FROM gcr.io/distroless/static:nonroot
 ARG GOARCH
 COPY --from=builder /workspace/cluster-autoscaler-$GOARCH /cluster-autoscaler

--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -73,6 +73,8 @@ make-image: make-image-arch-$(GOARCH)
 make-image-arch-%:
 	GOOS=$(GOOS) docker buildx build --pull --platform linux/$* \
 		--build-arg "GOARCH=$*" \
+		--build-arg "LDFLAGS_FLAG=${LDFLAGS_FLAG}" \
+		--build-arg "TAGS_FLAG=${TAGS_FLAG}" \
 		-t ${IMAGE}-$*:${TAG} \
 		-f Dockerfile .
 	@echo "Image ${TAG}${FOR_PROVIDER}-$* completed"


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The release process for cluster-autoscaler was taking approximately 15 minutes to complete (~5 mins/arch on my machine), largely due to redundant Go dependency downloads.

This commit introduces caching optimizations:
1. Dockerfile: Reordered instructions to copy go.mod/go.sum first and added 'RUN go mod download' to cache dependencies.
2. Build Cache: Added '--mount=type=cache' to utilize Go build cache.
3. Context: Added '.dockerignore' to reduce build context size.
4. Makefile: Updated to pass 'LDFLAGS_FLAG' and 'TAGS_FLAG' as build args.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9161 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
