### PR TITLE
Get rid of CapacityBuffersFakePodsRegistry.

### DIFF
--- a/cluster-autoscaler/builder/autoscaler.go
+++ b/cluster-autoscaler/builder/autoscaler.go
@@ -228,14 +228,13 @@ func (b *AutoscalerBuilder) Build(ctx context.Context) (core.Autoscaler, *loop.L
 			capacitybufferClient, capacitybufferClientError = capacityclient.NewCapacityBufferClientFromConfig(restConfig)
 		}
 		if capacitybufferClientError == nil && capacitybufferClient != nil {
-			buffersPodsRegistry := cbprocessor.NewDefaultCapacityBuffersFakePodsRegistry()
 			bufferPodInjector := cbprocessor.NewCapacityBufferPodListProcessor(
 				capacitybufferClient,
 				[]string{capacitybuffer.ActiveProvisioningStrategy},
-				buffersPodsRegistry, true)
+				true)
 			podListProcessor = pods.NewCombinedPodListProcessor([]pods.PodListProcessor{bufferPodInjector, podListProcessor})
 			opts.Processors.ScaleUpStatusProcessor = status.NewCombinedScaleUpStatusProcessor([]status.ScaleUpStatusProcessor{
-				cbprocessor.NewFakePodsScaleUpStatusProcessor(buffersPodsRegistry), opts.Processors.ScaleUpStatusProcessor})
+				cbprocessor.NewFakePodsScaleUpStatusProcessor(), opts.Processors.ScaleUpStatusProcessor})
 		}
 	}
 

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,28 +60,11 @@ type CapacityBufferPodListProcessor struct {
 	statusFilter             buffersfilter.Filter
 	podTemplateGenFilter     buffersfilter.Filter
 	provStrategies           map[string]bool
-	buffersRegistry          *CapacityBuffersFakePodsRegistry
 	forceSafeToEvictFakePods bool
 }
 
-// CapacityBuffersFakePodsRegistry a struct that keeps the status of capacity buffer
-// the fake pods generated for adding buffer event later
-type CapacityBuffersFakePodsRegistry struct {
-	FakePodsUIDToBuffer map[string]*v1beta1.CapacityBuffer
-}
-
-// NewCapacityBuffersFakePodsRegistry returns a new pointer to empty capacityBuffersFakePodsRegistry
-func NewCapacityBuffersFakePodsRegistry(fakePodsToBuffers map[string]*v1beta1.CapacityBuffer) *CapacityBuffersFakePodsRegistry {
-	return &CapacityBuffersFakePodsRegistry{FakePodsUIDToBuffer: fakePodsToBuffers}
-}
-
-// NewDefaultCapacityBuffersFakePodsRegistry returns a new pointer to empty capacityBuffersFakePodsRegistry
-func NewDefaultCapacityBuffersFakePodsRegistry() *CapacityBuffersFakePodsRegistry {
-	return &CapacityBuffersFakePodsRegistry{FakePodsUIDToBuffer: map[string]*v1beta1.CapacityBuffer{}}
-}
-
 // NewCapacityBufferPodListProcessor creates a new CapacityRequestPodListProcessor.
-func NewCapacityBufferPodListProcessor(client *client.CapacityBufferClient, provStrategies []string, buffersRegistry *CapacityBuffersFakePodsRegistry, forceSafeToEvictFakePods bool) *CapacityBufferPodListProcessor {
+func NewCapacityBufferPodListProcessor(client *client.CapacityBufferClient, provStrategies []string, forceSafeToEvictFakePods bool) *CapacityBufferPodListProcessor {
 	provStrategiesMap := map[string]bool{}
 	for _, ps := range provStrategies {
 		provStrategiesMap[ps] = true
@@ -93,7 +77,6 @@ func NewCapacityBufferPodListProcessor(client *client.CapacityBufferClient, prov
 		}),
 		podTemplateGenFilter:     buffersfilter.NewPodTemplateGenerationChangedFilter(client),
 		provStrategies:           provStrategiesMap,
-		buffersRegistry:          buffersRegistry,
 		forceSafeToEvictFakePods: forceSafeToEvictFakePods,
 	}
 }
