### PR TITLE
Remove deprecated flag scale-down-enabled

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -156,8 +156,6 @@ type AutoscalingOptions struct {
 	NodeGroups []string
 	// EnforceNodeGroupMinSize is used to allow CA to scale up the node group to the configured min size if needed.
 	EnforceNodeGroupMinSize bool
-	// ScaleDownEnabled is used to allow CA to scale down the cluster
-	ScaleDownEnabled bool
 	// ScaleDownUnreadyEnabled is used to allow CA to scale down unready nodes of the cluster
 	ScaleDownUnreadyEnabled bool
 	// ScaleDownDelayAfterAdd sets the duration from the last scale up to the time when CA starts to check scale down options

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -245,7 +245,6 @@ var (
 
 	// Deprecated flags
 	ignoreTaintsFlag = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
-	scaleDownEnabled = flag.Bool("scale-down-enabled", true, "[Deprecated] Should CA scale down the cluster")
 )
 
 var autoscalingOptions *config.AutoscalingOptions
@@ -306,10 +305,6 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		klog.Fatalf("--enable-dynamic-resource-allocation flag must be true: %t", ptr.Deref(enableDynamicResourceAllocation, false))
 	}
 
-	if *scaleDownEnabled == false {
-		klog.Warningf("--scale-down-enabled flag is deprecated and will be removed in a future release")
-	}
-
 	return config.AutoscalingOptions{
 		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
 			ScaleDownUtilizationThreshold:    *scaleDownUtilizationThreshold,
@@ -348,7 +343,6 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ScaleDownDelayTypeLocal:          *scaleDownDelayTypeLocal,
 		ScaleDownDelayAfterDelete:        *scaleDownDelayAfterDelete,
 		ScaleDownDelayAfterFailure:       *scaleDownDelayAfterFailure,
-		ScaleDownEnabled:                 *scaleDownEnabled,
 		ScaleDownUnreadyEnabled:          *scaleDownUnreadyEnabled,
 		ScaleDownNonEmptyCandidatesCount: *scaleDownNonEmptyCandidatesCount,
 		ScaleDownCandidatesPoolRatio:     *scaleDownCandidatesPoolRatio,

--- a/cluster-autoscaler/core/bench/benchmark_runonce_test.go
+++ b/cluster-autoscaler/core/bench/benchmark_runonce_test.go
@@ -487,7 +487,6 @@ func BenchmarkRunOnceScaleDown(b *testing.B) {
 			opts.MaxScaleDownParallelism = 1000
 			opts.MaxDrainParallelism = 1000
 			opts.ScaleDownDelayAfterAdd = 0
-			opts.ScaleDownEnabled = true
 			opts.ScaleDownNonEmptyCandidatesCount = 1000
 			opts.ScaleDownUnreadyEnabled = true
 			opts.ScaleDownSimulationTimeout = 60 * time.Second

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -809,7 +809,6 @@ func TestNewPlannerWithExistingDeletionCandidateNodes(t *testing.T) {
 				},
 				EstimatorName:            estimator.BinpackingEstimatorName,
 				EnforceNodeGroupMinSize:  true,
-				ScaleDownEnabled:         true,
 				MaxNodesTotal:            100,
 				MaxCoresTotal:            100,
 				MaxMemoryTotal:           100000,

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -592,102 +592,100 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		postScaleUp(scaleUpStart)
 	}
 
-	if a.ScaleDownEnabled {
-		unneededStart := time.Now()
+	unneededStart := time.Now()
 
-		klog.V(4).Infof("Calculating unneeded nodes")
+	klog.V(4).Infof("Calculating unneeded nodes")
 
-		var scaleDownCandidates []*apiv1.Node
-		var podDestinations []*apiv1.Node
+	var scaleDownCandidates []*apiv1.Node
+	var podDestinations []*apiv1.Node
 
-		// podDestinations and scaleDownCandidates are initialized based on allNodes variable, which contains only
-		// registered nodes in cluster.
-		// It does not include any upcoming nodes which can be part of clusterSnapshot. As an alternative to using
-		// allNodes here, we could use nodes from clusterSnapshot and explicitly filter out upcoming nodes here but it
-		// is of little (if any) benefit.
+	// podDestinations and scaleDownCandidates are initialized based on allNodes variable, which contains only
+	// registered nodes in cluster.
+	// It does not include any upcoming nodes which can be part of clusterSnapshot. As an alternative to using
+	// allNodes here, we could use nodes from clusterSnapshot and explicitly filter out upcoming nodes here but it
+	// is of little (if any) benefit.
 
-		if a.processors == nil || a.processors.ScaleDownNodeProcessor == nil {
-			scaleDownCandidates = allNodes
-			podDestinations = allNodes
-		} else {
-			var err caerrors.AutoscalerError
-			scaleDownCandidates, err = a.processors.ScaleDownNodeProcessor.GetScaleDownCandidates(
-				autoscalingCtx, allNodes)
-			if err != nil {
-				klog.Error(err)
-				return err
-			}
-			podDestinations, err = a.processors.ScaleDownNodeProcessor.GetPodDestinationCandidates(autoscalingCtx, allNodes)
-			if err != nil {
-				klog.Error(err)
-				return err
-			}
+	if a.processors == nil || a.processors.ScaleDownNodeProcessor == nil {
+		scaleDownCandidates = allNodes
+		podDestinations = allNodes
+	} else {
+		var err caerrors.AutoscalerError
+		scaleDownCandidates, err = a.processors.ScaleDownNodeProcessor.GetScaleDownCandidates(
+			autoscalingCtx, allNodes)
+		if err != nil {
+			klog.Error(err)
+			return err
 		}
+		podDestinations, err = a.processors.ScaleDownNodeProcessor.GetPodDestinationCandidates(autoscalingCtx, allNodes)
+		if err != nil {
+			klog.Error(err)
+			return err
+		}
+	}
 
-		typedErr := a.scaleDownPlanner.UpdateClusterState(podDestinations, scaleDownCandidates, scaleDownActuationStatus, currentTime)
-		// Update clusterStateRegistry and metrics regardless of whether ScaleDown was successful or not.
-		unneededNodes := a.scaleDownPlanner.UnneededNodes()
-		a.processors.ScaleDownCandidatesNotifier.Update(unneededNodes, currentTime)
-		metrics.UpdateUnneededNodesCount(len(unneededNodes))
+	typedErr = a.scaleDownPlanner.UpdateClusterState(podDestinations, scaleDownCandidates, scaleDownActuationStatus, currentTime)
+	// Update clusterStateRegistry and metrics regardless of whether ScaleDown was successful or not.
+	unneededNodes := a.scaleDownPlanner.UnneededNodes()
+	a.processors.ScaleDownCandidatesNotifier.Update(unneededNodes, currentTime)
+	metrics.UpdateUnneededNodesCount(len(unneededNodes))
+	if typedErr != nil {
+		scaleDownStatus.Result = scaledownstatus.ScaleDownError
+		klog.Errorf("Failed to scale down: %v", typedErr)
+		return typedErr
+	}
+
+	metrics.UpdateDurationFromStart(metrics.FindUnneeded, unneededStart)
+
+	scaleDownInCooldown := a.isScaleDownInCooldown(currentTime)
+	klog.V(4).Infof("Scale down status: lastScaleUpTime=%s lastScaleDownDeleteTime=%v "+
+		"lastScaleDownFailTime=%s scaleDownForbidden=%v scaleDownInCooldown=%v",
+		a.lastScaleUpTime, a.lastScaleDownDeleteTime, a.lastScaleDownFailTime,
+		a.processorCallbacks.disableScaleDownForLoop, scaleDownInCooldown)
+	metrics.UpdateScaleDownInCooldown(scaleDownInCooldown)
+	// We want to delete unneeded Node Groups only if here is no current delete
+	// in progress.
+	_, drained := scaleDownActuationStatus.DeletionsInProgress()
+	var removedNodeGroups []cloudprovider.NodeGroup
+	if len(drained) == 0 {
+		var err error
+		removedNodeGroups, err = a.processors.NodeGroupManager.RemoveUnneededNodeGroups(autoscalingCtx)
+		if err != nil {
+			klog.Errorf("Error while removing unneeded node groups: %v", err)
+		}
+		scaleDownStatus.RemovedNodeGroups = removedNodeGroups
+	}
+
+	if scaleDownInCooldown {
+		scaleDownStatus.Result = scaledownstatus.ScaleDownInCooldown
+		a.updateSoftDeletionTaints(allNodes)
+	} else if len(scaleDownCandidates) == 0 {
+		klog.V(4).Infof("Starting scale down: no scale down candidates. skipping...")
+		scaleDownStatus.Result = scaledownstatus.ScaleDownNoCandidates
+		metrics.UpdateLastTime(metrics.ScaleDown, time.Now())
+		a.updateSoftDeletionTaints(allNodes)
+	} else {
+		klog.V(4).Infof("Starting scale down")
+
+		scaleDownStart := time.Now()
+		metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
+		empty, needDrain := a.scaleDownPlanner.NodesToDelete(currentTime)
+		scaleDownResult, scaledDownNodes, typedErr := a.scaleDownActuator.StartDeletion(empty, needDrain)
+		scaleDownStatus.Result = scaleDownResult
+		scaleDownStatus.ScaledDownNodes = scaledDownNodes
+		metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
+		metrics.UpdateUnremovableNodesCount(countsByReason(a.scaleDownPlanner.UnremovableNodes()))
+
+		scaleDownStatus.RemovedNodeGroups = removedNodeGroups
+
+		if scaleDownStatus.Result == scaledownstatus.ScaleDownNodeDeleteStarted {
+			a.lastScaleDownDeleteTime = currentTime
+			a.clusterStateRegistry.Recalculate()
+		}
+		a.updateSoftDeletionTaints(allNodes)
 		if typedErr != nil {
-			scaleDownStatus.Result = scaledownstatus.ScaleDownError
 			klog.Errorf("Failed to scale down: %v", typedErr)
+			a.lastScaleDownFailTime = currentTime
 			return typedErr
-		}
-
-		metrics.UpdateDurationFromStart(metrics.FindUnneeded, unneededStart)
-
-		scaleDownInCooldown := a.isScaleDownInCooldown(currentTime)
-		klog.V(4).Infof("Scale down status: lastScaleUpTime=%s lastScaleDownDeleteTime=%v "+
-			"lastScaleDownFailTime=%s scaleDownForbidden=%v scaleDownInCooldown=%v",
-			a.lastScaleUpTime, a.lastScaleDownDeleteTime, a.lastScaleDownFailTime,
-			a.processorCallbacks.disableScaleDownForLoop, scaleDownInCooldown)
-		metrics.UpdateScaleDownInCooldown(scaleDownInCooldown)
-		// We want to delete unneeded Node Groups only if here is no current delete
-		// in progress.
-		_, drained := scaleDownActuationStatus.DeletionsInProgress()
-		var removedNodeGroups []cloudprovider.NodeGroup
-		if len(drained) == 0 {
-			var err error
-			removedNodeGroups, err = a.processors.NodeGroupManager.RemoveUnneededNodeGroups(autoscalingCtx)
-			if err != nil {
-				klog.Errorf("Error while removing unneeded node groups: %v", err)
-			}
-			scaleDownStatus.RemovedNodeGroups = removedNodeGroups
-		}
-
-		if scaleDownInCooldown {
-			scaleDownStatus.Result = scaledownstatus.ScaleDownInCooldown
-			a.updateSoftDeletionTaints(allNodes)
-		} else if len(scaleDownCandidates) == 0 {
-			klog.V(4).Infof("Starting scale down: no scale down candidates. skipping...")
-			scaleDownStatus.Result = scaledownstatus.ScaleDownNoCandidates
-			metrics.UpdateLastTime(metrics.ScaleDown, time.Now())
-			a.updateSoftDeletionTaints(allNodes)
-		} else {
-			klog.V(4).Infof("Starting scale down")
-
-			scaleDownStart := time.Now()
-			metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
-			empty, needDrain := a.scaleDownPlanner.NodesToDelete(currentTime)
-			scaleDownResult, scaledDownNodes, typedErr := a.scaleDownActuator.StartDeletion(empty, needDrain)
-			scaleDownStatus.Result = scaleDownResult
-			scaleDownStatus.ScaledDownNodes = scaledDownNodes
-			metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
-			metrics.UpdateUnremovableNodesCount(countsByReason(a.scaleDownPlanner.UnremovableNodes()))
-
-			scaleDownStatus.RemovedNodeGroups = removedNodeGroups
-
-			if scaleDownStatus.Result == scaledownstatus.ScaleDownNodeDeleteStarted {
-				a.lastScaleDownDeleteTime = currentTime
-				a.clusterStateRegistry.Recalculate()
-			}
-			a.updateSoftDeletionTaints(allNodes)
-			if typedErr != nil {
-				klog.Errorf("Failed to scale down: %v", typedErr)
-				a.lastScaleDownFailTime = currentTime
-				return typedErr
-			}
 		}
 	}
 

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -592,6 +592,40 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		postScaleUp(scaleUpStart)
 	}
 
+	if typedErr = a.scaleDown(currentTime, allNodes, scaleDownActuationStatus, scaleDownStatus); typedErr != nil {
+		return typedErr
+	}
+
+	if a.EnforceNodeGroupMinSize {
+		scaleUpStart := preScaleUp()
+		nodes := make([]*apiv1.Node, len(allNodeInfos))
+		for i, nodeInfo := range allNodeInfos {
+			nodes[i] = nodeInfo.Node()
+		}
+		nodeInfos := a.AutoscalingContext.TemplateNodeInfoRegistry.GetNodeInfos()
+		scaleUpStatus, typedErr = a.scaleUpOrchestrator.ScaleUpToNodeGroupMinSize(nodes, nodeInfos)
+		postScaleUp(scaleUpStart)
+	}
+
+	return nil
+}
+
+func (a *StaticAutoscaler) updateSoftDeletionTaints(allNodes []*apiv1.Node) {
+	if a.AutoscalingContext.AutoscalingOptions.MaxBulkSoftTaintCount != 0 {
+		taintableNodes := retrieveNodes(a.scaleDownPlanner.UnneededNodes())
+
+		// Make sure we are only cleaning taints from selected node groups.
+		selectedNodes := filterNodesFromSelectedGroups(a.CloudProvider, allNodes...)
+
+		// This is a sanity check to make sure `taintableNodes` only includes
+		// nodes from selected nodes.
+		taintableNodes = intersectNodes(selectedNodes, taintableNodes)
+		untaintableNodes := subtractNodes(selectedNodes, taintableNodes)
+		actuation.UpdateSoftDeletionTaints(a.AutoscalingContext, taintableNodes, untaintableNodes)
+	}
+}
+
+func (a *StaticAutoscaler) scaleDown(currentTime time.Time, allNodes []*apiv1.Node, scaleDownActuationStatus scaledown.ActuationStatus, scaleDownStatus *scaledownstatus.ScaleDownStatus) caerrors.AutoscalerError {
 	unneededStart := time.Now()
 
 	klog.V(4).Infof("Calculating unneeded nodes")
@@ -611,19 +645,19 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	} else {
 		var err caerrors.AutoscalerError
 		scaleDownCandidates, err = a.processors.ScaleDownNodeProcessor.GetScaleDownCandidates(
-			autoscalingCtx, allNodes)
+			a.AutoscalingContext, allNodes)
 		if err != nil {
 			klog.Error(err)
 			return err
 		}
-		podDestinations, err = a.processors.ScaleDownNodeProcessor.GetPodDestinationCandidates(autoscalingCtx, allNodes)
+		podDestinations, err = a.processors.ScaleDownNodeProcessor.GetPodDestinationCandidates(a.AutoscalingContext, allNodes)
 		if err != nil {
 			klog.Error(err)
 			return err
 		}
 	}
 
