### PR TITLE
Oci fix virtual node skip release 1.32

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/consts/annotations.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/consts/annotations.go
@@ -28,4 +28,7 @@ const (
 
 	// EphemeralStorageSize is the freeform tag key that would be used to determine the ephemeral-storage size of the node
 	EphemeralStorageSize = "cluster-autoscaler/node-ephemeral-storage"
+
+	// OciVirtualNodeResourceIdent is the string identifier in the ocid that indicates the resource is a virtual node pool
+	OciVirtualNodeResourceIdent = "virtualnode"
 )

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -630,6 +630,9 @@ func (m *ociManagerImpl) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance
 
 // GetNodePoolForInstance returns NodePool to which the given instance belongs.
 func (m *ociManagerImpl) GetNodePoolForInstance(instance ocicommon.OciRef) (NodePool, error) {
+	if strings.Contains(instance.InstanceID, npconsts.OciVirtualNodeResourceIdent) {
+		return nil, nil
+	}
 	if instance.NodePoolID == "" {
 		klog.V(4).Infof("node pool id missing from reference: %+v", instance)
 

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager_test.go
@@ -97,6 +97,16 @@ func TestGetNodePoolForInstance(t *testing.T) {
 	if np.Id() != "ocid2" {
 		t.Fatalf("got unexpected ocid %q ; wanted \"ocid2\"", np.Id())
 	}
+
+	// now verify node pool can be found via lookup up by instance id in cache
+	np, err = manager.GetNodePoolForInstance(ocicommon.OciRef{InstanceID: "virtualnode"})
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	if np != nil {
+		t.Fatalf("got unexpected ocid %q ; wanted nil", np.Id())
+	}
 }
 
 func TestGetNodePoolNodes(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR backports a fix for OCI clusters with mixed node types (managed nodes + virtual nodes).

Today, Cluster Autoscaler looks for the `oci.oraclecloud.com/node-pool-id` annotation on all non-self-managed nodes to determine the node pool a node belongs to. This breaks for virtual nodes, because virtual nodes do not have this annotation.

This change fixes that behavior by skipping virtual nodes during node pool identification, allowing Cluster Autoscaler to work correctly on mixed node clusters.

We need this in the release branch so updated images can be included in the April release, instead of shipping only the security-patched images without this fix.

#### Which issue(s) this PR fixes:

Fixes #NONE

#### Special notes for your reviewer:

This is a backport of an already merged fix for the OCI cloudprovider.

Customer impact:
- OCI Media Services is currently blocked from using Cluster Autoscaler on mixed node clusters because virtual nodes do not carry the `oci.oraclecloud.com/node-pool-id` annotation.

#### Does this PR introduce a user-facing change?

```release-note
OCI Cluster Autoscaler now skips virtual nodes when resolving node pool IDs in mixed managed-node and virtual-node clusters, fixing autoscaler support for this configuration.