### PR TITLE
Revert "Implemented HasInstance for GCE provider" as it is causing CA E2E test failures

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -122,25 +122,7 @@ func (gce *GceCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider
 func (gce *GceCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
-	ref, err := GceRefFromProviderId(node.Spec.ProviderID)
-	if err != nil {
-		return false, err
-	}
-
-	mig, err := gce.gceManager.GetMigForInstance(ref)
-	if err != nil {
-		return false, err
-	}
-
-	// Not managed by any registered MIG; there's not enough information to confidently say if this instance exists,
-	// so err on the side of safety and return an error. ErrNotImplemented is returned (vs. a generic error) to
-	// avoid repeated warning logging in clusterstate.
-	if mig == nil {
-		return true, cloudprovider.ErrNotImplemented
-	}
-
-	// Instance belongs to a managed MIG, so it's known to be backed by a live instance.
-	return true, nil
+	return true, cloudprovider.ErrNotImplemented
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -60,11 +60,7 @@ func (m *gceManagerMock) DeleteInstances(instances []GceRef) error {
 
 func (m *gceManagerMock) GetMigForInstance(instance GceRef) (Mig, error) {
 	args := m.Called(instance)
-	v := args.Get(0)
-	if v == nil {
-		return nil, args.Error(1)
-	}
-	return v.(*gceMig), args.Error(1)
+	return args.Get(0).(*gceMig), args.Error(1)
 }
 
 func (m *gceManagerMock) GetMigNodes(mig Mig) ([]GceInstance, error) {
@@ -467,86 +463,6 @@ func TestGceRefFromProviderId(t *testing.T) {
 	ref, err := GceRefFromProviderId("gce://project1/us-central1-b/name1")
 	assert.NoError(t, err)
 	assert.Equal(t, GceRef{"project1", "us-central1-b", "name1"}, ref)
-}
-
-func TestHasInstance(t *testing.T) {
-	migRef := GceRef{Project: "project1", Zone: "us-central1-b", Name: "mig-0"}
-	mig := &gceMig{gceRef: migRef}
-
-	nodeRef := GceRef{Project: "project1", Zone: "us-central1-b", Name: "mig-0-0001"}
-	nodeProviderID := "gce://project1/us-central1-b/mig-0-0001"
-
-	for _, tc := range []struct {
-		name         string
-		node         func() *apiv1.Node
-		setupMocks   func(*gceManagerMock)
-		expectExists bool
-		expectErr    bool
-	}{
-		{
-			name: "invalid provider ID returns error",
-			node: func() *apiv1.Node {
-				n := BuildTestNode("node1", 1000, 1000)
-				n.Spec.ProviderID = "not-a-valid-gce-provider-id"
-				return n
-			},
-			setupMocks: func(m *gceManagerMock) {},
-			expectErr:  true,
-		},
-		{
-			name: "failure to get mig for instance returns error",
-			node: func() *apiv1.Node {
-				n := BuildTestNode("mig-0-0001", 1000, 1000)
-				n.Spec.ProviderID = nodeProviderID
-				return n
-			},
-			setupMocks: func(m *gceManagerMock) {
-				m.On("GetMigForInstance", nodeRef).Return(nil, fmt.Errorf("lookup error")).Once()
-			},
-			expectErr: true,
-		},
-		{
-			// Instance belongs to either an unregistered MIG, or one that is not in scope of the provider
-			// (e.g., a node from a non-auto-discovered MIG).
-			name: "instance in unregistered MIG returns error",
-			node: func() *apiv1.Node {
-				n := BuildTestNode("mig-x-0001", 1000, 1000)
-				n.Spec.ProviderID = nodeProviderID
-				return n
-			},
-			setupMocks: func(m *gceManagerMock) {
-				m.On("GetMigForInstance", nodeRef).Return(nil, nil).Once()
-			},
-			expectErr: true,
-		},
-		{
-			name: "instance in registered MIG returns true",
-			node: func() *apiv1.Node {
-				n := BuildTestNode("mig-0-0001", 1000, 1000)
-				n.Spec.ProviderID = nodeProviderID
-				return n
-			},
-			setupMocks: func(m *gceManagerMock) {
-				m.On("GetMigForInstance", nodeRef).Return(mig, nil).Once()
-			},
-			expectExists: true,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			gceManagerMock := &gceManagerMock{}
-			tc.setupMocks(gceManagerMock)
-			defer mock.AssertExpectationsForObjects(t, gceManagerMock)
-			gce := &GceCloudProvider{gceManager: gceManagerMock}
-
-			exists, err := gce.HasInstance(tc.node())
-			if tc.expectErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.expectExists, exists)
-			}
-		})
-	}
 }
 
 func createString(s string) *string {


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This reverts commit 785b523e111d009e134fe53c422304180e38e856.

Since April 3rd both CA presubmits and periodic E2E tests fail:
https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-autoscaling-e2e-gci-gce-ca-test
https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gci-gce-autoscaling

I have reasons to think this change is causing CA E2E tests failures.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