-	typedErr = a.scaleDownPlanner.UpdateClusterState(podDestinations, scaleDownCandidates, scaleDownActuationStatus, currentTime)
+	typedErr := a.scaleDownPlanner.UpdateClusterState(podDestinations, scaleDownCandidates, scaleDownActuationStatus, currentTime)
 	// Update clusterStateRegistry and metrics regardless of whether ScaleDown was successful or not.
 	unneededNodes := a.scaleDownPlanner.UnneededNodes()
 	a.processors.ScaleDownCandidatesNotifier.Update(unneededNodes, currentTime)
@@ -648,7 +682,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	var removedNodeGroups []cloudprovider.NodeGroup
 	if len(drained) == 0 {
 		var err error
-		removedNodeGroups, err = a.processors.NodeGroupManager.RemoveUnneededNodeGroups(autoscalingCtx)
+		removedNodeGroups, err = a.processors.NodeGroupManager.RemoveUnneededNodeGroups(a.AutoscalingContext)
 		if err != nil {
 			klog.Errorf("Error while removing unneeded node groups: %v", err)
 		}
@@ -688,34 +722,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 			return typedErr
 		}
 	}
-
-	if a.EnforceNodeGroupMinSize {
-		scaleUpStart := preScaleUp()
-		nodes := make([]*apiv1.Node, len(allNodeInfos))
-		for i, nodeInfo := range allNodeInfos {
-			nodes[i] = nodeInfo.Node()
-		}
-		nodeInfos := a.AutoscalingContext.TemplateNodeInfoRegistry.GetNodeInfos()
-		scaleUpStatus, typedErr = a.scaleUpOrchestrator.ScaleUpToNodeGroupMinSize(nodes, nodeInfos)
-		postScaleUp(scaleUpStart)
-	}
-
 	return nil
