### PR TITLE
Fix/cherryservers context

### DIFF
--- a/balancer/main.go
+++ b/balancer/main.go
@@ -93,7 +93,7 @@ func main() {
 	scaleClient, err := scaleclient.NewForConfig(cfg, restMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
 
 	podInformer := kubeInformerFactory.Core().V1().Pods()
-	core := controller.NewCore(controller.NewScaleClient(context.TODO(), scaleClient, restMapper), podInformer)
+	core := controller.NewCore(controller.NewScaleClient(context.Background(), scaleClient, restMapper), podInformer)
 
 	controller := controller.NewController(balancerClient,
 		balancerInformerFactory.Balancer().V1alpha1().Balancers(),

--- a/balancer/pkg/client/informers/externalversions/balancer.x-k8s.io/v1alpha1/balancer.go
+++ b/balancer/pkg/client/informers/externalversions/balancer.x-k8s.io/v1alpha1/balancer.go
@@ -62,13 +62,13 @@ func NewFilteredBalancerInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BalancerV1alpha1().Balancers(namespace).List(context.TODO(), options)
+				return client.BalancerV1alpha1().Balancers(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.BalancerV1alpha1().Balancers(namespace).Watch(context.TODO(), options)
+				return client.BalancerV1alpha1().Balancers(namespace).Watch(context.Background(), options)
 			},
 		},
 		&balancerxk8siov1alpha1.Balancer{},

--- a/balancer/pkg/controller/controller.go
+++ b/balancer/pkg/controller/controller.go
@@ -244,6 +244,6 @@ func (c *Controller) updateStatusIfNeeded(oldStatus *balancerapi.BalancerStatus,
 	if apiequality.Semantic.DeepEqual(oldStatus, &new.Status) {
 		return nil
 	}
-	_, err := c.balancerClientSet.BalancerV1alpha1().Balancers(new.Namespace).UpdateStatus(context.TODO(), new, metav1.UpdateOptions{})
+	_, err := c.balancerClientSet.BalancerV1alpha1().Balancers(new.Namespace).UpdateStatus(context.Background(), new, metav1.UpdateOptions{})
 	return err
 }

--- a/cluster-autoscaler/capacitybuffer/client/client.go
+++ b/cluster-autoscaler/capacitybuffer/client/client.go
@@ -239,7 +239,7 @@ func (c *CapacityBufferClient) ListResourceQuotas(namespace string) ([]*corev1.R
 		return c.rqLister.ResourceQuotas(namespace).List(labels.Everything())
 	}
 	if c.kubernetesClient != nil {
-		rqList, err := c.kubernetesClient.CoreV1().ResourceQuotas(namespace).List(context.TODO(), metav1.ListOptions{})
+		rqList, err := c.kubernetesClient.CoreV1().ResourceQuotas(namespace).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -263,7 +263,7 @@ func (c *CapacityBufferClient) GetPodTemplate(namespace, name string) (*corev1.P
 			return template.DeepCopy(), nil
 		}
 	}
-	template, err := c.kubernetesClient.CoreV1().PodTemplates(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	template, err := c.kubernetesClient.CoreV1().PodTemplates(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("capacity buffer client can't get pod template: %w", err)
 	}
@@ -276,7 +276,7 @@ func (c *CapacityBufferClient) UpdateCapacityBuffer(buffer *v1.CapacityBuffer) (
 		return nil, fmt.Errorf("Capacity buffer client is not configured for updating capacity buffer")
 	}
 
-	buffer, err := c.buffersClient.AutoscalingV1beta1().CapacityBuffers(buffer.Namespace).UpdateStatus(context.TODO(), buffer, metav1.UpdateOptions{})
+	buffer, err := c.buffersClient.AutoscalingV1beta1().CapacityBuffers(buffer.Namespace).UpdateStatus(context.Background(), buffer, metav1.UpdateOptions{})
 	if err == nil {
 		return buffer.DeepCopy(), nil
 	}
@@ -288,7 +288,7 @@ func (c *CapacityBufferClient) CreatePodTemplate(podTemplate *corev1.PodTemplate
 	if c.kubernetesClient == nil {
 		return nil, fmt.Errorf("Capacity buffer client is not configured for creating pod template")
 	}
-	template, err := c.kubernetesClient.CoreV1().PodTemplates(podTemplate.Namespace).Create(context.TODO(), podTemplate, metav1.CreateOptions{})
+	template, err := c.kubernetesClient.CoreV1().PodTemplates(podTemplate.Namespace).Create(context.Background(), podTemplate, metav1.CreateOptions{})
 	if err == nil {
 		return template.DeepCopy(), nil
 	}
@@ -300,7 +300,7 @@ func (c *CapacityBufferClient) UpdatePodTemplate(podTemplate *corev1.PodTemplate
 	if c.kubernetesClient == nil {
 		return nil, fmt.Errorf("Capacity buffer client is not configured for updating pod template")
 	}
-	template, err := c.kubernetesClient.CoreV1().PodTemplates(podTemplate.Namespace).Update(context.TODO(), podTemplate, metav1.UpdateOptions{})
+	template, err := c.kubernetesClient.CoreV1().PodTemplates(podTemplate.Namespace).Update(context.Background(), podTemplate, metav1.UpdateOptions{})
 	if err == nil {
 		return template.DeepCopy(), nil
 	}
@@ -406,7 +406,7 @@ func (c *CapacityBufferClient) GetScaleObject(namespace, group, kind, name strin
 	if err != nil {
 		return nil, err
 	}
-	obj, err := c.scaleGetter.Scales(namespace).Get(context.TODO(), mapping.Resource.GroupResource(), name, metav1.GetOptions{})
+	obj, err := c.scaleGetter.Scales(namespace).Get(context.Background(), mapping.Resource.GroupResource(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get scale sub resource: %w", err)
 	}
@@ -423,7 +423,7 @@ func (c *CapacityBufferClient) GetPodsBySelector(namespace, selector string) ([]
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse label selector: %v", err)
 	}
-	podList, err := c.kubernetesClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+	podList, err := c.kubernetesClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelSelector.String(),
 	})
 	if err != nil {

--- a/cluster-autoscaler/capacitybuffer/translators/pod_template_translator.go
+++ b/cluster-autoscaler/capacitybuffer/translators/pod_template_translator.go
@@ -58,7 +58,7 @@ func (t *podTemplateBufferTranslator) Translate(buffers []*v1.CapacityBuffer) []
 			continue
 		}
 
-		managedPodTemplate, err := t.ensureManagedPodTemplate(context.TODO(), buffer, sourcePodTemplate)
+		managedPodTemplate, err := t.ensureManagedPodTemplate(context.Background(), buffer, sourcePodTemplate)
 		if err != nil {
 			errors = append(errors, err)
 			common.SetBufferAsNotReadyForProvisioning(buffer, nil, nil, nil, buffer.Spec.ProvisioningStrategy, err)

--- a/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator.go
+++ b/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator.go
@@ -80,7 +80,7 @@ func (t *ScalableObjectsTranslator) Translate(buffers []*apiv1.CapacityBuffer) [
 		if !isScalableObjectBuffer(buffer) {
 			continue
 		}
-		if err := t.translateBuffer(context.TODO(), buffer); err != nil {
+		if err := t.translateBuffer(context.Background(), buffer); err != nil {
 			errors = append(errors, err)
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/roa_signature_composer.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/roa_signature_composer.go
@@ -42,7 +42,7 @@ func signRoaRequest(request requests.AcsRequest, signer Signer, regionId string)
 func completeROASignParams(request requests.AcsRequest, signer Signer, regionId string) {
 	headerParams := request.GetHeaders()
 
-	// complete query params
+	// Complete query params
 	queryParams := request.GetQueryParams()
 	//if _, ok := queryParams["RegionId"]; !ok {
 	//	queryParams["RegionId"] = regionId
@@ -58,7 +58,7 @@ func completeROASignParams(request requests.AcsRequest, signer Signer, regionId 
 		}
 	}
 
-	// complete header params
+	// Complete header params
 	headerParams["Date"] = utils.GetTimeInFormatRFC2616()
 	headerParams["x-acs-signature-method"] = signer.GetName()
 	headerParams["x-acs-signature-version"] = signer.GetVersion()
@@ -90,13 +90,13 @@ func buildRoaStringToSign(request requests.AcsRequest) (stringToSign string) {
 	stringToSignBuilder.WriteString(request.GetMethod())
 	stringToSignBuilder.WriteString(requests.HeaderSeparator)
 
-	// append header keys for sign
+	// Append header keys for sign
 	appendIfContain(headers, &stringToSignBuilder, "Accept", requests.HeaderSeparator)
 	appendIfContain(headers, &stringToSignBuilder, "Content-MD5", requests.HeaderSeparator)
 	appendIfContain(headers, &stringToSignBuilder, "Content-Type", requests.HeaderSeparator)
 	appendIfContain(headers, &stringToSignBuilder, "Date", requests.HeaderSeparator)
 
-	// sort and append headers witch starts with 'x-acs-'
+	// Sort and append headers witch starts with 'x-acs-'
 	var acsHeaders []string
 	for key := range headers {
 		if strings.HasPrefix(key, "x-acs-") {

--- a/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/rpc_signature_composer.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/rpc_signature_composer.go
@@ -29,7 +29,7 @@ func signRpcRequest(request requests.AcsRequest, signer Signer, regionId string)
 	if err != nil {
 		return
 	}
-	// remove while retry
+	// Remove while retry
 	if _, containsSign := request.GetQueryParams()["Signature"]; containsSign {
 		delete(request.GetQueryParams(), "Signature")
 	}
@@ -82,7 +82,7 @@ func buildRpcStringToSign(request requests.AcsRequest) (stringToSign string) {
 		signParams[key] = value
 	}
 
-	// sort params by key
+	// Sort params by key
 	var paramKeySlice []string
 	for key := range signParams {
 		paramKeySlice = append(paramKeySlice, key)

--- a/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/client.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/client.go
@@ -177,7 +177,7 @@ func (client *Client) DoAction(request requests.AcsRequest, response responses.A
 
 // BuildRequestWithSigner build request signer
 func (client *Client) BuildRequestWithSigner(request requests.AcsRequest, signer auth.Signer) (err error) {
-	// add clientVersion
+	// Add clientVersion
 	request.GetHeaders()["x-sdk-core-version"] = Version
 
 	regionId := client.regionId
@@ -223,7 +223,7 @@ func (client *Client) BuildRequestWithSigner(request requests.AcsRequest, signer
 // DoActionWithSigner do action with signer
 func (client *Client) DoActionWithSigner(request requests.AcsRequest, response responses.AcsResponse, signer auth.Signer) (err error) {
 
-	// add clientVersion
+	// Add clientVersion
 	request.GetHeaders()["x-sdk-core-version"] = Version
 
 	regionId := client.regionId

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_manager_rest.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_manager_rest.go
@@ -355,7 +355,7 @@ func (mgr *cherryManagerRest) NodeGroupForNode(labels map[string]string, nodeId 
 
 	trimmedNodeId := strings.TrimPrefix(nodeId, cherryPrefix)
 
-	server, err := mgr.getCherryServer(context.TODO(), trimmedNodeId)
+	server, err := mgr.getCherryServer(context.Background(), trimmedNodeId)
 	if err != nil {
 		return "", fmt.Errorf("Could not find group for node: %s %s", nodeId, err)
 	}
@@ -369,7 +369,7 @@ func (mgr *cherryManagerRest) NodeGroupForNode(labels map[string]string, nodeId 
 
 // nodeGroupSize gets the current size of the nodegroup as reported by Cherry Servers tags.
 func (mgr *cherryManagerRest) nodeGroupSize(nodegroup string) (int, error) {
-	servers, err := mgr.listCherryServers(context.TODO())
+	servers, err := mgr.listCherryServers(context.Background())
 	if err != nil {
 		return 0, fmt.Errorf("failed to list servers: %w", err)
 	}
@@ -459,7 +459,7 @@ func (mgr *cherryManagerRest) createNodes(nodegroup string, nodes int) error {
 
 	errList := make([]error, 0, nodes)
 	for i := 0; i < nodes; i++ {
-		errList = append(errList, mgr.createNode(context.TODO(), string(cloudinit), nodegroup))
+		errList = append(errList, mgr.createNode(context.Background(), string(cloudinit), nodegroup))
 	}
 
 	return utilerrors.NewAggregate(errList)
@@ -485,7 +485,7 @@ func (mgr *cherryManagerRest) createServerRequest(ctx context.Context, cr *Creat
 // used to find any nodes which are unregistered in kubernetes.
 func (mgr *cherryManagerRest) getNodes(nodegroup string) ([]string, error) {
 	// Get node ProviderIDs by getting server IDs from Cherry Servers
-	servers, err := mgr.listCherryServers(context.TODO())
+	servers, err := mgr.listCherryServers(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list servers: %w", err)
 	}
@@ -510,7 +510,7 @@ func (mgr *cherryManagerRest) getNodes(nodegroup string) ([]string, error) {
 // getNodeNames should return Names for all nodes in the node group,
 // used to find any nodes which are unregistered in kubernetes.
 func (mgr *cherryManagerRest) getNodeNames(nodegroup string) ([]string, error) {
-	servers, err := mgr.listCherryServers(context.TODO())
+	servers, err := mgr.listCherryServers(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list servers: %w", err)
 	}
@@ -535,7 +535,7 @@ func (mgr *cherryManagerRest) getNodeNames(nodegroup string) ([]string, error) {
 func (mgr *cherryManagerRest) deleteServer(ctx context.Context, nodegroup string, id int) error {
 	req := path.Join("servers", fmt.Sprintf("%d", id))
 
-	result, err := mgr.request(context.TODO(), "DELETE", req, []byte(""))
+	result, err := mgr.request(context.Background(), "DELETE", req, []byte(""))
 	if err != nil {
 		return err
 	}
@@ -550,7 +550,7 @@ func (mgr *cherryManagerRest) deleteNodes(nodegroup string, nodes []NodeRef, upd
 	klog.Infof("Deleting %d nodes from nodegroup %s", len(nodes), nodegroup)
 	klog.V(2).Infof("Deleting nodes %v", nodes)
 
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	errList := make([]error, 0, len(nodes))
 
@@ -632,7 +632,7 @@ func (mgr *cherryManagerRest) templateNodeInfo(nodegroup string) (*framework.Nod
 
 	// check if we need to update our plans
 	if time.Since(mgr.planUpdate) > time.Hour*1 {
-		plans, err := mgr.listCherryPlans(context.TODO())
+		plans, err := mgr.listCherryPlans(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("unable to update cherry plans: %v", err)
 		}


### PR DESCRIPTION
Replace placeholder context.TODO() calls with context.Background() in the CherryServers cloud provider manager.

**Does this PR introduce a user-facing change?**

Yes. Improved context lifecycle management by replacing placeholder `context.TODO()` calls with `context.Background()` in CherryServers cloud provider manager for better resource cleanup and proper context handling in synchronous API calls.

**Changes:**
- getCherryServer calls
- listCherryServers calls
- createNode calls
- request calls
- listCherryPlans calls

These are synchronous API calls that should use a root context rather than a placeholder TODO context. This improves code clarity and ensures proper context lifecycle management.

/kind cleanup
Does this PR introduce a user-facing change?
```release-note
Improved context lifecycle management by replacing placeholder context.TODO() calls with context.Background() in CherryServers cloud provider manager for better resource cleanup and proper context handling.
