### PR TITLE
Log total nodes in the scale-up

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -260,7 +260,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	}
 
 	// Execute scale up.
-	klog.V(1).Infof("Final scale-up plan: %v", scaleUpInfos)
+	klog.V(1).Infof("Final scale-up plan: %v %v", totalCapacity, scaleUpInfos)
 	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, nodeInfos, now, allOrNothing)
 	if aErr != nil {
 		return status.UpdateScaleUpError(


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

One of the most important logs in this component is the one informing about the final scale-up decision. ATM this log is usually a multiline detailed log entry that informs about the scale-up size split into multiple node groups with their actual sizes and target sizes. That's very helpful when analyzing a single scale-up decision but too detailed when analyzing a sequence of scale-up decisions in a long time interval.

I propose adding to the log the final number of nodes added by the scale-up.

Current log (for a scale-up split into 3 node groups):
```
Final scale-up plan: [{<NODE_GROUP_ID> SIZE->TARGET (max: MAX_SIZE)} {<NODE_GROUP_ID> SIZE->TARGET (max: MAX_SIZE)} {<NODE_GROUP_ID> SIZE->TARGET (max: MAX_SIZE)}]
```

Proposed log:
```
Final scale-up plan: <SCALE_UP_SIZE> [{<NODE_GROUP_ID> SIZE->TARGET (max: MAX_SIZE)} {<NODE_GROUP_ID> SIZE->TARGET (max: MAX_SIZE)} {<NODE_GROUP_ID> SIZE->TARGET (max: MAX_SIZE)}]
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
