### PR TITLE
VPA - Fix input into e2e functions

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/e2e/v1/updater.go
@@ -441,9 +441,9 @@ func setupPodsForEviction(f *framework.Framework, hamsterCPU, hamsterMemory stri
 		AppendRecommendation(
 			test.Recommendation().
 				WithContainer(containerName).
-				WithTarget(containerName, "200m").
-				WithLowerBound(containerName, "200m").
-				WithUpperBound(containerName, "200m").
+				WithTarget("200m", "200Mi").
+				WithLowerBound("200m", "200Mi").
+				WithUpperBound("200m", "200Mi").
 				GetContainerResources()).
 		Get()
 
@@ -485,9 +485,9 @@ func setupPodsForInPlace(f *framework.Framework, hamsterCPU, hamsterMemory strin
 		vpaBuilder = vpaBuilder.AppendRecommendation(
 			test.Recommendation().
 				WithContainer(containerName).
-				WithTarget(containerName, "200m").
-				WithLowerBound(containerName, "200m").
-				WithUpperBound(containerName, "200m").
+				WithTarget("200m", "200Mi").
+				WithLowerBound("200m", "200Mi").
+				WithUpperBound("200m", "200Mi").
 				GetContainerResources())
 	}
 


### PR DESCRIPTION
Passing container name is incorrect, and ends up with a target of "0"

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I was looking at a VPA e2e test, and I noticed that the CPU target was set to 0. 
It confused me and made me wonder if we had a bug somewhere.

After falling down a few rabbit holes, I found that this function wasn't being called correctly, so I figured I'd fix it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
