### PR TITLE
Track node removal latency for empty and non-empty nodes

### DIFF
--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
@@ -40,6 +40,7 @@ const (
 type unneededNodeState struct {
 	unneededSince    time.Time
 	removalThreshold time.Duration
+	nodeType         metrics.UnneededNodeType
 }
 
 // NodeLatencyTracker keeps track of nodes that are marked as unneeded, when they became unneeded,
@@ -67,13 +68,15 @@ func (t *NodeLatencyTracker) UpdateScaleDownCandidates(list []*scaledown.Unneede
 			t.unneededNodes[nodeName] = unneededNodeState{
 				unneededSince:    timestamp,
 				removalThreshold: candidate.RemovalThreshold,
+				nodeType:         candidate.NodeType,
 			}
-			klog.V(6).Infof("Started tracking unneeded node %s at %v with removal threshold %v.", nodeName, timestamp, candidate.RemovalThreshold)
+			klog.V(6).Infof("Started tracking unneeded node %s at %v with removal threshold %v, nodeType: %v.", nodeName, timestamp, candidate.RemovalThreshold, candidate.NodeType)
 		} else {
-			if info.removalThreshold != candidate.RemovalThreshold {
+			if info.removalThreshold != candidate.RemovalThreshold || info.nodeType != candidate.NodeType {
 				info.removalThreshold = candidate.RemovalThreshold
+				info.nodeType = candidate.NodeType
 				t.unneededNodes[nodeName] = info
-				klog.V(6).Infof("Updated removal threshold for tracked node %s to %v.", nodeName, candidate.RemovalThreshold)
+				klog.V(6).Infof("Updated tracked node %s: removal threshold %v, nodeType: %v.", nodeName, candidate.RemovalThreshold, candidate.NodeType)
 			}
 		}
 	}
@@ -114,7 +117,7 @@ func (t *NodeLatencyTracker) recordAndCleanup(nodeName string, isRemoved bool) {
 	latency := duration - info.removalThreshold
 
 	if latency > 0 {
-		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, latency)
+		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, info.nodeType, latency)
 	} else {
 		klog.V(6).Infof("Node %q was unneeded for %s (threshold %s). Latency %s is <= 0, skipping metric. isRemoved: %v",
 			nodeName, duration, info.removalThreshold, latency, isRemoved)

--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
@@ -26,6 +26,7 @@ import (
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	processor "k8s.io/autoscaler/cluster-autoscaler/processors/status"
 )
 
@@ -53,12 +54,14 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 	// 1. Planner calculates unneeded nodes (UpdateScaleDownCandidates)
 	// 2. Actuator attempts deletion and reports status (Process)
 	type step struct {
-		unneededList     []string                 // Nodes found unneeded this loop
-		thresholds       map[string]time.Duration // Specific thresholds for this loop
-		scaledDownList   []string                 // Nodes successfully deleted this loop
-		unremovableList  []string                 // Nodes failed to delete this loop
-		wantTrackedNodes []string                 // Expected internal state after this loop
-		wantThresholds   map[string]time.Duration // Expected threshold values in internal state
+		unneededList     []string                            // Nodes found unneeded this loop
+		emptyList        []string                            // Nodes found empty this loop
+		thresholds       map[string]time.Duration            // Specific thresholds for this loop
+		scaledDownList   []string                            // Nodes successfully deleted this loop
+		unremovableList  []string                            // Nodes failed to delete this loop
+		wantTrackedNodes []string                            // Expected internal state after this loop
+		wantThresholds   map[string]time.Duration            // Expected threshold values in internal state
+		wantNodeType     map[string]metrics.UnneededNodeType // Expected nodeType values in internal state
 	}
 
 	tests := []struct {
@@ -148,6 +151,23 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "NodeType updates dynamically",
+			steps: []step{
+				{
+					unneededList:     []string{"node1"},
+					emptyList:        []string{"node1"},
+					wantTrackedNodes: []string{"node1"},
+					wantNodeType:     map[string]metrics.UnneededNodeType{"node1": metrics.EmptyUnneededNode},
+				},
+				{
+					unneededList:     []string{"node1"},
+					emptyList:        []string{},
+					wantTrackedNodes: []string{"node1"},
+					wantNodeType:     map[string]metrics.UnneededNodeType{"node1": metrics.NonEmptyUnneededNode},
+				},
+			},
+		},
 	}
 
 	baseTime := time.Now()
