### PR TITLE
cluster-autoscaler: fix Exoscale instance pool node groups ignoring configured minSize

### DIFF
--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
@@ -135,9 +135,39 @@ func (e *exoscaleCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 		debugf("found node %s belonging to SKS Nodepool %s", toNodeID(node.Spec.ProviderID), *sksNodepool.ID)
 	} else {
 		// Standalone Instance Pool
+
+		var nodeGroupSpec *dynamic.NodeGroupSpec
+
+		for _, spec := range e.manager.discoveryOpts.NodeGroupSpecs {
+			s, err := dynamic.SpecFromString(spec, scaleToZeroSupported)
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse node group spec: %v", err)
+			}
+
+			if s.Name == *instancePool.Name {
+				nodeGroupSpec = s
+				break
+			}
+		}
+
+		var minSize, maxSize int
+		if nodeGroupSpec != nil {
+			minSize = nodeGroupSpec.MinSize
+			maxSize = nodeGroupSpec.MaxSize
+		} else {
+			minSize = 1
+			maxSize, err = e.manager.computeInstanceQuota()
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		nodeGroup = &instancePoolNodeGroup{
 			instancePool: instancePool,
 			m:            e.manager,
+			minSize:      minSize,
+			maxSize:      maxSize,
 		}
 		debugf("found node %s belonging to Instance Pool %s", toNodeID(node.Spec.ProviderID), *instancePool.ID)
 	}

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider_test.go
@@ -171,6 +171,17 @@ func (ts *cloudProviderTestSuite) TestExoscaleCloudProvider_Name() {
 
 func (ts *cloudProviderTestSuite) TestExoscaleCloudProvider_NodeGroupForNode_InstancePool() {
 	ts.p.manager.client.(*exoscaleClientMock).
+		On("GetQuota", ts.p.manager.ctx, ts.p.manager.zone, "instance").
+		Return(
+			&egoscale.Quota{
+				Resource: &testComputeInstanceQuotaName,
+				Usage:    &testComputeInstanceQuotaUsage,
+				Limit:    &testComputeInstanceQuotaLimit,
+			},
+			nil,
+		)
+
+	ts.p.manager.client.(*exoscaleClientMock).
 		On("GetInstancePool", ts.p.manager.ctx, ts.p.manager.zone, testInstancePoolID).
 		Return(
 			&egoscale.InstancePool{

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -35,6 +35,9 @@ type instancePoolNodeGroup struct {
 
 	m *Manager
 
+	minSize int
+	maxSize int
+
 	sync.Mutex
 }
 
@@ -42,6 +45,9 @@ var errNoInstancePool = errors.New("not an Instance Pool member")
 
 // MaxSize returns maximum size of the node group.
 func (n *instancePoolNodeGroup) MaxSize() int {
+	if n.maxSize > 0 {
+		return n.maxSize
+	}
 	limit, err := n.m.computeInstanceQuota()
 	if err != nil {
 		return 0
@@ -52,7 +58,7 @@ func (n *instancePoolNodeGroup) MaxSize() int {
 
 // MinSize returns minimum size of the node group.
 func (n *instancePoolNodeGroup) MinSize() int {
-	return 1
+	return n.minSize
 }
 
 // TargetSize returns the current target size of the node group. It is possible that the

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -59,6 +59,8 @@ func (n *instancePoolNodeGroup) MaxSize() int {
 // MinSize returns minimum size of the node group.
 func (n *instancePoolNodeGroup) MinSize() int {
 
+	// NOTE: minSize is expected to be >= 1.
+	// Update this check to allow 0 if scale-from-zero support is added.
 	if n.minSize <= 0 {
 		return 1
 	}

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -58,6 +58,11 @@ func (n *instancePoolNodeGroup) MaxSize() int {
 
 // MinSize returns minimum size of the node group.
 func (n *instancePoolNodeGroup) MinSize() int {
+
+	if n.minSize <= 0 {
+		return 1
+	}
+
 	return n.minSize
 }
 

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool_test.go
@@ -52,7 +52,8 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_MinSize() {
 			ID:   &testInstancePoolID,
 			Name: &testInstancePoolName,
 		},
-		m: ts.p.manager,
+		m:       ts.p.manager,
+		minSize: 1,
 	}
 
 	ts.Require().Equal(1, nodeGroup.MinSize())
@@ -199,4 +200,17 @@ func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_Exist() {
 	}
 
 	ts.Require().True(nodeGroup.Exist())
+}
+
+func (ts *cloudProviderTestSuite) TestInstancePoolNodeGroup_MinSize_Custom() {
+	nodeGroup := &instancePoolNodeGroup{
+		instancePool: &egoscale.InstancePool{
+			ID:   &testInstancePoolID,
+			Name: &testInstancePoolName,
+		},
+		m:       ts.p.manager,
+		minSize: 3,
+	}
+
+	ts.Require().Equal(3, nodeGroup.MinSize())
 }

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool_test.go
@@ -67,7 +67,7 @@ func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_MinSize() {
 		maxSize: int(testComputeInstanceQuotaLimit),
 	}
 
-	ts.Require().Equal(1, nodeGroup.MinSize())
+	ts.Require().Equal(int(testSKSNodepoolSize), nodeGroup.MinSize())
 }
 
 func (ts *cloudProviderTestSuite) TestSKSNodepoolNodeGroup_TargetSize() {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Currently, Exoscale instance pool node groups ignore the configured minimum size and always fall back to 1. 

This happens because the instancePoolNodeGroup implementation does not carry over the minSize/maxSize from NodeGroupSpec, unlike the SKS nodepool implementation.

This PR fixes that by:
- Adding minSize and maxSize fields to instancePoolNodeGroup
- Passing the correct values from NodeGroupSpec
- Making the behavior consistent with SKS nodepools

After this change, the Cluster Autoscaler correctly respects the configured minimum size for instance pools.

#### Which issue(s) this PR fixes:
Fixes #9441

#### Special notes for your reviewer:

This brings instance pool behavior in line with the existing SKS implementation. Tests were updated accordingly and are passing for the Exoscale provider.

#### Does this PR introduce a user-facing change?
```release-note
Fixed an issue where Exoscale instance pool node groups ignored the configured minimum size and defaulted to 1.
```