### PR TITLE
Fix flaky CPU Startup boost e2e test

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/e2e/v1/full_vpa.go
@@ -384,7 +384,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 			}
 
 			containerName := utils.GetHamsterContainerNameByIndex(0)
-			factor := int32(100)
+			factor := int32(20)
 			vpaCRD := test.VerticalPodAutoscaler().
 				WithName("hamster-vpa").
 				WithNamespace(f.Namespace.Name).
@@ -406,10 +406,10 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 				f.ClientSet,
 				f.ScalesGetter)
 
-			// Pods should be created with boosted CPU (10m * 100 = 1000m)
+			// Pods should be created with boosted CPU (10m * 20 = 200m)
 			err := waitForResourceRequestInRangeInPods(
 				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-				ParseQuantityOrDie("900m"), ParseQuantityOrDie("1100m"))
+				ParseQuantityOrDie("180m"), ParseQuantityOrDie("220m"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Pods should be scaled back down in-place after they become Ready and
@@ -431,7 +431,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 			}
 
 			containerName := utils.GetHamsterContainerNameByIndex(0)
-			factor := int32(100)
+			factor := int32(20)
 			vpaCRD := test.VerticalPodAutoscaler().
 				WithName("hamster-vpa").
 				WithNamespace(f.Namespace.Name).
@@ -454,10 +454,10 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 				f.ClientSet,
 				f.ScalesGetter)
 
-			// Pods should be created with boosted CPU (10m * 100 = 1000m)
+			// Pods should be created with boosted CPU (10m * 20 = 200m)
 			err := waitForResourceRequestInRangeInPods(
 				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-				ParseQuantityOrDie("900m"), ParseQuantityOrDie("1100m"))
+				ParseQuantityOrDie("180m"), ParseQuantityOrDie("220m"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Pods should be scaled back down in-place after they become Ready and

--- a/vertical-pod-autoscaler/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/e2e/v1/updater.go
@@ -334,7 +334,8 @@ var _ = UpdaterE2eDescribe("Updater", func() {
 	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
 	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
 
-	f.It("Unboost pods when they become Ready", framework.WithFeatureGate(features.CPUStartupBoost), func() {
+	// Sets up a lease object updated periodically to signal - requires WithSerial()
+	f.It("Unboost pods when they become Ready", framework.WithFeatureGate(features.CPUStartupBoost), framework.WithSerial(), func() {
 		const statusUpdateInterval = 10 * time.Second
 
 		ginkgo.By("Setting up the Admission Controller status")


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:
The updater suite test needs to be marked serial. Also the full-vpa test is failing because the pods failed to be scheduled so reducing the boost will be better since the pods can fit without staying unscheduled.
