### PR TITLE
De-dupe the VPA portion of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,37 +4,15 @@ updates:
   directory: "/vertical-pod-autoscaler"
   schedule:
     interval: daily
-  open-pull-requests-limit: 0 # setting this to 0 means only allowing security updates, see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
   labels:
     - "area/vertical-pod-autoscaler"
     - "release-note-none"
     - "ok-to-test"
 - package-ecosystem: docker
-  directory: "/vertical-pod-autoscaler/pkg/recommender"
-  schedule:
-    interval: daily
-  ignore:
-    - dependency-name: "golang"
-      versions: ["*.*rc*"]
-  open-pull-requests-limit: 3
-  labels:
-    - "area/vertical-pod-autoscaler"
-    - "release-note-none"
-    - "ok-to-test"
-- package-ecosystem: docker
-  directory: "/vertical-pod-autoscaler/pkg/updater"
-  schedule:
-    interval: daily
-  ignore:
-    - dependency-name: "golang"
-      versions: ["*.*rc*"]
-  open-pull-requests-limit: 3
-  labels:
-    - "area/vertical-pod-autoscaler"
-    - "release-note-none"
-    - "ok-to-test"
-- package-ecosystem: docker
-  directory: "/vertical-pod-autoscaler/pkg/admission-controller"
+  directories:
+    - "/vertical-pod-autoscaler/pkg/admission-controller"
+    - "/vertical-pod-autoscaler/pkg/recommender"
+    - "/vertical-pod-autoscaler/pkg/updater"
   schedule:
     interval: daily
   ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,11 @@ updates:
     - "area/vertical-pod-autoscaler"
     - "release-note-none"
     - "ok-to-test"
+  groups:
+    actions:
+      update-types:
+        - "minor"
+        - "patch"
 - package-ecosystem: gomod
   directory: "/addon-resizer"
   schedule:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dependency

#### What this PR does / why we need it:

Relates to https://github.com/kubernetes/autoscaler/pull/9405

I was looking over the dependabot config. I have a feeling that both cluster autoscaler and GitHub Actions section aren't working, but I'm struggling to test that.
Anyway, while looking at it I was a way to simplify it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
