### PR TITLE
feat(vpa-chart): add PodMonitor support for Prometheus Operator

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -4,7 +4,7 @@ WARNING: This chart is currently under development and is not ready for producti
 
 Automatically adjust resources for your workloads
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
@@ -112,6 +112,11 @@ helm upgrade <release-name> <chart> \
 | admissionController.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | admissionController.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | admissionController.podLabels | object | `{}` |  |
+| admissionController.podMonitor | object | `{"annotations":{},"enabled":false,"extraPodMetricsEndpoints":[],"labels":{}}` | Enables a Prometheus Operator PodMonitor for the Admission Controller. Requires the prometheus-operator-crds to be installed in the cluster. |
+| admissionController.podMonitor.annotations | object | `{}` | Annotations to add to the PodMonitor. |
+| admissionController.podMonitor.enabled | bool | `false` | If true, create a PodMonitor resource for the Admission Controller. |
+| admissionController.podMonitor.extraPodMetricsEndpoints | list | `[]` | Additional podMetricsEndpoints to add to the PodMonitor. |
+| admissionController.podMonitor.labels | object | `{}` | Additional labels to add to the PodMonitor. |
 | admissionController.priorityClassName | string | `nil` |  |
 | admissionController.registerWebhook | bool | `false` | Whether to register webhook via the application itself or via Helm. Set to false when using Helm-managed webhook. Security issue: granting delete on mutatingwebhookconfigurations is a potential security risk as it allows the admission controller to remove any webhook configurations. |
 | admissionController.replicas | int | `2` |  |
@@ -176,6 +181,11 @@ helm upgrade <release-name> <chart> \
 | recommender.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | recommender.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | recommender.podLabels | object | `{}` |  |
+| recommender.podMonitor | object | `{"annotations":{},"enabled":false,"extraPodMetricsEndpoints":[],"labels":{}}` | Enables a Prometheus Operator PodMonitor for the Recommender. Requires the prometheus-operator-crds to be installed in the cluster. |
+| recommender.podMonitor.annotations | object | `{}` | Annotations to add to the PodMonitor. |
+| recommender.podMonitor.enabled | bool | `false` | If true, create a PodMonitor resource for the Recommender. |
+| recommender.podMonitor.extraPodMetricsEndpoints | list | `[]` | Additional podMetricsEndpoints to add to the PodMonitor. |
+| recommender.podMonitor.labels | object | `{}` | Additional labels to add to the PodMonitor. |
 | recommender.priorityClassName | string | `nil` |  |
 | recommender.replicas | int | `2` |  |
 | recommender.resources | object | `{}` |  |
@@ -207,6 +217,11 @@ helm upgrade <release-name> <chart> \
 | updater.podDisruptionBudget.maxUnavailable | int or string | `nil` | Maximum number/percentage of pods that can be unavailable after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | updater.podDisruptionBudget.minAvailable | int or string | `1` | Minimum number/percentage of pods that must be available after the eviction. IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both. |
 | updater.podLabels | object | `{}` |  |
+| updater.podMonitor | object | `{"annotations":{},"enabled":false,"extraPodMetricsEndpoints":[],"labels":{}}` | Enables a Prometheus Operator PodMonitor for the Updater. Requires the prometheus-operator-crds to be installed in the cluster. |
+| updater.podMonitor.annotations | object | `{}` | Annotations to add to the PodMonitor. |
+| updater.podMonitor.enabled | bool | `false` | If true, create a PodMonitor resource for the Updater. |
+| updater.podMonitor.extraPodMetricsEndpoints | list | `[]` | Additional podMetricsEndpoints to add to the PodMonitor. |
+| updater.podMonitor.labels | object | `{}` | Additional labels to add to the PodMonitor. |
 | updater.priorityClassName | string | `nil` |  |
 | updater.replicas | int | `2` |  |
 | updater.resources | object | `{}` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-podmonitor.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.admissionController.enabled .Values.admissionController.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
