### PR TITLE
Fix UpcomingNodes counting nodes for groups with no active scale-up or backed off

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -1074,6 +1074,20 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() (upcomingCounts map[string]i
 			// Negative value is unlikely but theoretically possible.
 			continue
 		}
+		// Don't count upcoming nodes for node groups that have upcoming nodes but no
+		// active scale-up request (the request was removed after instance creation
+		// failure or timeout) or are backed off. Otherwise, fake upcoming nodes
+		// injected into the cluster snapshot will make unschedulable pods appear
+		// schedulable, preventing ScaleUp from ever being called and considering
+		// alternative node groups.
+		if _, hasScaleUpRequest := csr.scaleUpRequests[id]; !hasScaleUpRequest {
+			klog.V(4).Infof("Skipping %d upcoming nodes for node group %s: no active scale-up request", newNodes, id)
+			continue
+		}
+		if backoffStatus := csr.backoff.BackoffStatus(nodeGroup, csr.nodeInfosForGroups[id], time.Now()); backoffStatus.IsBackedOff {
+			klog.V(4).Infof("Skipping %d upcoming nodes for backed-off node group %s: %s", newNodes, id, backoffStatus.ErrorInfo.ErrorMessage)
+			continue
+		}
 		upcomingCounts[id] = newNodes
 		// newNodes should include instances that have registered with k8s but aren't ready yet, instances that came up on the cloud provider side
 		// but haven't registered with k8s yet, and instances that haven't even come up on the cloud provider side yet (but are reflected in the target

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -688,6 +688,11 @@ func TestUpcomingNodes(t *testing.T) {
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), nodegroupchange.NewNodeGroupChangeObserversList())
+
+	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 6, now)
+	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng2"), 1, now)
+	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng3"), 2, now)
+
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1, ng3_1, ng4_1, ng5_1, ng5_2}, nil, now)
 	assert.NoError(t, err)
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
@@ -739,8 +744,8 @@ func TestTaintBasedNodeDeletion(t *testing.T) {
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
 
 	upcomingNodes, upcomingRegistered := clusterstate.GetUpcomingNodes()
-	assert.Equal(t, 1, upcomingNodes["ng1"])
-	assert.Empty(t, upcomingRegistered["ng1"]) // Only unregistered.
+	assert.Equal(t, 0, upcomingNodes["ng1"])
+	assert.Empty(t, upcomingRegistered["ng1"])
 }
 
 func TestIncorrectSize(t *testing.T) {
@@ -756,6 +761,7 @@ func TestIncorrectSize(t *testing.T) {
 		OkTotalUnreadyCount:       1,
 	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), nodegroupchange.NewNodeGroupChangeObserversList())
 	now := time.Now()
+
 	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now.Add(-5*time.Minute))
 	incorrect := clusterstate.incorrectNodeGroupSizes["ng1"]
 	assert.Equal(t, 5, incorrect.ExpectedSize)
@@ -791,6 +797,8 @@ func TestUnregisteredNodes(t *testing.T) {
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 10 * time.Second}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), nodegroupchange.NewNodeGroupChangeObserversList())
+
+	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 1, time.Now().Add(-time.Minute))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, time.Now().Add(-time.Minute))
 
 	assert.NoError(t, err)
