### PR TITLE
Add capacity buffer oldest reconciliation timestamp metric

### DIFF
--- a/cluster-autoscaler/builder/autoscaler.go
+++ b/cluster-autoscaler/builder/autoscaler.go
@@ -213,8 +213,7 @@ func (b *AutoscalerBuilder) Build(ctx context.Context) (core.Autoscaler, *loop.L
 			} else {
 				fakePodsResolver = fakepods.NewDefaultingResolver()
 			}
-			nodeBufferController := cbctrl.NewDefaultBufferController(capacitybufferClient, fakePodsResolver)
-			go nodeBufferController.Run(ctx.Done())
+			cbctrl.InitializeAndRunDefaultBufferController(ctx, capacitybufferClient, fakePodsResolver)
 		}
 	}
 

--- a/cluster-autoscaler/capacitybuffer/controller/controller.go
+++ b/cluster-autoscaler/capacitybuffer/controller/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -36,8 +37,10 @@ import (
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/fakepods"
 	filters "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/filters"
+	cbmetrics "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/metrics"
 	translators "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/translators"
 	updater "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/updater"
+	"k8s.io/utils/clock"
 )
 
 // BufferController performs updates on Buffers and convert them to pods to be injected
@@ -47,12 +50,14 @@ type BufferController interface {
 }
 
 type bufferController struct {
-	client         *cbclient.CapacityBufferClient
-	strategyFilter filters.Filter
-	translator     translators.Translator
-	quotaAllocator *resourceQuotaAllocator
-	updater        updater.StatusUpdater
-	queue          workqueue.TypedRateLimitingInterface[string]
+	client                  *cbclient.CapacityBufferClient
+	strategyFilter          filters.Filter
+	translator              translators.Translator
+	quotaAllocator          *resourceQuotaAllocator
+	updater                 updater.StatusUpdater
+	queue                   workqueue.TypedRateLimitingInterface[string]
+	clock                   clock.Clock
+	reconciliationTimeCache *cbmetrics.ReconciliationCache
 }
 
 // NewBufferController creates new bufferController object
@@ -61,6 +66,8 @@ func NewBufferController(
 	strategyFilter filters.Filter,
 	translator translators.Translator,
 	updater updater.StatusUpdater,
+	clock clock.Clock,
+	reconciliationTimeCache *cbmetrics.ReconciliationCache,
 ) BufferController {
 	bc := &bufferController{
 		client:         client,
@@ -71,20 +78,42 @@ func NewBufferController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "CapacityBuffers"},
 		),
+		clock:                   clock,
+		reconciliationTimeCache: reconciliationTimeCache,
 	}
 	bc.configureEventHandlers()
 	return bc
