### PR TITLE
feat(ca): add --startup-taint-prefix flag for custom startup taint prefixes

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -277,6 +277,8 @@ might stop working as it might assume the cluster is broken and should not be sc
 Startup taints are defined as:
 
 * all taints with the prefix `startup-taint.cluster-autoscaler.kubernetes.io/`,
+* all taints with the prefix `ignore-taint.cluster-autoscaler.kubernetes.io/` (deprecated),
+* all taints with prefixes specified using `--startup-taint-prefix` flag,
 * all taints defined using `--startup-taint` flag.
 
 ### Status taints
@@ -629,7 +631,7 @@ When using this class, Cluster Autoscaler performs following actions:
   Adds a Provisioned=True condition to the ProvReq if capacity is available.
   Adds a BookingExpired=True condition when the 10-minute reservation period expires.
 
-  Since Cluster Autoscaler version 1.33, it is possible to configure the autoscaler 
+  Since Cluster Autoscaler version 1.33, it is possible to configure the autoscaler
   to process only subset of check capacity ProvisioningRequests and ignore the rest.
   It should be done with caution by specifying `--check-capacity-processor-instance=<name>` flag.
   Then, ProvReq Parameters map should contain a key "processorInstance" with a value equal to the configured instance name.
@@ -1115,6 +1117,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `skip-nodes-with-local-storage`                      | If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath | true |
 | `skip-nodes-with-system-pods`                        | If true cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods) | true |
 | `startup-taint`                                      | Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint) | [] |
+| `startup-taint-prefix`                               | Specifies a taint key prefix. Any taint whose key starts with this prefix will be treated as a startup taint (in addition to the built-in prefixes). Can be used multiple times. | [] |
 | `status-config-map-name`                             | Status configmap name | "cluster-autoscaler-status" |
 | `status-taint`                                       | Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready | [] |
 | `stderrthreshold`                                    | logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) | 2 |

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -220,6 +220,9 @@ type AutoscalingOptions struct {
 	// status that should be removed when creating a node template for scheduling.
 	// startup taints are expected to appear during node startup.
 	StartupTaints []string
+	// StartupTaintPrefixes is a list of taint key prefixes. Any taint whose key starts
+	// with one of these prefixes will be treated as a startup taint.
+	StartupTaintPrefixes []string
 	// StatusTaints is a list of taints CA considers to reflect transient node
 	// status that should be removed when creating a node template for scheduling.
 	// The status taints are expected to appear during node lifetime, after startup.

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -165,6 +165,7 @@ var (
 	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'.")
 
 	startupTaintsFlag         = multiStringFlag("startup-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint)")
+	startupTaintPrefixesFlag  = multiStringFlag("startup-taint-prefix", "Specifies a taint key prefix. Any taint whose key starts with this prefix will be treated as a startup taint (in addition to the built-in prefixes). Can be used multiple times.")
 	statusTaintsFlag          = multiStringFlag("status-taint", "Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready")
 	balancingIgnoreLabelsFlag = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
 	balancingLabelsFlag       = multiStringFlag("balancing-label", "Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label.")
@@ -363,6 +364,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		Regional:                         *regional,
 		NewPodScaleUpDelay:               *newPodScaleUpDelay,
 		StartupTaints:                    append(*ignoreTaintsFlag, *startupTaintsFlag...),
+		StartupTaintPrefixes:             *startupTaintPrefixesFlag,
 		StatusTaints:                     *statusTaintsFlag,
 		BalancingExtraIgnoredLabels:      *balancingIgnoreLabelsFlag,
 		BalancingLabels:                  *balancingLabelsFlag,

--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -112,6 +112,13 @@ func NewTaintConfig(opts config.AutoscalingOptions) TaintConfig {
 		startupTaints[taintKey] = true
 	}
 
+	var startupTaintPrefixes []string
+	startupTaintPrefixes = append(startupTaintPrefixes, IgnoreTaintPrefix, StartupTaintPrefix)
+	for _, prefix := range opts.StartupTaintPrefixes {
+		klog.V(4).Infof("Adding custom startup taint prefix %s on all NodeGroups", prefix)
+		startupTaintPrefixes = append(startupTaintPrefixes, prefix)
+	}
+
 	statusTaints := make(TaintKeySet)
 	for _, taintKey := range opts.StatusTaints {
 		klog.V(4).Infof("Status taint %s on all NodeGroups", taintKey)
@@ -130,7 +137,7 @@ func NewTaintConfig(opts config.AutoscalingOptions) TaintConfig {
 	return TaintConfig{
 		startupTaints:            startupTaints,
 		statusTaints:             statusTaints,
-		startupTaintPrefixes:     []string{IgnoreTaintPrefix, StartupTaintPrefix},
+		startupTaintPrefixes:     startupTaintPrefixes,
 		statusTaintPrefixes:      []string{StatusTaintPrefix},
 		explicitlyReportedTaints: explicitlyReportedTaints,
 		scaleFromUnschedulable:   opts.ScaleFromUnschedulable,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds `--startup-taint-prefix` flag to allow users to specify custom taint key prefixes. Any taint whose key starts with one of these prefixes will be treated as a startup taint.

#### Which issue(s) this PR fixes:
Fixes #9243

#### Special notes for your reviewer: 
NONE

#### Does this PR introduce a user-facing change?
```release-note
Added `--startup-taint-prefix` flag to treat taints with matching key prefixes as startup taints.
```
####  Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
