### PR TITLE
chore: Replace static metrics-server YAML with Helm chart installation

### DIFF
--- a/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
@@ -73,10 +73,8 @@ export TAG=${TAG:-latest}
 
 # Deploy metrics server for E2E tests via Helm chart
 helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
-helm upgrade --install local-metrics-server metrics-server/metrics-server \
-  --version 3.12.2 \
-  --values "${SCRIPT_ROOT}/hack/e2e/values-metrics-server.yaml" \
-  --wait
+helm repo update metrics-server
+helm upgrade --install --set args={--kubelet-insecure-tls} metrics-server metrics-server/metrics-server --namespace kube-system --version 3.13.0 --wait
 
 # Build and load Docker images for each component
 for COMPONENT in ${COMPONENTS}; do

--- a/vertical-pod-autoscaler/hack/e2e/values-metrics-server.yaml
+++ b/vertical-pod-autoscaler/hack/e2e/values-metrics-server.yaml
@@ -1,5 +1,0 @@
-# Values for deploying metrics-server via Helm chart in e2e tests.
-# Replaces the static k8s-metrics-server.yaml manifest.
-# Chart: https://kubernetes-sigs.github.io/metrics-server/
-args:
-  - --kubelet-insecure-tls

--- a/vertical-pod-autoscaler/hack/run-integration-locally.sh
+++ b/vertical-pod-autoscaler/hack/run-integration-locally.sh
@@ -104,10 +104,8 @@ kubectl apply -f ${SCRIPT_ROOT}/hack/e2e/vpa-rbac.yaml
 kubectl apply -f ${SCRIPT_ROOT}/deploy/vpa-v1-crd-gen.yaml
 # Deploy metrics server for integration tests via Helm chart
 helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
-helm upgrade --install local-metrics-server metrics-server/metrics-server \
-  --version 3.12.2 \
-  --values ${SCRIPT_ROOT}/hack/e2e/values-metrics-server.yaml \
-  --wait
+helm repo update metrics-server
+helm upgrade --install --set args={--kubelet-insecure-tls} metrics-server metrics-server/metrics-server --namespace kube-system --version 3.13.0 --wait
 
 for i in ${COMPONENTS}; do
   ALL_ARCHITECTURES=${ARCH} make --directory ${SCRIPT_ROOT}/pkg/${i} docker-build REGISTRY=${REGISTRY} TAG=${TAG}


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Replaces the static metrics-server YAML manifest (`hack/e2e/k8s-metrics-server.yaml`) with a direct Helm chart installation in the e2e and integration test scripts. This aligns metrics-server deployment with how VPA itself is already deployed via Helm in these scripts.

Changes:
- Removed the 245-line static `k8s-metrics-server.yaml` manifest
- Added `hack/e2e/values-metrics-server.yaml` with the single non-default arg (`--kubelet-insecure-tls`)
- Updated `hack/deploy-for-e2e-locally.sh` to use `helm upgrade --install` (chart v3.12.2)
- Updated `hack/run-integration-locally.sh` to use `helm upgrade --install` and added `helm` to required commands

#### Which issue(s) this PR fixes:

Fixes #9329

#### Special notes for your reviewer:

All other container args from the static YAML (`--secure-port=10250`, `--cert-dir=/tmp`, `--kubelet-preferred-address-types`, `--kubelet-use-node-status-port`, `--metric-resolution=15s`) are defaults in the metrics-server Helm chart v3.12.2 and do not need to be explicitly set. The only non-default arg is `--kubelet-insecure-tls`, which is specified in the new values file.

#### Does this PR introduce a user-facing change?

```release-note
NONE
