### PR TITLE
Detect DRA resource mismatch against autoscaler node templates

### DIFF
--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -715,6 +715,8 @@ func (m *caMetrics) UpdateNodeGroupTargetSize(targetSizes map[string]int) {
 	}
 }
 
+// SetNodeTemplateResourcesMismatch records the number of resource mismatches between
+// predicted and real nodes in DRA-enabled node groups.
 func (m *caMetrics) SetNodeTemplateResourcesMismatch(driver string, mismatchType ResourceMismatchType, value uint32) {
 	m.nodeTemplateResourcesMismatch.With(map[string]string{
 		"driver":        driver,

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -121,6 +121,24 @@ const (
 	BulkListMigInstances       FunctionLabel = "bulkListInstances:listMigInstances"
 )
 
+// ResourceMismatchType mismatch type discovered when comparing DRA resources
+type ResourceMismatchType string
+
+const (
+	// ResourceMismatchTypeMissing mismatch type reported when resource pool is
+	// present on the template node, but missing on the real node
+	ResourceMismatchTypeMissing ResourceMismatchType = "missing"
+	// ResourceMismatchTypeExtra mismatch type reported when resource pool is
+	// present on the real node, but missing on the template one
+	ResourceMismatchTypeExtra ResourceMismatchType = "extra"
+	// ResourceMismatchTypeMismatch mismatch type reported when matching resource
+	// pool was found, but they have certain differences
+	ResourceMismatchTypeMismatch ResourceMismatchType = "mismatch"
+	// ResourceMismatchTypeUnknown mismatch type which we are not able to categorize,
+	// usually would indicate metric implementation level errors
+	ResourceMismatchTypeUnknown ResourceMismatchType = "unknown"
+)
+
 type caMetrics struct {
 	registry metrics.KubeRegistry
 
@@ -168,6 +186,9 @@ type caMetrics struct {
 	binpackingHeterogeneity          *k8smetrics.HistogramVec
 	maxNodeSkipEvalDurationSeconds   *k8smetrics.Gauge
 	scaleDownNodeRemovalLatency      *k8smetrics.HistogramVec
+
+	// Metrics related to autoscaler prediction correctness
+	nodeTemplateResourcesMismatch *k8smetrics.GaugeVec
 }
 
 func newCaMetrics() *caMetrics {
@@ -504,6 +525,14 @@ func newCaMetrics() *caMetrics {
 				Buckets:   k8smetrics.ExponentialBuckets(1, 1.5, 19), // ~1s → ~24min
 			}, []string{"deleted"},
 		),
+
+		nodeTemplateResourcesMismatch: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Namespace: caNamespace,
+				Name:      "dra_node_template_resources_mismatch",
+				Help:      "Count of resource mismatches between ready nodes and node templates",
+			}, []string{"driver", "mismatch_type"},
+		),
 	}
 }
 
@@ -552,6 +581,7 @@ func (m *caMetrics) RegisterAll(emitPerNodeGroupMetrics bool) {
 	m.mustRegister(m.binpackingHeterogeneity)
 	m.mustRegister(m.maxNodeSkipEvalDurationSeconds)
 	m.mustRegister(m.scaleDownNodeRemovalLatency)
+	m.mustRegister(m.nodeTemplateResourcesMismatch)
 
 	if emitPerNodeGroupMetrics {
 		m.mustRegister(m.nodesGroupMinNodes)
@@ -683,6 +713,13 @@ func (m *caMetrics) UpdateNodeGroupTargetSize(targetSizes map[string]int) {
 	for nodeGroup, targetSize := range targetSizes {
 		m.nodesGroupTargetSize.WithLabelValues(nodeGroup).Set(float64(targetSize))
 	}
+}
+
+func (m *caMetrics) SetNodeTemplateResourcesMismatch(driver string, mismatchType ResourceMismatchType, value uint32) {
+	m.nodeTemplateResourcesMismatch.With(map[string]string{
+		"driver":        driver,
+		"mismatch_type": string(mismatchType),
+	}).Set(float64(value))
 }
 
 // UpdateNodeGroupHealthStatus records if node group is healthy to autoscaling

--- a/cluster-autoscaler/processors/customresources/default_custom_processor.go
+++ b/cluster-autoscaler/processors/customresources/default_custom_processor.go
@@ -35,7 +35,7 @@ type DefaultCustomResourcesProcessor struct {
 func NewDefaultCustomResourcesProcessor(draEnabled bool, csiEnabled bool) CustomResourcesProcessor {
 	customProcessors := []CustomResourcesProcessor{&GpuCustomResourcesProcessor{}}
 	if draEnabled {
-		customProcessors = append(customProcessors, &DraCustomResourcesProcessor{})
+		customProcessors = append(customProcessors, NewDraCustomResourcesProcessor())
 	}
 	if csiEnabled {
 		customProcessors = append(customProcessors, &CSICustomResourcesProcessor{})

--- a/cluster-autoscaler/processors/customresources/dra_processor.go
+++ b/cluster-autoscaler/processors/customresources/dra_processor.go
@@ -18,21 +18,36 @@ package customresources
 
 import (
 	apiv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/resource/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	csisnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/csi/snapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/comparator"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/klog/v2"
 )
 
+// resourceDiscrepancyReporter defines the interface for reporting DRA discrepancies.
+type resourceDiscrepancyReporter interface {
+	ReportResourceDiscrepancies(nodeNames []string, templateSlices [][]*resourceapi.ResourceSlice, nodeSlices [][]*resourceapi.ResourceSlice)
+}
+
 // DraCustomResourcesProcessor handles DRA custom resource. It assumes,
 // that the DRA resources may not become allocatable immediately after the node creation.
 type DraCustomResourcesProcessor struct {
+	resourcesComparator resourceDiscrepancyReporter
+}
+
+// NewDraCustomResourcesProcessor returns an instance of DraCustomResourcesProcessor properly initialized.
+func NewDraCustomResourcesProcessor() *DraCustomResourcesProcessor {
+	return &DraCustomResourcesProcessor{
+		resourcesComparator: comparator.NewNodeResourcesComparator(metrics.DefaultMetrics),
+	}
 }
 
 // FilterOutNodesWithUnreadyResources removes nodes that should have DRA resource, but don't have
@@ -45,6 +60,10 @@ func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autosca
 		klog.Warningf("Cannot filter out nodes with unready DRA resources. The DRA snapshot is nil. Processing will be skipped.")
 		return allNodes, readyNodes
 	}
+
+	readyNodeNames := make([]string, 0, len(readyNodes))
+	readyTemplateSlices := make([][]*resourceapi.ResourceSlice, 0, len(readyNodes))
+	readyNodeSlices := make([][]*resourceapi.ResourceSlice, 0, len(readyNodes))
 
 	for _, node := range readyNodes {
 		ng, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)
@@ -68,10 +87,15 @@ func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autosca
 		nodeResourcesSlices, _ := draSnapshot.NodeResourceSlices(node.Name)
 		if areResourcePoolsReady(nodeResourcesSlices, templateNodeInfo.LocalResourceSlices) {
 			newReadyNodes = append(newReadyNodes, node)
+			readyNodeNames = append(readyNodeNames, node.Name)
+			readyTemplateSlices = append(readyTemplateSlices, templateNodeInfo.LocalResourceSlices)
+			readyNodeSlices = append(readyNodeSlices, nodeResourcesSlices)
 		} else {
 			nodesWithUnreadyDraResources[node.Name] = kubernetes.GetUnreadyNodeCopy(node, kubernetes.ResourceUnready)
 		}
 	}
+
+	p.resourcesComparator.ReportResourceDiscrepancies(readyNodeNames, readyTemplateSlices, readyNodeSlices)
 
 	// Override any node with unready DRA resources with its "unready" copy
 	for _, node := range allNodes {
@@ -116,7 +140,7 @@ type poolSpec struct {
 
 // areResourcePoolsReady returns boolean indicating whether resource slices from a real node
 // contain a minimal amount of ready resource pools as declared in the template.
-func areResourcePoolsReady(resourceSlices []*v1.ResourceSlice, templateNodeResourcesSlices []*v1.ResourceSlice) bool {
+func areResourcePoolsReady(resourceSlices []*resourceapi.ResourceSlice, templateNodeResourcesSlices []*resourceapi.ResourceSlice) bool {
 	templatePools := getCompleteResourcePools(templateNodeResourcesSlices)
 	realPools := getCompleteResourcePools(resourceSlices)
 
@@ -130,7 +154,7 @@ func areResourcePoolsReady(resourceSlices []*v1.ResourceSlice, templateNodeResou
 }
 
 // getCompleteResourcePools returns a map of drivers and count of ready resource pools mapped to it.
-func getCompleteResourcePools(resourceSlices []*v1.ResourceSlice) map[string]int {
+func getCompleteResourcePools(resourceSlices []*resourceapi.ResourceSlice) map[string]int {
 	poolStates := make(map[poolSpec]poolState, len(resourceSlices))
 
 	for _, rs := range resourceSlices {

--- a/cluster-autoscaler/processors/customresources/dra_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/dra_processor_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/resource/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/comparator"
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -38,8 +39,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	utils "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
+
+type noOpMetricsEmitter struct{}
+
+func (m noOpMetricsEmitter) SetNodeTemplateResourcesMismatch(driver string, mismatchType metrics.ResourceMismatchType, value uint32) {
+}
 
 type mockTemplateNodeInfoRegistry struct {
 	nodeInfos map[string]*framework.NodeInfo
@@ -564,7 +571,7 @@ func TestFilterOutNodesWithUnreadyDRAResources(t *testing.T) {
 				ClusterSnapshot:          clusterSnapshot,
 				TemplateNodeInfoRegistry: newMockTemplateNodeInfoRegistry(tc.registryNodeInfos),
 			}
-			processor := DraCustomResourcesProcessor{}
+			processor := DraCustomResourcesProcessor{resourcesComparator: comparator.NewNodeResourcesComparator(noOpMetricsEmitter{})}
 			newAllNodes, newReadyNodes := processor.FilterOutNodesWithUnreadyResources(autoscalingCtx, initialAllNodes, initialReadyNodes, draSnapshot, nil)
 
 			readyNodes := make(map[string]bool)
@@ -1115,5 +1122,84 @@ func BenchmarkGetCompleteResourcePools(b *testing.B) {
 
 	for b.Loop() {
 		getCompleteResourcePools(slices)
+	}
+}
+
+type fakeResourceDiscrepancyReporter struct {
+	reportedNodeNames      []string
+	reportedTemplateSlices [][]*resourceapi.ResourceSlice
+	reportedNodeSlices     [][]*resourceapi.ResourceSlice
+}
+
+func (m *fakeResourceDiscrepancyReporter) ReportResourceDiscrepancies(nodeNames []string, templateSlices [][]*resourceapi.ResourceSlice, nodeSlices [][]*resourceapi.ResourceSlice) {
+	m.reportedNodeNames = nodeNames
+	m.reportedTemplateSlices = templateSlices
+	m.reportedNodeSlices = nodeSlices
+}
+
+func TestDraProcessorResourceComparator(t *testing.T) {
+	templateSlices := buildResourceSlices("template", "driver", 1)
+	slicesReady := buildResourceSlices("node", "driver", 1)
+	slicesUnready := buildIncompleteResourceSlices("node", "driver", 1)
+
+	testCases := map[string]struct {
+		nodeSlices             []*resourceapi.ResourceSlice
+		templateSlices         []*resourceapi.ResourceSlice
+		expectedTemplateSlices [][]*resourceapi.ResourceSlice
+		expectedNodeSlices     [][]*resourceapi.ResourceSlice
+		expectReported         bool
+	}{
+		"Ready": {
+			nodeSlices:             slicesReady,
+			templateSlices:         templateSlices,
+			expectReported:         true,
+			expectedTemplateSlices: [][]*resourceapi.ResourceSlice{templateSlices},
+			expectedNodeSlices:     [][]*resourceapi.ResourceSlice{slicesReady},
+		},
+		"Unready": {
+			nodeSlices:     slicesUnready,
+			templateSlices: templateSlices,
+			expectReported: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			node := buildTestNode("node1", true)
+			nodeGroup := "ng1"
+
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
+			provider.AddAutoprovisionedNodeGroup(nodeGroup, 0, 10, 1, "template")
+			provider.AddNode(nodeGroup, node)
+
+			nodeResourceSlices := map[string][]*resourceapi.ResourceSlice{node.Name: tc.nodeSlices}
+			draSnapshot := drasnapshot.NewSnapshot(nil, nodeResourceSlices, nil, nil)
+			clusterSnapshotStore := store.NewBasicSnapshotStore()
+			clusterSnapshot, _, _ := testsnapshot.NewCustomTestSnapshotAndHandle(clusterSnapshotStore)
+			clusterSnapshot.SetClusterState([]*apiv1.Node{}, []*apiv1.Pod{}, draSnapshot, nil)
+
+			autoscalingCtx := &ca_context.AutoscalingContext{
+				CloudProvider:   provider,
+				ClusterSnapshot: clusterSnapshot,
+				TemplateNodeInfoRegistry: newMockTemplateNodeInfoRegistry(map[string]*framework.NodeInfo{
+					nodeGroup: createTemplateNodeInfo("template", tc.templateSlices),
+				}),
+			}
+
+			mockComparator := &fakeResourceDiscrepancyReporter{}
+			processor := DraCustomResourcesProcessor{resourcesComparator: mockComparator}
+
+			processor.FilterOutNodesWithUnreadyResources(autoscalingCtx, []*apiv1.Node{node}, []*apiv1.Node{node}, draSnapshot, nil)
+
+			if tc.expectReported {
+				assert.Equal(t, []string{node.Name}, mockComparator.reportedNodeNames)
+				assert.Equal(t, tc.expectedTemplateSlices, mockComparator.reportedTemplateSlices)
+				assert.Equal(t, tc.expectedNodeSlices, mockComparator.reportedNodeSlices)
+			} else {
+				assert.Empty(t, mockComparator.reportedNodeNames)
+				assert.Empty(t, mockComparator.reportedTemplateSlices)
+				assert.Empty(t, mockComparator.reportedNodeSlices)
+			}
+		})
 	}
 }

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
@@ -1,0 +1,172 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comparator
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"slices"
+	"strings"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/klog/v2"
+)
+
+const (
+	maxLoggedSampleSize          = 5
+	countOfDiscrepanciesEstimate = 10
+)
+
+// NodeComparisonData encapsulates the resource slices for a node and its template.
+type NodeComparisonData struct {
+	NodeName       string
+	TemplateSlices []*resourceapi.ResourceSlice
+	NodeSlices     []*resourceapi.ResourceSlice
+}
+
+// metricsEmitter interface is used to emit gauge metrics for DRA discrepancies.
+type metricsEmitter interface {
+	SetNodeTemplateResourcesMismatch(driver string, mismatchType metrics.ResourceMismatchType, value uint32)
+}
+
+// logger is a function that logs messages, used for testing purposes.
+type logger func(format string, args ...any)
+
+// NodeResourcesComparator detects discrepancies between expected and actual resource topologies.
+type NodeResourcesComparator struct {
+	metrics metricsEmitter
+	logger  logger
+}
+
+// NewNodeResourcesComparator returns a new stateful NodeResourcesComparator.
+func NewNodeResourcesComparator(metric metricsEmitter) *NodeResourcesComparator {
+	return &NodeResourcesComparator{
+		metrics: metric,
+		logger:  klog.Warningf,
+	}
+}
+
+type driverDiscrepancy struct {
+	missing  uint32
+	extra    uint32
+	mismatch uint32
+	unknown  uint32
+}
+
+func (c *NodeResourcesComparator) logSampledDiscrepancies(sampledNodes []string, sampledDeltas [][]resourceDelta) {
+	if len(sampledNodes) == 0 {
+		return
+	}
+
+	nodeReports := make([]string, len(sampledNodes))
+	for i, nodeName := range sampledNodes {
+		deltas := sampledDeltas[i]
+		deltaSummaries := make([]string, len(deltas))
+		for j, delta := range deltas {
+			deltaSummaries[j] = delta.Summary()
+		}
+		nodeReports[i] = fmt.Sprintf("- %s: %s", nodeName, strings.Join(deltaSummaries, ", "))
+	}
+
+	c.logger("DRA Resource Discrepancies detected between node templates and actual nodes:\n%s", strings.Join(nodeReports, "\n"))
+}
+
+func (c *NodeResourcesComparator) emitMetrics(aggregatedDiscrepancies map[string]driverDiscrepancy) {
+	for driver, disc := range aggregatedDiscrepancies {
+		if disc.missing > 0 {
+			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeMissing, disc.missing)
+		}
+		if disc.extra > 0 {
+			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeExtra, disc.extra)
+		}
+		if disc.mismatch > 0 {
+			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeMismatch, disc.mismatch)
+		}
+		if disc.unknown > 0 {
+			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeUnknown, disc.unknown)
+		}
+	}	
+}
+
+
+// ReportResourceDiscrepancies compares DRA resources for a batch of nodes,
+// aggregates discrepancies across all drivers, emits metrics, and logs a summary report.
+func (c *NodeResourcesComparator) ReportResourceDiscrepancies(data []NodeComparisonData) {
+	if len(data) == 0 {
+		return
+	}
+
+	aggregatedDiscrepancies := make(map[string]driverDiscrepancy, countOfDriversEstimate)
+	sampledNodes := make([]string, 0, maxLoggedSampleSize)
+	sampledDeltas := make([][]resourceDelta, 0, maxLoggedSampleSize)
+	deltas := make([]resourceDelta, 0, countOfDiscrepanciesEstimate)
+	discrepantNodesCount := 0
+	for nodeIndex := range data {
+		nodeData := &data[nodeIndex]
+		// No slices to compare, delta is missing
+		if len(nodeData.TemplateSlices) == 0 && len(nodeData.NodeSlices) == 0 {
+			continue
+		}
+
+		deltas = compareDraResources(nodeData.TemplateSlices, nodeData.NodeSlices, deltas)
+		if len(deltas) == 0 {
+			continue
+		}
+
+		for _, delta := range deltas {
+			disc := aggregatedDiscrepancies[delta.Driver]
+			switch delta.Type() {
+			case resourceDeltaTypeMissing:
+				disc.missing++
+			case resourceDeltaTypeExtra:
+				disc.extra++
+			case resourceDeltaTypeMismatch:
+				disc.mismatch++
+			case resourceDeltaTypeUnknown:
+				disc.unknown++
+			}
+			aggregatedDiscrepancies[delta.Driver] = disc
+		}
+
+		discrepantNodesCount++
+		if len(sampledNodes) < maxLoggedSampleSize {
+			sampledNodes = append(sampledNodes, nodeData.NodeName)
+			// Sampled deltas need to be cloned because the deltas slice is reused
+			sampledDeltas = append(sampledDeltas, slices.Clone(deltas))
+		} else {
+			// Only swap if the random index hits our target range
+			// to guarantee fairness of the sampling
+			j := rand.IntN(discrepantNodesCount)
+			if j < maxLoggedSampleSize {
+				sampledNodes[j] = nodeData.NodeName
+				// Sampled deltas need to be cloned because the deltas slice is reused
+				sampledDeltas[j] = slices.Clone(deltas)
+			}
+		}
+
+		// Reset the buffer for the next iteration
+		deltas = deltas[:0]
+	}
+
+	if len(aggregatedDiscrepancies) == 0 {
+		return
+	}
+
+	c.emitMetrics(aggregatedDiscrepancies)
+	c.logSampledDiscrepancies(sampledNodes, sampledDeltas)
+}

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
@@ -17,6 +17,8 @@ limitations under the License.
 package comparator
 
 import (
+	"slices"
+
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/klog/v2"
@@ -35,7 +37,12 @@ type metricsEmitter interface {
 
 // NodeResourcesComparator detects discrepancies between expected and actual resource topologies.
 // For more details on the algorithm - see resourcePoolComparator.CompareResourcePools.
+// Component assumes that it's working on the evolving set of nodes and it's not suitable
+// to use it interchangeably for completely disjoint sets of nodes.
 type NodeResourcesComparator struct {
+	// List of drivers which were seen in the latest evaluation loop.
+	// and had at least a single reported data point.
+	lastSeenDrivers []string
 	// Reusable map to store intermediate results while comparing nodes
 	discrepanciesPerDriver map[string]driverDiscrepancy
 	// Reusable buffer to store intermediate per node resource deltas
@@ -80,26 +87,19 @@ type driverDiscrepancy struct {
 // emitMetrics emits the aggregated discrepancies to the metrics emitter.
 func (c *NodeResourcesComparator) emitMetrics() {
 	for driver, disc := range c.discrepanciesPerDriver {
-		if disc.missing > 0 {
-			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeMissing, disc.missing)
-		}
-		if disc.extra > 0 {
-			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeExtra, disc.extra)
-		}
-		if disc.mismatch > 0 {
-			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeMismatch, disc.mismatch)
-		}
-		if disc.unknown > 0 {
-			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeUnknown, disc.unknown)
-		}
+		c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeMissing, disc.missing)
+		c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeExtra, disc.extra)
+		c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeMismatch, disc.mismatch)
+		c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeUnknown, disc.unknown)
 	}
 }
 
 // reset resets the comparator to its initial state making it ready for the next batch of nodes.
 func (c *NodeResourcesComparator) reset() {
 	c.sampler.Reset()
+	c.resetDiscrepanciesPerDriver()
+	c.lastSeenDrivers = c.lastSeenDrivers[:0]
 	c.deltas = c.deltas[:0]
-	clear(c.discrepanciesPerDriver)
 }
 
 // ReportResourceDiscrepancies compares DRA resources for a batch of nodes,
@@ -113,10 +113,6 @@ func (c *NodeResourcesComparator) ReportResourceDiscrepancies(
 	nodeSlices [][]*resourceapi.ResourceSlice,
 ) {
 	c.reset()
-
-	if len(nodeNames) == 0 {
-		return
-	}
 
 	if len(nodeNames) != len(templateSlices) || len(nodeNames) != len(nodeSlices) {
 		klog.Errorf("NodeResourcesComparator: nodeNames, templateSlices, and nodeSlices must have the same length")
@@ -135,14 +131,11 @@ func (c *NodeResourcesComparator) ReportResourceDiscrepancies(
 		}
 
 		c.updateDiscrepanciesPerDriver()
+		c.updateSeenDrivers()
 		c.sampler.Sample(nodeNames[nodeIndex], c.deltas)
 
 		// Reset the buffer for the next iteration
 		c.deltas = c.deltas[:0]
-	}
-
-	if len(c.discrepanciesPerDriver) == 0 {
-		return
 	}
 
 	c.emitMetrics()
@@ -165,5 +158,28 @@ func (c *NodeResourcesComparator) updateDiscrepanciesPerDriver() {
 			disc.unknown++
 		}
 		c.discrepanciesPerDriver[delta.Driver] = disc
+	}
+}
+
+// resetDiscrepanciesPerDriver resets the discrepanciesPerDriver map
+// while also recreates entries for drivers which were found during
+// the latest evaluation.
+func (c *NodeResourcesComparator) resetDiscrepanciesPerDriver() {
+	clear(c.discrepanciesPerDriver)
+	for _, driver := range c.lastSeenDrivers {
+		c.discrepanciesPerDriver[driver] = driverDiscrepancy{}
+	}
+}
+
+// updateSeenDrivers updates the list of drivers which were seen during the
+// latest evaluation loop.
+func (c *NodeResourcesComparator) updateSeenDrivers() {
+	for i := range c.deltas {
+		driver := c.deltas[i].Driver
+		if slices.Contains(c.lastSeenDrivers, driver) {
+			continue
+		}
+
+		c.lastSeenDrivers = append(c.lastSeenDrivers, driver)
 	}
 }

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
@@ -17,50 +17,59 @@ limitations under the License.
 package comparator
 
 import (
-	"fmt"
-	"math/rand/v2"
-	"slices"
-	"strings"
-
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/klog/v2"
 )
 
 const (
-	maxLoggedSampleSize          = 5
+	// countOfDiscrepanciesEstimate is an estimate of the number of discrepancies for
+	// a single report cycle
 	countOfDiscrepanciesEstimate = 10
 )
