### PR TITLE
VPA recommender: add optional cluster matcher for Prometheus history

### DIFF
--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -121,8 +121,8 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `prometheus-bearer-token` | string |  | The bearer token used in the Prometheus server bearer token auth |
 | `prometheus-bearer-token-file` | string |  | Path to the bearer token file used for authentication by the Prometheus server |
 | `prometheus-cadvisor-job-name` | string |  "kubernetes-cadvisor" | Name of the prometheus job name which scrapes the cAdvisor metrics  |
-| `prometheus-cluster-id` | string |  | Cluster label value used to scope Prometheus history queries  |
-| `prometheus-cluster-label` | string |  | Label name used to identify cluster-scoped metrics in Prometheus history queries  |
+| `prometheus-cluster-id` | string |  | Cluster label value used to scope Prometheus history queries |
+| `prometheus-cluster-label` | string |  | Label name used to identify cluster-scoped metrics in Prometheus history queries |
 | `prometheus-insecure` |  |  | Skip tls verify if https is used in the prometheus-address |
 | `prometheus-query-timeout` | string |  "5m" | How long to wait before killing long queries  |
 | `recommendation-lower-bound-cpu-percentile` | float |  0.5 | CPU usage percentile that will be used for the lower bound on CPU recommendation.  |

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -121,6 +121,8 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `prometheus-bearer-token` | string |  | The bearer token used in the Prometheus server bearer token auth |
 | `prometheus-bearer-token-file` | string |  | Path to the bearer token file used for authentication by the Prometheus server |
 | `prometheus-cadvisor-job-name` | string |  "kubernetes-cadvisor" | Name of the prometheus job name which scrapes the cAdvisor metrics  |
+| `prometheus-cluster-id` | string |  | Cluster label value used to scope Prometheus history queries  |
+| `prometheus-cluster-label` | string |  | Label name used to identify cluster-scoped metrics in Prometheus history queries  |
 | `prometheus-insecure` |  |  | Skip tls verify if https is used in the prometheus-address |
 | `prometheus-query-timeout` | string |  "5m" | How long to wait before killing long queries  |
 | `recommendation-lower-bound-cpu-percentile` | float |  0.5 | CPU usage percentile that will be used for the lower bound on CPU recommendation.  |

