### PR TITLE
fix(oci): correct OCPU-to-vCPU conversion for A1 shapes and instance pools

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_shape.go
@@ -7,6 +7,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -84,7 +85,7 @@ func (osf *shapeGetterImpl) GetNodePoolShape(np *oke.NodePool, ephemeralStorage 
 	if np.NodeShapeConfig != nil {
 		return &Shape{
 			Name: shapeName,
-			CPU:  *np.NodeShapeConfig.Ocpus * 2,
+			CPU:  ocpuToVCPU(shapeName, *np.NodeShapeConfig.Ocpus),
 			// num_bytes * kilo * mega * giga
 			MemoryInBytes:           *np.NodeShapeConfig.MemoryInGBs * 1024 * 1024 * 1024,
 			GPU:                     0,
@@ -119,7 +120,7 @@ func (osf *shapeGetterImpl) GetNodePoolShape(np *oke.NodePool, ephemeralStorage 
 		for _, s := range resp.Items {
 			osf.cache[*s.Shape] = &Shape{
 				Name:                    *s.Shape,
-				CPU:                     getFloat32(s.Ocpus) * 2, // convert ocpu to vcpu
+				CPU:                     ocpuToVCPU(*s.Shape, getFloat32(s.Ocpus)),
 				GPU:                     getInt(s.Gpus),
 				MemoryInBytes:           getFloat32(s.MemoryInGBs) * 1024 * 1024 * 1024,
 				EphemeralStorageInBytes: float32(ephemeralStorage),
@@ -171,7 +172,7 @@ func (osf *shapeGetterImpl) GetInstancePoolShape(ip *core.InstancePool) (*Shape,
 				shape.Name = *instanceDetails.LaunchDetails.Shape
 			}
 			if instanceDetails.LaunchDetails.ShapeConfig.Ocpus != nil {
-				shape.CPU = *instanceDetails.LaunchDetails.ShapeConfig.Ocpus
+				shape.CPU = ocpuToVCPU(shape.Name, *instanceDetails.LaunchDetails.ShapeConfig.Ocpus)
 				// Minimum amount of memory unless explicitly set higher
 				shape.MemoryInBytes = *instanceDetails.LaunchDetails.ShapeConfig.Ocpus * 1024 * 1024 * 1024
 			}
@@ -205,7 +206,7 @@ func (osf *shapeGetterImpl) GetInstancePoolShape(ip *core.InstancePool) (*Shape,
 				if *nextShape.Shape == *instanceDetails.LaunchDetails.Shape {
 					shape.Name = *nextShape.Shape
 					if nextShape.Ocpus != nil {
-						shape.CPU = *nextShape.Ocpus
+						shape.CPU = ocpuToVCPU(shape.Name, *nextShape.Ocpus)
 					}
 					if nextShape.MemoryInGBs != nil {
 						shape.MemoryInBytes = *nextShape.MemoryInGBs * 1024 * 1024 * 1024
@@ -227,6 +228,16 @@ func (osf *shapeGetterImpl) GetInstancePoolShape(ip *core.InstancePool) (*Shape,
 
 	osf.cache[*ip.Id] = shape
 	return shape, nil
+}
+
+// ocpuToVCPU converts OCPUs to vCPUs for the given shape. ARM A1 shapes have a
+// 1:1 OCPU-to-vCPU ratio, while all other shapes (x86, A2, A4) use 1:2.
+// See https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
+func ocpuToVCPU(shapeName string, ocpus float32) float32 {
+	if strings.Contains(shapeName, ".A1.") {
+		return ocpus
+	}
+	return ocpus * 2
 }
 
 // getFloat32 is a helper to get a float32 pointer value or default to 0.

--- a/cluster-autoscaler/cloudprovider/oci/common/oci_shape_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/common/oci_shape_test.go
@@ -109,7 +109,7 @@ func TestNodePoolGetShape(t *testing.T) {
 		shapeConfig *oke.NodeShapeConfig
 		expected    *Shape
 	}{
-		"basic shape": {
+		"basic x86 shape": {
 			shape: "VM.Standard1.2",
 			expected: &Shape{
 				Name:                    "VM.Standard1.2",
@@ -119,7 +119,7 @@ func TestNodePoolGetShape(t *testing.T) {
 				EphemeralStorageInBytes: -1,
 			},
 		},
-		"flex shape": {
+		"flex x86 shape": {
 			shape: "VM.Standard.E3.Flex",
 			shapeConfig: &oke.NodeShapeConfig{
 				Ocpus:       common.Float32(4),
@@ -129,6 +129,34 @@ func TestNodePoolGetShape(t *testing.T) {
 				Name:                    "VM.Standard.E3.Flex",
 				CPU:                     8,
 				MemoryInBytes:           4 * 16 * 1024 * 1024 * 1024,
+				GPU:                     0,
+				EphemeralStorageInBytes: -1,
+			},
+		},
+		"flex A1 shape uses 1:1 OCPU-to-vCPU": {
+			shape: "VM.Standard.A1.Flex",
+			shapeConfig: &oke.NodeShapeConfig{
+				Ocpus:       common.Float32(4),
+				MemoryInGBs: common.Float32(24),
+			},
+			expected: &Shape{
+				Name:                    "VM.Standard.A1.Flex",
+				CPU:                     4,
+				MemoryInBytes:           24 * 1024 * 1024 * 1024,
+				GPU:                     0,
+				EphemeralStorageInBytes: -1,
+			},
+		},
+		"flex A2 shape uses 1:2 OCPU-to-vCPU": {
+			shape: "VM.Standard.A2.Flex",
+			shapeConfig: &oke.NodeShapeConfig{
+				Ocpus:       common.Float32(4),
+				MemoryInGBs: common.Float32(24),
+			},
+			expected: &Shape{
+				Name:                    "VM.Standard.A2.Flex",
+				CPU:                     8,
+				MemoryInBytes:           24 * 1024 * 1024 * 1024,
 				GPU:                     0,
 				EphemeralStorageInBytes: -1,
 			},
@@ -174,7 +202,7 @@ func TestGetInstancePoolShape(t *testing.T) {
 			shape: "VM.Standard.E3.Flex",
 			expected: &Shape{
 				Name:          "VM.Standard.E3.Flex",
-				CPU:           8,
+				CPU:           16,
 				MemoryInBytes: float32(128) * 1024 * 1024 * 1024,
 				GPU:           0,
 			},
@@ -206,6 +234,33 @@ func TestGetInstancePoolShape(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+func TestOcpuToVCPU(t *testing.T) {
+	testCases := map[string]struct {
+		shape    string
+		ocpus    float32
+		expected float32
+	}{
+		"x86 E3":  {shape: "VM.Standard.E3.Flex", ocpus: 4, expected: 8},
+		"x86 E4":  {shape: "VM.Standard.E4.Flex", ocpus: 8, expected: 16},
+		"x86 E5":  {shape: "VM.Standard.E5.Flex", ocpus: 2, expected: 4},
+		"ARM A1":  {shape: "VM.Standard.A1.Flex", ocpus: 4, expected: 4},
+		"ARM A2":  {shape: "VM.Standard.A2.Flex", ocpus: 4, expected: 8},
+		"ARM A4":  {shape: "VM.Standard.A4.Flex", ocpus: 4, expected: 8},
+		"BM A1":   {shape: "BM.Standard.A1.160", ocpus: 160, expected: 160},
+		"GPU A10": {shape: "BM.GPU.A10.4", ocpus: 64, expected: 128},
+		"fixed":   {shape: "VM.Standard2.8", ocpus: 8, expected: 16},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := ocpuToVCPU(tc.shape, tc.ocpus)
+			if got != tc.expected {
+				t.Errorf("ocpuToVCPU(%q, %v) = %v, want %v", tc.shape, tc.ocpus, got, tc.expected)
+			}
 		})
 	}
 }


### PR DESCRIPTION
/area cluster-autoscaler
/area provider/oci

## What type of PR is this?
/kind bug

## What this PR does / why we need it

Fixes incorrect OCPU-to-vCPU conversion in the OCI cloud provider that causes the cluster autoscaler to overestimate CPU capacity for ARM A1 shapes by 2x, and underestimate it for x86 instance pools.

Per [Oracle's compute shape docs](https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm):
- 1 OCPU on **Arm A1** = **1 vCPU**
- 1 OCPU on Arm A2/A4 and x86 = **2 vCPUs**

### Changes

**`oci_shape.go`:**
- Adds `ocpuToVCPU(shapeName, ocpus)` helper that returns `ocpus * 1` for `.A1.` shapes and `ocpus * 2` for all others
- `GetNodePoolShape()`: replaces hardcoded `* 2` with `ocpuToVCPU()` (fixes A1 overestimate)
- `GetInstancePoolShape()`: adds missing `ocpuToVCPU()` call (fixes x86 underestimate in instance pools)

**`oci_shape_test.go`:**
- Adds `TestOcpuToVCPU` covering x86 (E3/E4/E5), ARM A1, ARM A2, ARM A4, bare-metal A1, GPU A10, and fixed shapes
- Adds A1 and A2 flex test cases to `TestNodePoolGetShape`
- Fixes `TestGetInstancePoolShape` expected CPU (E3 8 OCPUs → 16 vCPUs, was incorrectly 8)

## Which issue(s) this PR fixes

Fixes #9428

## Does this PR introduce a user-facing change?

```release-note
Fix OCI cloud provider OCPU-to-vCPU conversion: ARM A1 shapes now correctly use 1:1 ratio instead of 1:2, and instance pools now apply the conversion (previously missing).
```