@@ -110,10 +93,8 @@ func (p *CapacityBufferPodListProcessor) Process(autoscalingCtx *ca_context.Auto
 	_, buffers = p.podTemplateGenFilter.Filter(buffers)
 
 	totalFakePods := []*apiv1.Pod{}
-	p.clearCapacityBufferRegistry()
 	for _, buffer := range buffers {
 		fakePods := p.provision(buffer)
-		p.updateCapacityBufferRegistry(fakePods, buffer)
 		totalFakePods = append(totalFakePods, fakePods...)
 	}
 	klog.V(2).Infof("Capacity pod processor injecting %v fake pods provisioning %v capacity buffers", len(totalFakePods), len(buffers))
@@ -123,22 +104,6 @@ func (p *CapacityBufferPodListProcessor) Process(autoscalingCtx *ca_context.Auto
 
 // CleanUp is called at CA termination
 func (p *CapacityBufferPodListProcessor) CleanUp() {
-}
-
-func (p *CapacityBufferPodListProcessor) updateCapacityBufferRegistry(fakePods []*apiv1.Pod, buffer *v1beta1.CapacityBuffer) {
-	if p.buffersRegistry == nil {
-		return
-	}
-	for _, fakePod := range fakePods {
-		p.buffersRegistry.FakePodsUIDToBuffer[string(fakePod.UID)] = buffer
-	}
-}
-
-func (p *CapacityBufferPodListProcessor) clearCapacityBufferRegistry() {
-	if p.buffersRegistry == nil {
-		return
-	}
-	p.buffersRegistry.FakePodsUIDToBuffer = make(map[string]*v1beta1.CapacityBuffer, 0)
 }
 
 func (p *CapacityBufferPodListProcessor) provision(buffer *v1beta1.CapacityBuffer) []*apiv1.Pod {
@@ -202,6 +167,7 @@ func makeFakePods(buffer *v1beta1.CapacityBuffer, samplePodTemplate *apiv1.PodTe
 	samplePod := pod.GetPodFromTemplate(samplePodTemplate)
 	samplePod.Spec.NodeName = ""
 	samplePod = withCapacityBufferFakePodAnnotation(samplePod)
+	addOwnerReference(samplePod, buffer)
 	if forceSafeToEvictFakePods {
 		samplePod = withSafeToEvictAnnotation(samplePod)
 	}
@@ -213,6 +179,21 @@ func makeFakePods(buffer *v1beta1.CapacityBuffer, samplePodTemplate *apiv1.PodTe
 		fakePods = append(fakePods, fakePod)
 	}
 	return fakePods, nil
+}
+
+func addOwnerReference(pod *apiv1.Pod, buffer *v1beta1.CapacityBuffer) {
+	if ref := getBufferReference(pod); ref != nil {
+		return
+	}
+	pod.OwnerReferences = append(pod.OwnerReferences,
+		metav1.OwnerReference{
+			APIVersion: capacitybuffer.CapacityBufferApiVersion,
+			Kind:       buffer.Kind,
+			Name:       buffer.Name,
+			UID:        buffer.UID,
+			Controller: ptr.To(true),
+		},
+	)
 }
 
 func withCapacityBufferFakePodAnnotation(pod *apiv1.Pod) *apiv1.Pod {

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -191,7 +192,14 @@ func TestPodListProcessor(t *testing.T) {
 			fakeBuffersClient := buffersfake.NewSimpleClientset(test.objectsInBuffersClient...)
 			fakeCapacityBuffersClient, _ := client.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, nil, nil)
 
-			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, NewDefaultCapacityBuffersFakePodsRegistry(), test.forceSafeToEvict)
+			buffersMap := make(map[string]*apiv1.CapacityBuffer)
+			for _, obj := range test.objectsInBuffersClient {
+				if buffer, ok := obj.(*apiv1.CapacityBuffer); ok {
+					buffersMap[buffer.Name] = buffer
+				}
+			}
+
+			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, test.forceSafeToEvict)
 			resUnschedulablePods, err := processor.Process(nil, test.unschedulablePods)
 			assert.Equal(t, err != nil, test.expectError)
 
@@ -204,6 +212,21 @@ func TestPodListProcessor(t *testing.T) {
 					safeToEvict, err := strconv.ParseBool(pod.Annotations[drain.PodSafeToEvictKey])
 					assert.Equal(t, err == nil && safeToEvict, test.forceSafeToEvict)
 					fakePodsNames[pod.Name] = true
+
+					// Verify OwnerReference
+					assert.Len(t, pod.OwnerReferences, 1)
+					ownerName := pod.OwnerReferences[0].Name
+					originalBuffer, ok := buffersMap[ownerName]
+					assert.True(t, ok, "can't find original buffer for fake pod")
+
+					assert.Equal(t, metav1.OwnerReference{
+						Kind:       capacitybuffer.CapacityBufferKind,
+						APIVersion: capacitybuffer.CapacityBufferApiVersion,
+						Name:       originalBuffer.Name,
+						UID:        originalBuffer.UID,
+						Controller: ptr.To(true),
+					}, pod.OwnerReferences[0])
+					assert.Contains(t, pod.Name, originalBuffer.Name)
 				}
 			}
 			assert.Equal(t, test.expectedUnschedFakePodsCount, numberOfFakePods)
@@ -220,65 +243,6 @@ func TestPodListProcessor(t *testing.T) {
 					}
 				}
 				assert.True(t, found, "Condition %s not found", expectedCondition.Type)
