### PR TITLE
feat(ca): add configurable unschedulable gpu pod scale-up delay flags

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -1108,7 +1108,6 @@ The following startup parameters are supported for cluster autoscaler:
 | `scale-down-delay-after-delete` | How long after node deletion that scale down evaluation resumes | 0s |
 | `scale-down-delay-after-failure` | How long after scale down failure that scale down evaluation resumes | 3m0s |
 | `scale-down-delay-type-local` | Should --scale-down-delay-after-* flags be applied locally per nodegroup or globally across all nodegroups |  |
-| `scale-down-enabled` | [Deprecated] Should CA scale down the cluster | true |
 | `scale-down-gpu-utilization-threshold` | Sum of gpu requests of all pods running on the node divided by node's allocatable resource, below which a node can be considered for scale down.Utilization calculation only cares about gpu resource for accelerator node. cpu and memory utilization will be ignored. | 0.5 |
 | `scale-down-non-empty-candidates-count` | Maximum number of non empty nodes considered in one iteration as candidates for scale down with drain.Lower value means better CA responsiveness but possible slower scale down latency.Higher value can affect CA performance with big clusters (hundreds of nodes).Set to non positive value to turn this heuristic off - CA will not limit the number of nodes it considers. | 30 |
 | `scale-down-simulation-timeout` | How long should we run scale down simulation. | 30s |
@@ -1131,6 +1130,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `status-taint` | Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready | [] |
 | `stderrthreshold` | logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) | 2 |
 | `unremovable-node-recheck-timeout` | The timeout before we check again a node that couldn't be removed before | 5m0s |
+| `unschedulable-gpu-pod-scale-up-delay` | How old the oldest unschedulable pod with GPU should be before considering scale-up. GPU nodes are expensive, so we wait longer to make more informed scale-up decisions. | 30s |
 | `user-agent` | User agent used for HTTP calls. | "cluster-autoscaler" |
 | `v` | number for the log level verbosity |  |
 | `vmodule` | comma-separated list of pattern=N settings for file-filtered logging (only works for text log format) |  |

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -207,6 +207,9 @@ type AutoscalingOptions struct {
 	Regional bool
 	// Pods newer than this will not be considered as unschedulable for scale-up.
 	NewPodScaleUpDelay time.Duration
+	// UnschedulableGpuPodTimeBuffer is the minimum age of unschedulable pods
+	// with GPU resources before triggering scale-up.
+	UnschedulableGpuPodTimeBuffer time.Duration
 	// MaxBulkSoftTaint sets the maximum number of nodes that can be (un)tainted PreferNoSchedule during single scaling down run.
 	// Value of 0 turns turn off such tainting.
 	MaxBulkSoftTaintCount int

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -163,6 +163,7 @@ var (
 	expendablePodsPriorityCutoff  = flag.Int("expendable-pods-priority-cutoff", -10, "Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable.")
 	regional                      = flag.Bool("regional", false, "Cluster is regional.")
 	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'.")
+	unschedulableGpuPodTimeBuffer = flag.Duration("unschedulable-gpu-pod-scale-up-delay", 30*time.Second, "How old the oldest unschedulable pod with GPU should be before considering scale-up. GPU nodes are expensive, so we wait longer to make more informed scale-up decisions.")
 
 	startupTaintsFlag         = multiStringFlag("startup-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint)")
 	startupTaintPrefixesFlag  = multiStringFlag("startup-taint-prefix", "Specifies a taint key prefix. Any taint whose key starts with this prefix will be treated as a startup taint (in addition to the built-in prefixes). Can be used multiple times.")
@@ -358,6 +359,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ExpendablePodsPriorityCutoff:     *expendablePodsPriorityCutoff,
 		Regional:                         *regional,
 		NewPodScaleUpDelay:               *newPodScaleUpDelay,
+		UnschedulableGpuPodTimeBuffer:    *unschedulableGpuPodTimeBuffer,
 		StartupTaints:                    append(*ignoreTaintsFlag, *startupTaintsFlag...),
 		StartupTaintPrefixes:             *startupTaintPrefixesFlag,
 		StatusTaints:                     *statusTaintsFlag,

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -71,10 +71,6 @@ import (
 const (
 	// How old the oldest unschedulable pod should be before starting scale up.
 	unschedulablePodTimeBuffer = 2 * time.Second
-	// How old the oldest unschedulable pod with GPU should be before starting scale up.
-	// The idea is that nodes with GPU are very expensive and we're ready to sacrifice
-	// a bit more latency to wait for more pods and make a more informed scale-up decision.
-	unschedulablePodWithGpuTimeBuffer = 30 * time.Second
 )
 
 // StaticAutoscaler is an autoscaler which has all the core functionality of a CA but without the reconfiguration feature
@@ -568,7 +564,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 			noScaleUpInfoForPods = append(noScaleUpInfoForPods, noScaleUpInfo)
 		}
 		scaleUpStatus.PodsRemainUnschedulable = noScaleUpInfoForPods
-	} else if len(a.BypassedSchedulers) == 0 && allPodsAreNew(unschedulablePodsToHelp, currentTime) {
+	} else if len(a.BypassedSchedulers) == 0 && allPodsAreNew(unschedulablePodsToHelp, currentTime, a.UnschedulableGpuPodTimeBuffer) {
 		// The assumption here is that these pods have been created very recently and probably there
 		// is more pods to come. In theory we could check the newest pod time but then if pod were created
 		// slowly but at the pace of 1 every 2 seconds then no scale up would be triggered for long time.
@@ -1095,12 +1091,12 @@ func (a *StaticAutoscaler) reportTaintsCount(nodes []*apiv1.Node) {
 	}
 }
 
-func allPodsAreNew(pods []*apiv1.Pod, currentTime time.Time) bool {
+func allPodsAreNew(pods []*apiv1.Pod, currentTime time.Time, gpuPodTimeBuffer time.Duration) bool {
 	if core_utils.GetOldestCreateTime(pods).Add(unschedulablePodTimeBuffer).After(currentTime) {
 		return true
 	}
 	found, oldest := core_utils.GetOldestCreateTimeWithGpu(pods)
-	return found && oldest.Add(unschedulablePodWithGpuTimeBuffer).After(currentTime)
+	return found && oldest.Add(gpuPodTimeBuffer).After(currentTime)
 }
 
 func getUpcomingNodeInfos(upcomingCounts map[string]int, nodeInfos map[string]*framework.NodeInfo) (map[string][]*framework.NodeInfo, error) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds a new flags to configure the delay before triggering scale-up for unschedulable pods:
- `--unschedulable-gpu-pod-scale-up-delay` (default: 30s) for GPU pods

Previously, this value was a hardcoded constant (unschedulablePodWithGpuTimeBuffer), making it impossible for users to customize the scale-up responsiveness for GPU workloads based on their requirements.

This change maintains backward compatibility by using the same default values as the previous hardcoded constants.

#### Which issue(s) this PR fixes:
Fixes #9126

#### Special notes for your reviewer:
Add configurable flags for unschedulable pod scale-up delay

#### Does this PR introduce a user-facing change?
```release-note
Added `--unschedulable-gpu-pod-scale-up-delay` flags to configure scale-up delay for unschedulable pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```
