### PR TITLE
Do not override condition in buffers limits translator

### DIFF
--- a/cluster-autoscaler/capacitybuffer/testutil/testutil.go
+++ b/cluster-autoscaler/capacitybuffer/testutil/testutil.go
@@ -96,10 +96,15 @@ func GetBufferStatus(podTempRef *v1.LocalObjectRef, replicas *int32, podTemplate
 
 // GetConditionReady returns a list of conditions with a condition ready and empty message, should be used for testing purposes only
 func GetConditionReady() []metav1.Condition {
+	return GetConditionReadyWithMessage("")
+}
+
+// GetConditionReadyWithMessage returns a list of conditions with a condition ready and the specified message
+func GetConditionReadyWithMessage(message string) []metav1.Condition {
 	readyCondition := metav1.Condition{
 		Type:               capacitybuffer.ReadyForProvisioningCondition,
 		Status:             metav1.ConditionTrue,
-		Message:            "",
+		Message:            message,
 		Reason:             capacitybuffer.AttributesSetSuccessfullyReason,
 		LastTransitionTime: metav1.Time{},
 	}
@@ -108,10 +113,15 @@ func GetConditionReady() []metav1.Condition {
 
 // GetConditionNotReady returns a list of conditions with a condition not ready and empty message, should be used for testing purposes only
 func GetConditionNotReady() []metav1.Condition {
+	return GetConditionNotReadyWithMessage("")
+}
+
+// GetConditionNotReadyWithMessage returns a list of condition with a condition not ready and specified message.
+func GetConditionNotReadyWithMessage(message string) []metav1.Condition {
 	notReadyCondition := metav1.Condition{
 		Type:               capacitybuffer.ReadyForProvisioningCondition,
 		Status:             metav1.ConditionFalse,
-		Message:            "",
+		Message:            message,
 		Reason:             "error",
 		LastTransitionTime: metav1.Time{},
 	}
@@ -152,6 +162,13 @@ func WithPodTemplateRef(name string) BufferOption {
 func WithReplicas(replicas int32) BufferOption {
 	return func(b *v1.CapacityBuffer) {
 		b.Spec.Replicas = &replicas
+	}
+}
+
+// WithLimits sets the Spec.Limits
+func WithLimits(limits v1.ResourceList) BufferOption {
+	return func(b *v1.CapacityBuffer) {
+		b.Spec.Limits = &limits
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Limits translator overrides NotReadyForProvisioning condition when the buffer's `Status.PodTemplateRef` is nil, which means that the previous translators failed to resolve it. The overridden condition contains an error message from those translators. That hides the error from the user, making it harder to troubleshoot issues.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