@@ -159,7 +179,7 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 			for i, step := range tc.steps {
 				stepTime := baseTime.Add(testStepDuration)
 
-				candidates := candidatesFromNames(step.unneededList, step.thresholds)
+				candidates := candidatesFromNames(step.unneededList, step.thresholds, sets.New(step.emptyList...))
 				tracker.UpdateScaleDownCandidates(candidates, stepTime)
 
 				sd := newScaleDownStatus(step.scaledDownList, step.unremovableList)
@@ -178,10 +198,17 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 					if val, ok := step.wantThresholds[nodeName]; ok {
 						wantThreshold = val
 					}
+					wantNodeType := metrics.NonEmptyUnneededNode
+					if val, ok := step.wantNodeType[nodeName]; ok {
+						wantNodeType = val
+					}
 
 					if actualInfo, ok := tracker.unneededNodes[nodeName]; ok {
 						if actualInfo.removalThreshold != wantThreshold {
 							t.Errorf("Step %d: node %q incorrect threshold: got %v, want %v", i, nodeName, actualInfo.removalThreshold, wantThreshold)
+						}
+						if actualInfo.nodeType != wantNodeType {
+							t.Errorf("Step %d: node %q incorrect nodeType: got %v, want %v", i, nodeName, actualInfo.nodeType, wantNodeType)
 						}
 					} else {
 						t.Errorf("Step %d: node %q expected to be tracked but was not", i, nodeName)
@@ -193,16 +220,21 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 }
 
 // nodesFromNames is a test helper to convert a slice of node names and threshold  into a slice of *scaledown.UnneededNode
-func candidatesFromNames(names []string, thresholds map[string]time.Duration) []*scaledown.UnneededNode {
+func candidatesFromNames(names []string, thresholds map[string]time.Duration, emptyNodes sets.Set[string]) []*scaledown.UnneededNode {
 	list := make([]*scaledown.UnneededNode, len(names))
 	for i, name := range names {
 		t := time.Duration(0)
 		if val, ok := thresholds[name]; ok {
 			t = val
 		}
+		nodeType := metrics.NonEmptyUnneededNode
+		if emptyNodes.Has(name) {
+			nodeType = metrics.EmptyUnneededNode
+		}
 		list[i] = &scaledown.UnneededNode{
 			Node:             &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}},
 			RemovalThreshold: t,
+			NodeType:         nodeType,
 		}
 	}
 	return list

--- a/cluster-autoscaler/core/scaledown/scaledown.go
+++ b/cluster-autoscaler/core/scaledown/scaledown.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/utilization"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -96,4 +97,7 @@ type UnneededNode struct {
 	// This value is derived from either --scale-down-unneeded-time or
 	// --scale-down-unready-time, depending on the node's readiness state.
 	RemovalThreshold time.Duration
+
+	// NodeType indicates whether the node was empty (no pods to reschedule) or non-empty when it was scaled down.
+	NodeType metrics.UnneededNodeType
 }

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes.go
@@ -189,9 +189,14 @@ func (n *Nodes) AsList() []*scaledown.UnneededNode {
 	if n.cachedList == nil {
 		n.cachedList = make([]*scaledown.UnneededNode, 0, len(n.byName))
 		for _, v := range n.byName {
+			nodeType := metrics.NonEmptyUnneededNode
+			if len(v.ntbr.PodsToReschedule) == 0 {
+				nodeType = metrics.EmptyUnneededNode
+			}
 			n.cachedList = append(n.cachedList, &scaledown.UnneededNode{
 				Node:             v.ntbr.Node,
 				RemovalThreshold: v.removalThreshold,
+				NodeType:         nodeType,
 			})
 		}
 	}

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
@@ -28,9 +28,11 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	nodeprocessors "k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -165,6 +167,7 @@ func TestUpdate(t *testing.T) {
 				assert.Equal(t, tc.wantTimestamps[n.Node.Name], nn.since)
 				assert.Equal(t, tc.wantVersions[n.Node.Name], version(nn.ntbr))
 				assert.Equal(t, tc.wantThresholds[n.Node.Name], n.RemovalThreshold)
+				assert.Equal(t, metrics.EmptyUnneededNode, n.NodeType)
 			}
 		})
 	}
@@ -280,9 +283,9 @@ func TestRemovableAt(t *testing.T) {
 			}
 
 			candidates := n.AsList()
