### PR TITLE
Configure vpa-updater to use a single informer factory

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -18,7 +18,6 @@ package logic
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	corescheme "k8s.io/client-go/kubernetes/scheme"
@@ -91,6 +91,8 @@ type updater struct {
 func NewUpdater(
 	kubeClient kube_client.Interface,
 	vpaClient *vpa_clientset.Clientset,
+	kubeInformerFactory informers.SharedInformerFactory,
+	podLister listersv1.PodLister,
 	minReplicasForEviction int,
 	evictionRateLimit float64,
 	evictionRateBurst int,
@@ -113,20 +115,18 @@ func NewUpdater(
 	evictionRateLimiter := getRateLimiter(evictionRateLimit, evictionRateBurst)
 	// TODO: Create in-place rate limits for the in-place rate limiter
 	inPlaceRateLimiter := getRateLimiter(evictionRateLimit, evictionRateBurst)
-	factory, err := restriction.NewPodsRestrictionFactory(
+	factory := restriction.NewPodsRestrictionFactory(
 		kubeClient,
+		kubeInformerFactory,
 		minReplicasForEviction,
 		evictionToleranceFraction,
 		patchCalculators,
 		inPlaceSkipDisruptionBudget,
 	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create restriction factory: %v", err)
-	}
 
 	return &updater{
 		vpaLister:                    vpa_api_util.NewVpasLister(vpaClient, make(chan struct{}), namespace),
-		podLister:                    newPodLister(kubeClient, namespace),
+		podLister:                    podLister,
 		eventRecorder:                newEventRecorder(kubeClient),
 		restrictionFactory:           factory,
 		recommendationProcessor:      recommendationProcessor,
@@ -462,14 +462,15 @@ func filterDeletedPods(pods []*corev1.Pod) []*corev1.Pod {
 	})
 }
 
-func newPodLister(kubeClient kube_client.Interface, namespace string) listersv1.PodLister {
+// NewPodLister creates a new PodLister that lists pods based on the provided kubeClient and namespace.
+// It filters out pods that are not scheduled (spec.nodeName is empty) and pods that are in Succeeded or Failed phase, as these pods are not relevant for eviction or in-place updates.
+func NewPodLister(kubeClient kube_client.Interface, namespace string, stopCh <-chan struct{}) listersv1.PodLister {
 	selector := fields.ParseSelectorOrDie("spec.nodeName!=" + "" + ",status.phase!=" +
 		string(corev1.PodSucceeded) + ",status.phase!=" + string(corev1.PodFailed))
 	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", namespace, selector)
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	podLister := listersv1.NewPodLister(store)
 	podReflector := cache.NewReflector(podListWatch, &corev1.Pod{}, store, time.Hour)
-	stopCh := make(chan struct{})
 	go podReflector.Run(stopCh)
 
 	return podLister

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -146,24 +146,16 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 	kubeConfig := common.CreateKubeConfigOrDie(commonFlag.KubeConfig, float32(commonFlag.KubeApiQps), int(commonFlag.KubeApiBurst))
 	kubeClient := kube_client.NewForConfigOrDie(kubeConfig)
 	vpaClient := vpa_clientset.NewForConfigOrDie(kubeConfig)
-	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(commonFlag.VpaObjectNamespace))
-	targetSelectorFetcher := target.NewVpaTargetSelectorFetcher(kubeConfig, kubeClient, factory)
-	controllerFetcher := controllerfetcher.NewControllerFetcher(kubeConfig, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
+	kubeFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(commonFlag.VpaObjectNamespace))
+	podLister := updater.NewPodLister(kubeClient, commonFlag.VpaObjectNamespace, stopCh)
+	targetSelectorFetcher := target.NewVpaTargetSelectorFetcher(kubeConfig, kubeClient, kubeFactory)
+	controllerFetcher := controllerfetcher.NewControllerFetcher(kubeConfig, kubeClient, kubeFactory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
 
 	var limitRangeCalculator limitrange.LimitRangeCalculator
-	limitRangeCalculator, err := limitrange.NewLimitsRangeCalculator(factory)
+	limitRangeCalculator, err := limitrange.NewLimitsRangeCalculator(kubeFactory)
 	if err != nil {
 		klog.ErrorS(err, "Failed to create limitRangeCalculator, falling back to not checking limits")
 		limitRangeCalculator = limitrange.NewNoopLimitsCalculator()
-	}
-
-	factory.Start(stopCh)
-	informerMap := factory.WaitForCacheSync(stopCh)
-	for kind, synced := range informerMap {
-		if !synced {
-			klog.ErrorS(nil, fmt.Sprintf("Could not sync cache for the %s informer", kind.String()))
-			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
-		}
 	}
 
 	admissionControllerStatusNamespace := status.AdmissionControllerStatusNamespace
@@ -177,10 +169,11 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 
 	calculators := []patch.Calculator{inplace.NewResourceInPlaceUpdatesCalculator(recommendationProvider), inplace.NewInPlaceUpdatedCalculator(), inplace.NewUnboostAnnotationCalculator()}
 
-	// TODO: use SharedInformerFactory in updater
 	updater, err := updater.NewUpdater(
 		kubeClient,
 		vpaClient,
+		kubeFactory,
+		podLister,
 		config.MinReplicas,
 		config.EvictionRateLimit,
 		config.EvictionRateBurst,
@@ -203,6 +196,16 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 	if err != nil {
 		klog.ErrorS(err, "Failed to create updater")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
+
+	// Start factories
+	kubeFactory.Start(stopCh)
+	informerMap := kubeFactory.WaitForCacheSync(stopCh)
+	for kind, synced := range informerMap {
+		if !synced {
+			klog.ErrorS(nil, fmt.Sprintf("Could not sync cache for the %s informer", kind.String()))
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		}
 	}
 
 	// Start updating health check endpoint.

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory.go
@@ -25,20 +25,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	appsinformer "k8s.io/client-go/informers/apps/v1"
-	coreinformer "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
-)
-
-const (
-	resyncPeriod time.Duration = 1 * time.Minute
 )
 
 // ControllerKind is the type of controller that can manage a pod.
@@ -68,10 +62,7 @@ type PodsRestrictionFactory interface {
 // PodsRestrictionFactoryImpl is the implementation of the PodsRestrictionFactory interface.
 type PodsRestrictionFactoryImpl struct {
 	client                      kube_client.Interface
-	rcInformer                  cache.SharedIndexInformer // informer for Replication Controllers
-	ssInformer                  cache.SharedIndexInformer // informer for Stateful Sets
-	rsInformer                  cache.SharedIndexInformer // informer for Replica Sets
-	dsInformer                  cache.SharedIndexInformer // informer for Daemon Sets
+	informerFactory             informers.SharedInformerFactory
 	minReplicas                 int
 	evictionToleranceFraction   float64
 	clock                       clock.Clock
@@ -81,42 +72,23 @@ type PodsRestrictionFactoryImpl struct {
 }
 
 // NewPodsRestrictionFactory creates a new PodsRestrictionFactory.
-func NewPodsRestrictionFactory(client kube_client.Interface, minReplicas int, evictionToleranceFraction float64, patchCalculators []patch.Calculator, inPlaceSkipDisruptionBudget bool) (PodsRestrictionFactory, error) {
-	rcInformer, err := setupInformer(client, replicationController)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create rcInformer: %v", err)
-	}
-	ssInformer, err := setupInformer(client, statefulSet)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create ssInformer: %v", err)
-	}
-	rsInformer, err := setupInformer(client, replicaSet)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create rsInformer: %v", err)
-	}
-	dsInformer, err := setupInformer(client, daemonSet)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dsInformer: %v", err)
-	}
+func NewPodsRestrictionFactory(client kube_client.Interface, informerFactory informers.SharedInformerFactory, minReplicas int, evictionToleranceFraction float64, patchCalculators []patch.Calculator, inPlaceSkipDisruptionBudget bool) PodsRestrictionFactory {
 	return &PodsRestrictionFactoryImpl{
 		client:                      client,
-		rcInformer:                  rcInformer, // informer for Replication Controllers
-		ssInformer:                  ssInformer, // informer for Stateful Sets
-		rsInformer:                  rsInformer, // informer for Replica Sets
-		dsInformer:                  dsInformer, // informer for Daemon Sets
+		informerFactory:             informerFactory,
 		minReplicas:                 minReplicas,
 		evictionToleranceFraction:   evictionToleranceFraction,
 		clock:                       &clock.RealClock{},
 		lastInPlaceAttemptTimeMap:   make(map[string]time.Time),
 		patchCalculators:            patchCalculators,
 		inPlaceSkipDisruptionBudget: inPlaceSkipDisruptionBudget,
-	}, nil
+	}
 }
 
 func (f *PodsRestrictionFactoryImpl) getReplicaCount(creator podReplicaCreator) (int, error) {
 	switch creator.Kind {
 	case replicationController:
-		rcObj, exists, err := f.rcInformer.GetStore().GetByKey(creator.Namespace + "/" + creator.Name)
+		rcObj, exists, err := f.informerFactory.Core().V1().ReplicationControllers().Informer().GetStore().GetByKey(creator.Namespace + "/" + creator.Name)
 		if err != nil {
 			return 0, fmt.Errorf("replication controller %s/%s is not available, err: %v", creator.Namespace, creator.Name, err)
 		}
@@ -132,7 +104,7 @@ func (f *PodsRestrictionFactoryImpl) getReplicaCount(creator podReplicaCreator) 
 		}
 		return int(*rc.Spec.Replicas), nil
 	case replicaSet:
-		rsObj, exists, err := f.rsInformer.GetStore().GetByKey(creator.Namespace + "/" + creator.Name)
+		rsObj, exists, err := f.informerFactory.Apps().V1().ReplicaSets().Informer().GetStore().GetByKey(creator.Namespace + "/" + creator.Name)
 		if err != nil {
 			return 0, fmt.Errorf("replica set %s/%s is not available, err: %v", creator.Namespace, creator.Name, err)
 		}
@@ -148,7 +120,7 @@ func (f *PodsRestrictionFactoryImpl) getReplicaCount(creator podReplicaCreator) 
 		}
 		return int(*rs.Spec.Replicas), nil
 	case statefulSet:
-		ssObj, exists, err := f.ssInformer.GetStore().GetByKey(creator.Namespace + "/" + creator.Name)
+		ssObj, exists, err := f.informerFactory.Apps().V1().StatefulSets().Informer().GetStore().GetByKey(creator.Namespace + "/" + creator.Name)
 		if err != nil {
 			return 0, fmt.Errorf("stateful set %s/%s is not available, err: %v", creator.Namespace, creator.Name, err)
 		}
@@ -164,7 +136,7 @@ func (f *PodsRestrictionFactoryImpl) getReplicaCount(creator podReplicaCreator) 
 		}
 		return int(*ss.Spec.Replicas), nil
 	case daemonSet:
-		dsObj, exists, err := f.dsInformer.GetStore().GetByKey(creator.Namespace + "/" + creator.Name)
+		dsObj, exists, err := f.informerFactory.Apps().V1().DaemonSets().Informer().GetStore().GetByKey(creator.Namespace + "/" + creator.Name)
 		if err != nil {
 			return 0, fmt.Errorf("daemon set %s/%s is not available, err: %v", creator.Namespace, creator.Name, err)
 		}
@@ -320,33 +292,6 @@ func managingControllerRef(pod *corev1.Pod) *metav1.OwnerReference {
 		}
 	}
 	return &managingController
-}
-
-func setupInformer(kubeClient kube_client.Interface, kind controllerKind) (cache.SharedIndexInformer, error) {
-	var informer cache.SharedIndexInformer
-	switch kind {
-	case replicationController:
-		informer = coreinformer.NewReplicationControllerInformer(kubeClient, corev1.NamespaceAll,
-			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	case replicaSet:
-		informer = appsinformer.NewReplicaSetInformer(kubeClient, corev1.NamespaceAll,
-			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	case statefulSet:
-		informer = appsinformer.NewStatefulSetInformer(kubeClient, corev1.NamespaceAll,
-			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	case daemonSet:
-		informer = appsinformer.NewDaemonSetInformer(kubeClient, corev1.NamespaceAll,
-			resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	default:
-		return nil, fmt.Errorf("unknown controller kind: %v", kind)
-	}
-	stopCh := make(chan struct{})
-	go informer.Run(stopCh)
-	synced := cache.WaitForCacheSync(stopCh, informer.HasSynced)
-	if !synced {
-		return nil, fmt.Errorf("failed to sync %v cache", kind)
-	}
-	return informer, nil
 }
 
 type singleGroupStats struct {

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
@@ -26,10 +26,8 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	appsinformer "k8s.io/client-go/informers/apps/v1"
-	coreinformer "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/clock"
 	baseclocktest "k8s.io/utils/clock/testing"
@@ -721,45 +719,36 @@ func getRestrictionFactory(rc *corev1.ReplicationController, rs *appsv1.ReplicaS
 	ss *appsv1.StatefulSet, ds *appsv1.DaemonSet, minReplicas int,
 	evictionToleranceFraction float64, clock clock.Clock, lipuatm map[string]time.Time, patchCalculators []patch.Calculator, inPlaceSkipDisruptionBudget bool) (PodsRestrictionFactory, error) {
 	kubeClient := &fake.Clientset{}
-	rcInformer := coreinformer.NewReplicationControllerInformer(kubeClient, corev1.NamespaceAll,
-		0*time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	rsInformer := appsinformer.NewReplicaSetInformer(kubeClient, corev1.NamespaceAll,
-		0*time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	ssInformer := appsinformer.NewStatefulSetInformer(kubeClient, corev1.NamespaceAll,
-		0*time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	dsInformer := appsinformer.NewDaemonSetInformer(kubeClient, corev1.NamespaceAll,
-		0*time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0*time.Second)
+
 	if rc != nil {
-		err := rcInformer.GetIndexer().Add(rc)
-		if err != nil {
-			return nil, fmt.Errorf("Error adding object to cache: %v", err)
+		rcInformer := informerFactory.Core().V1().ReplicationControllers().Informer()
+		if err := rcInformer.GetStore().Add(rc); err != nil {
+			return nil, fmt.Errorf("Error adding ReplicationController to store: %v", err)
 		}
 	}
 	if rs != nil {
-		err := rsInformer.GetIndexer().Add(rs)
-		if err != nil {
-			return nil, fmt.Errorf("Error adding object to cache: %v", err)
+		rsInformer := informerFactory.Apps().V1().ReplicaSets().Informer()
+		if err := rsInformer.GetStore().Add(rs); err != nil {
+			return nil, fmt.Errorf("Error adding ReplicaSet to store: %v", err)
 		}
 	}
 	if ss != nil {
-		err := ssInformer.GetIndexer().Add(ss)
-		if err != nil {
-			return nil, fmt.Errorf("Error adding object to cache: %v", err)
+		ssInformer := informerFactory.Apps().V1().StatefulSets().Informer()
+		if err := ssInformer.GetStore().Add(ss); err != nil {
+			return nil, fmt.Errorf("Error adding StatefulSet to store: %v", err)
 		}
 	}
 	if ds != nil {
-		err := dsInformer.GetIndexer().Add(ds)
-		if err != nil {
-			return nil, fmt.Errorf("Error adding object to cache: %v", err)
+		dsInformer := informerFactory.Apps().V1().DaemonSets().Informer()
+		if err := dsInformer.GetStore().Add(ds); err != nil {
+			return nil, fmt.Errorf("Error adding DaemonSet to store: %v", err)
 		}
 	}
 
 	return &PodsRestrictionFactoryImpl{
 		client:                      kubeClient,
-		rcInformer:                  rcInformer,
-		ssInformer:                  ssInformer,
-		rsInformer:                  rsInformer,
-		dsInformer:                  dsInformer,
+		informerFactory:             informerFactory,
 		minReplicas:                 minReplicas,
 		evictionToleranceFraction:   evictionToleranceFraction,
 		clock:                       clock,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Prior to this change, we would see multiple informers start for the same resources. Ie:
```
I0411 12:27:34.718446       1 reflector.go:425] "Starting reflector" type="*v1.ReplicaSet" resyncPeriod="10m0s" reflector="pkg/mod/k8s.io/client-go@v0.36.0-beta.0/tools/cache/reflector.go:343"
I0411 12:27:34.927544       1 reflector.go:425] "Starting reflector" type="*v1.ReplicaSet" resyncPeriod="1m0s" reflector="pkg/mod/k8s.io/client-go@v0.36.0-beta.0/tools/cache/reflector.go:343"
```

This is an example of the two informers starting, with different resync periods.

This commit changes the vpa-updater to use a single informer factory, which should save on cache and watches

This should also help with the high memory consumption seen here: https://github.com/kubernetes/autoscaler/issues/9116

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9116

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
