### PR TITLE
Track cluster autoscaler decisions for DRA nodegroups ScaleUp/ScaleDown decisions

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups/asyncnodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/dynamicresources"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -121,7 +122,7 @@ type ScaleUpFailure struct {
 }
 
 type metricObserver interface {
-	RegisterFailedScaleUp(reason metrics.FailedScaleUpReason, gpuResourceName, gpuType string)
+	RegisterFailedScaleUp(reason metrics.FailedScaleUpReason, gpuResourceName, gpuType, draDrivers string)
 	RegisterFailedNodeCreations(reason metrics.FailedScaleUpReason, nodesCount int)
 }
 
@@ -308,18 +309,19 @@ func (csr *ClusterStateRegistry) updateScaleRequests(currentTime time.Time) {
 				"Nodes added to group %s failed to register within %v",
 				scaleUpRequest.NodeGroup.Id(), currentTime.Sub(scaleUpRequest.Time))
 			availableGPUTypes := csr.cloudProvider.GetAvailableGPUTypes()
-			gpuResource, gpuType := "", ""
+			gpuResource, gpuType, draDriverNames := "", "", ""
 			nodeInfo, err := scaleUpRequest.NodeGroup.TemplateNodeInfo()
 			if err != nil {
 				klog.Warningf("Failed to get template node info for a node group: %s", err)
 			} else {
 				gpuResource, gpuType = gpu.GetGpuInfoForMetrics(csr.cloudProvider.GetNodeGpuConfig(nodeInfo.Node()), availableGPUTypes, nodeInfo.Node(), scaleUpRequest.NodeGroup)
+				draDriverNames = dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
 			}
 			csr.registerFailedScaleUpNoLock(scaleUpRequest.NodeGroup, scaleUpRequest.Increase, metrics.Timeout, cloudprovider.InstanceErrorInfo{
 				ErrorClass:   cloudprovider.OtherErrorClass,
 				ErrorCode:    "timeout",
 				ErrorMessage: fmt.Sprintf("Scale-up timed out for node group %v after %v", nodeGroupName, currentTime.Sub(scaleUpRequest.Time)),
-			}, gpuResource, gpuType, currentTime)
+			}, gpuResource, gpuType, draDriverNames, currentTime)
 			delete(csr.scaleUpRequests, nodeGroupName)
 		}
 	}
@@ -343,14 +345,14 @@ func (csr *ClusterStateRegistry) backoffNodeGroup(nodeGroup cloudprovider.NodeGr
 // RegisterFailedScaleUp should be called after getting error from cloudprovider
 // when trying to scale-up node group. It will mark this group as not safe to autoscale
 // for some time.
-func (csr *ClusterStateRegistry) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, reason string, errorMessage, gpuResourceName, gpuType string, currentTime time.Time) {
+func (csr *ClusterStateRegistry) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, reason string, errorMessage, gpuResourceName, gpuType, draDriverNames string, currentTime time.Time) {
 	csr.Lock()
 	defer csr.Unlock()
 	csr.registerFailedScaleUpNoLock(nodeGroup, delta, metrics.FailedScaleUpReason(reason), cloudprovider.InstanceErrorInfo{
 		ErrorClass:   cloudprovider.OtherErrorClass,
 		ErrorCode:    string(reason),
 		ErrorMessage: errorMessage,
-	}, gpuResourceName, gpuType, currentTime)
+	}, gpuResourceName, gpuType, draDriverNames, currentTime)
 }
 
 // RegisterFailedScaleDown records failed scale-down for a nodegroup.
@@ -358,9 +360,9 @@ func (csr *ClusterStateRegistry) RegisterFailedScaleUp(nodeGroup cloudprovider.N
 func (csr *ClusterStateRegistry) RegisterFailedScaleDown(_ cloudprovider.NodeGroup, _ string, _ time.Time) {
 }
 
-func (csr *ClusterStateRegistry) registerFailedScaleUpNoLock(nodeGroup cloudprovider.NodeGroup, delta int, reason metrics.FailedScaleUpReason, errorInfo cloudprovider.InstanceErrorInfo, gpuResourceName, gpuType string, currentTime time.Time) {
+func (csr *ClusterStateRegistry) registerFailedScaleUpNoLock(nodeGroup cloudprovider.NodeGroup, delta int, reason metrics.FailedScaleUpReason, errorInfo cloudprovider.InstanceErrorInfo, gpuResourceName, gpuType, draDriverName string, currentTime time.Time) {
 	csr.scaleUpFailures[nodeGroup.Id()] = append(csr.scaleUpFailures[nodeGroup.Id()], ScaleUpFailure{NodeGroup: nodeGroup, Reason: reason, Time: currentTime})
-	csr.metrics.RegisterFailedScaleUp(reason, gpuResourceName, gpuType)
+	csr.metrics.RegisterFailedScaleUp(reason, gpuResourceName, gpuType, draDriverName)
 	csr.metrics.RegisterFailedNodeCreations(reason, delta)
 	csr.backoffNodeGroup(nodeGroup, errorInfo, currentTime)
 }
@@ -1203,12 +1205,13 @@ func (csr *ClusterStateRegistry) handleInstanceCreationErrorsForNodeGroup(
 				csr.buildErrorMessageEventString(currentUniqueErrorMessagesForErrorCode[errorCode]))
 
 			availableGPUTypes := csr.cloudProvider.GetAvailableGPUTypes()
-			gpuResource, gpuType := "", ""
+			gpuResource, gpuType, draDriverNames := "", "", ""
 			nodeInfo, err := nodeGroup.TemplateNodeInfo()
 			if err != nil {
 				klog.Warningf("Failed to get template node info for a node group: %s", err)
 			} else {
 				gpuResource, gpuType = gpu.GetGpuInfoForMetrics(csr.cloudProvider.GetNodeGpuConfig(nodeInfo.Node()), availableGPUTypes, nodeInfo.Node(), nodeGroup)
+				draDriverNames = dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
 			}
 			// Decrease the scale up request by the number of deleted nodes
 			csr.registerOrUpdateScaleUpNoLock(nodeGroup, -len(unseenInstanceIds), currentTime)
@@ -1216,7 +1219,7 @@ func (csr *ClusterStateRegistry) handleInstanceCreationErrorsForNodeGroup(
 				ErrorClass:   errorCode.class,
 				ErrorCode:    errorCode.code,
 				ErrorMessage: csr.buildErrorMessageEventString(currentUniqueErrorMessagesForErrorCode[errorCode]),
-			}, gpuResource, gpuType, currentTime)
+			}, gpuResource, gpuType, draDriverNames, currentTime)
 		}
 	}
 }

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -1733,7 +1733,7 @@ func TestFailedScaleUpWithDra(t *testing.T) {
 	nodeInfo.LocalResourceSlices = []*v1.ResourceSlice{
 		{
 			Spec: v1.ResourceSliceSpec{
-				Driver: "driver1",
+				Driver: "dra.net",
 			},
 		},
 		{
@@ -1757,7 +1757,7 @@ func TestFailedScaleUpWithDra(t *testing.T) {
 	// UpdateNodes will trigger handleInstanceCreationErrors
 	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
 	assert.NoError(t, err)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "", "", "driver1,driver2")
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "", "", "custom.driver,dra.net")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 1)
 }
 
