### PR TITLE
Fix admission-controller panic

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -265,7 +265,7 @@ func validateMemoryResolution(val apires.Quantity) error {
 
 func validatePerVPAFeatureFlag(vpa *vpa_types.VerticalPodAutoscaler) error {
 	featureFlagOn := features.Enabled(features.PerVPAConfig)
-	if !featureFlagOn && vpa.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil {
+	if !featureFlagOn && vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil {
 		return fmt.Errorf("EvictAfterOOMSeconds is not supported when feature flag %s is disabled", features.PerVPAConfig)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

When applying a regular VPA, this panis.

```
2026/04/10 15:33:35 http: panic serving 172.18.0.2:33326: runtime error: invalid memory address or nil pointer dereference
goroutine 196 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1907 +0xac
panic({0xe0ffc0?, 0x1b88340?})
	/usr/local/go/src/runtime/panic.go:860 +0x12c
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa.validatePerVPAFeatureFlag(0x5288459fab00)
	/workspace/pkg/admission-controller/resource/vpa/handler.go:268 +0x58
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa.ValidateVPA(0x5288459fab00, 0x1)
	/workspace/pkg/admission-controller/resource/vpa/handler.go:112 +0x2c
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa.(*resourceHandler).GetPatches(0x528845bdabb0, {0x528845e1e7e0?, 0x528845fc9880?}, 0xfee800?)
	/workspace/pkg/admission-controller/resource/vpa/handler.go:82 +0x9c
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/logic.(*AdmissionServer).admit(0x52884591aa08, {0x116b770, 0x528845cd4550}, {0x528845e79b00, 0x8e5, 0x900})
	/workspace/pkg/admission-controller/logic/server.go:125 +0x114
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/logic.(*AdmissionServer).Serve(0x52884591aa08, {0x1169a00, 0x528845f841e0}, 0x528845b1c8c0)
	/workspace/pkg/admission-controller/logic/server.go:196 +0x254
main.main.func1({0x1169a00?, 0x528845f841e0?}, 0x528845fbbb18?)
	/workspace/pkg/admission-controller/main.go:119 +0x3c
net/http.HandlerFunc.ServeHTTP(0x1baffa0?, {0x1169a00?, 0x528845f841e0?}, 0x528845fbbb00?)
	/usr/local/go/src/net/http/server.go:2286 +0x38
net/http.(*ServeMux).ServeHTTP(0x10?, {0x1169a00, 0x528845f841e0}, 0x528845b1c8c0)
	/usr/local/go/src/net/http/server.go:2828 +0x190
net/http.serverHandler.ServeHTTP({0x11632b8?}, {0x1169a00?, 0x528845f841e0?}, 0x1?)
	/usr/local/go/src/net/http/server.go:3311 +0xb0
net/http.(*conn).serve(0x528845c22ab0, {0x116b738, 0x528845e1ec60})
	/usr/local/go/src/net/http/server.go:2073 +0x51c
created by net/http.(*Server).Serve in goroutine 1
	/usr/local/go/src/net/http/server.go:3464 +0x37c
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc omerap12