+}
+
+// InitializeAndRunDefaultBufferController creates the default Capacity buffer controller and processing interval metric collector
+// and runs each of them asyncrounsly
+func InitializeAndRunDefaultBufferController(
+	ctx context.Context,
+	client *cbclient.CapacityBufferClient,
+	resolver fakepods.Resolver,
+
+) {
+	realClock := clock.RealClock{}
+	reconciledBuffersCache := cbmetrics.NewReconciliationCache()
+	// Accepting empty string as it represents nil value for ProvisioningStrategy
+	defaultStrategies := []string{capacitybuffer.ActiveProvisioningStrategy, ""}
+	controller := NewDefaultBufferController(client, resolver, defaultStrategies, reconciledBuffersCache, realClock)
+	go controller.Run(ctx.Done())
+
+	cbmetrics.RegisterReconciliationTimestampCollector(client, defaultStrategies, reconciledBuffersCache, realClock)
 }
 
 // NewDefaultBufferController creates bufferController with default configs
 func NewDefaultBufferController(
 	client *cbclient.CapacityBufferClient,
 	resolver fakepods.Resolver,
+	strategies []string,
+	reconciliationTimeCache *cbmetrics.ReconciliationCache,
+	clock clock.Clock,
 ) BufferController {
 	bc := &bufferController{
-		client: client,
-		// Accepting empty string as it represents nil value for ProvisioningStrategy
-		strategyFilter: filters.NewStrategyFilter([]string{capacitybuffer.ActiveProvisioningStrategy, ""}),
+		client:         client,
+		strategyFilter: filters.NewStrategyFilter(strategies),
 		translator: translators.NewCombinedTranslator(
 			[]translators.Translator{
 				translators.NewPodTemplateBufferTranslator(client, resolver),
@@ -97,6 +126,8 @@ func NewDefaultBufferController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "CapacityBuffers"},
 		),
+		clock:                   clock,
+		reconciliationTimeCache: reconciliationTimeCache,
 	}
 	bc.configureEventHandlers()
 	return bc
@@ -279,7 +310,10 @@ func (c *bufferController) reconcileNamespace(namespace string) error {
 
 	// Filter the desired provisioning strategy
 	// Note: We process ALL buffers in the namespace that match the strategy.
-	filteredBuffers, _ := c.strategyFilter.Filter(buffers)
+	filteredBuffers, filteredOutBuffers := c.strategyFilter.Filter(buffers)
+
+	// Update reconciliation time for filtered out buffers
+	c.updateReconciliationTimeCache(filteredOutBuffers)
 
 	if len(filteredBuffers) == 0 {
 		return nil
@@ -307,7 +341,8 @@ func (c *bufferController) reconcileNamespace(namespace string) error {
 	}
 
 	// Update buffer status by calling API server
-	updateErrors := c.updater.Update(filteredBuffers)
+	updatedBuffers, updateErrors := c.updater.Update(filteredBuffers)
+	c.updateReconciliationTimeCache(updatedBuffers)
 	for _, err := range updateErrors {
 		runtime.HandleError(fmt.Errorf("capacity buffer controller error: %w", err))
 	}
@@ -318,4 +353,11 @@ func (c *bufferController) reconcileNamespace(namespace string) error {
 	}
 
 	return nil
+}
+
+func (c *bufferController) updateReconciliationTimeCache(buffers []*v1.CapacityBuffer) {
+	if c.reconciliationTimeCache == nil || len(buffers) == 0 {
+		return
+	}
+	c.reconciliationTimeCache.Update(buffers, c.clock.Now())
 }

--- a/cluster-autoscaler/capacitybuffer/controller/controller_test.go
+++ b/cluster-autoscaler/capacitybuffer/controller/controller_test.go
@@ -29,17 +29,73 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	fakebuffers "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned/fake"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/fakepods"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 )
+
+func TestController_CacheUpdates(t *testing.T) {
+	now := metav1.Now().Time
+	fakeClock := testclock.NewFakeClock(now)
+	reconciliationCache := metrics.NewReconciliationCache()
+
+	bSupported := &v1.CapacityBuffer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "supported",
+			Namespace: "default",
+			UID:       types.UID("uid-supported"),
+		},
+		Spec: v1.CapacityBufferSpec{
+			ProvisioningStrategy: ptr.To(capacitybuffer.ActiveProvisioningStrategy),
+		},
+	}
+	bUnsupported := &v1.CapacityBuffer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unsupported",
+			Namespace: "default",
+			UID:       types.UID("uid-unsupported"),
+		},
+		Spec: v1.CapacityBufferSpec{
+			ProvisioningStrategy: ptr.To("unsupported-strategy"),
+		},
+	}
+
+	buffersClient := fakebuffers.NewSimpleClientset(bSupported, bUnsupported)
+	k8sClient := fakek8s.NewSimpleClientset()
+	client, _ := cbclient.NewCapacityBufferClientFromClients(buffersClient, k8sClient, nil, nil)
+
+	resolver := fakepods.NewDefaultingResolver()
+	controller := NewDefaultBufferController(
+		client,
+		resolver,
+		[]string{capacitybuffer.ActiveProvisioningStrategy},
+		reconciliationCache,
+		fakeClock,
+	).(*bufferController)
+
+	// Reconcile
+	err := controller.reconcileNamespace("default")
+	assert.NoError(t, err)
+
+	// Verify Cache
+	snapshot := reconciliationCache.Snapshot()
+	assert.Len(t, snapshot, 2)
+	assert.Contains(t, snapshot, types.UID("uid-supported"))
+	assert.Contains(t, snapshot, types.UID("uid-unsupported"))
+	assert.Equal(t, now, snapshot[types.UID("uid-supported")])
+	assert.Equal(t, now, snapshot[types.UID("uid-unsupported")])
+}
 
 func TestControllerIntegration_ResourceQuotas(t *testing.T) {
 	// TODO: refactor to ginkgo and envtest
@@ -91,7 +147,7 @@ func TestControllerIntegration_ResourceQuotas(t *testing.T) {
 
 	// TODO: use DryRunResolver once migrated to envtest
 	resolver := fakepods.NewDefaultingResolver()
-	controller := NewDefaultBufferController(client, resolver).(*bufferController)
+	controller := NewDefaultBufferController(client, resolver, []string{capacitybuffer.ActiveProvisioningStrategy}, metrics.NewReconciliationCache(), clock.RealClock{}).(*bufferController)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cluster-autoscaler/capacitybuffer/metrics/reconciliation_cache.go
+++ b/cluster-autoscaler/capacitybuffer/metrics/reconciliation_cache.go
@@ -1,0 +1,82 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+)
+
+// ReconciliationCache is a thread safe map for buffers last reconciliation time
+type ReconciliationCache struct {
+	reconciledBuffers map[types.UID]time.Time
+	mutex             sync.RWMutex
+}
+
+// NewReconciliationCache creates a new instance of ReconciliationCache
+func NewReconciliationCache() *ReconciliationCache {
+	return &ReconciliationCache{
+		reconciledBuffers: make(map[types.UID]time.Time),
+	}
+}
+
+// Update updates the underlying map with the provided buffers and time.
+func (r *ReconciliationCache) Update(buffers []*v1beta1.CapacityBuffer, t time.Time) {
+	if len(buffers) == 0 {
+		return
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	for _, buffer := range buffers {
+		r.reconciledBuffers[buffer.UID] = t
+	}
+}
+
+// Prune removes entries from the cache that are not present in the provided buffers list.
+func (r *ReconciliationCache) Prune(buffers []*v1beta1.CapacityBuffer) {
+	existingBuffers := sets.New[types.UID]()
+	for _, buffer := range buffers {
+		existingBuffers.Insert(buffer.UID)
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	for uid := range r.reconciledBuffers {
+		if !existingBuffers.Has(uid) {
+			delete(r.reconciledBuffers, uid)
+		}
+	}
+}
+
+// Snapshot creates and returns a copy of the current map.
+func (r *ReconciliationCache) Snapshot() map[types.UID]time.Time {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	snapshot := make(map[types.UID]time.Time, len(r.reconciledBuffers))
+	for key, value := range r.reconciledBuffers {
+		snapshot[key] = value
+	}
+
+	return snapshot
+}

--- a/cluster-autoscaler/capacitybuffer/metrics/reconciliation_cache_test.go
+++ b/cluster-autoscaler/capacitybuffer/metrics/reconciliation_cache_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+)
+
+func TestReconciliationCache(t *testing.T) {
+	now := time.Now()
+	testCases := []struct {
+		name        string
+		initialData []*v1beta1.CapacityBuffer
+		updateWith  []*v1beta1.CapacityBuffer
+		wantResult  map[types.UID]time.Time
+	}{
+		{
+			name:        "Empty initial, update with data",
+			initialData: []*v1beta1.CapacityBuffer{},
+			updateWith:  []*v1beta1.CapacityBuffer{{ObjectMeta: metav1.ObjectMeta{UID: "uid1"}}},
+			wantResult:  map[types.UID]time.Time{"uid1": now},
+		},
+		{
+			name:        "Existing data, update with new data (merge)",
+			initialData: []*v1beta1.CapacityBuffer{{ObjectMeta: metav1.ObjectMeta{UID: "uid1"}}},
+			updateWith:  []*v1beta1.CapacityBuffer{{ObjectMeta: metav1.ObjectMeta{UID: "uid2"}}},
+			wantResult:  map[types.UID]time.Time{"uid1": now, "uid2": now},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewReconciliationCache()
+			if len(tc.initialData) > 0 {
+				r.Update(tc.initialData, now)
+			}
+			r.Update(tc.updateWith, now)
+			snapshot := r.Snapshot()
+			assert.Equal(t, tc.wantResult, snapshot)
+
+			// Verify snapshot is a deep copy by modifying it and checking the cache remains unchanged
+			snapshot["deep-copy-check"] = time.Now()
+			assert.NotContains(t, r.Snapshot(), "deep-copy-check")
+		})
+	}
+}
+
+func TestReconciliationCache_Prune(t *testing.T) {
+	now := time.Now()
+	initBuffers := []*v1beta1.CapacityBuffer{
+		{ObjectMeta: metav1.ObjectMeta{UID: "uid1"}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "uid2"}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "uid3"}},
+	}
+
+	testCases := []struct {
+		name             string
+		supportedBuffers []*v1beta1.CapacityBuffer
+		wantSnapshot     map[types.UID]time.Time
+	}{
+		{
+			name:             "Prune all",
+			supportedBuffers: []*v1beta1.CapacityBuffer{},
+			wantSnapshot:     map[types.UID]time.Time{},
+		},
+		{
+			name: "Prune none",
+			supportedBuffers: []*v1beta1.CapacityBuffer{
+				{ObjectMeta: metav1.ObjectMeta{UID: "uid1"}},
+				{ObjectMeta: metav1.ObjectMeta{UID: "uid2"}},
+				{ObjectMeta: metav1.ObjectMeta{UID: "uid3"}},
+				{ObjectMeta: metav1.ObjectMeta{UID: "extra"}},
+			},
+			wantSnapshot: map[types.UID]time.Time{
+				"uid1": now,
+				"uid2": now,
+				"uid3": now,
+			},
+		},
+		{
+			name: "Prune some",
+			supportedBuffers: []*v1beta1.CapacityBuffer{
+				{ObjectMeta: metav1.ObjectMeta{UID: "uid2"}},
+			},
+			wantSnapshot: map[types.UID]time.Time{
+				"uid2": now,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewReconciliationCache()
+			r.Update(initBuffers, now)
+			r.Prune(tc.supportedBuffers)
+			assert.Equal(t, tc.wantSnapshot, r.Snapshot())
+		})
+	}
+}

