### PR TITLE
Check for shape Arm A1 before applying 2x OCPU to vCPU multiplier

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
@@ -7,6 +7,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -81,10 +82,16 @@ func (osf *shapeGetterImpl) Refresh() {
 // GetNodePoolShape gets the shape by querying the node pool's configuration
 func (osf *shapeGetterImpl) GetNodePoolShape(np *oke.NodePool, ephemeralStorage int64) (*Shape, error) {
 	shapeName := *np.NodeShape
+	// x86, Arm A2, Arm A4: 1 OCPU = 2 vCPUs.
+	// Arm A1: 1 OCPU = 1 vCPUs
+	cpuMultiplier := float32(2)
+	if strings.Contains(strings.ToLower(shapeName), strings.ToLower(".A1.")) {
+		cpuMultiplier = 1
+	}
 	if np.NodeShapeConfig != nil {
 		return &Shape{
 			Name: shapeName,
-			CPU:  *np.NodeShapeConfig.Ocpus * 2,
+			CPU:  *np.NodeShapeConfig.Ocpus * cpuMultiplier,
 			// num_bytes * kilo * mega * giga
 			MemoryInBytes:           *np.NodeShapeConfig.MemoryInGBs * 1024 * 1024 * 1024,
 			GPU:                     0,


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

cluster-autoscaler (OCI provider code)

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR fix a bug in the OCI provider where `GetNodePoolShape()` overestimates the CPU capacity of ARM A1shapes due to an incorrect 2x OCPU-to-vCPU conversion.

From the [docs](https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm)
> The following are the provisioning units for compute instances:
>     - 1 OCPU on Arm A1 (Compute) = 1 core on Arm A1 (Compute) or 1 vCPU
>     - 1 OCPU on Arm A2 (Compute) and A4 (Compute) = 2 cores on Arm A2 (Compute) and A4 (Compute) or 2 vCPUs
>     - 1 OCPU on x86 (AMD and Intel) = 2 vCPUs 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/autoscaler/issues/9337


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Correct vCPU calculation for ARM A1 shapes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```