### PR TITLE
VPA: match CronJob pods when jobTemplate pod labels are omitted

### DIFF
--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -157,11 +157,24 @@ func getLabelSelector(informer cache.SharedIndexInformer, kind, namespace, name 
 	case (*batchv1.Job):
 		return metav1.LabelSelectorAsSelector(apiObj.Spec.Selector)
 	case (*batchv1.CronJob):
-		return metav1.LabelSelectorAsSelector(metav1.SetAsLabelSelector(apiObj.Spec.JobTemplate.Spec.Template.Labels))
+		return getLabelSelectorFromCronJob(apiObj)
 	case (*corev1.ReplicationController):
 		return metav1.LabelSelectorAsSelector(metav1.SetAsLabelSelector(apiObj.Spec.Selector))
 	}
 	return nil, errors.New("don't know how to read label selector")
+}
+
+// getLabelSelectorFromCronJob returns the selector used to match pods for a VPA targeting this CronJob.
+// Omitted template labels deserialize as nil; SetAsLabelSelector(nil) yields a nil LabelSelector and
+// LabelSelectorAsSelector(nil) is labels.Nothing(), which matches no pods (issue #9483). Controller
+// identity is already enforced by targetRef name/kind elsewhere, so an empty template label set
+// means any pod labels for this CronJob's workload.
+func getLabelSelectorFromCronJob(apiObj *batchv1.CronJob) (labels.Selector, error) {
+	templateLabels := apiObj.Spec.JobTemplate.Spec.Template.Labels
+	if len(templateLabels) == 0 {
+		return labels.Everything(), nil
+	}
+	return metav1.LabelSelectorAsSelector(metav1.SetAsLabelSelector(templateLabels))
 }
 
 func (f *vpaTargetSelectorFetcher) getLabelSelectorFromResource(

--- a/vertical-pod-autoscaler/pkg/target/fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vertical-pod-autoscaler/pkg/target/fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestGetLabelSelectorCronJobNilOrEmptyTemplateLabels(t *testing.T) {
+	t.Parallel()
+	for name, labelsMap := range map[string]map[string]string{
+		"nil labels":   nil,
+		"empty labels": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cj := &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cj"},
+				Spec: batchv1.CronJobSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{Labels: labelsMap},
+							},
+						},
+					},
+				},
+			}
+			sel, err := getLabelSelectorFromCronJob(cj)
+			require.NoError(t, err)
+			assert.True(t, sel.Matches(labels.Set{}), "pod with no labels should match")
+			assert.True(t, sel.Matches(labels.Set{"batch.kubernetes.io/job-name": "cj-123"}), "pod with controller labels should match")
+		})
+	}
+}
+
+func TestGetLabelSelectorCronJobNonEmptyTemplateLabels(t *testing.T) {
+	t.Parallel()
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cj"},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "longrunning"}},
+					},
+				},
+			},
+		},
+	}
+	sel, err := getLabelSelectorFromCronJob(cj)
+	require.NoError(t, err)
+	assert.True(t, sel.Matches(labels.Set{"app": "longrunning"}))
+	assert.False(t, sel.Matches(labels.Set{"app": "other"}))
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When a `CronJob` omits `spec.jobTemplate.spec.template.labels`, the field is `nil`. Building the selector via `metav1.SetAsLabelSelector(nil)` leads to `metav1.LabelSelectorAsSelector(nil)`, i.e. `labels.Nothing()`, so no pod matched the VPA despite correct `targetRef` and parent-controller association. This PR returns `labels.Everything()` when the job pod template labels are nil or empty, and adds unit tests in `pkg/target`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #9483

#### Special notes for your reviewer:

Aligns omitted labels with an explicit empty map `labels: {}` on the job pod template. If multiple VPAs in one namespace only differed by this path, recommender overlap was already possible with `{}`; this change makes nil behave the same.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed Vertical Pod Autoscaler not applying recommendations to pods from CronJobs whose job pod template labels were omitted (nil). VPA now matches those pods the same as when an empty label map is set.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```NONE
```