### PR TITLE
[cluster-autoscaler-release-1.35] Fix overriding buffers conditions

### DIFF
--- a/cluster-autoscaler/capacitybuffer/common/common.go
+++ b/cluster-autoscaler/capacitybuffer/common/common.go
@@ -23,21 +23,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-// Constants to use in Capacity Buffers objects
-const (
-	ActiveProvisioningStrategy    = "buffer.x-k8s.io/active-capacity"
-	CapacityBufferKind            = "CapacityBuffer"
-	CapacityBufferApiVersion      = "autoscaling.x-k8s.io/v1beta1"
-	ReadyForProvisioningCondition = "ReadyForProvisioning"
-	ProvisioningCondition         = "Provisioning"
-	LimitedByQuotasCondition      = "LimitedByQuotas"
-	LimitedByQuotasReason         = "ResourceQuotasAllocated"
-	ConditionTrue                 = "True"
-	ConditionFalse                = "False"
 )
 
 // SetBufferAsReadyForProvisioning updates the passed buffer object with the rest of the attributes and sets its condition to ready
@@ -47,18 +35,21 @@ func SetBufferAsReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRef *
 	buffer.Status.PodTemplateGeneration = podTemplateGeneration
 	buffer.Status.ProvisioningStrategy = mapEmptyProvStrategyToDefault(provStrategy)
 	readyCondition := metav1.Condition{
-		Type:               ReadyForProvisioningCondition,
-		Status:             ConditionTrue,
+		Type:               capacitybuffer.ReadyForProvisioningCondition,
+		Status:             metav1.ConditionTrue,
 		Message:            "ready",
-		Reason:             "atrtibutesSetSuccessfully",
+		Reason:             capacitybuffer.AttributesSetSuccessfullyReason,
 		LastTransitionTime: metav1.Time{Time: time.Now()},
 	}
