### PR TITLE
VPA E2Es: switch from docker.io ubuntu to k8s-hosted image

### DIFF
--- a/vertical-pod-autoscaler/e2e/utils/common.go
+++ b/vertical-pod-autoscaler/e2e/utils/common.go
@@ -236,16 +236,16 @@ func NewNHamstersDeployment(f *framework.Framework, n int) *appsv1.Deployment {
 		panic("container count should be greater than 0")
 	}
 	d := framework_deployment.NewDeployment(
-		"hamster-deployment",                       /*deploymentName*/
-		DefaultHamsterReplicas,                     /*replicas*/
-		HamsterLabels,                              /*podLabels*/
-		GetHamsterContainerNameByIndex(0),          /*imageName*/
-		"ubuntu:latest",                            /*image*/
-		appsv1.RollingUpdateDeploymentStrategyType, /*strategyType*/
+		"hamster-deployment",                               /*deploymentName*/
+		DefaultHamsterReplicas,                             /*replicas*/
+		HamsterLabels,                                      /*podLabels*/
+		GetHamsterContainerNameByIndex(0),                  /*imageName*/
+		"registry.k8s.io/e2e-test-images/busybox:1.37.0-2", /*image*/
+		appsv1.RollingUpdateDeploymentStrategyType,         /*strategyType*/
 	)
 	d.ObjectMeta.Namespace = f.Namespace.Name
 	d.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh"}
-	d.Spec.Template.Spec.Containers[0].Args = []string{"-c", "/usr/bin/yes >/dev/null"}
+	d.Spec.Template.Spec.Containers[0].Args = []string{"-c", "yes >/dev/null"}
 	for i := 1; i < n; i++ {
 		d.Spec.Template.Spec.Containers = append(d.Spec.Template.Spec.Containers, d.Spec.Template.Spec.Containers[0])
 		d.Spec.Template.Spec.Containers[i].Name = GetHamsterContainerNameByIndex(i)

--- a/vertical-pod-autoscaler/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/e2e/v1/common.go
@@ -224,7 +224,7 @@ func SetupHamsterContainer(cpu, memory string) apiv1.Container {
 
 	return apiv1.Container{
 		Name:  "hamster",
-		Image: "registry.k8s.io/ubuntu-slim:0.14",
+		Image: "registry.k8s.io/e2e-test-images/busybox:1.37.0-2",
 		Resources: apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
 				apiv1.ResourceCPU:    cpuQuantity,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

The VPA E2E tests are using a Ubuntu image hosted on docker.io. Because docker.io performs rate limiting on unauthenticated image pulls, E2E tests can sometimes fail if the system under test happens to pull the Ubuntu image too quickly during the rate limit window.  This change switches to a Kubernetes-maintained test image based upon busybox which will not have the rate limiting failures problem.

```
...
     containerStatuses:
    - image: ubuntu:latest
      imageID: ""
      lastState: {}
      name: hamster
      ready: false
      restartCount: 0
      started: false
      state:
        waiting:
          message: 'Back-off pulling image "ubuntu:latest": ErrImagePull: unable to
            pull image or OCI artifact: pull image err: initializing source docker://ubuntu:latest:
            reading manifest latest in docker.io/library/ubuntu: toomanyrequests:
            You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit;
            artifact err: get manifest: build image source: reading manifest latest
            in docker.io/library/ubuntu: toomanyrequests: You have reached your unauthenticated
            pull rate limit. https://www.docker.com/increase-rate-limit'
          reason: ImagePullBackOff 
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None