### PR TITLE
Extend NoScaleUpInfo reporting by running simulation on skipped NodeGroups.

### DIFF
--- a/cluster-autoscaler/cloudprovider/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloud_provider.go
@@ -370,7 +370,7 @@ func ContainsCustomResources(resources []string) bool {
 	return false
 }
 
-// NodeGroupListToMapById returns a map of node group ID to nonode group
+// NodeGroupListToMapById returns a map of node group ID to node group
 func NodeGroupListToMapById(nodeGroups []NodeGroup) map[string]NodeGroup {
 	result := make(map[string]NodeGroup)
 	for _, nodeGroup := range nodeGroups {

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -370,6 +370,8 @@ type AutoscalingOptions struct {
 	// NodeRemovalLatencyTrackingEnabled is used to enable/disable node removal latency tracking.
 	NodeRemovalLatencyTrackingEnabled bool
 	CapacityQuotasEnabled             bool
+	// ScaleUpSimulationForSkippedNodeGroupsEnabled is used to enable/disable the scaleUpSimulation for the skipped node groups
+	ScaleUpSimulationForSkippedNodeGroupsEnabled bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -242,6 +242,7 @@ var (
 	nodeRemovalLatencyTrackingEnabled            = flag.Bool("node-removal-latency-tracking-enabled", false, "Whether to track latency from when an unneeded node is eligible for scale down until it is removed or needed again.")
 	maxNodeSkipEvalTimeTrackerEnabled            = flag.Bool("max-node-skip-eval-time-tracker-enabled", false, "Whether to enable the tracking of the maximum time of node being skipped during ScaleDown")
 	capacityQuotasEnabled                        = flag.Bool("capacity-quotas-enabled", false, "Whether to enable CapacityQuota CRD support.")
+	scaleUpSimulationForSkippedNodeGroupsEnabled = flag.Bool("scaleup-simulation-for-skipped-node-groups-enabled", false, "Whether to enable the scale up simulation for skipped node groups.")
 
 	// Deprecated flags
 	ignoreTaintsFlag = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
@@ -444,6 +445,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		NodeRemovalLatencyTrackingEnabled:            *nodeRemovalLatencyTrackingEnabled,
 		MaxNodeSkipEvalTimeTrackerEnabled:            *maxNodeSkipEvalTimeTrackerEnabled,
 		CapacityQuotasEnabled:                        *capacityQuotasEnabled,
+		ScaleUpSimulationForSkippedNodeGroupsEnabled: *scaleUpSimulationForSkippedNodeGroupsEnabled,
 	}
 }
 

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -170,7 +170,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 		klog.V(1).Info("No expansion options")
 		return &status.ScaleUpStatus{
 			Result:                  status.ScaleUpNoOptionsAvailable,
-			PodsRemainUnschedulable: GetRemainingPods(podEquivalenceGroups, skippedNodeGroups),
+			PodsRemainUnschedulable: o.GetRemainingPods(podEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
 			ConsideredNodeGroups:    nodeGroups,
 		}, nil
 	}
@@ -182,7 +182,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 		podEquivalenceGroups = markAllGroupsAsUnschedulable(podEquivalenceGroups, ExpansionOptionsFilteredOutReason)
 		return &status.ScaleUpStatus{
 			Result:                  status.ScaleUpNoOptionsAvailable,
-			PodsRemainUnschedulable: allPodsAsNoScaleUpInfo(podEquivalenceGroups, skippedNodeGroups),
+			PodsRemainUnschedulable: o.GetRemainingPods(podEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
 			ConsideredNodeGroups:    nodeGroups,
 		}, nil
 	}
@@ -211,7 +211,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
 			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
 			markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, AllOrNothingReason)
-			return buildNoOptionsAvailableStatus(markedEquivalenceGroups, skippedNodeGroups, nodeGroups), nil
+			return o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, skippedNodeGroups, nodeGroups, nodeInfos), nil
 		}
 	}
 
@@ -223,7 +223,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
 			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
 			markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, AllOrNothingReason)
-			return buildNoOptionsAvailableStatus(markedEquivalenceGroups, skippedNodeGroups, nodeGroups), nil
+			return o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, skippedNodeGroups, nodeGroups, nodeInfos), nil
 		}
 		var scaleUpStatus *status.ScaleUpStatus
 		oldId := bestOption.NodeGroup.Id()