--- a/cluster-autoscaler/capacitybuffer/metrics/reconciliation_collector.go
+++ b/cluster-autoscaler/capacitybuffer/metrics/reconciliation_collector.go
@@ -1,0 +1,167 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/blang/semver/v4"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
+	filters "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/filters"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/klogx"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+const (
+	metricFQName = "capacity_buffer_oldest_reconciliation_timestamp_seconds"
+	loggingQuota = 5
+)
+
+var (
+	oldestReconciliationTimestampMetricDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("cluster_autoscaler", "", metricFQName),
+		"Unix timestamp of the oldest capacity buffer last reconciliation time.",
+		[]string{"new_buffer"},
+		nil,
+	)
+)
+
+type capacityBufferClient interface {
+	ListCapacityBuffers(namespace string) ([]*v1beta1.CapacityBuffer, error)
+}
+
+// reconciliationTimestampCollector is a prometheus.Collector that collects capacity buffer reconciliation interval metrics.
+type reconciliationTimestampCollector struct {
+	client                 capacityBufferClient
+	reconciledBuffers      *ReconciliationCache
+	supportedBuffersFilter filters.Filter
+	clock                  clock.Clock
+}
+
+// NewReconciliationTimestampCollector creates a new collector instance.
+func NewReconciliationTimestampCollector(client capacityBufferClient, strategies []string, reconciledBuffers *ReconciliationCache, clock clock.Clock) *reconciliationTimestampCollector {
+	return &reconciliationTimestampCollector{
+		client:                 client,
+		reconciledBuffers:      reconciledBuffers,
+		supportedBuffersFilter: filters.NewStrategyFilter(strategies),
+		clock:                  clock,
+	}
+}
+
+// RegisterReconciliationTimestampCollector registers the reconciliation timestamp collector.
+func RegisterReconciliationTimestampCollector(client *cbclient.CapacityBufferClient, strategies []string, reconciledBuffers *ReconciliationCache, clock clock.Clock) {
+	collector := NewReconciliationTimestampCollector(client, strategies, reconciledBuffers, clock)
+	legacyregistry.MustRegister(collector)
+}
+
+// Describe implements the prometheus.Collector interface.
+func (c *reconciliationTimestampCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- oldestReconciliationTimestampMetricDesc
+}
+
+// Collect implements the prometheus.Collector interface.
+func (c *reconciliationTimestampCollector) Collect(ch chan<- prometheus.Metric) {
+	// List all capacity buffers
+	buffers, err := c.client.ListCapacityBuffers("")
+	if err != nil {
+		klog.Errorf("Failed to list capacity buffers with error: %v", err.Error())
+		return
+	}
+
+	// Delete buffers that no longer exist from cache
+	c.reconciledBuffers.Prune(buffers)
+
+	supportedBuffers, _ := c.supportedBuffersFilter.Filter(buffers)
+	reconciledBuffersSnapshot := c.reconciledBuffers.Snapshot()
+
+	now := c.clock.Now()
+	oldestNewBufferTimestamp := now
+	oldestReconciledBufferTimestamp := now
+
+	loggingQuota := klogx.NewLoggingQuota(loggingQuota)
+	for _, buffer := range supportedBuffers {
+		lastReconciliationTime, isNewBuffer, skipped := calculateBufferLastReconciliationTime(buffer, reconciledBuffersSnapshot)
+		if skipped {
+			klogx.V(2).UpTo(loggingQuota).Infof("Skipping capacity buffer %s/%s from %s metric: "+
+				"buffer is not registered in reconciled buffers cache while having conditions, expected when CA restarts.", buffer.Namespace, buffer.Name, metricFQName)
+			continue
+		}
+
+		if isNewBuffer {
+			oldestNewBufferTimestamp = updateOldest(oldestNewBufferTimestamp, lastReconciliationTime)
+		} else {
+			oldestReconciledBufferTimestamp = updateOldest(oldestReconciledBufferTimestamp, lastReconciliationTime)
+		}
+	}
+	klogx.V(2).Over(loggingQuota).Infof("Skipped %d other capacity buffers from %s metric "+
+		"for not being registered in reconciled buffers cache while having conditions, expected when CA restarts.", -loggingQuota.Left(), metricFQName)
+
+	c.reportMetric(ch, oldestNewBufferTimestamp, true)
+	c.reportMetric(ch, oldestReconciledBufferTimestamp, false)
+}
+
+func updateOldest(oldest, current time.Time) time.Time {
+	if current.Before(oldest) {
+		return current
+	}
+	return oldest
+}
+
+func (c *reconciliationTimestampCollector) reportMetric(ch chan<- prometheus.Metric, timestamp time.Time, isNew bool) {
+	ch <- prometheus.MustNewConstMetric(
+		oldestReconciliationTimestampMetricDesc,
+		prometheus.GaugeValue,
+		float64(timestamp.Unix()),
+		strconv.FormatBool(isNew),
+	)
+}
+
+// Create implements the k8smetrics.Registerable interface.
+func (c *reconciliationTimestampCollector) Create(version *semver.Version) bool {
+	return true
+}
+
+// ClearState implements the k8smetrics.Registerable interface.
+func (c *reconciliationTimestampCollector) ClearState() {
+	// No-op for stateless collector
+}
+
+// FQName implements the k8smetrics.Registerable interface.
+func (c *reconciliationTimestampCollector) FQName() string {
+	return metricFQName
+}
+
+func calculateBufferLastReconciliationTime(buffer *v1beta1.CapacityBuffer, reconciledBuffersSnapshot map[types.UID]time.Time) (time.Time, bool, bool) {
+	lastReconciliationTime, exists := reconciledBuffersSnapshot[buffer.UID]
+	if exists {
+		return lastReconciliationTime, false, false
+	}
+
+	if len(buffer.Status.Conditions) == 0 {
+		// non-cached buffers with no conditions are considered new buffers
+		return buffer.CreationTimestamp.Time, true, false
+	}
+
+	// non-cached buffers with conditions are skipped (CA restart)
+	return time.Time{}, false, true
+}