-			}
-		})
-	}
-}
-
-func TestCapacityBufferFakePodsRegistry(t *testing.T) {
-	tests := []struct {
-		name                      string
-		objectsInKubernetesClient []runtime.Object
-		objectsInBuffersClient    []runtime.Object
-		unschedulablePods         []*corev1.Pod
-		expectedUnschedPodsCount  int
-		expectedBuffersPodsNum    map[string]int
-	}{
-		{
-			name:                      "1 ready buffer and 1 not ready buffer",
-			objectsInKubernetesClient: []runtime.Object{getTestingPodTemplate("ref1", 1), getTestingPodTemplate("ref2", 1)},
-			objectsInBuffersClient: []runtime.Object{
-				getTestingBuffer("buffer1", "ref1", 2, 1, false, 1, testProvStrategyAllowed),
-				getTestingBuffer("buffer2", "ref2", 3, 1, true, 1, testProvStrategyAllowed),
-			},
-			unschedulablePods:        []*corev1.Pod{getTestingPod("Pod1"), getTestingPod("Pod2"), getTestingPod("Pod3")},
-			expectedUnschedPodsCount: 6,
-			expectedBuffersPodsNum:   map[string]int{"buffer2": 3},
-		},
-		{
-			name:                      "2 ready buffers",
-			objectsInKubernetesClient: []runtime.Object{getTestingPodTemplate("ref1", 1), getTestingPodTemplate("ref2", 1)},
-			objectsInBuffersClient: []runtime.Object{
-				getTestingBuffer("buffer1", "ref1", 2, 1, true, 1, testProvStrategyAllowed),
-				getTestingBuffer("buffer2", "ref2", 3, 1, true, 1, testProvStrategyAllowed),
-			},
-			unschedulablePods:        []*corev1.Pod{getTestingPod("Pod1"), getTestingPod("Pod2"), getTestingPod("Pod3")},
-			expectedUnschedPodsCount: 8,
-			expectedBuffersPodsNum:   map[string]int{"buffer1": 2, "buffer2": 3},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			fakeKubernetesClient := fakeclient.NewSimpleClientset(test.objectsInKubernetesClient...)
-			fakeBuffersClient := buffersfake.NewSimpleClientset(test.objectsInBuffersClient...)
-			fakeCapacityBuffersClient, _ := client.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, nil, nil)
-
-			registry := NewDefaultCapacityBuffersFakePodsRegistry()
-			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, registry, false)
-			resUnschedulablePods, err := processor.Process(nil, test.unschedulablePods)
-			assert.Equal(t, nil, err)
-			assert.Equal(t, test.expectedUnschedPodsCount, len(resUnschedulablePods))
-			for _, pod := range resUnschedulablePods {
-				if IsFakeCapacityBuffersPod(pod) {
-					podBufferObj, found := registry.FakePodsUIDToBuffer[string(pod.UID)]
-					assert.True(t, found)
-					expectedPodsNum, found := test.expectedBuffersPodsNum[podBufferObj.Name]
-					assert.True(t, found)
-					test.expectedBuffersPodsNum[podBufferObj.Name] = expectedPodsNum - 1
-				}
-			}
-			for bufferName := range test.expectedBuffersPodsNum {
-				assert.Equal(t, 0, test.expectedBuffersPodsNum[bufferName])
 			}
 		})
 	}

