### PR TITLE
docs: update VPA documentation to reflect in-place pod resource updates

### DIFF
--- a/vertical-pod-autoscaler/docs/components.md
+++ b/vertical-pod-autoscaler/docs/components.md
@@ -23,7 +23,7 @@ The VPA project consists of 3 components:
   provides recommended values for the containers' cpu and memory requests.
 
 - [Updater](#updater) - checks whether managed pods require resource updates based on recommendations
-  and may trigger pod eviction or in-place updates depending on the configured update mode.
+  and may trigger pod eviction, in-place updates or take no action depending on the configured update mode.
 
 - [Admission Controller](#admission-controller) - sets the correct resource requests on new pods (either just created
   or recreated by their controller due to Updater's activity).

--- a/vertical-pod-autoscaler/docs/components.md
+++ b/vertical-pod-autoscaler/docs/components.md
@@ -73,8 +73,8 @@ Updater component for Vertical Pod Autoscaler described in the [Vertical Pod Aut
 
 Updater runs in Kubernetes cluster and decides which pods require resource
 updates based on resources allocation recommendation calculated by Recommender.
-Depending on the configured update mode, the update may be applied in place or
-by evicting the pod.
+Depending on the configured update mode, the update may be applied in place,
+by evicting the pod or no action may be taken (in `Initial` mode).
 It respects the pod disruption budget, by using Eviction API to evict pods.
 Updater does not perform the actual resources update, but relies on Vertical Pod Autoscaler admission plugin
 to update pod resources when the pod is recreated after eviction.

--- a/vertical-pod-autoscaler/docs/components.md
+++ b/vertical-pod-autoscaler/docs/components.md
@@ -22,8 +22,8 @@ The VPA project consists of 3 components:
 - [Recommender](#recommender) - monitors the current and past resource consumption and, based on it,
   provides recommended values for the containers' cpu and memory requests.
 
-- [Updater](#updater) - checks which of the managed pods have correct resources set and, if not,
-  kills them so that they can be recreated by their controllers with the updated requests.
+- [Updater](#updater) - checks whether managed pods require resource updates based on recommendations
+  and may trigger pod eviction or in-place updates depending on the configured update mode.
 
 - [Admission Controller](#admission-controller) - sets the correct resource requests on new pods (either just created
   or recreated by their controller due to Updater's activity).
@@ -71,9 +71,10 @@ It then runs in a loop and at each step performs the following actions:
 
 Updater component for Vertical Pod Autoscaler described in the [Vertical Pod Autoscaler - design proposal](https://github.com/kubernetes/community/pull/338)
 
-Updater runs in Kubernetes cluster and decides which pods should be restarted
-based on resources allocation recommendation calculated by Recommender.
-If a pod should be updated, Updater will try to evict the pod.
+Updater runs in Kubernetes cluster and decides which pods require resource
+updates based on resources allocation recommendation calculated by Recommender.
+Depending on the configured update mode, the update may be applied in place or
+by evicting the pod.
 It respects the pod disruption budget, by using Eviction API to evict pods.
 Updater does not perform the actual resources update, but relies on Vertical Pod Autoscaler admission plugin
 to update pod resources when the pod is recreated after eviction.

--- a/vertical-pod-autoscaler/docs/known-limitations.md
+++ b/vertical-pod-autoscaler/docs/known-limitations.md
@@ -5,7 +5,7 @@
 
 - When VPA applies new resource recommendations, the Pod may be recreated if the resources
   cannot be updated in place. In such cases, all running containers are restarted and the Pod
-  may be scheduled on a different node.
+  may be scheduled on a different node. The `Initial` mode does not recreate running pods.
 - VPA cannot guarantee that pods it evicts or deletes to apply recommendations
   (when configured in `Auto` and `Recreate` modes) will be successfully
   recreated. This can be partly

--- a/vertical-pod-autoscaler/docs/known-limitations.md
+++ b/vertical-pod-autoscaler/docs/known-limitations.md
@@ -3,9 +3,9 @@
 <!-- toc -->
 <!-- /toc -->
 
-- Whenever VPA updates the pod resources, the pod is recreated, which causes all
-  running containers to be recreated. The pod may be recreated on a different
-  node.
+- When VPA applies new resource recommendations, the Pod may be recreated if the resources
+  cannot be updated in place. In such cases, all running containers are restarted and the Pod
+  may be scheduled on a different node.
 - VPA cannot guarantee that pods it evicts or deletes to apply recommendations
   (when configured in `Auto` and `Recreate` modes) will be successfully
   recreated. This can be partly


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:
Updated `docs/components.md` and `docs/known-limitations.md` 
Some existing descriptions implied that pod recreation is always required when VPA updates resources, which no longer reflects the current behavior.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: