### PR TITLE
Update OWNERS 2026-04-16

### DIFF
--- a/cluster-autoscaler/OWNERS
+++ b/cluster-autoscaler/OWNERS
@@ -1,14 +1,11 @@
 approvers:
 - aleksandra-malinowska
 - BigDarkClown
-- feiskyer
 - towca
 - x13n
 reviewers:
 - aleksandra-malinowska
 - BigDarkClown
-- feiskyer
-- vadasambar
 - x13n
 - elmiko
 labels:

--- a/cluster-autoscaler/cloudprovider/azure/OWNERS
+++ b/cluster-autoscaler/cloudprovider/azure/OWNERS
@@ -1,16 +1,14 @@
 approvers:
-- feiskyer
-- nilo19
 - tallaxes
 - comtalyst
 - jackfrancis
 reviewers:
-- feiskyer
-- nilo19
 - tallaxes
 - comtalyst
 - jackfrancis
 emeritus_approvers:
+- nilo19 # 2026-04-16
+- feisker #2026-04-16
 - marwanad
 
 labels:

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,11 +1,10 @@
 approvers:
-- kgolab
 - x13n
 - towca
 reviewers:
-- feiskyer
 - kgolab
 emeritus_approvers:
+- kgolab # 2026-04-16
 - piosz # 2022-09-30
 - aleksandra-malinowska # 2022-09-30
 - losipiuk # 2022-09-30


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR cleans up various OWNERS files to remove folks who haven't been active for > 1 year.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