--- a/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
@@ -28,18 +28,17 @@ import (
 
 // FakePodsScaleUpStatusProcessor is a ScaleUpStatusProcessor used for filtering out fake pods from scaleup status.
 type FakePodsScaleUpStatusProcessor struct {
-	buffersRegistry *CapacityBuffersFakePodsRegistry
 }
 
 type bufferInfo struct {
-	buffer         *v1beta1.CapacityBuffer
+	bufferRef      *apiv1.ObjectReference
 	numberOfPods   int
 	reasonMessages []string
 }
 
 // NewFakePodsScaleUpStatusProcessor return an instance of FakePodsScaleUpStatusProcessor
-func NewFakePodsScaleUpStatusProcessor(buffersRegistry *CapacityBuffersFakePodsRegistry) *FakePodsScaleUpStatusProcessor {
-	return &FakePodsScaleUpStatusProcessor{buffersRegistry: buffersRegistry}
+func NewFakePodsScaleUpStatusProcessor() *FakePodsScaleUpStatusProcessor {
+	return &FakePodsScaleUpStatusProcessor{}
 }
 
 // Process updates scaleupStatus to remove all capacity buffer fake pods from
@@ -61,45 +60,57 @@ func (p *FakePodsScaleUpStatusProcessor) createBuffersNoScaleUpEvents(context *c
 		consideredNodeGroupsMap := cloudprovider.NodeGroupListToMapById(scaleUpStatus.ConsideredNodeGroups)
 		buffersInfo := map[string]*bufferInfo{}
 		for _, noScaleUpInfo := range fakePodsRemainUnschedulable {
-			parentCapacityBuffer, found := p.buffersRegistry.FakePodsUIDToBuffer[string(noScaleUpInfo.Pod.UID)]
-			if found {
-				bufferUID := string(parentCapacityBuffer.UID)
-				if _, found := buffersInfo[bufferUID]; !found {
-					buffersInfo[bufferUID] = &bufferInfo{
-						buffer: parentCapacityBuffer,
-					}
-				}
-				buffersInfo[bufferUID].numberOfPods += 1
-				buffersInfo[bufferUID].reasonMessages = append(buffersInfo[bufferUID].reasonMessages,
-					status.ReasonsMessage(scaleUpStatus.Result, noScaleUpInfo, consideredNodeGroupsMap))
-			}
+			updateBufferInfo(buffersInfo, noScaleUpInfo.Pod, status.ReasonsMessage(scaleUpStatus.Result, noScaleUpInfo, consideredNodeGroupsMap))
 		}
 
 		for _, bufferInfo := range buffersInfo {
-			context.Recorder.Eventf(bufferInfo.buffer, apiv1.EventTypeNormal, "NotTriggerScaleUp",
+			context.Recorder.Eventf(bufferInfo.bufferRef, apiv1.EventTypeNormal, "NotTriggerScaleUp",
 				"capacity buffer %d fake pods didn't trigger scale-up: %s",
 				bufferInfo.numberOfPods, strings.Join(bufferInfo.reasonMessages, ","))
 		}
 	}
 }
 
+func updateBufferInfo(buffersInfo map[string]*bufferInfo, pod *apiv1.Pod, reason string) {
+	parentCapacityBufferRef := getBufferReference(pod)
+	if parentCapacityBufferRef != nil {
+		bufferUID := string(parentCapacityBufferRef.UID)
+		if _, found := buffersInfo[bufferUID]; !found {
+			buffersInfo[bufferUID] = &bufferInfo{
+				bufferRef: parentCapacityBufferRef,
+			}
+		}
+		buffersInfo[bufferUID].numberOfPods += 1
+		if reason != "" {
+			buffersInfo[bufferUID].reasonMessages = append(buffersInfo[bufferUID].reasonMessages,
+				reason)
+		}
+	}
+}
+
+func getBufferReference(pod *apiv1.Pod) *apiv1.ObjectReference {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind == capacitybuffer.CapacityBufferKind {
+			return &apiv1.ObjectReference{
+				Kind:       ref.Kind,
+				Name:       ref.Name,
+				UID:        ref.UID,
+				APIVersion: ref.APIVersion,
+				Namespace:  pod.Namespace,
+			}
+		}
+	}
+	return nil
+}
+
 func (p *FakePodsScaleUpStatusProcessor) createBuffersScaleUpEvents(context *ca_context.AutoscalingContext, scaleUpStatus *status.ScaleUpStatus, fakePodsTriggeredScaleUp []*apiv1.Pod) {
 	if len(scaleUpStatus.ScaleUpInfos) > 0 && len(fakePodsTriggeredScaleUp) > 0 {
 		buffersInfo := map[string]*bufferInfo{}
 		for _, pod := range fakePodsTriggeredScaleUp {
-			parentCapacityBuffer, found := p.buffersRegistry.FakePodsUIDToBuffer[string(pod.UID)]
-			if found {
-				bufferUID := string(parentCapacityBuffer.UID)
-				if _, found := buffersInfo[bufferUID]; !found {
-					buffersInfo[bufferUID] = &bufferInfo{
-						buffer: parentCapacityBuffer,
-					}
-				}
-				buffersInfo[bufferUID].numberOfPods += 1
-			}
+			updateBufferInfo(buffersInfo, pod, "")
 		}
 		for _, bufferInfo := range buffersInfo {
-			context.Recorder.Eventf(bufferInfo.buffer, apiv1.EventTypeNormal, "TriggeredScaleUp",
+			context.Recorder.Eventf(bufferInfo.bufferRef, apiv1.EventTypeNormal, "TriggeredScaleUp",
 				"capacity buffer %d fake pods triggered scale-up: %v", bufferInfo.numberOfPods, scaleUpStatus.ScaleUpInfos)
 		}
 	}

--- a/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor_test.go
@@ -24,6 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
@@ -52,24 +53,24 @@ func TestProcess(t *testing.T) {
 		expectedPodsTriggeredScaleUp    []*apiv1.Pod
 	}{
 		"Fake pods are removed from PodsRemainUnschedulable": {
-			podsRemainUnschedulable:         []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
-			expectedPodsRemainUnschedulable: []*apiv1.Pod{createPod("pod-1", false)},
+			podsRemainUnschedulable:         []*apiv1.Pod{createPod("pod-1", false, nil), createPod("fake-pod-1", true, nil)},
+			expectedPodsRemainUnschedulable: []*apiv1.Pod{createPod("pod-1", false, nil)},
 		},
 		"Fake pods are removed from PodsTriggerScaleup": {
-			podsTriggeredScaleUp:         []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
-			expectedPodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false)},
+			podsTriggeredScaleUp:         []*apiv1.Pod{createPod("pod-1", false, nil), createPod("fake-pod-1", true, nil)},
+			expectedPodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false, nil)},
 		},
 		"Fake pods are removed from PodsAwaitEvaluation": {
-			podsAwaitEvaluation:         []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
-			expectedPodsAwaitEvaluation: []*apiv1.Pod{createPod("pod-1", false)},
+			podsAwaitEvaluation:         []*apiv1.Pod{createPod("pod-1", false, nil), createPod("fake-pod-1", true, nil)},
+			expectedPodsAwaitEvaluation: []*apiv1.Pod{createPod("pod-1", false, nil)},
 		},
 		"Fake pods are removed from all pod related lists in scaleup status": {
-			podsTriggeredScaleUp:            []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
-			expectedPodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false)},
-			podsRemainUnschedulable:         []*apiv1.Pod{createPod("pod-2", false), createPod("fake-pod-2", true)},
-			expectedPodsRemainUnschedulable: []*apiv1.Pod{createPod("pod-2", false)},
-			podsAwaitEvaluation:             []*apiv1.Pod{createPod("pod-3", false), createPod("fake-pod-3", true)},
-			expectedPodsAwaitEvaluation:     []*apiv1.Pod{createPod("pod-3", false)},
+			podsTriggeredScaleUp:            []*apiv1.Pod{createPod("pod-1", false, nil), createPod("fake-pod-1", true, nil)},
+			expectedPodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false, nil)},
+			podsRemainUnschedulable:         []*apiv1.Pod{createPod("pod-2", false, nil), createPod("fake-pod-2", true, nil)},
+			expectedPodsRemainUnschedulable: []*apiv1.Pod{createPod("pod-2", false, nil)},
+			podsAwaitEvaluation:             []*apiv1.Pod{createPod("pod-3", false, nil), createPod("fake-pod-3", true, nil)},
+			expectedPodsAwaitEvaluation:     []*apiv1.Pod{createPod("pod-3", false, nil)},
 		},
 	}
 
