### PR TITLE
Bump go version to 1.26 to match the main kubernetes repo

### DIFF
--- a/.github/workflows/ca-test.yaml
+++ b/.github/workflows/ca-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.26'
+          go-version-file: '${{ env.GOPATH}}/src/k8s.io/autoscaler/cluster-autoscaler/go.mod'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/cluster-autoscaler/go.sum
 

--- a/.github/workflows/ca-test.yaml
+++ b/.github/workflows/ca-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/cluster-autoscaler/go.sum
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache-dependency-path: |
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/cluster-autoscaler/go.sum
              ${{ env.GOPATH}}/src/k8s.io/autoscaler/vertical-pod-autoscaler/go.sum

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 
 WORKDIR /workspace
 

--- a/cluster-autoscaler/apis/go.mod
+++ b/cluster-autoscaler/apis/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/autoscaler/cluster-autoscaler/apis
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2

--- a/cluster-autoscaler/cloudprovider/azure/test/go.mod
+++ b/cluster-autoscaler/cloudprovider/azure/test/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test
 
-go 1.24.0
+go 1.26.0
 
 toolchain go1.24.4
 

--- a/cluster-autoscaler/core/scaledown/resource/limits.go
+++ b/cluster-autoscaler/core/scaledown/resource/limits.go
@@ -146,7 +146,7 @@ func (lf *LimitsFinder) customResourcesTotal(autoscalingCtx *ca_context.Autoscal
 		if !cacheHit {
 			resourceTargets, err = lf.crp.GetNodeResourceTargets(autoscalingCtx, node, nodeGroup)
 			if err != nil {
-				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("cannot get custom resource count for node %v when calculating cluster custom resource usage")
+				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("cannot get custom resource count for node %v when calculating cluster custom resource usage: ", node.Name)
 			}
 			if nodeGroup != nil {
 				ngCache[nodeGroup.Id()] = resourceTargets
@@ -185,7 +185,7 @@ func (lf *LimitsFinder) DeltaForNode(autoscalingCtx *ca_context.AutoscalingConte
 	if cloudprovider.ContainsCustomResources(resourcesWithLimits) {
 		resourceTargets, err := lf.crp.GetNodeResourceTargets(autoscalingCtx, node, nodeGroup)
 		if err != nil {
-			return Delta{}, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to get node %v custom resources: %v", node.Name)
+			return Delta{}, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to get node %v custom resources: ", node.Name)
 		}
 		for _, resourceTarget := range resourceTargets {
 			resultScaleDownDelta[resourceTarget.ResourceType] = resourceTarget.ResourceCount

--- a/cluster-autoscaler/e2e/go.mod
+++ b/cluster-autoscaler/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/autoscaler/cluster-autoscaler/e2e
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -1,8 +1,8 @@
 module k8s.io/autoscaler/cluster-autoscaler
 
-go 1.25.0
+go 1.26.0
 
-godebug default=go1.25
+godebug default=go1.26
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/cluster-autoscaler/hack/genproto/go.mod
+++ b/cluster-autoscaler/hack/genproto/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/autoscaler/cluster-autoscaler/genproto
 
-go 1.25.3
+go 1.26.0
 
 tool (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc

--- a/cluster-autoscaler/provisioningrequest/provreqclient/client.go
+++ b/cluster-autoscaler/provisioningrequest/provreqclient/client.go
@@ -116,7 +116,7 @@ func (c *ProvisioningRequestClient) UpdateProvisioningRequest(pr *v1.Provisionin
 	if err != nil {
 		return pr, err
 	}
-	klog.V(4).Infof("Updated ProvisioningRequest %s/%s,  status: %q,", updatedPr.Namespace, updatedPr.Name, updatedPr.Status)
+	klog.V(4).Infof("Updated ProvisioningRequest %s/%s,  status: %+v,", updatedPr.Namespace, updatedPr.Name, updatedPr.Status)
 	return updatedPr, nil
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/scheduling_error.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/scheduling_error.go
@@ -102,7 +102,7 @@ func (se *schedulingError) Error() string {
 	case NoNodesPassingPredicatesFoundError:
 		msg = fmt.Sprintf("couldn't find a matching Node with passing predicates")
 	default:
-		msg = fmt.Sprintf("SchedulingErrorType type %q unknown - this shouldn't happen", se.errorType)
+		msg = fmt.Sprintf("SchedulingErrorType type %d unknown - this shouldn't happen", se.errorType)
 	}
 
 	return fmt.Sprintf("can't schedule pod %s/%s: %s", se.pod.Namespace, se.pod.Name, msg)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
Bumps go version to 1.26 which is already used in the main kubernetes repo.
Also, the change fixes some bugs that were picked up by strict `vet` checks introduced in 1.26



```release-note
Bump go version to 1.26
```