+  {{- with .Values.admissionController.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.admissionController.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vertical-pod-autoscaler.admissionController.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: prometheus
+  {{- with .Values.admissionController.podMonitor.extraPodMetricsEndpoints }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-podmonitor.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.recommender.enabled .Values.recommender.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
+  {{- with .Values.recommender.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.recommender.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vertical-pod-autoscaler.recommender.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: prometheus
+  {{- with .Values.recommender.podMonitor.extraPodMetricsEndpoints }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-podmonitor.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater-podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.updater.enabled .Values.updater.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
+  {{- with .Values.updater.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.updater.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vertical-pod-autoscaler.updater.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: prometheus
+  {{- with .Values.updater.podMonitor.extraPodMetricsEndpoints }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -73,12 +73,12 @@ admissionController:
 
   # Resources for the Admission Controller default container.
   resources: {}
-    # limits:
-    #   cpu: 200m
-    #   memory: 500Mi
-    # requests:
-    #   cpu: 50m
-    #   memory: 200Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 500Mi
+  # requests:
+  #   cpu: 50m
+  #   memory: 200Mi
 
   # Node selector labels for scheduling the Admission Controller.
   nodeSelector: {}
@@ -87,15 +87,15 @@ admissionController:
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: app.kubernetes.io/component
-              operator: In
-              values:
-              - admission-controller
-          topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - admission-controller
+            topologyKey: kubernetes.io/hostname
 
   # List of node taints to tolerate.
   tolerations: []
@@ -115,7 +115,7 @@ admissionController:
       tag: v20231011-8b53cabe0
       # admissionController.certGen.image.pullPolicy -- The pull policy for the certgen image. Recommend not changing this
       pullPolicy: IfNotPresent
-       # admissionController.certGen.env -- Additional environment variables to be added to the certgen container. Format is KEY: Value format
+      # admissionController.certGen.env -- Additional environment variables to be added to the certgen container. Format is KEY: Value format
     env: {}
     # admissionController.certGen.resources -- The resources block for the certgen pod
     resources: {}
@@ -147,7 +147,6 @@ admissionController:
     objectSelector: {}
     # admissionController.mutatingWebhookConfiguration.timeoutSeconds -- Sets the amount of time the API server will wait on a response from the webhook service
     timeoutSeconds: 5
-
 
   tls:
     # If true, Helm will generate the TLS secret using genCA/genSignedCert
@@ -185,6 +184,18 @@ admissionController:
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
     maxUnavailable:
     # maxUnavailable: 1
+
+  # -- Enables a Prometheus Operator PodMonitor for the Admission Controller.
+  # Requires the prometheus-operator-crds to be installed in the cluster.
+  podMonitor:
+    # admissionController.podMonitor.enabled -- If true, create a PodMonitor resource for the Admission Controller.
+    enabled: false
+    # admissionController.podMonitor.annotations -- Annotations to add to the PodMonitor.
+    annotations: {}
+    # admissionController.podMonitor.labels -- Additional labels to add to the PodMonitor.
+    labels: {}
+    # admissionController.podMonitor.extraPodMetricsEndpoints -- Additional podMetricsEndpoints to add to the PodMonitor.
+    extraPodMetricsEndpoints: []
 
   # name of priorityclass for scheduling
   priorityClassName:
@@ -232,12 +243,12 @@ recommender:
 
   # Resources for the Recommender default container.
   resources: {}
-    # limits:
-    #   cpu: 200m
-    #   memory: 1000Mi
-    # requests:
-    #   cpu: 50m
-    #   memory: 500Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 1000Mi
+  # requests:
+  #   cpu: 50m
+  #   memory: 500Mi
 
   # Node selector labels for scheduling the Recommender.
   nodeSelector: {}
@@ -246,15 +257,15 @@ recommender:
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: app.kubernetes.io/component
-              operator: In
-              values:
-              - recommender
-          topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - recommender
+            topologyKey: kubernetes.io/hostname
 
   # Tolerations for scheduling the Recommender.
   tolerations: []
@@ -285,6 +296,18 @@ recommender:
     # IMPORTANT: You can specify either 'minAvailable' or 'maxUnavailable', but not both.
     maxUnavailable:
     # maxUnavailable: 1
+
+  # -- Enables a Prometheus Operator PodMonitor for the Recommender.
+  # Requires the prometheus-operator-crds to be installed in the cluster.
+  podMonitor:
+    # recommender.podMonitor.enabled -- If true, create a PodMonitor resource for the Recommender.
+    enabled: false
+    # recommender.podMonitor.annotations -- Annotations to add to the PodMonitor.
+    annotations: {}
+    # recommender.podMonitor.labels -- Additional labels to add to the PodMonitor.
+    labels: {}
+    # recommender.podMonitor.extraPodMetricsEndpoints -- Additional podMetricsEndpoints to add to the PodMonitor.
+    extraPodMetricsEndpoints: []
 
   # name of priorityclass for scheduling
   priorityClassName:
@@ -330,15 +353,15 @@ updater:
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: app.kubernetes.io/component
-              operator: In
-              values:
-              - updater
-          topologyKey: kubernetes.io/hostname
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - updater
+            topologyKey: kubernetes.io/hostname
 
   # Node selector labels for scheduling the Updater.
   nodeSelector: {}
@@ -374,12 +397,24 @@ updater:
 
   # Resources for the updater Controller
   resources: {}
-    # limits:
-    #   cpu: 200m
-    #   memory: 500Mi
-    # requests:
-    #   cpu: 50m
-    #   memory: 200Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 500Mi
+  # requests:
+  #   cpu: 50m
+  #   memory: 200Mi
+
+  # -- Enables a Prometheus Operator PodMonitor for the Updater.
+  # Requires the prometheus-operator-crds to be installed in the cluster.
+  podMonitor:
+    # updater.podMonitor.enabled -- If true, create a PodMonitor resource for the Updater.
+    enabled: false
+    # updater.podMonitor.annotations -- Annotations to add to the PodMonitor.
+    annotations: {}
+    # updater.podMonitor.labels -- Additional labels to add to the PodMonitor.
+    labels: {}
+    # updater.podMonitor.extraPodMetricsEndpoints -- Additional podMetricsEndpoints to add to the PodMonitor.
+    extraPodMetricsEndpoints: []
 
   # name of priorityclass for scheduling
   priorityClassName:


### PR DESCRIPTION
Add optional PodMonitor resources for all three VPA components (recommender, updater, admission-controller).

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9481 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Added optional PodMonitors to vertical-pod-autoscaler chart
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