@@ -82,7 +83,7 @@ func TestProcess(t *testing.T) {
 			}
 			autoscalingCtx := &ca_context.AutoscalingContext{}
 
-			p := NewFakePodsScaleUpStatusProcessor(NewDefaultCapacityBuffersFakePodsRegistry())
+			p := NewFakePodsScaleUpStatusProcessor()
 			p.Process(autoscalingCtx, scaleUpStatus)
 
 			assert.ElementsMatch(t, tc.expectedPodsRemainUnschedulable, extractPodsFromNoScaleUpInfo(scaleUpStatus.PodsRemainUnschedulable))
@@ -109,12 +110,20 @@ func TestBuffersEvent(t *testing.T) {
 		MaxSize:     nodeGroup1.MaxSize(),
 	}
 	buffer1 := &v1beta1.CapacityBuffer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       capacitybuffer.CapacityBufferKind,
+			APIVersion: capacitybuffer.CapacityBufferApiVersion,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "buffer_1",
 			UID:  "buffer_1",
 		},
 	}
 	buffer2 := &v1beta1.CapacityBuffer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       capacitybuffer.CapacityBufferKind,
+			APIVersion: capacitybuffer.CapacityBufferApiVersion,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "buffer_2",
 			UID:  "buffer_2",
@@ -129,17 +138,15 @@ func TestBuffersEvent(t *testing.T) {
 	}
 	testCases := map[string]struct {
 		state                       *status.ScaleUpStatus
-		buffersRegistry             *CapacityBuffersFakePodsRegistry
 		expectedTriggeredScaleUp    int
 		expectedNotTriggeredScaleUp int
 	}{
 		"One fake pod, successful scale up": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:                  status.ScaleUpSuccessful,
 				ConsideredNodeGroups:    consideredNodeGroups,
 				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{scaleUpInfo1},
-				PodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
+				PodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false, nil), createPod("fake-pod-1", true, buffer1)},
 				PodsRemainUnschedulable: []status.NoScaleUpInfo{},
 				PodsAwaitEvaluation:     []*apiv1.Pod{},
 			},
