### PR TITLE
fix: calculate resource diff for priority as max across containers

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go
@@ -46,10 +46,9 @@ func (*defaultPriorityProcessor) GetUpdatePriority(pod *corev1.Pod, vpa *vpa_typ
 	recommendation *vpa_types.RecommendedPodResources) PodPriority {
 	outsideRecommendedRange := false
 	scaleUp := false
-	// Sum of requests over all containers, per resource type.
-	totalRequestPerResource := make(map[corev1.ResourceName]int64)
-	// Sum of recommendations over all containers, per resource type.
-	totalRecommendedPerResource := make(map[corev1.ResourceName]int64)
+	// Maximum relative diff across all (container, resource) pairs.
+	// Using max per-container ensures that a single container with a large change reflects in the pod resource diff.
+	maxResourceDiff := 0.0
 
 	hasObservedContainers, vpaContainerSet := parseVpaObservedContainers(pod)
 
@@ -62,19 +61,23 @@ func (*defaultPriorityProcessor) GetUpdatePriority(pod *corev1.Pod, vpa *vpa_typ
 		if recommendedRequest == nil {
 			continue
 		}
+		requests, _ := resourcehelpers.ContainerRequestsAndLimits(podContainer.Name, pod)
 		for resourceName, recommended := range recommendedRequest.Target {
-			totalRecommendedPerResource[resourceName] += recommended.MilliValue()
 			lowerBound, hasLowerBound := recommendedRequest.LowerBound[resourceName]
 			upperBound, hasUpperBound := recommendedRequest.UpperBound[resourceName]
-			requests, _ := resourcehelpers.ContainerRequestsAndLimits(podContainer.Name, pod)
 			if request, hasRequest := requests[resourceName]; hasRequest {
-				totalRequestPerResource[resourceName] += request.MilliValue()
 				if recommended.MilliValue() > request.MilliValue() {
 					scaleUp = true
 				}
 				if (hasLowerBound && request.Cmp(lowerBound) < 0) ||
 					(hasUpperBound && request.Cmp(upperBound) > 0) {
 					outsideRecommendedRange = true
+				}
+				// Per-container relative diff for this resource.
+				requestFloat := math.Max(float64(request.MilliValue()), 1.0)
+				containerDiff := math.Abs(float64(request.MilliValue())-float64(recommended.MilliValue())) / requestFloat
+				if containerDiff > maxResourceDiff {
+					maxResourceDiff = containerDiff
 				}
 			} else {
 				// Note: if the request is not specified, the container will use the
@@ -83,17 +86,18 @@ func (*defaultPriorityProcessor) GetUpdatePriority(pod *corev1.Pod, vpa *vpa_typ
 				// be to always calculate the 'effective' request.
 				scaleUp = true
 				outsideRecommendedRange = true
+				// No current request; treat as 100% diff if there is a recommendation.
+				if recommended.MilliValue() > 0 {
+					if 1.0 > maxResourceDiff {
+						maxResourceDiff = 1.0
+					}
+				}
 			}
 		}
-	}
-	resourceDiff := 0.0
-	for resource, totalRecommended := range totalRecommendedPerResource {
-		totalRequest := math.Max(float64(totalRequestPerResource[resource]), 1.0)
-		resourceDiff += math.Abs(totalRequest-float64(totalRecommended)) / totalRequest
 	}
 	return PodPriority{
 		OutsideRecommendedRange: outsideRecommendedRange,
 		ScaleUp:                 scaleUp,
-		ResourceDiff:            resourceDiff,
+		ResourceDiff:            maxResourceDiff,
 	}
 }

--- a/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/priority_processor_test.go
@@ -121,7 +121,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("6", "20M").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
-				ResourceDiff:            1.0 + 1.0, // summed relative diffs for resources
+				ResourceDiff:            1.0, // max(CPU 3->6, Mem 10M->20M)
 				ScaleUp:                 true,
 			},
 		}, {
@@ -130,7 +130,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "20M").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
-				ResourceDiff:            1.5 + 0.0, // summed relative diffs for resources
+				ResourceDiff:            1.0, // max(CPU 4->2, Mem 10->20)
 				ScaleUp:                 true,
 			},
 		}, {
@@ -139,7 +139,7 @@ func TestGetUpdatePriority(t *testing.T) {
 			vpa:  test.VerticalPodAutoscaler().WithContainer(containerName).WithTarget("2", "10M").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
-				ResourceDiff:            0.5 + 0.5, // summed relative diffs for resources
+				ResourceDiff:            0.5, // max(CPU 4->2, Mem 20M->10M)
 				ScaleUp:                 false,
 			},
 		}, {
@@ -151,7 +151,7 @@ func TestGetUpdatePriority(t *testing.T) {
 				WithUpperBound("3", "30M").Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: true,
-				ResourceDiff:            0.5 + 0.5, // summed relative diffs for resources
+				ResourceDiff:            0.5, // max(CPU 4->2, Mem 20M->10M)
 				ScaleUp:                 false,
 			},
 		}, {
@@ -165,7 +165,7 @@ func TestGetUpdatePriority(t *testing.T) {
 					WithTarget("8", "").GetContainerResources()).Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
-				ResourceDiff:            3.0, // relative diff between summed requests and summed recommendations
+				ResourceDiff:            3.0, // max(1->4, 2->8)
 				ScaleUp:                 true,
 			},
 		}, {
@@ -179,7 +179,7 @@ func TestGetUpdatePriority(t *testing.T) {
 					WithTarget("2", "").GetContainerResources()).Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
-				ResourceDiff:            0.7, // relative diff between summed requests and summed recommendations
+				ResourceDiff:            5.0 / 7.0, // max(3->1, 7->2)
 				ScaleUp:                 false,
 			},
 		}, {
@@ -196,14 +196,11 @@ func TestGetUpdatePriority(t *testing.T) {
 					WithUpperBound("10", "").GetContainerResources()).Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: true,
-				ResourceDiff:            3.0, // relative diff between summed requests and summed recommendations
+				ResourceDiff:            3.0, // max(1->4, 2->8)
 				ScaleUp:                 true,
 			},
 		}, {
 			name: "multiple containers, multiple resources",
-			//   container1: request={6 CPU, 10 MB}, recommended={8 CPU, 20 MB}
-			//   container2: request={4 CPU, 30 MB}, recommended={7 CPU, 30 MB}
-			//   total:      request={10 CPU, 40 MB}, recommended={15 CPU, 50 MB}
 			pod: test.Pod().WithName("POD1").AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("6")).WithMemRequest(resource.MustParse("10M")).Get()).
 				AddContainer(test.Container().WithName("test-container-2").WithCPURequest(resource.MustParse("4")).WithMemRequest(resource.MustParse("30M")).Get()).Get(),
 			vpa: test.VerticalPodAutoscaler().WithContainer(containerName).
