### PR TITLE
Add GetMigIsStable and refactor MigInfoProvider

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -72,6 +72,7 @@ type GceCache struct {
 	autoscalingOptionsCache          map[GceRef]map[string]string
 	machinesCache                    map[MachineTypeKey]MachineType
 	migTargetSizeCache               map[GceRef]int64
+	migIsStableCache                 map[GceRef]bool
 	migBaseNameCache                 map[GceRef]string
 	migInstancesStateCountCache      map[GceRef]map[cloudprovider.InstanceState]int64
 	listManagedInstancesResultsCache map[GceRef]string
@@ -91,6 +92,7 @@ func NewGceCache() *GceCache {
 		autoscalingOptionsCache:          map[GceRef]map[string]string{},
 		machinesCache:                    map[MachineTypeKey]MachineType{},
 		migTargetSizeCache:               map[GceRef]int64{},
+		migIsStableCache:                 map[GceRef]bool{},
 		migBaseNameCache:                 map[GceRef]string{},
 		migInstancesStateCountCache:      map[GceRef]map[cloudprovider.InstanceState]int64{},
 		listManagedInstancesResultsCache: map[GceRef]string{},
@@ -350,6 +352,35 @@ func (gc *GceCache) InvalidateAllMigTargetSizes() {
 
 	klog.V(5).Infof("Target size cache invalidated")
 	gc.migTargetSizeCache = map[GceRef]int64{}
+}
+
+// GetMigIsStable returns the cached isStable for a GceRef
+func (gc *GceCache) GetMigIsStable(ref GceRef) (bool, bool) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	isStable, found := gc.migIsStableCache[ref]
+	if found {
+		klog.V(5).Infof("IsStable cache hit for %s", ref)
+	}
+	return isStable, found
+}
+
+// SetMigIsStable sets isStable for a GceRef
+func (gc *GceCache) SetMigIsStable(ref GceRef, isStable bool) {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	gc.migIsStableCache[ref] = isStable
+}
+
+// InvalidateAllMigIsStable clears the isStable cache
+func (gc *GceCache) InvalidateAllMigIsStable() {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	klog.V(5).Infof("IsStable cache invalidated")
+	gc.migIsStableCache = map[GceRef]bool{}
 }
 
 // GetMigInstanceTemplateName returns the cached instance template ref for a mig GceRef

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -201,6 +201,8 @@ type Mig interface {
 	cloudprovider.NodeGroup
 
 	GceRef() GceRef
+	// IsStable returns whether the MIG is stable. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.
+	IsStable() (bool, error)
 }
 
 type gceMig struct {
@@ -215,6 +217,11 @@ type gceMig struct {
 // GceRef returns Mig's GceRef
 func (mig *gceMig) GceRef() GceRef {
 	return mig.gceRef
+}
+
+// IsStable returns whether the MIG is stable. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.
+func (mig *gceMig) IsStable() (bool, error) {
+	return mig.gceManager.IsMigStable(mig)
 }
 
 // MaxSize returns maximum size of the node group.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -43,6 +43,11 @@ func (m *gceManagerMock) GetMigSize(mig Mig) (int64, error) {
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *gceManagerMock) IsMigStable(mig Mig) (bool, error) {
+	args := m.Called(mig)
+	return args.Get(0).(bool), args.Error(1)
+}
+
 func (m *gceManagerMock) SetMigSize(mig Mig, size int64) error {
 	args := m.Called(mig, size)
 	return args.Error(0)

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -335,6 +335,7 @@ func newTestGceManager(t *testing.T, testServerURL string, regional bool) *gceMa
 		instances:               make(map[GceRef][]GceInstance),
 		instancesUpdateTime:     make(map[GceRef]time.Time),
 		instancesToMig:          make(map[GceRef]GceRef),
+		migIsStableCache:        make(map[GceRef]bool),
 		instancesFromUnknownMig: make(map[GceRef]bool),
 		autoscalingOptionsCache: map[GceRef]map[string]string{},
 		machinesCache: map[MachineTypeKey]MachineType{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

* Added an IsStable() method to the Mig interface. A MIG is considered "stable" when no instances are undergoing changes
     (creation, deletion, etc.), no future changes are scheduled, and the group itself is not being modified.
*  Centralized MIG Fetching: Refactored AutoscalingGceClient to include a FetchMig method. Existing methods (like FetchMigTargetSize and FetchMigBasename) now use this central helper, reducing boilerplate and redundant API calls.

```release-note
NONE
```