@@ -1794,7 +1794,7 @@ func TestFailedScaleUpWithDraAndGpu(t *testing.T) {
 	nodeInfo.LocalResourceSlices = []*v1.ResourceSlice{
 		{
 			Spec: v1.ResourceSliceSpec{
-				Driver: "driver1",
+				Driver: "dra.net",
 			},
 		},
 		{
@@ -1818,7 +1818,7 @@ func TestFailedScaleUpWithDraAndGpu(t *testing.T) {
 	// UpdateNodes will trigger handleInstanceCreationErrors
 	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
 	assert.NoError(t, err)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "dra_gpu-driver", "not-listed", "driver1,driver2")
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "dra_gpu-driver", "not-listed", "custom.driver,dra.net")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 1)
 }
 

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
@@ -553,7 +554,7 @@ func TestExpiredScaleUp(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	mockMetrics := &mockMetrics{}
-	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{
@@ -563,7 +564,7 @@ func TestExpiredScaleUp(t *testing.T) {
 	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 4, now.Add(-3*time.Minute))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now)
 	assert.NoError(t, err)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.Timeout, 4)
 	assert.True(t, clusterstate.IsClusterHealthy())
 	assert.False(t, clusterstate.IsNodeGroupHealthy("ng1"))
@@ -924,7 +925,7 @@ func TestScaleUpBackoff(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	mockMetrics := &mockMetrics{}
-	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	clusterstate := newClusterStateRegistry(
@@ -938,7 +939,7 @@ func TestScaleUpBackoff(t *testing.T) {
 	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 1, now.Add(-180*time.Second))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, ng1_3}, nil, now)
 	assert.NoError(t, err)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.Timeout, 1)
 	assert.True(t, clusterstate.IsClusterHealthy())
 	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
@@ -1148,18 +1149,18 @@ func TestScaleUpFailures(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
-	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
 
-	clusterstate.RegisterFailedScaleUp(provider.GetNodeGroup("ng1"), 3, string(metrics.Timeout), "", "", "", now)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+	clusterstate.RegisterFailedScaleUp(provider.GetNodeGroup("ng1"), 3, string(metrics.Timeout), "", "", "", "", now)
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.Timeout, 3)
-	clusterstate.RegisterFailedScaleUp(provider.GetNodeGroup("ng2"), 2, string(metrics.Timeout), "", "", "", now)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "")
+	clusterstate.RegisterFailedScaleUp(provider.GetNodeGroup("ng2"), 2, string(metrics.Timeout), "", "", "", "", now)
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.Timeout, 2)
-	clusterstate.RegisterFailedScaleUp(provider.GetNodeGroup("ng1"), 1, string(metrics.APIError), "", "", "", now.Add(time.Minute))
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.APIError, "", "")
+	clusterstate.RegisterFailedScaleUp(provider.GetNodeGroup("ng1"), 1, string(metrics.APIError), "", "", "", "", now.Add(time.Minute))
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.APIError, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.APIError, 1)
 
 	failures := clusterstate.GetScaleUpFailures()