-
-// NodeComparisonData encapsulates the resource slices for a node and its template.
-type NodeComparisonData struct {
-	NodeName       string
-	TemplateSlices []*resourceapi.ResourceSlice
-	NodeSlices     []*resourceapi.ResourceSlice
-}
 
 // metricsEmitter interface is used to emit gauge metrics for DRA discrepancies.
 type metricsEmitter interface {
 	SetNodeTemplateResourcesMismatch(driver string, mismatchType metrics.ResourceMismatchType, value uint32)
 }
 
-// logger is a function that logs messages, used for testing purposes.
-type logger func(format string, args ...any)
-
 // NodeResourcesComparator detects discrepancies between expected and actual resource topologies.
+// For more details on the algorithm - see resourcePoolComparator.CompareResourcePools.
 type NodeResourcesComparator struct {
-	metrics metricsEmitter
-	logger  logger
+	// Reusable map to store intermediate results while comparing nodes
+	discrepanciesPerDriver map[string]driverDiscrepancy
+	// Reusable buffer to store intermediate per node resource deltas
+	// while comparing nodes
+	deltas []resourceDelta
+
+	metrics    metricsEmitter
+	comparator resourcePoolComparator
+	sampler    loggingSampler
 }
 
 // NewNodeResourcesComparator returns a new stateful NodeResourcesComparator.
 func NewNodeResourcesComparator(metric metricsEmitter) *NodeResourcesComparator {
 	return &NodeResourcesComparator{
-		metrics: metric,
-		logger:  klog.Warningf,
+		metrics:                metric,
+		comparator:             newResourcePoolComparator(),
+		sampler:                newLoggingSampler(),
+		deltas:                 make([]resourceDelta, 0, countOfDiscrepanciesEstimate),
+		discrepanciesPerDriver: make(map[string]driverDiscrepancy, countOfDriversEstimate),
 	}
 }
 
