### PR TITLE
Add annotation in the capacity buffer pods about provisioningStrategy.

### DIFF
--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -41,6 +41,9 @@ const (
 	CapacityBufferFakePodAnnotationKey   = "podType"
 	CapacityBufferFakePodAnnotationValue = "capacityBufferFakePod"
 
+	// CapacityBufferProvisioningStrategyAnnotation is annotation in capacity buffer fake pods that specifies the provisioning strategy of the buffer.
+	CapacityBufferProvisioningStrategyAnnotation = "buffer.x-k8s.io/provisioning-strategy"
+
 	// NotReadyForProvisioningReason is the reason used when the buffer is not ready for provisioning.
 	NotReadyForProvisioningReason = "NotReadyForProvisioning"
 	// BufferIsEmptyReason is the reason used when the buffer has 0 replicas.
@@ -171,6 +174,7 @@ func makeFakePods(buffer *v1beta1.CapacityBuffer, samplePodTemplate *apiv1.PodTe
 	if forceSafeToEvictFakePods {
 		samplePod = withSafeToEvictAnnotation(samplePod)
 	}
+	samplePod = withBufferProvisioningStrategyAnnotation(samplePod, buffer.Status.ProvisioningStrategy)
 	for i := 1; i <= podCount; i++ {
 		fakePod := samplePod.DeepCopy()
 		fakePod.Name = fmt.Sprintf("capacity-buffer-%s-%d", buffer.Name, i)
@@ -209,6 +213,18 @@ func withSafeToEvictAnnotation(pod *apiv1.Pod) *apiv1.Pod {
 		pod.Annotations = make(map[string]string, 1)
 	}
 	pod.Annotations[drain.PodSafeToEvictKey] = "true"
+	return pod
+}
+
+func withBufferProvisioningStrategyAnnotation(pod *apiv1.Pod, strategy *string) *apiv1.Pod {
+	s := ""
+	if strategy != nil {
+		s = *strategy
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string, 1)
+	}
+	pod.Annotations[CapacityBufferProvisioningStrategyAnnotation] = s
 	return pod
 }
 

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
@@ -219,6 +219,8 @@ func TestPodListProcessor(t *testing.T) {
 					originalBuffer, ok := buffersMap[ownerName]
 					assert.True(t, ok, "can't find original buffer for fake pod")
 
+					assert.Equal(t, *originalBuffer.Status.ProvisioningStrategy, pod.Annotations[CapacityBufferProvisioningStrategyAnnotation])
+
 					assert.Equal(t, metav1.OwnerReference{
 						Kind:       capacitybuffer.CapacityBufferKind,
 						APIVersion: capacitybuffer.CapacityBufferApiVersion,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add annotation in the capacity buffer pods about provisioningStrategy.

We need it to have a way to know the provisioningStrategy in order to emit metrics for capacity buffers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
