### PR TITLE
Fix nil pointer dereference in atomicScaleDownNode

### DIFF
--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -18,6 +18,7 @@ package planner
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -342,7 +343,7 @@ func (p *Planner) atomicScaleDownNode(node *simulator.NodeToBeRemoved) bool {
 		klog.Errorf("failed to get node info for %v: %s", node.Node.Name, err)
 		return false
 	}
-	if nodeGroup == nil {
+	if nodeGroup == nil || reflect.ValueOf(nodeGroup).IsNil() {
 		klog.Errorf("Node group for node %s not found", node.Node.Name)
 		return false
 	}


### PR DESCRIPTION
NodeGroupForNode can return (nil, nil) when a node's instance is no longer part of any registered node group. This can happen when the GCE MIG instance cache is regenerated (by the background hourly goroutine or during a concurrent fillMigInstances call) between the pre-filtering step and the atomicScaleDownNode call: the node passes the pre-filter with stale cache data, but by the time atomicScaleDownNode queries NodeGroupForNode again, the refreshed cache no longer maps the instance to a MIG.

In any cases, the CloudProvider interface spec allows providers to return nil:

```go
	// NodeGroupForNode returns the node group for the given node, nil if the node
	// should not be processed by cluster autoscaler, or non-nil error if such
	// occurred. Must be implemented.
	NodeGroupForNode(*apiv1.Node) (NodeGroup, error)
```

The crash manifests as:

```
  panic: runtime error: invalid memory address or nil pointer dereference
  goroutine 11809 [running]:
  ...scaledown/planner.(*Planner).atomicScaleDownNode(0xc00183c000, 0xc0f066c5c0)
    planner.go:322 +0x8b
```

Add a nil check for the returned nodeGroup, consistent with all other call sites of NodeGroupForNode in the codebase (pre_filtering_processor, eligibility checker).

#### What type of PR is this?

/kind bug