-}
-
-func (a *StaticAutoscaler) updateSoftDeletionTaints(allNodes []*apiv1.Node) {
-	if a.AutoscalingContext.AutoscalingOptions.MaxBulkSoftTaintCount != 0 {
-		taintableNodes := retrieveNodes(a.scaleDownPlanner.UnneededNodes())
-
-		// Make sure we are only cleaning taints from selected node groups.
-		selectedNodes := filterNodesFromSelectedGroups(a.CloudProvider, allNodes...)
-
-		// This is a sanity check to make sure `taintableNodes` only includes
-		// nodes from selected nodes.
-		taintableNodes = intersectNodes(selectedNodes, taintableNodes)
-		untaintableNodes := subtractNodes(selectedNodes, taintableNodes)
-		actuation.UpdateSoftDeletionTaints(a.AutoscalingContext, taintableNodes, untaintableNodes)
-	}
 }
 
 func (a *StaticAutoscaler) addUpcomingNodesToClusterSnapshot(upcomingCounts map[string]int) error {

--- a/cluster-autoscaler/core/static_autoscaler_csi_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_csi_test.go
@@ -257,7 +257,6 @@ func TestStaticAutoscalerCSI(t *testing.T) {
 						ScaleDownUtilizationThreshold: 0.7,
 						MaxNodeProvisionTime:          time.Hour,
 					},
-					ScaleDownEnabled:               true,
 					MaxNodesTotal:                  1000,
 					MaxCoresTotal:                  1000,
 					MaxMemoryTotal:                 100000000,

--- a/cluster-autoscaler/core/static_autoscaler_dra_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_dra_test.go
@@ -409,7 +409,6 @@ func TestStaticAutoscalerDynamicResources(t *testing.T) {
 					ScaleDownSimulationTimeout:       1 * time.Hour,
 					OkTotalUnreadyCount:              9999999,
 					MaxTotalUnreadyPercentage:        1.0,
-					ScaleDownEnabled:                 true,
 					MaxScaleDownParallelism:          10,
 					MaxDrainParallelism:              10,
 					NodeDeletionBatcherInterval:      0 * time.Second,

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -400,9 +400,9 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName:                  estimator.BinpackingEstimatorName,
-		EnforceNodeGroupMinSize:        true,
-		ScaleDownEnabled:               true,
+		EstimatorName:           estimator.BinpackingEstimatorName,
+		EnforceNodeGroupMinSize: true,
+
 		MaxNodesTotal:                  1,
 		MaxCoresTotal:                  10,
 		MaxMemoryTotal:                 100000,
@@ -657,9 +657,9 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 					ScaleDownUtilizationThreshold: 0.5,
 					MaxNodeProvisionTime:          10 * time.Second,
 				},
-				EstimatorName:                  estimator.BinpackingEstimatorName,
-				EnforceNodeGroupMinSize:        true,
-				ScaleDownEnabled:               true,
+				EstimatorName:           estimator.BinpackingEstimatorName,
+				EnforceNodeGroupMinSize: true,
+
 				MaxNodesTotal:                  1,
 				MaxCoresTotal:                  10,
 				MaxMemoryTotal:                 100000,
@@ -812,8 +812,8 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName:                  estimator.BinpackingEstimatorName,
-		ScaleDownEnabled:               true,
+		EstimatorName: estimator.BinpackingEstimatorName,
+
 		MaxNodesTotal:                  100,
 		MaxCoresTotal:                  100,
 		MaxMemoryTotal:                 100000,
@@ -960,8 +960,8 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 					ScaleDownUtilizationThreshold: 0.5,
 					MaxNodeProvisionTime:          10 * time.Second,
 				},
