### PR TITLE
[VPA] Enable revive rules - 5

### DIFF
--- a/vertical-pod-autoscaler/.golangci.yaml
+++ b/vertical-pod-autoscaler/.golangci.yaml
@@ -69,6 +69,7 @@ linters:
         - name: redefines-builtin-id
         - name: redundant-import-alias
         - name: confusing-results
+        - name: unused-receiver
 
         # Below lists the rules disabled
 

--- a/vertical-pod-autoscaler/.golangci.yaml
+++ b/vertical-pod-autoscaler/.golangci.yaml
@@ -68,6 +68,7 @@ linters:
         - name: early-return
         - name: redefines-builtin-id
         - name: redundant-import-alias
+        - name: confusing-results
 
         # Below lists the rules disabled
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/certs_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/certs_test.go
@@ -40,7 +40,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
-func generateCerts(t *testing.T, org string, caCert *x509.Certificate, caKey *rsa.PrivateKey) ([]byte, []byte) {
+func generateCerts(t *testing.T, org string, caCert *x509.Certificate, caKey *rsa.PrivateKey) (certPemBytes []byte, certKeyBytes []byte) {
 	cert := &x509.Certificate{
 		SerialNumber: big.NewInt(0),
 		Subject: pkix.Name{
@@ -78,7 +78,9 @@ func generateCerts(t *testing.T, org string, caCert *x509.Certificate, caKey *rs
 	if err != nil {
 		t.Error(err)
 	}
-	return certPem.Bytes(), certKeyPem.Bytes()
+	certPemBytes = certPem.Bytes()
+	certKeyBytes = certKeyPem.Bytes()
+	return certPemBytes, certKeyBytes
 }
 
 func TestKeypairReloader(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
@@ -77,7 +77,7 @@ func (s *AdmissionServer) RegisterResourceHandler(resourceHandler resource.Handl
 }
 
 // addDeprecationWarnings adds deprecation warnings to the admission response for VPA objects using deprecated modes
-func (s *AdmissionServer) addDeprecationWarnings(req *admissionv1.AdmissionRequest, resp *admissionv1.AdmissionResponse) {
+func (*AdmissionServer) addDeprecationWarnings(req *admissionv1.AdmissionRequest, resp *admissionv1.AdmissionResponse) {
 	if req.Object.Raw == nil {
 		return
 	}

--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server_test.go
@@ -34,25 +34,25 @@ import (
 // InfiniteReader simulates an endless stream of bytes to trigger an oversized request error.
 type InfiniteReader struct{}
 
-func (r *InfiniteReader) Read(p []byte) (n int, err error) {
+func (*InfiniteReader) Read(p []byte) (n int, err error) {
 	for i := range p {
 		p[i] = 'a'
 	}
 	return len(p), nil
 }
 
-func (r *InfiniteReader) Close() error {
+func (*InfiniteReader) Close() error {
 	return nil
 }
 
 // FailureReader simulates a read failure that is not an oversized error.
 type FailureReader struct{}
 
-func (r *FailureReader) Read(p []byte) (n int, err error) {
+func (*FailureReader) Read(p []byte) (n int, err error) {
 	return 0, errors.New("simulated read error")
 }
 
-func (r *FailureReader) Close() error {
+func (*FailureReader) Close() error {
 	return nil
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler.go
@@ -49,17 +49,17 @@ func NewResourceHandler(preProcessor PreProcessor, vpaMatcher vpa.Matcher, patch
 }
 
 // AdmissionResource returns resource type this handler accepts.
-func (h *resourceHandler) AdmissionResource() admission.AdmissionResource {
+func (*resourceHandler) AdmissionResource() admission.AdmissionResource {
 	return admission.Pod
 }
 
 // GroupResource returns Group and Resource type this handler accepts.
-func (h *resourceHandler) GroupResource() metav1.GroupResource {
+func (*resourceHandler) GroupResource() metav1.GroupResource {
 	return metav1.GroupResource{Group: "", Resource: "pods"}
 }
 
 // DisallowIncorrectObjects decides whether incorrect objects (eg. unparsable, not passing validations) should be disallowed by Admission Server.
-func (h *resourceHandler) DisallowIncorrectObjects() bool {
+func (*resourceHandler) DisallowIncorrectObjects() bool {
 	// Incorrect Pods are validated by API Server.
 	return false
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
@@ -174,7 +174,7 @@ func getContainerStartupBoostPolicy(container *corev1.Container, vpa *vpa_types.
 	return startupBoost
 }
 
-func (c *resourcesUpdatesPatchCalculator) calculateBoostedCPUValue(baseCPU resource.Quantity, startupBoost *vpa_types.StartupBoost) (*resource.Quantity, error) {
+func (*resourcesUpdatesPatchCalculator) calculateBoostedCPUValue(baseCPU resource.Quantity, startupBoost *vpa_types.StartupBoost) (*resource.Quantity, error) {
 	boostType := startupBoost.CPU.Type
 	if boostType == "" {
 		boostType = vpa_types.FactorStartupBoostType

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/pre_processor.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/pre_processor.go
@@ -29,7 +29,7 @@ type PreProcessor interface {
 type NoopPreProcessor struct{}
 
 // Process leaves the pod unchanged
-func (p *NoopPreProcessor) Process(pod corev1.Pod) (corev1.Pod, error) {
+func (*NoopPreProcessor) Process(pod corev1.Pod) (corev1.Pod, error) {
 	return pod, nil
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -41,17 +41,17 @@ func NewResourceHandler(preProcessor PreProcessor) resource.Handler {
 }
 
 // AdmissionResource returns resource type this handler accepts.
-func (h *resourceHandler) AdmissionResource() admission.AdmissionResource {
+func (*resourceHandler) AdmissionResource() admission.AdmissionResource {
 	return admission.Vpa
 }
 
 // GroupResource returns Group and Resource type this handler accepts.
-func (h *resourceHandler) GroupResource() metav1.GroupResource {
+func (*resourceHandler) GroupResource() metav1.GroupResource {
 	return metav1.GroupResource{Group: "autoscaling.k8s.io", Resource: "verticalpodautoscalers"}
 }
 
 // DisallowIncorrectObjects decides whether incorrect objects (eg. unparsable, not passing validations) should be disallowed by Admission Server.
-func (h *resourceHandler) DisallowIncorrectObjects() bool {
+func (*resourceHandler) DisallowIncorrectObjects() bool {
 	return true
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/pre_processor.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/pre_processor.go
@@ -29,7 +29,7 @@ type PreProcessor interface {
 type noopPreProcessor struct{}
 
 // Process leaves the pod unchanged
-func (p *noopPreProcessor) Process(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) (*vpa_types.VerticalPodAutoscaler, error) {
+func (*noopPreProcessor) Process(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) (*vpa_types.VerticalPodAutoscaler, error) {
 	return vpa, nil
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -136,7 +136,7 @@ func (cs *fakeClusterState) VPAs() map[model.VpaID]*model.Vpa {
 	return cs.stubbedVPAs
 }
 
-func (cs *fakeClusterState) StateMapSize() int {
+func (*fakeClusterState) StateMapSize() int {
 	return 0
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -62,79 +62,79 @@ type mockPrometheusAPI struct {
 	mock.Mock
 }
 
-func (m *mockPrometheusAPI) AlertManagers(ctx context.Context) (prometheusv1.AlertManagersResult, error) {
+func (*mockPrometheusAPI) AlertManagers(ctx context.Context) (prometheusv1.AlertManagersResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Alerts(ctx context.Context) (prometheusv1.AlertsResult, error) {
+func (*mockPrometheusAPI) Alerts(ctx context.Context) (prometheusv1.AlertsResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) CleanTombstones(ctx context.Context) error {
+func (*mockPrometheusAPI) CleanTombstones(ctx context.Context) error {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Config(ctx context.Context) (prometheusv1.ConfigResult, error) {
+func (*mockPrometheusAPI) Config(ctx context.Context) (prometheusv1.ConfigResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error {
+func (*mockPrometheusAPI) DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Flags(ctx context.Context) (prometheusv1.FlagsResult, error) {
+func (*mockPrometheusAPI) Flags(ctx context.Context) (prometheusv1.FlagsResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...prometheusv1.Option) ([]string, prometheusv1.Warnings, error) {
+func (*mockPrometheusAPI) LabelNames(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...prometheusv1.Option) ([]string, prometheusv1.Warnings, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time, opts ...prometheusv1.Option) (prommodel.LabelValues, prometheusv1.Warnings, error) {
+func (*mockPrometheusAPI) LabelValues(ctx context.Context, label string, matches []string, startTime time.Time, endTime time.Time, opts ...prometheusv1.Option) (prommodel.LabelValues, prometheusv1.Warnings, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...prometheusv1.Option) ([]prommodel.LabelSet, prometheusv1.Warnings, error) {
+func (*mockPrometheusAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time, opts ...prometheusv1.Option) ([]prommodel.LabelSet, prometheusv1.Warnings, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Rules(ctx context.Context) (prometheusv1.RulesResult, error) {
+func (*mockPrometheusAPI) Rules(ctx context.Context) (prometheusv1.RulesResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Snapshot(ctx context.Context, skipHead bool) (prometheusv1.SnapshotResult, error) {
+func (*mockPrometheusAPI) Snapshot(ctx context.Context, skipHead bool) (prometheusv1.SnapshotResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Targets(ctx context.Context) (prometheusv1.TargetsResult, error) {
+func (*mockPrometheusAPI) Targets(ctx context.Context) (prometheusv1.TargetsResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) TargetsMetadata(ctx context.Context, _, _, _ string) ([]prometheusv1.MetricMetadata, error) {
+func (*mockPrometheusAPI) TargetsMetadata(ctx context.Context, _, _, _ string) ([]prometheusv1.MetricMetadata, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Buildinfo(ctx context.Context) (prometheusv1.BuildinfoResult, error) {
+func (*mockPrometheusAPI) Buildinfo(ctx context.Context) (prometheusv1.BuildinfoResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Metadata(ctx context.Context, metric string, limit string) (map[string][]prometheusv1.Metadata, error) {
+func (*mockPrometheusAPI) Metadata(ctx context.Context, metric string, limit string) (map[string][]prometheusv1.Metadata, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) QueryExemplars(ctx context.Context, query string, startTime time.Time, endTime time.Time) ([]prometheusv1.ExemplarQueryResult, error) {
+func (*mockPrometheusAPI) QueryExemplars(ctx context.Context, query string, startTime time.Time, endTime time.Time) ([]prometheusv1.ExemplarQueryResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) Runtimeinfo(ctx context.Context) (prometheusv1.RuntimeinfoResult, error) {
+func (*mockPrometheusAPI) Runtimeinfo(ctx context.Context) (prometheusv1.RuntimeinfoResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) TSDB(ctx context.Context, opts ...prometheusv1.Option) (prometheusv1.TSDBResult, error) {
+func (*mockPrometheusAPI) TSDB(ctx context.Context, opts ...prometheusv1.Option) (prometheusv1.TSDBResult, error) {
 	panic("not implemented")
 }
 
-func (m *mockPrometheusAPI) WalReplay(ctx context.Context) (prometheusv1.WalReplayStatus, error) {
+func (*mockPrometheusAPI) WalReplay(ctx context.Context) (prometheusv1.WalReplayStatus, error) {
 	panic("not implemented")
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer.go
@@ -124,7 +124,7 @@ func findStatus(name string, containerStatuses []corev1.ContainerStatus) *corev1
 }
 
 // OnAdd is Noop
-func (o *observer) OnAdd(obj any, isInInitialList bool) {}
+func (*observer) OnAdd(obj any, isInInitialList bool) {}
 
 // OnUpdate inspects if the update contains oom information and
 // passess it to the ObservedOomsChannel

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -314,7 +314,7 @@ func (a *AggregateContainerState) isEmpty() bool {
 	return a.TotalSamplesCount == 0
 }
 
-func (a *AggregateContainerState) convertQuantityToFloat64(quantity *resource.Quantity) float64 {
+func (*AggregateContainerState) convertQuantityToFloat64(quantity *resource.Quantity) float64 {
 	if quantity == nil {
 		return 0.0
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/cpu_integer_post_processor.go
@@ -41,7 +41,7 @@ var _ RecommendationPostProcessor = &IntegerCPUPostProcessor{}
 
 // Process apply the capping post-processing to the recommendation.
 // For this post processor the CPU value is rounded up to an integer
-func (p *IntegerCPUPostProcessor) Process(vpa *vpa_types.VerticalPodAutoscaler, recommendation *vpa_types.RecommendedPodResources) *vpa_types.RecommendedPodResources {
+func (*IntegerCPUPostProcessor) Process(vpa *vpa_types.VerticalPodAutoscaler, recommendation *vpa_types.RecommendedPodResources) *vpa_types.RecommendedPodResources {
 	amendedRecommendation := recommendation.DeepCopy()
 
 	for key, value := range vpa.Annotations {

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go
@@ -38,7 +38,7 @@ import (
 
 type mockPodResourceRecommender struct{}
 
-func (m *mockPodResourceRecommender) GetRecommendedPodResources(containerNameToAggregateStateMap model.ContainerNameToAggregateStateMap) logic.RecommendedPodResources {
+func (*mockPodResourceRecommender) GetRecommendedPodResources(containerNameToAggregateStateMap model.ContainerNameToAggregateStateMap) logic.RecommendedPodResources {
 	return logic.RecommendedPodResources{}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram_mock.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram_mock.go
@@ -69,11 +69,11 @@ func (m *MockHistogram) String() string {
 }
 
 // SaveToChekpoint is a mock implementation of Histogram.SaveToChekpoint.
-func (m *MockHistogram) SaveToChekpoint() (*vpa_types.HistogramCheckpoint, error) {
+func (*MockHistogram) SaveToChekpoint() (*vpa_types.HistogramCheckpoint, error) {
 	return &vpa_types.HistogramCheckpoint{}, nil
 }
 
 // LoadFromCheckpoint is a mock implementation of Histogram.LoadFromCheckpoint.
-func (m *MockHistogram) LoadFromCheckpoint(checkpoint *vpa_types.HistogramCheckpoint) error {
+func (*MockHistogram) LoadFromCheckpoint(checkpoint *vpa_types.HistogramCheckpoint) error {
 	return nil
 }

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_fake.go
@@ -23,7 +23,7 @@ type FakeControllerFetcher struct{}
 
 // FindTopMostWellKnownOrScalable returns the same key for that fake implementation and returns and error when the kind is Node
 // See pkg/target/controller_fetcher/controller_fetcher.go:296 where the original implementation does the same.
-func (f FakeControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context, controller *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+func (FakeControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context, controller *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
 	if controller.Kind == "Node" {
 		return nil, ErrNodeInvalidOwner
 	}
@@ -34,7 +34,7 @@ func (f FakeControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context,
 type NilControllerFetcher struct{}
 
 // FindTopMostWellKnownOrScalable always returns nil
-func (f NilControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context, _ *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+func (NilControllerFetcher) FindTopMostWellKnownOrScalable(_ context.Context, _ *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
 	return nil, nil
 }
 

--- a/vertical-pod-autoscaler/pkg/updater/inplace/unboost_patch_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/inplace/unboost_patch_calculator.go
@@ -38,7 +38,7 @@ func (*unboostAnnotationPatchCalculator) PatchResourceTarget() patch.PatchResour
 }
 
 // CalculatePatches calculates the patch to remove the startup CPU boost annotation if the pod is ready to be unboosted.
-func (c *unboostAnnotationPatchCalculator) CalculatePatches(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) ([]resource_admission.PatchRecord, error) {
+func (*unboostAnnotationPatchCalculator) CalculatePatches(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) ([]resource_admission.PatchRecord, error) {
 	var patches []resource_admission.PatchRecord
 	for _, annotationKey := range vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa) {
 		patches = append(patches, patch.GetRemoveAnnotationPatch(annotationKey))

--- a/vertical-pod-autoscaler/pkg/updater/priority/pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/pod_eviction_admission.go
@@ -72,10 +72,10 @@ func (a *sequentialPodEvictionAdmission) CleanUp() {
 
 type noopPodEvictionAdmission struct{}
 
-func (n *noopPodEvictionAdmission) LoopInit(allLivePods []*corev1.Pod, vpaControlledPods map[*vpa_types.VerticalPodAutoscaler][]*corev1.Pod) {
+func (*noopPodEvictionAdmission) LoopInit(allLivePods []*corev1.Pod, vpaControlledPods map[*vpa_types.VerticalPodAutoscaler][]*corev1.Pod) {
 }
-func (n *noopPodEvictionAdmission) Admit(pod *corev1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
+func (*noopPodEvictionAdmission) Admit(pod *corev1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
 	return true
 }
-func (n *noopPodEvictionAdmission) CleanUp() {
+func (*noopPodEvictionAdmission) CleanUp() {
 }

--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
@@ -89,7 +89,7 @@ func (s *scalingDirectionPodEvictionAdmission) checkEvictionRequirementsForConta
 	return true
 }
 
-func (s *scalingDirectionPodEvictionAdmission) checkChangeRequirement(currentRequests int64, recommendation int64, changeRequirement vpa_types.EvictionChangeRequirement) bool {
+func (*scalingDirectionPodEvictionAdmission) checkChangeRequirement(currentRequests int64, recommendation int64, changeRequirement vpa_types.EvictionChangeRequirement) bool {
 	if changeRequirement == vpa_types.TargetHigherThanRequests {
 		return recommendation > currentRequests
 	}

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -176,7 +176,7 @@ func (calc *UpdatePriorityCalculator) GetSortedPods(admission PodEvictionAdmissi
 
 // GetProcessedRecommendationTargets takes a RecommendedPodResources object and returns a formatted string
 // with the recommended pod resources. Specifically, it formats the target and uncapped target CPU and memory.
-func (calc *UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_types.RecommendedPodResources) string {
+func (*UpdatePriorityCalculator) GetProcessedRecommendationTargets(r *vpa_types.RecommendedPodResources) string {
 	sb := &strings.Builder{}
 	for _, cr := range r.ContainerRecommendations {
 		sb.WriteString(cr.ContainerName)

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator_test.go
@@ -486,11 +486,11 @@ func TestNoPods(t *testing.T) {
 
 type pod1Admission struct{}
 
-func (p *pod1Admission) LoopInit([]*corev1.Pod, map[*vpa_types.VerticalPodAutoscaler][]*corev1.Pod) {}
-func (p *pod1Admission) Admit(pod *corev1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
+func (*pod1Admission) LoopInit([]*corev1.Pod, map[*vpa_types.VerticalPodAutoscaler][]*corev1.Pod) {}
+func (*pod1Admission) Admit(pod *corev1.Pod, recommendation *vpa_types.RecommendedPodResources) bool {
 	return pod.Name == "POD1"
 }
-func (p *pod1Admission) CleanUp() {}
+func (*pod1Admission) CleanUp() {}
 
 func TestAdmission(t *testing.T) {
 	pod1 := test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("2")).Get()).Get()

--- a/vertical-pod-autoscaler/pkg/updater/restriction/fake_pods_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/fake_pods_restriction.go
@@ -41,6 +41,6 @@ func (f *FakePodsRestrictionFactory) NewPodsInPlaceRestriction(creatorToSingleGr
 }
 
 // GetCreatorMaps returns nil maps.
-func (f *FakePodsRestrictionFactory) GetCreatorMaps(pods []*corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) (map[podReplicaCreator]singleGroupStats, map[string]podReplicaCreator, error) {
+func (*FakePodsRestrictionFactory) GetCreatorMaps(pods []*corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) (map[podReplicaCreator]singleGroupStats, map[string]podReplicaCreator, error) {
 	return nil, nil, nil
 }

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
@@ -776,7 +776,7 @@ func (c *fakeResizePatchCalculator) CalculatePatches(_ *corev1.Pod, _ *vpa_types
 	return c.patches, c.err
 }
 
-func (c *fakeResizePatchCalculator) PatchResourceTarget() patch.PatchResourceTarget {
+func (*fakeResizePatchCalculator) PatchResourceTarget() patch.PatchResourceTarget {
 	return patch.Resize
 }
 

--- a/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
+++ b/vertical-pod-autoscaler/pkg/utils/limitrange/limit_range_calculator.go
@@ -37,11 +37,11 @@ type LimitRangeCalculator interface {
 
 type noopLimitsRangeCalculator struct{}
 
-func (lc *noopLimitsRangeCalculator) GetContainerLimitRangeItem(namespace string) (*corev1.LimitRangeItem, error) {
+func (*noopLimitsRangeCalculator) GetContainerLimitRangeItem(namespace string) (*corev1.LimitRangeItem, error) {
 	return nil, nil
 }
 
-func (lc *noopLimitsRangeCalculator) GetPodLimitRangeItem(namespace string) (*corev1.LimitRangeItem, error) {
+func (*noopLimitsRangeCalculator) GetPodLimitRangeItem(namespace string) (*corev1.LimitRangeItem, error) {
 	return nil, nil
 }
 

--- a/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
+++ b/vertical-pod-autoscaler/pkg/utils/resources/resourcehelpers.go
@@ -32,21 +32,25 @@ import (
 //   - Otherwise, fallback to the resource requests defined in the pod spec.
 //
 // [1] https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
-func ContainerRequestsAndLimits(containerName string, pod *corev1.Pod) (corev1.ResourceList, corev1.ResourceList) {
+func ContainerRequestsAndLimits(containerName string, pod *corev1.Pod) (requests corev1.ResourceList, limits corev1.ResourceList) {
 	cs := containerStatusFor(containerName, pod)
 	if cs != nil && cs.Resources != nil {
 		metrics_resources.RecordGetResourcesCount(metrics_resources.ContainerStatus)
-		return cs.Resources.Requests.DeepCopy(), cs.Resources.Limits.DeepCopy()
+		requests = cs.Resources.Requests.DeepCopy()
+		limits = cs.Resources.Limits.DeepCopy()
+		return requests, limits
 	}
 
 	klog.V(6).InfoS("Container resources not found in containerStatus for container. Falling back to resources defined in the pod spec. This is expected for clusters with in-place pod updates feature disabled.", "container", containerName, "containerStatus", cs)
 	container := findContainer(containerName, pod)
 	if container != nil {
 		metrics_resources.RecordGetResourcesCount(metrics_resources.PodSpecContainer)
-		return container.Resources.Requests.DeepCopy(), container.Resources.Limits.DeepCopy()
+		requests = container.Resources.Requests.DeepCopy()
+		limits = container.Resources.Limits.DeepCopy()
+		return requests, limits
 	}
 
-	return nil, nil
+	return requests, limits
 }
 
 // InitContainerRequestsAndLimits returns a copy of the actual resource requests
@@ -57,21 +61,25 @@ func ContainerRequestsAndLimits(containerName string, pod *corev1.Pod) (corev1.R
 //   - Otherwise, fallback to the resource requests defined in the pod spec.
 //
 // [1] https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
-func InitContainerRequestsAndLimits(initContainerName string, pod *corev1.Pod) (corev1.ResourceList, corev1.ResourceList) {
+func InitContainerRequestsAndLimits(initContainerName string, pod *corev1.Pod) (requests corev1.ResourceList, limits corev1.ResourceList) {
 	cs := initContainerStatusFor(initContainerName, pod)
 	if cs != nil && cs.Resources != nil {
 		metrics_resources.RecordGetResourcesCount(metrics_resources.InitContainerStatus)
-		return cs.Resources.Requests.DeepCopy(), cs.Resources.Limits.DeepCopy()
+		requests = cs.Resources.Requests.DeepCopy()
+		limits = cs.Resources.Limits.DeepCopy()
+		return requests, limits
 	}
 
 	klog.V(6).InfoS("initContainer resources not found in initContainerStatus for initContainer. Falling back to resources defined in the pod spec. This is expected for clusters with in-place pod updates feature disabled.", "initContainer", initContainerName, "initContainerStatus", cs)
 	initContainer := findInitContainer(initContainerName, pod)
 	if initContainer != nil {
 		metrics_resources.RecordGetResourcesCount(metrics_resources.PodSpecInitContainer)
-		return initContainer.Resources.Requests.DeepCopy(), initContainer.Resources.Limits.DeepCopy()
+		requests = initContainer.Resources.Requests.DeepCopy()
+		limits = initContainer.Resources.Limits.DeepCopy()
+		return requests, limits
 	}
 
-	return nil, nil
+	return requests, limits
 }
 
 func findContainer(containerName string, pod *corev1.Pod) *corev1.Container {

--- a/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
+++ b/vertical-pod-autoscaler/pkg/utils/test/test_utils.go
@@ -172,7 +172,7 @@ func (m *PodListerMock) List(selector labels.Selector) (ret []*corev1.Pod, err e
 }
 
 // Get is not implemented for this mock
-func (m *PodListerMock) Get(name string) (*corev1.Pod, error) {
+func (*PodListerMock) Get(name string) (*corev1.Pod, error) {
 	return nil, errors.New("unimplemented")
 }
 
@@ -203,7 +203,7 @@ func (m *VerticalPodAutoscalerListerMock) VerticalPodAutoscalers(namespace strin
 }
 
 // Get is not implemented for this mock
-func (m *VerticalPodAutoscalerListerMock) Get(name string) (*vpa_types.VerticalPodAutoscaler, error) {
+func (*VerticalPodAutoscalerListerMock) Get(name string) (*vpa_types.VerticalPodAutoscaler, error) {
 	return nil, errors.New("unimplemented")
 }
 
@@ -233,7 +233,7 @@ func (m *VerticalPodAutoscalerCheckPointListerMock) VerticalPodAutoscalerCheckpo
 }
 
 // Get is not implemented for this mock
-func (m *VerticalPodAutoscalerCheckPointListerMock) Get(name string) (*vpa_types.VerticalPodAutoscalerCheckpoint, error) {
+func (*VerticalPodAutoscalerCheckPointListerMock) Get(name string) (*vpa_types.VerticalPodAutoscalerCheckpoint, error) {
 	return nil, errors.New("unimplemented")
 }
 
@@ -264,7 +264,7 @@ func (m *VerticalPodAutoscalerV1Beta1ListerMock) VerticalPodAutoscalers(namespac
 }
 
 // Get is not implemented for this mock
-func (m *VerticalPodAutoscalerV1Beta1ListerMock) Get(name string) (*vpa_types_v1beta1.VerticalPodAutoscaler, error) {
+func (*VerticalPodAutoscalerV1Beta1ListerMock) Get(name string) (*vpa_types_v1beta1.VerticalPodAutoscaler, error) {
 	return nil, errors.New("unimplemented")
 }
 
@@ -292,7 +292,7 @@ func (m *RecommendationProcessorMock) Apply(vpa *vpa_types.VerticalPodAutoscaler
 type FakeRecommendationProcessor struct{}
 
 // Apply is a dummy implementation of RecommendationProcessor.Apply which returns provided podRecommendation
-func (f *FakeRecommendationProcessor) Apply(vpa *vpa_types.VerticalPodAutoscaler,
+func (*FakeRecommendationProcessor) Apply(vpa *vpa_types.VerticalPodAutoscaler,
 	pod *corev1.Pod) (*vpa_types.RecommendedPodResources, map[string][]string, error) {
 	return vpa.Status.Recommendation, nil, nil
 }
@@ -301,18 +301,18 @@ func (f *FakeRecommendationProcessor) Apply(vpa *vpa_types.VerticalPodAutoscaler
 type fakeEventRecorder struct{}
 
 // Event is a dummy implementation of record.EventRecorder interface.
-func (f *fakeEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {}
+func (*fakeEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {}
 
 // Eventf is a dummy implementation of record.EventRecorder interface.
-func (f *fakeEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...any) {
+func (*fakeEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...any) {
 }
 
 // PastEventf is a dummy implementation of record.EventRecorder interface.
-func (f *fakeEventRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...any) {
+func (*fakeEventRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...any) {
 }
 
 // AnnotatedEventf is a dummy implementation of record.EventRecorder interface.
-func (f *fakeEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...any) {
+func (*fakeEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...any) {
 }
 
 // FakeEventRecorder returns a dummy implementation of record.EventRecorder.
@@ -331,15 +331,15 @@ func (m *mockedEventRecorder) Event(object runtime.Object, eventtype, reason, me
 }
 
 // Eventf is a dummy implementation of record.EventRecorder interface.
-func (m *mockedEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...any) {
+func (*mockedEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...any) {
 }
 
 // PastEventf is a dummy implementation of record.EventRecorder interface.
-func (m *mockedEventRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...any) {
+func (*mockedEventRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...any) {
 }
 
 // AnnotatedEventf is a dummy implementation of record.EventRecorder interface.
-func (m *mockedEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...any) {
+func (*mockedEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...any) {
 }
 
 // MockEventRecorder returns a dummy implementation of record.EventRecorder.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Enables revive rules.
Below are the revive linter rules enabled as part of this PR
        - name: confusing-results - Ensures if multiple return types are same, then it should be named.
        - name: unused-receiver - Ensures there are no unused receiver set if its not used.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Updates #8986

#### Special notes for your reviewer:
Continuation from this [PR](https://github.com/kubernetes/autoscaler/pull/9155)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
