### PR TITLE
VPA: Fetch go version from go.mod for GitHub actions 

### DIFF
--- a/.github/workflows/vpa-golangci-lint.yaml
+++ b/.github/workflows/vpa-golangci-lint.yaml
@@ -26,7 +26,7 @@ jobs:
           path: ${{ env.GOPATH }}/src/k8s.io/autoscaler
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.25'
+          go-version-file: '${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.mod'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/e2e/go.sum

--- a/.github/workflows/vpa-test.yaml
+++ b/.github/workflows/vpa-test.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.25'
+          go-version-file: '${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.mod'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/e2e/go.sum


### PR DESCRIPTION
Rather than hard-coding the go version, let's fetch it from the go.mod file

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Over in https://github.com/kubernetes/autoscaler/pull/9404 I bumped the go version along with the kubernetes dependencies.
Our actions broke.

This PR fixes 2 of the 3 failures, by using a dynamic version rather than hardcoding it.

To fix the 3rd failure I'll need to modify the "Verify Go" job to be split along cluster-autoscaler and vertical-pod-autoscaler.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