-				EstimatorName:                    estimator.BinpackingEstimatorName,
-				ScaleDownEnabled:                 true,
+				EstimatorName: estimator.BinpackingEstimatorName,
+
 				MaxNodesTotal:                    10,
 				MaxCoresTotal:                    10,
 				MaxMemoryTotal:                   100000,
@@ -1125,8 +1125,8 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 			ScaleDownUnreadyTime:          time.Minute,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName:                  estimator.BinpackingEstimatorName,
-		ScaleDownEnabled:               true,
+		EstimatorName: estimator.BinpackingEstimatorName,
+
 		MaxNodesTotal:                  10,
 		MaxCoresTotal:                  10,
 		MaxMemoryTotal:                 100000,
@@ -1259,7 +1259,6 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
 		EstimatorName:                  estimator.BinpackingEstimatorName,
-		ScaleDownEnabled:               false,
 		MaxNodesTotal:                  10,
 		MaxCoresTotal:                  10,
 		MaxMemoryTotal:                 100000,
@@ -1357,7 +1356,6 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
 		EstimatorName:                  estimator.BinpackingEstimatorName,
-		ScaleDownEnabled:               false,
 		MaxNodesTotal:                  10,
 		MaxCoresTotal:                  10,
 		MaxMemoryTotal:                 100000,
