### PR TITLE
fix: OperationPreempted does not retry when failed delete operation

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// When Azure Dedicated Host is enabled or using isolated vm skus, force deleting a VMSS fails with the following error:
+// When Azure Dedicated Host is enabled or using isolated vm skus, force deleting a VMSS fails with the following er:
 //
 // "predominantErrorDetail": {
 //   "innererror": {
@@ -96,4 +96,17 @@ func isOperationNotAllowed(err error) bool {
 		return azerr.ErrorCode == azerrors.OperationNotAllowed
 	}
 	return strings.Contains(err.Error(), azerrors.OperationNotAllowed)
+}
+
+const operationPreemptedErrorMessage = "Operation execution has been preempted by a more recent operation"
+
+// isOperationPreempted checks if `error` is an OperationPreempted error.
+func isOperationPreempted(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(
+		strings.ToLower(err.Error()),
+		strings.ToLower(operationPreemptedErrorMessage),
+	)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
@@ -98,15 +98,15 @@ func isOperationNotAllowed(err error) bool {
 	return strings.Contains(err.Error(), azerrors.OperationNotAllowed)
 }
 
-const operationPreemptedErrorMessage = "Operation execution has been preempted by a more recent operation"
+const operationPreemptedErrorCode = "OperationPreempted"
 
 // isOperationPreempted checks if `error` is an OperationPreempted error.
 func isOperationPreempted(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(
-		strings.ToLower(err.Error()),
-		strings.ToLower(operationPreemptedErrorMessage),
-	)
+	if azerr := azerrors.IsResponseError(err); azerr != nil {
+		return azerr.ErrorCode == operationPreemptedErrorCode
+	}
+	return strings.Contains(err.Error(), operationPreemptedErrorCode)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// When Azure Dedicated Host is enabled or using isolated vm skus, force deleting a VMSS fails with the following er:
+// When Azure Dedicated Host is enabled or using isolated vm skus, force deleting a VMSS fails with the following error:
 //
 // "predominantErrorDetail": {
 //   "innererror": {

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,18 +79,18 @@ func TestIsOperationPreempted(t *testing.T) {
 		assert.Equal(t, isOperationPreempted(err), false)
 	})
 
-	t.Run("should return true for exact preempted message", func(t *testing.T) {
-		err := errors.New("Operation execution has been preempted by a more recent operation")
+	t.Run("should return true for azcore.ResponseError with OperationPreempted code", func(t *testing.T) {
+		err := &azcore.ResponseError{ErrorCode: "OperationPreempted"}
 		assert.Equal(t, isOperationPreempted(err), true)
 	})
 
-	t.Run("should return true for case-varied message", func(t *testing.T) {
-		err := errors.New("OPERATION EXECUTION HAS BEEN PREEMPTED BY A MORE RECENT OPERATION")
-		assert.Equal(t, isOperationPreempted(err), true)
+	t.Run("should return false for azcore.ResponseError with different code", func(t *testing.T) {
+		err := &azcore.ResponseError{ErrorCode: "SomeOtherError"}
+		assert.Equal(t, isOperationPreempted(err), false)
 	})
 
-	t.Run("should return true for embedded message", func(t *testing.T) {
-		err := errors.New("Azure error: Operation execution has been preempted by a more recent operation: details here")
+	t.Run("should return true for plain error containing OperationPreempted code", func(t *testing.T) {
+		err := errors.New("Code: OperationPreempted, Message: operation was preempted")
 		assert.Equal(t, isOperationPreempted(err), true)
 	})
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
@@ -67,3 +67,29 @@ func TestIsOperationNotAllowed(t *testing.T) {
 	// function should return true.
 
 }
+
+func TestIsOperationPreempted(t *testing.T) {
+	t.Run("should return false because error is nil", func(t *testing.T) {
+		assert.Equal(t, isOperationPreempted(nil), false)
+	})
+
+	t.Run("should return false for unrelated error", func(t *testing.T) {
+		err := errors.New("BadRequest: something went wrong")
+		assert.Equal(t, isOperationPreempted(err), false)
+	})
+
+	t.Run("should return true for exact preempted message", func(t *testing.T) {
+		err := errors.New("Operation execution has been preempted by a more recent operation")
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
+
+	t.Run("should return true for case-varied message", func(t *testing.T) {
+		err := errors.New("OPERATION EXECUTION HAS BEEN PREEMPTED BY A MORE RECENT OPERATION")
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
+
+	t.Run("should return true for embedded message", func(t *testing.T) {
+		err := errors.New("Azure error: Operation execution has been preempted by a more recent operation: details here")
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
+}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -586,6 +586,24 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 		}
 		return
 	}
+
+	// Retry once on OperationPreempted, mirroring the pattern in vmssvmclient.updateVMSSVMs()
+	if isOperationPreempted(err) {
+		klog.V(2).Infof("PollUntilDone for DeleteInstances(%v) for %s was preempted, retrying once", requiredIds.InstanceIDs, scaleSet.Name)
+		retryCtx, retryCancel := getContextWithTimeout(vmssContextTimeout)
+		retryPoller, retryErr := scaleSet.deleteInstances(retryCtx, requiredIds, scaleSet.Name)
+		retryCancel()
+		if retryErr == nil && retryPoller != nil {
+			_, retryErr = retryPoller.PollUntilDone(ctx, nil)
+		}
+		if retryErr == nil {
+			klog.V(3).Infof("PollUntilDone for DeleteInstances(%v) for %s retry success", requiredIds.InstanceIDs, scaleSet.Name)
+			scaleSet.invalidateInstanceCache()
+			return
+		}
+		klog.Errorf("PollUntilDone for DeleteInstances(%v) for %s retry failed: %v", requiredIds.InstanceIDs, scaleSet.Name, retryErr)
+	}
+
 	if !scaleSet.manager.config.StrictCacheUpdates {
 		scaleSet.invalidateInstanceCache()
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -587,7 +587,12 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 		return
 	}
 
-	// Retry once on OperationPreempted, mirroring the pattern in vmssvmclient.updateVMSSVMs()
+	// Retry once on OperationPreempted: this CRP error means a concurrent VMSS
+	// mutation (e.g., scale-up, update, another delete) superseded our delete.
+	// A single retry is statistically sufficient — two consecutive preemptions
+	// would require three operations racing on the same VMSS, which is unlikely
+	// in CAS's scale-down flow. This mirrors the pattern from the legacy track1
+	// vmssvmclient.updateVMSSVMs().
 	if isOperationPreempted(err) {
 		klog.V(2).Infof("PollUntilDone for DeleteInstances(%v) for %s was preempted, retrying once", requiredIds.InstanceIDs, scaleSet.Name)
 		retryCtx, retryCancel := getContextWithTimeout(vmssContextTimeout)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package azure
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -1512,4 +1516,235 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 			assert.NotNil(t, status.ErrorInfo)
 		})
 	})
+}
+
+// testPollingHandler implements runtime.PollingHandler[T] for testing.
+// It returns the configured error on Poll() and reports done after the error is returned.
+type testPollingHandler[T any] struct {
+	err    error
+	polled bool
+}
+
+func (h *testPollingHandler[T]) Done() bool {
+	return h.polled && h.err == nil
+}
+
+func (h *testPollingHandler[T]) Poll(_ context.Context) (*http.Response, error) {
+	h.polled = true
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, h.err
+}
+
+func (h *testPollingHandler[T]) Result(_ context.Context, _ *T) error {
+	return h.err
+}
+
+// newTestPollerWithError creates a runtime.Poller that returns the given error on PollUntilDone.
+func newTestPollerWithError(err error) *runtime.Poller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse] {
+	resp := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Header:     http.Header{},
+		Body:       http.NoBody,
+	}
+	pl := runtime.NewPipeline("test", "v0.0.0", runtime.PipelineOptions{}, nil)
+	poller, pollerErr := runtime.NewPoller[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse](resp, pl, &runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse]{
+		Handler: &testPollingHandler[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse]{err: err},
+	})
+	if pollerErr != nil {
+		panic(pollerErr)
+	}
+	return poller
+}
+
+func TestWaitForDeleteInstancesWithOperationPreemptedRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+
+	expectedScaleSets := []*armcompute.VirtualMachineScaleSet{
+		{
+			Name: &vmssName,
+			SKU: &armcompute.SKU{
+				Capacity: &vmssCapacity,
+			},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+		},
+	}
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	// Override the default delete client mock: expect exactly 1 retry call to BeginDeleteInstances
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
+	manager.explicitlyConfigured["test-asg"] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	requiredIds := &armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+		InstanceIDs: []*string{ptr.To("0")},
+	}
+
+	scaleSet := newTestScaleSet(manager, "test-asg")
+
+	// lastInstanceRefresh starts at zero value for a new ScaleSet
+	assert.True(t, scaleSet.lastInstanceRefresh.IsZero())
+
+	// Create a poller that returns an OperationPreempted error on PollUntilDone
+	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
+
+	// Act: the initial PollUntilDone fails with OperationPreempted, triggering a retry.
+	// The retry calls deleteInstances which returns (nil, nil) from the mock — retryPoller is nil,
+	// so retryErr stays nil, which counts as success. The function should invalidate cache and return.
+	scaleSet.waitForDeleteInstances(preemptedPoller, requiredIds)
+
+	// Assert: BeginDeleteInstances was called exactly once (the retry). gomock.Times(1) enforces this.
+	// Assert: instance cache was invalidated (lastInstanceRefresh changed from zero)
+	assert.False(t, scaleSet.lastInstanceRefresh.IsZero(),
+		"expected instance cache to be invalidated after preempted retry success")
+}
+
+func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+
+	expectedScaleSets := []*armcompute.VirtualMachineScaleSet{
+		{
+			Name: &vmssName,
+			SKU: &armcompute.SKU{
+				Capacity: &vmssCapacity,
+			},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+		},
+	}
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	// Override the default delete client mock: expect exactly 0 calls to BeginDeleteInstances.
+	// If the retry path is accidentally triggered, gomock will fail the test.
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
+	manager.explicitlyConfigured["test-asg"] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	requiredIds := &armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+		InstanceIDs: []*string{ptr.To("0")},
+	}
+
+	scaleSet := newTestScaleSet(manager, "test-asg")
+
+	// Create a poller that returns a non-preempted error
+	otherErrorPoller := newTestPollerWithError(errors.New("InternalServerError: something went wrong"))
+
+	// Act: PollUntilDone fails with a non-preempted error — should NOT trigger retry
+	scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds)
+
+	// Assert: BeginDeleteInstances was never called. gomock.Times(0) enforces this.
+}
+
+func TestWaitForDeleteInstancesRetryFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+
+	expectedScaleSets := []*armcompute.VirtualMachineScaleSet{
+		{
+			Name: &vmssName,
+			SKU: &armcompute.SKU{
+				Capacity: &vmssCapacity,
+			},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+		},
+	}
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	// Override the default delete client mock: the retry call to deleteInstances itself fails
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("ResourceGroupNotFound")).Times(1)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
+	manager.explicitlyConfigured["test-asg"] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	requiredIds := &armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+		InstanceIDs: []*string{ptr.To("0")},
+	}
+
+	scaleSet := newTestScaleSet(manager, "test-asg")
+
+	// lastInstanceRefresh starts at zero value for a new ScaleSet
+	assert.True(t, scaleSet.lastInstanceRefresh.IsZero())
+
+	// Create a poller that returns OperationPreempted
+	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
+
+	// Act: PollUntilDone fails with OperationPreempted, retry is attempted but deleteInstances fails.
+	// Should fall through to the error path and invalidate cache.
+	scaleSet.waitForDeleteInstances(preemptedPoller, requiredIds)
+
+	// Assert: retry was attempted exactly once (gomock.Times(1) enforces this)
+	// Assert: cache was still invalidated despite failure (the !StrictCacheUpdates path)
+	assert.False(t, scaleSet.lastInstanceRefresh.IsZero(),
+		"expected instance cache to be invalidated after retry failure")
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/stretchr/testify/assert"
@@ -1609,7 +1610,7 @@ func TestWaitForDeleteInstancesWithOperationPreemptedRetry(t *testing.T) {
 	assert.True(t, scaleSet.lastInstanceRefresh.IsZero())
 
 	// Create a poller that returns an OperationPreempted error on PollUntilDone
-	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
+	preemptedPoller := newTestPollerWithError(&azcore.ResponseError{ErrorCode: "OperationPreempted"})
 
 	// Act: the initial PollUntilDone fails with OperationPreempted, triggering a retry.
 	// The retry calls deleteInstances which returns (nil, nil) from the mock — retryPoller is nil,
@@ -1737,7 +1738,7 @@ func TestWaitForDeleteInstancesRetryFailure(t *testing.T) {
 	assert.True(t, scaleSet.lastInstanceRefresh.IsZero())
 
 	// Create a poller that returns OperationPreempted
-	preemptedPoller := newTestPollerWithError(errors.New("Operation execution has been preempted by a more recent operation"))
+	preemptedPoller := newTestPollerWithError(&azcore.ResponseError{ErrorCode: "OperationPreempted"})
 
 	// Act: PollUntilDone fails with OperationPreempted, retry is attempted but deleteInstances fails.
 	// Should fall through to the error path and invalidate cache.


### PR DESCRIPTION
#### What type of PR is this?
Fixing no retry issues in OperationPreempted in delete operation race condition.
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
azure: OperationPreempted does not retry if delete fails
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
