### PR TITLE
cluster-autoscaler/chart: fix misplaced end tag in pdb template

### DIFF
--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.55.1
+version: 9.55.2

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/pdb.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/pdb.yaml
@@ -19,6 +19,7 @@ spec:
 {{ toYaml .Values.podDisruptionBudget.selector | indent 6 }}
 {{- else }}
 {{ include "cluster-autoscaler.instance-name" . | indent 6 }}
+{{- end }}
   {{- if and .Values.podDisruptionBudget.minAvailable (not .Values.podDisruptionBudget.maxUnavailable) }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
@@ -26,4 +27,3 @@ spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end -}}
-{{- end }}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Fix a bug introduced in https://github.com/kubernetes/autoscaler/pull/9144 in pdb.yaml

The `{{- end }}` closing the selector if/else block was incorrectly placed at the end of the file, causing `minAvailable` and `maxUnavailable` fields to be nested inside the else branch. This moves it to the correct position so these fields are always rendered within the spec block regardless of selector configuration.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None