--- a/vertical-pod-autoscaler/pkg/recommender/config/config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config.go
@@ -69,6 +69,8 @@ type RecommenderConfig struct {
 	PrometheusAddress         string
 	PrometheusInsecure        bool
 	PrometheusJobName         string
+	PrometheusClusterLabel    string
+	PrometheusClusterID       string
 	HistoryLength             string
 	HistoryResolution         string
 	HistoryCPUMetric          string
@@ -141,6 +143,8 @@ func DefaultRecommenderConfig() *RecommenderConfig {
 		PrometheusAddress:         "http://prometheus.monitoring.svc",
 		PrometheusInsecure:        false,
 		PrometheusJobName:         "kubernetes-cadvisor",
+		PrometheusClusterLabel:    "",
+		PrometheusClusterID:       "",
 		HistoryLength:             "8d",
 		HistoryResolution:         "1h",
 		HistoryCPUMetric:          "container_cpu_usage_seconds_total",
@@ -214,6 +218,8 @@ func InitRecommenderFlags() *RecommenderConfig {
 	flag.StringVar(&config.PrometheusAddress, "prometheus-address", config.PrometheusAddress, `Where to reach for Prometheus metrics`)
 	flag.BoolVar(&config.PrometheusInsecure, "prometheus-insecure", config.PrometheusInsecure, `Skip tls verify if https is used in the prometheus-address`)
 	flag.StringVar(&config.PrometheusJobName, "prometheus-cadvisor-job-name", config.PrometheusJobName, `Name of the prometheus job name which scrapes the cAdvisor metrics`)
+	flag.StringVar(&config.PrometheusClusterLabel, "prometheus-cluster-label", config.PrometheusClusterLabel, `Label name used to identify cluster-scoped metrics in Prometheus history queries`)
+	flag.StringVar(&config.PrometheusClusterID, "prometheus-cluster-id", config.PrometheusClusterID, `Cluster label value used to scope Prometheus history queries`)
 	flag.StringVar(&config.HistoryLength, "history-length", config.HistoryLength, `How much time back prometheus have to be queried to get historical metrics`)
 	flag.StringVar(&config.HistoryResolution, "history-resolution", config.HistoryResolution, `Resolution at which Prometheus is queried for historical metrics`)
 	flag.StringVar(&config.HistoryCPUMetric, "history-cpu-metric", config.HistoryCPUMetric, `Name of the metric to use for CPU history when querying Prometheus.`)
@@ -273,6 +279,11 @@ func ValidateRecommenderConfig(config *RecommenderConfig) {
 
 	if config.PrometheusBearerToken != "" && config.PrometheusBearerTokenFile != "" && config.Username != "" {
 		klog.ErrorS(nil, "--bearer-token, --bearer-token-file and --username are mutually exclusive and can't be set together.")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
+
+	if (config.PrometheusClusterLabel == "") != (config.PrometheusClusterID == "") {
+		klog.ErrorS(nil, "--prometheus-cluster-label and --prometheus-cluster-id must be set together")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -89,6 +91,7 @@ type PrometheusHistoryProviderConfig struct {
 	PodLabelPrefix, PodLabelsMetricName              string
 	PodNamespaceLabel, PodNameLabel                  string
 	CtrNamespaceLabel, CtrPodNameLabel, CtrNameLabel string
+	ClusterLabel, ClusterID                          string
 	CadvisorMetricsJobName                           string
 	Namespace                                        string
 	CPUMetricName, MemoryMetricName                  string
@@ -327,47 +330,189 @@ func (p *prometheusHistoryProvider) readLastLabels(res map[model.PodID]*PodHisto
 	if err != nil {
 		return fmt.Errorf("cannot get timeseries for labels: %v", err)
 	}
-
-	matrix, ok := result.(prommodel.Matrix)
-	if !ok {
-		return fmt.Errorf("expected query to return a matrix; got result type %T", result)
-	}
-
-	for _, ts := range matrix {
-		podID, err := p.getPodIDFromLabels(ts.Metric)
-		if err != nil {
-			return fmt.Errorf("cannot get container ID from labels %v: %v", ts.Metric, err)
+	switch value := result.(type) {
+	case prommodel.Vector:
+		for _, sample := range value {
+			if err := p.updatePodLabelsFromMetric(res, sample.Metric, sample.Timestamp.Time()); err != nil {
+				return err
+			}
 		}
-		podHistory, ok := res[*podID]
-		if !ok {
-			podHistory = newEmptyHistory()
-			res[*podID] = podHistory
+	case prommodel.Matrix:
+		for _, ts := range value {
+			// time series results will always be sorted chronologically from oldest to
+			// newest, so the last element is the latest sample
+			lastSample := ts.Values[len(ts.Values)-1]
+			if err := p.updatePodLabelsFromMetric(res, ts.Metric, lastSample.Timestamp.Time()); err != nil {
+				return err
+			}
 		}
-		podLabels := p.getPodLabelsMap(ts.Metric)
-
-		// time series results will always be sorted chronologically from oldest to
-		// newest, so the last element is the latest sample
-		lastSample := ts.Values[len(ts.Values)-1]
-		if lastSample.Timestamp.Time().After(podHistory.LastSeen) {
-			podHistory.LastSeen = lastSample.Timestamp.Time()
-			podHistory.LastLabels = podLabels
-		}
+	default:
+		return fmt.Errorf("expected query to return a matrix or vector; got result type %T", result)
 	}
 	return nil
 }
 
+func (p *prometheusHistoryProvider) updatePodLabelsFromMetric(res map[model.PodID]*PodHistory, metric prommodel.Metric, sampleTime time.Time) error {
+	if p.config.ClusterLabel != "" {
+		clusterLabelValue, ok := metric[prommodel.LabelName(p.config.ClusterLabel)]
+		if !ok || string(clusterLabelValue) != p.config.ClusterID {
+			return nil
+		}
+	}
+	podID, err := p.getPodIDFromLabels(metric)
+	if err != nil {
+		return fmt.Errorf("cannot get container ID from labels %v: %v", metric, err)
+	}
+	podHistory, ok := res[*podID]
+	if !ok {
+		podHistory = newEmptyHistory()
+		res[*podID] = podHistory
+	}
+	podLabels := p.getPodLabelsMap(metric)
+	if sampleTime.After(podHistory.LastSeen) {
+		podHistory.LastSeen = sampleTime
+		podHistory.LastLabels = podLabels
+	}
+	return nil
+}
+
+type clusterMatcherStatus int
+
+const (
+	clusterMatcherMissing clusterMatcherStatus = iota
+	clusterMatcherCompatible
+	clusterMatcherIncompatible
+)
+
+var metricNamePattern = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+
+func matchRegexOperator(expr, clusterID string) (bool, error) {
+	compiled, err := regexp.Compile("^(?:" + expr + ")$")
+	if err != nil {
+		return false, fmt.Errorf("invalid regex matcher %q: %v", expr, err)
+	}
+	return compiled.MatchString(clusterID), nil
+}
+
+func isRegexExactlyClusterID(expr, clusterID string) bool {
+	trimmed := strings.TrimSpace(expr)
+	escapedClusterID := regexp.QuoteMeta(clusterID)
+	return trimmed == escapedClusterID || trimmed == "^"+escapedClusterID+"$"
+}
+
+func isStrictClusterRegex(expr, clusterID string) (bool, error) {
+	matchesClusterID, err := matchRegexOperator(expr, clusterID)
+	if err != nil {
+		return false, err
+	}
+	if !matchesClusterID {
+		return false, nil
+	}
+	return isRegexExactlyClusterID(expr, clusterID), nil
+}
+
+func getClusterMatcherStatus(selector, clusterLabel, clusterID string) (clusterMatcherStatus, error) {
+	escapedLabel := regexp.QuoteMeta(clusterLabel)
+	matcherPattern := fmt.Sprintf(`(^|,)\s*%s\s*(=~|!~|=|!=)\s*"(?:[^"\\]|\\.)*"\s*(,|$)`, escapedLabel)
+	matcherRegex := regexp.MustCompile(matcherPattern)
+	matches := matcherRegex.FindAllStringSubmatch(selector, -1)
+	if len(matches) == 0 {
+		return clusterMatcherMissing, nil
+	}
+	if len(matches) > 1 {
+		return clusterMatcherIncompatible, fmt.Errorf("pod label query selector %q contains multiple matchers for label %q", selector, clusterLabel)
+	}
+
+	fullMatcher := strings.TrimSpace(matches[0][0])
+	operator := matches[0][2]
+	valueRegex := regexp.MustCompile(`"(?:[^"\\]|\\.)*"`)
+	quotedValue := valueRegex.FindString(fullMatcher)
+	if quotedValue == "" {
+		return clusterMatcherIncompatible, fmt.Errorf("pod label query selector %q has invalid matcher for label %q", selector, clusterLabel)
+	}
+	rawValue, err := strconv.Unquote(quotedValue)
+	if err != nil {
+		return clusterMatcherIncompatible, fmt.Errorf("cannot parse matcher value %q for label %q: %v", quotedValue, clusterLabel, err)
+	}
+
+	switch operator {
+	case "=":
+		if rawValue == clusterID {
+			return clusterMatcherCompatible, nil
+		}
+		return clusterMatcherIncompatible, nil
+	case "!=":
+		return clusterMatcherIncompatible, nil
+	case "=~":
+		isStrictMatcher, err := isStrictClusterRegex(rawValue, clusterID)
+		if err != nil {
+			return clusterMatcherIncompatible, err
+		}
+		if isStrictMatcher {
+			return clusterMatcherCompatible, nil
+		}
+		return clusterMatcherIncompatible, nil
+	case "!~":
+		return clusterMatcherIncompatible, nil
+	default:
+		return clusterMatcherIncompatible, fmt.Errorf("unsupported operator %q for label %q", operator, clusterLabel)
+	}
+}
+
+func (p *prometheusHistoryProvider) getClusterScopedPodLabelsQuery() (string, error) {
+	query := strings.TrimSpace(p.config.PodLabelsMetricName)
+	if p.config.ClusterLabel == "" {
+		return query, nil
+	}
+
+	clusterMatcher := fmt.Sprintf(`%s="%s"`, p.config.ClusterLabel, p.config.ClusterID)
+	open := strings.Index(query, "{")
+	close := strings.LastIndex(query, "}")
+	if open == -1 && close == -1 {
+		// Plain metric names (for example "up") are valid selector queries.
+		// Convert them into an explicitly cluster-scoped selector.
+		if metricNamePattern.MatchString(query) {
+			return fmt.Sprintf(`%s{%s}`, query, clusterMatcher), nil
+		}
+		return "", fmt.Errorf("cannot inject cluster matcher into pod label query %q", query)
+	}
+	if open == -1 || close == -1 || close < open {
+		return "", fmt.Errorf("cannot inject cluster matcher into pod label query %q", query)
+	}
+
+	selector := strings.TrimSpace(query[open+1 : close])
+	matcherStatus, err := getClusterMatcherStatus(selector, p.config.ClusterLabel, p.config.ClusterID)
+	if err != nil {
+		return "", err
+	}
+	if matcherStatus == clusterMatcherCompatible {
+		return query, nil
+	}
+
+	if selector == "" {
+		return query[:open+1] + clusterMatcher + query[close:], nil
+	}
+	return query[:close] + ", " + clusterMatcher + query[close:], nil
+}
+
 func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHistory, error) {
 	res := make(map[model.PodID]*PodHistory)
-	var podSelector string
+
+	selectorParts := []string{}
 	if p.config.CadvisorMetricsJobName != "" {
-		podSelector = fmt.Sprintf("job=\"%s\", ", p.config.CadvisorMetricsJobName)
+		selectorParts = append(selectorParts, fmt.Sprintf("job=\"%s\"", p.config.CadvisorMetricsJobName))
 	}
-	podSelector = podSelector + fmt.Sprintf("%s=~\".+\", %s!=\"POD\", %s!=\"\"",
-		p.config.CtrPodNameLabel, p.config.CtrNameLabel, p.config.CtrNameLabel)
+	if p.config.ClusterLabel != "" {
+		selectorParts = append(selectorParts, fmt.Sprintf("%s=\"%s\"", p.config.ClusterLabel, p.config.ClusterID))
+	}
+	selectorParts = append(selectorParts, fmt.Sprintf("%s=~\".+\"", p.config.CtrPodNameLabel))
+	selectorParts = append(selectorParts, fmt.Sprintf("%s!=\"POD\"", p.config.CtrNameLabel))
+	selectorParts = append(selectorParts, fmt.Sprintf("%s!=\"\"", p.config.CtrNameLabel))
 
 	if p.config.Namespace != "" {
-		podSelector = fmt.Sprintf("%s, %s=\"%s\"", podSelector, p.config.CtrNamespaceLabel, p.config.Namespace)
+		selectorParts = append(selectorParts, fmt.Sprintf("%s=\"%s\"", p.config.CtrNamespaceLabel, p.config.Namespace))
 	}
+	podSelector := strings.Join(selectorParts, ", ")
 	historicalCpuQuery := fmt.Sprintf("rate(%s{%s}[%s])", p.config.CPUMetricName, podSelector, p.config.HistoryResolution)
 	klog.V(4).InfoS("Historical CPU usage query", "query", historicalCpuQuery)
 	err := p.readResourceHistory(res, historicalCpuQuery, model.ResourceCPU)
@@ -386,7 +531,11 @@ func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHis
 			sort.Slice(samples, func(i, j int) bool { return samples[i].MeasureStart.Before(samples[j].MeasureStart) })
 		}
 	}
-	err = p.readLastLabels(res, p.config.PodLabelsMetricName)
+	labelsQuery, err := p.getClusterScopedPodLabelsQuery()
+	if err != nil {
+		return nil, fmt.Errorf("cannot scope pod labels query by cluster: %v", err)
+	}
+	err = p.readLastLabels(res, labelsQuery)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read last labels: %v", err)
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -467,8 +467,8 @@ func (p *prometheusHistoryProvider) getClusterScopedPodLabelsQuery() (string, er
 
 	clusterMatcher := fmt.Sprintf(`%s="%s"`, p.config.ClusterLabel, p.config.ClusterID)
 	open := strings.Index(query, "{")
-	close := strings.LastIndex(query, "}")
-	if open == -1 && close == -1 {
+	selectorEnd := strings.LastIndex(query, "}")
+	if open == -1 && selectorEnd == -1 {
 		// Plain metric names (for example "up") are valid selector queries.
 		// Convert them into an explicitly cluster-scoped selector.
 		if metricNamePattern.MatchString(query) {
@@ -476,11 +476,11 @@ func (p *prometheusHistoryProvider) getClusterScopedPodLabelsQuery() (string, er
 		}
 		return "", fmt.Errorf("cannot inject cluster matcher into pod label query %q", query)
 	}
-	if open == -1 || close == -1 || close < open {
+	if open == -1 || selectorEnd == -1 || selectorEnd < open {
 		return "", fmt.Errorf("cannot inject cluster matcher into pod label query %q", query)
 	}
 
-	selector := strings.TrimSpace(query[open+1 : close])
+	selector := strings.TrimSpace(query[open+1 : selectorEnd])
 	matcherStatus, err := getClusterMatcherStatus(selector, p.config.ClusterLabel, p.config.ClusterID)
 	if err != nil {
 		return "", err
@@ -490,9 +490,9 @@ func (p *prometheusHistoryProvider) getClusterScopedPodLabelsQuery() (string, er
 	}
 
 	if selector == "" {
-		return query[:open+1] + clusterMatcher + query[close:], nil
+		return query[:open+1] + clusterMatcher + query[selectorEnd:], nil
 	}
-	return query[:close] + ", " + clusterMatcher + query[close:], nil
+	return query[:selectorEnd] + ", " + clusterMatcher + query[selectorEnd:], nil
 }
 
 func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHistory, error) {

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -33,11 +33,14 @@ import (
 )
 
 const (
-	cpuQuery              = "rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}[30s])"
-	memoryQuery           = "container_memory_working_set_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}"
-	labelsQuery           = "up{job=\"kubernetes-pods\"}"
-	cpuNamespacedQuery    = "rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\", namespace=\"kube-system\"}[30s])"
-	memoryNamespacedQuery = "container_memory_working_set_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\", namespace=\"kube-system\"}"
+	cpuQuery                 = "rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}[30s])"
+	memoryQuery              = "container_memory_working_set_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}"
+	labelsQuery              = "up{job=\"kubernetes-pods\"}"
+	clusterScopedLabelsQuery = "up{job=\"kubernetes-pods\", cluster=\"cluster-a\"}"
+	clusterScopedCPUQuery    = "rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", cluster=\"cluster-a\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}[30s])"
+	clusterScopedMemQuery    = "container_memory_working_set_bytes{job=\"kubernetes-cadvisor\", cluster=\"cluster-a\", pod_name=~\".+\", name!=\"POD\", name!=\"\"}"
+	cpuNamespacedQuery       = "rate(container_cpu_usage_seconds_total{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\", namespace=\"kube-system\"}[30s])"
+	memoryNamespacedQuery    = "container_memory_working_set_bytes{job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\", namespace=\"kube-system\"}"
 )
 
 func getDefaultPrometheusHistoryProviderConfigForTest() PrometheusHistoryProviderConfig {
@@ -52,6 +55,8 @@ func getDefaultPrometheusHistoryProviderConfigForTest() PrometheusHistoryProvide
 		CtrNamespaceLabel:      "namespace",
 		CtrPodNameLabel:        "pod_name",
 		CtrNameLabel:           "name",
+		ClusterLabel:           "",
+		ClusterID:              "",
 		CadvisorMetricsJobName: "kubernetes-cadvisor",
 		CPUMetricName:          "container_cpu_usage_seconds_total",
 		MemoryMetricName:       "container_memory_working_set_bytes",
@@ -163,7 +168,7 @@ func TestGetEmptyClusterHistory(t *testing.T) {
 		prometheusClient: &mockClient,
 	}
 	mockClient.On("Query", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("time.Time")).Times(1).Return(
-		prommodel.Matrix{}, nil)
+		prommodel.Vector{}, nil)
 	mockClient.On("QueryRange", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("v1.Range")).Return().Times(2).Return(
 		prommodel.Matrix{}, nil)
 	tss, err := historyProvider.GetClusterHistory()
@@ -208,7 +213,7 @@ func TestGetCPUSamples(t *testing.T) {
 		},
 		nil)
 	mockClient.On("QueryRange", mock.Anything, memoryQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
-	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Matrix{}, nil)
+	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Vector{}, nil)
 	podID := model.PodID{Namespace: "default", PodName: "pod"}
 	podHistory := &PodHistory{
 		LastLabels: map[string]string{},
@@ -246,7 +251,7 @@ func TestGetMemorySamples(t *testing.T) {
 				},
 			},
 		}, nil)
-	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Matrix{}, nil)
+	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Vector{}, nil)
 	podID := model.PodID{Namespace: "default", PodName: "pod"}
 	podHistory := &PodHistory{
 		LastLabels: map[string]string{},
@@ -287,7 +292,7 @@ func TestGetNamespacedMemorySamples(t *testing.T) {
 				},
 			},
 		}, nil)
-	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Matrix{}, nil)
+	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Vector{}, nil)
 	podID := model.PodID{Namespace: "kube-system", PodName: "pod"}
 	podHistory := &PodHistory{
 		LastLabels: map[string]string{},
@@ -311,19 +316,15 @@ func TestGetLabels(t *testing.T) {
 	mockClient.On("QueryRange", mock.Anything, cpuQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
 	mockClient.On("QueryRange", mock.Anything, memoryQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
 	mockClient.On("Query", mock.Anything, labelsQuery, mock.AnythingOfType("time.Time")).Return(
-		prommodel.Matrix{
+		prommodel.Vector{
 			{
 				Metric: map[prommodel.LabelName]prommodel.LabelValue{
 					"kubernetes_namespace": "default",
 					"kubernetes_pod_name":  "pod",
 					"pod_label_x":          "y",
 				},
-				Values: []prommodel.SamplePair{
-					{
-						Timestamp: prommodel.TimeFromUnix(1),
-						Value:     12345,
-					},
-				},
+				Timestamp: prommodel.TimeFromUnix(1),
+				Value:     12345,
 			},
 			{
 				Metric: map[prommodel.LabelName]prommodel.LabelValue{
@@ -331,12 +332,8 @@ func TestGetLabels(t *testing.T) {
 					"kubernetes_pod_name":  "pod",
 					"pod_label_x":          "z",
 				},
-				Values: []prommodel.SamplePair{
-					{
-						Timestamp: prommodel.TimeFromUnix(20),
-						Value:     12345,
-					},
-				},
+				Timestamp: prommodel.TimeFromUnix(20),
+				Value:     12345,
 			},
 		}, nil)
 	podID := model.PodID{Namespace: "default", PodName: "pod"}
@@ -348,6 +345,180 @@ func TestGetLabels(t *testing.T) {
 	histories, err := historyProvider.GetClusterHistory()
 	assert.Nil(t, err)
 	assert.Equal(t, histories, map[model.PodID]*PodHistory{podID: podHistory})
+}
+
+func TestGetClusterScopedQueries(t *testing.T) {
+	mockClient := mockPrometheusAPI{}
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	historyProvider := prometheusHistoryProvider{
+		config:           promConfig,
+		prometheusClient: &mockClient,
+	}
+
+	mockClient.On("QueryRange", mock.Anything, clusterScopedCPUQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("QueryRange", mock.Anything, clusterScopedMemQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("Query", mock.Anything, clusterScopedLabelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Vector{}, nil)
+	_, err := historyProvider.GetClusterHistory()
+	assert.Nil(t, err)
+}
+
+func TestGetClusterScopedLabels(t *testing.T) {
+	mockClient := mockPrometheusAPI{}
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	historyProvider := prometheusHistoryProvider{
+		config:           promConfig,
+		prometheusClient: &mockClient,
+	}
+
+	mockClient.On("QueryRange", mock.Anything, clusterScopedCPUQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("QueryRange", mock.Anything, clusterScopedMemQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("Query", mock.Anything, clusterScopedLabelsQuery, mock.AnythingOfType("time.Time")).Return(
+		prommodel.Vector{
+			{
+				Metric: map[prommodel.LabelName]prommodel.LabelValue{
+					"cluster":              "cluster-b",
+					"kubernetes_namespace": "default",
+					"kubernetes_pod_name":  "pod-b",
+					"pod_label_x":          "b",
+				},
+				Timestamp: prommodel.TimeFromUnix(1),
+				Value:     1,
+			},
+			{
+				Metric: map[prommodel.LabelName]prommodel.LabelValue{
+					"cluster":              "cluster-a",
+					"kubernetes_namespace": "default",
+					"kubernetes_pod_name":  "pod-a",
+					"pod_label_x":          "a",
+				},
+				Timestamp: prommodel.TimeFromUnix(2),
+				Value:     1,
+			},
+		}, nil)
+
+	histories, err := historyProvider.GetClusterHistory()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(histories))
+	_, ok := histories[model.PodID{Namespace: "default", PodName: "pod-a"}]
+	assert.True(t, ok)
+}
+
+func TestGetClusterScopedLabelsQueryPlainMetricName(t *testing.T) {
+	mockClient := mockPrometheusAPI{}
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	promConfig.PodLabelsMetricName = "up"
+	historyProvider := prometheusHistoryProvider{
+		config:           promConfig,
+		prometheusClient: &mockClient,
+	}
+
+	mockClient.On("QueryRange", mock.Anything, clusterScopedCPUQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("QueryRange", mock.Anything, clusterScopedMemQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("Query", mock.Anything, `up{cluster="cluster-a"}`, mock.AnythingOfType("time.Time")).Return(prommodel.Vector{}, nil)
+	_, err := historyProvider.GetClusterHistory()
+	assert.Nil(t, err)
+}
+
+func TestGetClusterScopedLabelsQueryInjectionFailure(t *testing.T) {
+	mockClient := mockPrometheusAPI{}
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	promConfig.PodLabelsMetricName = "sum(up)"
+	historyProvider := prometheusHistoryProvider{
+		config:           promConfig,
+		prometheusClient: &mockClient,
+	}
+
+	mockClient.On("QueryRange", mock.Anything, clusterScopedCPUQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("QueryRange", mock.Anything, clusterScopedMemQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	_, err := historyProvider.GetClusterHistory()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot scope pod labels query by cluster")
+}
+
+func TestGetClusterScopedLabelsQueryAlreadyContainsMatcher(t *testing.T) {
+	mockClient := mockPrometheusAPI{}
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	promConfig.PodLabelsMetricName = clusterScopedLabelsQuery
+	historyProvider := prometheusHistoryProvider{
+		config:           promConfig,
+		prometheusClient: &mockClient,
+	}
+
+	mockClient.On("QueryRange", mock.Anything, clusterScopedCPUQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("QueryRange", mock.Anything, clusterScopedMemQuery, mock.AnythingOfType("v1.Range")).Return().Return(prommodel.Matrix{}, nil)
+	mockClient.On("Query", mock.Anything, clusterScopedLabelsQuery, mock.AnythingOfType("time.Time")).Return(prommodel.Vector{}, nil)
+	_, err := historyProvider.GetClusterHistory()
+	assert.Nil(t, err)
+}
+
+func TestGetClusterScopedPodLabelsQueryWhitespaceMatcher(t *testing.T) {
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	promConfig.PodLabelsMetricName = `up{job="kubernetes-pods",  cluster = "cluster-a"}`
+	historyProvider := prometheusHistoryProvider{config: promConfig}
+
+	query, err := historyProvider.getClusterScopedPodLabelsQuery()
+	assert.Nil(t, err)
+	assert.Equal(t, promConfig.PodLabelsMetricName, query)
+}
+
+func TestGetClusterScopedPodLabelsQueryRegexMatcher(t *testing.T) {
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	promConfig.PodLabelsMetricName = `up{job="kubernetes-pods", cluster=~"cluster-a|cluster-b"}`
+	historyProvider := prometheusHistoryProvider{config: promConfig}
+
+	query, err := historyProvider.getClusterScopedPodLabelsQuery()
+	assert.Nil(t, err)
+	assert.Equal(t, `up{job="kubernetes-pods", cluster=~"cluster-a|cluster-b", cluster="cluster-a"}`, query)
+}
+
+func TestGetClusterScopedPodLabelsQueryStrictRegexMatcher(t *testing.T) {
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	promConfig.PodLabelsMetricName = `up{job="kubernetes-pods", cluster=~"^cluster-a$"}`
+	historyProvider := prometheusHistoryProvider{config: promConfig}
+
+	query, err := historyProvider.getClusterScopedPodLabelsQuery()
+	assert.Nil(t, err)
+	assert.Equal(t, promConfig.PodLabelsMetricName, query)
+}
+
+func TestGetClusterScopedPodLabelsQueryConflictingMatcher(t *testing.T) {
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	promConfig.PodLabelsMetricName = `up{job="kubernetes-pods", cluster=~"cluster-b|cluster-c"}`
+	historyProvider := prometheusHistoryProvider{config: promConfig}
+
+	query, err := historyProvider.getClusterScopedPodLabelsQuery()
+	assert.Nil(t, err)
+	assert.Equal(t, `up{job="kubernetes-pods", cluster=~"cluster-b|cluster-c", cluster="cluster-a"}`, query)
+}
+
+func TestGetClusterScopedPodLabelsQueryNegativeMatcher(t *testing.T) {
+	promConfig := getDefaultPrometheusHistoryProviderConfigForTest()
+	promConfig.ClusterLabel = "cluster"
+	promConfig.ClusterID = "cluster-a"
+	promConfig.PodLabelsMetricName = `up{job="kubernetes-pods", cluster!="cluster-b"}`
+	historyProvider := prometheusHistoryProvider{config: promConfig}
+
+	query, err := historyProvider.getClusterScopedPodLabelsQuery()
+	assert.Nil(t, err)
+	assert.Equal(t, `up{job="kubernetes-pods", cluster!="cluster-b", cluster="cluster-a"}`, query)
 }
 
 func TestPrometheusAuth(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -272,6 +272,8 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
 			CtrNamespaceLabel:      config.CtrNamespaceLabel,
 			CtrPodNameLabel:        config.CtrPodNameLabel,
 			CtrNameLabel:           config.CtrNameLabel,
+			ClusterLabel:           config.PrometheusClusterLabel,
+			ClusterID:              config.PrometheusClusterID,
 			CadvisorMetricsJobName: config.PrometheusJobName,
 			Namespace:              commonFlag.VpaObjectNamespace,
 			Authentication: history.PrometheusCredentials{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind api-change

#### What this PR does / why we need it:
Adds optional VPA recommender flags to scope Prometheus history queries to a specific cluster when using shared multi-cluster backends (e.g., Thanos).

This addresses cross-cluster metric mixing in `--storage=prometheus` mode by wiring:
- `--prometheus-cluster-label`
- `--prometheus-cluster-id`

When set together, CPU and memory history queries include the matcher, and the pod-label query path (`--metric-for-pod-labels`) is cluster-scoped as well.

#### Which issue(s) this PR fixes:
Fixes #9491

#### Special notes for your reviewer:
Implementation details that may look non-obvious:
- **Both flags required together**: config validation fails fast if only one of label/id is set, to avoid partial scoping mistakes.
- **Backward compatibility**: if cluster flags are unset, behavior is unchanged.
- **Pod-label query handling (`--metric-for-pod-labels`)**:
  - Supports plain metric names (e.g., `up`) by rewriting to a scoped selector.
  - Preserves existing exact cluster matcher as-is.
  - For existing non-exact matchers (e.g., `=~`, `!=`, `!~`), appends exact matcher (`cluster=\"<id>\"`) to safely narrow via PromQL intersection instead of failing startup.
  - Keeps fail-fast behavior only for structurally non-injectable expressions.
- **Label fetch performance**: keeps pod label fetch as instant `Query` (not `QueryRange`) and supports both vector/matrix result types to avoid historical over-scan regressions.
- **Defense in depth**: retains client-side filtering by cluster label while also enforcing query-side scoping.

#### Does this PR introduce a user-facing change?
```release-note
VPA recommender now supports optional Prometheus cluster scoping flags in `--storage=prometheus` mode: `--prometheus-cluster-label` and `--prometheus-cluster-id`.
When both are set, Prometheus history queries for CPU, memory, and pod labels are scoped to the selected cluster to avoid cross-cluster metric mixing with shared backends.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [Issue context]: https://github.com/kubernetes/autoscaler/issues/9491
- [Usage]: `vertical-pod-autoscaler/docs/flags.md` updated with new recommender flags.
```