### PR TITLE
Add Suspended state to clusterstate.Readiness.

### DIFF
--- a/cluster-autoscaler/clusterstate/api/types.go
+++ b/cluster-autoscaler/clusterstate/api/types.go
@@ -77,6 +77,7 @@ type RegisteredNodeCount struct {
 	Total      int `json:"total" yaml:"total"`
 	Ready      int `json:"ready" yaml:"ready"`
 	NotStarted int `json:"notStarted" yaml:"notStarted"`
+	Suspended  int `json:"suspended" yaml:"suspended"`
 	// Number of nodes that are being currently deleted. They exist in K8S but are not included in NodeGroup.TargetSize().
 	BeingDeleted int                        `json:"beingDeleted,omitempty" yaml:"beingDeleted,omitempty"`
 	Unready      RegisteredUnreadyNodeCount `json:"unready,omitempty" yaml:"unready,omitempty"`

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -51,6 +51,8 @@ const (
 	maxErrorMessageSize = 500
 	// messageTrancated is displayed at the end of a trancated message.
 	messageTrancated = "<truncated>"
+	// suspendedNodeCondition is the node condition type for suspended nodes.
+	suspendedNodeCondition = "Suspended"
 )
 
 var (
@@ -462,13 +464,13 @@ func (csr *ClusterStateRegistry) IsNodeGroupHealthy(nodeGroupName string) bool {
 
 	unjustifiedUnready := 0
 	// Too few nodes, something is missing. Below the expected node count.
-	if len(readiness.Ready) < acceptable.MinNodes {
-		unjustifiedUnready += acceptable.MinNodes - len(readiness.Ready)
+	if len(readiness.Ready)+len(readiness.Suspended) < acceptable.MinNodes {
+		unjustifiedUnready += acceptable.MinNodes - len(readiness.Ready) - len(readiness.Suspended)
 	}
 	// TODO: verify against max nodes as well.
 	if unjustifiedUnready > csr.config.OkTotalUnreadyCount &&
 		float64(unjustifiedUnready) > csr.config.MaxTotalUnreadyPercentage/100.0*
-			float64(len(readiness.Ready)+len(readiness.Unready)+len(readiness.NotStarted)) {
+			float64(len(readiness.Ready)+len(readiness.Unready)+len(readiness.NotStarted)+len(readiness.Suspended)) {
 		return false
 	}
 
@@ -620,6 +622,8 @@ type Readiness struct {
 	Deleted []string
 	// Names of nodes that are not yet fully started.
 	NotStarted []string
+	// Names of suspended nodes, identified by node condition "Suspended=True".
+	Suspended []string
 	// Names of all registered nodes in the group (ready/unready/deleted/etc).
 	Registered []string
 	// Names of nodes that failed to register within a reasonable limit.
@@ -632,6 +636,15 @@ type Readiness struct {
 	// This field is only used for exposing information externally and
 	// doesn't influence CA behavior.
 	ResourceUnready []string
+}
+
+func isSuspendedNode(node *apiv1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == suspendedNodeCondition {
+			return condition.Status == apiv1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func (csr *ClusterStateRegistry) updateReadinessStats(currentTime time.Time) {
@@ -649,6 +662,8 @@ func (csr *ClusterStateRegistry) updateReadinessStats(currentTime time.Time) {
 		current.Registered = append(current.Registered, node.Name)
 		if _, isDeleted := csr.deletedNodes[node.Name]; isDeleted {
 			current.Deleted = append(current.Deleted, node.Name)
+		} else if isSuspendedNode(node) {
+			current.Suspended = append(current.Suspended, node.Name)
 		} else if nr.Ready {
 			current.Ready = append(current.Ready, node.Name)
 		} else if node.CreationTimestamp.Time.Add(maxNodeStartupTime).After(currentTime) {
@@ -862,6 +877,7 @@ func buildNodeCount(readiness Readiness) api.NodeCount {
 			Total:        len(readiness.Registered),
 			Ready:        len(readiness.Ready),
 			NotStarted:   len(readiness.NotStarted),
+			Suspended:    len(readiness.Suspended),
 			BeingDeleted: len(readiness.Deleted),
 			Unready: api.RegisteredUnreadyNodeCount{
 				Total:           len(readiness.Unready),
@@ -1033,7 +1049,7 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() (upcomingCounts map[string]i
 		readiness := csr.perNodeGroupReadiness[id]
 		ar := csr.acceptableRanges[id]
 		// newNodes is the number of nodes that
-		newNodes := ar.CurrentTarget - (len(readiness.Ready) + len(readiness.Unready) + len(readiness.LongUnregistered))
+		newNodes := ar.CurrentTarget - (len(readiness.Ready) + len(readiness.Unready) + len(readiness.Suspended) + len(readiness.LongUnregistered))
 		if newNodes <= 0 {
 			// Negative value is unlikely but theoretically possible.
 			continue

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -1717,3 +1717,121 @@ func (m *mockMetrics) RegisterFailedScaleUp(reason metrics.FailedScaleUpReason, 
 func (m *mockMetrics) RegisterFailedNodeCreations(reason metrics.FailedScaleUpReason, nodesCount int) {
 	m.Called(reason, nodesCount)
 }
+
+func TestSuspendedNodes(t *testing.T) {
+	now := time.Now()
+
+	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
+	SetNodeReadyState(ng1_1, true, now.Add(-time.Minute))
+
+	ng1_2 := BuildTestNode("ng1-2", 1000, 1000)
+	// Suspended node
+	ng1_2.Status.Conditions = append(ng1_2.Status.Conditions, apiv1.NodeCondition{
+		Type:   apiv1.NodeConditionType(suspendedNodeCondition),
+		Status: apiv1.ConditionTrue,
+	})
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 1, 10, 2)
+	provider.AddNode("ng1", ng1_1)
+	provider.AddNode("ng1", ng1_2)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	clusterstate := NewClusterStateRegistry(provider, ClusterStateRegistryConfig{
+		MaxTotalUnreadyPercentage: 10,
+		OkTotalUnreadyCount:       1,
+	}, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker())
+
+	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2}, nil, now)
+	assert.NoError(t, err)
+
+	// Check readiness stats
+	readiness := clusterstate.GetClusterReadiness()
+	expectedReadiness := Readiness{
+		Registered: []string{"ng1-1", "ng1-2"},
+		Ready:      []string{"ng1-1"},
+		Suspended:  []string{"ng1-2"},
+		Time:       now,
+	}
+	assert.Equal(t, expectedReadiness, readiness)
+
+	// Check node group health - Suspended nodes should count towards health
+	// Target is 2, 1 Ready + 1 Suspended = 2. Should be healthy.
+	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
+
+	// Check upcoming nodes
+	// Target is 2, 1 Ready + 1 Suspended = 2. Upcoming should be 0.
+	upcomingNodes, _ := clusterstate.GetUpcomingNodes()
+	assert.Equal(t, 0, upcomingNodes["ng1"])
+
+	// Check status
+	status := clusterstate.GetStatus(now)
+	assert.Equal(t, 1, status.ClusterWide.Health.NodeCounts.Registered.Suspended)
+}
+
+func TestIsSuspendedNode(t *testing.T) {
+	testCases := []struct {
+		name     string
+		node     *apiv1.Node
+		expected bool
+	}{
+		{
+			name: "Node with Suspended=True condition",
+			node: &apiv1.Node{
+				Status: apiv1.NodeStatus{
+					Conditions: []apiv1.NodeCondition{
+						{
+							Type:   apiv1.NodeConditionType(suspendedNodeCondition),
+							Status: apiv1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Node with Suspended=False condition",
+			node: &apiv1.Node{
+				Status: apiv1.NodeStatus{
+					Conditions: []apiv1.NodeCondition{
+						{
+							Type:   apiv1.NodeConditionType(suspendedNodeCondition),
+							Status: apiv1.ConditionFalse,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Node with other conditions",
+			node: &apiv1.Node{
+				Status: apiv1.NodeStatus{
+					Conditions: []apiv1.NodeCondition{
+						{
+							Type:   apiv1.NodeReady,
+							Status: apiv1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Node with no conditions",
+			node: &apiv1.Node{
+				Status: apiv1.NodeStatus{
+					Conditions: []apiv1.NodeCondition{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isSuspendedNode(tc.node))
+		})
+	}
+}

--- a/cluster-autoscaler/clusterstate/utils/status_test.go
+++ b/cluster-autoscaler/clusterstate/utils/status_test.go
@@ -97,7 +97,7 @@ func TestWriteStatusConfigMap(t *testing.T) {
 			Namespace:   "kube-system",
 			Annotations: map[string]string{ConfigMapLastUpdatedKey: "2023-12-21 00:00:00 +0000 UTC"},
 		},
-		Data: map[string]string{"status": "clusterWide:\n  health:\n    lastProbeTime: null\n    lastTransitionTime: null\n    nodeCounts:\n      longUnregistered: 0\n      registered:\n        notStarted: 0\n        ready: 0\n        total: 0\n        unready:\n          resourceUnready: 0\n          total: 0\n      unregistered: 0\n  scaleDown:\n    lastProbeTime: null\n    lastTransitionTime: null\n  scaleUp:\n    lastProbeTime: null\n    lastTransitionTime: null\nmessage: TEST_MSG\ntime: 2023-12-21 00:00:00 +0000 UTC\n"},
+		Data: map[string]string{"status": "clusterWide:\n  health:\n    lastProbeTime: null\n    lastTransitionTime: null\n    nodeCounts:\n      longUnregistered: 0\n      registered:\n        notStarted: 0\n        ready: 0\n        suspended: 0\n        total: 0\n        unready:\n          resourceUnready: 0\n          total: 0\n      unregistered: 0\n  scaleDown:\n    lastProbeTime: null\n    lastTransitionTime: null\n  scaleUp:\n    lastProbeTime: null\n    lastTransitionTime: null\nmessage: TEST_MSG\ntime: 2023-12-21 00:00:00 +0000 UTC\n"},
 	}
 	testCases := []struct {
 		name             string
@@ -175,9 +175,10 @@ var status api.ClusterAutoscalerStatus = api.ClusterAutoscalerStatus{
 			Status: "Healthy",
 			NodeCounts: api.NodeCount{
 				Registered: api.RegisteredNodeCount{
-					Total:        10,
+					Total:        11,
 					Ready:        4,
 					NotStarted:   3,
+					Suspended:    1,
 					BeingDeleted: 1,
 					Unready: api.RegisteredUnreadyNodeCount{
 						Total:           2,
@@ -208,9 +209,10 @@ var status api.ClusterAutoscalerStatus = api.ClusterAutoscalerStatus{
 			Status: "Healthy",
 			NodeCounts: api.NodeCount{
 				Registered: api.RegisteredNodeCount{
-					Total:        10,
+					Total:        11,
 					Ready:        4,
 					NotStarted:   3,
+					Suspended:    1,
 					BeingDeleted: 1,
 					Unready: api.RegisteredUnreadyNodeCount{
 						Total:           2,

--- a/cluster-autoscaler/clusterstate/utils/status_test.yaml
+++ b/cluster-autoscaler/clusterstate/utils/status_test.yaml
@@ -6,9 +6,10 @@ clusterWide:
     status: "Healthy"
     nodeCounts:
       registered:
-        total: 10
+        total: 11
         ready: 4
         notStarted: 3
+        suspended: 1
         beingDeleted: 1
         unready:
           total: 2
@@ -33,9 +34,10 @@ nodeGroups:
       status: "Healthy"
       nodeCounts:
         registered:
-          total: 10
+          total: 11
           ready: 4
           notStarted: 3
+          suspended: 1
           beingDeleted: 1
           unready:
             total: 2

--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -115,7 +115,7 @@ func UpdateClusterStateMetrics(csr *clusterstate.ClusterStateRegistry) {
 	}
 	metrics.UpdateClusterSafeToAutoscale(csr.IsClusterHealthy())
 	readiness := csr.GetClusterReadiness()
-	metrics.UpdateNodesCount(len(readiness.Ready), len(readiness.Unready), len(readiness.NotStarted), len(readiness.LongUnregistered), len(readiness.Unregistered))
+	metrics.UpdateNodesCount(len(readiness.Ready), len(readiness.Unready), len(readiness.NotStarted), len(readiness.Suspended), len(readiness.LongUnregistered), len(readiness.Unregistered))
 }
 
 // GetOldestCreateTime returns oldest creation time out of the pods in the set

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -60,8 +60,8 @@ func UpdateClusterSafeToAutoscale(safe bool) {
 }
 
 // UpdateNodesCount records the number of nodes in cluster
-func UpdateNodesCount(ready, unready, starting, longUnregistered, unregistered int) {
-	DefaultMetrics.UpdateNodesCount(ready, unready, starting, longUnregistered, unregistered)
+func UpdateNodesCount(ready, unready, starting, suspended, longUnregistered, unregistered int) {
+	DefaultMetrics.UpdateNodesCount(ready, unready, starting, suspended, longUnregistered, unregistered)
 }
 
 // UpdateNodeGroupsCount records the number of node groups managed by CA

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -54,6 +54,7 @@ const (
 	readyLabel            = "ready"
 	unreadyLabel          = "unready"
 	startingLabel         = "notStarted"
+	suspendedLabel        = "suspended"
 	unregisteredLabel     = "unregistered"
 	longUnregisteredLabel = "longUnregistered"
 
@@ -614,10 +615,11 @@ func (m *caMetrics) UpdateClusterSafeToAutoscale(safe bool) {
 }
 
 // UpdateNodesCount records the number of nodes in cluster
-func (m *caMetrics) UpdateNodesCount(ready, unready, starting, longUnregistered, unregistered int) {
+func (m *caMetrics) UpdateNodesCount(ready, unready, starting, suspended, longUnregistered, unregistered int) {
 	m.nodesCount.WithLabelValues(readyLabel).Set(float64(ready))
 	m.nodesCount.WithLabelValues(unreadyLabel).Set(float64(unready))
 	m.nodesCount.WithLabelValues(startingLabel).Set(float64(starting))
+	m.nodesCount.WithLabelValues(suspendedLabel).Set(float64(suspended))
 	m.nodesCount.WithLabelValues(longUnregisteredLabel).Set(float64(longUnregistered))
 	m.nodesCount.WithLabelValues(unregisteredLabel).Set(float64(unregistered))
 }

--- a/cluster-autoscaler/metrics/metrics_test.go
+++ b/cluster-autoscaler/metrics/metrics_test.go
@@ -54,3 +54,18 @@ func TestEnabledPerNodeGroupMetrics(t *testing.T) {
 	assert.Equal(t, 2, int(testutil.ToFloat64(m.nodesGroupMinNodes.GaugeVec.WithLabelValues("foo"))))
 	assert.Equal(t, 100, int(testutil.ToFloat64(m.nodesGroupMaxNodes.GaugeVec.WithLabelValues("foo"))))
 }
+
+func TestUpdateNodesCount(t *testing.T) {
+	reg := metrics.NewKubeRegistry()
+	m := newCaMetricsWithRegistry(reg)
+	m.RegisterAll(false)
+
+	m.UpdateNodesCount(1, 2, 3, 4, 5, 6)
+
+	assert.Equal(t, 1, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(readyLabel))))
+	assert.Equal(t, 2, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(unreadyLabel))))
+	assert.Equal(t, 3, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(startingLabel))))
+	assert.Equal(t, 4, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(suspendedLabel))))
+	assert.Equal(t, 5, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(longUnregisteredLabel))))
+	assert.Equal(t, 6, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(unregisteredLabel))))
+}

--- a/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
+++ b/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
@@ -70,7 +70,7 @@ func OnEmptyCluster(autoscalingCtx *ca_context.AutoscalingContext, status string
 	autoscalingCtx.ProcessorCallbacks.ResetUnneededNodes()
 	// updates metrics related to empty cluster's state.
 	metrics.UpdateClusterSafeToAutoscale(false)
-	metrics.UpdateNodesCount(0, 0, 0, 0, 0)
+	metrics.UpdateNodesCount(0, 0, 0, 0, 0, 0)
 	if autoscalingCtx.WriteStatusConfigMap {
 		utils.WriteStatusConfigMap(autoscalingCtx.ClientSet, autoscalingCtx.ConfigNamespace, api.ClusterAutoscalerStatus{AutoscalerStatus: api.ClusterAutoscalerInitializing, Message: status}, autoscalingCtx.LogRecorder, autoscalingCtx.StatusConfigMapName, time.Now())
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Add Suspended state to clusterstate.Readiness.

This is important for many reasons, mainly suspended nodes are unreachable and considered unhealthy which results into:
- If the suspended node lifetime is less than maxNodeStartupTime, it will be considered as NotStarted and CA loop will replace it with upcoming node which results into unintended behaviors.
- Otherwise, the suspended node is treated as Unready which can fails nodegroup or cluster health checks when the cluster is okay.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
"cluster-autoscaler-status" config map will have a new state "suspended" that shows how many nodes are suspended, identified by node condition "Suspended = True". 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