@@ -1694,7 +1695,7 @@ func TestHandleInstanceCreationErrors(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
-	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
 	clusterstate.RegisterScaleUp(mockedNodeGroup, 1, now)
@@ -1702,16 +1703,131 @@ func TestHandleInstanceCreationErrors(t *testing.T) {
 	// UpdateNodes will trigger handleInstanceCreationErrors
 	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
 	assert.NoError(t, err)
-	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "", "")
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 2)
+}
+
+func TestFailedScaleUpWithDra(t *testing.T) {
+	now := time.Now()
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	mockedNodeGroup := &mockprovider.NodeGroup{}
+	mockedNodeGroup.On("Id").Return("ng1")
+	mockedNodeGroup.On("Nodes").Return([]cloudprovider.Instance{
+		{
+			Id: "instance1",
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    "RESOURCE_POOL_EXHAUSTED",
+					ErrorMessage: "",
+				},
+			},
+		},
+	}, nil)
+	mockedNodeGroup.On("Autoprovisioned").Return(false)
+	mockedNodeGroup.On("TargetSize").Return(1, nil)
+	node := BuildTestNode("ng1_1", 1000, 1000)
+	nodeInfo := framework.NewTestNodeInfo(node)
+	nodeInfo.LocalResourceSlices = []*v1.ResourceSlice{
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver1",
+			},
+		},
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver2",
+			},
+		},
+	}
+	mockedNodeGroup.On("TemplateNodeInfo").Return(nodeInfo, nil)
+	mockedNodeGroup.On("GetOptions", mock.Anything).Return(&config.NodeGroupAutoscalingOptions{}, nil)
+	provider.InsertNodeGroup(mockedNodeGroup)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	mockMetrics := &mockMetrics{}
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+	clusterstate.RegisterScaleUp(mockedNodeGroup, 1, now)
+
+	// UpdateNodes will trigger handleInstanceCreationErrors
+	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "", "", "driver1,driver2")
+	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 1)
+}
+
+func TestFailedScaleUpWithDraAndGpu(t *testing.T) {
+	now := time.Now()
+
+	builder := testprovider.NewTestCloudProviderBuilder()
+	provider := builder.WithNodeGpuConfig(func(node *apiv1.Node) *cloudprovider.GpuConfig {
+		return &cloudprovider.GpuConfig{
+			Type:          "gpu-type",
+			Label:         "gpu-resource-label",
+			DraDriverName: "gpu-driver",
+		}
+	}).Build()
+	mockedNodeGroup := &mockprovider.NodeGroup{}
+	mockedNodeGroup.On("Id").Return("ng1")
+	mockedNodeGroup.On("Nodes").Return([]cloudprovider.Instance{
+		{
+			Id: "instance1",
+			Status: &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    "RESOURCE_POOL_EXHAUSTED",
+					ErrorMessage: "",
+				},
+			},
+		},
+	}, nil)
+	mockedNodeGroup.On("Autoprovisioned").Return(false)
+	mockedNodeGroup.On("TargetSize").Return(1, nil)
+	node := BuildTestNode("ng1_1", 1000, 1000)
+	nodeInfo := framework.NewTestNodeInfo(node)
+	nodeInfo.LocalResourceSlices = []*v1.ResourceSlice{
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver1",
+			},
+		},
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver2",
+			},
+		},
+	}
+	mockedNodeGroup.On("TemplateNodeInfo").Return(nodeInfo, nil)
+	mockedNodeGroup.On("GetOptions", mock.Anything).Return(&config.NodeGroupAutoscalingOptions{}, nil)
+	provider.InsertNodeGroup(mockedNodeGroup)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	mockMetrics := &mockMetrics{}
+	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+	clusterstate := newClusterStateRegistry(provider, ClusterStateRegistryConfig{}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+	clusterstate.RegisterScaleUp(mockedNodeGroup, 1, now)
+
+	// UpdateNodes will trigger handleInstanceCreationErrors
+	err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
+	assert.NoError(t, err)
+	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "dra_gpu-driver", "not-listed", "driver1,driver2")
+	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 1)
 }
 
 type mockMetrics struct {
 	mock.Mock
 }
 