+// newNodeResourcesComparatorWithLogger returns a new NodeResourcesComparator with a custom logger.
+func newNodeResourcesComparatorWithLogger(metric metricsEmitter, logger logger) *NodeResourcesComparator {
+	return &NodeResourcesComparator{
+		metrics:                metric,
+		comparator:             newResourcePoolComparator(),
+		sampler:                newLoggingSamplerWithLogger(logger),
+		deltas:                 make([]resourceDelta, 0, countOfDiscrepanciesEstimate),
+		discrepanciesPerDriver: make(map[string]driverDiscrepancy, countOfDriversEstimate),
+	}
+}
+
+// driverDiscrepancy holds aggregate discrepancies for a single driver.
 type driverDiscrepancy struct {
 	missing  uint32
 	extra    uint32
@@ -68,26 +77,9 @@ type driverDiscrepancy struct {
 	unknown  uint32
 }
 
-func (c *NodeResourcesComparator) logSampledDiscrepancies(sampledNodes []string, sampledDeltas [][]resourceDelta) {
-	if len(sampledNodes) == 0 {
-		return
-	}
-
-	nodeReports := make([]string, len(sampledNodes))
-	for i, nodeName := range sampledNodes {
-		deltas := sampledDeltas[i]
-		deltaSummaries := make([]string, len(deltas))
-		for j, delta := range deltas {
-			deltaSummaries[j] = delta.Summary()
-		}
-		nodeReports[i] = fmt.Sprintf("- %s: %s", nodeName, strings.Join(deltaSummaries, ", "))
-	}
-
-	c.logger("DRA Resource Discrepancies detected between node templates and actual nodes:\n%s", strings.Join(nodeReports, "\n"))
-}
-
-func (c *NodeResourcesComparator) emitMetrics(aggregatedDiscrepancies map[string]driverDiscrepancy) {
-	for driver, disc := range aggregatedDiscrepancies {
+// emitMetrics emits the aggregated discrepancies to the metrics emitter.
+func (c *NodeResourcesComparator) emitMetrics() {
+	for driver, disc := range c.discrepanciesPerDriver {
 		if disc.missing > 0 {
 			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeMissing, disc.missing)
 		}
@@ -100,73 +92,78 @@ func (c *NodeResourcesComparator) emitMetrics(aggregatedDiscrepancies map[string
 		if disc.unknown > 0 {
 			c.metrics.SetNodeTemplateResourcesMismatch(driver, metrics.ResourceMismatchTypeUnknown, disc.unknown)
 		}
-	}	
+	}
 }
 
+// reset resets the comparator to its initial state making it ready for the next batch of nodes.
+func (c *NodeResourcesComparator) reset() {
+	c.sampler.Reset()
+	c.deltas = c.deltas[:0]
+	clear(c.discrepanciesPerDriver)
+}
 
 // ReportResourceDiscrepancies compares DRA resources for a batch of nodes,
 // aggregates discrepancies across all drivers, emits metrics, and logs a summary report.
-func (c *NodeResourcesComparator) ReportResourceDiscrepancies(data []NodeComparisonData) {
-	if len(data) == 0 {
+//
+// Function assumes that nodeNames, templateSlices, and nodeSlices have the same length,
+// and aborts execution if they don't.
+func (c *NodeResourcesComparator) ReportResourceDiscrepancies(
+	nodeNames []string,
+	templateSlices [][]*resourceapi.ResourceSlice,
+	nodeSlices [][]*resourceapi.ResourceSlice,
+) {
+	c.reset()
+
+	if len(nodeNames) == 0 {
 		return
 	}
 
-	aggregatedDiscrepancies := make(map[string]driverDiscrepancy, countOfDriversEstimate)
-	sampledNodes := make([]string, 0, maxLoggedSampleSize)
-	sampledDeltas := make([][]resourceDelta, 0, maxLoggedSampleSize)
-	deltas := make([]resourceDelta, 0, countOfDiscrepanciesEstimate)
-	discrepantNodesCount := 0
-	for nodeIndex := range data {
-		nodeData := &data[nodeIndex]
+	if len(nodeNames) != len(templateSlices) || len(nodeNames) != len(nodeSlices) {
+		klog.Errorf("NodeResourcesComparator: nodeNames, templateSlices, and nodeSlices must have the same length")
+		return
+	}
+
+	for nodeIndex := range nodeNames {
 		// No slices to compare, delta is missing
-		if len(nodeData.TemplateSlices) == 0 && len(nodeData.NodeSlices) == 0 {
+		if len(templateSlices[nodeIndex]) == 0 && len(nodeSlices[nodeIndex]) == 0 {
 			continue
 		}
 
-		deltas = compareDraResources(nodeData.TemplateSlices, nodeData.NodeSlices, deltas)
-		if len(deltas) == 0 {
+		c.deltas = c.comparator.CompareResourcePools(templateSlices[nodeIndex], nodeSlices[nodeIndex], c.deltas)
+		if len(c.deltas) == 0 {
 			continue
 		}
 
-		for _, delta := range deltas {
-			disc := aggregatedDiscrepancies[delta.Driver]
-			switch delta.Type() {
-			case resourceDeltaTypeMissing:
-				disc.missing++
-			case resourceDeltaTypeExtra:
-				disc.extra++
-			case resourceDeltaTypeMismatch:
-				disc.mismatch++
-			case resourceDeltaTypeUnknown:
-				disc.unknown++
-			}
-			aggregatedDiscrepancies[delta.Driver] = disc
-		}
-
-		discrepantNodesCount++
-		if len(sampledNodes) < maxLoggedSampleSize {
-			sampledNodes = append(sampledNodes, nodeData.NodeName)
-			// Sampled deltas need to be cloned because the deltas slice is reused
-			sampledDeltas = append(sampledDeltas, slices.Clone(deltas))
-		} else {
-			// Only swap if the random index hits our target range
-			// to guarantee fairness of the sampling
-			j := rand.IntN(discrepantNodesCount)
-			if j < maxLoggedSampleSize {
-				sampledNodes[j] = nodeData.NodeName
-				// Sampled deltas need to be cloned because the deltas slice is reused
-				sampledDeltas[j] = slices.Clone(deltas)
-			}
-		}
+		c.updateDiscrepanciesPerDriver()
+		c.sampler.Sample(nodeNames[nodeIndex], c.deltas)
 
 		// Reset the buffer for the next iteration
-		deltas = deltas[:0]
+		c.deltas = c.deltas[:0]
 	}
 
-	if len(aggregatedDiscrepancies) == 0 {
+	if len(c.discrepanciesPerDriver) == 0 {
 		return
 	}
 
-	c.emitMetrics(aggregatedDiscrepancies)
-	c.logSampledDiscrepancies(sampledNodes, sampledDeltas)
+	c.emitMetrics()
+	c.sampler.LogSampled()
+}
+
+// updateDiscrepanciesPerDriver iterates through comparator found deltas and increases
+// disrepancy counters accordingly to deltas found during the last comparison.
+func (c *NodeResourcesComparator) updateDiscrepanciesPerDriver() {
+	for _, delta := range c.deltas {
+		disc := c.discrepanciesPerDriver[delta.Driver]
+		switch delta.Type() {
+		case resourceDeltaTypeMissing:
+			disc.missing++
+		case resourceDeltaTypeExtra:
+			disc.extra++
+		case resourceDeltaTypeMismatch:
+			disc.mismatch++
+		case resourceDeltaTypeUnknown:
+			disc.unknown++
+		}
+		c.discrepanciesPerDriver[delta.Driver] = disc
+	}
 }

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/node_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/node_test.go
@@ -39,6 +39,10 @@ func (f *fakeMetricsEmitter) SetNodeTemplateResourcesMismatch(driver string, mis
 	f.metrics[key] = value
 }
 
+func (f *fakeMetricsEmitter) Reset() {
+	clear(f.metrics)
+}
+
 // nodeComparisonData is used to simulate node resource topology for testing,
 // has no difference from passing raw slices, but drastically improves readability
 // by grouping related data together.
@@ -86,7 +90,10 @@ func TestEmitMetrics(t *testing.T) {
 				"driver-1": {missing: 1},
 			},
 			wantMetrics: map[string]uint32{
-				"driver-1/missing": 1,
+				"driver-1/missing":  1,
+				"driver-1/extra":    0,
+				"driver-1/mismatch": 0,
+				"driver-1/unknown":  0,
 			},
 		},
 		"ExtraDiscrepancy": {
@@ -94,7 +101,10 @@ func TestEmitMetrics(t *testing.T) {
 				"driver-1": {extra: 2},
 			},
 			wantMetrics: map[string]uint32{
-				"driver-1/extra": 2,
+				"driver-1/extra":    2,
+				"driver-1/missing":  0,
+				"driver-1/mismatch": 0,
+				"driver-1/unknown":  0,
 			},
 		},
 		"MismatchDiscrepancy": {
@@ -103,6 +113,9 @@ func TestEmitMetrics(t *testing.T) {
 			},
 			wantMetrics: map[string]uint32{
 				"driver-1/mismatch": 3,
+				"driver-1/missing":  0,
+				"driver-1/extra":    0,
+				"driver-1/unknown":  0,
 			},
 		},
 		"UnknownDiscrepancy": {
@@ -110,7 +123,10 @@ func TestEmitMetrics(t *testing.T) {
 				"driver-1": {unknown: 4},
 			},
 			wantMetrics: map[string]uint32{
-				"driver-1/unknown": 4,
+				"driver-1/unknown":  4,
+				"driver-1/missing":  0,
+				"driver-1/extra":    0,
+				"driver-1/mismatch": 0,
 			},
 		},
 		"AllMetricsCombined": {
@@ -131,6 +147,12 @@ func TestEmitMetrics(t *testing.T) {
 			},
 			wantMetrics: map[string]uint32{
 				"driver-1/missing":  1,
+				"driver-1/unknown":  0,
+				"driver-1/extra":    0,
+				"driver-1/mismatch": 0,
+
+				"driver-2/missing":  0,
+				"driver-2/unknown":  0,
 				"driver-2/extra":    5,
 				"driver-2/mismatch": 2,
 			},
@@ -139,7 +161,12 @@ func TestEmitMetrics(t *testing.T) {
 			aggregatedDiscrepancies: map[string]driverDiscrepancy{
 				"driver-1": {missing: 0, extra: 0},
 			},
-			wantMetrics: nil,
+			wantMetrics: map[string]uint32{
+				"driver-1/missing":  0,
+				"driver-1/extra":    0,
+				"driver-1/mismatch": 0,
+				"driver-1/unknown":  0,
+			},
 		},
 	}
 
@@ -199,7 +226,10 @@ func TestReportResourceDiscrepancies(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]uint32{
-				"driver/missing": 1,
+				"driver/missing":  1,
+				"driver/extra":    0,
+				"driver/mismatch": 0,
+				"driver/unknown":  0,
 			},
 		},
 		"ExtraResourcePool": {
@@ -214,7 +244,10 @@ func TestReportResourceDiscrepancies(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]uint32{
-				"driver/extra": 1,
+				"driver/extra":    1,
+				"driver/missing":  0,
+				"driver/mismatch": 0,
+				"driver/unknown":  0,
 			},
 		},
 		"FuzzyMismatch_Attributes": {
@@ -227,6 +260,9 @@ func TestReportResourceDiscrepancies(t *testing.T) {
 			},
 			wantMetrics: map[string]uint32{
 				"driver/mismatch": 1,
+				"driver/missing":  0,
+				"driver/extra":    0,
+				"driver/unknown":  0,
 			},
 		},
 		"FuzzyMismatch_DeviceCount": {
@@ -239,20 +275,30 @@ func TestReportResourceDiscrepancies(t *testing.T) {
 			},
 			wantMetrics: map[string]uint32{
 				"driver/mismatch": 1,
+				"driver/missing":  0,
+				"driver/extra":    0,
+				"driver/unknown":  0,
 			},
 		},
 		"IgnoredDriver": {
 			data: []nodeComparisonData{
 				{
-					NodeName:       "node-1",
-					TemplateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("known-driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+					NodeName: "node-1",
+					TemplateSlices: []*resourceapi.ResourceSlice{
+						makeSingleResourceSlice("known-driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+					},
 					NodeSlices: []*resourceapi.ResourceSlice{
 						makeSingleResourceSlice("known-driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA}),
-						makeSingleResourceSlice("rogue-driver", "pool", poolDevices{deviceCount: 5, shape: deviceShapeB}),
+						makeSingleResourceSlice("node-only-driver", "pool", poolDevices{deviceCount: 5, shape: deviceShapeB}),
 					},
 				},
 			},
-			wantMetrics: nil,
+			wantMetrics: map[string]uint32{
+				"node-only-driver/missing":  0,
+				"node-only-driver/extra":    1,
+				"node-only-driver/mismatch": 0,
+				"node-only-driver/unknown":  0,
+			},
 		},
 		"MultiNodeMultiDriver": {
 			data: []nodeComparisonData{
@@ -284,7 +330,13 @@ func TestReportResourceDiscrepancies(t *testing.T) {
 			wantMetrics: map[string]uint32{
 				"driver-A/missing":  1,
 				"driver-A/mismatch": 1,
+				"driver-A/extra":    0,
+				"driver-A/unknown":  0,
+
+				"driver-B/missing":  0,
 				"driver-B/extra":    1,
+				"driver-B/mismatch": 0,
+				"driver-B/unknown":  0,
 			},
 		},
 		"MultipleMissing": {
@@ -300,7 +352,10 @@ func TestReportResourceDiscrepancies(t *testing.T) {
 				},
 			},
 			wantMetrics: map[string]uint32{
-				"driver/missing": 3,
+				"driver/missing":  3,
+				"driver/extra":    0,
+				"driver/mismatch": 0,
+				"driver/unknown":  0,
 			},
 		},
 	}
@@ -314,6 +369,79 @@ func TestReportResourceDiscrepancies(t *testing.T) {
 				t.Errorf("ReportResourceDiscrepancies() metrics diff (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestMissingNodesGaugesAreReset(t *testing.T) {
+	nodeNames := []string{"node-1"}
+
+	templateSlices := [][]*resourceapi.ResourceSlice{
+		{
+			makeSingleResourceSlice("driver1", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+			makeSingleResourceSlice("driver2", "pool", poolDevices{deviceCount: 4, shape: deviceShapeA}),
+			makeSingleResourceSlice("driver3", "pool", poolDevices{deviceCount: 1, shape: deviceShapeABC}),
+		},
+	}
+
+	nodeSlices := [][]*resourceapi.ResourceSlice{
+		{
+			makeSingleResourceSlice("driver1", "pool1", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+			makeSingleResourceSlice("driver2", "pool", poolDevices{deviceCount: 2, shape: deviceShapeA}),
+			makeSingleResourceSlice("driver1", "pool2", poolDevices{deviceCount: 1, shape: deviceShapeABC}),
+		},
+	}
+
+	wantMetricsBeforeScaleDown := map[string]uint32{
+		"driver1/mismatch": 1,
+		"driver1/unknown":  0,
+		"driver1/extra":    1,
+		"driver1/missing":  0,
+
+		"driver2/mismatch": 1,
+		"driver2/unknown":  0,
+		"driver2/extra":    0,
+		"driver2/missing":  0,
+
+		"driver3/mismatch": 0,
+		"driver3/unknown":  0,
+		"driver3/extra":    0,
+		"driver3/missing":  1,
+	}
+
+	wantMetricsAfterScaleDown := map[string]uint32{
+		"driver1/mismatch": 0,
+		"driver1/unknown":  0,
+		"driver1/extra":    0,
+		"driver1/missing":  0,
+
+		"driver2/mismatch": 0,
+		"driver2/unknown":  0,
+		"driver2/extra":    0,
+		"driver2/missing":  0,
+
+		"driver3/mismatch": 0,
+		"driver3/unknown":  0,
+		"driver3/extra":    0,
+		"driver3/missing":  0,
+	}
+
+	fake := &fakeMetricsEmitter{}
+	c := NewNodeResourcesComparator(fake)
+	c.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
+	if diff := cmp.Diff(wantMetricsBeforeScaleDown, fake.metrics); diff != "" {
+		t.Errorf("ReportResourceDiscrepancies() metrics diff (-want +got):\n%s", diff)
+	}
+
+	fake.Reset()
+	c.ReportResourceDiscrepancies([]string{}, [][]*resourceapi.ResourceSlice{}, [][]*resourceapi.ResourceSlice{})
+	if diff := cmp.Diff(wantMetricsAfterScaleDown, fake.metrics); diff != "" {
+		t.Errorf("ReportResourceDiscrepancies() metrics diff (-want +got):\n%s", diff)
+	}
+
+	fake.Reset()
+	c.ReportResourceDiscrepancies([]string{}, [][]*resourceapi.ResourceSlice{}, [][]*resourceapi.ResourceSlice{})
+	if len(fake.metrics) != 0 {
+		t.Errorf("Expected no metrics after second reset, while reported: %v", fake.metrics)
 	}
 }
 

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/node_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/node_test.go
@@ -1,0 +1,354 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comparator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	resourceapi "k8s.io/api/resource/v1"
+	v1 "k8s.io/api/resource/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+)
+
+func TestLogSampledDiscrepancies(t *testing.T) {
+	tests := map[string]struct {
+		sampledNodes  []string
+		sampledDeltas [][]resourceDelta
+		want          string
+	}{
+		"Empty": {
+			sampledNodes:  []string{},
+			sampledDeltas: [][]resourceDelta{},
+			want:          "",
+		},
+		"SingleNodeSingleDelta": {
+			sampledNodes: []string{"node-1"},
+			sampledDeltas: [][]resourceDelta{
+				{
+					{
+						Driver:               "test-driver",
+						TemplateResourcePool: "pool-1",
+						DeviceCountDelta:     1,
+						TemplateSignatureMap: signatureMap{v1.QualifiedName("attr1"): {}},
+					},
+				},
+			},
+			want: "DRA Resource Discrepancies detected between node templates and actual nodes:\n- node-1: MissingResource{Driver=\"test-driver\", ResourcePool=\"pool-1\", DeviceCount=\"1\", AttributeSignature=\"attr1\"}",
+		},
+		"MultipleNodesMultipleDeltas": {
+			sampledNodes: []string{"node-1", "node-2"},
+			sampledDeltas: [][]resourceDelta{
+				{
+					{
+						Driver:           "test-driver",
+						NodeResourcePool: "pool-1",
+						DeviceCountDelta: -1,
+						NodeSignatureMap: signatureMap{v1.QualifiedName("attr2"): {}},
+					},
+				},
+				{
+					{
+						Driver:               "test-driver",
+						TemplateResourcePool: "pool-1",
+						NodeResourcePool:     "pool-2",
+						DeviceCountDelta:     0,
+						TemplateSignatureMap: signatureMap{v1.QualifiedName("attr1"): {}},
+						NodeSignatureMap:     signatureMap{v1.QualifiedName("attr2"): {}},
+					},
+				},
+			},
+			want: "DRA Resource Discrepancies detected between node templates and actual nodes:\n- node-1: ExtraResource{Driver=\"test-driver\", ResourcePool=\"pool-1\", DeviceCount=\"1\", AttributeSignature=\"attr2\"}\n- node-2: MismatchResource{Driver=\"test-driver\", TemplatePool=\"pool-1\", NodePool=\"pool-2\", DeviceCountDelta=\"0\", MissingAttributes=\"attr1\", ExtraAttributes=\"attr2\"}",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got string
+			c := &NodeResourcesComparator{
+				logger: func(format string, args ...any) {
+					got = fmt.Sprintf(format, args...)
+				},
+			}
+
+			c.logSampledDiscrepancies(tc.sampledNodes, tc.sampledDeltas)
+
+			if got != tc.want {
+				t.Errorf("logSampledDiscrepancies() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+
+type fakeMetricsEmitter struct {
+	metrics map[string]uint32
+}
+
+func (f *fakeMetricsEmitter) SetNodeTemplateResourcesMismatch(driver string, mismatchType metrics.ResourceMismatchType, value uint32) {
+	if f.metrics == nil {
+		f.metrics = make(map[string]uint32)
+	}
+	key := fmt.Sprintf("%s/%s", driver, mismatchType)
+	f.metrics[key] = value
+}
+
+func TestEmitMetrics(t *testing.T) {
+	tests := map[string]struct {
+		aggregatedDiscrepancies map[string]driverDiscrepancy
+		wantMetrics             map[string]uint32
+	}{
+		"Empty": {
+			aggregatedDiscrepancies: map[string]driverDiscrepancy{},
+			wantMetrics:             nil,
+		},
+		"MissingDiscrepancy": {
+			aggregatedDiscrepancies: map[string]driverDiscrepancy{
+				"driver-1": {missing: 1},
+			},
+			wantMetrics: map[string]uint32{
+				"driver-1/missing": 1,
+			},
+		},
+		"ExtraDiscrepancy": {
+			aggregatedDiscrepancies: map[string]driverDiscrepancy{
+				"driver-1": {extra: 2},
+			},
+			wantMetrics: map[string]uint32{
+				"driver-1/extra": 2,
+			},
+		},
+		"MismatchDiscrepancy": {
+			aggregatedDiscrepancies: map[string]driverDiscrepancy{
+				"driver-1": {mismatch: 3},
+			},
+			wantMetrics: map[string]uint32{
+				"driver-1/mismatch": 3,
+			},
+		},
+		"UnknownDiscrepancy": {
+			aggregatedDiscrepancies: map[string]driverDiscrepancy{
+				"driver-1": {unknown: 4},
+			},
+			wantMetrics: map[string]uint32{
+				"driver-1/unknown": 4,
+			},
+		},
+		"AllMetricsCombined": {
+			aggregatedDiscrepancies: map[string]driverDiscrepancy{
+				"driver-1": {missing: 1, extra: 2, mismatch: 3, unknown: 4},
+			},
+			wantMetrics: map[string]uint32{
+				"driver-1/missing":  1,
+				"driver-1/extra":    2,
+				"driver-1/mismatch": 3,
+				"driver-1/unknown":  4,
+			},
+		},
+		"MultipleDriversMixedMetrics": {
+			aggregatedDiscrepancies: map[string]driverDiscrepancy{
+				"driver-1": {missing: 1},
+				"driver-2": {extra: 5, mismatch: 2},
+			},
+			wantMetrics: map[string]uint32{
+				"driver-1/missing":  1,
+				"driver-2/extra":    5,
+				"driver-2/mismatch": 2,
+			},
+		},
+		"ZeroValueMetrics": {
+			aggregatedDiscrepancies: map[string]driverDiscrepancy{
+				"driver-1": {missing: 0, extra: 0},
+			},
+			wantMetrics: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fake := &fakeMetricsEmitter{}
+			c := &NodeResourcesComparator{metrics: fake}
+			c.emitMetrics(tc.aggregatedDiscrepancies)
+
+			if diff := cmp.Diff(tc.wantMetrics, fake.metrics); diff != "" {
+				t.Errorf("emitMetrics() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type noOpMetricsEmitter struct{}
+
+func (n *noOpMetricsEmitter) SetNodeTemplateResourcesMismatch(driver string, mismatchType metrics.ResourceMismatchType, value uint32) {}
+
+
+func BenchmarkReportResourceDiscrepancies_1Node_0Discrepancies(b *testing.B) {
+	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
+	comparator.logger = func(format string, args ...any) {}
+
+	data := []NodeComparisonData{
+		{
+			NodeName:       "node-1",
+			TemplateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+			NodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+		},
+	}
+
+	for b.Loop() {
+		comparator.ReportResourceDiscrepancies(data)
+	}
+}
+
+func BenchmarkReportResourceDiscrepancies_1Node_NoDRA(b *testing.B) {
+	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
+	comparator.logger = func(format string, args ...any) {}
+
+	data := []NodeComparisonData{
+		{
+			NodeName:       "node-1",
+			TemplateSlices: nil,
+			NodeSlices:     nil,
+		},
+	}
+
+	for b.Loop() {
+		comparator.ReportResourceDiscrepancies(data)
+	}
+}
+
+func BenchmarkReportResourceDiscrepancies_1Node_10Discrepancies(b *testing.B) {
+	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
+	comparator.logger = func(format string, args ...any) {}
+
+	templateSlices := make([]*resourceapi.ResourceSlice, 10)
+	for i := 0; i < 10; i++ {
+		templateSlices[i] = makeSingleResourceSlice("driver", fmt.Sprintf("pool-%d", i), poolDevices{deviceCount: 1, shape: deviceShapeA})
+	}
+	data := []NodeComparisonData{
+		{
+			NodeName:       "node-1",
+			TemplateSlices: templateSlices,
+			NodeSlices:     nil,
+		},
+	}
+
+	for b.Loop() {
+		comparator.ReportResourceDiscrepancies(data)
+	}
+}
+
+func BenchmarkReportResourceDiscrepancies_10Nodes_10DiscrepanciesEach(b *testing.B) {
+	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
+	comparator.logger = func(format string, args ...any) {}
+
+	data := make([]NodeComparisonData, 10)
+	for n := 0; n < 10; n++ {
+		templateSlices := make([]*resourceapi.ResourceSlice, 10)
+		for i := 0; i < 10; i++ {
+			templateSlices[i] = makeSingleResourceSlice("driver", fmt.Sprintf("pool-%d", i), poolDevices{deviceCount: 1, shape: deviceShapeA})
+		}
+		data[n] = NodeComparisonData{
+			NodeName:       fmt.Sprintf("node-%d", n),
+			TemplateSlices: templateSlices,
+			NodeSlices:     nil,
+		}
+	}
+
+	for b.Loop() {
+		comparator.ReportResourceDiscrepancies(data)
+	}
+}
+
+func BenchmarkReportResourceDiscrepancies_10Nodes_NoDRA(b *testing.B) {
+	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
+	comparator.logger = func(format string, args ...any) {}
+
+	data := make([]NodeComparisonData, 10)
+	for n := 0; n < 10; n++ {
+		data[n] = NodeComparisonData{
+			NodeName:       fmt.Sprintf("node-%d", n),
+			TemplateSlices: nil,
+			NodeSlices:     nil,
+		}
+	}
+
+	for b.Loop() {
+		comparator.ReportResourceDiscrepancies(data)
+	}
+}
+
+func BenchmarkReportResourceDiscrepancies_10Nodes_0Discrepancies(b *testing.B) {
+	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
+	comparator.logger = func(format string, args ...any) {}
+
+	data := make([]NodeComparisonData, 10)
+	for n := 0; n < 10; n++ {
+		slice := makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})
+		data[n] = NodeComparisonData{
+			NodeName:       fmt.Sprintf("node-%d", n),
+			TemplateSlices: []*resourceapi.ResourceSlice{slice},
+			NodeSlices:     []*resourceapi.ResourceSlice{slice},
+		}
+	}
+
+	for b.Loop() {
+		comparator.ReportResourceDiscrepancies(data)
+	}
+}
+func BenchmarkReportResourceDiscrepancies_1Node_10Drivers_10Discrepancies(b *testing.B) {
+	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
+	comparator.logger = func(format string, args ...any) {}
+
+	templateSlices := make([]*resourceapi.ResourceSlice, 10)
+	for i := 0; i < 10; i++ {
+		templateSlices[i] = makeSingleResourceSlice(fmt.Sprintf("driver-%d", i), "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})
+	}
+	data := []NodeComparisonData{
+		{
+			NodeName:       "node-1",
+			TemplateSlices: templateSlices,
+			NodeSlices:     nil,
+		},
+	}
+
+	for b.Loop() {
+		comparator.ReportResourceDiscrepancies(data)
+	}
+}
+
+func BenchmarkReportResourceDiscrepancies_10Nodes_10Drivers_10DiscrepanciesEach(b *testing.B) {
+	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
+	comparator.logger = func(format string, args ...any) {}
+
+	data := make([]NodeComparisonData, 10)
+	for n := 0; n < 10; n++ {
+		templateSlices := make([]*resourceapi.ResourceSlice, 10)
+		for i := 0; i < 10; i++ {
+			templateSlices[i] = makeSingleResourceSlice(fmt.Sprintf("driver-%d", i), "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})
+		}
+		data[n] = NodeComparisonData{
+			NodeName:       fmt.Sprintf("node-%d", n),
+			TemplateSlices: templateSlices,
+			NodeSlices:     nil,
+		}
+	}
+
+	for b.Loop() {
+		comparator.ReportResourceDiscrepancies(data)
+	}
+}

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/node_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/node_test.go
@@ -22,79 +22,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	resourceapi "k8s.io/api/resource/v1"
-	v1 "k8s.io/api/resource/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 )
 
-func TestLogSampledDiscrepancies(t *testing.T) {
-	tests := map[string]struct {
-		sampledNodes  []string
-		sampledDeltas [][]resourceDelta
-		want          string
-	}{
-		"Empty": {
-			sampledNodes:  []string{},
-			sampledDeltas: [][]resourceDelta{},
-			want:          "",
-		},
-		"SingleNodeSingleDelta": {
-			sampledNodes: []string{"node-1"},
-			sampledDeltas: [][]resourceDelta{
-				{
-					{
-						Driver:               "test-driver",
-						TemplateResourcePool: "pool-1",
-						DeviceCountDelta:     1,
-						TemplateSignatureMap: signatureMap{v1.QualifiedName("attr1"): {}},
-					},
-				},
-			},
-			want: "DRA Resource Discrepancies detected between node templates and actual nodes:\n- node-1: MissingResource{Driver=\"test-driver\", ResourcePool=\"pool-1\", DeviceCount=\"1\", AttributeSignature=\"attr1\"}",
-		},
-		"MultipleNodesMultipleDeltas": {
-			sampledNodes: []string{"node-1", "node-2"},
-			sampledDeltas: [][]resourceDelta{
-				{
-					{
-						Driver:           "test-driver",
-						NodeResourcePool: "pool-1",
-						DeviceCountDelta: -1,
-						NodeSignatureMap: signatureMap{v1.QualifiedName("attr2"): {}},
-					},
-				},
-				{
-					{
-						Driver:               "test-driver",
-						TemplateResourcePool: "pool-1",
-						NodeResourcePool:     "pool-2",
-						DeviceCountDelta:     0,
-						TemplateSignatureMap: signatureMap{v1.QualifiedName("attr1"): {}},
-						NodeSignatureMap:     signatureMap{v1.QualifiedName("attr2"): {}},
-					},
-				},
-			},
-			want: "DRA Resource Discrepancies detected between node templates and actual nodes:\n- node-1: ExtraResource{Driver=\"test-driver\", ResourcePool=\"pool-1\", DeviceCount=\"1\", AttributeSignature=\"attr2\"}\n- node-2: MismatchResource{Driver=\"test-driver\", TemplatePool=\"pool-1\", NodePool=\"pool-2\", DeviceCountDelta=\"0\", MissingAttributes=\"attr1\", ExtraAttributes=\"attr2\"}",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			var got string
-			c := &NodeResourcesComparator{
-				logger: func(format string, args ...any) {
-					got = fmt.Sprintf(format, args...)
-				},
-			}
-
-			c.logSampledDiscrepancies(tc.sampledNodes, tc.sampledDeltas)
-
-			if got != tc.want {
-				t.Errorf("logSampledDiscrepancies() = %q, want %q", got, tc.want)
-			}
-		})
-	}
-}
-
+var noOpLogger logger = func(format string, args ...any) {}
 
 type fakeMetricsEmitter struct {
 	metrics map[string]uint32
@@ -106,6 +37,39 @@ func (f *fakeMetricsEmitter) SetNodeTemplateResourcesMismatch(driver string, mis
 	}
 	key := fmt.Sprintf("%s/%s", driver, mismatchType)
 	f.metrics[key] = value
+}
+
+// nodeComparisonData is used to simulate node resource topology for testing,
+// has no difference from passing raw slices, but drastically improves readability
+// by grouping related data together.
+type nodeComparisonData struct {
+	NodeName       string
+	TemplateSlices []*resourceapi.ResourceSlice
+	NodeSlices     []*resourceapi.ResourceSlice
+}
+
+func nodeNamesArray(data []nodeComparisonData) []string {
+	result := make([]string, len(data))
+	for i, d := range data {
+		result[i] = d.NodeName
+	}
+	return result
+}
+
+func nodeSlicesArray(data []nodeComparisonData) [][]*resourceapi.ResourceSlice {
+	result := make([][]*resourceapi.ResourceSlice, len(data))
+	for i, d := range data {
+		result[i] = d.NodeSlices
+	}
+	return result
+}
+
+func templateSlicesArray(data []nodeComparisonData) [][]*resourceapi.ResourceSlice {
+	result := make([][]*resourceapi.ResourceSlice, len(data))
+	for i, d := range data {
+		result[i] = d.TemplateSlices
+	}
+	return result
 }
 
 func TestEmitMetrics(t *testing.T) {
@@ -182,8 +146,8 @@ func TestEmitMetrics(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			fake := &fakeMetricsEmitter{}
-			c := &NodeResourcesComparator{metrics: fake}
-			c.emitMetrics(tc.aggregatedDiscrepancies)
+			c := &NodeResourcesComparator{metrics: fake, discrepanciesPerDriver: tc.aggregatedDiscrepancies}
+			c.emitMetrics()
 
 			if diff := cmp.Diff(tc.wantMetrics, fake.metrics); diff != "" {
 				t.Errorf("emitMetrics() diff (-want +got):\n%s", diff)
@@ -194,161 +158,296 @@ func TestEmitMetrics(t *testing.T) {
 
 type noOpMetricsEmitter struct{}
 
-func (n *noOpMetricsEmitter) SetNodeTemplateResourcesMismatch(driver string, mismatchType metrics.ResourceMismatchType, value uint32) {}
+func (n *noOpMetricsEmitter) SetNodeTemplateResourcesMismatch(driver string, mismatchType metrics.ResourceMismatchType, value uint32) {
+}
 
-
-func BenchmarkReportResourceDiscrepancies_1Node_0Discrepancies(b *testing.B) {
-	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
-	comparator.logger = func(format string, args ...any) {}
-
-	data := []NodeComparisonData{
-		{
-			NodeName:       "node-1",
-			TemplateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
-			NodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+func TestReportResourceDiscrepancies(t *testing.T) {
+	tests := map[string]struct {
+		data        []nodeComparisonData
+		wantMetrics map[string]uint32
+	}{
+		"EmptyData": {
+			data:        nil,
+			wantMetrics: nil,
+		},
+		"NoSlicesToCompare": {
+			data: []nodeComparisonData{
+				{
+					NodeName:       "node-1",
+					TemplateSlices: nil,
+					NodeSlices:     nil,
+				},
+			},
+			wantMetrics: nil,
+		},
+		"PerfectMatch": {
+			data: []nodeComparisonData{
+				{
+					NodeName:       "node-1",
+					TemplateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 2, shape: deviceShapeA})},
+					NodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 2, shape: deviceShapeA})},
+				},
+			},
+			wantMetrics: nil,
+		},
+		"MissingResourcePool": {
+			data: []nodeComparisonData{
+				{
+					NodeName:       "node-1",
+					TemplateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+					NodeSlices:     nil,
+				},
+			},
+			wantMetrics: map[string]uint32{
+				"driver/missing": 1,
+			},
+		},
+		"ExtraResourcePool": {
+			data: []nodeComparisonData{
+				{
+					NodeName:       "node-1",
+					TemplateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool-1", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+					NodeSlices: []*resourceapi.ResourceSlice{
+						makeSingleResourceSlice("driver", "pool-1", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+						makeSingleResourceSlice("driver", "pool-2", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+					},
+				},
+			},
+			wantMetrics: map[string]uint32{
+				"driver/extra": 1,
+			},
+		},
+		"FuzzyMismatch_Attributes": {
+			data: []nodeComparisonData{
+				{
+					NodeName:       "node-1",
+					TemplateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+					NodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeB})},
+				},
+			},
+			wantMetrics: map[string]uint32{
+				"driver/mismatch": 1,
+			},
+		},
+		"FuzzyMismatch_DeviceCount": {
+			data: []nodeComparisonData{
+				{
+					NodeName:       "node-1",
+					TemplateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 4, shape: deviceShapeA})},
+					NodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 2, shape: deviceShapeA})},
+				},
+			},
+			wantMetrics: map[string]uint32{
+				"driver/mismatch": 1,
+			},
+		},
+		"IgnoredDriver": {
+			data: []nodeComparisonData{
+				{
+					NodeName:       "node-1",
+					TemplateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("known-driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+					NodeSlices: []*resourceapi.ResourceSlice{
+						makeSingleResourceSlice("known-driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+						makeSingleResourceSlice("rogue-driver", "pool", poolDevices{deviceCount: 5, shape: deviceShapeB}),
+					},
+				},
+			},
+			wantMetrics: nil,
+		},
+		"MultiNodeMultiDriver": {
+			data: []nodeComparisonData{
+				{
+					// Node 1: driver-A is missing a pool
+					NodeName: "node-1",
+					TemplateSlices: []*resourceapi.ResourceSlice{
+						makeSingleResourceSlice("driver-A", "pool-1", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+						makeSingleResourceSlice("driver-B", "pool-1", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+					},
+					NodeSlices: []*resourceapi.ResourceSlice{
+						makeSingleResourceSlice("driver-B", "pool-1", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+					},
+				},
+				{
+					// Node 2: driver-A has a fuzzy mismatch, driver-B has an extra pool
+					NodeName: "node-2",
+					TemplateSlices: []*resourceapi.ResourceSlice{
+						makeSingleResourceSlice("driver-A", "pool-1", poolDevices{deviceCount: 2, shape: deviceShapeA}),
+						makeSingleResourceSlice("driver-B", "pool-1", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+					},
+					NodeSlices: []*resourceapi.ResourceSlice{
+						makeSingleResourceSlice("driver-A", "pool-1", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+						makeSingleResourceSlice("driver-B", "pool-1", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+						makeSingleResourceSlice("driver-B", "pool-2", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+					},
+				},
+			},
+			wantMetrics: map[string]uint32{
+				"driver-A/missing":  1,
+				"driver-A/mismatch": 1,
+				"driver-B/extra":    1,
+			},
+		},
+		"MultipleMissing": {
+			data: []nodeComparisonData{
+				{
+					NodeName: "node-1",
+					TemplateSlices: []*resourceapi.ResourceSlice{
+						makeSingleResourceSlice("driver", "pool1", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+						makeSingleResourceSlice("driver", "pool2", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+						makeSingleResourceSlice("driver", "pool3", poolDevices{deviceCount: 1, shape: deviceShapeABC}),
+					},
+					NodeSlices: []*resourceapi.ResourceSlice{},
+				},
+			},
+			wantMetrics: map[string]uint32{
+				"driver/missing": 3,
+			},
 		},
 	}
 
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fake := &fakeMetricsEmitter{}
+			c := NewNodeResourcesComparator(fake)
+			c.ReportResourceDiscrepancies(nodeNamesArray(tc.data), templateSlicesArray(tc.data), nodeSlicesArray(tc.data))
+			if diff := cmp.Diff(tc.wantMetrics, fake.metrics); diff != "" {
+				t.Errorf("ReportResourceDiscrepancies() metrics diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkReportResourceDiscrepancies_1Node_0Discrepancies(b *testing.B) {
+	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
+	nodeNames := []string{"node-1"}
+	templateSlices := [][]*resourceapi.ResourceSlice{
+		{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+	}
+	nodeSlices := [][]*resourceapi.ResourceSlice{
+		{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+	}
+
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(data)
+		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
 	}
 }
 
 func BenchmarkReportResourceDiscrepancies_1Node_NoDRA(b *testing.B) {
-	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
-	comparator.logger = func(format string, args ...any) {}
-
-	data := []NodeComparisonData{
-		{
-			NodeName:       "node-1",
-			TemplateSlices: nil,
-			NodeSlices:     nil,
-		},
-	}
+	comparator := newNodeResourcesComparatorWithLogger(&noOpMetricsEmitter{}, noOpLogger)
+	nodeNames := []string{"node-1"}
+	templateSlices := [][]*resourceapi.ResourceSlice{nil}
+	nodeSlices := [][]*resourceapi.ResourceSlice{nil}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(data)
+		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
 	}
 }
 
 func BenchmarkReportResourceDiscrepancies_1Node_10Discrepancies(b *testing.B) {
-	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
-	comparator.logger = func(format string, args ...any) {}
+	comparator := newNodeResourcesComparatorWithLogger(&noOpMetricsEmitter{}, noOpLogger)
 
-	templateSlices := make([]*resourceapi.ResourceSlice, 10)
+	templateSlice := make([]*resourceapi.ResourceSlice, 10)
 	for i := 0; i < 10; i++ {
-		templateSlices[i] = makeSingleResourceSlice("driver", fmt.Sprintf("pool-%d", i), poolDevices{deviceCount: 1, shape: deviceShapeA})
-	}
-	data := []NodeComparisonData{
-		{
-			NodeName:       "node-1",
-			TemplateSlices: templateSlices,
-			NodeSlices:     nil,
-		},
+		templateSlice[i] = makeSingleResourceSlice("driver", fmt.Sprintf("pool-%d", i), poolDevices{deviceCount: 1, shape: deviceShapeA})
 	}
 
+	nodeNames := []string{"node-1"}
+	nodeSlices := [][]*resourceapi.ResourceSlice{{}}
+	templateSlices := [][]*resourceapi.ResourceSlice{templateSlice}
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(data)
+		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
 	}
 }
 
 func BenchmarkReportResourceDiscrepancies_10Nodes_10DiscrepanciesEach(b *testing.B) {
-	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
-	comparator.logger = func(format string, args ...any) {}
+	comparator := newNodeResourcesComparatorWithLogger(&noOpMetricsEmitter{}, noOpLogger)
+	templateSlices := make([][]*resourceapi.ResourceSlice, 10)
+	nodeSlices := make([][]*resourceapi.ResourceSlice, 10)
+	nodeNames := make([]string, 10)
 
-	data := make([]NodeComparisonData, 10)
 	for n := 0; n < 10; n++ {
-		templateSlices := make([]*resourceapi.ResourceSlice, 10)
+		templateSlice := make([]*resourceapi.ResourceSlice, 10)
 		for i := 0; i < 10; i++ {
-			templateSlices[i] = makeSingleResourceSlice("driver", fmt.Sprintf("pool-%d", i), poolDevices{deviceCount: 1, shape: deviceShapeA})
+			templateSlice[i] = makeSingleResourceSlice("driver", fmt.Sprintf("pool-%d", i), poolDevices{deviceCount: 1, shape: deviceShapeA})
 		}
-		data[n] = NodeComparisonData{
-			NodeName:       fmt.Sprintf("node-%d", n),
-			TemplateSlices: templateSlices,
-			NodeSlices:     nil,
-		}
+
+		nodeNames[n] = fmt.Sprintf("node-%d", n)
+		templateSlices[n] = templateSlice
+		nodeSlices[n] = nil
 	}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(data)
+		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
 	}
 }
 
 func BenchmarkReportResourceDiscrepancies_10Nodes_NoDRA(b *testing.B) {
-	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
-	comparator.logger = func(format string, args ...any) {}
+	comparator := newNodeResourcesComparatorWithLogger(&noOpMetricsEmitter{}, noOpLogger)
+	nodeNames := make([]string, 10)
+	templateSlices := make([][]*resourceapi.ResourceSlice, 10)
+	nodeSlices := make([][]*resourceapi.ResourceSlice, 10)
 
-	data := make([]NodeComparisonData, 10)
 	for n := 0; n < 10; n++ {
-		data[n] = NodeComparisonData{
-			NodeName:       fmt.Sprintf("node-%d", n),
-			TemplateSlices: nil,
-			NodeSlices:     nil,
-		}
+		nodeNames[n] = fmt.Sprintf("node-%d", n)
+		templateSlices[n] = nil
+		nodeSlices[n] = nil
 	}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(data)
+		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
 	}
 }
 
 func BenchmarkReportResourceDiscrepancies_10Nodes_0Discrepancies(b *testing.B) {
-	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
-	comparator.logger = func(format string, args ...any) {}
+	comparator := newNodeResourcesComparatorWithLogger(&noOpMetricsEmitter{}, noOpLogger)
+	names := make([]string, 10)
+	tpl := make([][]*resourceapi.ResourceSlice, 10)
+	nodes := make([][]*resourceapi.ResourceSlice, 10)
 
-	data := make([]NodeComparisonData, 10)
 	for n := 0; n < 10; n++ {
 		slice := makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})
-		data[n] = NodeComparisonData{
-			NodeName:       fmt.Sprintf("node-%d", n),
-			TemplateSlices: []*resourceapi.ResourceSlice{slice},
-			NodeSlices:     []*resourceapi.ResourceSlice{slice},
-		}
+		names[n] = fmt.Sprintf("node-%d", n)
+		tpl[n] = []*resourceapi.ResourceSlice{slice}
+		nodes[n] = []*resourceapi.ResourceSlice{slice}
 	}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(data)
+		comparator.ReportResourceDiscrepancies(names, tpl, nodes)
 	}
 }
 func BenchmarkReportResourceDiscrepancies_1Node_10Drivers_10Discrepancies(b *testing.B) {
-	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
-	comparator.logger = func(format string, args ...any) {}
-
+	comparator := newNodeResourcesComparatorWithLogger(&noOpMetricsEmitter{}, noOpLogger)
 	templateSlices := make([]*resourceapi.ResourceSlice, 10)
 	for i := 0; i < 10; i++ {
 		templateSlices[i] = makeSingleResourceSlice(fmt.Sprintf("driver-%d", i), "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})
 	}
-	data := []NodeComparisonData{
-		{
-			NodeName:       "node-1",
-			TemplateSlices: templateSlices,
-			NodeSlices:     nil,
-		},
-	}
+
+	names := []string{"node-1"}
+	tpl := [][]*resourceapi.ResourceSlice{templateSlices}
+	nodes := [][]*resourceapi.ResourceSlice{nil}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(data)
+		comparator.ReportResourceDiscrepancies(names, tpl, nodes)
 	}
 }
 
 func BenchmarkReportResourceDiscrepancies_10Nodes_10Drivers_10DiscrepanciesEach(b *testing.B) {
-	comparator := NewNodeResourcesComparator(&noOpMetricsEmitter{})
-	comparator.logger = func(format string, args ...any) {}
+	comparator := newNodeResourcesComparatorWithLogger(&noOpMetricsEmitter{}, noOpLogger)
 
-	data := make([]NodeComparisonData, 10)
-	for n := 0; n < 10; n++ {
+	names := make([]string, 10)
+	tpl := make([][]*resourceapi.ResourceSlice, 10)
+	nodes := make([][]*resourceapi.ResourceSlice, 10)
+	for i := 0; i < 10; i++ {
 		templateSlices := make([]*resourceapi.ResourceSlice, 10)
-		for i := 0; i < 10; i++ {
-			templateSlices[i] = makeSingleResourceSlice(fmt.Sprintf("driver-%d", i), "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})
+		for j := 0; j < 10; j++ {
+			templateSlices[j] = makeSingleResourceSlice(fmt.Sprintf("driver-%d", j), "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})
 		}
-		data[n] = NodeComparisonData{
-			NodeName:       fmt.Sprintf("node-%d", n),
-			TemplateSlices: templateSlices,
-			NodeSlices:     nil,
-		}
+		names[i] = fmt.Sprintf("node-%d", i)
+		tpl[i] = templateSlices
+		nodes[i] = nil
 	}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(data)
+		comparator.ReportResourceDiscrepancies(names, tpl, nodes)
 	}
 }

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
@@ -193,7 +193,7 @@ func (c *resourcePoolComparator) resetBuffers() {
 // Algorithm for deltas detection consists of the following steps:
 // 1. Define a list of drivers used for the current comparison, in order to do that we search drivers
 // which have at least a single resource pool being incomplete or having multiple generations as this
-// point of time and remove them from the list of drivers exposed through template resource slices
+// point of time and remove them from the list of drivers exposed through template or nodes resource slices
 // 2. Organize list of node and template slices into resource groups ignoring non-compared drivers, each
 // resource group representing different resource pool or device attribute signature. We assume that resource
 // pool consists of homogeneous set of devices, but if this assumption doesn't hold true - resource
@@ -207,8 +207,6 @@ func (c *resourcePoolComparator) resetBuffers() {
 // missing on the node, and as extra when resource is only defined in the node, but missing from the template
 //
 // Warnings:
-//   - Resource pool exposed for a driver X in the real node is only checked if the template
-//     exposes at least one resource pool for the same driver, otherwise - it's ignored.
 //   - Drivers which have at least a single resource pool with multiple generation numbers
 //     or incomplete resource pools are not compared.
 //   - Function is not thread-safe and manipulates internal buffers of the comparator
@@ -223,7 +221,7 @@ func (c *resourcePoolComparator) CompareResourcePools(
 	c.resetBuffers()
 
 	c.populateDriversInFlux(nodeSlices)
-	c.populateComparedDrivers(templateSlices)
+	c.populateComparedDrivers(templateSlices, nodeSlices)
 	c.populateTemplateGroups(templateSlices)
 	c.populateNodeGroups(nodeSlices)
 	c.eliminateExactMatchResources()
@@ -287,7 +285,7 @@ func (c *resourcePoolComparator) populateDriversInFlux(resourceSlices []*v1.Reso
 
 // populateComparedDrivers populates the list of drivers that should be compared, assumes that
 // drivers in flux are already filtered out.
-func (c *resourcePoolComparator) populateComparedDrivers(templateSlices []*v1.ResourceSlice) {
+func (c *resourcePoolComparator) populateComparedDrivers(templateSlices []*v1.ResourceSlice, nodeSlices []*v1.ResourceSlice) {
 	for _, t := range templateSlices {
 		if slices.Contains(c.comparedDrivers, t.Spec.Driver) {
 			continue
@@ -298,6 +296,18 @@ func (c *resourcePoolComparator) populateComparedDrivers(templateSlices []*v1.Re
 		}
 
 		c.comparedDrivers = append(c.comparedDrivers, t.Spec.Driver)
+	}
+
+	for _, n := range nodeSlices {
+		if slices.Contains(c.comparedDrivers, n.Spec.Driver) {
+			continue
+		}
+
+		if slices.Contains(c.driversInFlux, n.Spec.Driver) {
+			continue
+		}
+
+		c.comparedDrivers = append(c.comparedDrivers, n.Spec.Driver)
 	}
 }
 

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
@@ -17,11 +17,9 @@ limitations under the License.
 package comparator
 
 import (
-	"fmt"
 	"hash/maphash"
 	"math"
 	"slices"
-	"strings"
 
 	v1 "k8s.io/api/resource/v1"
 )
@@ -40,18 +38,42 @@ var (
 type resourceDeltaType uint8
 
 const (
-	resourceDeltaTypeUnknown  resourceDeltaType = 0
-	resourceDeltaTypeMissing  resourceDeltaType = 1
-	resourceDeltaTypeExtra    resourceDeltaType = 2
-	resourceDeltaTypeMismatch resourceDeltaType = 3
+	resourceDeltaTypeUnknown  resourceDeltaType = 1
+	resourceDeltaTypeMissing  resourceDeltaType = 2
+	resourceDeltaTypeExtra    resourceDeltaType = 3
+	resourceDeltaTypeMismatch resourceDeltaType = 4
 )
 
-type signatureMap = map[v1.QualifiedName]v1.DeviceAttribute
+func (t resourceDeltaType) String() string {
+	switch t {
+	case resourceDeltaTypeMissing:
+		return "Missing"
+	case resourceDeltaTypeExtra:
+		return "Extra"
+	case resourceDeltaTypeMismatch:
+		return "Mismatch"
+	default:
+		return "Unknown"
+	}
+}
+
+type attributesMap map[v1.QualifiedName]v1.DeviceAttribute
 
 // resourceDelta represents a discrepancy between expected and actual DRA resource topologies.
+//
+// State Matrix:
+//
+// | TemplatePool | NodePool | Delta Type | DeviceCountDelta          |
+// |--------------|----------|------------|---------------------------|
+// | Present      | Present  | Mismatch   | TemplateCount - NodeCount |
+// | Present      | Empty    | Missing    | TemplateCount (Positive)  |
+// | Empty        | Present  | Extra      | -NodeCount (Negative)     |
+// | Empty        | Empty    | Unknown    | 0                         |
 type resourceDelta struct {
-	// DeviceCountDelta is the difference in the number of devices between the template and the node.
-	DeviceCountDelta int64
+	// TemplateSignatureMap is the signature of the attributes of the resource pool.
+	TemplateSignatureMap attributesMap
+	// NodeSignatureMap is the signature of the attributes of the resource pool.
+	NodeSignatureMap attributesMap
 	// Driver is the name of the driver.
 	Driver string
 	// TemplateResourcePool is the name of the resource pool in the template,
@@ -60,32 +82,11 @@ type resourceDelta struct {
 	// NodeResourcePool is the name of the resource pool in the node,
 	// is empty if there's no matching template resource pool
 	NodeResourcePool string
-	// TemplateSignatureMap is the signature of the attributes of the resource pool.
-	TemplateSignatureMap signatureMap
-	// NodeSignatureMap is the signature of the attributes of the resource pool.
-	NodeSignatureMap signatureMap
+	// DeviceCountDelta is the difference in the number of devices between the template and the node.
+	DeviceCountDelta int64
 }
 
-// MissingAttributes returns the list of attributes that are present in the template but not in the node.
-func (d *resourceDelta) MissingAttributes() []string {
-	return mapKeyDifference(d.TemplateSignatureMap, d.NodeSignatureMap)
-}
-
-// ExtraAttributes returns the list of attributes that are present in the node but not in the template.
-func (d *resourceDelta) ExtraAttributes() []string {
-	return mapKeyDifference(d.NodeSignatureMap, d.TemplateSignatureMap)
-}
-
-// TemplateSignature returns the list of attributes of the resource pool in the template.
-func (d *resourceDelta) TemplateSignature() []string {
-	return mapKeys(d.TemplateSignatureMap)
-}
-
-// NodeSignature returns the list of attributes of the resource pool in the node.
-func (d *resourceDelta) NodeSignature() []string {
-	return mapKeys(d.NodeSignatureMap)
-}
-
+// Type returns the type of the resource delta.
 func (d *resourceDelta) Type() resourceDeltaType {
 	if d.TemplateResourcePool == "" && d.NodeResourcePool == "" {
 		return resourceDeltaTypeUnknown
@@ -100,176 +101,115 @@ func (d *resourceDelta) Type() resourceDeltaType {
 	return resourceDeltaTypeMismatch
 }
 
-// Summary returns a human-readable summary of the discrepancy.
-func (d *resourceDelta) Summary() string {
-	switch d.Type() {
-	case resourceDeltaTypeMissing:
-		return fmt.Sprintf("MissingResource{Driver=%q, ResourcePool=%q, DeviceCount=%q, AttributeSignature=%q}",
-			d.Driver, d.TemplateResourcePool, fmt.Sprintf("%d", d.DeviceCountDelta), strings.Join(d.TemplateSignature(), ";"))
-	case resourceDeltaTypeExtra:
-		return fmt.Sprintf("ExtraResource{Driver=%q, ResourcePool=%q, DeviceCount=%q, AttributeSignature=%q}",
-			d.Driver, d.NodeResourcePool, fmt.Sprintf("%d", -d.DeviceCountDelta), strings.Join(d.NodeSignature(), ";"))
-	case resourceDeltaTypeMismatch:
-		return fmt.Sprintf("MismatchResource{Driver=%q, TemplatePool=%q, NodePool=%q, DeviceCountDelta=%q, MissingAttributes=%q, ExtraAttributes=%q}",
-			d.Driver, d.TemplateResourcePool, d.NodeResourcePool, fmt.Sprintf("%d", d.DeviceCountDelta),
-			strings.Join(d.MissingAttributes(), ";"), strings.Join(d.ExtraAttributes(), ";"))
-	default:
-		return fmt.Sprintf("UnknownResourceDelta{%+v}", d)
-	}
-}
-
 // resourceGroup represents a group of devices with the same attributes, driver and resource pool.
 type resourceGroup struct {
+	attrs       attributesMap
 	driver      string
 	pool        string
 	deviceCount uint64
 	signature   uint64
-	attrs       map[v1.QualifiedName]v1.DeviceAttribute
 }
 
-// resourceGroupIdentifier is used to identify a group of devices with the same attributes and driver.
-type resourceGroupIdentifier struct {
+// nodeResourceIdentifier is used to identify a group of devices with the same attributes and driver.
+type nodeResourceIdentifier struct {
 	driver    string
 	signature uint64
 }
 
+// resourcePoolComparator is used to compare the resource topologies of the template and the node.
+// Component heavily relies on reusable buffers to minimize allocations and thus is not thread-safe
+// and functions apart of CompareResourcePools are not recommended to be called directly as it may
+// break integrity of the state.
+type resourcePoolComparator struct {
+	// poolStates keeps track of the state of each pool, it serves as a helper
+	// for determining if a pool is in flux or not.
+	poolStates map[poolReference]poolState
+	// nodeResourceAddressMap is a map of node resource identifiers to indices
+	// in the nodeResources slice, may contain collisions when driver has multiple
+	// resource pools with the same signature.
+	nodeResourceAddressMap map[nodeResourceIdentifier]int
+	// nodePoolAddressMap is a map of node resource pool identifiers to indices
+	// in the nodeResources slice
+	nodePoolAddressMap map[resourcePoolIdentifier]int
+	// templatePoolAddressMap is a map of template resource pool identifiers to indices
+	// in the templateResources slice
+	templatePoolAddressMap map[resourcePoolIdentifier]int
+	// driversInFlux represents drivers which have at least a single resource
+	// pool with multiple generation numbers or incomplete resource pools.
+	driversInFlux []string
+	// comparedDrivers represents drivers are compared by the comparator.
+	comparedDrivers []string
+	// templateResources represents a list of resource groups from the template.
+	templateResources []resourceGroup
+	// nodeResources represents a list of resource groups from the node.
+	nodeResources []resourceGroup
+}
+
+// newResourcePoolComparator creates a new resource pool comparator.
+func newResourcePoolComparator() resourcePoolComparator {
+	return resourcePoolComparator{
+		poolStates:             make(map[poolReference]poolState),
+		nodeResourceAddressMap: make(map[nodeResourceIdentifier]int),
+		nodePoolAddressMap:     make(map[resourcePoolIdentifier]int),
+		templatePoolAddressMap: make(map[resourcePoolIdentifier]int),
+	}
+}
+
+// resetBuffers resets the buffers used by the resource pool comparator.
+func (c *resourcePoolComparator) resetBuffers() {
+	clear(c.poolStates)
+	clear(c.nodeResourceAddressMap)
+	clear(c.nodePoolAddressMap)
+	clear(c.templatePoolAddressMap)
+	c.driversInFlux = c.driversInFlux[:0]
+	c.comparedDrivers = c.comparedDrivers[:0]
+	c.templateResources = c.templateResources[:0]
+	c.nodeResources = c.nodeResources[:0]
+}
+
 // compareDraResources compares the resource topologies of the template and the node and
 // returns a list of ResourceDelta that represent the differences between the two.
-// Function uses a three-phase approach to find matching resource groups:
 //
-// Phase 1: Find and eliminate resource groups that match exactly
-// Phase 2: Find and eliminate resource groups that match with the best overlap and report discrepancies
-// Phase 3: Report the differences not reported by other phases (e.g. completely different pools, missing attributes)
+// Algorithm for deltas detection consists of the following steps:
+// 1. Define a list of drivers used for the current comparison, in order to do that we search drivers
+// which have at least a single resource pool being incomplete or having multiple generations as this
+// point of time and remove them from the list of drivers exposed through template resource slices
+// 2. Organize list of node and template slices into resource groups ignoring non-compared drivers, each
+// resource group representing different resource pool or device attribute signature. We assume that resource
+// pool consists of homogeneous set of devices, but if this assumption doesn't hold true - resource
+// pool will be split into N resource groups where N is the amount of different device signatures available in it
+// 3. Mutually eliminate node and template resource groups if they exactly match by the amount of devices and
+// attribute signature, these resource groups were fulfilled and there's no deltas between them
+// 4. Search and eliminate most similar resource groups among node and template slices prioritizing attribute
+// signature overlap and device count (in order) when match found - difference between them is reported as a
+// resource delta.
+// 5. Left out resource groups from any source are reported as missing when they are coming from template but are
+// missing on the node, and as extra when resource is only defined in the node, but missing from the template
 //
 // Warnings:
 //   - Resource pool exposed for a driver X in the real node is only checked if the template
 //     exposes at least one resource pool for the same driver, otherwise - it's ignored.
 //   - Drivers which have at least a single resource pool with multiple generation numbers
 //     or incomplete resource pools are not compared.
-func compareDraResources(
+//   - Function is not thread-safe and manipulates internal buffers of the comparator
+//     to minimize re-allocations.
+//   - Device attribute values are not compared at any point of time, we only ensure
+//     that the same set of attribute keys is present.
+func (c *resourcePoolComparator) CompareResourcePools(
 	templateSlices []*v1.ResourceSlice,
 	nodeSlices []*v1.ResourceSlice,
 	deltasBuffer []resourceDelta,
 ) []resourceDelta {
-	driversToCompare := findComparedDrivers(templateSlices, nodeSlices)
-	templateResources := buildResourceGroups(templateSlices, driversToCompare)
-	nodeResources := buildResourceGroups(nodeSlices, driversToCompare)
-	// For node resources we maintain a map of identifier to index in the nodeResources slice.
-	// This is used to quickly find a matching resource group in the node resources,
-	// in case of hash collision we iterate over the node resources to find the matching resource group instead
-	nodeResourceAddresses := make(map[resourceGroupIdentifier]int, len(nodeResources))
-	for i, n := range nodeResources {
-		identifier := resourceGroupIdentifier{driver: n.driver, signature: n.signature}
-		nodeResourceAddresses[identifier] = i
-	}
+	c.resetBuffers()
 
-	// Phase 1: Exact Match
-	for i := len(templateResources) - 1; i >= 0; i-- {
-		t := templateResources[i]
-		identifier := resourceGroupIdentifier{driver: t.driver, signature: t.signature}
-		index, ok := nodeResourceAddresses[identifier]
-		if !ok {
-			continue
-		}
+	c.populateDriversInFlux(nodeSlices)
+	c.populateComparedDrivers(templateSlices)
+	c.populateTemplateGroups(templateSlices)
+	c.populateNodeGroups(nodeSlices)
+	c.eliminateExactMatchResources()
+	deltasBuffer = c.eliminateFuzzyMatchResources(deltasBuffer)
 
-		// Fast path: check if the resource group at the found index matches exactly
-		if attributesMatch(t.attrs, nodeResources[index].attrs) && t.deviceCount == nodeResources[index].deviceCount {
-			templateResources = swapDelete(templateResources, i)
-			nodeResources = swapDelete(nodeResources, index)
-
-			// Update address map with a new moved element and clear old entry
-			delete(nodeResourceAddresses, identifier)
-			if index < len(nodeResources) {
-				movedIdentifier := resourceGroupIdentifier{
-					driver:    nodeResources[index].driver,
-					signature: nodeResources[index].signature,
-				}
-				nodeResourceAddresses[movedIdentifier] = index
-			}
-
-			continue
-		}
-
-		// Slow path: in case of a hash collision, iterate over the node resources to find the matching resource group
-		for j, n := range nodeResources {
-			if n.signature != t.signature || n.driver != t.driver {
-				continue
-			}
-
-			if attributesMatch(t.attrs, n.attrs) && t.deviceCount == n.deviceCount {
-				templateResources = swapDelete(templateResources, i)
-				nodeResources = swapDelete(nodeResources, j)
-
-				// Update address map with a new moved element and clear old entry
-				delete(nodeResourceAddresses, identifier)
-				if j < len(nodeResources) {
-					movedIdentifier := resourceGroupIdentifier{
-						driver:    nodeResources[j].driver,
-						signature: nodeResources[j].signature,
-					}
-					nodeResourceAddresses[movedIdentifier] = j
-				}
-
-				break
-			}
-		}
-	}
-
-	// Phase 2 & 3: Fuzzy Match & Diff Reporting
-	for i := len(templateResources) - 1; i >= 0; i-- {
-		t := templateResources[i]
-		bestMatchIndex := -1
-		bestOverlap := -1
-		bestMatchCountDelta := int64(math.MaxInt64)
-
-		// Find the best unmatched candidate
-		for j, n := range nodeResources {
-			if t.driver != n.driver {
-				continue
-			}
-
-			overlap := computeSetOverlap(t.attrs, n.attrs)
-			deviceCountDelta := int64(t.deviceCount) - int64(n.deviceCount)
-
-			if overlap < bestOverlap {
-				continue
-			}
-
-			// Primary objective: Maximize attribute overlap
-			// Secondary objective: Minimize difference in device counts
-			if overlap > bestOverlap || absInt64(deviceCountDelta) < absInt64(bestMatchCountDelta) {
-				bestMatchCountDelta = deviceCountDelta
-				bestOverlap = overlap
-				bestMatchIndex = j
-			}
-		}
-
-		// Completely unmatched driver pool
-		if bestMatchIndex == -1 {
-			continue
-		}
-
-		bestMatch := nodeResources[bestMatchIndex]
-		templateResources = swapDelete(templateResources, i)
-		nodeResources = swapDelete(nodeResources, bestMatchIndex)
-		hasMissing := mapsHaveKeyDifference(t.attrs, bestMatch.attrs)
-		hasExtra := mapsHaveKeyDifference(bestMatch.attrs, t.attrs)
-
-		// Only report if a real diff exists (e.g. different attributes or device count)
-		if hasMissing || hasExtra || bestMatchCountDelta != 0 {
-			deltasBuffer = append(deltasBuffer, resourceDelta{
-				Driver:               t.driver,
-				TemplateResourcePool: t.pool,
-				NodeResourcePool:     bestMatch.pool,
-				DeviceCountDelta:     bestMatchCountDelta,
-				TemplateSignatureMap: t.attrs,
-				NodeSignatureMap:     bestMatch.attrs,
-			})
-		}
-	}
-
-	// Report on remaining template resources
-	for _, t := range templateResources {
+	for _, t := range c.templateResources {
 		deltasBuffer = append(deltasBuffer, resourceDelta{
 			Driver:               t.driver,
 			TemplateResourcePool: t.pool,
@@ -279,7 +219,7 @@ func compareDraResources(
 	}
 
 	// Report on remaining node resources
-	for _, n := range nodeResources {
+	for _, n := range c.nodeResources {
 		deltasBuffer = append(deltasBuffer, resourceDelta{
 			Driver:           n.driver,
 			NodeResourcePool: n.pool,
@@ -291,143 +231,270 @@ func compareDraResources(
 	return deltasBuffer
 }
 
+// findNodeFuzzyMatch finds the best matching resource group available on the node
+// and returns the index of the found group in the nodeResources list or -1 if none
+// found
+func (c *resourcePoolComparator) findNodeFuzzyMatch(target *resourceGroup) int {
+	bestMatchIndex := -1
+	bestOverlap := -1
+	bestDeviceCountDelta := int64(math.MaxInt64)
+
+	for j, node := range c.nodeResources {
+		if target.driver != node.driver {
+			continue
+		}
+
+		overlap := computeSetOverlap(target.attrs, node.attrs)
+		deviceCountDelta := int64(target.deviceCount) - int64(node.deviceCount)
+
+		if overlap < bestOverlap {
+			continue
+		}
+
+		// Primary objective: Maximize attribute overlap
+		// Secondary objective: Minimize difference in device counts
+		if overlap > bestOverlap || absInt64(deviceCountDelta) < absInt64(bestDeviceCountDelta) {
+			bestDeviceCountDelta = deviceCountDelta
+			bestOverlap = overlap
+			bestMatchIndex = j
+		}
+	}
+
+	return bestMatchIndex
+}
+
+// eliminateFuzzyMatchResources eliminates resource groups that match with the best overlap and reports discrepancies.
+func (c *resourcePoolComparator) eliminateFuzzyMatchResources(deltasBuffer []resourceDelta) []resourceDelta {
+	for i := len(c.templateResources) - 1; i >= 0; i-- {
+		template := &c.templateResources[i]
+		bestMatchIndex := c.findNodeFuzzyMatch(template)
+
+		// Completely unmatched driver pool
+		if bestMatchIndex == -1 {
+			continue
+		}
+
+		bestMatch := c.nodeResources[bestMatchIndex]
+		c.templateResources = swapDelete(c.templateResources, i)
+		c.nodeResources = swapDelete(c.nodeResources, bestMatchIndex)
+		hasMissing := mapsHaveKeyDifference(template.attrs, bestMatch.attrs)
+		hasExtra := mapsHaveKeyDifference(bestMatch.attrs, template.attrs)
+		deviceCountDelta := int64(template.deviceCount) - int64(bestMatch.deviceCount)
+
+		// Only report if a real diff exists (e.g. different attributes or device count)
+		if hasMissing || hasExtra || deviceCountDelta != 0 {
+			deltasBuffer = append(deltasBuffer, resourceDelta{
+				Driver:               template.driver,
+				TemplateResourcePool: template.pool,
+				NodeResourcePool:     bestMatch.pool,
+				DeviceCountDelta:     deviceCountDelta,
+				TemplateSignatureMap: template.attrs,
+				NodeSignatureMap:     bestMatch.attrs,
+			})
+		}
+	}
+
+	return deltasBuffer
+}
+
+// eliminateExactMatchResources eliminates resource groups that match exactly by attribute signatures and device counts.
+func (c *resourcePoolComparator) eliminateExactMatchResources() {
+	for i := len(c.templateResources) - 1; i >= 0; i-- {
+		t := c.templateResources[i]
+		identifier := nodeResourceIdentifier{driver: t.driver, signature: t.signature}
+		index, ok := c.nodeResourceAddressMap[identifier]
+		if !ok {
+			continue
+		}
+
+		// Fast path: check if the resource group at the found index matches exactly
+		if attributesMatch(t.attrs, c.nodeResources[index].attrs) && t.deviceCount == c.nodeResources[index].deviceCount {
+			c.templateResources = swapDelete(c.templateResources, i)
+			c.nodeResources = swapDelete(c.nodeResources, index)
+
+			// Update address map with a new moved element and clear old entry
+			delete(c.nodeResourceAddressMap, identifier)
+			if index < len(c.nodeResources) {
+				movedIdentifier := nodeResourceIdentifier{
+					driver:    c.nodeResources[index].driver,
+					signature: c.nodeResources[index].signature,
+				}
+				c.nodeResourceAddressMap[movedIdentifier] = index
+			}
+
+			continue
+		}
+
+		// Slow path: in case of a hash collision, iterate over the node resources to find the matching resource group
+		for j, n := range c.nodeResources {
+			if n.signature != t.signature || n.driver != t.driver {
+				continue
+			}
+
+			if attributesMatch(t.attrs, n.attrs) && t.deviceCount == n.deviceCount {
+				c.templateResources = swapDelete(c.templateResources, i)
+				c.nodeResources = swapDelete(c.nodeResources, j)
+
+				// Update address map with a new moved element and clear old entry
+				delete(c.nodeResourceAddressMap, identifier)
+				if j < len(c.nodeResources) {
+					movedIdentifier := nodeResourceIdentifier{
+						driver:    c.nodeResources[j].driver,
+						signature: c.nodeResources[j].signature,
+					}
+					c.nodeResourceAddressMap[movedIdentifier] = j
+				}
+
+				break
+			}
+		}
+	}
+}
+
+// populateTemplateGroups populates the template resource groups from the template slices.
+func (c *resourcePoolComparator) populateTemplateGroups(templateSlices []*v1.ResourceSlice) {
+	c.templateResources = c.buildResourceGroups(templateSlices, c.templateResources, c.templatePoolAddressMap)
+}
+
+// populateNodeGroups populates the node resource groups from the node slices.
+func (c *resourcePoolComparator) populateNodeGroups(nodeSlices []*v1.ResourceSlice) {
+	c.nodeResources = c.buildResourceGroups(nodeSlices, c.nodeResources, c.nodePoolAddressMap)
+	for i, n := range c.nodeResources {
+		identifier := nodeResourceIdentifier{driver: n.driver, signature: n.signature}
+		c.nodeResourceAddressMap[identifier] = i
+	}
+}
+
 // poolReference is used to identify a resource pool.
 type poolReference struct {
 	driver string
 	pool   string
 }
 
+// poolState is used to track the state of a resource pool.
 type poolState struct {
 	generation    int64
 	count         int64
 	completeCount int64
 }
 
-// findComparedDrivers returns a list of drivers that should be compared using following
-// algorithm:
-//  1. Collect all drivers present in the template - those are drivers we care about.
-//  2. Detect drivers in flux (drivers with at least a single resource pool with
-//     multiple generation numbers).
-//  3. Return the list of drivers that are not in flux.
-func findComparedDrivers(templateSlices, nodeSlices []*v1.ResourceSlice) []string {
-	templateDrivers := make([]string, 0, countOfDriversEstimate)
+// populateComparedDrivers populates the list of drivers that should be compared, assumes that
+// drivers in flux are already filtered out.
+func (c *resourcePoolComparator) populateComparedDrivers(templateSlices []*v1.ResourceSlice) {
 	for _, t := range templateSlices {
-		if slices.Contains(templateDrivers, t.Spec.Driver) {
+		if slices.Contains(c.comparedDrivers, t.Spec.Driver) {
 			continue
 		}
 
-		templateDrivers = append(templateDrivers, t.Spec.Driver)
-	}
-
-	driversInFlux := detectDriversInFlux(nodeSlices)
-
-	comparedDrivers := make([]string, 0, len(templateDrivers))
-	for _, driver := range templateDrivers {
-		if slices.Contains(driversInFlux, driver) {
+		if slices.Contains(c.driversInFlux, t.Spec.Driver) {
 			continue
 		}
 
-		comparedDrivers = append(comparedDrivers, driver)
+		c.comparedDrivers = append(c.comparedDrivers, t.Spec.Driver)
 	}
-
-	return comparedDrivers
 }
 
-// detectDriversInFlux detects drivers which have at least a single resource pool with multiple generation numbers.
-func detectDriversInFlux(resourceSlices []*v1.ResourceSlice) []string {
-	poolStates := make(map[poolReference]poolState, len(resourceSlices))
-	var driversInFlux []string
+// populateDriversInFlux detects drivers which have at least a single resource pool with multiple generation numbers.
+func (c *resourcePoolComparator) populateDriversInFlux(resourceSlices []*v1.ResourceSlice) {
 	for _, rs := range resourceSlices {
 		poolDriver := rs.Spec.Driver
-		if slices.Contains(driversInFlux, poolDriver) {
+		if slices.Contains(c.driversInFlux, poolDriver) {
 			continue
 		}
 
 		poolGeneration := rs.Spec.Pool.Generation
 		poolRef := poolReference{driver: poolDriver, pool: rs.Spec.Pool.Name}
 
-		if state, ok := poolStates[poolRef]; ok {
+		if state, ok := c.poolStates[poolRef]; ok {
 			if state.generation != poolGeneration {
-				driversInFlux = append(driversInFlux, poolDriver)
+				c.driversInFlux = append(c.driversInFlux, poolDriver)
 			}
-
 			state.count++
-			poolStates[poolRef] = state
+			c.poolStates[poolRef] = state
 			continue
 		}
 
-		poolStates[poolRef] = poolState{
+		c.poolStates[poolRef] = poolState{
 			generation:    poolGeneration,
 			completeCount: rs.Spec.Pool.ResourceSliceCount,
 			count:         1,
 		}
 	}
 
-	for ref, state := range poolStates {
-		if state.count != state.completeCount && !slices.Contains(driversInFlux, ref.driver) {
-			driversInFlux = append(driversInFlux, ref.driver)
+	for ref, state := range c.poolStates {
+		if state.count != state.completeCount && !slices.Contains(c.driversInFlux, ref.driver) {
+			c.driversInFlux = append(c.driversInFlux, ref.driver)
 		}
 	}
-
-	return driversInFlux
 }
 
-// poolShapeIdentifier is used to identify a group of devices with the same attributes, driver and resource pool.
-type poolShapeIdentifier struct {
+// resourcePoolIdentifier is used to identify a group of devices with the same attributes, driver and resource pool.
+type resourcePoolIdentifier struct {
 	driver    string
 	pool      string
 	signature uint64
 }
 
+// ingestPoolDevice ingests device into a resource group by either placing it into one of the
+// known groups or creating one if it's not found
+func (c *resourcePoolComparator) ingestPoolDevice(
+	driver string,
+	pool string,
+	attributes attributesMap,
+	groups []resourceGroup,
+	addresses map[resourcePoolIdentifier]int,
+) []resourceGroup {
+	signature := computeAttrMapHash(attributes)
+	identifier := resourcePoolIdentifier{driver: driver, pool: pool, signature: signature}
+
+	if idx, ok := addresses[identifier]; ok {
+		// Fast path: if the attributes match the attributes of the resource group at the found index
+		if attributesMatch(groups[idx].attrs, attributes) {
+			groups[idx].deviceCount++
+			return groups
+		}
+
+		// Slow path: in case of a hash collision, iterate over the resource groups to find the matching resource group
+		for i := range groups {
+			if groups[i].signature == signature && groups[i].driver == driver && groups[i].pool == pool {
+				if attributesMatch(groups[i].attrs, attributes) {
+					groups[i].deviceCount++
+					return groups
+				}
+			}
+		}
+	}
+
+	// Insert a new resource group with a single device so far
+	groups = append(groups, resourceGroup{
+		driver:      driver,
+		pool:        pool,
+		attrs:       attributes,
+		signature:   signature,
+		deviceCount: 1,
+	})
+	addresses[identifier] = len(groups) - 1
+	return groups
+}
+
 // buildResourceGroups extracts resource groups from resource slices and splits them on a basis
 // of driver, pool and attribute signature.
-func buildResourceGroups(resourceSlices []*v1.ResourceSlice, allowedDrivers []string) []resourceGroup {
-	groups := make([]resourceGroup, 0, len(resourceSlices))
-	address := make(map[poolShapeIdentifier]int, len(resourceSlices))
+func (c *resourcePoolComparator) buildResourceGroups(
+	resourceSlices []*v1.ResourceSlice,
+	groups []resourceGroup,
+	addresses map[resourcePoolIdentifier]int,
+) []resourceGroup {
+	if len(c.comparedDrivers) == 0 {
+		return groups
+	}
 
 	for _, rs := range resourceSlices {
-		if allowedDrivers != nil && !slices.Contains(allowedDrivers, rs.Spec.Driver) {
+		if !slices.Contains(c.comparedDrivers, rs.Spec.Driver) {
 			continue
 		}
 
-		driver := rs.Spec.Driver
-		pool := rs.Spec.Pool.Name
 		for _, device := range rs.Spec.Devices {
-			signature := computeAttrMapHash(device.Attributes)
-			identifier := poolShapeIdentifier{driver: driver, pool: pool, signature: signature}
-
-			foundGroup := false
-			if idx, ok := address[identifier]; ok {
-				// Fast path: if the attributes match the attributes of the resource group at the found index
-				if attributesMatch(groups[idx].attrs, device.Attributes) {
-					groups[idx].deviceCount++
-					foundGroup = true
-				} else {
-					// Slow path: in case of a hash collision, iterate over the resource groups to find the matching resource group
-					for i := range groups {
-						if groups[i].signature == signature && groups[i].driver == driver && groups[i].pool == pool {
-							if attributesMatch(groups[i].attrs, device.Attributes) {
-								groups[i].deviceCount++
-								foundGroup = true
-								break
-							}
-						}
-					}
-				}
-			}
-
-			if foundGroup {
-				continue
-			}
-
-			groups = append(groups, resourceGroup{
-				driver:      driver,
-				pool:        pool,
-				attrs:       device.Attributes,
-				signature:   signature,
-				deviceCount: 1,
-			})
-			address[identifier] = len(groups) - 1
+			groups = c.ingestPoolDevice(rs.Spec.Driver, rs.Spec.Pool.Name, device.Attributes, groups, addresses)
 		}
 	}
 
@@ -435,7 +502,7 @@ func buildResourceGroups(resourceSlices []*v1.ResourceSlice, allowedDrivers []st
 }
 
 // attributesMatch checks if two maps of attributes exactly match.
-func attributesMatch(attributes, deviceAttributes map[v1.QualifiedName]v1.DeviceAttribute) bool {
+func attributesMatch(attributes, deviceAttributes attributesMap) bool {
 	if len(attributes) != len(deviceAttributes) {
 		return false
 	}
@@ -450,7 +517,7 @@ func attributesMatch(attributes, deviceAttributes map[v1.QualifiedName]v1.Device
 }
 
 // computeSetOverlap counts overlap without allocating a new set.
-func computeSetOverlap(a, b map[v1.QualifiedName]v1.DeviceAttribute) int {
+func computeSetOverlap(a, b attributesMap) int {
 	count := 0
 	// Always iterate over the smaller map
 	if len(a) > len(b) {
@@ -467,7 +534,7 @@ func computeSetOverlap(a, b map[v1.QualifiedName]v1.DeviceAttribute) int {
 // computeAttrMapHash computes a hash of the attribute map. It uses an XOR operation
 // on the individual key hashes to guarantee order-independent determinism without
 // requiring memory allocations for sorting strings.
-func computeAttrMapHash(keys map[v1.QualifiedName]v1.DeviceAttribute) uint64 {
+func computeAttrMapHash(keys attributesMap) uint64 {
 	var hash uint64
 
 	for k := range keys {
@@ -492,19 +559,8 @@ func absInt64(a int64) int64 {
 	return a
 }
 
-// mapKeyDifference returns the keys that are in the base map but not in the subtract map.
-func mapKeyDifference(base, subtract map[v1.QualifiedName]v1.DeviceAttribute) []string {
-	var diff []string
-	for k := range base {
-		if _, ok := subtract[k]; !ok {
-			diff = append(diff, string(k))
-		}
-	}
-	return diff
-}
-
 // mapsHaveKeyDifference checks if two maps have any difference.
-func mapsHaveKeyDifference(base, subtract map[v1.QualifiedName]v1.DeviceAttribute) bool {
+func mapsHaveKeyDifference(base, subtract attributesMap) bool {
 	if len(base) != len(subtract) {
 		return true
 	}
@@ -516,13 +572,4 @@ func mapsHaveKeyDifference(base, subtract map[v1.QualifiedName]v1.DeviceAttribut
 	}
 
 	return false
-}
-
-// mapKeys extracts the keys from a map and returns them as a slice.
-func mapKeys(m map[v1.QualifiedName]v1.DeviceAttribute) []string {
-	res := make([]string, 0, len(m))
-	for k := range m {
-		res = append(res, string(k))
-	}
-	return res
 }

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
@@ -1,0 +1,528 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comparator
+
+import (
+	"fmt"
+	"hash/maphash"
+	"math"
+	"slices"
+	"strings"
+
+	v1 "k8s.io/api/resource/v1"
+)
+
+const (
+	// countOfDriversEstimate is an estimate of the number of DRA drivers in the cluster.
+	// In case this assumption doesn't hold true - the performance of the algorithm would
+	// degrade by increasing amount of allocations.
+	countOfDriversEstimate = 10
+)
+
+var (
+	mapHashSeed = maphash.MakeSeed()
+)
+
+type resourceDeltaType uint8
+
+const (
+	resourceDeltaTypeUnknown  resourceDeltaType = 0
+	resourceDeltaTypeMissing  resourceDeltaType = 1
+	resourceDeltaTypeExtra    resourceDeltaType = 2
+	resourceDeltaTypeMismatch resourceDeltaType = 3
+)
+
+type signatureMap = map[v1.QualifiedName]v1.DeviceAttribute
+
+// resourceDelta represents a discrepancy between expected and actual DRA resource topologies.
+type resourceDelta struct {
+	// DeviceCountDelta is the difference in the number of devices between the template and the node.
+	DeviceCountDelta int64
+	// Driver is the name of the driver.
+	Driver string
+	// TemplateResourcePool is the name of the resource pool in the template,
+	// is empty if there's no matching node resource pool
+	TemplateResourcePool string
+	// NodeResourcePool is the name of the resource pool in the node,
+	// is empty if there's no matching template resource pool
+	NodeResourcePool string
+	// TemplateSignatureMap is the signature of the attributes of the resource pool.
+	TemplateSignatureMap signatureMap
+	// NodeSignatureMap is the signature of the attributes of the resource pool.
+	NodeSignatureMap signatureMap
+}
+
+// MissingAttributes returns the list of attributes that are present in the template but not in the node.
+func (d *resourceDelta) MissingAttributes() []string {
+	return mapKeyDifference(d.TemplateSignatureMap, d.NodeSignatureMap)
+}
+
+// ExtraAttributes returns the list of attributes that are present in the node but not in the template.
+func (d *resourceDelta) ExtraAttributes() []string {
+	return mapKeyDifference(d.NodeSignatureMap, d.TemplateSignatureMap)
+}
+
+// TemplateSignature returns the list of attributes of the resource pool in the template.
+func (d *resourceDelta) TemplateSignature() []string {
+	return mapKeys(d.TemplateSignatureMap)
+}
+
+// NodeSignature returns the list of attributes of the resource pool in the node.
+func (d *resourceDelta) NodeSignature() []string {
+	return mapKeys(d.NodeSignatureMap)
+}
+
+func (d *resourceDelta) Type() resourceDeltaType {
+	if d.TemplateResourcePool == "" && d.NodeResourcePool == "" {
+		return resourceDeltaTypeUnknown
+	}
+	if d.TemplateResourcePool == "" {
+		return resourceDeltaTypeExtra
+	}
+	if d.NodeResourcePool == "" {
+		return resourceDeltaTypeMissing
+	}
+
+	return resourceDeltaTypeMismatch
+}
+
+// Summary returns a human-readable summary of the discrepancy.
+func (d *resourceDelta) Summary() string {
+	switch d.Type() {
+	case resourceDeltaTypeMissing:
+		return fmt.Sprintf("MissingResource{Driver=%q, ResourcePool=%q, DeviceCount=%q, AttributeSignature=%q}",
+			d.Driver, d.TemplateResourcePool, fmt.Sprintf("%d", d.DeviceCountDelta), strings.Join(d.TemplateSignature(), ";"))
+	case resourceDeltaTypeExtra:
+		return fmt.Sprintf("ExtraResource{Driver=%q, ResourcePool=%q, DeviceCount=%q, AttributeSignature=%q}",
+			d.Driver, d.NodeResourcePool, fmt.Sprintf("%d", -d.DeviceCountDelta), strings.Join(d.NodeSignature(), ";"))
+	case resourceDeltaTypeMismatch:
+		return fmt.Sprintf("MismatchResource{Driver=%q, TemplatePool=%q, NodePool=%q, DeviceCountDelta=%q, MissingAttributes=%q, ExtraAttributes=%q}",
+			d.Driver, d.TemplateResourcePool, d.NodeResourcePool, fmt.Sprintf("%d", d.DeviceCountDelta),
+			strings.Join(d.MissingAttributes(), ";"), strings.Join(d.ExtraAttributes(), ";"))
+	default:
+		return fmt.Sprintf("UnknownResourceDelta{%+v}", d)
+	}
+}
+
+// resourceGroup represents a group of devices with the same attributes, driver and resource pool.
+type resourceGroup struct {
+	driver      string
+	pool        string
+	deviceCount uint64
+	signature   uint64
+	attrs       map[v1.QualifiedName]v1.DeviceAttribute
+}
+
+// resourceGroupIdentifier is used to identify a group of devices with the same attributes and driver.
+type resourceGroupIdentifier struct {
+	driver    string
+	signature uint64
+}
+
+// compareDraResources compares the resource topologies of the template and the node and
+// returns a list of ResourceDelta that represent the differences between the two.
+// Function uses a three-phase approach to find matching resource groups:
+//
+// Phase 1: Find and eliminate resource groups that match exactly
+// Phase 2: Find and eliminate resource groups that match with the best overlap and report discrepancies
+// Phase 3: Report the differences not reported by other phases (e.g. completely different pools, missing attributes)
+//
+// Warnings:
+//   - Resource pool exposed for a driver X in the real node is only checked if the template
+//     exposes at least one resource pool for the same driver, otherwise - it's ignored.
+//   - Drivers which have at least a single resource pool with multiple generation numbers
+//     or incomplete resource pools are not compared.
+func compareDraResources(
+	templateSlices []*v1.ResourceSlice,
+	nodeSlices []*v1.ResourceSlice,
+	deltasBuffer []resourceDelta,
+) []resourceDelta {
+	driversToCompare := findComparedDrivers(templateSlices, nodeSlices)
+	templateResources := buildResourceGroups(templateSlices, driversToCompare)
+	nodeResources := buildResourceGroups(nodeSlices, driversToCompare)
+	// For node resources we maintain a map of identifier to index in the nodeResources slice.
+	// This is used to quickly find a matching resource group in the node resources,
+	// in case of hash collision we iterate over the node resources to find the matching resource group instead
+	nodeResourceAddresses := make(map[resourceGroupIdentifier]int, len(nodeResources))
+	for i, n := range nodeResources {
+		identifier := resourceGroupIdentifier{driver: n.driver, signature: n.signature}
+		nodeResourceAddresses[identifier] = i
+	}
+
+	// Phase 1: Exact Match
+	for i := len(templateResources) - 1; i >= 0; i-- {
+		t := templateResources[i]
+		identifier := resourceGroupIdentifier{driver: t.driver, signature: t.signature}
+		index, ok := nodeResourceAddresses[identifier]
+		if !ok {
+			continue
+		}
+
+		// Fast path: check if the resource group at the found index matches exactly
+		if attributesMatch(t.attrs, nodeResources[index].attrs) && t.deviceCount == nodeResources[index].deviceCount {
+			templateResources = swapDelete(templateResources, i)
+			nodeResources = swapDelete(nodeResources, index)
+
+			// Update address map with a new moved element and clear old entry
+			delete(nodeResourceAddresses, identifier)
+			if index < len(nodeResources) {
+				movedIdentifier := resourceGroupIdentifier{
+					driver:    nodeResources[index].driver,
+					signature: nodeResources[index].signature,
+				}
+				nodeResourceAddresses[movedIdentifier] = index
+			}
+
+			continue
+		}
+
+		// Slow path: in case of a hash collision, iterate over the node resources to find the matching resource group
+		for j, n := range nodeResources {
+			if n.signature != t.signature || n.driver != t.driver {
+				continue
+			}
+
+			if attributesMatch(t.attrs, n.attrs) && t.deviceCount == n.deviceCount {
+				templateResources = swapDelete(templateResources, i)
+				nodeResources = swapDelete(nodeResources, j)
+
+				// Update address map with a new moved element and clear old entry
+				delete(nodeResourceAddresses, identifier)
+				if j < len(nodeResources) {
+					movedIdentifier := resourceGroupIdentifier{
+						driver:    nodeResources[j].driver,
+						signature: nodeResources[j].signature,
+					}
+					nodeResourceAddresses[movedIdentifier] = j
+				}
+
+				break
+			}
+		}
+	}
+
+	// Phase 2 & 3: Fuzzy Match & Diff Reporting
+	for i := len(templateResources) - 1; i >= 0; i-- {
+		t := templateResources[i]
+		bestMatchIndex := -1
+		bestOverlap := -1
+		bestMatchCountDelta := int64(math.MaxInt64)
+
+		// Find the best unmatched candidate
+		for j, n := range nodeResources {
+			if t.driver != n.driver {
+				continue
+			}
+
+			overlap := computeSetOverlap(t.attrs, n.attrs)
+			deviceCountDelta := int64(t.deviceCount) - int64(n.deviceCount)
+
+			if overlap < bestOverlap {
+				continue
+			}
+
+			// Primary objective: Maximize attribute overlap
+			// Secondary objective: Minimize difference in device counts
+			if overlap > bestOverlap || absInt64(deviceCountDelta) < absInt64(bestMatchCountDelta) {
+				bestMatchCountDelta = deviceCountDelta
+				bestOverlap = overlap
+				bestMatchIndex = j
+			}
+		}
+
+		// Completely unmatched driver pool
+		if bestMatchIndex == -1 {
+			continue
+		}
+
+		bestMatch := nodeResources[bestMatchIndex]
+		templateResources = swapDelete(templateResources, i)
+		nodeResources = swapDelete(nodeResources, bestMatchIndex)
+		hasMissing := mapsHaveKeyDifference(t.attrs, bestMatch.attrs)
+		hasExtra := mapsHaveKeyDifference(bestMatch.attrs, t.attrs)
+
+		// Only report if a real diff exists (e.g. different attributes or device count)
+		if hasMissing || hasExtra || bestMatchCountDelta != 0 {
+			deltasBuffer = append(deltasBuffer, resourceDelta{
+				Driver:               t.driver,
+				TemplateResourcePool: t.pool,
+				NodeResourcePool:     bestMatch.pool,
+				DeviceCountDelta:     bestMatchCountDelta,
+				TemplateSignatureMap: t.attrs,
+				NodeSignatureMap:     bestMatch.attrs,
+			})
+		}
+	}
+
+	// Report on remaining template resources
+	for _, t := range templateResources {
+		deltasBuffer = append(deltasBuffer, resourceDelta{
+			Driver:               t.driver,
+			TemplateResourcePool: t.pool,
+			TemplateSignatureMap: t.attrs,
+			DeviceCountDelta:     int64(t.deviceCount),
+		})
+	}
+
+	// Report on remaining node resources
+	for _, n := range nodeResources {
+		deltasBuffer = append(deltasBuffer, resourceDelta{
+			Driver:           n.driver,
+			NodeResourcePool: n.pool,
+			NodeSignatureMap: n.attrs,
+			DeviceCountDelta: -int64(n.deviceCount),
+		})
+	}
+
+	return deltasBuffer
+}
+
+// poolReference is used to identify a resource pool.
+type poolReference struct {
+	driver string
+	pool   string
+}
+
+type poolState struct {
+	generation    int64
+	count         int64
+	completeCount int64
+}
+
+// findComparedDrivers returns a list of drivers that should be compared using following
+// algorithm:
+//  1. Collect all drivers present in the template - those are drivers we care about.
+//  2. Detect drivers in flux (drivers with at least a single resource pool with
+//     multiple generation numbers).
+//  3. Return the list of drivers that are not in flux.
+func findComparedDrivers(templateSlices, nodeSlices []*v1.ResourceSlice) []string {
+	templateDrivers := make([]string, 0, countOfDriversEstimate)
+	for _, t := range templateSlices {
+		if slices.Contains(templateDrivers, t.Spec.Driver) {
+			continue
+		}
+
+		templateDrivers = append(templateDrivers, t.Spec.Driver)
+	}
+
+	driversInFlux := detectDriversInFlux(nodeSlices)
+
+	comparedDrivers := make([]string, 0, len(templateDrivers))
+	for _, driver := range templateDrivers {
+		if slices.Contains(driversInFlux, driver) {
+			continue
+		}
+
+		comparedDrivers = append(comparedDrivers, driver)
+	}
+
+	return comparedDrivers
+}
+
+// detectDriversInFlux detects drivers which have at least a single resource pool with multiple generation numbers.
+func detectDriversInFlux(resourceSlices []*v1.ResourceSlice) []string {
+	poolStates := make(map[poolReference]poolState, len(resourceSlices))
+	var driversInFlux []string
+	for _, rs := range resourceSlices {
+		poolDriver := rs.Spec.Driver
+		if slices.Contains(driversInFlux, poolDriver) {
+			continue
+		}
+
+		poolGeneration := rs.Spec.Pool.Generation
+		poolRef := poolReference{driver: poolDriver, pool: rs.Spec.Pool.Name}
+
+		if state, ok := poolStates[poolRef]; ok {
+			if state.generation != poolGeneration {
+				driversInFlux = append(driversInFlux, poolDriver)
+			}
+
+			state.count++
+			poolStates[poolRef] = state
+			continue
+		}
+
+		poolStates[poolRef] = poolState{
+			generation:    poolGeneration,
+			completeCount: rs.Spec.Pool.ResourceSliceCount,
+			count:         1,
+		}
+	}
+
+	for ref, state := range poolStates {
+		if state.count != state.completeCount && !slices.Contains(driversInFlux, ref.driver) {
+			driversInFlux = append(driversInFlux, ref.driver)
+		}
+	}
+
+	return driversInFlux
+}
+
+// poolShapeIdentifier is used to identify a group of devices with the same attributes, driver and resource pool.
+type poolShapeIdentifier struct {
+	driver    string
+	pool      string
+	signature uint64
+}
+
+// buildResourceGroups extracts resource groups from resource slices and splits them on a basis
+// of driver, pool and attribute signature.
+func buildResourceGroups(resourceSlices []*v1.ResourceSlice, allowedDrivers []string) []resourceGroup {
+	groups := make([]resourceGroup, 0, len(resourceSlices))
+	address := make(map[poolShapeIdentifier]int, len(resourceSlices))
+
+	for _, rs := range resourceSlices {
+		if allowedDrivers != nil && !slices.Contains(allowedDrivers, rs.Spec.Driver) {
+			continue
+		}
+
+		driver := rs.Spec.Driver
+		pool := rs.Spec.Pool.Name
+		for _, device := range rs.Spec.Devices {
+			signature := computeAttrMapHash(device.Attributes)
+			identifier := poolShapeIdentifier{driver: driver, pool: pool, signature: signature}
+
+			foundGroup := false
+			if idx, ok := address[identifier]; ok {
+				// Fast path: if the attributes match the attributes of the resource group at the found index
+				if attributesMatch(groups[idx].attrs, device.Attributes) {
+					groups[idx].deviceCount++
+					foundGroup = true
+				} else {
+					// Slow path: in case of a hash collision, iterate over the resource groups to find the matching resource group
+					for i := range groups {
+						if groups[i].signature == signature && groups[i].driver == driver && groups[i].pool == pool {
+							if attributesMatch(groups[i].attrs, device.Attributes) {
+								groups[i].deviceCount++
+								foundGroup = true
+								break
+							}
+						}
+					}
+				}
+			}
+
+			if foundGroup {
+				continue
+			}
+
+			groups = append(groups, resourceGroup{
+				driver:      driver,
+				pool:        pool,
+				attrs:       device.Attributes,
+				signature:   signature,
+				deviceCount: 1,
+			})
+			address[identifier] = len(groups) - 1
+		}
+	}
+
+	return groups
+}
+
+// attributesMatch checks if two maps of attributes exactly match.
+func attributesMatch(attributes, deviceAttributes map[v1.QualifiedName]v1.DeviceAttribute) bool {
+	if len(attributes) != len(deviceAttributes) {
+		return false
+	}
+
+	for k := range deviceAttributes {
+		if _, ok := attributes[k]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// computeSetOverlap counts overlap without allocating a new set.
+func computeSetOverlap(a, b map[v1.QualifiedName]v1.DeviceAttribute) int {
+	count := 0
+	// Always iterate over the smaller map
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+	for k := range a {
+		if _, exists := b[k]; exists {
+			count++
+		}
+	}
+	return count
+}
+
+// computeAttrMapHash computes a hash of the attribute map. It uses an XOR operation
+// on the individual key hashes to guarantee order-independent determinism without
+// requiring memory allocations for sorting strings.
+func computeAttrMapHash(keys map[v1.QualifiedName]v1.DeviceAttribute) uint64 {
+	var hash uint64
+
+	for k := range keys {
+		hash ^= maphash.String(mapHashSeed, string(k))
+	}
+
+	return hash
+}
+
+// swapDelete removes an element from a slice by swapping it with the last
+// element and shrinking the slice.
+func swapDelete[T any](s []T, i int) []T {
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
+}
+
+// absInt64 returns the absolute value of an int64.
+func absInt64(a int64) int64 {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+// mapKeyDifference returns the keys that are in the base map but not in the subtract map.
+func mapKeyDifference(base, subtract map[v1.QualifiedName]v1.DeviceAttribute) []string {
+	var diff []string
+	for k := range base {
+		if _, ok := subtract[k]; !ok {
+			diff = append(diff, string(k))
+		}
+	}
+	return diff
+}
+
+// mapsHaveKeyDifference checks if two maps have any difference.
+func mapsHaveKeyDifference(base, subtract map[v1.QualifiedName]v1.DeviceAttribute) bool {
+	if len(base) != len(subtract) {
+		return true
+	}
+
+	for k := range base {
+		if _, ok := subtract[k]; !ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// mapKeys extracts the keys from a map and returns them as a slice.
+func mapKeys(m map[v1.QualifiedName]v1.DeviceAttribute) []string {
+	res := make([]string, 0, len(m))
+	for k := range m {
+		res = append(res, string(k))
+	}
+	return res
+}

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
@@ -116,6 +116,26 @@ type nodeResourceIdentifier struct {
 	signature uint64
 }
 
+// resourcePoolIdentifier is used to identify a group of devices with the same attributes, driver and resource pool.
+type resourcePoolIdentifier struct {
+	driver    string
+	pool      string
+	signature uint64
+}
+
+// poolReference is used to identify a resource pool.
+type poolReference struct {
+	driver string
+	pool   string
+}
+
+// poolState is used to track the state of a resource pool.
+type poolState struct {
+	generation    int64
+	count         int64
+	completeCount int64
+}
+
 // resourcePoolComparator is used to compare the resource topologies of the template and the node.
 // Component heavily relies on reusable buffers to minimize allocations and thus is not thread-safe
 // and functions apart of CompareResourcePools are not recommended to be called directly as it may
@@ -231,169 +251,6 @@ func (c *resourcePoolComparator) CompareResourcePools(
 	return deltasBuffer
 }
 
-// findNodeFuzzyMatch finds the best matching resource group available on the node
-// and returns the index of the found group in the nodeResources list or -1 if none
-// found
-func (c *resourcePoolComparator) findNodeFuzzyMatch(target *resourceGroup) int {
-	bestMatchIndex := -1
-	bestOverlap := -1
-	bestDeviceCountDelta := int64(math.MaxInt64)
-
-	for j, node := range c.nodeResources {
-		if target.driver != node.driver {
-			continue
-		}
-
-		overlap := computeSetOverlap(target.attrs, node.attrs)
-		deviceCountDelta := int64(target.deviceCount) - int64(node.deviceCount)
-
-		if overlap < bestOverlap {
-			continue
-		}
-
-		// Primary objective: Maximize attribute overlap
-		// Secondary objective: Minimize difference in device counts
-		if overlap > bestOverlap || absInt64(deviceCountDelta) < absInt64(bestDeviceCountDelta) {
-			bestDeviceCountDelta = deviceCountDelta
-			bestOverlap = overlap
-			bestMatchIndex = j
-		}
-	}
-
-	return bestMatchIndex
-}
-
-// eliminateFuzzyMatchResources eliminates resource groups that match with the best overlap and reports discrepancies.
-func (c *resourcePoolComparator) eliminateFuzzyMatchResources(deltasBuffer []resourceDelta) []resourceDelta {
-	for i := len(c.templateResources) - 1; i >= 0; i-- {
-		template := &c.templateResources[i]
-		bestMatchIndex := c.findNodeFuzzyMatch(template)
-
-		// Completely unmatched driver pool
-		if bestMatchIndex == -1 {
-			continue
-		}
-
-		bestMatch := c.nodeResources[bestMatchIndex]
-		c.templateResources = swapDelete(c.templateResources, i)
-		c.nodeResources = swapDelete(c.nodeResources, bestMatchIndex)
-		hasMissing := mapsHaveKeyDifference(template.attrs, bestMatch.attrs)
-		hasExtra := mapsHaveKeyDifference(bestMatch.attrs, template.attrs)
-		deviceCountDelta := int64(template.deviceCount) - int64(bestMatch.deviceCount)
-
-		// Only report if a real diff exists (e.g. different attributes or device count)
-		if hasMissing || hasExtra || deviceCountDelta != 0 {
-			deltasBuffer = append(deltasBuffer, resourceDelta{
-				Driver:               template.driver,
-				TemplateResourcePool: template.pool,
-				NodeResourcePool:     bestMatch.pool,
-				DeviceCountDelta:     deviceCountDelta,
-				TemplateSignatureMap: template.attrs,
-				NodeSignatureMap:     bestMatch.attrs,
-			})
-		}
-	}
-
-	return deltasBuffer
-}
-
-// eliminateExactMatchResources eliminates resource groups that match exactly by attribute signatures and device counts.
-func (c *resourcePoolComparator) eliminateExactMatchResources() {
-	for i := len(c.templateResources) - 1; i >= 0; i-- {
-		t := c.templateResources[i]
-		identifier := nodeResourceIdentifier{driver: t.driver, signature: t.signature}
-		index, ok := c.nodeResourceAddressMap[identifier]
-		if !ok {
-			continue
-		}
-
-		// Fast path: check if the resource group at the found index matches exactly
-		if attributesMatch(t.attrs, c.nodeResources[index].attrs) && t.deviceCount == c.nodeResources[index].deviceCount {
-			c.templateResources = swapDelete(c.templateResources, i)
-			c.nodeResources = swapDelete(c.nodeResources, index)
-
-			// Update address map with a new moved element and clear old entry
-			delete(c.nodeResourceAddressMap, identifier)
-			if index < len(c.nodeResources) {
-				movedIdentifier := nodeResourceIdentifier{
-					driver:    c.nodeResources[index].driver,
-					signature: c.nodeResources[index].signature,
-				}
-				c.nodeResourceAddressMap[movedIdentifier] = index
-			}
-
-			continue
-		}
-
-		// Slow path: in case of a hash collision, iterate over the node resources to find the matching resource group
-		for j, n := range c.nodeResources {
-			if n.signature != t.signature || n.driver != t.driver {
-				continue
-			}
-
-			if attributesMatch(t.attrs, n.attrs) && t.deviceCount == n.deviceCount {
-				c.templateResources = swapDelete(c.templateResources, i)
-				c.nodeResources = swapDelete(c.nodeResources, j)
-
-				// Update address map with a new moved element and clear old entry
-				delete(c.nodeResourceAddressMap, identifier)
-				if j < len(c.nodeResources) {
-					movedIdentifier := nodeResourceIdentifier{
-						driver:    c.nodeResources[j].driver,
-						signature: c.nodeResources[j].signature,
-					}
-					c.nodeResourceAddressMap[movedIdentifier] = j
-				}
-
-				break
-			}
-		}
-	}
-}
-
-// populateTemplateGroups populates the template resource groups from the template slices.
-func (c *resourcePoolComparator) populateTemplateGroups(templateSlices []*v1.ResourceSlice) {
-	c.templateResources = c.buildResourceGroups(templateSlices, c.templateResources, c.templatePoolAddressMap)
-}
-
-// populateNodeGroups populates the node resource groups from the node slices.
-func (c *resourcePoolComparator) populateNodeGroups(nodeSlices []*v1.ResourceSlice) {
-	c.nodeResources = c.buildResourceGroups(nodeSlices, c.nodeResources, c.nodePoolAddressMap)
-	for i, n := range c.nodeResources {
-		identifier := nodeResourceIdentifier{driver: n.driver, signature: n.signature}
-		c.nodeResourceAddressMap[identifier] = i
-	}
-}
-
-// poolReference is used to identify a resource pool.
-type poolReference struct {
-	driver string
-	pool   string
-}
-
-// poolState is used to track the state of a resource pool.
-type poolState struct {
-	generation    int64
-	count         int64
-	completeCount int64
-}
-
-// populateComparedDrivers populates the list of drivers that should be compared, assumes that
-// drivers in flux are already filtered out.
-func (c *resourcePoolComparator) populateComparedDrivers(templateSlices []*v1.ResourceSlice) {
-	for _, t := range templateSlices {
-		if slices.Contains(c.comparedDrivers, t.Spec.Driver) {
-			continue
-		}
-
-		if slices.Contains(c.driversInFlux, t.Spec.Driver) {
-			continue
-		}
-
-		c.comparedDrivers = append(c.comparedDrivers, t.Spec.Driver)
-	}
-}
-
 // populateDriversInFlux detects drivers which have at least a single resource pool with multiple generation numbers.
 func (c *resourcePoolComparator) populateDriversInFlux(resourceSlices []*v1.ResourceSlice) {
 	for _, rs := range resourceSlices {
@@ -428,11 +285,139 @@ func (c *resourcePoolComparator) populateDriversInFlux(resourceSlices []*v1.Reso
 	}
 }
 
-// resourcePoolIdentifier is used to identify a group of devices with the same attributes, driver and resource pool.
-type resourcePoolIdentifier struct {
-	driver    string
-	pool      string
-	signature uint64
+// populateComparedDrivers populates the list of drivers that should be compared, assumes that
+// drivers in flux are already filtered out.
+func (c *resourcePoolComparator) populateComparedDrivers(templateSlices []*v1.ResourceSlice) {
+	for _, t := range templateSlices {
+		if slices.Contains(c.comparedDrivers, t.Spec.Driver) {
+			continue
+		}
+
+		if slices.Contains(c.driversInFlux, t.Spec.Driver) {
+			continue
+		}
+
+		c.comparedDrivers = append(c.comparedDrivers, t.Spec.Driver)
+	}
+}
+
+// populateTemplateGroups populates the template resource groups from the template slices.
+func (c *resourcePoolComparator) populateTemplateGroups(templateSlices []*v1.ResourceSlice) {
+	c.templateResources = c.buildResourceGroups(templateSlices, c.templateResources, c.templatePoolAddressMap)
+}
+
+// populateNodeGroups populates the node resource groups from the node slices.
+func (c *resourcePoolComparator) populateNodeGroups(nodeSlices []*v1.ResourceSlice) {
+	c.nodeResources = c.buildResourceGroups(nodeSlices, c.nodeResources, c.nodePoolAddressMap)
+	for i, n := range c.nodeResources {
+		identifier := nodeResourceIdentifier{driver: n.driver, signature: n.signature}
+		c.nodeResourceAddressMap[identifier] = i
+	}
+}
+
+// eliminateExactMatchResources eliminates resource groups that match exactly by attribute signatures and device counts.
+func (c *resourcePoolComparator) eliminateExactMatchResources() {
+	for i := len(c.templateResources) - 1; i >= 0; i-- {
+		t := c.templateResources[i]
+		identifier := nodeResourceIdentifier{driver: t.driver, signature: t.signature}
+		index, ok := c.nodeResourceAddressMap[identifier]
+
+		// Fast path: check if the resource group at the found index matches exactly
+		if ok && attributesMatch(t.attrs, c.nodeResources[index].attrs) && t.deviceCount == c.nodeResources[index].deviceCount {
+			c.templateResources = swapDelete(c.templateResources, i)
+			c.nodeResources = swapDelete(c.nodeResources, index)
+			c.deleteNodeResourceAddress(identifier, index)
+
+			continue
+		}
+
+		// Slow path: in case of a hash collision, iterate over the node resources to find the matching resource group
+		for j, n := range c.nodeResources {
+			if n.signature != t.signature || n.driver != t.driver {
+				continue
+			}
+
+			if attributesMatch(t.attrs, n.attrs) && t.deviceCount == n.deviceCount {
+				c.templateResources = swapDelete(c.templateResources, i)
+				c.nodeResources = swapDelete(c.nodeResources, j)
+				c.deleteNodeResourceAddress(identifier, j)
+				break
+			}
+		}
+	}
+}
+
+// eliminateFuzzyMatchResources eliminates resource groups that match with the best overlap and reports discrepancies.
+func (c *resourcePoolComparator) eliminateFuzzyMatchResources(deltasBuffer []resourceDelta) []resourceDelta {
+	for i := len(c.templateResources) - 1; i >= 0; i-- {
+		template := &c.templateResources[i]
+		bestMatchIndex := c.findNodeFuzzyMatch(template)
+
+		// Completely unmatched driver pool
+		if bestMatchIndex == -1 {
+			continue
+		}
+
+		bestMatch := c.nodeResources[bestMatchIndex]
+		c.templateResources = swapDelete(c.templateResources, i)
+		c.nodeResources = swapDelete(c.nodeResources, bestMatchIndex)
+		deviceCountDelta := int64(template.deviceCount) - int64(bestMatch.deviceCount)
+
+		deltasBuffer = append(deltasBuffer, resourceDelta{
+			Driver:               template.driver,
+			TemplateResourcePool: template.pool,
+			NodeResourcePool:     bestMatch.pool,
+			DeviceCountDelta:     deviceCountDelta,
+			TemplateSignatureMap: template.attrs,
+			NodeSignatureMap:     bestMatch.attrs,
+		})
+	}
+
+	return deltasBuffer
+}
+
+// findNodeFuzzyMatch finds the best matching resource group available on the node
+// and returns the index of the found group in the nodeResources list or -1 if none
+// found
+func (c *resourcePoolComparator) findNodeFuzzyMatch(target *resourceGroup) int {
+	bestMatchIndex := -1
+	bestOverlap := -1
+	bestDeviceCountDelta := int64(math.MaxInt64)
+
+	for j, node := range c.nodeResources {
+		if target.driver != node.driver {
+			continue
+		}
+
+		overlap := computeSetOverlap(target.attrs, node.attrs)
+		deviceCountDelta := int64(target.deviceCount) - int64(node.deviceCount)
+
+		if overlap < bestOverlap {
+			continue
+		}
+
+		// Primary objective: Maximize attribute overlap
+		// Secondary objective: Minimize difference in device counts
+		if overlap > bestOverlap || absInt64(deviceCountDelta) < absInt64(bestDeviceCountDelta) {
+			bestDeviceCountDelta = deviceCountDelta
+			bestOverlap = overlap
+			bestMatchIndex = j
+		}
+	}
+
+	return bestMatchIndex
+}
+
+// deleteNodeResourceAddress deletes the node resource address from the map and updates the map with a new moved element.
+func (c *resourcePoolComparator) deleteNodeResourceAddress(identifier nodeResourceIdentifier, index int) {
+	delete(c.nodeResourceAddressMap, identifier)
+	if index < len(c.nodeResources) {
+		movedIdentifier := nodeResourceIdentifier{
+			driver:    c.nodeResources[index].driver,
+			signature: c.nodeResources[index].signature,
+		}
+		c.nodeResourceAddressMap[movedIdentifier] = index
+	}
 }
 
 // ingestPoolDevice ingests device into a resource group by either placing it into one of the
@@ -444,8 +429,8 @@ func (c *resourcePoolComparator) ingestPoolDevice(
 	groups []resourceGroup,
 	addresses map[resourcePoolIdentifier]int,
 ) []resourceGroup {
-	signature := computeAttrMapHash(attributes)
-	identifier := resourcePoolIdentifier{driver: driver, pool: pool, signature: signature}
+	hash := computeAttrMapHash(attributes)
+	identifier := resourcePoolIdentifier{driver: driver, pool: pool, signature: hash}
 
 	if idx, ok := addresses[identifier]; ok {
 		// Fast path: if the attributes match the attributes of the resource group at the found index
@@ -456,7 +441,7 @@ func (c *resourcePoolComparator) ingestPoolDevice(
 
 		// Slow path: in case of a hash collision, iterate over the resource groups to find the matching resource group
 		for i := range groups {
-			if groups[i].signature == signature && groups[i].driver == driver && groups[i].pool == pool {
+			if groups[i].signature == hash && groups[i].driver == driver && groups[i].pool == pool {
 				if attributesMatch(groups[i].attrs, attributes) {
 					groups[i].deviceCount++
 					return groups
@@ -470,7 +455,7 @@ func (c *resourcePoolComparator) ingestPoolDevice(
 		driver:      driver,
 		pool:        pool,
 		attrs:       attributes,
-		signature:   signature,
+		signature:   hash,
 		deviceCount: 1,
 	})
 	addresses[identifier] = len(groups) - 1
@@ -557,19 +542,4 @@ func absInt64(a int64) int64 {
 		return -a
 	}
 	return a
-}
-
-// mapsHaveKeyDifference checks if two maps have any difference.
-func mapsHaveKeyDifference(base, subtract attributesMap) bool {
-	if len(base) != len(subtract) {
-		return true
-	}
-
-	for k := range base {
-		if _, ok := subtract[k]; !ok {
-			return true
-		}
-	}
-
-	return false
 }

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta.go
@@ -359,10 +359,7 @@ func (c *resourcePoolComparator) eliminateFuzzyMatchResources(deltasBuffer []res
 		}
 
 		bestMatch := c.nodeResources[bestMatchIndex]
-		c.templateResources = swapDelete(c.templateResources, i)
-		c.nodeResources = swapDelete(c.nodeResources, bestMatchIndex)
 		deviceCountDelta := int64(template.deviceCount) - int64(bestMatch.deviceCount)
-
 		deltasBuffer = append(deltasBuffer, resourceDelta{
 			Driver:               template.driver,
 			TemplateResourcePool: template.pool,
@@ -371,6 +368,9 @@ func (c *resourcePoolComparator) eliminateFuzzyMatchResources(deltasBuffer []res
 			TemplateSignatureMap: template.attrs,
 			NodeSignatureMap:     bestMatch.attrs,
 		})
+
+		c.templateResources = swapDelete(c.templateResources, i)
+		c.nodeResources = swapDelete(c.nodeResources, bestMatchIndex)
 	}
 
 	return deltasBuffer

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta_test.go
@@ -1,0 +1,530 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comparator
+
+import (
+	gocmp "cmp"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	resourceapi "k8s.io/api/resource/v1"
+	v1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	deviceShapeA     = map[string]struct{}{"A": {}}
+	deviceShapeB     = map[string]struct{}{"B": {}}
+	deviceShapeAB    = map[string]struct{}{"A": {}, "B": {}}
+	deviceShapeEmpty = map[string]struct{}{}
+	deviceShapeABC   = map[string]struct{}{"A": {}, "B": {}, "C": {}}
+	deviceShapeABCD  = map[string]struct{}{"A": {}, "B": {}, "C": {}, "D": {}}
+	deviceShapeA_BC  = map[string]struct{}{"A": {}, "BC": {}}
+	deviceShapeAB_C  = map[string]struct{}{"AB": {}, "C": {}}
+)
+
+func TestCompareDraResources(t *testing.T) {
+	tests := map[string]struct {
+		templateSlices []*resourceapi.ResourceSlice
+		nodeSlices     []*resourceapi.ResourceSlice
+		wantReports    []resourceDelta
+	}{
+		"Empty": {
+			templateSlices: []*resourceapi.ResourceSlice{},
+			nodeSlices:     []*resourceapi.ResourceSlice{},
+			wantReports:    []resourceDelta{},
+		},
+		"TemplateOnly": {
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+			nodeSlices:     []*resourceapi.ResourceSlice{},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     signatureMap{},
+					DeviceCountDelta:     1,
+				},
+			},
+		},
+		"NoDriverInTemplate": {
+			templateSlices: []*resourceapi.ResourceSlice{},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+			wantReports:    []resourceDelta{},
+		},
+		"ShapeMismatch": {
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeB})},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool",
+					NodeResourcePool:     "pool",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     signatureMap{v1.QualifiedName("B"): {}},
+					DeviceCountDelta:     0,
+				},
+			},
+		},
+		"ExactMatch": {
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 2, shape: deviceShapeA})},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 2, shape: deviceShapeA})},
+			wantReports:    []resourceDelta{},
+		},
+		"ExactMatchDifferentPoolName": {
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "template-pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "node-pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+			wantReports:    []resourceDelta{},
+		},
+		"MissingHardware": {
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 3, shape: deviceShapeA})},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 2, shape: deviceShapeA})},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool",
+					NodeResourcePool:     "pool",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					DeviceCountDelta:     1,
+				},
+			},
+		},
+		"FuzzyMatchSubset": {
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeAB})},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool",
+					NodeResourcePool:     "pool",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}},
+				},
+			},
+		},
+		"FuzzyMatchSuperset": {
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeAB})},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool",
+					NodeResourcePool:     "pool",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+				},
+			},
+		},
+		"HeterogeneousPoolExactMatch": {
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{1, deviceShapeA}, poolDevices{1, deviceShapeB})},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{1, deviceShapeB}, poolDevices{1, deviceShapeA})},
+			wantReports:    []resourceDelta{},
+		},
+		"ExtraNodeResourcePool": {
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{1, deviceShapeA})},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver", "pool", poolDevices{1, deviceShapeA}),
+				makeSingleResourceSlice("driver", "pool-extra", poolDevices{1, deviceShapeB}),
+			},
+			wantReports: []resourceDelta{
+				{
+					Driver:           "driver",
+					NodeResourcePool: "pool-extra",
+					NodeSignatureMap: signatureMap{v1.QualifiedName("B"): {}},
+					DeviceCountDelta: -1,
+				},
+			},
+		},
+		"FragmentedNodeSlices": {
+			templateSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver", "pool-a", poolDevices{deviceCount: 4, shape: deviceShapeA}),
+			},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				makeResourceSlice("driver", "pool-a", 2, poolDevices{deviceCount: 2, shape: deviceShapeA}),
+				makeResourceSlice("driver", "pool-a", 2, poolDevices{deviceCount: 2, shape: deviceShapeA}),
+			},
+			wantReports: []resourceDelta{},
+		},
+		"MultiplePoolsWithMixedDeltas": {
+			templateSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver", "pool-1", poolDevices{deviceCount: 2, shape: deviceShapeA}),
+				makeSingleResourceSlice("driver", "pool-2", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+			},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				// pool-1 is missing a device (count 1 instead of 2)
+				makeSingleResourceSlice("driver", "pool-1", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+				// pool-2 has an extra attribute (shape AB instead of B)
+				makeSingleResourceSlice("driver", "pool-2", poolDevices{deviceCount: 1, shape: deviceShapeAB}),
+			},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool-1",
+					NodeResourcePool:     "pool-1",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}},
+					DeviceCountDelta:     1,
+				},
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool-2",
+					NodeResourcePool:     "pool-2",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("B"): {}},
+					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+				},
+			},
+		},
+		"CrossDriver": {
+			templateSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver-alpha", "pool-a", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+				makeSingleResourceSlice("driver-beta", "pool-b", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+			},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				// alpha matches perfectly
+				makeSingleResourceSlice("driver-alpha", "pool-a", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+				// beta has a mismatch
+				makeSingleResourceSlice("driver-beta", "pool-b", poolDevices{deviceCount: 1, shape: deviceShapeAB}),
+				// gamma should be completely ignored (not in template)
+				makeSingleResourceSlice("driver-gamma", "pool-c", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+			},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver-beta",
+					TemplateResourcePool: "pool-b",
+					NodeResourcePool:     "pool-b",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("B"): {}},
+					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+				},
+			},
+		},
+		"HashDelimiterAntiCollision": { // "A"+"BC" and "AB"+"C" both concat to "ABC".
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA_BC})},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeAB_C})},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool",
+					NodeResourcePool:     "pool",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("BC"): {}},
+					NodeSignatureMap:     signatureMap{v1.QualifiedName("AB"): {}, v1.QualifiedName("C"): {}},
+				},
+			},
+		},
+		"FuzzyPriorityOverlapOverCount": {
+			templateSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver", "pool-t", poolDevices{deviceCount: 5, shape: deviceShapeABC}),
+			},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver", "pool-n1", poolDevices{deviceCount: 5, shape: deviceShapeAB}),
+				makeSingleResourceSlice("driver", "pool-n2", poolDevices{deviceCount: 3, shape: deviceShapeABCD}),
+			},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool-t",
+					NodeResourcePool:     "pool-n2",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}, v1.QualifiedName("C"): {}},
+					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}, v1.QualifiedName("C"): {}, v1.QualifiedName("D"): {}},
+					DeviceCountDelta:     2,
+				},
+				{
+					Driver:           "driver",
+					NodeResourcePool: "pool-n1",
+					NodeSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					DeviceCountDelta: -5,
+				},
+			},
+		},
+		"EmptyAttributesBoundary": {
+			// Verifies that devices with zero attributes are processed and diffed correctly
+			templateSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 2, shape: deviceShapeEmpty}),
+			},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeEmpty}),
+				makeSingleResourceSlice("driver", "missing", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+			},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "driver",
+					TemplateResourcePool: "pool",
+					NodeResourcePool:     "pool",
+					TemplateSignatureMap: signatureMap{},
+					NodeSignatureMap:     signatureMap{},
+					DeviceCountDelta:     1,
+				},
+				{
+					Driver:           "driver",
+					NodeResourcePool: "missing",
+					NodeSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					DeviceCountDelta: -1,
+				},
+			},
+		},
+		"DriverWithPoolInFlux_GenerationMismatch": {
+			templateSlices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name: "pool",
+						},
+						Devices: []resourceapi.Device{
+							{
+								Attributes: makeAttributesFromShape(deviceShapeA),
+							},
+						},
+					},
+				},
+			},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:       "pool",
+							Generation: 1,
+						},
+						Devices: []resourceapi.Device{
+							{
+								Attributes: makeAttributesFromShape(deviceShapeB),
+							},
+						},
+					},
+				},
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:       "pool",
+							Generation: 2,
+						},
+						Devices: []resourceapi.Device{
+							{
+								Attributes: makeAttributesFromShape(deviceShapeABC),
+							},
+						},
+					},
+				},
+			},
+			wantReports: []resourceDelta{},
+		},
+		"DriverWithPoolInFlux_IncompletePool": {
+			templateSlices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name: "pool",
+						},
+						Devices: []resourceapi.Device{
+							{
+								Attributes: makeAttributesFromShape(deviceShapeA),
+							},
+						},
+					},
+				},
+			},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "driver",
+						Pool: resourceapi.ResourcePool{
+							Name:               "pool",
+							ResourceSliceCount: 2,
+						},
+						Devices: []resourceapi.Device{
+							{
+								Attributes: makeAttributesFromShape(deviceShapeB),
+							},
+						},
+					},
+				},
+			},
+			wantReports: []resourceDelta{},
+		},
+		"AllInOne": {
+			templateSlices: []*resourceapi.ResourceSlice{
+				// DRIVER 1: GPU
+				makeSingleResourceSlice("gpu-driver", "gpu-expected-pool", poolDevices{deviceCount: 2, shape: deviceShapeAB}),
+				makeSingleResourceSlice("gpu-driver", "gpu-expected-pool", poolDevices{deviceCount: 2, shape: deviceShapeAB}),
+				// DRIVER 2: CUSTOM
+				makeSingleResourceSlice("custom-driver", "custom-expected-pool",
+					poolDevices{deviceCount: 2, shape: deviceShapeA},
+					poolDevices{deviceCount: 2, shape: deviceShapeAB},
+				),
+				// DRIVER 3: MISSING
+				makeSingleResourceSlice("missing-driver", "missing-pool", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+			},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				// DRIVER 1: GPU
+				makeSingleResourceSlice("gpu-driver", "gpu-actual-pool", poolDevices{deviceCount: 3, shape: deviceShapeAB}),
+				makeSingleResourceSlice("gpu-driver", "gpu-actual-pool", poolDevices{deviceCount: 1, shape: deviceShapeAB}),
+				// DRIVER 2: CUSTOM
+				makeSingleResourceSlice("custom-driver", "custom-actual-exact", poolDevices{deviceCount: 2, shape: deviceShapeA}),
+				makeSingleResourceSlice("custom-driver", "custom-actual-fuzzy-1", poolDevices{deviceCount: 2, shape: deviceShapeB}),
+				makeSingleResourceSlice("custom-driver", "custom-actual-fuzzy-2", poolDevices{deviceCount: 5, shape: deviceShapeA}),
+				// DRIVER 4: ROGUE
+				makeSingleResourceSlice("rogue-driver", "rogue-pool", poolDevices{deviceCount: 99, shape: deviceShapeAB}),
+			},
+			wantReports: []resourceDelta{
+				{
+					Driver:               "custom-driver",
+					TemplateResourcePool: "custom-expected-pool",
+					NodeResourcePool:     "custom-actual-fuzzy-1",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					NodeSignatureMap:     signatureMap{v1.QualifiedName("B"): {}},
+				},
+				{
+					Driver:               "missing-driver",
+					TemplateResourcePool: "missing-pool",
+					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     signatureMap{},
+					DeviceCountDelta:     1,
+				},
+				{
+					Driver:           "custom-driver",
+					NodeResourcePool: "custom-actual-fuzzy-2",
+					NodeSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					DeviceCountDelta: -5,
+				},
+			},
+		},
+	}
+
+	cmdOpt := cmpopts.EquateEmpty()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			reports := compareDraResources(test.templateSlices, test.nodeSlices, nil)
+			reports = normalizeReports(reports)
+			test.wantReports = normalizeReports(test.wantReports)
+			if diff := cmp.Diff(test.wantReports, reports, cmdOpt); diff != "" {
+				t.Errorf("CompareDraResources() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkCompareDraResourcesExact(b *testing.B) {
+	templateSlices := []*resourceapi.ResourceSlice{
+		makeResourceSlice("gpu-driver", "gpu-expected-pool", 1, poolDevices{deviceCount: 10, shape: deviceShapeAB}),
+	}
+	nodeSlices := []*resourceapi.ResourceSlice{
+		makeResourceSlice("gpu-driver", "gpu-actual-pool", 1, poolDevices{deviceCount: 10, shape: deviceShapeAB}),
+	}
+	for i := 0; i < b.N; i++ {
+		compareDraResources(templateSlices, nodeSlices, nil)
+	}
+}
+
+func BenchmarkCompareDraResourcesFuzzy(b *testing.B) {
+	templateSlices := []*resourceapi.ResourceSlice{
+		makeResourceSlice("gpu-driver", "gpu-expected-pool", 1, poolDevices{deviceCount: 10, shape: deviceShapeAB}),
+	}
+	nodeSlices := []*resourceapi.ResourceSlice{
+		makeResourceSlice("gpu-driver", "gpu-actual-pool", 1, poolDevices{deviceCount: 10, shape: deviceShapeABC}),
+	}
+	for i := 0; i < b.N; i++ {
+		compareDraResources(templateSlices, nodeSlices, nil)
+	}
+}
+
+func BenchmarkCompareDraResourcesRankingFuzzy(b *testing.B) {
+	templateSlices := []*resourceapi.ResourceSlice{
+		makeResourceSlice("gpu-driver", "gpu-expected-pool", 1, poolDevices{deviceCount: 10, shape: deviceShapeAB}),
+	}
+	nodeSlices := []*resourceapi.ResourceSlice{
+		makeResourceSlice("gpu-driver", "gpu-actual-pool", 3, poolDevices{deviceCount: 9, shape: deviceShapeABC}),
+		makeResourceSlice("gpu-driver", "gpu-actual-pool", 3, poolDevices{deviceCount: 11, shape: deviceShapeA}),
+		makeResourceSlice("gpu-driver", "gpu-actual-pool", 3, poolDevices{deviceCount: 10, shape: deviceShapeB}),
+	}
+	for i := 0; i < b.N; i++ {
+		compareDraResources(templateSlices, nodeSlices, nil)
+	}
+}
+
+func normalizeReports(reports []resourceDelta) []resourceDelta {
+	slices.SortStableFunc(reports, func(a, b resourceDelta) int {
+		if diff := gocmp.Compare(a.Driver, b.Driver); diff != 0 {
+			return diff
+		}
+		if diff := gocmp.Compare(a.TemplateResourcePool, b.TemplateResourcePool); diff != 0 {
+			return diff
+		}
+		if diff := gocmp.Compare(a.NodeResourcePool, b.NodeResourcePool); diff != 0 {
+			return diff
+		}
+		return 0
+	})
+
+	return reports
+}
+
+type poolDevices struct {
+	deviceCount int
+	shape       map[string]struct{}
+}
+
+func makeAttributesFromShape(shape map[string]struct{}) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
+	for attr := range shape {
+		attributes[resourceapi.QualifiedName(attr)] = resourceapi.DeviceAttribute{}
+	}
+	return attributes
+}
+
+func makeResourceSlice(driver string, pool string, slicesCount int, devices ...poolDevices) *resourceapi.ResourceSlice {
+	totalDevices := 0
+	for _, shape := range devices {
+		totalDevices += shape.deviceCount
+	}
+
+	sliceDevices := make([]resourceapi.Device, totalDevices)
+	createdDevices := 0
+	for i, shape := range devices {
+		for j := 0; j < shape.deviceCount; j++ {
+			sliceDevices[createdDevices] = resourceapi.Device{
+				Name:       fmt.Sprintf("dev-%d-%d", i, j),
+				Attributes: makeAttributesFromShape(shape.shape),
+			}
+			createdDevices++
+		}
+	}
+
+	return &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("slice-%s-%d", pool, slicesCount),
+		},
+		Spec: resourceapi.ResourceSliceSpec{
+			Driver: driver,
+			Pool: resourceapi.ResourcePool{
+				Name:               pool,
+				ResourceSliceCount: int64(slicesCount),
+				Generation:         1,
+			},
+			Devices: sliceDevices,
+		},
+	}
+}
+
+func makeSingleResourceSlice(driver string, pool string, devices ...poolDevices) *resourceapi.ResourceSlice {
+	return makeResourceSlice(driver, pool, 1, devices...)
+}

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta_test.go
@@ -30,15 +30,93 @@ import (
 )
 
 var (
-	deviceShapeA     = map[string]struct{}{"A": {}}
-	deviceShapeB     = map[string]struct{}{"B": {}}
-	deviceShapeAB    = map[string]struct{}{"A": {}, "B": {}}
-	deviceShapeEmpty = map[string]struct{}{}
-	deviceShapeABC   = map[string]struct{}{"A": {}, "B": {}, "C": {}}
-	deviceShapeABCD  = map[string]struct{}{"A": {}, "B": {}, "C": {}, "D": {}}
-	deviceShapeA_BC  = map[string]struct{}{"A": {}, "BC": {}}
-	deviceShapeAB_C  = map[string]struct{}{"AB": {}, "C": {}}
+	deviceShapeA       = map[string]struct{}{"A": {}}
+	deviceShapeB       = map[string]struct{}{"B": {}}
+	deviceShapeAB      = map[string]struct{}{"A": {}, "B": {}}
+	deviceShapeEmpty   = map[string]struct{}{}
+	deviceShapeABC     = map[string]struct{}{"A": {}, "B": {}, "C": {}}
+	deviceShapeABCD    = map[string]struct{}{"A": {}, "B": {}, "C": {}, "D": {}}
+	deviceShapeAPlusBC = map[string]struct{}{"A": {}, "BC": {}}
+	deviceShapeABPlusC = map[string]struct{}{"AB": {}, "C": {}}
 )
+
+func TestResourceDeltaType(t *testing.T) {
+	tests := map[string]struct {
+		delta      resourceDelta
+		want       resourceDeltaType
+		wantString string
+	}{
+		"Missing": {
+			delta:      resourceDelta{TemplateResourcePool: "pool", NodeResourcePool: ""},
+			want:       resourceDeltaTypeMissing,
+			wantString: "Missing",
+		},
+		"Extra": {
+			delta:      resourceDelta{TemplateResourcePool: "", NodeResourcePool: "pool"},
+			want:       resourceDeltaTypeExtra,
+			wantString: "Extra",
+		},
+		"Mismatch": {
+			delta:      resourceDelta{TemplateResourcePool: "pool1", NodeResourcePool: "pool2"},
+			want:       resourceDeltaTypeMismatch,
+			wantString: "Mismatch",
+		},
+		"Unknown": {
+			delta:      resourceDelta{TemplateResourcePool: "", NodeResourcePool: ""},
+			want:       resourceDeltaTypeUnknown,
+			wantString: "Unknown",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			deltaType := tc.delta.Type()
+			if deltaType != tc.want {
+				t.Errorf("resourceDelta.Type() = %v, want %v", deltaType, tc.want)
+			}
+			if deltaType.String() != tc.wantString {
+				t.Errorf("resourceDelta.String() = %v, want %v", deltaType.String(), tc.wantString)
+			}
+		})
+	}
+}
+
+func TestAttributesMatch(t *testing.T) {
+	tests := map[string]struct {
+		a    attributesMap
+		b    attributesMap
+		want bool
+	}{
+		"EmptyMatch": {
+			a:    attributesMap{},
+			b:    attributesMap{},
+			want: true,
+		},
+		"LengthMismatch": {
+			a:    attributesMap{v1.QualifiedName("A"): {}},
+			b:    attributesMap{},
+			want: false,
+		},
+		"KeyMismatch": {
+			a:    attributesMap{v1.QualifiedName("A"): {}},
+			b:    attributesMap{v1.QualifiedName("B"): {}},
+			want: false,
+		},
+		"ExactMatch": {
+			a:    attributesMap{v1.QualifiedName("A"): {}},
+			b:    attributesMap{v1.QualifiedName("A"): {}},
+			want: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := attributesMatch(tc.a, tc.b); got != tc.want {
+				t.Errorf("attributesMatch() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestCompareDraResources(t *testing.T) {
 	tests := map[string]struct {
@@ -58,8 +136,8 @@ func TestCompareDraResources(t *testing.T) {
 				{
 					Driver:               "driver",
 					TemplateResourcePool: "pool",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
-					NodeSignatureMap:     signatureMap{},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     attributesMap{},
 					DeviceCountDelta:     1,
 				},
 			},
@@ -77,8 +155,8 @@ func TestCompareDraResources(t *testing.T) {
 					Driver:               "driver",
 					TemplateResourcePool: "pool",
 					NodeResourcePool:     "pool",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
-					NodeSignatureMap:     signatureMap{v1.QualifiedName("B"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("B"): {}},
 					DeviceCountDelta:     0,
 				},
 			},
@@ -101,8 +179,8 @@ func TestCompareDraResources(t *testing.T) {
 					Driver:               "driver",
 					TemplateResourcePool: "pool",
 					NodeResourcePool:     "pool",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
-					NodeSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("A"): {}},
 					DeviceCountDelta:     1,
 				},
 			},
@@ -115,8 +193,8 @@ func TestCompareDraResources(t *testing.T) {
 					Driver:               "driver",
 					TemplateResourcePool: "pool",
 					NodeResourcePool:     "pool",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
-					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("A"): {}},
 				},
 			},
 		},
@@ -128,8 +206,8 @@ func TestCompareDraResources(t *testing.T) {
 					Driver:               "driver",
 					TemplateResourcePool: "pool",
 					NodeResourcePool:     "pool",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
-					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
 				},
 			},
 		},