@@ -147,7 +154,6 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 0,
 		},
 		"One fake pod, error scale up": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:                  status.ScaleUpError,
 				ConsideredNodeGroups:    consideredNodeGroups,
@@ -160,24 +166,22 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 0,
 		},
 		"One fake pod, empty scale up infos": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:                  status.ScaleUpError,
 				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{},
-				PodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
+				PodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false, nil), createPod("fake-pod-1", true, buffer1)},
 				PodsRemainUnschedulable: []status.NoScaleUpInfo{},
 				PodsAwaitEvaluation:     []*apiv1.Pod{},
 			},
 			expectedTriggeredScaleUp:    0,
 			expectedNotTriggeredScaleUp: 0,
 		},
-		"One fake pod, with no node in Registry": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{}),
+		"One fake pod, with no ownerReference": {
 			state: &status.ScaleUpStatus{
 				Result:                  status.ScaleUpError,
 				ConsideredNodeGroups:    consideredNodeGroups,
 				ScaleUpInfos:            []nodegroupset.ScaleUpInfo{},
-				PodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
+				PodsTriggeredScaleUp:    []*apiv1.Pod{createPod("pod-1", false, nil), createPod("fake-pod-1", true, nil)},
 				PodsRemainUnschedulable: []status.NoScaleUpInfo{},
 				PodsAwaitEvaluation:     []*apiv1.Pod{},
 			},
@@ -185,15 +189,14 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 0,
 		},
 		"One fake pod, unschedulalble": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:               status.ScaleUpNoOptionsAvailable,
 				ConsideredNodeGroups: consideredNodeGroups,
 				ScaleUpInfos:         []nodegroupset.ScaleUpInfo{},
