### PR TITLE
fix(comments): clarified comment for short circuiting logic for Eviction Requirements

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
@@ -81,7 +81,7 @@ func (s *scalingDirectionPodEvictionAdmission) checkEvictionRequirementsForConta
 			recommendedValue := recommendedResources[resource]
 			resultsForResources = append(resultsForResources, s.checkChangeRequirement(currentlyRequestedValue.MilliValue(), recommendedValue.MilliValue(), requirement.ChangeRequirement))
 		}
-		// *All* EvictionRequirements need to be evaluated to `true`, so if there's a single one which evaluates to `false`, we can exit here and don't admit the Container
+		// *All* EvictionRequirements need to be evaluated to `true`. Each requirement passes if *at least one* of its resources satisfies changeRequirement. So if there's a single EvictionRequirement which evaluates to `false` because none of its resources satisfies changeRequirement, we can exit here and don't admit the Container
 		if !slices.Contains(resultsForResources, true) {
 			return false
 		}

--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
@@ -81,7 +81,7 @@ func (s *scalingDirectionPodEvictionAdmission) checkEvictionRequirementsForConta
 			recommendedValue := recommendedResources[resource]
 			resultsForResources = append(resultsForResources, s.checkChangeRequirement(currentlyRequestedValue.MilliValue(), recommendedValue.MilliValue(), requirement.ChangeRequirement))
 		}
-		// *All* EvictionRequirements need to be evaluated to `true`, so if there's a single one which evaluates to `false`, we can exit here and don't admit the Container
+		// *All* EvictionRequirements need to be evaluated to `true`. Each requirement passes if *at least one* of its resources satisfies changeRequirement. So if there's a single EvictionRequirement which evaluates to `false` because none of its resources satisifes changeRequirement, we can exit here and don't admit the Container
 		if !slices.Contains(resultsForResources, true) {
 			return false
 		}

--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
@@ -81,7 +81,7 @@ func (s *scalingDirectionPodEvictionAdmission) checkEvictionRequirementsForConta
 			recommendedValue := recommendedResources[resource]
 			resultsForResources = append(resultsForResources, s.checkChangeRequirement(currentlyRequestedValue.MilliValue(), recommendedValue.MilliValue(), requirement.ChangeRequirement))
 		}
-		// *All* EvictionRequirements need to be evaluated to `true`. Each requirement passes if *at least one* of its resources satisfies changeRequirement. So if there's a single EvictionRequirement which evaluates to `false` because none of its resources satisifes changeRequirement, we can exit here and don't admit the Container
+		// *All* EvictionRequirements need to be evaluated to `true`, so if there's a single one which evaluates to `false`, we can exit here and don't admit the Container
 		if !slices.Contains(resultsForResources, true) {
 			return false
 		}


### PR DESCRIPTION
##### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation
/area vertical-pod-autoscaler

#### What this PR does / why we need it:

Clarifies comment logic.

In `vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go`:

```go
type EvictionRequirement struct {
	// Resources is a list of one or more resources that the condition applies
	// to. If more than one resource is given, the EvictionRequirement is fulfilled
	// if at least one resource meets `changeRequirement`.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9486

##### Release Note:
/release-note-none