--- a/cluster-autoscaler/capacitybuffer/metrics/reconciliation_collector_test.go
+++ b/cluster-autoscaler/capacitybuffer/metrics/reconciliation_collector_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	filters "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/filters"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
+)
+
+type fakeClient struct {
+	buffers []*v1beta1.CapacityBuffer
+}
+
+func (m *fakeClient) ListCapacityBuffers(namespace string) ([]*v1beta1.CapacityBuffer, error) {
+	return m.buffers, nil
+}
+
+func newFakeClient(buffers []*v1beta1.CapacityBuffer) *fakeClient {
+	return &fakeClient{buffers: buffers}
+}
+
+func newTestCapacityBuffer(uid, strategy string, creationTime time.Time, conditions []metav1.Condition) *v1beta1.CapacityBuffer {
+	return &v1beta1.CapacityBuffer{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:               types.UID(uid),
+			CreationTimestamp: metav1.Time{Time: creationTime},
+		},
+		Spec: v1beta1.CapacityBufferSpec{
+			ProvisioningStrategy: ptr.To(strategy),
+		},
+		Status: v1beta1.CapacityBufferStatus{
+			Conditions: conditions,
+		},
+	}
+}
+
+func TestReconciliationTimestampCollector_Collect(t *testing.T) {
+	now := time.Unix(1710410000, 0) // Fixed "now" for deterministic tests
+	time5mAgo := now.Add(-5 * time.Minute)
+	time10mAgo := now.Add(-10 * time.Minute)
+	time15mAgo := now.Add(-15 * time.Minute)
+	time20mAgo := now.Add(-20 * time.Minute)
+
+	testCases := []struct {
+		name                string
+		buffers             []*v1beta1.CapacityBuffer
+		initialCache        map[types.UID]time.Time
+		supportedStrategies []string
+		wantNew             float64
+		wantReconciled      float64
+		wantFinalSnapshot   map[types.UID]time.Time
+	}{
+		{
+			name:                "No buffers",
+			buffers:             []*v1beta1.CapacityBuffer{},
+			initialCache:        nil,
+			supportedStrategies: []string{""},
+			wantNew:             float64(now.Unix()),
+			wantReconciled:      float64(now.Unix()),
+			wantFinalSnapshot:   map[types.UID]time.Time{},
+		},
+		{
+			name: "New and reconciled buffers",
+			buffers: []*v1beta1.CapacityBuffer{
+				newTestCapacityBuffer("new-uid", "", time10mAgo, nil),
+				newTestCapacityBuffer("proc-uid", "", now, nil),
+			},
+			initialCache: map[types.UID]time.Time{
+				"proc-uid": time5mAgo,
+			},
+			supportedStrategies: []string{""},
+			wantNew:             float64(time10mAgo.Unix()),
+			wantReconciled:      float64(time5mAgo.Unix()),
+			wantFinalSnapshot: map[types.UID]time.Time{
+				"proc-uid": time5mAgo,
+			},
+		},
+		{
+			name: "Complex scenario with multiple buffer states",
+			buffers: []*v1beta1.CapacityBuffer{
+				newTestCapacityBuffer("unsupported-uid", "unsupported", now, nil),
+				newTestCapacityBuffer("skipped-uid", "", now, []metav1.Condition{{Type: "Ready", Status: "True"}}),
+				newTestCapacityBuffer("new-uid-1", "", time10mAgo, nil),
+				newTestCapacityBuffer("new-uid-2", "", time20mAgo, nil),
+				newTestCapacityBuffer("proc-uid-1", "", now, nil),
+				newTestCapacityBuffer("proc-uid-2", "", now, nil),
+			},
+			initialCache: map[types.UID]time.Time{
+				"proc-uid-1":      time5mAgo,
+				"proc-uid-2":      time15mAgo,
+				"unsupported-uid": time5mAgo,
+			},
+			supportedStrategies: []string{""},
+			wantNew:             float64(time20mAgo.Unix()),
+			wantReconciled:      float64(time15mAgo.Unix()),
+			wantFinalSnapshot: map[types.UID]time.Time{
+				"proc-uid-1":      time5mAgo,
+				"proc-uid-2":      time15mAgo,
+				"unsupported-uid": time5mAgo,
+			},
+		},
+		{
+			name: "Cleanup of stale cache entries",
+			buffers: []*v1beta1.CapacityBuffer{
+				newTestCapacityBuffer("active-uid", "", now, nil),
+				newTestCapacityBuffer("unsupported-uid", "unsupported", now, nil),
+			},
+			initialCache: map[types.UID]time.Time{
+				"active-uid":      time5mAgo,
+				"unsupported-uid": time5mAgo,
+				"stale-uid":       time10mAgo,
+			},
+			supportedStrategies: []string{""},
+			wantNew:             float64(now.Unix()),
+			wantReconciled:      float64(time5mAgo.Unix()),
+			wantFinalSnapshot: map[types.UID]time.Time{
+				"active-uid":      time5mAgo,
+				"unsupported-uid": time5mAgo,
+			},
+		},
+		{
+			name: "Oldest value is reported when cache has multiple entries",
+			buffers: []*v1beta1.CapacityBuffer{
+				newTestCapacityBuffer("proc-uid-old", "", now, nil),
+				newTestCapacityBuffer("proc-uid-new", "", now, nil),
+			},
+			initialCache: map[types.UID]time.Time{
+				"proc-uid-old": time20mAgo,
+				"proc-uid-new": time5mAgo,
+			},
+			supportedStrategies: []string{""},
+			wantNew:             float64(now.Unix()),
+			wantReconciled:      float64(time20mAgo.Unix()),
+			wantFinalSnapshot: map[types.UID]time.Time{
+				"proc-uid-old": time20mAgo,
+				"proc-uid-new": time5mAgo,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClock := clocktesting.NewFakeClock(now)
+
+			c := newFakeClient(tc.buffers)
+			reconciledCache := NewReconciliationCache()
+			if len(tc.initialCache) > 0 {
+				// Inject initial cache directly for testing varied timestamps
+				for uid, ts := range tc.initialCache {
+					buf := []*v1beta1.CapacityBuffer{{ObjectMeta: metav1.ObjectMeta{UID: uid}}}
+					reconciledCache.Update(buf, ts)
+				}
+			}
+
+			filter := filters.NewStrategyFilter(tc.supportedStrategies)
+
+			collector := &reconciliationTimestampCollector{
+				client:                 c,
+				reconciledBuffers:      reconciledCache,
+				supportedBuffersFilter: filter,
+				clock:                  fakeClock,
+			}
+
+			metricsChan := make(chan prometheus.Metric)
+			go func() {
+				collector.Collect(metricsChan)
+				close(metricsChan)
+			}()
+
+			var gotNew, gotReconciled float64
+			var foundNew, foundReconciled bool
+			for m := range metricsChan {
+				metricDto := &dto.Metric{}
+				m.Write(metricDto)
+				isNew := false
+				for _, lp := range metricDto.Label {
+					if *lp.Name == "new_buffer" && *lp.Value == "true" {
+						isNew = true
+						break
+					}
+				}
+				if isNew {
+					gotNew = *metricDto.Gauge.Value
+					foundNew = true
+				} else {
+					gotReconciled = *metricDto.Gauge.Value
+					foundReconciled = true
+				}
+			}
+
+			assert.True(t, foundNew, "new_buffer=true metric not found")
+			assert.True(t, foundReconciled, "new_buffer=false metric not found")
+			assert.Equal(t, tc.wantNew, gotNew, "new_buffer=true timestamp mismatch")
+			assert.Equal(t, tc.wantReconciled, gotReconciled, "new_buffer=false timestamp mismatch")
+
+			finalSnapshot := reconciledCache.Snapshot()
+			assert.Equal(t, tc.wantFinalSnapshot, finalSnapshot)
+		})
+	}
+}

