### PR TITLE
fix(ca): fix blank line accumulation in update-faq-flags.sh

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -990,6 +990,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `bulk-mig-instances-listing-enabled` | Fetch GCE mig instances in bulk instead of per mig |  |
 | `bypassed-scheduler-names` | Names of schedulers to bypass. If set to non-empty value, CA will not wait for pods to reach a certain age before triggering a scale-up. |  |
 | `capacity-buffer-controller-enabled` | Whether to enable the default controller for capacity buffers or not |  |
+| `capacity-buffer-pod-dry-run-enabled` | Whether to use server dry run to build managed pod templates for capacity buffers. That ensures that the buffers' fake pods will more reliably resemble real pods by going through the pod defaulting, mutating and validating webhooks. No-op if --capacity-buffer-controller-enabled is false. Note: requires "create" permission on pods to call server dry run. No real pods will be created. | true |
 | `capacity-buffer-pod-injection-enabled` | Whether to enable pod list processor that processes ready capacity buffers and injects fake pods accordingly |  |
 | `capacity-quotas-enabled` | Whether to enable CapacityQuota CRD support. |  |
 | `check-capacity-batch-processing` | Whether to enable batch processing for check capacity requests. |  |
@@ -1134,8 +1135,6 @@ The following startup parameters are supported for cluster autoscaler:
 | `v` | number for the log level verbosity |  |
 | `vmodule` | comma-separated list of pattern=N settings for file-filtered logging (only works for text log format) |  |
 | `write-status-configmap` | Should CA write status information to a configmap | true |
-
-
 
 # Troubleshooting
 

--- a/cluster-autoscaler/hack/update-faq-flags.sh
+++ b/cluster-autoscaler/hack/update-faq-flags.sh
@@ -71,9 +71,13 @@ TABLE=$(printf "%s\n" "${ARGS[@]}")
 # Search the flag table
 TITLE_PATTERN="\|[[:space:]]*Parameter[[:space:]]*\|[[:space:]]*Description[[:space:]]*\|[[:space:]]*Default[[:space:]]*\|"
 START_LINE=$($GREP_CMD -n -E "${TITLE_PATTERN}" "${TARGET_FILE}" | cut -d: -f1)
-# next empty line
-END_LINE=$(awk -v start="${START_LINE}" 'NR > start && /^[[:space:]]*$/{print NR; exit}' "${TARGET_FILE}")
-((END_LINE--))
+# Find the last consecutive empty line after the table
+END_LINE=$(awk -v start="${START_LINE}" '
+    BEGIN { last_empty = 0; found = 0 }
+    NR > start && /^[[:space:]]*$/ { last_empty = NR; next }
+    NR > start && last_empty > 0 && /[^[:space:]]/ { print last_empty; found = 1; exit }
+    END { if (found == 0 && last_empty > 0) print last_empty }
+' "${TARGET_FILE}")
 
 # Replace the table with the generated one
 TEMP=$(mktemp)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Fixes a bug in `hack/update-faq-flags.sh` where blank lines after the flags table would accumulate on each run.

The script previously found only the first empty line after the table, which caused an extra blank line to be added every time the script ran. Now it correctly identifies the last consecutive empty line,making the script idempotent.

#### Special notes for your reviewer:
This is a follow-up fix to PR #9129. After that PR merged, we noticed the script still had an issue where blank lines would accumulate on each run. This PR fixes that remaining issue.
#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
