### PR TITLE
[oci][bugfix] Ignore string case when comparing instance pool summary state

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
@@ -213,7 +213,7 @@ func (c *instancePoolCache) findInstanceByDetails(ociInstance ocicommon.OciRef) 
 
 	if c.unownedInstances[ociInstance] {
 		// We already know this instance is not part of a configured pool. Return early and avoid additional API calls.
-		klog.V(4).Infof("Node " + ociInstance.Name + " is known to not be a member of any of the specified instance pool(s)")
+		klog.V(4).Info("Node " + ociInstance.Name + " is known to not be a member of any of the specified instance pool(s)")
 		return nil, errInstanceInstancePoolNotFound
 	}
 
@@ -307,7 +307,7 @@ func (c *instancePoolCache) findInstanceByDetails(ociInstance ocicommon.OciRef) 
 	}
 
 	c.unownedInstances[ociInstance] = true
-	klog.V(4).Infof(ociInstance.Name + " is not a member of any of the specified instance pool(s)")
+	klog.V(4).Info(ociInstance.Name + " is not a member of any of the specified instance pool(s)")
 	return nil, errInstanceInstancePoolNotFound
 }
 

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_manager_test.go
@@ -6,13 +6,14 @@ package instancepools
 
 import (
 	"context"
+	"reflect"
+	"testing"
+
 	apiv1 "k8s.io/api/core/v1"
 	ocicommon "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/common"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/core"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/workrequests"
 	kubeletapis "k8s.io/kubelet/pkg/apis"
-	"reflect"
-	"testing"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common"
@@ -372,6 +373,12 @@ func TestGetInstancePoolNodes(t *testing.T) {
 		AvailabilityDomain: common.String("PHX-AD-1"),
 		State:              common.String(string(core.InstanceLifecycleStateTerminating)),
 	},
+		{
+			// Instance state is running with varied capitalization
+			Id:                 common.String("ocid1.instance.oc1.phx.aaa3"),
+			AvailabilityDomain: common.String("PHX-AD-1"),
+			State:              common.String("Running"),
+		},
 	}
 
 	expected := []cloudprovider.Instance{
@@ -385,6 +392,12 @@ func TestGetInstancePoolNodes(t *testing.T) {
 			Id: "ocid1.instance.oc1.phx.aaa2",
 			Status: &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceDeleting,
+			},
+		},
+		{
+			Id: "ocid1.instance.oc1.phx.aaa3",
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceRunning,
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
This fixes an issue where existing nodes would be categorized as upcoming. When the cluster state was updated and HasInstance was called, this function would be invoked to check the instance state. The OCI API for instance pools actually returns "Running" (instead of the expected "RUNNING"); this would cause the instance to be flagged as 'Deleted' in the readiness state, and when the calculation for newNodes was made, since a running node belonging to the pool instance was counted as deleted and not registered, the upcoming node count was incorrectly non-zero.

The behavior seems like an inconsistency on OCI's side:
```
# List Instance Pool Instances
oci compute-management instance-pool list-instances --compartment-id <compartment-id> --instance-pool-id <instnace-pool-id> | jq '.data[0].state'
"Running"

# List Instances
oci compute instance list --compartment-id <compartment-id> | jq '.data[0]."lifecycle-state"'
"RUNNING"

# Get Instance
oci compute instance get --instance-id <instance-id> | jq '.data."lifecycle-state"'
"RUNNING"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
OCI: Ignore string case when comparing instance pool summary state
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
