### PR TITLE
fix: respect resource quotas when balancing similar nodegroups

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -239,7 +239,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 		nodeGroups = appendCreatedNodeGroups(nodeGroups, oldId, createNodeGroupResults)
 	}
 
-	scaleUpInfos, aErr := o.balanceScaleUps(now, bestOption.NodeGroup, newNodes, nodeInfos, schedulablePodGroups)
+	scaleUpInfos, aErr := o.balanceScaleUps(now, bestOption.NodeGroup, newNodes, nodeInfos, schedulablePodGroups, tracker)
 	if aErr != nil {
 		return status.UpdateScaleUpError(
 			&status.ScaleUpStatus{CreateNodeGroupResults: createNodeGroupResults, PodsTriggeredScaleUp: bestOption.Pods},
@@ -725,6 +725,7 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 	newNodes int,
 	nodeInfos map[string]*framework.NodeInfo,
 	schedulablePodGroups map[string][]estimator.PodEquivalenceGroup,
+	tracker *resourcequotas.Tracker,
 ) ([]nodegroupset.ScaleUpInfo, errors.AutoscalerError) {
 	// Recompute similar node groups in case they need to be updated
 	similarNodeGroups := o.ComputeSimilarNodeGroups(nodeGroup, nodeInfos, schedulablePodGroups, now)
@@ -741,6 +742,21 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 		klog.V(2).Info("No similar node groups found")
 	}
 
+	// Filter out similar node groups that already exceed their quota.
+	var quotaValidGroups []cloudprovider.NodeGroup
+	for _, ng := range similarNodeGroups {
+		nodeInfo, found := nodeInfos[ng.Id()]
+		if !found {
+			continue
+		}
+		if skipReason := o.IsNodeGroupResourceExceeded(tracker, ng, nodeInfo, 1); skipReason != nil {
+			klog.V(2).Infof("Ignoring node group %s when balancing: quota exceeded", ng.Id())
+			continue
+		}
+		quotaValidGroups = append(quotaValidGroups, ng)
+	}
+	similarNodeGroups = quotaValidGroups
+
 	targetNodeGroups := []cloudprovider.NodeGroup{nodeGroup}
 	for _, ng := range similarNodeGroups {
 		targetNodeGroups = append(targetNodeGroups, ng)
@@ -753,7 +769,59 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 		}
 		klog.V(1).Infof("Splitting scale-up between %v similar node groups: {%v}", len(targetNodeGroups), strings.Join(names, ", "))
 	}
-	return o.processors.NodeGroupSetProcessor.BalanceScaleUpBetweenGroups(o.autoscalingCtx, targetNodeGroups, newNodes)
+	scaleUpInfos, aErr := o.processors.NodeGroupSetProcessor.BalanceScaleUpBetweenGroups(o.autoscalingCtx, targetNodeGroups, newNodes)
+	if aErr != nil {
+		return nil, aErr
+	}
+	return o.capScaleUpsByQuota(scaleUpInfos, nodeInfos, tracker), nil
+}
+
+// capScaleUpsByQuota caps each group's scale-up delta by its available quota and filters
+// out groups capped to zero. Uses ConsumeQuota to commit consumed quota so subsequent groups
+// sharing the same quota see the updated limits.
+// Note: unclaimed capacity from a capped group is not redistributed to other groups;
+// a group capped below its balanced delta may leave some pods unschedulable until the
+// next autoscaler cycle.
+func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
+	scaleUpInfos []nodegroupset.ScaleUpInfo,
+	nodeInfos map[string]*framework.NodeInfo,
+	tracker *resourcequotas.Tracker,
+) []nodegroupset.ScaleUpInfo {
+	for i := range scaleUpInfos {
+		sui := &scaleUpInfos[i]
+		delta := sui.NewSize - sui.CurrentSize
+		if delta <= 0 {
+			continue
+		}
+		nodeInfo, found := nodeInfos[sui.Group.Id()]
+		if !found {
+			continue
+		}
+		checkResult, err := tracker.CheckQuota(o.autoscalingCtx, sui.Group, nodeInfo.Node(), delta)
+		if err != nil {
+			klog.Errorf("Failed to check quota for balanced group %s: %v", sui.Group.Id(), err)
+			continue
+		}
+		allowedDelta := checkResult.AllowedDelta
+		if allowedDelta < delta {
+			klog.V(1).Infof("Capping scale-up of %s from %d to %d nodes due to quota", sui.Group.Id(), delta, allowedDelta)
+			sui.NewSize = sui.CurrentSize + allowedDelta
+		}
+		if allowedDelta > 0 {
+			if _, err := tracker.ConsumeQuota(o.autoscalingCtx, sui.Group, nodeInfo.Node(), allowedDelta); err != nil {
+				klog.Errorf("Failed to apply quota delta for balanced group %s: %v", sui.Group.Id(), err)
+			}
+		}
+	}
+
+	// Filter out groups that were capped to zero additional nodes by quota.
+	filtered := make([]nodegroupset.ScaleUpInfo, 0, len(scaleUpInfos))
+	for _, sui := range scaleUpInfos {
+		if sui.NewSize != sui.CurrentSize {
+			filtered = append(filtered, sui)
+		}
+	}
+	return filtered
 }
 
 // ComputeSimilarNodeGroups finds similar node groups which can schedule the same

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -1727,6 +1727,164 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 	}
 }
 