--- a/cluster-autoscaler/capacitybuffer/updater/status_updater.go
+++ b/cluster-autoscaler/capacitybuffer/updater/status_updater.go
@@ -34,15 +34,21 @@ func NewStatusUpdater(client *cbclient.CapacityBufferClient) *StatusUpdater {
 }
 
 // Update updates the buffer status with pod capacity
-func (u *StatusUpdater) Update(buffers []*v1.CapacityBuffer) []error {
+func (u *StatusUpdater) Update(buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []error) {
 	var errors []error
+	var updatedBuffers []*v1.CapacityBuffer
+
 	for _, buffer := range buffers {
-		_, err := u.client.UpdateCapacityBuffer(buffer)
+		updatedBuffer, err := u.client.UpdateCapacityBuffer(buffer)
 		if err != nil {
 			errors = append(errors, err)
+			continue
+		}
+		if updatedBuffer != nil {
+			updatedBuffers = append(updatedBuffers, updatedBuffer)
 		}
 	}
-	return errors
+	return updatedBuffers, errors
 }
 
 // CleanUp cleans up the updater's internal structures.

--- a/cluster-autoscaler/capacitybuffer/updater/status_updater_test.go
+++ b/cluster-autoscaler/capacitybuffer/updater/status_updater_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	fakeclientset "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned/fake"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
@@ -34,6 +35,7 @@ func TestStatusUpdater(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "buffer1",
 			Namespace: "default",
+			UID:       types.UID("uid1"),
 		},
 		Spec: v1.CapacityBufferSpec{},
 	}
