### PR TITLE
CI: skip docs-only changes in VPA workflows

### DIFF
--- a/.github/workflows/vpa-golangci-lint.yaml
+++ b/.github/workflows/vpa-golangci-lint.yaml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'vertical-pod-autoscaler/**'
-    paths-ignore:
-      - '**/*.md'
+      - '!vertical-pod-autoscaler/**/*.md'
   pull_request:
     paths:
       - 'vertical-pod-autoscaler/**'
-    paths-ignore:
-      - '**/*.md'
+      - '!vertical-pod-autoscaler/**/*.md'
 
 env:
   GOPATH: ${{ github.workspace }}/go

--- a/.github/workflows/vpa-test.yaml
+++ b/.github/workflows/vpa-test.yaml
@@ -4,13 +4,11 @@ on:
   push:
     paths:
       - 'vertical-pod-autoscaler/**'
-    paths-ignore:
-      - '**/*.md'
+      - '!vertical-pod-autoscaler/**/*.md'
   pull_request:
     paths:
       - 'vertical-pod-autoscaler/**'
-    paths-ignore:
-      - '**/*.md'
+      - '!vertical-pod-autoscaler/**/*.md'
 
 env:
   GOPATH: ${{ github.workspace }}/go


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Adds `paths-ignore` to the Vertical Pod Autoscaler workflows so that docs-only changes no longer trigger CI, saving unnecessary runs, reducing wasted CI time.
#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:
- This only affects GitHub Actions triggers - no code or functionality changes.
- Please confirm that no tests depend on Markdown files.
#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