+func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialSizes  map[string]int
+		maxSize       int
+		quotas        []resourcequotas.Quota
+		expectedSizes map[string]int
+	}{
+		{
+			name:         "per-group quota caps one group",
+			initialSizes: map[string]int{"ng1": 1, "ng2": 1, "ng3": 1},
+			maxSize:      5,
+			quotas: []resourcequotas.Quota{
+				&resourcequotas.FakeQuota{
+					Name:        "quota-ng2",
+					AppliesToFn: matchNodeGroups([]string{"ng2"}),
+					LimitsVal:   map[string]int64{"cpu": 2},
+				},
+			},
+			// ng2 has 1 node (1 core), quota allows 2 cores → room for 1 more.
+			// Balance tries 2 each, ng2 capped to 1. ng1: 1→3, ng2: 1→2, ng3: 1→3.
+			expectedSizes: map[string]int{"ng1": 3, "ng2": 2, "ng3": 3},
+		},
+		{
+			name:         "shared quota including bestOption caps total before balancing",
+			initialSizes: map[string]int{"ng1": 1, "ng2": 2, "ng3": 2},
+			maxSize:      10,
+			quotas: []resourcequotas.Quota{
+				&resourcequotas.FakeQuota{
+					Name:        "shared-quota",
+					AppliesToFn: matchNodeGroups([]string{"ng1", "ng2", "ng3"}),
+					LimitsVal:   map[string]int64{"nodes": 6},
+				},
+			},
+			// 5 existing nodes, shared quota of 6 → room for 1. applyLimits caps total to 1.
+			// ng1 (size 1) is smallest, so balance assigns it the 1 node.
+			expectedSizes: map[string]int{"ng1": 2, "ng2": 2, "ng3": 2},
+		},
+		{
+			name:         "shared quota on similar groups only",
+			initialSizes: map[string]int{"ng1": 1, "ng2": 1, "ng3": 2},
+			maxSize:      10,
+			quotas: []resourcequotas.Quota{
+				&resourcequotas.FakeQuota{
+					Name:        "shared-quota-ng2-ng3",
+					AppliesToFn: matchNodeGroups([]string{"ng2", "ng3"}),
+					LimitsVal:   map[string]int64{"nodes": 4},
+				},
+			},
+			// Shared quota on ng2+ng3 (3 existing, limit 4, room for 1). ng1 uncapped.
+			// ng2 (size 1) is smaller than ng3 (size 2), so balance sorts ng2 first.
+			// ng2 gets the 1 quota slot via ApplyDelta; ng3 sees 0 remaining, capped.
+			expectedSizes: map[string]int{"ng1": 4, "ng2": 2, "ng3": 2},
+		},
+		{
+			name:         "pre-filter excludes group already at quota limit",
+			initialSizes: map[string]int{"ng1": 1, "ng2": 1, "ng3": 1},
+			maxSize:      5,
+			quotas: []resourcequotas.Quota{
+				&resourcequotas.FakeQuota{
+					Name:        "quota-ng2",
+					AppliesToFn: matchNodeGroups([]string{"ng2"}),
+					LimitsVal:   map[string]int64{"cpu": 1},
+				},
+			},
+			// ng2 has 1 node (1 core), quota allows 1 core → no room.
+			// Pre-filter excludes ng2 from balancing entirely. Only ng1 and ng3 participate.
+			expectedSizes: map[string]int{"ng1": 4, "ng2": 1, "ng3": 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleUp(func(string, int) error {
+				return nil
+			}).Build()
+
+			type ngInfo struct {
+				min, max, size int
+			}
+			testCfg := map[string]ngInfo{
+				"ng1": {min: 1, max: tt.maxSize, size: tt.initialSizes["ng1"]},
+				"ng2": {min: 1, max: tt.maxSize, size: tt.initialSizes["ng2"]},
+				"ng3": {min: 1, max: tt.maxSize, size: tt.initialSizes["ng3"]},
+			}
+			podList := make([]*apiv1.Pod, 0)
+			nodes := make([]*apiv1.Node, 0)
+
+			now := time.Now()
+
+			for gid, gconf := range testCfg {
+				provider.AddNodeGroup(gid, gconf.min, gconf.max, gconf.size)
+				for i := 0; i < gconf.size; i++ {
+					nodeName := fmt.Sprintf("%v-node-%v", gid, i)
+					node := BuildTestNode(nodeName, 100, 1000)
+					node.Labels[nodeGroupLabel] = gid
+					SetNodeReadyState(node, true, now.Add(-2*time.Minute))
+					nodes = append(nodes, node)
+
+					pod := BuildTestPod(fmt.Sprintf("%v-pod-%v", gid, i), 80, 0)
+					pod.Spec.NodeName = nodeName
+					podList = append(podList, pod)
+
+					provider.AddNode(gid, node)
+				}
+			}
+
+			podLister := kube_util.NewTestPodLister(podList)
+			listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
+
+			options := config.AutoscalingOptions{
+				EstimatorName:                  estimator.BinpackingEstimatorName,
+				BalanceSimilarNodeGroups:       true,
+				MaxCoresTotal:                  config.DefaultMaxClusterCores,
+				MaxMemoryTotal:                 config.DefaultMaxClusterMemory,
+				MaxNodeGroupBinpackingDuration: 1 * time.Second,
+			}
+			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
+			// Override NodeGroupSetProcessor to ignore nodeGroupLabel so ng1/ng2/ng3 are recognized as similar.
+			processors.NodeGroupSetProcessor = nodegroupset.NewDefaultNodeGroupSetProcessor([]string{nodeGroupLabel}, config.NodeGroupDifferenceRatios{})
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+			assert.NoError(t, err)
+			err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, podList, nil, nil)
+			assert.NoError(t, err)
+			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+			nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
+			clusterState := clusterstate.NewClusterStateRegistry(provider, clusterstate.ClusterStateRegistryConfig{}, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker())
+			clusterState.UpdateNodes(nodes, nodeInfos, time.Now())
+
+			pods := make([]*apiv1.Pod, 0)
+			for i := 0; i < 6; i++ {
+				pods = append(pods, BuildTestPod(fmt.Sprintf("test-pod-%v", i), 80, 0))
+			}
+
+			autoscalingCtx.ExpanderStrategy = NewMockReportingStrategy(t, &GroupSizeChange{GroupName: "ng1", SizeChange: 6}, nil)
+
+			cloudQuotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
+			fakeQuotasProvider := resourcequotas.NewFakeProvider(tt.quotas)
+			trackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
+				QuotaProvider:            resourcequotas.NewCombinedQuotasProvider([]resourcequotas.Provider{cloudQuotasProvider, fakeQuotasProvider}),
+				CustomResourcesProcessor: processors.CustomResourcesProcessor,
+			})
+			suOrchestrator := New()
+			suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
+			scaleUpStatus, typedErr := suOrchestrator.ScaleUp(pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+
+			assert.NoError(t, typedErr)
+			assert.True(t, scaleUpStatus.WasSuccessful())
+
+			for _, group := range provider.NodeGroups() {
+				size, err := group.TargetSize()
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedSizes[group.Id()], size, "unexpected size for %s", group.Id())
+			}
+		})
+	}
+}
+
 func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	createdGroups := make(chan string, 10)
 	expandedGroups := make(chan string, 10)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