@@ -148,7 +226,7 @@ func TestCompareDraResources(t *testing.T) {
 				{
 					Driver:           "driver",
 					NodeResourcePool: "pool-extra",
-					NodeSignatureMap: signatureMap{v1.QualifiedName("B"): {}},
+					NodeSignatureMap: attributesMap{v1.QualifiedName("B"): {}},
 					DeviceCountDelta: -1,
 				},
 			},
@@ -179,16 +257,16 @@ func TestCompareDraResources(t *testing.T) {
 					Driver:               "driver",
 					TemplateResourcePool: "pool-1",
 					NodeResourcePool:     "pool-1",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
-					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("A"): {}},
 					DeviceCountDelta:     1,
 				},
 				{
 					Driver:               "driver",
 					TemplateResourcePool: "pool-2",
 					NodeResourcePool:     "pool-2",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("B"): {}},
-					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("B"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
 				},
 			},
 		},
@@ -210,21 +288,21 @@ func TestCompareDraResources(t *testing.T) {
 					Driver:               "driver-beta",
 					TemplateResourcePool: "pool-b",
 					NodeResourcePool:     "pool-b",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("B"): {}},
-					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("B"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
 				},
 			},
 		},
 		"HashDelimiterAntiCollision": { // "A"+"BC" and "AB"+"C" both concat to "ABC".
-			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA_BC})},
-			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeAB_C})},
+			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeAPlusBC})},
+			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeABPlusC})},
 			wantReports: []resourceDelta{
 				{
 					Driver:               "driver",
 					TemplateResourcePool: "pool",
 					NodeResourcePool:     "pool",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("BC"): {}},
-					NodeSignatureMap:     signatureMap{v1.QualifiedName("AB"): {}, v1.QualifiedName("C"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("BC"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("AB"): {}, v1.QualifiedName("C"): {}},
 				},
 			},
 		},