-				PodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false)},
+				PodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false, nil)},
 				PodsRemainUnschedulable: []status.NoScaleUpInfo{
 					{
-						Pod:                createPod("fake-pod-1", true),
+						Pod:                createPod("fake-pod-1", true, buffer1),
 						RejectedNodeGroups: reasons,
 					},
 				},
@@ -203,15 +206,14 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 1,
 		},
 		"One fake pod, unschedulalble with error": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:               status.ScaleUpError,
 				ConsideredNodeGroups: consideredNodeGroups,
 				ScaleUpInfos:         []nodegroupset.ScaleUpInfo{},
-				PodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false)},
+				PodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false, nil)},
 				PodsRemainUnschedulable: []status.NoScaleUpInfo{
 					{
-						Pod:                createPod("fake-pod-1", true),
+						Pod:                createPod("fake-pod-1", true, buffer1),
 						RejectedNodeGroups: reasons,
 					},
 				},
@@ -221,15 +223,14 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 0,
 		},
 		"two fake pods for same buffer, one triggers scale up and the other doesn't": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{"fake-pod-1": buffer1, "fake-pod-2": buffer1}),
 			state: &status.ScaleUpStatus{
 				Result:               status.ScaleUpNoOptionsAvailable,
 				ConsideredNodeGroups: consideredNodeGroups,
 				ScaleUpInfos:         []nodegroupset.ScaleUpInfo{scaleUpInfo1},
-				PodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false), createPod("fake-pod-1", true)},
+				PodsTriggeredScaleUp: []*apiv1.Pod{createPod("pod-1", false, nil), createPod("fake-pod-1", true, buffer1)},
 				PodsRemainUnschedulable: []status.NoScaleUpInfo{
 					{
-						Pod:                createPod("fake-pod-2", true),
+						Pod:                createPod("fake-pod-2", true, buffer1),
 						RejectedNodeGroups: reasons,
 					},
 				},
