### PR TITLE
cleanup: remove unused FetchingHistory condition logic

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -53,17 +53,9 @@ func NewCheckpointWriter(cluster model.ClusterState, vpaCheckpointClient vpa_api
 	}
 }
 
-func isFetchingHistory(vpa *model.Vpa) bool {
-	return vpa.ConditionActive(vpa_types.FetchingHistory)
-}
-
 func getVpasToCheckpoint(clusterVpas map[model.VpaID]*model.Vpa) []*model.Vpa {
 	vpas := make([]*model.Vpa, 0, len(clusterVpas))
 	for _, vpa := range clusterVpas {
-		if isFetchingHistory(vpa) {
-			klog.V(3).InfoS("VPA is loading history, skipping checkpoints", "vpa", klog.KRef(vpa.ID.Namespace, vpa.ID.VpaName))
-			continue
-		}
 		vpas = append(vpas, vpa)
 	}
 	sort.Slice(vpas, func(i, j int) bool {

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer_test.go
@@ -105,48 +105,6 @@ func TestMergeContainerStateForCheckpointDropsRecentMemoryPeak(t *testing.T) {
 	}
 }
 
-func TestIsFetchingHistory(t *testing.T) {
-	testCases := []struct {
-		vpa               *model.Vpa
-		isFetchingHistory bool
-	}{
-		{
-			vpa:               &model.Vpa{},
-			isFetchingHistory: false,
-		},
-		{
-			vpa: func() *model.Vpa {
-				vpa := model.NewVpa(model.VpaID{}, nil, time.Time{})
-				vpa.SetConditionsMap(map[vpa_types.VerticalPodAutoscalerConditionType]vpa_types.VerticalPodAutoscalerCondition{
-					vpa_types.FetchingHistory: {
-						Type:   vpa_types.FetchingHistory,
-						Status: corev1.ConditionFalse,
-					},
-				})
-				return vpa
-			}(),
-			isFetchingHistory: false,
-		},
-		{
-			vpa: func() *model.Vpa {
-				vpa := model.NewVpa(model.VpaID{}, nil, time.Time{})
-				vpa.SetConditionsMap(map[vpa_types.VerticalPodAutoscalerConditionType]vpa_types.VerticalPodAutoscalerCondition{
-					vpa_types.FetchingHistory: {
-						Type:   vpa_types.FetchingHistory,
-						Status: corev1.ConditionTrue,
-					},
-				})
-				return vpa
-			}(),
-			isFetchingHistory: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		assert.Equalf(t, tc.isFetchingHistory, isFetchingHistory(tc.vpa), "%+v should have %v as isFetchingHistoryResult", tc.vpa, tc.isFetchingHistory)
-	}
-}
-
 func TestGetVpasToCheckpointSorts(t *testing.T) {
 	time1 := time.Unix(10000, 0)
 	time2 := time.Unix(20000, 0)


### PR DESCRIPTION
Fixes #8969. This PR removes the \FetchingHistory\ condition check and its related code from the VPA recommender's checkpoint writer, as it was non-functional and not properly implemented.