@@ -241,14 +319,14 @@ func TestCompareDraResources(t *testing.T) {
 					Driver:               "driver",
 					TemplateResourcePool: "pool-t",
 					NodeResourcePool:     "pool-n2",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}, v1.QualifiedName("C"): {}},
-					NodeSignatureMap:     signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}, v1.QualifiedName("C"): {}, v1.QualifiedName("D"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}, v1.QualifiedName("C"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}, v1.QualifiedName("C"): {}, v1.QualifiedName("D"): {}},
 					DeviceCountDelta:     2,
 				},
 				{
 					Driver:           "driver",
 					NodeResourcePool: "pool-n1",
-					NodeSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					NodeSignatureMap: attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
 					DeviceCountDelta: -5,
 				},
 			},
@@ -267,14 +345,14 @@ func TestCompareDraResources(t *testing.T) {
 					Driver:               "driver",
 					TemplateResourcePool: "pool",
 					NodeResourcePool:     "pool",
-					TemplateSignatureMap: signatureMap{},
-					NodeSignatureMap:     signatureMap{},
+					TemplateSignatureMap: attributesMap{},
+					NodeSignatureMap:     attributesMap{},
 					DeviceCountDelta:     1,
 				},
 				{
 					Driver:           "driver",
 					NodeResourcePool: "missing",
-					NodeSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
 					DeviceCountDelta: -1,
 				},
 			},
