### PR TITLE
Fix cluster-autoscaler VPA template with empty containerPolicy

### DIFF
--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.56.0
+version: 9.56.1

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/vpa.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/vpa.yaml
@@ -18,5 +18,7 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: {{ template "cluster-autoscaler.name" . }}
-      {{- .Values.vpa.containerPolicy | toYaml | nindent 6 }}
+      {{- with .Values.vpa.containerPolicy }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- end -}}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

Fixes the cluster-autoscaler Helm chart VPA template (`templates/vpa.yaml`) which renders invalid YAML when `vpa.containerPolicy` is set to `{}` (the default value).

## Which issue(s) this PR fixes

None found -- filing via this PR.

## Bug

When `vpa.enabled: true` with the default `containerPolicy: {}`, the template on line 21:

```
    - containerName: {{ template "cluster-autoscaler.name" . }}
      {{- .Values.vpa.containerPolicy | toYaml | nindent 6 }}
```

Renders as:

```yaml
    - containerName: aws-cluster-autoscaler
      {}
```

A flow mapping `{}` after an already-started block mapping key is a YAML syntax error, causing `helm template` to fail:

```
Error: YAML parse error on cluster-autoscaler/templates/vpa.yaml:
error converting YAML to JSON: yaml: line 22: did not find expected key
```

## Fix

Wrap the `containerPolicy` rendering in a `with` block so an empty map produces no output instead of `{}`:

```yaml
    - containerName: {{ template "cluster-autoscaler.name" . }}
      {{- with .Values.vpa.containerPolicy }}
      {{- toYaml . | nindent 6 }}
      {{- end }}
```

## How to reproduce

```bash
helm template test cluster-autoscaler \
  --repo https://kubernetes.github.io/autoscaler \
  --version 9.56.0 \
  --set vpa.enabled=true \
  --set vpa.updateMode=Off
```

## Verification

After the fix, both cases render valid YAML:
- `containerPolicy: {}` -- renders `containerName` only (no extra output)
- `containerPolicy: {controlledResources: [cpu, memory]}` -- renders correctly with resources listed