### PR TITLE
Add warning explaining why boilerplate validation may fail for files introduced in 2026+ year.

### DIFF
--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -33,6 +33,6 @@ if [[ ${#files_need_boilerplate[@]} -gt 0 ]]; then
   for file in "${files_need_boilerplate[@]}"; do
     echo "Boilerplate header is wrong for: ${file}" >&2
   done
-
+  echo "Warning: new files should no longer include year in the copyright header" >&2
   exit 1
 fi


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Existing validation requires headers not to include dates in the copyright notice further than 2025 year. The time has come and right now there's no clear way on how to figure out that boilerplate was rejected without running the `hack/boilerplate/boilerplate.py` with verbose mode and actually reading source code. This warning will help to save time when discovering such errors. I don't expect it being misleading most of the time as usually boilerplate header is just getting copied over from another file and this is one of not many errors which may happen apart of the header actually being missing.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