@@ -390,20 +468,20 @@ func TestCompareDraResources(t *testing.T) {
 					Driver:               "custom-driver",
 					TemplateResourcePool: "custom-expected-pool",
 					NodeResourcePool:     "custom-actual-fuzzy-1",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
-					NodeSignatureMap:     signatureMap{v1.QualifiedName("B"): {}},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("B"): {}},
 				},
 				{
 					Driver:               "missing-driver",
 					TemplateResourcePool: "missing-pool",
-					TemplateSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
-					NodeSignatureMap:     signatureMap{},
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     attributesMap{},
 					DeviceCountDelta:     1,
 				},
 				{
 					Driver:           "custom-driver",
 					NodeResourcePool: "custom-actual-fuzzy-2",
-					NodeSignatureMap: signatureMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
 					DeviceCountDelta: -5,
 				},
 			},
@@ -413,7 +491,8 @@ func TestCompareDraResources(t *testing.T) {
 	cmdOpt := cmpopts.EquateEmpty()
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			reports := compareDraResources(test.templateSlices, test.nodeSlices, nil)
+			comparator := newResourcePoolComparator()
+			reports := comparator.CompareResourcePools(test.templateSlices, test.nodeSlices, nil)
 			reports = normalizeReports(reports)
 			test.wantReports = normalizeReports(test.wantReports)
 			if diff := cmp.Diff(test.wantReports, reports, cmdOpt); diff != "" {
@@ -430,8 +509,12 @@ func BenchmarkCompareDraResourcesExact(b *testing.B) {
 	nodeSlices := []*resourceapi.ResourceSlice{
 		makeResourceSlice("gpu-driver", "gpu-actual-pool", 1, poolDevices{deviceCount: 10, shape: deviceShapeAB}),
 	}
-	for i := 0; i < b.N; i++ {
-		compareDraResources(templateSlices, nodeSlices, nil)
+
+	comparator := newResourcePoolComparator()
+	deltas := make([]resourceDelta, 0)
+	for b.Loop() {
+		deltas = comparator.CompareResourcePools(templateSlices, nodeSlices, deltas)
+		deltas = deltas[:0]
 	}
 }
 
@@ -442,8 +525,12 @@ func BenchmarkCompareDraResourcesFuzzy(b *testing.B) {
 	nodeSlices := []*resourceapi.ResourceSlice{
 		makeResourceSlice("gpu-driver", "gpu-actual-pool", 1, poolDevices{deviceCount: 10, shape: deviceShapeABC}),
 	}
-	for i := 0; i < b.N; i++ {
-		compareDraResources(templateSlices, nodeSlices, nil)
+
+	comparator := newResourcePoolComparator()
+	deltas := make([]resourceDelta, 0)
+	for b.Loop() {
+		deltas = comparator.CompareResourcePools(templateSlices, nodeSlices, deltas)
+		deltas = deltas[:0]
 	}
 }
 
@@ -456,8 +543,12 @@ func BenchmarkCompareDraResourcesRankingFuzzy(b *testing.B) {
 		makeResourceSlice("gpu-driver", "gpu-actual-pool", 3, poolDevices{deviceCount: 11, shape: deviceShapeA}),
 		makeResourceSlice("gpu-driver", "gpu-actual-pool", 3, poolDevices{deviceCount: 10, shape: deviceShapeB}),
 	}
-	for i := 0; i < b.N; i++ {
-		compareDraResources(templateSlices, nodeSlices, nil)
+
+	comparator := newResourcePoolComparator()
+	deltas := make([]resourceDelta, 0)
+	for b.Loop() {
+		deltas = comparator.CompareResourcePools(templateSlices, nodeSlices, deltas)
+		deltas = deltas[:0]
 	}
 }
 

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta_test.go
@@ -293,7 +293,7 @@ func TestCompareDraResources(t *testing.T) {
 				},
 			},
 		},
-		"HashDelimiterAntiCollision": { // "A"+"BC" and "AB"+"C" both concat to "ABC".
+		"HashWithDelimiter": { // "A"+"BC" and "AB"+"C" both concat to "ABC".
 			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeAPlusBC})},
 			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeABPlusC})},
 			wantReports: []resourceDelta{
@@ -305,6 +305,17 @@ func TestCompareDraResources(t *testing.T) {
 					NodeSignatureMap:     attributesMap{v1.QualifiedName("AB"): {}, v1.QualifiedName("C"): {}},
 				},
 			},
