### PR TITLE
fix(azure): prevent catastrophic scale-down when getCurSize() returns 0 for live VMSS

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -250,13 +250,19 @@ func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 	curSize := *set.SKU.Capacity
 	vmssSizeMutex.Unlock()
 
+	if curSize == 0 && scaleSet.curSize > 0 {
+		klog.Warningf("getCurSize: VMSS %q API returned capacity=0 but in-memory size is %d. "+
+			"Suspected transient API anomaly, retaining in-memory size to prevent catastrophic scale-down.",
+			scaleSet.Name, scaleSet.curSize)
+		scaleSet.lastSizeRefresh = time.Now()
+		return scaleSet.curSize, nil
+	}
+
 	if scaleSet.curSize != curSize {
-		// Invalidate the instance cache if the capacity has changed.
 		klog.V(5).Infof("VMSS %q size changed from: %d to %d, invalidating instance cache", scaleSet.Name, scaleSet.curSize, curSize)
 		scaleSet.invalidateInstanceCache()
 	}
 	klog.V(3).Infof("VMSS: %s, in-memory size: %d, new size: %d", scaleSet.Name, scaleSet.curSize, curSize)
-
 	scaleSet.curSize = curSize
 	scaleSet.lastSizeRefresh = time.Now()
 	return scaleSet.curSize, nil

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -1513,3 +1513,28 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 		})
 	})
 }
+
+func TestGetCurSizeReturnsInMemorySizeWhenAPIReturnsZeroForLargeVMSS(t *testing.T) {
+
+	// test for bug #9452
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+
+	vmssListWithZeroCapacity := newTestVMSSList(0, "test-asg", testLocation, armcompute.OrchestrationModeUniform)
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(vmssListWithZeroCapacity, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	ss := newTestScaleSet(manager, "test-asg")
+	ss.curSize = 90
+	ss.lastSizeRefresh = time.Now().Add(-2 * manager.azureCache.refreshInterval)
+
+	size, err2 := ss.getCurSize()
+	assert.Nil(t, err2)
+	assert.Equal(t, int64(90), size, "getCurSize() must not accept capacity=0 when in-memory size is 90 (transient API anomaly)")
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


#### What this PR does / why we need it:

When the Azure API transiently returns SKU.Capacity=0 for a VMSS with running nodes, cluster-autoscaler would unconditionally accept the value, then issue a CreateOrUpdate setting capacity to 1 - destroying all existing nodes.

Guard against this by retaining the in-memory size when the API returns 0 and the known size is positive. The next refresh cycle will re-verify.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9452

#### Release note:
```release-note
Fix catastrophic Azure VMSS scale-down when getCurSize() transiently returns 0
```