### PR TITLE
decouple CanInPlace from InPlace function

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -125,23 +125,26 @@ func (ip *PodsInPlaceRestrictionImpl) CanUnboost(pod *corev1.Pod, vpa *vpa_types
 	cr, present := ip.podToReplicaCreatorMap[getPodID(pod)]
 	if present {
 		singleGroupStats, present := ip.creatorToSingleGroupStatsMap[cr]
+		if pod.Status.Phase == corev1.PodPending {
+			return false
+		}
 		if present {
+			if isInPlaceUpdating(pod) {
+				return false
+			}
 			return singleGroupStats.isPodDisruptable()
 		}
 	}
 	return false
 }
 
-// InPlaceUpdate sends calculates patches and sends resize request to api client. Returns error if pod cannot be in-place updated or if client returned error.
+// InPlaceUpdate sends calculates patches and sends resize request to api client. Returns error if client returned error.
 // Does not check if pod was actually in-place updated after grace period.
+// CanInPlaceUpdate / CanUnboost should be called first.
 func (ip *PodsInPlaceRestrictionImpl) InPlaceUpdate(podToUpdate *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler, eventRecorder record.EventRecorder) error {
 	cr, present := ip.podToReplicaCreatorMap[getPodID(podToUpdate)]
 	if !present {
 		return fmt.Errorf("pod not suitable for in-place update %v: not in replicated pods map", podToUpdate.Name)
-	}
-
-	if ip.CanInPlaceUpdate(podToUpdate) != utils.InPlaceApproved {
-		return fmt.Errorf("cannot in-place update pod %s", klog.KObj(podToUpdate))
 	}
 
 	// separate patches since we have to patch resize and spec separately

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
@@ -331,10 +331,6 @@ func TestEvictionToleranceForInPlace(t *testing.T) {
 		err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should evict with no error")
 	}
-	for _, pod := range pods[4:] {
-		err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
-		assert.Error(t, err, "Error expected")
-	}
 }
 
 func TestEvictionToleranceForInPlaceWithSkipDisruptionBudget(t *testing.T) {
@@ -593,6 +589,10 @@ func TestInPlaceSkipDisruptionBudgetWithResizePolicy(t *testing.T) {
 
 			successCount := 0
 			for _, pod := range pods {
+				decision := inplace.CanInPlaceUpdate(pod)
+				if decision != utils.InPlaceApproved {
+					continue
+				}
 				err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
 				if err == nil {
 					successCount++
@@ -636,17 +636,15 @@ func TestInPlaceAtLeastOne(t *testing.T) {
 	assert.NoError(t, err)
 	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
-	for _, pod := range pods {
-		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod))
-	}
-
 	for _, pod := range pods[:1] {
+		assert.Equal(t, utils.InPlaceApproved, inplace.CanInPlaceUpdate(pod))
 		err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
 		assert.Nil(t, err, "Should in-place update with no error")
 	}
 	for _, pod := range pods[1:] {
+		assert.Equal(t, utils.InPlaceDeferred, inplace.CanInPlaceUpdate(pod))
 		err := inplace.InPlaceUpdate(pod, basicVpa, test.FakeEventRecorder())
-		assert.Error(t, err, "Error expected")
+		assert.Nil(t, err, "Error should not be expected")
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
@@ -536,8 +536,6 @@ func TestDisruptReplicatedByController(t *testing.T) {
 					err := inplace.InPlaceUpdate(p.pod, testCase.vpa, test.FakeEventRecorder())
 					if p.inPlaceUpdateSuccess {
 						assert.NoErrorf(t, err, "unexpected InPlaceUpdate result for pod-%v %#v", i, p.pod)
-					} else {
-						assert.Errorf(t, err, "unexpected InPlaceUpdate result for pod-%v %#v", i, p.pod)
 					}
 				} else {
 					err := eviction.Evict(p.pod, testCase.vpa, test.FakeEventRecorder())


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
decouple CanInPlace from InPlace function
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: https://github.com/kubernetes/autoscaler/pull/8888#discussion_r3051993304

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
/assign @adrianmoisey @maxcao13 