### PR TITLE
Clarify the VPA's ability to traverse ownership chains

### DIFF
--- a/vertical-pod-autoscaler/docs/faq.md
+++ b/vertical-pod-autoscaler/docs/faq.md
@@ -128,6 +128,9 @@ resource recommendations, this ensures that all Pods with a matching VPA object 
 recreate them after eviction. Furthermore, it avoids misconfigurations that happened in the past when label selectors
 were specified manually.
 
+> [!WARNING]
+> VPA can only manage Pods that are directly owned by the targeted Custom Resource. It does not support indirect ownership (e.g., targeting a resource that owns another controller, which in turn owns the Pods).
+
 ### How can I use Prometheus as a history provider for the VPA recommender
 
 Configure your Prometheus to get metrics from cadvisor. Make sure that the metrics from the cadvisor have the label `job=kubernetes-cadvisor`

--- a/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/target/controller_fetcher/controller_fetcher_test.go
@@ -59,7 +59,10 @@ func simpleControllerFetcher() *controllerFetcher {
 	f.informersMap = make(map[wellKnownController]cache.SharedIndexInformer)
 	f.scaleSubresourceCacheStorage = newControllerCacheStorage(time.Second, time.Minute, 0.1)
 	versioned := map[string][]metav1.APIResource{
-		"Foo": {{Kind: "Foo", Name: "bah", Group: "foo"}, {Kind: "Scale", Name: "iCanScale", Group: "foo"}},
+		"Foo": {
+			{Kind: "NotScalingResource", Name: "iCanNotScale", Group: "foo"},
+			{Kind: "ScalingResource", Name: "iCanScale", Group: "foo"},
+		},
 	}
 	fakeMapper := []*restmapper.APIGroupResources{
 		{
@@ -76,8 +79,8 @@ func simpleControllerFetcher() *controllerFetcher {
 	scaleNamespacer := &scalefake.FakeScaleClient{}
 	f.scaleNamespacer = scaleNamespacer
 
-	// return not found if if tries to find the scale subresource on bah
-	scaleNamespacer.AddReactor("get", "bah", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+	// return not found if it tries to find the scale subresource on iCanNotScale
+	scaleNamespacer.AddReactor("get", "iCanNotScale", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		groupResource := schema.GroupResource{}
 		err = apierrors.NewNotFound(groupResource, "Foo")
 		return true, nil, err
@@ -330,14 +333,14 @@ func TestControllerFetcher(t *testing.T) {
 						{
 							APIVersion: "Foo/Foo",
 							Controller: &trueVar,
-							Kind:       "Foo",
-							Name:       "bah",
+							Kind:       "NotScalingResource",
+							Name:       "iCanNotScale",
 						},
 					},
 				},
 			}},
 			expectedKey: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
-				Name: testDeployment, Kind: "Deployment", Namespace: testNamespace}}, // Parent does not support scale subresource so should return itself"
+				Name: testDeployment, Kind: "Deployment", Namespace: testNamespace}}, // Parent does not support scale subresource so should return itself
 			expectedError: nil,
 		},
 		{
@@ -356,14 +359,14 @@ func TestControllerFetcher(t *testing.T) {
 						{
 							APIVersion: "Foo/Foo",
 							Controller: &trueVar,
-							Kind:       "Scale",
+							Kind:       "ScalingResource",
 							Name:       "iCanScale",
 						},
 					},
 				},
 			}},
 			expectedKey: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
-				Name: "iCanScale", Kind: "Scale", Namespace: testNamespace}, ApiVersion: "Foo/Foo"}, // Parent supports scale subresource"
+				Name: "iCanScale", Kind: "ScalingResource", Namespace: testNamespace}, ApiVersion: "Foo/Foo"}, // Parent supports scale subresource so it is returned
 			expectedError: nil,
 		},
 		{
@@ -395,7 +398,7 @@ func TestControllerFetcher(t *testing.T) {
 			name: "custom resource with no scale subresource",
 			key: &ControllerKeyWithAPIVersion{
 				ApiVersion: "Foo/Foo", ControllerKey: ControllerKey{
-					Name: "bah", Kind: "Foo", Namespace: testNamespace},
+					Name: "iCanNotScale", Kind: "NotScalingResource", Namespace: testNamespace},
 			},
 			objects:       []runtime.Object{},
 			expectedKey:   nil, // Pod owner does not support scale subresource so should return nil"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:
Clarify the VPA's ability to traverse ownership chains
Also change names in tests a little to be clearer

My plan was to make a test that proved the current behaviour, but with our current testing framework that was a bit difficult.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #9072

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc iamzili 