### PR TITLE
feat(vpa): add configuration for hostUsers in helm chart

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -86,6 +86,7 @@ helm upgrade <release-name> <chart> \
 | admissionController.certGen.affinity | object | `{}` |  |
 | admissionController.certGen.enabled | bool | `true` |  |
 | admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
+| admissionController.certGen.hostUsers | string | `nil` |  |
 | admissionController.certGen.image.pullPolicy | string | `"IfNotPresent"` | The pull policy for the certgen image. Recommend not changing this |
 | admissionController.certGen.image.repository | string | `"registry.k8s.io/ingress-nginx/kube-webhook-certgen"` | An image that contains certgen for creating certificates. |
 | admissionController.certGen.image.tag | string | `"v20231011-8b53cabe0"` | An image tag for the admissionController.certGen.image.repository image. |
@@ -98,6 +99,7 @@ helm upgrade <release-name> <chart> \
 | admissionController.extraArgs | list | `[]` |  |
 | admissionController.extraEnv | list | `[]` |  |
 | admissionController.hostNetwork | bool | `false` | Enable host network for the admission controller pod. Set to true when the pod needs direct access to the host's network namespace. Note: this bypasses Kubernetes network isolation and may cause port conflicts if multiple replicas run on the same node. |
+| admissionController.hostUsers | string | `nil` |  |
 | admissionController.image.pullPolicy | string | `"IfNotPresent"` |  |
 | admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` |  |
 | admissionController.image.tag | string | `nil` |  |
@@ -161,6 +163,7 @@ helm upgrade <release-name> <chart> \
 | recommender.enabled | bool | `true` |  |
 | recommender.extraArgs | list | `[]` |  |
 | recommender.extraEnv | list | `[]` |  |
+| recommender.hostUsers | string | `nil` |  |
 | recommender.image.pullPolicy | string | `"IfNotPresent"` |  |
 | recommender.image.repository | string | `"registry.k8s.io/autoscaling/vpa-recommender"` |  |
 | recommender.image.tag | string | `nil` |  |
@@ -192,6 +195,7 @@ helm upgrade <release-name> <chart> \
 | updater.annotations | object | `{}` |  |
 | updater.enabled | bool | `true` |  |
 | updater.extraArgs | list | `[]` |  |
+| updater.hostUsers | string | `nil` |  |
 | updater.image.pullPolicy | string | `"IfNotPresent"` |  |
 | updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` |  |
 | updater.image.tag | string | `nil` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certgen-patch.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certgen-patch.yaml
@@ -63,6 +63,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version) (kindIs "bool" .Values.admissionController.certGen.hostUsers) }}
+      hostUsers: {{ .Values.admissionController.certGen.hostUsers }}
+      {{- end }}
       {{- with .Values.admissionController.certGen.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certgen.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certgen.yaml
@@ -63,6 +63,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version) (kindIs "bool" .Values.admissionController.certGen.hostUsers) }}
+      hostUsers: {{ .Values.admissionController.certGen.hostUsers }}
+      {{- end }}
       {{- with .Values.admissionController.certGen.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -52,6 +52,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version) (kindIs "bool" .Values.admissionController.hostUsers) }}
+      hostUsers: {{ .Values.admissionController.hostUsers }}
+      {{- end }}
       {{- with .Values.admissionController.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-deployment.yaml
@@ -110,6 +110,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version) (kindIs "bool" .Values.recommender.hostUsers) }}
+      hostUsers: {{ .Values.recommender.hostUsers }}
+      {{- end }}
       {{- with .Values.recommender.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-deployment.yaml
@@ -44,6 +44,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version) (kindIs "bool" .Values.updater.hostUsers) }}
+      hostUsers: {{ .Values.updater.hostUsers }}
+      {{- end }}
       {{- with .Values.updater.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -97,6 +97,11 @@ admissionController:
               - admission-controller
           topologyKey: kubernetes.io/hostname
 
+  # Whether to use user namespace or not
+  # Kubernetes version 1.30 for feature beta (1.33 for GA) or higher is required with support from OS and OCI runtime
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+  hostUsers: null
+
   # List of node taints to tolerate.
   tolerations: []
 
@@ -135,6 +140,11 @@ admissionController:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+
+    # Whether to use user namespace or not
+    # Kubernetes version 1.30 for feature beta (1.33 for GA) or higher is required with support from OS and OCI runtime
+    # ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+    hostUsers: null
 
   mutatingWebhookConfiguration:
     # admissionController.mutatingWebhookConfiguration.annotations -- Additional annotations for the MutatingWebhookConfiguration
@@ -256,6 +266,11 @@ recommender:
               - recommender
           topologyKey: kubernetes.io/hostname
 
+  # Whether to use user namespace or not
+  # Kubernetes version 1.30 for feature beta (1.33 for GA) or higher is required with support from OS and OCI runtime
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+  hostUsers: null
+
   # Tolerations for scheduling the Recommender.
   tolerations: []
 
@@ -339,6 +354,11 @@ updater:
               values:
               - updater
           topologyKey: kubernetes.io/hostname
+
+  # Whether to use user namespace or not
+  # Kubernetes version 1.30 for feature beta (1.33 for GA) or higher is required with support from OS and OCI runtime
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+  hostUsers: null
 
   # Node selector labels for scheduling the Updater.
   nodeSelector: {}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
With Kubernetes 1.33, [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) are supported to enhance pod security by isolating pod processes in a separate user namespace, reducing the risk of privilege escalation. This PR adds an opt-in configuration to enable user namespaces.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feat(vpa): add configuration for hostUsers in helm chart
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
