### PR TITLE
Add Capacity buffers updater interface to allow wrapping updating logic

### DIFF
--- a/cluster-autoscaler/capacitybuffer/controller/controller.go
+++ b/cluster-autoscaler/capacitybuffer/controller/controller.go
@@ -51,7 +51,7 @@ type bufferController struct {
 	strategyFilter filters.Filter
 	translator     translators.Translator
 	quotaAllocator *resourceQuotaAllocator
-	updater        updater.StatusUpdater
+	updater        updater.BufferUpdater
 	queue          workqueue.TypedRateLimitingInterface[string]
 }
 
@@ -60,7 +60,7 @@ func NewBufferController(
 	client *cbclient.CapacityBufferClient,
 	strategyFilter filters.Filter,
 	translator translators.Translator,
-	updater updater.StatusUpdater,
+	updater updater.BufferUpdater,
 ) BufferController {
 	bc := &bufferController{
 		client:         client,
@@ -93,7 +93,7 @@ func NewDefaultBufferController(
 			},
 		),
 		quotaAllocator: newResourceQuotaAllocator(client),
-		updater:        *updater.NewStatusUpdater(client),
+		updater:        updater.NewStatusUpdater(client),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "CapacityBuffers"},
 		),
@@ -307,7 +307,7 @@ func (c *bufferController) reconcileNamespace(namespace string) error {
 	}
 
 	// Update buffer status by calling API server
-	updateErrors := c.updater.Update(filteredBuffers)
+	_, updateErrors := c.updater.Update(filteredBuffers)
 	for _, err := range updateErrors {
 		runtime.HandleError(fmt.Errorf("capacity buffer controller error: %w", err))
 	}

--- a/cluster-autoscaler/capacitybuffer/updater/status_updater.go
+++ b/cluster-autoscaler/capacitybuffer/updater/status_updater.go
@@ -33,16 +33,19 @@ func NewStatusUpdater(client *cbclient.CapacityBufferClient) *StatusUpdater {
 	}
 }
 
-// Update updates the buffer status with pod capacity
-func (u *StatusUpdater) Update(buffers []*v1.CapacityBuffer) []error {
+// Update updates the buffer status and returns the updated buffers objects and list of errors
+func (u *StatusUpdater) Update(buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []error) {
 	var errors []error
+	var updatedBuffers []*v1.CapacityBuffer
 	for _, buffer := range buffers {
-		_, err := u.client.UpdateCapacityBuffer(buffer)
+		updatedBuffer, err := u.client.UpdateCapacityBuffer(buffer)
 		if err != nil {
 			errors = append(errors, err)
+		} else {
+			updatedBuffers = append(updatedBuffers, updatedBuffer)
 		}
 	}
-	return errors
+	return updatedBuffers, errors
 }
 
 // CleanUp cleans up the updater's internal structures.

--- a/cluster-autoscaler/capacitybuffer/updater/status_updater_test.go
+++ b/cluster-autoscaler/capacitybuffer/updater/status_updater_test.go
@@ -89,9 +89,10 @@ func TestStatusUpdater(t *testing.T) {
 				},
 			)
 			buffersUpdater := NewStatusUpdater(fakeCapacityBuffersClient)
-			errors := buffersUpdater.Update(test.buffers)
+			updatedBuffers, errors := buffersUpdater.Update(test.buffers)
 			assert.Equal(t, test.expectedNumberOfErrors, len(errors))
 			assert.Equal(t, test.expectedNumberOfCalls, updateCallsCount)
+			assert.Equal(t, len(test.buffers)-test.expectedNumberOfErrors, len(updatedBuffers))
 		})
 	}
 }

--- a/cluster-autoscaler/capacitybuffer/updater/updater.go
+++ b/cluster-autoscaler/capacitybuffer/updater/updater.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package updater
+
+import (
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+)
+
+// BufferUpdater updates the passed buffers via API server call and returns the
+// successfully updated buffers and list of errors
+type BufferUpdater interface {
+	Update(buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []error)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
Adding Capacity buffers updater interface and use the interface in the controller to allow the injection of different implementations of the updating logic where the current status updater would be the default implementation to be used by the controller

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