-			candidateMap := make(map[string]time.Duration)
+			candidateMap := make(map[string]*scaledown.UnneededNode)
 			for _, c := range candidates {
-				candidateMap[c.Node.Name] = c.RemovalThreshold
+				candidateMap[c.Node.Name] = c
 			}
 
 			for _, node := range gotEmptyToRemove {
@@ -290,8 +293,27 @@ func TestRemovableAt(t *testing.T) {
 				got, ok := candidateMap[nodeName]
 				if !ok {
 					t.Errorf("Node %s not found in AsList", nodeName)
-				} else if got != expectedThreshold {
-					t.Errorf("Node %s has threshold %v, want %v", nodeName, got, expectedThreshold)
+				} else {
+					if got.RemovalThreshold != expectedThreshold {
+						t.Errorf("Node %s has threshold %v, want %v", nodeName, got.RemovalThreshold, expectedThreshold)
+					}
+					if got.NodeType != metrics.EmptyUnneededNode {
+						t.Errorf("Node %s in emptyToRemove list has NodeType=%v", nodeName, got.NodeType)
+					}
+				}
+			}
+			for _, node := range gotDrainToRemove {
+				nodeName := node.Node.Name
+				got, ok := candidateMap[nodeName]
+				if !ok {
+					t.Errorf("Node %s not found in AsList", nodeName)
+				} else {
+					if got.RemovalThreshold != expectedThreshold {
+						t.Errorf("Node %s has threshold %v, want %v", nodeName, got.RemovalThreshold, expectedThreshold)
+					}
+					if got.NodeType != metrics.NonEmptyUnneededNode {
+						t.Errorf("Node %s in drainToRemove list has NodeType=%v", nodeName, got.NodeType)
+					}
 				}
 			}
 		})

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -248,8 +248,8 @@ func ObserveBinpackingHeterogeneity(instanceType, cpuCount, namespaceCount strin
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
 // again after being marked unneded
-func UpdateScaleDownNodeRemovalLatency(deleted bool, duration time.Duration) {
-	DefaultMetrics.UpdateScaleDownNodeRemovalLatency(deleted, duration)
+func UpdateScaleDownNodeRemovalLatency(deleted bool, nodeType UnneededNodeType, duration time.Duration) {
+	DefaultMetrics.UpdateScaleDownNodeRemovalLatency(deleted, nodeType, duration)
 }
 
 // ObserveMaxNodeSkipEvalDurationSeconds records the longest time during which node was skipped during ScaleDown.

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -36,6 +36,9 @@ import (
 // NodeScaleDownReason describes reason for removing node
 type NodeScaleDownReason string
 
+// UnneededNodeType describes if an unneeded node is empty or non-empty
+type UnneededNodeType string
+
 // FailedScaleUpReason describes reason of failed scale-up
 type FailedScaleUpReason string
 
@@ -96,6 +99,11 @@ const (
 	PodEvictionSucceed PodEvictionResult = "succeeded"
 	// PodEvictionFailed means creation of the pod eviction object failed
 	PodEvictionFailed PodEvictionResult = "failed"
+
+	// EmptyUnneededNode is an unneeded node with no pods to reschedule
+	EmptyUnneededNode UnneededNodeType = "empty"
+	// NonEmptyUnneededNode is an unneeded node with pods to reschedule
+	NonEmptyUnneededNode UnneededNodeType = "non-empty"
 )
 
 // Names of Cluster Autoscaler operations
@@ -492,7 +500,7 @@ func newCaMetrics() *caMetrics {
 				Name:      "node_removal_latency_seconds",
 				Help:      "Latency from when an unneeded node is eligible for scale down until it is removed (deleted=true) or it became needed again (deleted=false).",
 				Buckets:   k8smetrics.ExponentialBuckets(1, 1.5, 19), // ~1s → ~24min
-			}, []string{"deleted"},
+			}, []string{"deleted", "type"},
 		),
 	}
 }
@@ -831,8 +839,8 @@ func (m *caMetrics) ObserveBinpackingHeterogeneity(instanceType, cpuCount, names
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
 // again after being marked unneded
-func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, duration time.Duration) {
-	m.scaleDownNodeRemovalLatency.WithLabelValues(strconv.FormatBool(deleted)).Observe(duration.Seconds())
+func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, nodeType UnneededNodeType, duration time.Duration) {
+	m.scaleDownNodeRemovalLatency.WithLabelValues(strconv.FormatBool(deleted), string(nodeType)).Observe(duration.Seconds())
 }
 
 // ObserveMaxNodeSkipEvalDurationSeconds records the longest time during which node was skipped during ScaleDown.


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This change adds `type` label to the `node_removal_latency_seconds` metric. This allows to track the scaledown latency of empty and non-empty nodes separately. 


