### PR TITLE
Remove yq/kubectl from VPA benchmark, use Helm values file

### DIFF
--- a/vertical-pod-autoscaler/benchmark/hack/configure-vpa.sh
+++ b/vertical-pod-autoscaler/benchmark/hack/configure-vpa.sh
@@ -18,29 +18,26 @@
 # - Increased QPS/burst on all components (to avoid client-side throttling)
 # - Longer updater interval (steps can take longer than the default 60s at scale)
 #
-# Prerequisites: kubectl, yq
+# Prerequisites: helm
 #
 # Usage: ./configure-vpa.sh
 
 set -euo pipefail
 
-VPA_NAMESPACE="${VPA_NAMESPACE:-kube-system}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VPA_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-vpa}"
+HELM_NAMESPACE="${HELM_NAMESPACE:-kube-system}"
+HELM_CHART_PATH="${VPA_DIR}/charts/vertical-pod-autoscaler"
+VALUES_FILE="${SCRIPT_DIR}/values-benchmark.yaml"
 
 echo "=== Configuring VPA deployments for benchmark ==="
 
-echo "  Configuring vpa-recommender (QPS=100, burst=200, memory-saver=true)..."
-kubectl get deployment vpa-recommender -n "${VPA_NAMESPACE}" -o yaml | \
-  yq '.spec.template.spec.containers[0].args = ["--kube-api-qps=100", "--kube-api-burst=200", "--memory-saver=true"]' | \
-  kubectl apply -f -
-
-echo "  Configuring vpa-updater (QPS=100, burst=200, updater-interval=2m)..."
-kubectl get deployment vpa-updater -n "${VPA_NAMESPACE}" -o yaml | \
-  yq '.spec.template.spec.containers[0].args = ["--kube-api-qps=100", "--kube-api-burst=200", "--updater-interval=2m"]' | \
-  kubectl apply -f -
-
-echo "  Configuring vpa-admission-controller (QPS=100, burst=200)..."
-kubectl get deployment vpa-admission-controller -n "${VPA_NAMESPACE}" -o yaml | \
-  yq '.spec.template.spec.containers[0].args = ["--kube-api-qps=100", "--kube-api-burst=200"]' | \
-  kubectl apply -f -
+helm upgrade "${HELM_RELEASE_NAME}" "${HELM_CHART_PATH}" \
+  --namespace "${HELM_NAMESPACE}" \
+  --values "${VALUES_FILE}" \
+  --reuse-values \
+  --wait
 
 echo "=== VPA configuration complete ==="

--- a/vertical-pod-autoscaler/benchmark/hack/full-benchmark.sh
+++ b/vertical-pod-autoscaler/benchmark/hack/full-benchmark.sh
@@ -17,7 +17,7 @@
 # Full local benchmark workflow: creates a Kind cluster, deploys VPA, installs
 # KWOK, configures VPA for benchmarking, and runs the benchmark.
 #
-# Prerequisites: go, kind, kubectl, yq, docker
+# Prerequisites: go, kind, kubectl, helm, docker
 #
 # Usage:
 #   ./full-benchmark.sh [benchmark flags...]

--- a/vertical-pod-autoscaler/benchmark/hack/values-benchmark.yaml
+++ b/vertical-pod-autoscaler/benchmark/hack/values-benchmark.yaml
@@ -1,0 +1,20 @@
+# Helm values for VPA benchmark configuration.
+# Increases QPS/burst on all components to avoid client-side throttling
+# and extends the updater interval for scale-heavy benchmark steps.
+
+recommender:
+  extraArgs:
+    - --kube-api-qps=100
+    - --kube-api-burst=200
+    - --memory-saver=true
+
+updater:
+  extraArgs:
+    - --kube-api-qps=100
+    - --kube-api-burst=200
+    - --updater-interval=2m
+
+admissionController:
+  extraArgs:
+    - --kube-api-qps=100
+    - --kube-api-burst=200


### PR DESCRIPTION
## Description

With the Helm chart migration in #9297, the VPA benchmark's `configure-vpa.sh` still uses `kubectl get | yq | kubectl apply` pipelines to patch deployment args. This replaces that approach with a dedicated Helm values file, consistent with how the rest of the VPA deployment is now configured.

## Changes

1. **New `values-benchmark.yaml`** — Helm values file that configures benchmark-specific `extraArgs` (QPS/burst, memory-saver, updater interval) for all three VPA components.
2. **Rewritten `configure-vpa.sh`** — Replaced three `kubectl get | yq | kubectl apply` pipelines with a single `helm upgrade --reuse-values --values values-benchmark.yaml`.
3. **Updated `full-benchmark.sh`** — Changed prerequisites from `yq` to `helm`.

## Type of Change
- [x] Code refactoring

## Related Issues
Fixes #9304

## Checklist Before Submitting
- [x] My code has been tested locally.
- [x] Documentation has been updated as needed.
- [x] New or updated tests are included where applicable.