@@ -1483,11 +1481,10 @@ func TestStaticAutoscalerRunOnceWithBypassedSchedulers(t *testing.T) {
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName:    estimator.BinpackingEstimatorName,
-		ScaleDownEnabled: true,
-		MaxNodesTotal:    10,
-		MaxCoresTotal:    10,
-		MaxMemoryTotal:   100000,
+		EstimatorName:  estimator.BinpackingEstimatorName,
+		MaxNodesTotal:  10,
+		MaxCoresTotal:  10,
+		MaxMemoryTotal: 100000,
 		BypassedSchedulers: scheduler.SchedulersMap([]string{
 			apiv1.DefaultSchedulerName,
 			bypassedScheduler,
@@ -1693,9 +1690,9 @@ func TestStaticAutoscalerRunOnceWithExistingDeletionCandidateNodes(t *testing.T)
 					ScaleDownUtilizationThreshold: 0.5,
 					MaxNodeProvisionTime:          10 * time.Second,
 				},
-				EstimatorName:                  estimator.BinpackingEstimatorName,
-				EnforceNodeGroupMinSize:        true,
-				ScaleDownEnabled:               true,
+				EstimatorName:           estimator.BinpackingEstimatorName,
+				EnforceNodeGroupMinSize: true,
+
 				MaxNodesTotal:                  100,
 				MaxCoresTotal:                  100,
 				MaxMemoryTotal:                 100000,
@@ -1816,8 +1813,8 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 					ScaleDownUtilizationThreshold: 0.5,
 					MaxNodeProvisionTime:          10 * time.Second,
 				},
-				EstimatorName:                  estimator.BinpackingEstimatorName,
-				ScaleDownEnabled:               true,
+				EstimatorName: estimator.BinpackingEstimatorName,
+
 				MaxNodesTotal:                  10,
 				MaxCoresTotal:                  10,
 				MaxMemoryTotal:                 100000,
@@ -2192,8 +2189,8 @@ func setupTestStaticAutoscalerInstanceCreationErrorsForZeroOrMaxScaling(t *testi
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName:                estimator.BinpackingEstimatorName,
-		ScaleDownEnabled:             true,
+		EstimatorName: estimator.BinpackingEstimatorName,
+
 		MaxNodesTotal:                10,
 		MaxCoresTotal:                10,
 		MaxMemoryTotal:               100000,
@@ -2484,7 +2481,7 @@ func TestStaticAutoscalerUpcomingScaleDownCandidates(t *testing.T) {
 
 	// Create context with minimal autoscalingOptions that guarantee we reach the tested logic.
 	// We're only testing the input to UpdateClusterState which should be called whenever scale-down is enabled, other autoscalingOptions shouldn't matter.
-	autoscalingOptions := config.AutoscalingOptions{ScaleDownEnabled: true}
+	autoscalingOptions := config.AutoscalingOptions{}
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOptions)
 	autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOptions, &fake.Clientset{}, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
@@ -2924,11 +2921,10 @@ func TestStaticAutoscalerRunOnceInvokesScaleDownStatusProcessor(t *testing.T) {
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName:    estimator.BinpackingEstimatorName,
-		ScaleDownEnabled: true,
-		MaxNodesTotal:    10,
-		MaxCoresTotal:    10,
-		MaxMemoryTotal:   100000,
+		EstimatorName:  estimator.BinpackingEstimatorName,
+		MaxNodesTotal:  10,
+		MaxCoresTotal:  10,
+		MaxMemoryTotal: 100000,
 	}
 	now := time.Now()
 	n1 := BuildTestNode("n1", 1000, 1000)
@@ -3271,7 +3267,6 @@ func buildStaticAutoscaler(t *testing.T, provider cloudprovider.CloudProvider, a
 		},
 		MaxScaleDownParallelism:    10,
 		MaxDrainParallelism:        1,
-		ScaleDownEnabled:           true,
 		MaxBulkSoftTaintCount:      20,
 		MaxBulkSoftTaintTime:       5 * time.Second,
 		NodeDeleteDelayAfterTaint:  5 * time.Minute,
@@ -3452,7 +3447,6 @@ func TestStaticAutoscalerWithNodeDeclaredFeatures(t *testing.T) {
 		},
 		EstimatorName:                  estimator.BinpackingEstimatorName,
 		EnforceNodeGroupMinSize:        true,
-		ScaleDownEnabled:               false,
 		MaxNodesTotal:                  10,
 		MaxCoresTotal:                  10,
 		MaxMemoryTotal:                 1000,

--- a/cluster-autoscaler/test/integration/config.go
+++ b/cluster-autoscaler/test/integration/config.go
@@ -17,9 +17,10 @@ limitations under the License.
 package integration
 
 import (
+	"time"
+
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
-	"time"
 )
 
 // DefaultAutoscalingOptions provides the baseline configuration for all tests.
@@ -37,7 +38,6 @@ var DefaultAutoscalingOptions = config.AutoscalingOptions{
 	ScaleDownDelayAfterDelete:  0,
 	ScaleDownDelayAfterFailure: 0,
 	ScaleDownDelayTypeLocal:    true,
-	ScaleDownEnabled:           true,
 	MaxNodesTotal:              10,
 	MaxCoresTotal:              10,
 	MaxMemoryTotal:             100000,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cleanup the deprecated flag scale-down-enabled
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The deprecated flag scale-down-enabled is removed, passing it will break cluster-autoscaler
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