+		},
+		"DuplicateCollision": {
+			templateSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+				makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+			},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+				makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+			},
+			wantReports: []resourceDelta{},
 		},
 		"FuzzyPriorityOverlapOverCount": {
 			templateSlices: []*resourceapi.ResourceSlice{

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/resource_delta_test.go
@@ -145,7 +145,14 @@ func TestCompareDraResources(t *testing.T) {
 		"NoDriverInTemplate": {
 			templateSlices: []*resourceapi.ResourceSlice{},
 			nodeSlices:     []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
-			wantReports:    []resourceDelta{},
+			wantReports: []resourceDelta{
+				{
+					Driver:           "driver",
+					NodeResourcePool: "pool",
+					NodeSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
+					DeviceCountDelta: -1,
+				},
+			},
 		},
 		"ShapeMismatch": {
 			templateSlices: []*resourceapi.ResourceSlice{makeSingleResourceSlice("driver", "pool", poolDevices{deviceCount: 1, shape: deviceShapeA})},
@@ -274,14 +281,15 @@ func TestCompareDraResources(t *testing.T) {
 			templateSlices: []*resourceapi.ResourceSlice{
 				makeSingleResourceSlice("driver-alpha", "pool-a", poolDevices{deviceCount: 1, shape: deviceShapeA}),
 				makeSingleResourceSlice("driver-beta", "pool-b", poolDevices{deviceCount: 1, shape: deviceShapeB}),
+				makeSingleResourceSlice("driver-gamma", "pool-c", poolDevices{deviceCount: 1, shape: deviceShapeA}),
 			},
 			nodeSlices: []*resourceapi.ResourceSlice{
 				// alpha matches perfectly
 				makeSingleResourceSlice("driver-alpha", "pool-a", poolDevices{deviceCount: 1, shape: deviceShapeA}),
 				// beta has a mismatch
 				makeSingleResourceSlice("driver-beta", "pool-b", poolDevices{deviceCount: 1, shape: deviceShapeAB}),
-				// gamma should be completely ignored (not in template)
-				makeSingleResourceSlice("driver-gamma", "pool-c", poolDevices{deviceCount: 1, shape: deviceShapeA}),
+				// gamma has wrong count
+				makeSingleResourceSlice("driver-gamma", "pool-c", poolDevices{deviceCount: 2, shape: deviceShapeA}),
 			},
 			wantReports: []resourceDelta{
 				{
@@ -290,6 +298,14 @@ func TestCompareDraResources(t *testing.T) {
 					NodeResourcePool:     "pool-b",
 					TemplateSignatureMap: attributesMap{v1.QualifiedName("B"): {}},
 					NodeSignatureMap:     attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+				},
+				{
+					Driver:               "driver-gamma",
+					TemplateResourcePool: "pool-c",
+					NodeResourcePool:     "pool-c",
+					TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
+					NodeSignatureMap:     attributesMap{v1.QualifiedName("A"): {}},
+					DeviceCountDelta:     -1,
 				},
 			},
 		},
@@ -472,7 +488,7 @@ func TestCompareDraResources(t *testing.T) {
 				makeSingleResourceSlice("custom-driver", "custom-actual-fuzzy-1", poolDevices{deviceCount: 2, shape: deviceShapeB}),
 				makeSingleResourceSlice("custom-driver", "custom-actual-fuzzy-2", poolDevices{deviceCount: 5, shape: deviceShapeA}),
 				// DRIVER 4: ROGUE
-				makeSingleResourceSlice("rogue-driver", "rogue-pool", poolDevices{deviceCount: 99, shape: deviceShapeAB}),
+				makeSingleResourceSlice("only-node-driver", "only-node-driver-pool", poolDevices{deviceCount: 99, shape: deviceShapeAB}),
 			},
 			wantReports: []resourceDelta{
 				{
@@ -494,6 +510,12 @@ func TestCompareDraResources(t *testing.T) {
 					NodeResourcePool: "custom-actual-fuzzy-2",
 					NodeSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
 					DeviceCountDelta: -5,
+				},
+				{
+					Driver:           "only-node-driver",
+					NodeResourcePool: "only-node-driver-pool",
+					NodeSignatureMap: attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+					DeviceCountDelta: -99,
 				},
 			},
 		},

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/sampler.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/sampler.go
@@ -1,0 +1,210 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comparator
+
+import (
+	"math/rand/v2"
+	"slices"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// loggedSampleSize is the max number of deltas to log in a single entry
+	loggedSampleSize = 5
+	// attributesCountEstimate is an estimate of the number of attributes per resource pool
+	attributesCountEstimate = 20
+	// bytesPerDeltaSummaryEstimate is an estimate of the number of bytes per delta summary
+	bytesPerDeltaSummaryEstimate = 256
+)
+
+// logger is a function that logs messages, used for testing purposes.
+type logger func(format string, args ...any)
+
+// loggingSampler is aggregator that collects a representative subset of resource
+// discrepancies. To avoid being spammy and to reduce performance and memory footprint
+// of the component - sampler hard caps the amount of logged entry nodes and randomly
+// picks ones from a dataset, to guarantee selection fairness - it uses reservoir sampling
+type loggingSampler struct {
+	// summaryBuilder is used to build the summary of the sampled deltas
+	summaryBuilder strings.Builder
+	// attributeBuffers is used to store the signatures of the sampled deltas
+	attributeBuffers []string
+	// logger is the logger to use for logging the sampled deltas
+	logger logger
+	// sampledNodes is the list of node names that have been sampled.
+	sampledNodes []string
+	// sampledDeltas is the list of resource deltas that have been sampled.
+	sampledDeltas [][]resourceDelta
+	// deltasProcessed is the number of deltas that have been processed by sampler.
+	deltasProcessed uint64
+}
+
+// newLoggingSampler creates a new logging sampler.
+func newLoggingSampler() loggingSampler {
+	return newLoggingSamplerWithLogger(klog.Warningf)
+}
+
+// newLoggingSamplerWithLogger creates a new logging sampler with the given logger.
+func newLoggingSamplerWithLogger(logger logger) loggingSampler {
+	return loggingSampler{
+		attributeBuffers: make([]string, 0, attributesCountEstimate),
+		summaryBuilder:   strings.Builder{},
+		logger:           logger,
+		sampledNodes:     make([]string, 0, loggedSampleSize),
+		sampledDeltas:    make([][]resourceDelta, 0, loggedSampleSize),
+	}
+}
+
+// Sample samples the given resource deltas for the given node name.
+// It uses reservoir sampling to select a random sample of deltas to log,
+// ensuring that each delta has an equal probability of being selected.
+func (s *loggingSampler) Sample(nodeName string, deltas []resourceDelta) {
+	s.deltasProcessed++
+
+	if len(s.sampledNodes) < loggedSampleSize {
+		s.sampledNodes = append(s.sampledNodes, nodeName)
+		s.sampledDeltas = append(s.sampledDeltas, slices.Clone(deltas))
+		return
+	}
+
+	// Only swap if the random index hits our target range
+	// to guarantee fairness of the sampling
+	j := rand.Uint64N(s.deltasProcessed)
+	if j < loggedSampleSize {
+		s.sampledNodes[j] = nodeName
+		s.sampledDeltas[j] = slices.Clone(deltas)
+	}
+}
+
+// Reset resets sampler internal buffers and trackers to initial values without
+// dropping already allocated capacity
+func (s *loggingSampler) Reset() {
+	s.deltasProcessed = 0
+	s.summaryBuilder.Reset()
+	s.attributeBuffers = s.attributeBuffers[:0]
+	s.sampledNodes = s.sampledNodes[:0]
+	s.sampledDeltas = s.sampledDeltas[:0]
+}
+
+// LogSampled flushes the collected samples to the logger without
+// clearing internal buffers.
+func (s *loggingSampler) LogSampled() {
+	if s.deltasProcessed == 0 {
+		return
+	}
+
+	deltasInSample := 0
+	for i := range s.sampledDeltas {
+		deltasInSample += len(s.sampledDeltas[i])
+	}
+
+	s.summaryBuilder.Grow(bytesPerDeltaSummaryEstimate * deltasInSample)
+	for i, nodeName := range s.sampledNodes {
+		s.summaryBuilder.WriteString("- ")
+		s.summaryBuilder.WriteString(nodeName)
+		s.summaryBuilder.WriteString(": ")
+
+		deltas := s.sampledDeltas[i]
+		for j := range deltas {
+			if j > 0 {
+				s.summaryBuilder.WriteString(", ")
+			}
+			s.writeDeltaSummary(&deltas[j])
+		}
+
+		if i < len(s.sampledNodes)-1 {
+			s.summaryBuilder.WriteString("\n")
+		}
+	}
+
+	if len(s.sampledNodes) > 0 {
+		s.logger("DRA Resource Discrepancies detected between node templates and actual nodes:\n%s", s.summaryBuilder.String())
+	}
+}
+
+// writeDeltaSummary writes the resource delta representation to the internal string builder.
+func (s *loggingSampler) writeDeltaSummary(d *resourceDelta) {
+	builder := &s.summaryBuilder
+
+	builder.WriteString(`ResourceDelta{Type="`)
+	builder.WriteString(d.Type().String())
+
+	builder.WriteString(`", Driver="`)
+	builder.WriteString(d.Driver)
+
+	builder.WriteString(`", TemplatePool="`)
+	builder.WriteString(d.TemplateResourcePool)
+
+	builder.WriteString(`", NodePool="`)
+	builder.WriteString(d.NodeResourcePool)
+
+	builder.WriteString(`", DeviceCountDelta="`)
+	builder.WriteString(strconv.FormatInt(d.DeviceCountDelta, 10))
+
+	builder.WriteString(`", TemplateSignature="`)
+	s.writeAttributes(d.TemplateSignatureMap)
+
+	builder.WriteString(`", NodeSignature="`)
+	s.writeAttributes(d.NodeSignatureMap)
+
+	builder.WriteString(`", MissingAttributes="`)
+	s.writeAttributesDifference(d.TemplateSignatureMap, d.NodeSignatureMap)
+
+	builder.WriteString(`", ExtraAttributes="`)
+	s.writeAttributesDifference(d.NodeSignatureMap, d.TemplateSignatureMap)
+
+	builder.WriteString(`"}`)
+}
+
+// writeAttributes writes given attribute keys to the internal string builder
+func (s *loggingSampler) writeAttributes(m attributesMap) {
+	s.attributeBuffers = s.attributeBuffers[:0]
+	for k := range m {
+		s.attributeBuffers = append(s.attributeBuffers, string(k))
+	}
+	slices.Sort(s.attributeBuffers)
+
+	builder := &s.summaryBuilder
+	for i, k := range s.attributeBuffers {
+		if i > 0 {
+			builder.WriteString(";")
+		}
+		builder.WriteString(k)
+	}
+}
+
+// writeAttributesDifference writes given a difference of given attribute keys to the internal string builder
+func (s *loggingSampler) writeAttributesDifference(base, subtract attributesMap) {
+	s.attributeBuffers = s.attributeBuffers[:0]
+	for k := range base {
+		if _, ok := subtract[k]; !ok {
+			s.attributeBuffers = append(s.attributeBuffers, string(k))
+		}
+	}
+	slices.Sort(s.attributeBuffers)
+
+	builder := &s.summaryBuilder
+	for i, k := range s.attributeBuffers {
+		if i > 0 {
+			builder.WriteString(";")
+		}
+		builder.WriteString(k)
+	}
+}

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/sampler_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/sampler_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comparator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/resource/v1"
+)
+
+func TestSampleSize(t *testing.T) {
+	tests := map[string]struct {
+		nodesToSample  []string
+		wantSampleSize int
+	}{
+		"FewerThanLimit": {
+			nodesToSample:  []string{"node-1", "node-2"},
+			wantSampleSize: 2,
+		},
+		"ExactlyLimit": {
+			nodesToSample:  []string{"node-1", "node-2", "node-3", "node-4", "node-5"},
+			wantSampleSize: 5,
+		},
+		"MoreThanLimit": {
+			nodesToSample:  []string{"node-1", "node-2", "node-3", "node-4", "node-5", "node-6"},
+			wantSampleSize: 5,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := newLoggingSampler()
+			for _, node := range tc.nodesToSample {
+				s.Sample(node, nil)
+			}
+			if len(s.sampledNodes) != tc.wantSampleSize {
+				t.Errorf("Sample() got size %d, want %d", len(s.sampledNodes), tc.wantSampleSize)
+			}
+		})
+	}
+}
+
+func TestLogSampled(t *testing.T) {
+	tests := map[string]struct {
+		samples []struct {
+			nodeName string
+			deltas   []resourceDelta
+		}
+		wantOutput string
+	}{
+		"Empty": {
+			samples:    nil,
+			wantOutput: "",
+		},
+		"SingleNodeSingleDelta": {
+			samples: []struct {
+				nodeName string
+				deltas   []resourceDelta
+			}{
+				{
+					nodeName: "node-1",
+					deltas: []resourceDelta{
+						{
+							Driver:               "driver-1",
+							TemplateResourcePool: "pool-1",
+							NodeResourcePool:     "pool-1",
+							DeviceCountDelta:     1,
+							TemplateSignatureMap: attributesMap{v1.QualifiedName("attr-1"): {}},
+							NodeSignatureMap:     attributesMap{v1.QualifiedName("attr-1"): {}},
+						},
+					},
+				},
+			},
+			wantOutput: `DRA Resource Discrepancies detected between node templates and actual nodes:
+- node-1: ResourceDelta{Type="Mismatch", Driver="driver-1", TemplatePool="pool-1", NodePool="pool-1", DeviceCountDelta="1", TemplateSignature="attr-1", NodeSignature="attr-1", MissingAttributes="", ExtraAttributes=""}`,
+		},
+		"MultipleNodesAndDeltas": {
+			samples: []struct {
+				nodeName string
+				deltas   []resourceDelta
+			}{
+				{
+					nodeName: "node-1",
+					deltas: []resourceDelta{
+						{
+							Driver:               "driver-1",
+							TemplateResourcePool: "pool-1",
+							NodeResourcePool:     "pool-1",
+							DeviceCountDelta:     2,
+							TemplateSignatureMap: attributesMap{v1.QualifiedName("A"): {}},
+							NodeSignatureMap:     attributesMap{v1.QualifiedName("B"): {}},
+						},
+					},
+				},
+				{
+					nodeName: "node-2",
+					deltas: []resourceDelta{
+						{
+							Driver:               "driver-2",
+							TemplateResourcePool: "pool-2",
+							NodeResourcePool:     "pool-2",
+							DeviceCountDelta:     0,
+							TemplateSignatureMap: attributesMap{v1.QualifiedName("X"): {}, v1.QualifiedName("Y"): {}},
+							NodeSignatureMap:     attributesMap{v1.QualifiedName("X"): {}, v1.QualifiedName("Z"): {}},
+						},
+						{
+							Driver:               "driver-3",
+							TemplateResourcePool: "pool-3",
+							NodeResourcePool:     "pool-3",
+							DeviceCountDelta:     -1,
+						},
+					},
+				},
+			},
+			wantOutput: `DRA Resource Discrepancies detected between node templates and actual nodes:
+- node-1: ResourceDelta{Type="Mismatch", Driver="driver-1", TemplatePool="pool-1", NodePool="pool-1", DeviceCountDelta="2", TemplateSignature="A", NodeSignature="B", MissingAttributes="A", ExtraAttributes="B"}
+- node-2: ResourceDelta{Type="Mismatch", Driver="driver-2", TemplatePool="pool-2", NodePool="pool-2", DeviceCountDelta="0", TemplateSignature="X;Y", NodeSignature="X;Z", MissingAttributes="Y", ExtraAttributes="Z"}, ResourceDelta{Type="Mismatch", Driver="driver-3", TemplatePool="pool-3", NodePool="pool-3", DeviceCountDelta="-1", TemplateSignature="", NodeSignature="", MissingAttributes="", ExtraAttributes=""}`,
+		},
+		"MissingAndExtraPools": {
+			samples: []struct {
+				nodeName string
+				deltas   []resourceDelta
+			}{
+				{
+					nodeName: "node-1",
+					deltas: []resourceDelta{
+						{
+							Driver:               "driver-1",
+							TemplateResourcePool: "pool-1",
+							DeviceCountDelta:     1,
+						},
+						{
+							Driver:           "driver-1",
+							NodeResourcePool: "pool-2",
+							DeviceCountDelta: -1,
+						},
+					},
+				},
+			},
+			wantOutput: `DRA Resource Discrepancies detected between node templates and actual nodes:
+- node-1: ResourceDelta{Type="Missing", Driver="driver-1", TemplatePool="pool-1", NodePool="", DeviceCountDelta="1", TemplateSignature="", NodeSignature="", MissingAttributes="", ExtraAttributes=""}, ResourceDelta{Type="Extra", Driver="driver-1", TemplatePool="", NodePool="pool-2", DeviceCountDelta="-1", TemplateSignature="", NodeSignature="", MissingAttributes="", ExtraAttributes=""}`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var gotOutput string
+			logger := func(format string, args ...any) {
+				gotOutput = fmt.Sprintf(format, args...)
+			}
+			s := newLoggingSamplerWithLogger(logger)
+			for _, sample := range tc.samples {
+				s.Sample(sample.nodeName, sample.deltas)
+			}
+			s.LogSampled()
+
+			if diff := cmp.Diff(tc.wantOutput, gotOutput); diff != "" {
+				t.Errorf("LogSampled() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWriteAttributes(t *testing.T) {
+	tests := map[string]struct {
+		m          attributesMap
+		wantOutput string
+	}{
+		"Empty": {
+			m:          attributesMap{},
+			wantOutput: "",
+		},
+		"SingleKey": {
+			m:          attributesMap{v1.QualifiedName("A"): {}},
+			wantOutput: "A",
+		},
+		"MultipleKeysSorted": {
+			m:          attributesMap{v1.QualifiedName("C"): {}, v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+			wantOutput: "A;B;C",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sampler := newLoggingSampler()
+			sampler.writeAttributes(tc.m)
+			if got := sampler.summaryBuilder.String(); got != tc.wantOutput {
+				t.Errorf("writeAttributes() = %q, want %q", got, tc.wantOutput)
+			}
+		})
+	}
+}
+
+func TestWriteAttributesDifference(t *testing.T) {
+	tests := map[string]struct {
+		base       attributesMap
+		subtract   attributesMap
+		wantOutput string
+	}{
+		"Empty": {
+			base:       attributesMap{},
+			subtract:   attributesMap{},
+			wantOutput: "",
+		},
+		"NoDifference": {
+			base:       attributesMap{v1.QualifiedName("A"): {}},
+			subtract:   attributesMap{v1.QualifiedName("A"): {}},
+			wantOutput: "",
+		},
+		"PartialDifference": {
+			base:       attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+			subtract:   attributesMap{v1.QualifiedName("B"): {}},
+			wantOutput: "A",
+		},
+		"NoDifference_NonExistentKey": {
+			base:       attributesMap{v1.QualifiedName("A"): {}, v1.QualifiedName("B"): {}},
+			subtract:   attributesMap{v1.QualifiedName("C"): {}},
+			wantOutput: "A;B",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sampler := newLoggingSampler()
+			sampler.writeAttributesDifference(tc.base, tc.subtract)
+			if got := sampler.summaryBuilder.String(); got != tc.wantOutput {
+				t.Errorf("writeMapKeyDifference() = %q, want %q", got, tc.wantOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a metric and reporting process for it to detect drift between cluster autoscaler in-memory DRA resources and real nodes. It does so by comparing attribute signatures of the resource pools found in resource slices attached to the ready nodes and template node infos. Exact algorithm for finding mismatches can be found in the resourcePoolComparator.CompareResourcePools(...) documentation

The workflow of this metric would be that we'll maintain a gauge indicating the amount of resource deltas found, their drivers and delta types. For closer inspection - autoscaler logs be be observed to see a summary of the deltas found for a fixed count of nodes

The performance impact of this change should be negligible as we barely do any allocations and at worst spending 5 microseconds for a node which has a lot of deltas, while being called just a single time once per loop. The amount of allocations is close to zero so it shouldn't make situation with CA memory pressure any worse. Non DRA nodes are barely affected by the change as there's little to no work performed for them during comparison

```
goos: linux
goarch: amd64
pkg: k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/comparator
cpu: AMD EPYC 7B12
BenchmarkReportResourceDiscrepancies_1Node_0Discrepancies-24                               10000               635.3 ns/op             0 B/op          0 allocs/op
BenchmarkReportResourceDiscrepancies_1Node_NoDRA-24                                        10000                13.45 ns/op            0 B/op          0 allocs/op
BenchmarkReportResourceDiscrepancies_1Node_10Discrepancies-24                              10000              7007 ns/op            3488 B/op          4 allocs/op
BenchmarkReportResourceDiscrepancies_10Nodes_10DiscrepanciesEach-24                        10000             47358 ns/op           19932 B/op         11 allocs/op
BenchmarkReportResourceDiscrepancies_10Nodes_NoDRA-24                                      10000                21.44 ns/op            0 B/op          0 allocs/op
BenchmarkReportResourceDiscrepancies_10Nodes_0Discrepancies-24                             10000              5906 ns/op               0 B/op          0 allocs/op
BenchmarkReportResourceDiscrepancies_1Node_10Drivers_10Discrepancies-24                    10000              7891 ns/op            3488 B/op          4 allocs/op
BenchmarkReportResourceDiscrepancies_10Nodes_10Drivers_10DiscrepanciesEach-24              10000             49441 ns/op           19926 B/op         11 allocs/op
BenchmarkCompareDraResourcesExact-24                                                       10000              4440 ns/op               0 B/op          0 allocs/op
BenchmarkCompareDraResourcesFuzzy-24                                                       10000              4738 ns/op               0 B/op          0 allocs/op
BenchmarkCompareDraResourcesRankingFuzzy-24                                                10000              8412 ns/op               0 B/op          0 allocs/op
```

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

In this change I've tried to apply couple practices to bring allocations down and drastically improve performance, namely store buffers for reusability. While the change differs from most of the cluster autoscaler code in style primarily due to buffer reuse - it achieves close to zero allocation rate per function call.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added cluster autoscaler metric detecting DRA resource mismatches in cluster nodes (dra_node_template_resources_mismatch)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
