### PR TITLE
fix: replace context.TODO() with context.Background() across autoscaler

### DIFF
--- a/balancer/main.go
+++ b/balancer/main.go
@@ -93,7 +93,7 @@ func main() {
 	scaleClient, err := scaleclient.NewForConfig(cfg, restMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
 
 	podInformer := kubeInformerFactory.Core().V1().Pods()
-	core := controller.NewCore(controller.NewScaleClient(context.TODO(), scaleClient, restMapper), podInformer)
+	core := controller.NewCore(controller.NewScaleClient(context.Background(), scaleClient, restMapper), podInformer)
 
 	controller := controller.NewController(balancerClient,
 		balancerInformerFactory.Balancer().V1alpha1().Balancers(),

--- a/balancer/pkg/client/informers/externalversions/balancer.x-k8s.io/v1alpha1/balancer.go
+++ b/balancer/pkg/client/informers/externalversions/balancer.x-k8s.io/v1alpha1/balancer.go
@@ -62,13 +62,13 @@ func NewFilteredBalancerInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BalancerV1alpha1().Balancers(namespace).List(context.TODO(), options)
+				return client.BalancerV1alpha1().Balancers(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BalancerV1alpha1().Balancers(namespace).Watch(context.TODO(), options)
+				return client.BalancerV1alpha1().Balancers(namespace).Watch(context.Background(), options)
 			},
 		},
 		&balancerxk8siov1alpha1.Balancer{},

--- a/balancer/pkg/controller/controller.go
+++ b/balancer/pkg/controller/controller.go
@@ -244,6 +244,6 @@ func (c *Controller) updateStatusIfNeeded(oldStatus *balancerapi.BalancerStatus,
 	if apiequality.Semantic.DeepEqual(oldStatus, &new.Status) {
 		return nil
 	}
-	_, err := c.balancerClientSet.BalancerV1alpha1().Balancers(new.Namespace).UpdateStatus(context.TODO(), new, metav1.UpdateOptions{})
+	_, err := c.balancerClientSet.BalancerV1alpha1().Balancers(new.Namespace).UpdateStatus(context.Background(), new, metav1.UpdateOptions{})
 	return err
 }

--- a/cluster-autoscaler/capacitybuffer/client/client.go
+++ b/cluster-autoscaler/capacitybuffer/client/client.go
@@ -239,7 +239,7 @@ func (c *CapacityBufferClient) ListResourceQuotas(namespace string) ([]*corev1.R
 		return c.rqLister.ResourceQuotas(namespace).List(labels.Everything())
 	}
 	if c.kubernetesClient != nil {
-		rqList, err := c.kubernetesClient.CoreV1().ResourceQuotas(namespace).List(context.TODO(), metav1.ListOptions{})
+		rqList, err := c.kubernetesClient.CoreV1().ResourceQuotas(namespace).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -263,7 +263,7 @@ func (c *CapacityBufferClient) GetPodTemplate(namespace, name string) (*corev1.P
 			return template.DeepCopy(), nil
 		}
 	}
-	template, err := c.kubernetesClient.CoreV1().PodTemplates(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	template, err := c.kubernetesClient.CoreV1().PodTemplates(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("capacity buffer client can't get pod template: %w", err)
 	}
@@ -276,7 +276,7 @@ func (c *CapacityBufferClient) UpdateCapacityBuffer(buffer *v1.CapacityBuffer) (
 		return nil, fmt.Errorf("Capacity buffer client is not configured for updating capacity buffer")
 	}
 
-	buffer, err := c.buffersClient.AutoscalingV1beta1().CapacityBuffers(buffer.Namespace).UpdateStatus(context.TODO(), buffer, metav1.UpdateOptions{})
+	buffer, err := c.buffersClient.AutoscalingV1beta1().CapacityBuffers(buffer.Namespace).UpdateStatus(context.Background(), buffer, metav1.UpdateOptions{})
 	if err == nil {
 		return buffer.DeepCopy(), nil
 	}
@@ -288,7 +288,7 @@ func (c *CapacityBufferClient) CreatePodTemplate(podTemplate *corev1.PodTemplate
 	if c.kubernetesClient == nil {
 		return nil, fmt.Errorf("Capacity buffer client is not configured for creating pod template")
 	}
-	template, err := c.kubernetesClient.CoreV1().PodTemplates(podTemplate.Namespace).Create(context.TODO(), podTemplate, metav1.CreateOptions{})
+	template, err := c.kubernetesClient.CoreV1().PodTemplates(podTemplate.Namespace).Create(context.Background(), podTemplate, metav1.CreateOptions{})
 	if err == nil {
 		return template.DeepCopy(), nil
 	}
@@ -300,7 +300,7 @@ func (c *CapacityBufferClient) UpdatePodTemplate(podTemplate *corev1.PodTemplate
 	if c.kubernetesClient == nil {
 		return nil, fmt.Errorf("Capacity buffer client is not configured for updating pod template")
 	}
-	template, err := c.kubernetesClient.CoreV1().PodTemplates(podTemplate.Namespace).Update(context.TODO(), podTemplate, metav1.UpdateOptions{})
+	template, err := c.kubernetesClient.CoreV1().PodTemplates(podTemplate.Namespace).Update(context.Background(), podTemplate, metav1.UpdateOptions{})
 	if err == nil {
 		return template.DeepCopy(), nil
 	}
@@ -406,7 +406,7 @@ func (c *CapacityBufferClient) GetScaleObject(namespace, group, kind, name strin
 	if err != nil {
 		return nil, err
 	}
-	obj, err := c.scaleGetter.Scales(namespace).Get(context.TODO(), mapping.Resource.GroupResource(), name, metav1.GetOptions{})
+	obj, err := c.scaleGetter.Scales(namespace).Get(context.Background(), mapping.Resource.GroupResource(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get scale sub resource: %w", err)
 	}
@@ -423,7 +423,7 @@ func (c *CapacityBufferClient) GetPodsBySelector(namespace, selector string) ([]
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse label selector: %v", err)
 	}
-	podList, err := c.kubernetesClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+	podList, err := c.kubernetesClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelSelector.String(),
 	})
 	if err != nil {

--- a/cluster-autoscaler/capacitybuffer/translators/pod_template_translator.go
+++ b/cluster-autoscaler/capacitybuffer/translators/pod_template_translator.go
@@ -58,7 +58,7 @@ func (t *podTemplateBufferTranslator) Translate(buffers []*v1.CapacityBuffer) []
 			continue
 		}
 
-		managedPodTemplate, err := t.ensureManagedPodTemplate(context.TODO(), buffer, sourcePodTemplate)
+		managedPodTemplate, err := t.ensureManagedPodTemplate(context.Background(), buffer, sourcePodTemplate)
 		if err != nil {
 			errors = append(errors, err)
 			common.SetBufferAsNotReadyForProvisioning(buffer, nil, nil, nil, buffer.Spec.ProvisioningStrategy, err)

--- a/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator.go
+++ b/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator.go
@@ -80,7 +80,7 @@ func (t *ScalableObjectsTranslator) Translate(buffers []*apiv1.CapacityBuffer) [
 		if !isScalableObjectBuffer(buffer) {
 			continue
 		}
-		if err := t.translateBuffer(context.TODO(), buffer); err != nil {
+		if err := t.translateBuffer(context.Background(), buffer); err != nil {
 			errors = append(errors, err)
 		}
 	}


### PR DESCRIPTION
Replace placeholder context.TODO() calls with context.Background() in multiple files across the autoscaler project:

## Files Changed:
- balancer/main.go
- balancer/pkg/client/informers/externalversions/balancer.x-k8s.io/v1alpha1/balancer.go
- balancer/pkg/controller/controller.go
- cluster-autoscaler/capacitybuffer/translators/pod_template_translator.go
- cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator.go

## Why:
These are synchronous API calls that should use a root context (context.Background()) rather than placeholder TODO contexts. This improves code clarity and ensures proper context lifecycle management.

/kind cleanup
