### PR TITLE
Implement HasInstance for GCE provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -122,7 +122,25 @@ func (gce *GceCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
 func (gce *GceCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
-	return true, cloudprovider.ErrNotImplemented
+	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
+	if err != nil {
+		return false, err
+	}
+
+	mig, err := gce.gceManager.GetMigForInstance(ref)
+	if err != nil {
+		return false, err
+	}
+
+	// Not managed by any registered MIG; there's not enough information to confidently say if this instance exists,
+	// so err on the side of safety and return an error. ErrNotImplemented is returned (vs. a generic error) to
+	// avoid repeated warning logging in clusterstate.
+	if mig == nil {
+		return true, cloudprovider.ErrNotImplemented
+	}
+
+	// Instance belongs to a managed MIG, so it's known to be backed by a live instance.
+	return true, nil
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We encountered an issue where GCE pods drained by the cluster-autoscaler with long termination grace periods would get miscategorized by the CA upcoming nodes, which led to skipped scale up for legitimate pending workloads. This matched the behavior documented in #3949 and #4456, for which the HasInstance mechanism was implemented as a way to distinguish between actively deleting nodes and truly missing nodes.

This PR implements that behavior for the GCE provider, following general patterns from AWS and Azure. The implementation errs on the side of caution and only returns the instance exists if there is certainty from a MIG cache resolution of the instance ref; otherwise, it returns an error such that the behavior defaults to the current behavior of inspecting the nodes taints.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes an issue on GCE where draining nodes can be miscategorized as upcoming nodes
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
