### PR TITLE
VPA: use shared kind-config.yaml in run-integration-locally.sh

### DIFF
--- a/vertical-pod-autoscaler/hack/run-integration-locally.sh
+++ b/vertical-pod-autoscaler/hack/run-integration-locally.sh
@@ -19,6 +19,7 @@ set -o pipefail
 
 BASE_NAME=$(basename $0)
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
+KIND_CONFIG="${SCRIPT_ROOT}/../.github/kind-config.yaml"
 source "${SCRIPT_ROOT}/hack/lib/util.sh"
 
 ARCH=$(kube::util::host_arch)
@@ -80,11 +81,14 @@ esac
 echo "Deleting KIND cluster 'kind'."
 kind delete cluster -n kind -q
 
+if [ ! -f "${KIND_CONFIG}" ]; then
+  echo "Missing KIND config file: ${KIND_CONFIG}"
+  exit 1
+fi
+
 echo "Creating KIND cluster 'kind'"
-KIND_VERSION="kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
-if ! kind create cluster --image=${KIND_VERSION}; then
-    echo "Failed to create KIND cluster. Exiting. Make sure kind version is updated."
-    echo "Available versions: https://github.com/kubernetes-sigs/kind/releases"
+if ! kind create cluster --config "${KIND_CONFIG}"; then
+    echo "Failed to create KIND cluster using ${KIND_CONFIG}. Exiting."
     exit 1
 fi
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This is a follow-up to PR #9257 and addresses the remaining script mentioned in issue #9253. 

As discussed with @omerap12, this updates `vertical-pod-autoscaler/hack/run-integration-locally.sh` to use the shared `.github/kind-config.yaml` file instead of a hardcoded `KIND_VERSION`. 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This applies the exact same logic agreed upon in PR #9257 for `run-e2e-locally.sh`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
