### PR TITLE
Fix function IsPodReadyAndStartupBoostDurationPassed

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -294,8 +294,15 @@ func CreateOrUpdateVpaCheckpoint(vpaCheckpointClient vpa_api.VerticalPodAutoscal
 }
 
 // IsPodReadyAndStartupBoostDurationPassed returns true if the pod is ready and all container startup boost durations have passed.
+// TODO(kamarabbas99): Instead of allowing the pod to be unboosted only after all containers have passed their boost duration, we
+// can allow unboosting as soon as any container has passed its boost duration. This will require changes in the
+// way we track unboost and unboosting logic in the updater.
 func IsPodReadyAndStartupBoostDurationPassed(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) bool {
 	if !PodHasCPUBoostInProgressAnnotation(pod) {
+		return false
+	}
+
+	if !podutil.IsPodReady(pod) {
 		return false
 	}
 
@@ -320,10 +327,6 @@ func IsPodReadyAndStartupBoostDurationPassed(pod *corev1.Pod, vpa *vpa_types.Ver
 
 	if maxBoostDuration == 0 {
 		return true
-	}
-
-	if !podutil.IsPodReady(pod) {
-		return false
 	}
 
 	readyTime := time.Time{}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -425,11 +425,19 @@ func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "No duration in StartupBoost, with annotation",
+			name: "No duration in StartupBoost, with annotation and pod ready",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"startup-cpu-boost": "",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Pod ready condition has higher priority over duration passed as mentioned in KEP. Also adding todo to enable container level unboost. This will require having a state for boost opration for all containers.

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

The pod ready needs to be checked before the duration.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: (https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost#aep-7862-cpu-startup-boost)
```
