### PR TITLE
Remove rc ignore for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,6 @@ updates:
     - "/vertical-pod-autoscaler/pkg/updater"
   schedule:
     interval: daily
-  ignore:
-    - dependency-name: "golang"
-      versions: ["*.*rc*"]
   open-pull-requests-limit: 3
   labels:
     - "area/vertical-pod-autoscaler"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area dependency 

#### What this PR does / why we need it:

After merging https://github.com/kubernetes/autoscaler/pull/9415 I got this error:
https://github.com/kubernetes/autoscaler/runs/69006757489

```
The property '#/updates/1/ignore/0/versions' includes invalid version requirements for a docker ignore condition
```

I have a feeling that this has always been broken.
I couldn't figure out how to fix it, so I deleted it. If in the future we do get PRs to use rc versions, we can figure out the real fix.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