@@ -1594,6 +1602,7 @@ func TestUpcomingNodesFromUpcomingNodeGroups(t *testing.T) {
 		nodeGroups                        map[string]int
 		expectedGroupsUpcomingNodesNumber map[string]int
 		updateNodes                       bool
+		scaleUpGroups                     map[string]int
 	}{
 		{
 			isUpcomingMockMap:                 map[string]bool{"ng": true},
@@ -1612,12 +1621,14 @@ func TestUpcomingNodesFromUpcomingNodeGroups(t *testing.T) {
 			nodeGroups:                        map[string]int{"ng": 2},
 			expectedGroupsUpcomingNodesNumber: map[string]int{"ng": 2},
 			updateNodes:                       true,
+			scaleUpGroups:                     map[string]int{"ng": 2},
 		},
 		{
 			isUpcomingMockMap:                 map[string]bool{"ng": true},
 			nodeGroups:                        map[string]int{"ng": 2, "ng2": 1},
 			expectedGroupsUpcomingNodesNumber: map[string]int{"ng": 2, "ng2": 1},
 			updateNodes:                       true,
+			scaleUpGroups:                     map[string]int{"ng2": 1},
 		},
 		{
 			isUpcomingMockMap:                 map[string]bool{"ng": true},
@@ -1648,6 +1659,10 @@ func TestUpcomingNodesFromUpcomingNodeGroups(t *testing.T) {
 			&asyncnodegroups.MockAsyncNodeGroupStateChecker{IsUpcomingNodeGroup: tc.isUpcomingMockMap},
 			nodegroupchange.NewNodeGroupChangeObserversList(),
 		)
+
+		for groupName, delta := range tc.scaleUpGroups {
+			clusterstate.RegisterScaleUp(provider.GetNodeGroup(groupName), delta, now)
+		}
 		if tc.updateNodes {
 			err := clusterstate.UpdateNodes([]*apiv1.Node{}, nil, now)
 			assert.NoError(t, err)
@@ -1829,6 +1844,89 @@ func TestFailedScaleUpWithDraAndGpu(t *testing.T) {
 	assert.NoError(t, err)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "dra_gpu-driver", "not-listed", "custom.driver,dra.net")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 1)
+}
+
+func TestGetUpcomingNodesSkipsWithoutScaleUpRequestOrBackoff(t *testing.T) {
+	now := time.Now()
+
+	// Setup: node group "ng1" with target=3 but only 1 ready node.
+	// This means newNodes = 2 in the upcoming calculation.
+	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
+	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 1, 10, 3)
+	provider.AddNode("ng1", ng1_1)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system",
+		kube_record.NewFakeRecorder(5), false, "configmap-1")
+
+	t.Run("no scale-up request means no upcoming nodes", func(t *testing.T) {
+		clusterstate := NewClusterStateRegistry(provider, ClusterStateRegistryConfig{
+			MaxTotalUnreadyPercentage: 10,
+			OkTotalUnreadyCount:       1,
+		}, fakeLogRecorder, newBackoff(),
+			nodegroupconfig.NewDefaultNodeGroupConfigProcessor(
+				config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}),
+			asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(),
+			nodegroupchange.NewNodeGroupChangeObserversList())
+
+		// NO RegisterScaleUp — simulates expired/removed request
+		err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now)
+		assert.NoError(t, err)
+
+		upcomingNodes, _ := clusterstate.GetUpcomingNodes()
+		// Bug fix: without a scale-up request, upcoming should be 0
+		// even though target (3) > ready nodes (1).
+		assert.Equal(t, 0, upcomingNodes["ng1"])
+	})
+
+	t.Run("with active scale-up request upcoming nodes are counted", func(t *testing.T) {
+		clusterstate := NewClusterStateRegistry(provider, ClusterStateRegistryConfig{
+			MaxTotalUnreadyPercentage: 10,
+			OkTotalUnreadyCount:       1,
+		}, fakeLogRecorder, newBackoff(),
+			nodegroupconfig.NewDefaultNodeGroupConfigProcessor(
+				config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}),
+			asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(),
+			nodegroupchange.NewNodeGroupChangeObserversList())
+
+		clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 2, now)
+		err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now)
+		assert.NoError(t, err)
+
+		upcomingNodes, _ := clusterstate.GetUpcomingNodes()
+		assert.Equal(t, 2, upcomingNodes["ng1"])
+	})
+
+	t.Run("backed-off node group means no upcoming nodes", func(t *testing.T) {
+		// Use short MaxNodeProvisionTime so the scale-up times out
+		// and puts the group in backoff.
+		mockMetrics := &mockMetrics{}
+		mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+		mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+
+		clusterstate := newClusterStateRegistryWithMetrics(provider, ClusterStateRegistryConfig{
+			MaxTotalUnreadyPercentage: 10,
+			OkTotalUnreadyCount:       1,
+		}, fakeLogRecorder, newBackoff(),
+			nodegroupconfig.NewDefaultNodeGroupConfigProcessor(
+				config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute}),
+			asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(), mockMetrics)
+
+		// Register scale-up 3 minutes ago with 2-minute provision time → will timeout
+		clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 2, now.Add(-3*time.Minute))
+		err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, nil, now)
+		assert.NoError(t, err)
+
+		// After timeout, group is in backoff. Register a new scale-up request.
+		clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 2, now)
+
+		upcomingNodes, _ := clusterstate.GetUpcomingNodes()
+		// Bug fix: backed-off group should not report upcoming nodes.
+		assert.Equal(t, 0, upcomingNodes["ng1"])
+	})
 }
 
 type mockMetrics struct {

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -2495,6 +2495,10 @@ func TestStaticAutoscalerUpcomingScaleDownCandidates(t *testing.T) {
 	csrConfig := clusterstate.ClusterStateRegistryConfig{OkTotalUnreadyCount: nodeGroupCount * unreadyNodesCount}
 	csr := clusterstate.NewNotifiedClusterStateRegistry(provider, csrConfig, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 15 * time.Minute}), processors.AsyncNodeGroupStateChecker, processors.ScaleStateNotifier)
 
+	for ngNum := 0; ngNum < nodeGroupCount; ngNum++ {
+		csr.RegisterScaleUp(provider.GetNodeGroup(fmt.Sprintf("ng-%d", ngNum)), unreadyNodesCount, startTime)
+	}
+
 	// Setting the Actuator is necessary for testing any scale-down logic, it shouldn't have anything to do in this test.
 	actuator := actuation.NewActuator(&autoscalingCtx, csr, deletiontracker.NewNodeDeletionTracker(0*time.Second), options.NodeDeleteOptions{}, nil, processors.NodeGroupConfigProcessor)
 	autoscalingCtx.ScaleDownActuator = actuator


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`UpcomingNodes()` computes upcoming node counts based on the delta between a node group's target size and its registered nodes. However, it does not check whether the node group still has an active scale-up request or whether it is currently backed off.

When a scale-up request is removed (after instance creation failure or timeout) or a node group is backed off, the upcoming nodes are still counted and injected into the cluster snapshot as fake schedulable capacity. This makes unschedulable pods appear schedulable, so `ScaleUp` is never called and the autoscaler cannot consider alternative node groups. The cluster gets stuck in a deadlock: pods stay `Pending` indefinitely.

This PR adds two checks in the `UpcomingNodes()` loop to skip node groups that:
1. Have no active scale-up request.
2. Are currently backed off.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 
- https://github.com/kubernetes/autoscaler/issues/5903
- https://github.com/kubernetes/autoscaler/issues/9043
- https://github.com/kubernetes/autoscaler/issues/8317

#### Special notes for your reviewer:
The fix is intentionally minimal — two guard clauses inserted right after the existing `newNodes <= 0` check. Both conditions use data already available on `ClusterStateRegistry` (`scaleUpRequests` map and `backoff`), so there is no additional cost.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix cluster-autoscaler deadlock where upcoming nodes from failed or backed-off node groups block scale-up to alternative groups, leaving pods Pending indefinitely.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