-func (m *mockMetrics) RegisterFailedScaleUp(reason metrics.FailedScaleUpReason, gpuResourceName, gpuType string) {
-	m.Called(reason, gpuResourceName, gpuType)
+func (m *mockMetrics) RegisterFailedScaleUp(reason metrics.FailedScaleUpReason, gpuResourceName, gpuType, draDrivers string) {
+	m.Called(reason, gpuResourceName, gpuType, draDrivers)
 }
 
 func (m *mockMetrics) RegisterFailedNodeCreations(reason metrics.FailedScaleUpReason, nodesCount int) {

--- a/cluster-autoscaler/core/scaleup/orchestrator/executor.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/executor.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/observers/nodegroupchange"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups/asyncnodegroups"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/dynamicresources"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 )
@@ -161,6 +162,7 @@ func (e *scaleUpExecutor) executeScaleUp(
 ) errors.AutoscalerError {
 	gpuConfig := e.autoscalingCtx.CloudProvider.GetNodeGpuConfig(nodeInfo.Node())
 	gpuResourceName, gpuType := gpu.GetGpuInfoForMetrics(gpuConfig, availableGPUTypes, nodeInfo.Node(), nil)
+	draDriverNames := dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
 	klog.V(0).Infof("Scale-up: setting group %s size to %d", info.Group.Id(), info.NewSize)
 	e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
 		"Scale-up: setting group %s size to %d instead of %d (max: %d)", info.Group.Id(), info.NewSize, info.CurrentSize, info.MaxSize)
@@ -168,7 +170,7 @@ func (e *scaleUpExecutor) executeScaleUp(
 	if err := e.increaseSize(info.Group, increase, atomic); err != nil {
 		e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "FailedToScaleUpGroup", "Scale-up failed for group %s: %v", info.Group.Id(), err)
 		aerr := errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to increase node group size: ")
-		e.scaleStateNotifier.RegisterFailedScaleUp(info.Group, increase, string(aerr.Type()), aerr.Error(), gpuResourceName, gpuType, now)
+		e.scaleStateNotifier.RegisterFailedScaleUp(info.Group, increase, string(aerr.Type()), aerr.Error(), gpuResourceName, gpuType, draDriverNames, now)
 		return aerr
 	}
 	if increase < 0 {
@@ -180,7 +182,7 @@ func (e *scaleUpExecutor) executeScaleUp(
 		return nil
 	}
 	e.scaleStateNotifier.RegisterScaleUp(info.Group, increase, time.Now())
-	metrics.RegisterScaleUp(increase, gpuResourceName, gpuType)
+	metrics.RegisterScaleUp(increase, gpuResourceName, gpuType, draDriverNames)
 	e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
 		"Scale-up: group %s size set to %d instead of %d (max: %d)", info.Group.Id(), info.NewSize, info.CurrentSize, info.MaxSize)
 	return nil

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -2043,7 +2043,7 @@ func TestAuthErrorHandling(t *testing.T) {
 	results := runSimpleScaleUpTest(t, config)
 	assert.Equal(t, errors.AutoscalerErrorType("authError"), results.ScaleUpError.Type())
 	assert.Equal(t, "failed to increase node group size: auth error", results.ScaleUpError.Error())
-	assertLegacyRegistryEntry(t, "cluster_autoscaler_failed_scale_ups_total{reason=\"authError\"} 1")
+	assertLegacyRegistryEntry(t, "cluster_autoscaler_failed_scale_ups_total{dra_drivers=\"\",gpu_name=\"\",gpu_resource_name=\"\",reason=\"authError\"} 1")
 }
 
 func TestScaleUpSimulationForSkippedNodeGroups(t *testing.T) {

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -136,18 +136,18 @@ func RegisterError(err errors.AutoscalerError) {
 }
 
 // RegisterScaleUp records number of nodes added by scale up
-func RegisterScaleUp(nodesCount int, gpuResourceName, gpuType string) {
-	DefaultMetrics.RegisterScaleUp(nodesCount, gpuResourceName, gpuType)
+func RegisterScaleUp(nodesCount int, gpuResourceName, gpuType, draDrivers string) {
+	DefaultMetrics.RegisterScaleUp(nodesCount, gpuResourceName, gpuType, draDrivers)
 }
 
 // RegisterFailedScaleUp records a failed scale-up operation
-func RegisterFailedScaleUp(reason FailedScaleUpReason, gpuResourceName, gpuType string) {
-	DefaultMetrics.RegisterFailedScaleUp(reason, gpuResourceName, gpuType)
+func RegisterFailedScaleUp(reason FailedScaleUpReason, gpuResourceName, gpuType, draDrivers string) {
+	DefaultMetrics.RegisterFailedScaleUp(reason, gpuResourceName, gpuType, draDrivers)
 }
 
 // RegisterScaleDown records number of nodes removed by scale down
-func RegisterScaleDown(nodesCount int, gpuResourceName, gpuType string, reason NodeScaleDownReason) {
-	DefaultMetrics.RegisterScaleDown(nodesCount, gpuResourceName, gpuType, reason)
+func RegisterScaleDown(nodesCount int, gpuResourceName, gpuType string, reason NodeScaleDownReason, draDrivers string) {
+	DefaultMetrics.RegisterScaleDown(nodesCount, gpuResourceName, gpuType, reason, draDrivers)
 }
 
 // RegisterEvictions records number of evicted pods succeed or failed

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -98,7 +98,7 @@ const (
 	// PodEvictionFailed means creation of the pod eviction object failed
 	PodEvictionFailed PodEvictionResult = "failed"
 
-	gpuNodeMetricsDeprecatedVersion = "1.35.0"
+	gpuNodeMetricsDeprecatedVersion = "1.36.0"
 )
 
 // Names of Cluster Autoscaler operations

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -97,6 +97,8 @@ const (
 	PodEvictionSucceed PodEvictionResult = "succeeded"
 	// PodEvictionFailed means creation of the pod eviction object failed
 	PodEvictionFailed PodEvictionResult = "failed"
+
+	gpuNodeMetricsDeprecatedVersion = "1.35.0"
 )
 
 // Names of Cluster Autoscaler operations
@@ -340,9 +342,10 @@ func newCaMetrics() *caMetrics {
 
 		gpuScaleUpCount: k8smetrics.NewCounterVec(
 			&k8smetrics.CounterOpts{
-				Namespace: caNamespace,
-				Name:      "scaled_up_gpu_nodes_total",
-				Help:      "Number of GPU nodes added by CA, by GPU name.",
+				Namespace:         caNamespace,
+				Name:              "scaled_up_gpu_nodes_total",
+				Help:              "Number of GPU nodes added by CA, by GPU name.",
+				DeprecatedVersion: gpuNodeMetricsDeprecatedVersion,
 			}, []string{"gpu_resource_name", "gpu_name"},
 		),
 
@@ -364,9 +367,10 @@ func newCaMetrics() *caMetrics {
 
 		failedGPUScaleUpCount: k8smetrics.NewCounterVec(
 			&k8smetrics.CounterOpts{
-				Namespace: caNamespace,
-				Name:      "failed_gpu_scale_ups_total",
-				Help:      "Number of times scale-up operation has failed.",
+				Namespace:         caNamespace,
+				Name:              "failed_gpu_scale_ups_total",
+				Help:              "Number of times scale-up operation has failed.",
+				DeprecatedVersion: gpuNodeMetricsDeprecatedVersion,
 			}, []string{"reason", "gpu_resource_name", "gpu_name"},
 		),
 
@@ -380,9 +384,10 @@ func newCaMetrics() *caMetrics {
 
 		gpuScaleDownCount: k8smetrics.NewCounterVec(
 			&k8smetrics.CounterOpts{
-				Namespace: caNamespace,
-				Name:      "scaled_down_gpu_nodes_total",
-				Help:      "Number of GPU nodes removed by CA, by reason and GPU name.",
+				Namespace:         caNamespace,
+				Name:              "scaled_down_gpu_nodes_total",
+				Help:              "Number of GPU nodes removed by CA, by reason and GPU name.",
+				DeprecatedVersion: gpuNodeMetricsDeprecatedVersion,
 			}, []string{"reason", "gpu_resource_name", "gpu_name"},
 		),
 

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -147,7 +147,7 @@ type caMetrics struct {
 
 	// Metrics related to autoscaler operations
 	errorsCount                      *k8smetrics.CounterVec
-	scaleUpCount                     *k8smetrics.Counter
+	scaleUpCount                     *k8smetrics.CounterVec
 	gpuScaleUpCount                  *k8smetrics.CounterVec
 	failedScaleUpCount               *k8smetrics.CounterVec
 	failedNodeCreationCount          *k8smetrics.CounterVec
@@ -330,12 +330,12 @@ func newCaMetrics() *caMetrics {
 			}, []string{"type"},
 		),
 
-		scaleUpCount: k8smetrics.NewCounter(
+		scaleUpCount: k8smetrics.NewCounterVec(
 			&k8smetrics.CounterOpts{
 				Namespace: caNamespace,
 				Name:      "scaled_up_nodes_total",
 				Help:      "Number of nodes added by CA.",
-			},
+			}, []string{"gpu_resource_name", "gpu_name", "dra_drivers"},
 		),
 
 		gpuScaleUpCount: k8smetrics.NewCounterVec(
@@ -351,7 +351,7 @@ func newCaMetrics() *caMetrics {
 				Namespace: caNamespace,
 				Name:      "failed_scale_ups_total",
 				Help:      "Number of times scale-up operation has failed.",
-			}, []string{"reason"},
+			}, []string{"reason", "gpu_resource_name", "gpu_name", "dra_drivers"},
 		),
 
 		failedNodeCreationCount: k8smetrics.NewCounterVec(
@@ -375,7 +375,7 @@ func newCaMetrics() *caMetrics {
 				Namespace: caNamespace,
 				Name:      "scaled_down_nodes_total",
 				Help:      "Number of nodes removed by CA.",
-			}, []string{"reason"},
+			}, []string{"reason", "gpu_resource_name", "gpu_name", "dra_drivers"},
 		),
 
 		gpuScaleDownCount: k8smetrics.NewCounterVec(
@@ -569,8 +569,11 @@ func (m *caMetrics) InitMetrics() {
 	}
 
 	for _, reason := range []FailedScaleUpReason{CloudProviderError, APIError, Timeout} {
-		m.scaleDownCount.WithLabelValues(string(reason)).Add(0)
-		m.failedScaleUpCount.WithLabelValues(string(reason)).Add(0)
+		m.failedScaleUpCount.WithLabelValues(string(reason), "", "", "").Add(0)
+	}
+
+	for _, reason := range []NodeScaleDownReason{Underutilized, Empty, Unready} {
+		m.scaleDownCount.WithLabelValues(string(reason), "", "", "").Add(0)
 	}
 
 	for _, result := range []PodEvictionResult{PodEvictionSucceed, PodEvictionFailed} {
@@ -716,16 +719,27 @@ func (m *caMetrics) RegisterError(err errors.AutoscalerError) {
 }
 
 // RegisterScaleUp records number of nodes added by scale up
-func (m *caMetrics) RegisterScaleUp(nodesCount int, gpuResourceName, gpuType string) {
-	m.scaleUpCount.Add(float64(nodesCount))
+func (m *caMetrics) RegisterScaleUp(nodesCount int, gpuResourceName, gpuType, draDrivers string) {
+	m.scaleUpCount.With(map[string]string{
+		"gpu_resource_name": gpuResourceName,
+		"gpu_name":          gpuType,
+		"dra_drivers":       draDrivers,
+	}).Add(float64(nodesCount))
+
 	if gpuType != gpu.MetricsNoGPU {
 		m.gpuScaleUpCount.WithLabelValues(gpuResourceName, gpuType).Add(float64(nodesCount))
 	}
 }
 
 // RegisterFailedScaleUp records a failed scale-up operation
-func (m *caMetrics) RegisterFailedScaleUp(reason FailedScaleUpReason, gpuResourceName, gpuType string) {
-	m.failedScaleUpCount.WithLabelValues(string(reason)).Inc()
+func (m *caMetrics) RegisterFailedScaleUp(reason FailedScaleUpReason, gpuResourceName, gpuType, draDrivers string) {
+	m.failedScaleUpCount.With(map[string]string{
+		"reason":            string(reason),
+		"gpu_resource_name": gpuResourceName,
+		"gpu_name":          gpuType,
+		"dra_drivers":       draDrivers,
+	}).Inc()
+
 	if gpuType != gpu.MetricsNoGPU {
 		m.failedGPUScaleUpCount.WithLabelValues(string(reason), gpuResourceName, gpuType).Inc()
 	}
@@ -737,8 +751,14 @@ func (m *caMetrics) RegisterFailedNodeCreations(reason FailedScaleUpReason, node
 }
 
 // RegisterScaleDown records number of nodes removed by scale down
-func (m *caMetrics) RegisterScaleDown(nodesCount int, gpuResourceName, gpuType string, reason NodeScaleDownReason) {
-	m.scaleDownCount.WithLabelValues(string(reason)).Add(float64(nodesCount))
+func (m *caMetrics) RegisterScaleDown(nodesCount int, gpuResourceName, gpuType string, reason NodeScaleDownReason, draDrivers string) {
+	m.scaleDownCount.With(map[string]string{
+		"reason":            string(reason),
+		"gpu_resource_name": gpuResourceName,
+		"gpu_name":          gpuType,
+		"dra_drivers":       draDrivers,
+	}).Add(float64(nodesCount))
+
 	if gpuType != gpu.MetricsNoGPU {
 		m.gpuScaleDownCount.WithLabelValues(string(reason), gpuResourceName, gpuType).Add(float64(nodesCount))
 	}

--- a/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
+++ b/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
@@ -36,7 +36,7 @@ type NodeGroupChangeObserver interface {
 	// RegisterFailedScaleUp records failed scale-up for a nodegroup.
 	// reason denotes optional reason for failed scale-up
 	// errMsg denotes the actual error message
-	RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, reason string, errMsg string, gpuResourceName, gpuType string, currentTime time.Time)
+	RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, reason string, errMsg string, gpuResourceName, gpuType string, draDriverNames string, currentTime time.Time)
 	// RegisterFailedScaleDown records failed scale-down for a nodegroup.
 	RegisterFailedScaleDown(nodeGroup cloudprovider.NodeGroup, reason string, currentTime time.Time)
 }
@@ -75,12 +75,11 @@ func (l *NodeGroupChangeObserversList) RegisterScaleDown(nodeGroup cloudprovider
 }
 
 // RegisterFailedScaleUp calls RegisterFailedScaleUp for each observer.
-func (l *NodeGroupChangeObserversList) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int,
-	reason string, errMsg, gpuResourceName, gpuType string, currentTime time.Time) {
+func (l *NodeGroupChangeObserversList) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, reason string, errMsg, gpuResourceName, gpuType, draDriverNames string, currentTime time.Time) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	for _, observer := range l.observers {
-		observer.RegisterFailedScaleUp(nodeGroup, delta, reason, errMsg, gpuResourceName, gpuType, currentTime)
+		observer.RegisterFailedScaleUp(nodeGroup, delta, reason, errMsg, gpuResourceName, gpuType, draDriverNames, currentTime)
 	}
 }
 

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
@@ -104,8 +104,7 @@ func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleDown(nodeGroup cloudpro
 }
 
 // RegisterFailedScaleUp records when the last scale up failed for a nodegroup.
-func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleUp(_ cloudprovider.NodeGroup, _ int,
-	_ string, _ string, _ string, _ string, _ time.Time) {
+func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleUp(_ cloudprovider.NodeGroup, _ int, _ string, _ string, _ string, _ string, _ string, currentTime time.Time) {
 }
 
 // RegisterFailedScaleDown records failed scale-down for a nodegroup.

--- a/cluster-autoscaler/utils/dynamicresources/metrics.go
+++ b/cluster-autoscaler/utils/dynamicresources/metrics.go
@@ -1,0 +1,31 @@
+package dynamicresources
+
+import (
+	"slices"
+	"strings"
+
+	v1 "k8s.io/api/resource/v1"
+)
+
+// GetDriverNamesForMetrics returns a slice of sorted unique driver names for the given node info.
+// For metrics we want to ensure that we always get the same order of driver names
+// to reduce cardinality.
+func GetDriverNamesForMetrics(resourceSlices []*v1.ResourceSlice) []string {
+	if len(resourceSlices) == 0 {
+		return nil
+	}
+
+	driverNames := make([]string, len(resourceSlices))
+	for i, resourceSlice := range resourceSlices {
+		driverNames[i] = resourceSlice.Spec.Driver
+	}
+
+	slices.Sort(driverNames)
+	return slices.Compact(driverNames)
+}
+
+// GetDriverNamesForMetricsCompacted returns a comma separated string of sorted unique driver names.
+func GetDriverNamesForMetricsCompacted(resourceSlices []*v1.ResourceSlice) string {
+	drivers := GetDriverNamesForMetrics(resourceSlices)
+	return strings.Join(drivers, ",")
+}

--- a/cluster-autoscaler/utils/dynamicresources/metrics.go
+++ b/cluster-autoscaler/utils/dynamicresources/metrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dynamicresources
 
 import (

--- a/cluster-autoscaler/utils/dynamicresources/metrics.go
+++ b/cluster-autoscaler/utils/dynamicresources/metrics.go
@@ -23,9 +23,37 @@ import (
 	v1 "k8s.io/api/resource/v1"
 )
 
-// GetDriverNamesForMetrics returns a slice of sorted unique driver names for the given node info.
-// For metrics we want to ensure that we always get the same order of driver names
-// to reduce cardinality.
+const (
+	// customDriverName is the name of the driver that we want to report for metrics.
+	// when a node has a driver that is not in the wantReportedDrivers list
+	customDriverName = "custom.driver"
+	// computeDomainNvidiaDriverName is the name of the NVIDIA compute domain driver.
+	computeDomainNvidiaDriverName = "compute-domain.nvidia.com"
+	// draNetDriverName is the name of the DRANET driver.
+	draNetDriverName = "dra.net"
+	// gpuNvidiaDriverName is the name of the NVIDIA GPU driver.
+	gpuNvidiaDriverName = "gpu.nvidia.com"
+	// tpuGoogleDriverName is the name of the Google TPU driver.
+	tpuGoogleDriverName = "tpu.google.com"
+)
+
+// getMetricNameForDriver returns the name of the driver that we want to report for metrics.
+//
+// We want to minimize amount of drivers reported to reduce the cardinality of the metric.
+// Currently driver names are concatenated in a string - cardinality is defined as 2^N
+// where N is the number of drivers. Reaching 10 drivers would mean 1024 combinations.
+func getMetricNameForDriver(driver string) string {
+	switch driver {
+	case computeDomainNvidiaDriverName, draNetDriverName, gpuNvidiaDriverName, tpuGoogleDriverName:
+		return driver
+	default:
+		return customDriverName
+	}
+}
+
+// GetDriverNamesForMetrics returns a slice of sorted unique driver names for the given
+// list of resource slices. For metrics we want to ensure that we always get the same
+// order of driver names to reduce cardinality.
 func GetDriverNamesForMetrics(resourceSlices []*v1.ResourceSlice) []string {
 	if len(resourceSlices) == 0 {
 		return nil
@@ -33,7 +61,7 @@ func GetDriverNamesForMetrics(resourceSlices []*v1.ResourceSlice) []string {
 
 	driverNames := make([]string, len(resourceSlices))
 	for i, resourceSlice := range resourceSlices {
-		driverNames[i] = resourceSlice.Spec.Driver
+		driverNames[i] = getMetricNameForDriver(resourceSlice.Spec.Driver)
 	}
 
 	slices.Sort(driverNames)

--- a/cluster-autoscaler/utils/dynamicresources/metrics_test.go
+++ b/cluster-autoscaler/utils/dynamicresources/metrics_test.go
@@ -138,7 +138,6 @@ func BenchmarkGetDriverNamesForMetrics(b *testing.B) {
 		},
 	}
 
-	b.ResetTimer()
 	for b.Loop() {
 		GetDriverNamesForMetrics(resourceSlices)
 	}

--- a/cluster-autoscaler/utils/dynamicresources/metrics_test.go
+++ b/cluster-autoscaler/utils/dynamicresources/metrics_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dynamicresources
 
 import (

--- a/cluster-autoscaler/utils/dynamicresources/metrics_test.go
+++ b/cluster-autoscaler/utils/dynamicresources/metrics_test.go
@@ -1,0 +1,153 @@
+package dynamicresources
+
+import (
+	"slices"
+	"testing"
+
+	v1 "k8s.io/api/resource/v1"
+)
+
+func TestGetDriverNamesForMetrics(t *testing.T) {
+	tests := map[string]struct {
+		resourceSlices       []*v1.ResourceSlice
+		wantDrivers          []string
+		wantDriversCompacted string
+	}{
+		"NilSlice": {
+			resourceSlices:       nil,
+			wantDrivers:          nil,
+			wantDriversCompacted: "",
+		},
+		"EmptySlice": {
+			resourceSlices:       []*v1.ResourceSlice{},
+			wantDrivers:          nil,
+			wantDriversCompacted: "",
+		},
+		"OneDriver": {
+			resourceSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+					},
+				},
+			},
+			wantDrivers:          []string{"driver1"},
+			wantDriversCompacted: "driver1",
+		},
+		"TwoDrivers": {
+			resourceSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver2",
+					},
+				},
+			},
+			wantDrivers:          []string{"driver1", "driver2"},
+			wantDriversCompacted: "driver1,driver2",
+		},
+		"TwoDriversUnsorted": {
+			resourceSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver2",
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+					},
+				},
+			},
+			wantDrivers:          []string{"driver1", "driver2"},
+			wantDriversCompacted: "driver1,driver2",
+		},
+		"TwoDriversWithDuplicates": {
+			resourceSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver2",
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "driver1",
+					},
+				},
+			},
+			wantDrivers:          []string{"driver1", "driver2"},
+			wantDriversCompacted: "driver1,driver2",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			drivers := GetDriverNamesForMetrics(test.resourceSlices)
+			if !slices.Equal(drivers, test.wantDrivers) {
+				t.Errorf("GetDriverNamesForMetrics() = %v, want %v", drivers, test.wantDrivers)
+			}
+			compacted := GetDriverNamesForMetricsCompacted(test.resourceSlices)
+			if compacted != test.wantDriversCompacted {
+				t.Errorf("GetDriverNamesForMetricsCompacted() = %v, want %v", compacted, test.wantDriversCompacted)
+			}
+		})
+	}
+}
+
+func BenchmarkGetDriverNamesForMetrics(b *testing.B) {
+	resourceSlices := []*v1.ResourceSlice{
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver1",
+			},
+		},
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver2",
+			},
+		},
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver1",
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		GetDriverNamesForMetrics(resourceSlices)
+	}
+}
+
+func BenchmarkGetDriverNamesForMetricsCompacted(b *testing.B) {
+	resourceSlices := []*v1.ResourceSlice{
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver1",
+			},
+		},
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver2",
+			},
+		},
+		{
+			Spec: v1.ResourceSliceSpec{
+				Driver: "driver1",
+			},
+		},
+	}
+
+	for b.Loop() {
+		GetDriverNamesForMetricsCompacted(resourceSlices)
+	}
+}