@@ -257,7 +257,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
 			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
 			markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, AllOrNothingReason)
-			return buildNoOptionsAvailableStatus(markedEquivalenceGroups, skippedNodeGroups, nodeGroups), nil
+			return o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, skippedNodeGroups, nodeGroups, nodeInfos), nil
 		}
 	}
 
@@ -279,7 +279,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	return &status.ScaleUpStatus{
 		Result:                  status.ScaleUpSuccessful,
 		ScaleUpInfos:            scaleUpInfos,
-		PodsRemainUnschedulable: GetRemainingPods(podEquivalenceGroups, skippedNodeGroups),
+		PodsRemainUnschedulable: o.GetRemainingPods(podEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
 		ConsideredNodeGroups:    nodeGroups,
 		CreateNodeGroupResults:  createNodeGroupResults,
 		PodsTriggeredScaleUp:    bestOption.Pods,
@@ -800,6 +800,87 @@ func (o *ScaleUpOrchestrator) ComputeSimilarNodeGroups(
 	return validSimilarNodeGroups
 }
 
+// GetRemainingPods returns information about pods which CA is unable to help
+// at this moment.
+func (o *ScaleUpOrchestrator) GetRemainingPods(egs []*equivalence.PodGroup, nodeGroups []cloudprovider.NodeGroup, skipped map[string]status.Reasons, nodeInfos map[string]*framework.NodeInfo) []status.NoScaleUpInfo {
+	if !o.autoscalingCtx.ScaleUpSimulationForSkippedNodeGroupsEnabled {
+		remaining := []status.NoScaleUpInfo{}
+		for _, eg := range egs {
+			if eg.Schedulable {
+				continue
+			}
+			for _, pod := range eg.Pods {
+				noScaleUpInfo := status.NoScaleUpInfo{
+					Pod:                pod,
+					RejectedNodeGroups: eg.SchedulingErrors,
+					SkippedNodeGroups:  skipped,
+				}
+				remaining = append(remaining, noScaleUpInfo)
+			}
+		}
+		return remaining
+	}
+	// If ScaleUpSimulationForSkippedNodeGroupsEnabled is true we do the SchedulablePodGroups simulation for the skipped node groups.
+	nonSchedulableEgs := []*equivalence.PodGroup{}
+	for _, eg := range egs {
+		// there is no need to run the simulation for the schedulable pod groups, because for them we still do not return anything.
+		if !eg.Schedulable {
+			nonSchedulableEgs = append(nonSchedulableEgs, eg)
+		}
+	}
+	return o.getRemainingPodsConsideringSkippedNodeGroups(nonSchedulableEgs, nodeGroups, skipped, nodeInfos)
+}
+
+func (o *ScaleUpOrchestrator) getRemainingPodsConsideringSkippedNodeGroups(egs []*equivalence.PodGroup, nodeGroups []cloudprovider.NodeGroup, skipped map[string]status.Reasons, nodeInfos map[string]*framework.NodeInfo) []status.NoScaleUpInfo {
+	remaining := []status.NoScaleUpInfo{}
+	// Perform the SchedulablePodGroups simulation for the skipped node groups.
+	for _, nodeGroup := range nodeGroups {
+		nodeGroupId := nodeGroup.Id()
+		if _, found := skipped[nodeGroupId]; !found {
+			continue
+		}
+		nodeInfo, found := nodeInfos[nodeGroupId]
+		if !found {
+			klog.Errorf("No node info for: %s", nodeGroupId)
+			continue
+		}
+		// We ignore the return value here, because we are not interested in which egs are now (theoretically) schedulable or not. We are only interested in the rejected node groups per eg.
+		_ = o.SchedulablePodGroups(egs, nodeGroup, nodeInfo)
+	}
+	// For all egs here we need to generate the NoScaleUpInfo object because we only considered egs that are unschedulable in the first place.
+	// eg.SchedulingErrors will contain scheduling errors of this eg for not skipped nodegroups from the previous simulation + errors for skipped nodegroups from current simulation.
+	for _, eg := range egs {
+		for _, pod := range eg.Pods {
+			noScaleUpInfo := status.NoScaleUpInfo{
+				Pod:                pod,
+				RejectedNodeGroups: eg.SchedulingErrors,
+				SkippedNodeGroups:  findSkippedNodeGroupsSatisfyingPodPredicates(eg, skipped),
+			}
+			remaining = append(remaining, noScaleUpInfo)
+		}
+	}
+	return remaining
+}
+
+func (o *ScaleUpOrchestrator) buildNoOptionsAvailableStatus(egs []*equivalence.PodGroup, skipped map[string]status.Reasons, ngs []cloudprovider.NodeGroup, nodeInfos map[string]*framework.NodeInfo) *status.ScaleUpStatus {
+	return &status.ScaleUpStatus{
+		Result:                  status.ScaleUpNoOptionsAvailable,
+		PodsRemainUnschedulable: o.GetRemainingPods(egs, ngs, skipped, nodeInfos),
+		ConsideredNodeGroups:    ngs,
+	}
+}
+
+func findSkippedNodeGroupsSatisfyingPodPredicates(eg *equivalence.PodGroup, skipped map[string]status.Reasons) map[string]status.Reasons {
+	matchingNodeGroups := make(map[string]status.Reasons)
+	for skippedNodeGroupId, skipReason := range skipped {
+		// if a node group is in skipped and for this eg it is not in scheduling errors, it means that it will stay in skipped, because it satisfies the pod predicates.
+		if _, hasPredicateError := eg.SchedulingErrors[skippedNodeGroupId]; !hasPredicateError {
+			matchingNodeGroups[skippedNodeGroupId] = skipReason
+		}
+	}
+	return matchingNodeGroups
+}
+
 func matchingSchedulablePodGroups(podGroups []estimator.PodEquivalenceGroup, similarPodGroups []estimator.PodEquivalenceGroup) bool {
 	schedulableSamplePods := make(map[*apiv1.Pod]bool)
 	for _, podGroup := range similarPodGroups {
@@ -826,51 +907,6 @@ func markAllGroupsAsUnschedulable(egs []*equivalence.PodGroup, reason status.Rea
 		}
 	}
 	return egs
-}
-
-func buildNoOptionsAvailableStatus(egs []*equivalence.PodGroup, skipped map[string]status.Reasons, ngs []cloudprovider.NodeGroup) *status.ScaleUpStatus {
-	return &status.ScaleUpStatus{
-		Result:                  status.ScaleUpNoOptionsAvailable,
-		PodsRemainUnschedulable: GetRemainingPods(egs, skipped),
-		ConsideredNodeGroups:    ngs,
-	}
-}
-
-// GetRemainingPods returns information about pods which CA is unable to help
-// at this moment.
-func GetRemainingPods(egs []*equivalence.PodGroup, skipped map[string]status.Reasons) []status.NoScaleUpInfo {
-	remaining := []status.NoScaleUpInfo{}
-	for _, eg := range egs {
-		if eg.Schedulable {
-			continue
-		}
-		for _, pod := range eg.Pods {
-			noScaleUpInfo := status.NoScaleUpInfo{
-				Pod:                pod,
-				RejectedNodeGroups: eg.SchedulingErrors,
-				SkippedNodeGroups:  skipped,
-			}
-			remaining = append(remaining, noScaleUpInfo)
-		}
-	}
-	return remaining
-}
-
-// allPodsAsNoScaleUpInfo flattens all equivalence groups into a list of NoScaleUpInfo
-func allPodsAsNoScaleUpInfo(egs []*equivalence.PodGroup, skipped map[string]status.Reasons) []status.NoScaleUpInfo {
-	noScaleUpInfos := make([]status.NoScaleUpInfo, 0, len(egs))
-	for _, eg := range egs {
-		for _, pod := range eg.Pods {
-			noScaleUpInfo := status.NoScaleUpInfo{
-				Pod:                pod,
-				RejectedNodeGroups: eg.SchedulingErrors,
-				SkippedNodeGroups:  skipped,
-			}
-			noScaleUpInfos = append(noScaleUpInfos, noScaleUpInfo)
-		}
-	}
-
-	return noScaleUpInfos
 }
 
 // GetPodsAwaitingEvaluation returns list of pods for which CA was unable to help

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -2046,6 +2046,187 @@ func TestAuthErrorHandling(t *testing.T) {
 	assertLegacyRegistryEntry(t, "cluster_autoscaler_failed_scale_ups_total{reason=\"authError\"} 1")
 }
 
+func TestScaleUpSimulationForSkippedNodeGroups(t *testing.T) {
+	node1 := BuildTestNode("n1", 2000, 2000)
+	SetNodeReadyState(node1, true, time.Time{})
+	nodeInfo1 := framework.NewTestNodeInfo(node1)
+
+	node2 := BuildTestNode("n2", 1000, 1000)
+	SetNodeReadyState(node2, true, time.Time{})
+	nodeInfo2 := framework.NewTestNodeInfo(node2)
+
+	node3 := BuildTestNode("n3", 1000, 1000)
+	SetNodeReadyState(node3, true, time.Time{})
+	nodeInfo3 := framework.NewTestNodeInfo(node3)
+
+	// p1 needs 1500 cpu. It fits n1 but not n2 or n3.
+	p1 := BuildTestPod("p1", 1500, 1500)
+	// p2 asks for 3000 cpu, so it will fail to schedule on n1, n2, and n3.
+	p2 := BuildTestPod("p2", 3000, 3000)
+	// p3 asks for 500 cpu, which fits n2.
+	p3 := BuildTestPod("p3", 500, 500)
+
+	provider := testprovider.NewTestCloudProviderBuilder().
+		WithMachineTypes([]string{"ng1", "ng2", "ng3"}).
+		WithMachineTemplates(map[string]*framework.NodeInfo{"ng1": nodeInfo1, "ng2": nodeInfo2, "ng3": nodeInfo3}).
+		WithOnScaleUp(func(string, int) error { return nil }).Build()
+
+	// ng1 will be skipped due to MaxLimitReached (MaxSize=1, current size=1)
+	provider.AddNodeGroup("ng1", 0, 1, 1)
+	// ng2 will not be skipped (MaxSize=2, current size=1)
+	provider.AddNodeGroup("ng2", 0, 2, 1)
+	// ng3 will be skipped due to MaxLimitReached (MaxSize=1, current size=1)
+	provider.AddNodeGroup("ng3", 0, 1, 1)
+	provider.AddNode("ng1", node1)
+	provider.AddNode("ng2", node2)
+	provider.AddNode("ng3", node3)
+
+	testCases := []struct {
+		name                                         string
+		pods                                         []*apiv1.Pod
+		scaleUpSimulationForSkippedNodeGroupsEnabled bool
+		expectedResult                               status.ScaleUpResult
+		expectedNoScaleUpInfo                        map[string]status.NoScaleUpInfo
+	}{
+		{
+			name:           "feature flag is disabled: ng2 is rejected and ng1 and ng3 are skipped for both p1 and p2",
+			pods:           []*apiv1.Pod{p1, p2},
+			expectedResult: status.ScaleUpNoOptionsAvailable,
+			expectedNoScaleUpInfo: map[string]status.NoScaleUpInfo{
+				p1.Name: {
+					Pod: p1,
+					RejectedNodeGroups: map[string]status.Reasons{
+						"ng2": NewRejectedReasons(""),
+					},
+					SkippedNodeGroups: map[string]status.Reasons{
+						"ng1": NotReadyReason,
+						"ng3": NotReadyReason,
+					},
+				},
+				p2.Name: {
+					Pod: p2,
+					RejectedNodeGroups: map[string]status.Reasons{
+						"ng2": NewRejectedReasons(""),
+					},
+					SkippedNodeGroups: map[string]status.Reasons{
+						"ng1": NotReadyReason,
+						"ng3": NotReadyReason,
+					},
+				},
+			},
+		},
+		{
+			name: "feature flag is enabled: ng3 moves to rejected for p1 and ng1 and ng3 move to rejected for p2",
+			// ng1 satisfies the predicates of p1, so it remains skipped for p1, but it does not for p2, so it is moved to rejected for p2.
+			pods: []*apiv1.Pod{p1, p2},
+			scaleUpSimulationForSkippedNodeGroupsEnabled: true,
+			expectedResult: status.ScaleUpNoOptionsAvailable,
+			expectedNoScaleUpInfo: map[string]status.NoScaleUpInfo{
+				p1.Name: {
+					Pod: p1,
+					RejectedNodeGroups: map[string]status.Reasons{
+						"ng2": NewRejectedReasons(""),
+						"ng3": NewRejectedReasons(""),
+					},
+					SkippedNodeGroups: map[string]status.Reasons{
+						"ng1": NotReadyReason,
+					},
+				},
+				p2.Name: {
+					Pod: p2,
+					RejectedNodeGroups: map[string]status.Reasons{
+						"ng2": NewRejectedReasons(""),
+						"ng1": NewRejectedReasons(""),
+						"ng3": NewRejectedReasons(""),
+					},
+				},
+			},
+		},
+		{
+			name: "feature flag is enabled: partial scale-up successful - p3 triggers scale up, p1 and p2 behave the same as in the previous test case",
+			pods: []*apiv1.Pod{p1, p2, p3},
+			scaleUpSimulationForSkippedNodeGroupsEnabled: true,
+			expectedResult: status.ScaleUpSuccessful,
+			expectedNoScaleUpInfo: map[string]status.NoScaleUpInfo{
+				p1.Name: {
+					Pod: p1,
+					RejectedNodeGroups: map[string]status.Reasons{
+						"ng2": NewRejectedReasons(""),
+						"ng3": NewRejectedReasons(""),
+					},
+					SkippedNodeGroups: map[string]status.Reasons{
+						"ng1": NotReadyReason,
+					},
+				},
+				p2.Name: {
+					Pod: p2,
+					RejectedNodeGroups: map[string]status.Reasons{
+						"ng2": NewRejectedReasons(""),
+						"ng1": NewRejectedReasons(""),
+						"ng3": NewRejectedReasons(""),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			options := config.AutoscalingOptions{
+				// enable this flag to test the simulation run for the skipped node groups
+				ScaleUpSimulationForSkippedNodeGroupsEnabled: tc.scaleUpSimulationForSkippedNodeGroupsEnabled,
+				EstimatorName: estimator.BinpackingEstimatorName,
+			}
+
+			podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
+			listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
+			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
+			fakeClient := &fake.Clientset{}
+
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, listers, provider, nil, nil, templateNodeInfoRegistry)
+			assert.NoError(t, err)
+
+			nodes := []*apiv1.Node{node1, node2, node3}
+			err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, nil, nil, nil)
+			assert.NoError(t, err)
+			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
+			nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
+
+			registryConfig := clusterstate.ClusterStateRegistryConfig{}
+			clusterState := clusterstate.NewClusterStateRegistry(provider, registryConfig, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker())
+			clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+
+			quotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
+			trackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
+				QuotaProvider:            quotasProvider,
+				CustomResourcesProcessor: processors.CustomResourcesProcessor,
+			})
+
+			suOrchestrator := New()
+			suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
+
+			scaleUpStatus, err := suOrchestrator.ScaleUp(tc.pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, scaleUpStatus.Result)
+
+			remaining := scaleUpStatus.PodsRemainUnschedulable
+			assert.Equal(t, len(tc.expectedNoScaleUpInfo), len(remaining))
+			for _, actualInfo := range remaining {
+				expectedInfo, expectedInfoFound := tc.expectedNoScaleUpInfo[actualInfo.Pod.Name]
+				assert.True(t, expectedInfoFound, "Unexpected pod found in remaining pods: "+actualInfo.Pod.Name)
+				assert.Equal(t, len(expectedInfo.SkippedNodeGroups), len(actualInfo.SkippedNodeGroups))
+				assert.Equal(t, len(expectedInfo.RejectedNodeGroups), len(actualInfo.RejectedNodeGroups))
+				for ng := range expectedInfo.SkippedNodeGroups {
+					assert.Contains(t, actualInfo.SkippedNodeGroups, ng)
+				}
+				for ng := range expectedInfo.RejectedNodeGroups {
+					assert.Contains(t, actualInfo.RejectedNodeGroups, ng)
+				}
+			}
+		})
+	}
+}
+
 func assertLegacyRegistryEntry(t *testing.T, entry string) {
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {


### PR DESCRIPTION
This change introduces the following change:
* run SchedulablePodGroups on skipped node groups (NG) during the ScaleUp simulation to check if skipped NGs satisfy predicates of podEquivalenceGroups:
    * if a skipped NG satisfies the predicate of a pod group then it stays in the SkippedNodeGroups list associated to this pod group's pods.
    * otherwise this NG moves to the RejectedNodeGroups.
* since this change introduces the scale up performance overhead, it is covered by the feature flag. 

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change will give better understanding to the user of why the scale up did fail and improve overall observability. If a NG is in the backoff but it does not satisfy the predicate, user will know it right away instead of waiting for when this NG becomes available and we would consider it again.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->
```release-note
Adds new "scaleup-simulation-for-skipped-node-groups-enabled" flag which enables an extra SchedulablePodGroups run for the skipped node groups during ScaleUp simulation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