@@ -41,6 +43,7 @@ func TestStatusUpdater(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "buffer2",
 			Namespace: "default",
+			UID:       types.UID("uid2"),
 		},
 		Spec: v1.CapacityBufferSpec{},
 	}
@@ -48,26 +51,29 @@ func TestStatusUpdater(t *testing.T) {
 	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClient(fakeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	tests := []struct {
-		name                   string
-		buffers                []*v1.CapacityBuffer
-		expectedNumberOfCalls  int
-		expectedNumberOfErrors int
+		name               string
+		buffers            []*v1.CapacityBuffer
+		wantNumberOfCalls  int
+		wantNumberOfErrors int
+		wantUpdatedCount   int
 	}{
 		{
 			name: "Update one buffer",
 			buffers: []*v1.CapacityBuffer{
 				exitingBuffer,
 			},
-			expectedNumberOfCalls:  1,
-			expectedNumberOfErrors: 0,
+			wantNumberOfCalls:  1,
+			wantNumberOfErrors: 0,
+			wantUpdatedCount:   1,
 		},
 		{
 			name: "Update one buffer not existing",
 			buffers: []*v1.CapacityBuffer{
 				notExistingBuffer,
 			},
-			expectedNumberOfCalls:  1,
-			expectedNumberOfErrors: 1,
+			wantNumberOfCalls:  1,
+			wantNumberOfErrors: 1,
+			wantUpdatedCount:   0,
 		},
 		{
 			name: "Update multiple buffers",
@@ -75,12 +81,13 @@ func TestStatusUpdater(t *testing.T) {
 				exitingBuffer,
 				notExistingBuffer,
 			},
-			expectedNumberOfCalls:  2,
-			expectedNumberOfErrors: 1,
+			wantNumberOfCalls:  2,
+			wantNumberOfErrors: 1,
+			wantUpdatedCount:   1,
 		},
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			updateCallsCount := 0
 			fakeClient.Fake.PrependReactor("update", "capacitybuffers",
 				func(action ctesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -89,9 +96,10 @@ func TestStatusUpdater(t *testing.T) {
 				},
 			)
 			buffersUpdater := NewStatusUpdater(fakeCapacityBuffersClient)
-			errors := buffersUpdater.Update(test.buffers)
-			assert.Equal(t, test.expectedNumberOfErrors, len(errors))
-			assert.Equal(t, test.expectedNumberOfCalls, updateCallsCount)
+			updatedBuffers, errors := buffersUpdater.Update(tc.buffers)
+			assert.Equal(t, tc.wantNumberOfErrors, len(errors))
+			assert.Equal(t, tc.wantNumberOfCalls, updateCallsCount)
+			assert.Equal(t, tc.wantUpdatedCount, len(updatedBuffers))
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds a new metric, capacity_buffer_oldest_reconciliation_timestamp_seconds, to monitor the Capacity Buffers controller. This metric tracks the oldest Capacity Buffer was last successfully processed, helping to ensure the controller loop is operating as expected.

The metric uses a label `new_buffer` to differentiate between newly created buffers and those that have been processed at least once.

Implementation:

* The controller caches the timestamp of the last successful processing for each buffer (both supported and unsupported buffers). 
* A Prometheus collector calculates iterates over the cached objects to get the min value for new buffers and processed ones.


#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add capacity_buffer_oldest_reconciliation_timestamp_seconds metric 

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