-	buffer.Status.Conditions = []metav1.Condition{readyCondition}
+	if buffer.Status.Conditions == nil {
+		buffer.Status.Conditions = make([]metav1.Condition, 0)
+	}
+	meta.SetStatusCondition(&buffer.Status.Conditions, readyCondition)
 }
 
 // SetBufferAsNotReadyForProvisioning updates the passed buffer object with the rest of the attributes and sets its condition to not ready with the passed error
 func SetBufferAsNotReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRef *v1.LocalObjectRef, podTemplateGeneration *int64, replicas *int32, provStrategy *string, err error) {
-	errorMessage := "Buffer not ready for provisioing"
+	errorMessage := "Buffer not ready for provisioning"
 	if err != nil {
 		errorMessage = err.Error()
 	}
@@ -68,42 +59,53 @@ func SetBufferAsNotReadyForProvisioning(buffer *v1.CapacityBuffer, PodTemplateRe
 	buffer.Status.PodTemplateGeneration = podTemplateGeneration
 	buffer.Status.ProvisioningStrategy = mapEmptyProvStrategyToDefault(provStrategy)
 	notReadyCondition := metav1.Condition{
-		Type:               ReadyForProvisioningCondition,
-		Status:             ConditionFalse,
+		Type:               capacitybuffer.ReadyForProvisioningCondition,
+		Status:             metav1.ConditionFalse,
 		Message:            errorMessage,
 		Reason:             "error",
 		LastTransitionTime: metav1.Time{Time: time.Now()},
 	}
-	buffer.Status.Conditions = []metav1.Condition{notReadyCondition}
+	if buffer.Status.Conditions == nil {
+		buffer.Status.Conditions = make([]metav1.Condition, 0)
+	}
+	meta.SetStatusCondition(&buffer.Status.Conditions, notReadyCondition)
 }
 
 func mapEmptyProvStrategyToDefault(ps *string) *string {
 	if ps != nil && *ps == "" {
-		defaultProvStrategy := ActiveProvisioningStrategy
+		defaultProvStrategy := capacitybuffer.ActiveProvisioningStrategy
 		ps = &defaultProvStrategy
 	}
 	return ps
 }
 
-// UpdateBufferStatusToFailedProvisioing updates the status of the passed buffer and set Provisioning to false with the passes reason and message
-func UpdateBufferStatusToFailedProvisioing(buffer *v1.CapacityBuffer, reason, errorMessage string) {
-	buffer.Status.Conditions = []metav1.Condition{{
-		Type:               ProvisioningCondition,
-		Status:             ConditionFalse,
+// UpdateBufferStatusToFailedProvisioning updates the status of the passed buffer and set Provisioning to false with the passes reason and message
+func UpdateBufferStatusToFailedProvisioning(buffer *v1.CapacityBuffer, reason, errorMessage string) bool {
+	newCondition := metav1.Condition{
+		Type:               capacitybuffer.ProvisioningCondition,
+		Status:             metav1.ConditionFalse,
 		Message:            errorMessage,
 		Reason:             reason,
 		LastTransitionTime: metav1.Time{Time: time.Now()},
-	}}
+	}
+	if buffer.Status.Conditions == nil {
+		buffer.Status.Conditions = make([]metav1.Condition, 0)
+	}
+	return meta.SetStatusCondition(&buffer.Status.Conditions, newCondition)
 }
 
-// UpdateBufferStatusToSuccessfullyProvisioing updates the status of the passed buffer and set Provisioning to true with the passes reason
-func UpdateBufferStatusToSuccessfullyProvisioing(buffer *v1.CapacityBuffer, reason string) {
-	buffer.Status.Conditions = []metav1.Condition{{
-		Type:               ProvisioningCondition,
-		Status:             ConditionTrue,
+// UpdateBufferStatusToSuccessfullyProvisioning updates the status of the passed buffer and set Provisioning to true with the passes reason
+func UpdateBufferStatusToSuccessfullyProvisioning(buffer *v1.CapacityBuffer, reason string) {
+	newCondition := metav1.Condition{
+		Type:               capacitybuffer.ProvisioningCondition,
+		Status:             metav1.ConditionTrue,
 		Reason:             reason,
 		LastTransitionTime: metav1.Time{Time: time.Now()},
-	}}
+	}
+	if buffer.Status.Conditions == nil {
+		buffer.Status.Conditions = make([]metav1.Condition, 0)
+	}
+	meta.SetStatusCondition(&buffer.Status.Conditions, newCondition)
 }
 
 // MarkBufferAsLimitedByQuota adds or updates the LimitedByQuotas condition with True
@@ -118,16 +120,16 @@ func MarkBufferAsLimitedByQuota(buffer *v1.CapacityBuffer, desiredReplicas, allo
 
 // UpdateBufferStatusLimitedByQuotas adds or updates the LimitedByQuotas condition
 func UpdateBufferStatusLimitedByQuotas(buffer *v1.CapacityBuffer, isLimited bool, message string) {
-	status := ConditionFalse
+	status := metav1.ConditionFalse
 	if isLimited {
-		status = ConditionTrue
+		status = metav1.ConditionTrue
 	}
 
 	newCondition := metav1.Condition{
-		Type:               LimitedByQuotasCondition,
-		Status:             metav1.ConditionStatus(status),
+		Type:               capacitybuffer.LimitedByQuotasCondition,
+		Status:             status,
 		Message:            message,
-		Reason:             LimitedByQuotasReason,
+		Reason:             capacitybuffer.LimitedByQuotasReason,
 		LastTransitionTime: metav1.Time{Time: time.Now()},
 		ObservedGeneration: buffer.Generation,
 	}

--- a/cluster-autoscaler/capacitybuffer/common/common_test.go
+++ b/cluster-autoscaler/capacitybuffer/common/common_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
+	"k8s.io/utils/ptr"
+)
+
+func TestConditionUpdates(t *testing.T) {
+	existingCondition := metav1.Condition{
+		Type:               "ExistingCondition",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Existing",
+		Message:            "Existing message",
+		LastTransitionTime: metav1.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	tests := []struct {
+		name           string
+		initialBuffer  *v1.CapacityBuffer
+		updateFunc     func(*v1.CapacityBuffer)
+		wantConditions []metav1.Condition
+	}{
+		{
+			name: "SetBufferAsReadyForProvisioning preserves existing conditions",
+			initialBuffer: testutil.NewBuffer(func(b *v1.CapacityBuffer) {
+				b.Status.Conditions = []metav1.Condition{existingCondition}
+			}),
+			updateFunc: func(b *v1.CapacityBuffer) {
+				SetBufferAsReadyForProvisioning(b, &v1.LocalObjectRef{Name: "pt"}, ptr.To(int64(1)), ptr.To(int32(1)), ptr.To(capacitybuffer.ActiveProvisioningStrategy))
+			},
+			wantConditions: []metav1.Condition{
+				existingCondition,
+				{
+					Type:    capacitybuffer.ReadyForProvisioningCondition,
+					Status:  metav1.ConditionTrue,
+					Reason:  capacitybuffer.AttributesSetSuccessfullyReason,
+					Message: "ready",
+				},
+			},
+		},
+		{
+			name: "SetBufferAsNotReadyForProvisioning preserves existing conditions",
+			initialBuffer: testutil.NewBuffer(func(b *v1.CapacityBuffer) {
+				b.Status.Conditions = []metav1.Condition{existingCondition}
+			}),
+			updateFunc: func(b *v1.CapacityBuffer) {
+				SetBufferAsNotReadyForProvisioning(b, &v1.LocalObjectRef{Name: "pt"}, ptr.To(int64(1)), ptr.To(int32(1)), ptr.To(capacitybuffer.ActiveProvisioningStrategy), errors.New("some error"))
+			},
+			wantConditions: []metav1.Condition{
+				existingCondition,
+				{
+					Type:    capacitybuffer.ReadyForProvisioningCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  "error",
+					Message: "some error",
+				},
+			},
+		},
+		{
+			name: "UpdateBufferStatusToFailedProvisioning preserves existing conditions",
+			initialBuffer: testutil.NewBuffer(func(b *v1.CapacityBuffer) {
+				b.Status.Conditions = []metav1.Condition{existingCondition}
+			}),
+			updateFunc: func(b *v1.CapacityBuffer) {
+				UpdateBufferStatusToFailedProvisioning(b, "FailedReason", "failed message")
+			},
+			wantConditions: []metav1.Condition{
+				existingCondition,
+				{
+					Type:    capacitybuffer.ProvisioningCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  "FailedReason",
+					Message: "failed message",
+				},
+			},
+		},
+		{
+			name: "UpdateBufferStatusToSuccessfullyProvisioning preserves existing conditions",
+			initialBuffer: testutil.NewBuffer(func(b *v1.CapacityBuffer) {
+				b.Status.Conditions = []metav1.Condition{existingCondition}
+			}),
+			updateFunc: func(b *v1.CapacityBuffer) {
+				UpdateBufferStatusToSuccessfullyProvisioning(b, "SuccessReason")
+			},
+			wantConditions: []metav1.Condition{
+				existingCondition,
+				{
+					Type:    capacitybuffer.ProvisioningCondition,
+					Status:  metav1.ConditionTrue,
+					Reason:  "SuccessReason",
+					Message: "",
+				},
+			},
+		},
+		{
+			name: "MarkBufferAsLimitedByQuota preserves existing conditions",
+			initialBuffer: testutil.NewBuffer(func(b *v1.CapacityBuffer) {
+				b.Status.Conditions = []metav1.Condition{existingCondition}
+			}),
+			updateFunc: func(b *v1.CapacityBuffer) {
+				MarkBufferAsLimitedByQuota(b, 10, 5, []string{"quota-1", "quota-2"})
+			},
+			wantConditions: []metav1.Condition{
+				existingCondition,
+				{
+					Type:    capacitybuffer.LimitedByQuotasCondition,
+					Status:  metav1.ConditionTrue,
+					Reason:  capacitybuffer.LimitedByQuotasReason,
+					Message: "Buffer replicas limited from 10 to 5 due to quotas: quota-1, quota-2",
+				},
+			},
+		},
+		{
+			name: "UpdateBufferStatusLimitedByQuotas preserves existing conditions",
+			initialBuffer: testutil.NewBuffer(func(b *v1.CapacityBuffer) {
+				b.Status.Conditions = []metav1.Condition{existingCondition}
+			}),
+			updateFunc: func(b *v1.CapacityBuffer) {
+				UpdateBufferStatusLimitedByQuotas(b, false, "")
+			},
+			wantConditions: []metav1.Condition{
+				existingCondition,
+				{
+					Type:   capacitybuffer.LimitedByQuotasCondition,
+					Status: metav1.ConditionFalse,
+					Reason: capacitybuffer.LimitedByQuotasReason,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.updateFunc(tc.initialBuffer)
+
+			sortOpt := cmpopts.SortSlices(func(a, b metav1.Condition) bool {
+				return a.Type < b.Type
+			})
+			ignoreTime := cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")
+
+			if diff := cmp.Diff(tc.wantConditions, tc.initialBuffer.Status.Conditions, sortOpt, ignoreTime); diff != "" {
+				t.Errorf("Conditions mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/capacitybuffer/constants.go
+++ b/cluster-autoscaler/capacitybuffer/constants.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitybuffer
+
+// Constants to use in Capacity Buffers objects
+const (
+	ActiveProvisioningStrategy      = "buffer.x-k8s.io/active-capacity"
+	CapacityBufferKind              = "CapacityBuffer"
+	CapacityBufferApiVersion        = "autoscaling.x-k8s.io/v1beta1"
+	ReadyForProvisioningCondition   = "ReadyForProvisioning"
+	ProvisioningCondition           = "Provisioning"
+	LimitedByQuotasCondition        = "LimitedByQuotas"
+	LimitedByQuotasReason           = "ResourceQuotasAllocated"
+	AttributesSetSuccessfullyReason = "AttributesSetSuccessfully"
+)

--- a/cluster-autoscaler/capacitybuffer/controller/controller.go
+++ b/cluster-autoscaler/capacitybuffer/controller/controller.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
-	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	filters "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/filters"
 	translators "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/translators"
 	updater "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/updater"
@@ -81,7 +81,7 @@ func NewDefaultBufferController(
 	bc := &bufferController{
 		client: client,
 		// Accepting empty string as it represents nil value for ProvisioningStrategy
-		strategyFilter: filters.NewStrategyFilter([]string{common.ActiveProvisioningStrategy, ""}),
+		strategyFilter: filters.NewStrategyFilter([]string{capacitybuffer.ActiveProvisioningStrategy, ""}),
 		translator: translators.NewCombinedTranslator(
 			[]translators.Translator{
 				translators.NewPodTemplateBufferTranslator(client),

--- a/cluster-autoscaler/capacitybuffer/controller/controller_test.go
+++ b/cluster-autoscaler/capacitybuffer/controller/controller_test.go
@@ -32,8 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	fakebuffers "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned/fake"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
-	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -113,7 +113,7 @@ func TestControllerIntegration_ResourceQuotas(t *testing.T) {
 			if checkLimited {
 				hasLimit := false
 				for _, c := range b.Status.Conditions {
-					if c.Type == common.LimitedByQuotasCondition && c.Status == common.ConditionTrue {
+					if c.Type == capacitybuffer.LimitedByQuotasCondition && c.Status == metav1.ConditionTrue {
 						hasLimit = true
 					}
 				}
@@ -128,7 +128,7 @@ func TestControllerIntegration_ResourceQuotas(t *testing.T) {
 			b, _ := buffersClient.AutoscalingV1beta1().CapacityBuffers("default").Get(ctx, name, metav1.GetOptions{})
 			var gotLimited bool
 			for _, c := range b.Status.Conditions {
-				if c.Type == common.LimitedByQuotasCondition && c.Status == common.ConditionTrue {
+				if c.Type == capacitybuffer.LimitedByQuotasCondition && c.Status == metav1.ConditionTrue {
 					gotLimited = true
 				}
 			}

--- a/cluster-autoscaler/capacitybuffer/controller/resourcequotas_test.go
+++ b/cluster-autoscaler/capacitybuffer/controller/resourcequotas_test.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
-	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
 	fakeClient "k8s.io/client-go/kubernetes/fake"
 )
@@ -475,7 +475,7 @@ func TestResourceQuotaAllocator(t *testing.T) {
 
 				var limitCondition *metav1.Condition
 				for _, c := range buffer.Status.Conditions {
-					if c.Type == common.LimitedByQuotasCondition {
+					if c.Type == capacitybuffer.LimitedByQuotasCondition {
 						limitCondition = c.DeepCopy()
 						break
 					}

--- a/cluster-autoscaler/capacitybuffer/filters/status_filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/status_filter_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
-	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
 )
 
@@ -47,7 +47,7 @@ func TestStatusFilter(t *testing.T) {
 		},
 		{
 			name:                  "One buffer, filter out ready for provisioning",
-			conditionsToFilterOut: map[string]string{common.ReadyForProvisioningCondition: common.ConditionTrue},
+			conditionsToFilterOut: map[string]string{capacitybuffer.ReadyForProvisioningCondition: string(metav1.ConditionTrue)},
 			buffers: []*v1.CapacityBuffer{
 				getTestBufferWithCondition(testutil.SomePodTemplateRefName, testutil.GetConditionReady()),
 			},
@@ -58,7 +58,7 @@ func TestStatusFilter(t *testing.T) {
 		},
 		{
 			name:                  "Two buffers, one Filtered",
-			conditionsToFilterOut: map[string]string{common.ReadyForProvisioningCondition: common.ConditionTrue},
+			conditionsToFilterOut: map[string]string{capacitybuffer.ReadyForProvisioningCondition: string(metav1.ConditionTrue)},
 			buffers: []*v1.CapacityBuffer{
 				getTestBufferWithCondition(testutil.SomePodTemplateRefName, testutil.GetConditionReady()),
 				getTestBufferWithCondition(testutil.AnotherPodTemplateRefName, testutil.GetConditionNotReady()),

--- a/cluster-autoscaler/capacitybuffer/testutil/testutil.go
+++ b/cluster-autoscaler/capacitybuffer/testutil/testutil.go
@@ -20,12 +20,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
-	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 )
 
 // To use their pointers in creating testing capacity buffer objects
 var (
-	ProvisioningStrategy      = common.ActiveProvisioningStrategy
+	ProvisioningStrategy      = capacitybuffer.ActiveProvisioningStrategy
 	SomeNumberOfReplicas      = int32(3)
 	AnotherNumberOfReplicas   = int32(5)
 	SomePodTemplateRefName    = "some-pod-template"
@@ -97,10 +97,10 @@ func GetBufferStatus(podTempRef *v1.LocalObjectRef, replicas *int32, podTemplate
 // GetConditionReady returns a list of conditions with a condition ready and empty message, should be used for testing purposes only
 func GetConditionReady() []metav1.Condition {
 	readyCondition := metav1.Condition{
-		Type:               common.ReadyForProvisioningCondition,
-		Status:             common.ConditionTrue,
+		Type:               capacitybuffer.ReadyForProvisioningCondition,
+		Status:             metav1.ConditionTrue,
 		Message:            "",
-		Reason:             "atrtibutesSetSuccessfully",
+		Reason:             capacitybuffer.AttributesSetSuccessfullyReason,
 		LastTransitionTime: metav1.Time{},
 	}
 	return []metav1.Condition{readyCondition}
@@ -109,8 +109,8 @@ func GetConditionReady() []metav1.Condition {
 // GetConditionNotReady returns a list of conditions with a condition not ready and empty message, should be used for testing purposes only
 func GetConditionNotReady() []metav1.Condition {
 	notReadyCondition := metav1.Condition{
-		Type:               common.ReadyForProvisioningCondition,
-		Status:             common.ConditionFalse,
+		Type:               capacitybuffer.ReadyForProvisioningCondition,
+		Status:             metav1.ConditionFalse,
 		Message:            "",
 		Reason:             "error",
 		LastTransitionTime: metav1.Time{},
@@ -172,7 +172,7 @@ func WithStatusReplicas(replicas int32) BufferOption {
 // WithActiveProvisioningStrategy sets the ProvisioningStrategy to ActiveProvisioningStrategy
 func WithActiveProvisioningStrategy() BufferOption {
 	return func(b *v1.CapacityBuffer) {
-		strategy := common.ActiveProvisioningStrategy
+		strategy := capacitybuffer.ActiveProvisioningStrategy
 		b.Spec.ProvisioningStrategy = &strategy
 	}
 }

--- a/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator.go
+++ b/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator.go
@@ -19,6 +19,7 @@ package translator
 import (
 	"fmt"
 
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 
@@ -156,8 +157,8 @@ func (t *ScalableObjectsTranslator) getPodTemplateFromSpecs(pts *corev1.PodTempl
 			Namespace: buffer.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         common.CapacityBufferApiVersion,
-					Kind:               common.CapacityBufferKind,
+					APIVersion:         capacitybuffer.CapacityBufferApiVersion,
+					Kind:               capacitybuffer.CapacityBufferKind,
 					Name:               buffer.Name,
 					UID:                buffer.UID,
 					Controller:         pointerBool(true),

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -26,9 +26,8 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	capacityclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
-	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	"k8s.io/autoscaler/cluster-autoscaler/config/flags"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaleup/orchestrator"
 	"k8s.io/autoscaler/cluster-autoscaler/debuggingsnapshot"
@@ -49,7 +48,7 @@ import (
 	"k8s.io/apiserver/pkg/server/routes"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cbv1beta1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
-	capacitybuffer "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/controller"
+	cbctrl "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/controller"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/core"
 	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
@@ -184,7 +183,7 @@ func buildAutoscaler(ctx context.Context, debuggingSnapshotter debuggingsnapshot
 		restConfig := kube_util.GetKubeConfig(autoscalingOptions.KubeClientOpts)
 		capacitybufferClient, capacitybufferClientError = capacityclient.NewCapacityBufferClientFromConfig(restConfig)
 		if capacitybufferClientError == nil && capacitybufferClient != nil {
-			nodeBufferController := capacitybuffer.NewDefaultBufferController(capacitybufferClient)
+			nodeBufferController := cbctrl.NewDefaultBufferController(capacitybufferClient)
 			go nodeBufferController.Run(make(chan struct{}))
 		}
 	}
@@ -202,7 +201,7 @@ func buildAutoscaler(ctx context.Context, debuggingSnapshotter debuggingsnapshot
 			buffersPodsRegistry := cbprocessor.NewDefaultCapacityBuffersFakePodsRegistry()
 			bufferPodInjector := cbprocessor.NewCapacityBufferPodListProcessor(
 				capacitybufferClient,
-				[]string{common.ActiveProvisioningStrategy},
+				[]string{capacitybuffer.ActiveProvisioningStrategy},
 				buffersPodsRegistry, true)
 			podListProcessor = pods.NewCombinedPodListProcessor([]pods.PodListProcessor{bufferPodInjector, podListProcessor})
 			opts.Processors.ScaleUpStatusProcessor = status.NewCombinedScaleUpStatusProcessor([]status.ScaleUpStatusProcessor{

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -19,13 +19,16 @@ package capacitybufferpodlister
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 	"k8s.io/klog/v2"
 
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
-	client "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	buffersfilter "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/filters"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
@@ -36,6 +39,17 @@ import (
 const (
 	CapacityBufferFakePodAnnotationKey   = "podType"
 	CapacityBufferFakePodAnnotationValue = "capacityBufferFakePod"
+
+	// NotReadyForProvisioningReason is the reason used when the buffer is not ready for provisioning.
+	NotReadyForProvisioningReason = "NotReadyForProvisioning"
+	// BufferIsEmptyReason is the reason used when the buffer has 0 replicas.
+	BufferIsEmptyReason = "BufferIsEmpty"
+	// FailedToGetPodTemplateReason is the reason used when the pod template cannot be retrieved.
+	FailedToGetPodTemplateReason = "FailedToGetPodTemplate"
+	// FailedToMakeFakePodsReason is the reason used when creating fake pods fails.
+	FailedToMakeFakePodsReason = "FailedToMakeFakePods"
+	// FakePodsInjectedReason is the reason used when fake pods are successfully injected.
+	FakePodsInjectedReason = "FakePodsInjected"
 )
 
 // CapacityBufferPodListProcessor processes the pod lists before scale up
@@ -74,8 +88,8 @@ func NewCapacityBufferPodListProcessor(client *client.CapacityBufferClient, prov
 	return &CapacityBufferPodListProcessor{
 		client: client,
 		statusFilter: buffersfilter.NewStatusFilter(map[string]string{
-			common.ReadyForProvisioningCondition: common.ConditionTrue,
-			common.ProvisioningCondition:         common.ConditionTrue,
+			capacitybuffer.ReadyForProvisioningCondition: string(metav1.ConditionTrue),
+			capacitybuffer.ProvisioningCondition:         string(metav1.ConditionTrue),
 		}),
 		podTemplateGenFilter:     buffersfilter.NewPodTemplateGenerationChangedFilter(client),
 		provStrategies:           provStrategiesMap,
@@ -128,24 +142,39 @@ func (p *CapacityBufferPodListProcessor) clearCapacityBufferRegistry() {
 }
 
 func (p *CapacityBufferPodListProcessor) provision(buffer *v1beta1.CapacityBuffer) []*apiv1.Pod {
-	if buffer.Status.PodTemplateRef == nil || buffer.Status.Replicas == nil || *buffer.Status.Replicas == 0 {
+	if buffer.Status.PodTemplateRef == nil || buffer.Status.Replicas == nil || meta.IsStatusConditionFalse(buffer.Status.Conditions, capacitybuffer.ReadyForProvisioningCondition) {
+		changed := common.UpdateBufferStatusToFailedProvisioning(buffer, NotReadyForProvisioningReason, "CapacityBuffer is not ready for provisioning")
+		if changed {
+			p.updateBufferStatus(buffer)
+		}
+		return []*apiv1.Pod{}
+	}
+	if *buffer.Status.Replicas == 0 {
+		changed := common.UpdateBufferStatusToFailedProvisioning(buffer, BufferIsEmptyReason, "CapacityBuffer has zero replicas")
+		if changed {
+			p.updateBufferStatus(buffer)
+		}
 		return []*apiv1.Pod{}
 	}
 	podTemplateName := buffer.Status.PodTemplateRef.Name
 	replicas := buffer.Status.Replicas
 	podTemplate, err := p.client.GetPodTemplate(buffer.Namespace, podTemplateName)
 	if err != nil {
-		common.UpdateBufferStatusToFailedProvisioing(buffer, "FailedToGetPodTemplate", fmt.Sprintf("failed to get pod template with error: %v", err.Error()))
-		p.updateBufferStatus(buffer)
+		changed := common.UpdateBufferStatusToFailedProvisioning(buffer, FailedToGetPodTemplateReason, fmt.Sprintf("failed to get pod template with error: %v", err.Error()))
+		if changed {
+			p.updateBufferStatus(buffer)
+		}
 		return []*apiv1.Pod{}
 	}
 	fakePods, err := makeFakePods(buffer, &podTemplate.Template, int(*replicas), p.forceSafeToEvictFakePods)
 	if err != nil {
-		common.UpdateBufferStatusToFailedProvisioing(buffer, "FailedToMakeFakePods", fmt.Sprintf("failed to create fake pods with error: %v", err.Error()))
-		p.updateBufferStatus(buffer)
+		changed := common.UpdateBufferStatusToFailedProvisioning(buffer, FailedToMakeFakePodsReason, fmt.Sprintf("failed to create fake pods with error: %v", err.Error()))
+		if changed {
+			p.updateBufferStatus(buffer)
+		}
 		return []*apiv1.Pod{}
 	}
-	common.UpdateBufferStatusToSuccessfullyProvisioing(buffer, "FakePodsInjected")
+	common.UpdateBufferStatusToSuccessfullyProvisioning(buffer, FakePodsInjectedReason)
 	p.updateBufferStatus(buffer)
 	return fakePods
 }

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
-	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/common"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 
 	corev1 "k8s.io/api/core/v1"
@@ -89,7 +89,7 @@ func TestPodListProcessor(t *testing.T) {
 			unschedulablePods:            []*corev1.Pod{getTestingPod("Pod")},
 			expectedUnschedPodsCount:     1,
 			expectedUnschedFakePodsCount: 0,
-			expectedBuffersProvCondition: map[string]metav1.Condition{"buffer": {Type: common.ProvisioningCondition, Status: common.ConditionFalse}},
+			expectedBuffersProvCondition: map[string]metav1.Condition{"buffer": {Type: capacitybuffer.ProvisioningCondition, Status: metav1.ConditionFalse}},
 			expectError:                  false,
 		},
 		{
@@ -100,7 +100,7 @@ func TestPodListProcessor(t *testing.T) {
 			forceSafeToEvict:             true,
 			expectedUnschedPodsCount:     2,
 			expectedUnschedFakePodsCount: 1,
-			expectedBuffersProvCondition: map[string]metav1.Condition{"buffer": {Type: common.ProvisioningCondition, Status: common.ConditionTrue}},
+			expectedBuffersProvCondition: map[string]metav1.Condition{"buffer": {Type: capacitybuffer.ProvisioningCondition, Status: metav1.ConditionTrue}},
 			expectError:                  false,
 		},
 		{
@@ -125,8 +125,8 @@ func TestPodListProcessor(t *testing.T) {
 			expectedUnschedPodsCount:     11,
 			expectedUnschedFakePodsCount: 8,
 			expectedBuffersProvCondition: map[string]metav1.Condition{
-				"buffer1": {Type: common.ProvisioningCondition, Status: common.ConditionTrue},
-				"buffer2": {Type: common.ProvisioningCondition, Status: common.ConditionTrue},
+				"buffer1": {Type: capacitybuffer.ProvisioningCondition, Status: metav1.ConditionTrue},
+				"buffer2": {Type: capacitybuffer.ProvisioningCondition, Status: metav1.ConditionTrue},
 			},
 			expectError: false,
 		},
@@ -140,8 +140,49 @@ func TestPodListProcessor(t *testing.T) {
 			unschedulablePods:            []*corev1.Pod{getTestingPod("Pod1"), getTestingPod("Pod2"), getTestingPod("Pod3")},
 			expectedUnschedPodsCount:     8,
 			expectedUnschedFakePodsCount: 5,
-			expectedBuffersProvCondition: map[string]metav1.Condition{"buffer2": {Type: common.ProvisioningCondition, Status: common.ConditionTrue}},
+			expectedBuffersProvCondition: map[string]metav1.Condition{"buffer2": {Type: capacitybuffer.ProvisioningCondition, Status: metav1.ConditionTrue}},
 			expectError:                  false,
+		},
+		{
+			name:                      "Buffer not ready for provisioning and provisioning set to true",
+			objectsInKubernetesClient: []runtime.Object{getTestingPodTemplate("ref", 1)},
+			objectsInBuffersClient: []runtime.Object{testutil.NewBuffer(
+				testutil.WithName("buffer"),
+				testutil.WithStatusPodTemplateRef("ref"),
+				testutil.WithStatusReplicas(1),
+				func(cb *apiv1.CapacityBuffer) {
+					cb.Status.Conditions = []metav1.Condition{
+						{
+							Type:   capacitybuffer.ReadyForProvisioningCondition,
+							Status: metav1.ConditionFalse,
+						},
+						{
+							Type:   capacitybuffer.ProvisioningCondition,
+							Status: metav1.ConditionTrue,
+						},
+					}
+					cb.Status.ProvisioningStrategy = &testProvStrategyAllowed
+				},
+			)},
+			unschedulablePods:            []*corev1.Pod{getTestingPod("Pod")},
+			expectedUnschedPodsCount:     1,
+			expectedUnschedFakePodsCount: 0,
+			expectedBuffersProvCondition: map[string]metav1.Condition{"buffer": {
+				Type: capacitybuffer.ProvisioningCondition, Status: metav1.ConditionFalse, Reason: NotReadyForProvisioningReason,
+			}},
+			expectError: false,
+		},
+		{
+			name:                         "Buffer with zero replicas",
+			objectsInKubernetesClient:    []runtime.Object{getTestingPodTemplate("ref", 1)},
+			objectsInBuffersClient:       []runtime.Object{getTestingBuffer("buffer", "ref", 0, 1, true, 1, testProvStrategyAllowed)},
+			unschedulablePods:            []*corev1.Pod{getTestingPod("Pod")},
+			forceSafeToEvict:             true,
+			expectedUnschedPodsCount:     1,
+			expectedUnschedFakePodsCount: 0,
+			expectedBuffersProvCondition: map[string]metav1.Condition{"buffer": {
+				Type: capacitybuffer.ProvisioningCondition, Status: metav1.ConditionFalse, Reason: BufferIsEmptyReason,
+			}},
 		},
 	}
 	for _, test := range tests {
@@ -167,12 +208,18 @@ func TestPodListProcessor(t *testing.T) {
 			}
 			assert.Equal(t, test.expectedUnschedFakePodsCount, numberOfFakePods)
 
-			for buffer, condition := range test.expectedBuffersProvCondition {
-				buffer, err := fakeBuffersClient.AutoscalingV1beta1().CapacityBuffers(corev1.NamespaceDefault).Get(context.TODO(), buffer, metav1.GetOptions{})
+			for bufferName, expectedCondition := range test.expectedBuffersProvCondition {
+				buffer, err := fakeBuffersClient.AutoscalingV1beta1().CapacityBuffers(corev1.NamespaceDefault).Get(context.TODO(), bufferName, metav1.GetOptions{})
 				assert.Equal(t, err, nil)
-				assert.Equal(t, len(buffer.Status.Conditions), 1)
-				assert.Equal(t, string(buffer.Status.Conditions[0].Type), string(condition.Type))
-				assert.Equal(t, string(buffer.Status.Conditions[0].Status), string(condition.Status))
+				found := false
+				for _, cond := range buffer.Status.Conditions {
+					if cond.Type == expectedCondition.Type {
+						assert.Equal(t, string(expectedCondition.Status), string(cond.Status))
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Condition %s not found", expectedCondition.Type)
 			}
 		})
 	}
@@ -242,11 +289,17 @@ func getTestingPod(name string) *corev1.Pod {
 }
 
 func getTestingPodTemplate(name string, generation int64) *corev1.PodTemplate {
-	return &corev1.PodTemplate{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Generation: generation}}
+	return &corev1.PodTemplate{
+		TypeMeta:   metav1.TypeMeta{Kind: "PodTemplate", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Generation: generation},
+	}
 }
 
 func getTestingBuffer(bufferName, refName string, replicas int32, generation int64, ready bool, bufferGeneration int64, provStrategy string) *apiv1.CapacityBuffer {
-	buffer := &apiv1.CapacityBuffer{ObjectMeta: metav1.ObjectMeta{Name: bufferName, Namespace: "default", Generation: bufferGeneration, UID: types.UID(fmt.Sprintf("%s-uid", bufferName))}}
+	buffer := &apiv1.CapacityBuffer{
+		TypeMeta:   metav1.TypeMeta{Kind: "CapacityBuffer", APIVersion: "autoscaling.x-k8s.io/v1beta1"},
+		ObjectMeta: metav1.ObjectMeta{Name: bufferName, Namespace: "default", Generation: bufferGeneration, UID: types.UID(fmt.Sprintf("%s-uid", bufferName))},
+	}
 	buffer.Status = *testutil.GetBufferStatus(&apiv1.LocalObjectRef{Name: refName}, &replicas, &generation, &provStrategy, nil)
 	if ready {
 		buffer.Status.Conditions = testutil.GetConditionReady()


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This is a manual cherry pick of https://github.com/kubernetes/autoscaler/pull/9128

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed overwriting CapacityBuffer conditions and fixed typos in condition messages and reasons
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