[`balanceScaleUps`](https://github.com/kubernetes/autoscaler/blob/0f6d1785ae/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go#L722) distributes new nodes evenly across similar groups but does not check per-group resource quotas. This allows a group to receive more nodes than its quota permits.

The resource quotas system was introduced in [#8662](https://github.com/kubernetes/autoscaler/pull/8662) and integrated with scale-up in [#8835](https://github.com/kubernetes/autoscaler/pull/8835). The [`applyLimits`](https://github.com/kubernetes/autoscaler/blob/0f6d1785ae/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go#L310-L322) call before balancing only checks the bestOption group. After balancing redistributes nodes to similar groups, per-group quotas are not enforced.

This PR adds:
  1. A **post-balance capping loop** that checks each group's delta against the quota tracker. Uses `ApplyDelta` (not just `CheckDelta`) so consumed quota is committed and subsequent groups sharing the same quota see updated limits.
  2. A **pre-filter in `balanceScaleUps`** to exclude groups that already exceed their quota from participating in the balance.

Unclaimed capacity from a capped group is not redistributed. This is consistent with how `BalanceScaleUpBetweenGroups` handles `MaxSize` caps. The remaining pod is picked up in the next scaleup loop.

#### Testing
This change was deployed and validated on a cluster

I created a capacity quota like so:
```
 apiVersion: autoscaling.x-k8s.io/v1alpha1
 kind: CapacityQuota
 metadata:
   name: test-zone-limit
 spec:
   selector:
     matchLabels:
       topology.kubernetes.io/zone: "zone-a" 
   limits:
     resources:
       nodes: "20"
```
And I had 3 similar node groups, 1 in each zone. I triggered scaleups and confirmed "zone-a" stopped scaling up once it reached 20 nodes, whereas other zones were able to keep scaling.

Example log:
```
Capping scale-up of <redacted> from 9 to 3 nodes due to quota
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix BalanceSimilarNodeGroups bypassing resource quota checks during scale-up
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