@@ -239,34 +240,27 @@ func TestBuffersEvent(t *testing.T) {
 			expectedNotTriggeredScaleUp: 1,
 		},
 		"multiple pods for multiple buffers with mixed conditions": {
-			buffersRegistry: NewCapacityBuffersFakePodsRegistry(map[string]*v1beta1.CapacityBuffer{
-				"fake-pod-1": buffer1,
-				"fake-pod-2": buffer1,
-				"fake-pod-3": buffer2,
-				"fake-pod-4": buffer2,
-				"fake-pod-5": buffer2,
-			}),
 			state: &status.ScaleUpStatus{
 				Result:               status.ScaleUpNoOptionsAvailable,
 				ScaleUpInfos:         []nodegroupset.ScaleUpInfo{scaleUpInfo1, scaleUpInfo2},
 				ConsideredNodeGroups: consideredNodeGroups,
 				PodsTriggeredScaleUp: []*apiv1.Pod{
-					createPod("pod-1", false),
-					createPod("fake-pod-2", true),
-					createPod("fake-pod-4", true),
-					createPod("fake-pod-5", true),
+					createPod("pod-1", false, nil),
+					createPod("fake-pod-2", true, buffer1),
+					createPod("fake-pod-4", true, buffer2),
+					createPod("fake-pod-5", true, buffer2),
 				},
 				PodsRemainUnschedulable: []status.NoScaleUpInfo{
 					{
-						Pod:                createPod("fake-pod-1", true),
+						Pod:                createPod("fake-pod-1", true, buffer1),
 						RejectedNodeGroups: reasons,
 					},
 					{
-						Pod:                createPod("fake-pod-3", true),
+						Pod:                createPod("fake-pod-3", true, buffer2),
 						RejectedNodeGroups: reasons,
 					},
 					{
-						Pod:                createPod("pod-2", false),
+						Pod:                createPod("pod-2", false, nil),
 						RejectedNodeGroups: reasons,
 					},
 				},
@@ -280,12 +274,12 @@ func TestBuffersEvent(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			fakeRecorder := kube_record.NewFakeRecorder(5)
-			ctx := &context.AutoscalingContext{
+			ctx := &ca_context.AutoscalingContext{
 				AutoscalingKubeClients: context.AutoscalingKubeClients{
 					Recorder: fakeRecorder,
 				},
 			}
-			p := NewFakePodsScaleUpStatusProcessor(tc.buffersRegistry)
+			p := NewFakePodsScaleUpStatusProcessor()
 			p.Process(ctx, tc.state)
 
 			triggeredScaleUp := 0
@@ -311,12 +305,89 @@ func TestBuffersEvent(t *testing.T) {
 	}
 }
 
-func createPod(name string, isFake bool) *apiv1.Pod {
+func TestGetBufferReference(t *testing.T) {
+	buffer := &v1beta1.CapacityBuffer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       capacitybuffer.CapacityBufferKind,
+			APIVersion: capacitybuffer.CapacityBufferApiVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-buffer",
+			Namespace: "test-ns",
+			UID:       "test-uid",
+		},
+	}
+	expectedRef := &apiv1.ObjectReference{
+		Kind:       capacitybuffer.CapacityBufferKind,
+		APIVersion: capacitybuffer.CapacityBufferApiVersion,
+		Name:       "test-buffer",
+		UID:        "test-uid",
+		Namespace:  "test-ns",
+	}
+
+	tests := []struct {
+		name          string
+		pod           *apiv1.Pod
+		expectedFound bool
+		expectedOwner *apiv1.ObjectReference
+	}{
+		{
+			name:          "Pod with CapacityBuffer owner",
+			pod:           createPod("pod-1", true, buffer),
+			expectedFound: true,
+			expectedOwner: expectedRef,
+		},
+		{
+			name:          "Pod with no owner",
+			pod:           createPod("pod-2", true, nil),
+			expectedFound: false,
+		},
+		{
+			name: "Pod with different owner type",
+			pod: BuildTestPod("pod-3", 10, 10, func(p *apiv1.Pod) {
+				p.OwnerReferences = []metav1.OwnerReference{
+					{
+						Kind:       "ReplicaSet",
+						Name:       "rs-1",
+						APIVersion: "apps/v1",
+						UID:        "rs-uid",
+					},
+				}
+			}),
+			expectedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner := getBufferReference(tt.pod)
+			if tt.expectedFound {
+				assert.NotNil(t, owner)
+				assert.Equal(t, tt.expectedOwner, owner)
+			} else {
+				assert.Nil(t, owner)
+			}
+		})
+	}
+}
+
+func createPod(name string, isFake bool, owner *v1beta1.CapacityBuffer) *apiv1.Pod {
 	return BuildTestPod(name, 10, 10, func(p *apiv1.Pod) {
 		if !isFake {
 			return
 		}
 		*p = *withCapacityBufferFakePodAnnotation(p)
+		if owner != nil {
+			p.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: owner.APIVersion,
+					Kind:       owner.Kind,
+					Name:       owner.Name,
+					UID:        owner.UID,
+				},
+			}
+			p.Namespace = owner.Namespace
+		}
 	})
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Get rid of CapacityBuffersFakePodsRegistry.

Reasons:
- We don't need it. We can just set the main buffer info in OwnerReference.
- Avoid depending on registry that is cleared every-loop which doesn't work well when having multiple pod list processors for different buffer strategies.

Previous attempt was done in https://github.com/kubernetes/autoscaler/pull/9353 but discarded in favor of this PR per review discussions.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
