### PR TITLE
[oci][feature] Add support for instancepool autodiscovery

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/README.md
+++ b/cluster-autoscaler/cloudprovider/oci/README.md
@@ -167,9 +167,16 @@ use-instance-principals = true
 n/a
 
 ### Node Group Auto Discovery
-`--node-group-auto-discovery` could be given in below pattern. It would discover the nodepools under given compartment by matching the nodepool tags (either they are Freeform or Defined tags). All of the parameters are mandatory.
+`--node-group-auto-discovery` could be given via the below patterns. It would discover the nodepools or instancepools under given compartment by matching the tags (either they are Freeform or Defined tags). All of the parameters are mandatory.
+
+#### Nodepools
 ```
 clusterId:<clusterId>,compartmentId:<compartmentId>,nodepoolTags:<tagKey1>=<tagValue1>&<tagKey2>=<tagValue2>,min:<min>,max:<max>
+```
+
+#### Instancepools
+```
+compartmentId:<compartmentId>,instancepoolTags:<tagKey1>=<tagValue1>&<tagKey2>=<tagValue2>,min:<min>,max:<max>
 ```
 Auto discovery can not be used along with static discovery (`node` parameter) to prevent conflicts.
 

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool.go
@@ -27,6 +27,16 @@ type InstancePoolNodeGroup struct {
 	maxSize    int
 }
 
+type nodeGroupAutoDiscovery struct {
+	manager    InstancePoolManager
+	kubeClient kubernetes.Interface
+
+	compartmentId string
+	tags          map[string]string
+	minSize       int
+	maxSize       int
+}
+
 // MaxSize returns maximum size of the instance-pool based node group.
 func (ip *InstancePoolNodeGroup) MaxSize() int {
 	return ip.maxSize

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
@@ -29,6 +29,7 @@ type ComputeMgmtClient interface {
 	GetInstancePoolInstance(context.Context, core.GetInstancePoolInstanceRequest) (core.GetInstancePoolInstanceResponse, error)
 	ListInstancePoolInstances(context.Context, core.ListInstancePoolInstancesRequest) (core.ListInstancePoolInstancesResponse, error)
 	DetachInstancePoolInstance(context.Context, core.DetachInstancePoolInstanceRequest) (core.DetachInstancePoolInstanceResponse, error)
+	ListInstancePools(context.Context, core.ListInstancePoolsRequest) (core.ListInstancePoolsResponse, error)
 }
 
 // ComputeClient wraps core.ComputeClient exposing the functions we actually require.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds support for autodiscovery on instance pools. Previously, the OCI provider only supported auto discovery on node pools; this PR extends the coverage to also include auto-discovery of instance pools. The implementation is based on the implementation for nodepools and follows a similar structure.

##### Startup:
Using the following configuration:
```
--node-group-auto-discovery=compartmentId:<compartment-id>,instancepoolTags:myCluster.nodes=true,min:0,max:100
```
Yields
```
I0223 14:56:12.745297     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment:<compartment-id>, instancePoolId: <instancepool-id-0>, minSize: 0, maxSize: 100
I0223 14:56:12.745338     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-1>, minSize: 0, maxSize: 100
I0223 14:56:12.745343     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-2>, minSize: 0, maxSize: 100
I0223 14:56:12.745346     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-3>, minSize: 0, maxSize: 100
```

##### New Instance Pool Added
```
I0223 15:01:20.638002     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-0>, minSize: 0, maxSize: 100
I0223 15:01:20.638007     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-1>, minSize: 0, maxSize: 100
I0223 15:01:20.638011     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-2>, minSize: 0, maxSize: 100
I0223 15:01:20.638015     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-3>, minSize: 0, maxSize: 100
I0223 15:01:20.638028     635 oci_instance_pool_manager.go:407] New instance pool discovered. [id: <instancepool-id-4>, minSize: 0, maxSize: 100]
```

##### Instance Pool Deleted (Terminated)
```
I0223 15:06:30.253983     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-0>, minSize: 0, maxSize: 100
I0223 15:06:30.253998     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-1>, minSize: 0, maxSize: 100
I0223 15:06:30.254011     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-2>, minSize: 0, maxSize: 100
I0223 15:06:30.254019     635 oci_instance_pool_manager.go:346] auto discovered instance pool in compartment: <compartment-id>, instancePoolId: <instancepool-id-3>, minSize: 0, maxSize: 100
I0223 15:06:30.254041     635 oci_instance_pool_manager.go:415] Previously auto-discovered instance pool removed from the managed instance pool list [id: <instancepool-id-4>]

```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for auto-discovery for instancepools in the OCI cloud provider. Users can now supply --node-group-auto-discovery with the compartment ID, instance pool tags, and min/max size to let CAS detect and scale matching instance pools.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
