### PR TITLE
clean up clusterapi imports

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_processors.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_processors.go
@@ -17,7 +17,7 @@ limitations under the License.
 package clusterapi
 
 import (
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	klog "k8s.io/klog/v2"
@@ -37,14 +37,14 @@ func NewScaleDownNodeUpgradeProcessor(c *machineController) *ScaleDownNodeUpgrad
 
 // GetPodDestinationCandidates returns nodes as is no processing is required here
 func (p *ScaleDownNodeUpgradeProcessor) GetPodDestinationCandidates(ctx *context.AutoscalingContext,
-	nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	nodes []*corev1.Node) ([]*corev1.Node, errors.AutoscalerError) {
 	return nodes, nil
 }
 
 // GetScaleDownCandidates returns filter nodes based on if scale down is enabled or disabled per nodegroup.
 func (p *ScaleDownNodeUpgradeProcessor) GetScaleDownCandidates(ctx *context.AutoscalingContext,
-	nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
-	result := []*apiv1.Node{}
+	nodes []*corev1.Node) ([]*corev1.Node, errors.AutoscalerError) {
+	result := []*corev1.Node{}
 
 	for _, node := range nodes {
 		// check scale down, continue if not good

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	apiv1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -227,8 +226,8 @@ func (r *unstructuredScalableResource) Labels() map[string]string {
 	return allLabels
 }
 
-func (r *unstructuredScalableResource) Taints() []apiv1.Taint {
-	var allTaints []apiv1.Taint
+func (r *unstructuredScalableResource) Taints() []corev1.Taint {
+	var allTaints []corev1.Taint
 
 	// Read taints from spec.template.spec.taints. Requires CAPI v1.12+ with the
 	// MachineTaintPropagation feature gate enabled.
@@ -238,7 +237,7 @@ func (r *unstructuredScalableResource) Taints() []apiv1.Taint {
 			if !ok {
 				continue
 			}
-			taint := apiv1.Taint{}
+			taint := corev1.Taint{}
 			if key, ok := taintMap["key"].(string); ok {
 				taint.Key = key
 			}
@@ -246,7 +245,7 @@ func (r *unstructuredScalableResource) Taints() []apiv1.Taint {
 				taint.Value = value
 			}
 			if effect, ok := taintMap["effect"].(string); ok {
-				taint.Effect = apiv1.TaintEffect(effect)
+				taint.Effect = corev1.TaintEffect(effect)
 			}
 			allTaints = append(allTaints, taint)
 		}
@@ -376,7 +375,7 @@ func (r *unstructuredScalableResource) InstanceCapacity() (map[corev1.ResourceNa
 
 // InstanceSystemInfo sets the nodeSystemInfo from the infrastructure reference resource.
 // If the infrastructure reference resource is not found, returns nil.
-func (r *unstructuredScalableResource) InstanceSystemInfo() *apiv1.NodeSystemInfo {
+func (r *unstructuredScalableResource) InstanceSystemInfo() *corev1.NodeSystemInfo {
 	infraObj, err := r.readInfrastructureReferenceResource()
 	if err != nil || infraObj == nil {
 		return nil
@@ -576,8 +575,8 @@ func resourceCapacityFromInfrastructureObject(infraobj *unstructured.Unstructure
 	return capacity
 }
 
-func systemInfoFromInfrastructureObject(infraobj *unstructured.Unstructured) apiv1.NodeSystemInfo {
-	nsi := apiv1.NodeSystemInfo{}
+func systemInfoFromInfrastructureObject(infraobj *unstructured.Unstructured) corev1.NodeSystemInfo {
+	nsi := corev1.NodeSystemInfo{}
 	infransi, found, err := unstructured.NestedStringMap(infraobj.Object, "status", "nodeInfo")
 	if !found || err != nil {
 		return nsi
@@ -656,19 +655,19 @@ func parseCSIDriverAnnotation(annotationValue string) []storagev1.CSINodeDriver 
 }
 
 // adapted from https://github.com/kubernetes/kubernetes/blob/release-1.25/pkg/util/taints/taints.go#L39
-func parseTaint(st string) (apiv1.Taint, error) {
-	var taint apiv1.Taint
+func parseTaint(st string) (corev1.Taint, error) {
+	var taint corev1.Taint
 
 	var key string
 	var value string
-	var effect apiv1.TaintEffect
+	var effect corev1.TaintEffect
 
 	parts := strings.Split(st, ":")
 	switch len(parts) {
 	case 1:
 		key = parts[0]
 	case 2:
-		effect = apiv1.TaintEffect(parts[1])
+		effect = corev1.TaintEffect(parts[1])
 
 		partsKV := strings.Split(parts[0], "=")
 		if len(partsKV) > 2 {


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This change aligns the imports around the k8s v1 api so that all the files are using the same import alias.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