--- a/cluster-autoscaler/utils/dynamicresources/metrics_test.go
+++ b/cluster-autoscaler/utils/dynamicresources/metrics_test.go
@@ -43,65 +43,108 @@ func TestGetDriverNamesForMetrics(t *testing.T) {
 			resourceSlices: []*v1.ResourceSlice{
 				{
 					Spec: v1.ResourceSliceSpec{
-						Driver: "driver1",
+						Driver: "compute-domain.nvidia.com",
 					},
 				},
 			},
-			wantDrivers:          []string{"driver1"},
-			wantDriversCompacted: "driver1",
+			wantDrivers:          []string{"compute-domain.nvidia.com"},
+			wantDriversCompacted: "compute-domain.nvidia.com",
 		},
 		"TwoDrivers": {
 			resourceSlices: []*v1.ResourceSlice{
 				{
 					Spec: v1.ResourceSliceSpec{
-						Driver: "driver1",
+						Driver: "compute-domain.nvidia.com",
 					},
 				},
 				{
 					Spec: v1.ResourceSliceSpec{
-						Driver: "driver2",
+						Driver: "dra.net",
 					},
 				},
 			},
-			wantDrivers:          []string{"driver1", "driver2"},
-			wantDriversCompacted: "driver1,driver2",
+			wantDrivers:          []string{"compute-domain.nvidia.com", "dra.net"},
+			wantDriversCompacted: "compute-domain.nvidia.com,dra.net",
 		},
 		"TwoDriversUnsorted": {
 			resourceSlices: []*v1.ResourceSlice{
 				{
 					Spec: v1.ResourceSliceSpec{
-						Driver: "driver2",
+						Driver: "dra.net",
 					},
 				},
 				{
 					Spec: v1.ResourceSliceSpec{
-						Driver: "driver1",
+						Driver: "compute-domain.nvidia.com",
 					},
 				},
 			},
-			wantDrivers:          []string{"driver1", "driver2"},
-			wantDriversCompacted: "driver1,driver2",
+			wantDrivers:          []string{"compute-domain.nvidia.com", "dra.net"},
+			wantDriversCompacted: "compute-domain.nvidia.com,dra.net",
 		},
 		"TwoDriversWithDuplicates": {
 			resourceSlices: []*v1.ResourceSlice{
 				{
 					Spec: v1.ResourceSliceSpec{
-						Driver: "driver1",
+						Driver: "compute-domain.nvidia.com",
 					},
 				},
 				{
 					Spec: v1.ResourceSliceSpec{
-						Driver: "driver2",
+						Driver: "dra.net",
 					},
 				},
 				{
 					Spec: v1.ResourceSliceSpec{
-						Driver: "driver1",
+						Driver: "compute-domain.nvidia.com",
 					},
 				},
 			},
-			wantDrivers:          []string{"driver1", "driver2"},
-			wantDriversCompacted: "driver1,driver2",
+			wantDrivers:          []string{"compute-domain.nvidia.com", "dra.net"},
+			wantDriversCompacted: "compute-domain.nvidia.com,dra.net",
+		},
+		"CustomDriver": {
+			resourceSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "custom-driver",
+					},
+				},
+			},
+			wantDrivers:          []string{customDriverName},
+			wantDriversCompacted: customDriverName,
+		},
+		"KnownDriverAndCustomDriver": {
+			resourceSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "compute-domain.nvidia.com",
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "custom-driver",
+					},
+				},
+			},
+			wantDrivers:          []string{"compute-domain.nvidia.com", customDriverName},
+			wantDriversCompacted: "compute-domain.nvidia.com," + customDriverName,
+		},
+		"KnownDriverAndCustomDriverUnsorted": {
+			resourceSlices: []*v1.ResourceSlice{
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "custom-driver",
+					},
+				},
+				{
+					Spec: v1.ResourceSliceSpec{
+						Driver: "compute-domain.nvidia.com",
+					},
+				},
+			},
+			wantDrivers:          []string{"compute-domain.nvidia.com", customDriverName},
+			wantDriversCompacted: "compute-domain.nvidia.com," + customDriverName,
 		},
 	}
 