@@ -213,9 +210,8 @@ func TestGetUpdatePriority(t *testing.T) {
 					WithTarget("7", "30M").GetContainerResources()).Get(),
 			expectedPrio: PodPriority{
 				OutsideRecommendedRange: false,
-				// relative diff between summed requests and summed recommendations, summed over resources
-				ResourceDiff: 0.5 + 0.25,
-				ScaleUp:      true,
+				ResourceDiff:            1.0, // max(CPU 6->8, Mem 10M->20M, CPU 4->7, Mem 30M->30M)
+				ScaleUp:                 true,
 			},
 		},
 	}

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -235,7 +235,8 @@ type PodPriority struct {
 	OutsideRecommendedRange bool
 	// Does any container want to grow.
 	ScaleUp bool
-	// Relative difference between the total requested and total recommended resources.
+	// Difference between requested and recommended resources, expressed as the
+	// maximum relative diff over all container-resource pairs.
 	ResourceDiff float64
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

ResourceDiff is calculated by summing all container requests per resource type and then calculating the percentage difference of these totals. This might lead to cases where even though per container diff might be high it doesn't reflect accurately in pod resource diff. In this change we take a max diff across all container-resource pairs so thresholds allow for these pods to be evicted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8903 

#### Special notes for your reviewer:

Does this behavior change need to be highlighted in case users are setting thresholds very low to compensate for current behavior that averages out diffs across containers? They might see more frequent evictions with this fix.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix resource diff calculation logic to use max diff across all container-resource pairs instead of diff percentage after summing across containers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
