### PR TITLE
Add safe-to-evict=on-completion

### DIFF
--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -332,17 +332,24 @@ func (a *Actuator) deleteNodesAsync(nodes []*apiv1.Node, nodeGroup cloudprovider
 			continue
 		}
 
-		podsToRemove, _, _, err := simulator.GetPodsToMove(nodeInfo, a.deleteOptions, a.drainabilityRules, registry, remainingPdbTracker, time.Now())
+		podMoveInfo, err := simulator.GetPodsToMove(nodeInfo, a.deleteOptions, a.drainabilityRules, registry, remainingPdbTracker, time.Now())
 		if err != nil {
 			nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "GetPodsToMove for %q returned error: %v", node.Name, err)}
 			a.nodeDeletionScheduler.AbortNodeDeletion(node, nodeGroup.Id(), drain, "failed to get pods to move on node", nodeDeleteResult, true)
 			continue
 		}
 
-		if !drain && len(podsToRemove) != 0 {
-			nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "failed to delete empty node %q, new pods scheduled", node.Name)}
-			a.nodeDeletionScheduler.AbortNodeDeletion(node, nodeGroup.Id(), drain, "node is not empty", nodeDeleteResult, true)
-			continue
+		if !drain {
+			if len(podMoveInfo.Pods) != 0 {
+				nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "failed to delete empty node %q, new pods scheduled", node.Name)}
+				a.nodeDeletionScheduler.AbortNodeDeletion(node, nodeGroup.Id(), drain, "node is not empty", nodeDeleteResult, true)
+				continue
+			}
+			if len(podMoveInfo.OnCompletionPods) != 0 {
+				nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "failed to delete empty node %q, active on-completion pods present", node.Name)}
+				a.nodeDeletionScheduler.AbortNodeDeletion(node, nodeGroup.Id(), drain, "active on-completion pods present", nodeDeleteResult, true)
+				continue
+			}
 		}
 
 		if force {

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -173,6 +173,15 @@ func (p *Planner) NodesToDelete(_ time.Time) (empty, needDrain []*apiv1.Node) {
 	p.addUnremovableNodes(unremovableNodes)
 
 	for _, nodeToRemove := range nodesToRemove {
+		if len(nodeToRemove.OnCompletionPods) > 0 {
+			klog.V(2).Infof("Node %s has active on-completion pods, delaying scale down", nodeToRemove.Node.Name)
+			p.addUnremovableNodes([]simulator.UnremovableNode{{
+				Node:   nodeToRemove.Node,
+				Reason: simulator.BlockedByOnCompletionPod,
+			}})
+			continue
+		}
+
 		if len(nodeToRemove.PodsToReschedule) > 0 {
 			needDrain = append(needDrain, nodeToRemove.Node)
 		} else {

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -860,6 +860,26 @@ func TestNodesToDelete(t *testing.T) {
 			wantDrain:      []*apiv1.Node{},
 		},
 		{
+			name: "single empty with on-completion pods delayed",
+			removableNodes: map[cloudprovider.NodeGroup][]simulator.NodeToBeRemoved{
+				sizedNodeGroup("test-ng", 3, false): {
+					buildRemovableNodeWithOnCompletionPods("test-node", 0, 1),
+				},
+			},
+			wantEmpty: []*apiv1.Node{},
+			wantDrain: []*apiv1.Node{},
+		},
+		{
+			name: "single drain with on-completion pods delayed",
+			removableNodes: map[cloudprovider.NodeGroup][]simulator.NodeToBeRemoved{
+				sizedNodeGroup("test-ng", 3, false): {
+					buildRemovableNodeWithOnCompletionPods("test-node", 1, 1),
+				},
+			},
+			wantEmpty: []*apiv1.Node{},
+			wantDrain: []*apiv1.Node{},
+		},
+		{
 			name: "single empty",
 			removableNodes: map[cloudprovider.NodeGroup][]simulator.NodeToBeRemoved{
 				sizedNodeGroup("test-ng", 3, false): {
@@ -1059,6 +1079,23 @@ func buildRemovableNode(name string, podCount int) simulator.NodeToBeRemoved {
 		Node:             BuildTestNode(name, 1000, 10),
 		PodsToReschedule: podsToReschedule,
 	}
+}
+
+func buildRemovableNodeWithOnCompletionPods(name string, regularPodCount, onCompletionPodCount int) simulator.NodeToBeRemoved {
+	node := buildRemovableNode(name, regularPodCount)
+	for i := 0; i < onCompletionPodCount; i++ {
+		pod := &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-on-completion-pod-%d", name, i),
+				Namespace: "default",
+				Annotations: map[string]string{
+					drain.PodSafeToEvictKey: drain.PodSafeToEvictOnCompletionValue,
+				},
+			},
+		}
+		node.OnCompletionPods = append(node.OnCompletionPods, pod)
+	}
+	return node
 }
 
 func generateReplicaSets(name string, replicas int32) []*appsv1.ReplicaSet {

--- a/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting.go
@@ -49,7 +49,7 @@ type EmptySorting struct {
 	nodeInfoGetter
 	deleteOptions     options.NodeDeleteOptions
 	drainabilityRules rules.Rules
-	isEmptyCache      map[string]bool
+	isEmptyCache      map[string]emptyInfo
 }
 
 // NewEmptySortingProcessor return EmptySorting struct.
@@ -58,24 +58,32 @@ func NewEmptySortingProcessor(n nodeInfoGetter, deleteOptions options.NodeDelete
 		nodeInfoGetter:    n,
 		deleteOptions:     deleteOptions,
 		drainabilityRules: drainabilityRules,
-		isEmptyCache:      make(map[string]bool),
+		isEmptyCache:      make(map[string]emptyInfo),
 	}
 }
 
-// ScaleDownEarlierThan return true if node1 is empty and node2 isn't.
+// ScaleDownEarlierThan return true if node1 is empty and node2 isn't, and differentiates by on-completion pods.
 func (p *EmptySorting) ScaleDownEarlierThan(node1, node2 *apiv1.Node) bool {
-	if p.isNodeEmpty(node1) && !p.isNodeEmpty(node2) {
-		return true
+	n1EmptyInfo := p.getNodeEmptyInfo(node1)
+	n2EmptyInfo := p.getNodeEmptyInfo(node2)
+
+	if n1EmptyInfo.IsEmpty != n2EmptyInfo.IsEmpty {
+		return n1EmptyInfo.IsEmpty
 	}
-	return false
+	return !n1EmptyInfo.HasOnCompletionPods && n2EmptyInfo.HasOnCompletionPods
+}
+
+type emptyInfo struct {
+	IsEmpty             bool
+	HasOnCompletionPods bool
 }
 
 // ResetState resets internal state before every sorting.
 func (p *EmptySorting) ResetState() {
-	p.isEmptyCache = make(map[string]bool)
+	p.isEmptyCache = make(map[string]emptyInfo)
 }
 
-func (p *EmptySorting) isNodeEmpty(node *apiv1.Node) bool {
+func (p *EmptySorting) getNodeEmptyInfo(node *apiv1.Node) emptyInfo {
 	if val, ok := p.isEmptyCache[node.Name]; ok {
 		return val
 	}
@@ -84,14 +92,17 @@ func (p *EmptySorting) isNodeEmpty(node *apiv1.Node) bool {
 	return val
 }
 
-func (p *EmptySorting) isNodeEmptyNoCache(node *apiv1.Node) bool {
+func (p *EmptySorting) isNodeEmptyNoCache(node *apiv1.Node) emptyInfo {
 	nodeInfo, err := p.nodeInfoGetter.GetNodeInfo(node.Name)
 	if err != nil {
-		return false
+		return emptyInfo{IsEmpty: false}
 	}
-	podsToRemove, _, _, err := simulator.GetPodsToMove(nodeInfo, p.deleteOptions, p.drainabilityRules, nil, nil, time.Now())
-	if err == nil && len(podsToRemove) == 0 {
-		return true
+	podMoveInfo, err := simulator.GetPodsToMove(nodeInfo, p.deleteOptions, p.drainabilityRules, nil, nil, time.Now())
+	if err == nil && len(podMoveInfo.Pods) == 0 {
+		return emptyInfo{
+			IsEmpty:             true,
+			HasOnCompletionPods: len(podMoveInfo.OnCompletionPods) > 0,
+		}
 	}
-	return false
+	return emptyInfo{IsEmpty: false}
 }

--- a/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting_test.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
 
@@ -53,9 +54,15 @@ func TestScaleDownEarlierThan(t *testing.T) {
 	pod := BuildTestPod("p1", 0, 100)
 	niNonEmpty := framework.NewTestNodeInfo(nodeNonEmpty, pod)
 
+	nodeWithOnCompletionName := "nodeWithOnCompletionPods"
+	nodeWithOnCompletion := BuildTestNode(nodeWithOnCompletionName, 0, 100)
+	onCompPod := BuildTestPod("p2", 0, 100)
+	onCompPod.Annotations = map[string]string{drain.PodSafeToEvictKey: drain.PodSafeToEvictOnCompletionValue}
+	niWithOnCompletion := framework.NewTestNodeInfo(nodeWithOnCompletion, onCompPod)
+
 	noNodeInfoNode := BuildTestNode("n1", 0, 100)
 
-	niGetter := testNodeInfoGetter{map[string]*framework.NodeInfo{nodeEmptyName: niEmpty, nodeNonEmptyName: niNonEmpty, nodeEmptyName2: niEmpty2}}
+	niGetter := testNodeInfoGetter{map[string]*framework.NodeInfo{nodeEmptyName: niEmpty, nodeNonEmptyName: niNonEmpty, nodeEmptyName2: niEmpty2, nodeWithOnCompletionName: niWithOnCompletion}}
 
 	deleteOptions := options.NodeDeleteOptions{
 		SkipNodesWithSystemPods:           true,
@@ -102,6 +109,24 @@ func TestScaleDownEarlierThan(t *testing.T) {
 			name:  "Empty node is not earlier that another empty node",
 			node1: nodeEmpty,
 			node2: nodeEmpty2,
+		},
+		{
+			name:        "Empty node earlier that node with on-completion pod",
+			node1:       nodeEmpty,
+			node2:       nodeWithOnCompletion,
+			wantEarlier: true,
+		},
+		{
+			name:        "Node with on-completion pod is not earlier that empty node",
+			node1:       nodeWithOnCompletion,
+			node2:       nodeEmpty,
+			wantEarlier: false,
+		},
+		{
+			name:        "Node with on-completion pod earlier that non-empty node",
+			node1:       nodeWithOnCompletion,
+			node2:       nodeNonEmpty,
+			wantEarlier: true,
 		},
 	}
 	for _, test := range tests {

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -45,6 +45,8 @@ type NodeToBeRemoved struct {
 	// PodsToReschedule contains pods on the node that should be rescheduled elsewhere.
 	PodsToReschedule []*apiv1.Pod
 	DaemonSetPods    []*apiv1.Pod
+	// OnCompletionPods contains pods on the node that have safe-to-evict=on-completion annotation
+	OnCompletionPods []*apiv1.Pod
 }
 
 // UnremovableNode represents a node that can't be removed by CA.
@@ -95,6 +97,8 @@ const (
 	UnexpectedError
 	// NoNodeInfo - node can't be removed because it doesn't have any node info in the cluster snapshot.
 	NoNodeInfo
+	// BlockedByOnCompletionPod - node can't be removed because it has a pod with safe-to-evict=on-completion annotation
+	BlockedByOnCompletionPod
 )
 
 // RemovalSimulator is a helper object for simulating node removal scenarios.
@@ -141,17 +145,17 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 	}
 	klog.V(2).Infof("Simulating node %s removal", nodeName)
 
-	podsToRemove, daemonSetPods, blockingPod, err := GetPodsToMove(nodeInfo, r.deleteOptions, r.drainabilityRules, r.listers, remainingPdbTracker, timestamp)
+	podMoveInfo, err := GetPodsToMove(nodeInfo, r.deleteOptions, r.drainabilityRules, r.listers, remainingPdbTracker, timestamp)
 	if err != nil {
 		klog.V(2).Infof("Node %s cannot be removed: %v", nodeName, err)
-		if blockingPod != nil {
-			return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: BlockedByPod, BlockingPod: blockingPod}
+		if podMoveInfo.BlockingPod != nil {
+			return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: BlockedByPod, BlockingPod: podMoveInfo.BlockingPod}
 		}
 		return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: UnexpectedError}
 	}
 
 	err = r.withForkedSnapshot(func() error {
-		return r.findPlaceFor(nodeName, podsToRemove, destinationMap, timestamp)
+		return r.findPlaceFor(nodeName, podMoveInfo.Pods, destinationMap, timestamp)
 	})
 	if err != nil {
 		klog.V(2).Infof("Node %s is not suitable for removal: %v", nodeName, err)
@@ -160,8 +164,9 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 	klog.V(2).Infof("Node %s may be removed", nodeName)
 	return &NodeToBeRemoved{
 		Node:             nodeInfo.Node(),
-		PodsToReschedule: podsToRemove,
-		DaemonSetPods:    daemonSetPods,
+		PodsToReschedule: podMoveInfo.Pods,
+		DaemonSetPods:    podMoveInfo.DaemonSetPods,
+		OnCompletionPods: podMoveInfo.OnCompletionPods,
 	}, nil
 }
 

--- a/cluster-autoscaler/simulator/drain.go
+++ b/cluster-autoscaler/simulator/drain.go
@@ -30,6 +30,14 @@ import (
 	pod_util "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 )
 
+// PodMoveInfo contains the pods that should be relocated and those that are blocking the drain.
+type PodMoveInfo struct {
+	Pods             []*apiv1.Pod
+	DaemonSetPods    []*apiv1.Pod
+	OnCompletionPods []*apiv1.Pod
+	BlockingPod      *drain.BlockingPod
+}
+
 // GetPodsToMove returns a list of pods that should be moved elsewhere and a
 // list of DaemonSet pods that should be evicted if the node is drained.
 // Raises error if there is an unreplicated pod.
@@ -38,7 +46,7 @@ import (
 // with dangling created-by annotation).
 // If listers is not nil it checks whether RC, DS, Jobs and RS that created
 // these pods still exist.
-func GetPodsToMove(nodeInfo *framework.NodeInfo, deleteOptions options.NodeDeleteOptions, drainabilityRules rules.Rules, listers kube_util.ListerRegistry, remainingPdbTracker pdb.RemainingPdbTracker, timestamp time.Time) (pods []*apiv1.Pod, daemonSetPods []*apiv1.Pod, blockingPod *drain.BlockingPod, err error) {
+func GetPodsToMove(nodeInfo *framework.NodeInfo, deleteOptions options.NodeDeleteOptions, drainabilityRules rules.Rules, listers kube_util.ListerRegistry, remainingPdbTracker pdb.RemainingPdbTracker, timestamp time.Time) (PodMoveInfo, error) {
 	if drainabilityRules == nil {
 		drainabilityRules = rules.Default(deleteOptions)
 	}
@@ -50,22 +58,29 @@ func GetPodsToMove(nodeInfo *framework.NodeInfo, deleteOptions options.NodeDelet
 		Listers:             listers,
 		Timestamp:           timestamp,
 	}
+
+	podMoveInfo := PodMoveInfo{}
+
 	for _, podInfo := range nodeInfo.Pods() {
 		pod := podInfo.Pod
+
 		status := drainabilityRules.Drainable(drainCtx, pod, nodeInfo)
 		switch status.Outcome {
 		case drainability.UndefinedOutcome, drainability.DrainOk:
 			if pod_util.IsDaemonSetPod(pod) {
-				daemonSetPods = append(daemonSetPods, pod)
+				podMoveInfo.DaemonSetPods = append(podMoveInfo.DaemonSetPods, pod)
 			} else {
-				pods = append(pods, pod)
+				podMoveInfo.Pods = append(podMoveInfo.Pods, pod)
 			}
+		case drainability.WaitForCompletion:
+			podMoveInfo.OnCompletionPods = append(podMoveInfo.OnCompletionPods, pod)
 		case drainability.BlockDrain:
-			return nil, nil, &drain.BlockingPod{
+			podMoveInfo.BlockingPod = &drain.BlockingPod{
 				Pod:    pod,
 				Reason: status.BlockingReason,
-			}, status.Error
+			}
+			return podMoveInfo, status.Error
 		}
 	}
-	return pods, daemonSetPods, nil, nil
+	return podMoveInfo, nil
 }

--- a/cluster-autoscaler/simulator/drain_test.go
+++ b/cluster-autoscaler/simulator/drain_test.go
@@ -514,19 +514,32 @@ func TestGetPodsToMove(t *testing.T) {
 				DisruptionsAllowed: 1,
 			},
 		}
+		onCompletionPod = &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "default",
+				Annotations: map[string]string{
+					drain.PodSafeToEvictKey: drain.PodSafeToEvictOnCompletionValue,
+				},
+			},
+			Spec: apiv1.PodSpec{
+				NodeName: "node",
+			},
+		}
 	)
 
 	testCases := []struct {
-		desc         string
-		pods         []*apiv1.Pod
-		pdbs         []*policyv1.PodDisruptionBudget
-		rcs          []*apiv1.ReplicationController
-		replicaSets  []*appsv1.ReplicaSet
-		rules        rules.Rules
-		wantPods     []*apiv1.Pod
-		wantDs       []*apiv1.Pod
-		wantBlocking *drain.BlockingPod
-		wantErr      bool
+		desc             string
+		pods             []*apiv1.Pod
+		pdbs             []*policyv1.PodDisruptionBudget
+		rcs              []*apiv1.ReplicationController
+		replicaSets      []*appsv1.ReplicaSet
+		rules            rules.Rules
+		wantPods         []*apiv1.Pod
+		wantDs           []*apiv1.Pod
+		wantOnCompletion []*apiv1.Pod
+		wantBlocking     *drain.BlockingPod
+		wantErr          bool
 	}{
 		{
 			desc:    "Unreplicated pod",
@@ -575,9 +588,10 @@ func TestGetPodsToMove(t *testing.T) {
 			wantPods: []*apiv1.Pod{drainableBlockingSystemPod},
 		},
 		{
-			desc:    "Kube-system no pdb system pods blocking",
-			pods:    []*apiv1.Pod{drainableBlockingSystemPod, nonDrainableBlockingSystemPod},
-			wantErr: true,
+			desc:     "Kube-system no pdb system pods blocking",
+			pods:     []*apiv1.Pod{drainableBlockingSystemPod, nonDrainableBlockingSystemPod},
+			wantErr:  true,
+			wantPods: []*apiv1.Pod{drainableBlockingSystemPod},
 			wantBlocking: &drain.BlockingPod{
 				Pod:    nonDrainableBlockingSystemPod,
 				Reason: drain.UnmovableKubeSystemPod,
@@ -790,6 +804,11 @@ func TestGetPodsToMove(t *testing.T) {
 			wantErr:      true,
 			wantBlocking: &drain.BlockingPod{Pod: kubeSystemRcPod, Reason: drain.UnmovableKubeSystemPod},
 		},
+		{
+			desc:             "pod with safe-to-evict=on-completion annotation",
+			pods:             []*apiv1.Pod{onCompletionPod},
+			wantOnCompletion: []*apiv1.Pod{onCompletionPod},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -819,15 +838,16 @@ func TestGetPodsToMove(t *testing.T) {
 			tracker := pdb.NewBasicRemainingPdbTracker()
 			tracker.SetPdbs(tc.pdbs)
 			ni := framework.NewTestNodeInfo(nil, tc.pods...)
-			p, d, b, err := GetPodsToMove(ni, deleteOptions, rules, registry, tracker, testTime)
+			podMoveInfo, err := GetPodsToMove(ni, deleteOptions, rules, registry, tracker, testTime)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.ElementsMatch(t, tc.wantPods, p)
-			assert.ElementsMatch(t, tc.wantDs, d)
-			assert.Equal(t, tc.wantBlocking, b)
+			assert.ElementsMatch(t, tc.wantPods, podMoveInfo.Pods)
+			assert.ElementsMatch(t, tc.wantDs, podMoveInfo.DaemonSetPods)
+			assert.ElementsMatch(t, tc.wantOnCompletion, podMoveInfo.OnCompletionPods)
+			assert.Equal(t, tc.wantBlocking, podMoveInfo.BlockingPod)
 		})
 	}
 }

--- a/cluster-autoscaler/simulator/drainability/rules/oncompletion/rule.go
+++ b/cluster-autoscaler/simulator/drainability/rules/oncompletion/rule.go
@@ -1,0 +1,45 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oncompletion
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
+)
+
+// Rule is a drainability rule on how to handle on-completion pods.
+type Rule struct{}
+
+// New creates a new Rule.
+func New() *Rule {
+	return &Rule{}
+}
+
+// Name returns the name of the rule.
+func (r *Rule) Name() string {
+	return "OnCompletion"
+}
+
+// Drainable decides what to do with on-completion pods on node drain.
+func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod, _ *framework.NodeInfo) drainability.Status {
+	if drain.HasSafeToEvictOnCompletionAnnotation(pod) {
+		return drainability.NewWaitStatus()
+	}
+	return drainability.NewUndefinedStatus()
+}

--- a/cluster-autoscaler/simulator/drainability/rules/oncompletion/rule_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/oncompletion/rule_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oncompletion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestDrainable(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *apiv1.Pod
+		want drainability.Status
+	}{
+		{
+			name: "regular pod",
+			pod:  BuildTestPod("pod1", 100, 0),
+			want: drainability.NewUndefinedStatus(),
+		},
+		{
+			name: "safe to evict on-completion pod",
+			pod: func() *apiv1.Pod {
+				p := BuildTestPod("pod2", 100, 0)
+				p.Annotations = map[string]string{
+					drain.PodSafeToEvictKey: drain.PodSafeToEvictOnCompletionValue,
+				}
+				return p
+			}(),
+			want: drainability.NewWaitStatus(),
+		},
+		{
+			name: "pod with true safe-to-evict annotation",
+			pod: func() *apiv1.Pod {
+				p := BuildTestPod("pod3", 100, 0)
+				p.Annotations = map[string]string{
+					drain.PodSafeToEvictKey: "true",
+				}
+				return p
+			}(),
+			want: drainability.NewUndefinedStatus(),
+		},
+		{
+			name: "pod with false safe-to-evict annotation",
+			pod: func() *apiv1.Pod {
+				p := BuildTestPod("pod4", 100, 0)
+				p.Annotations = map[string]string{
+					drain.PodSafeToEvictKey: "false",
+				}
+				return p
+			}(),
+			want: drainability.NewUndefinedStatus(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := New().Drainable(nil, tc.pod, nil)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cluster-autoscaler/simulator/drainability/rules/rules.go
+++ b/cluster-autoscaler/simulator/drainability/rules/rules.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/longterminating"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/mirror"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/notsafetoevict"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/oncompletion"
 	pdbrule "k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/replicacount"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules/replicated"
@@ -62,6 +63,7 @@ func Default(deleteOptions options.NodeDeleteOptions) Rules {
 		{rule: daemonset.New()},
 		{rule: safetoevict.New()},
 		{rule: terminal.New()},
+		{rule: oncompletion.New()},
 
 		// Blocking checks
 		{rule: replicated.New(deleteOptions.SkipNodesWithCustomControllerPods)},

--- a/cluster-autoscaler/simulator/drainability/status.go
+++ b/cluster-autoscaler/simulator/drainability/status.go
@@ -35,6 +35,9 @@ const (
 	// SkipDrain means that the pod doesn't block drain of other pods, but
 	// should not be drained itself.
 	SkipDrain
+	// WaitForCompletion means that the pod should be allowed to run to
+	// completion before the node is drained.
+	WaitForCompletion
 )
 
 // Status contains all information about drainability of a single pod.
@@ -76,6 +79,13 @@ func NewBlockedStatus(reason drain.BlockingPodReason, err error) Status {
 func NewSkipStatus() Status {
 	return Status{
 		Outcome: SkipDrain,
+	}
+}
+
+// NewWaitStatus returns a new Status indicating that a pod should be allowed to run to completion.
+func NewWaitStatus() Status {
+	return Status{
+		Outcome: WaitForCompletion,
 	}
 }
 

--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -34,6 +34,11 @@ const (
 	// PodSafeToEvictKey - annotation that ignores constraints to evict a pod like not being replicated, being on
 	// kube-system namespace or having a local storage.
 	PodSafeToEvictKey = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+
+	// PodSafeToEvictOnCompletionValue - value for safe-to-evict annotation
+	// that allows the pod to finish execution naturally without being actively evicted.
+	PodSafeToEvictOnCompletionValue = "on-completion"
+
 	// SafeToEvictLocalVolumesKey - annotation that ignores (doesn't block on) a local storage volume during node scale down
 	SafeToEvictLocalVolumesKey = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
 )
@@ -144,6 +149,12 @@ func isLocalVolume(volume *apiv1.Volume) bool {
 // HasSafeToEvictAnnotation checks if pod has PodSafeToEvictKey annotation.
 func HasSafeToEvictAnnotation(pod *apiv1.Pod) bool {
 	return pod.GetAnnotations()[PodSafeToEvictKey] == "true"
+}
+
+// HasSafeToEvictOnCompletionAnnotation checks if pod has PodSafeToEvictKey
+// annotation set to "on-completion".
+func HasSafeToEvictOnCompletionAnnotation(pod *apiv1.Pod) bool {
+	return pod.GetAnnotations()[PodSafeToEvictKey] == PodSafeToEvictOnCompletionValue
 }
 
 // HasNotSafeToEvictAnnotation checks if pod has PodSafeToEvictKey annotation


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This PR introduces the `cluster-autoscaler.kubernetes.io/safe-to-evict: "on-completion"` annotation value. It allows users to specify that a pod should not be actively evicted by the Cluster Autoscaler during a scale-down event, but rather should be allowed to run to completion.

When scaling down, the Cluster Autoscaler will wait for pods with this annotation to complete successfully rather than forcefully evicting them. Nodes containing only daemonset pods and "on-completion" pods are prioritized for scale-down after completely empty nodes, but before nodes requiring active pod eviction. 

This is particularly useful for AI/ML workloads or batch jobs that cannot be easily interrupted or checkpointed, ensuring they finish their computation naturally before the underlying node is scaled down.

#### Special notes for your reviewer:

PR adds a new drainability rule `oncompletion` which skips pods annotated with `cluster-autoscaler.kubernetes.io/safe-to-evict=on-completion`. To surface this state cleanly to the rest of the CA logic, the `simulator.GetPodsToMove` function was refactored to return a `PodMoveInfo` struct rather than multiple slice return values. This cleans up the signature and allows better handling of special pod categories like `OnCompletionPods`.

The `ScaleDownNodeProcessor` sorting logic is also updated to prioritize nodes with only on-completion pods right after completely empty nodes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduced `cluster-autoscaler.kubernetes.io/safe-to-evict: "on-completion"` annotation value. Pods with this annotation will not be forcefully evicted during node scale-down; instead, the Cluster Autoscaler will wait for them to natively run to completion before scaling down the node. Nodes with only these pods are prioritized for scale-down over nodes with standard pods requiring eviction.
```