@@ -123,17 +166,17 @@ func BenchmarkGetDriverNamesForMetrics(b *testing.B) {
 	resourceSlices := []*v1.ResourceSlice{
 		{
 			Spec: v1.ResourceSliceSpec{
-				Driver: "driver1",
+				Driver: "compute-domain.nvidia.com",
 			},
 		},
 		{
 			Spec: v1.ResourceSliceSpec{
-				Driver: "driver2",
+				Driver: "dra.net",
 			},
 		},
 		{
 			Spec: v1.ResourceSliceSpec{
-				Driver: "driver1",
+				Driver: "custom-driver",
 			},
 		},
 	}
@@ -147,17 +190,17 @@ func BenchmarkGetDriverNamesForMetricsCompacted(b *testing.B) {
 	resourceSlices := []*v1.ResourceSlice{
 		{
 			Spec: v1.ResourceSliceSpec{
-				Driver: "driver1",
+				Driver: "compute-domain.nvidia.com",
 			},
 		},
 		{
 			Spec: v1.ResourceSliceSpec{
-				Driver: "driver2",
+				Driver: "dra.net",
 			},
 		},
 		{
 			Spec: v1.ResourceSliceSpec{
-				Driver: "driver1",
+				Driver: "custom-driver",
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This change modifies following metrics with additional labels containing information about DRA drivers they have enabled:
* failed_scale_ups_total
* scaled_down_nodes_total
* scaled_up_nodes_total

As part of the PR we are also deprecating separate metrics for such decisions introduced for GPUs as they can be acquired via simple filtering queries from the general metrics.

Having a list of DRA drivers contained in the label may result in slight cardinality bump, but in practice it shouldn't explode because the amount of drivers in cluster shouldn't be enormous (expected <10) and sorting them should keep it controlled

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add DRA ScaleUp/ScaleDown metrics
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
