### PR TITLE
fix: CPU Startup boost multi container support

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
@@ -159,7 +159,8 @@ func (c *resourcesUpdatesPatchCalculator) applyCPUStartupBoost(container *corev1
 	if err != nil {
 		return nil, err
 	}
-	patches = append(patches, GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, originalResources))
+	annotationKey := annotations.GetStartupCPUBoostAnnotationKey(container.Name)
+	patches = append(patches, GetAddAnnotationPatch(annotationKey, originalResources))
 
 	return patches, nil
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates_test.go
@@ -417,7 +417,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
 				addResourceRequestPatch(0, cpu, "200m"),
 				addResourceLimitPatch(0, cpu, "200m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
@@ -456,7 +456,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
 				addResourceRequestPatch(0, cpu, "200m"),
 				addResourceLimitPatch(0, cpu, "200m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
@@ -495,7 +495,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
 				addResourceRequestPatch(0, cpu, "600m"),
 				addResourceLimitPatch(0, cpu, "600m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
@@ -593,7 +593,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"400m\"},\"limits\":{\"cpu\":\"400m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"400m\"},\"limits\":{\"cpu\":\"400m\"}}"),
 				addResourceRequestPatch(0, cpu, "700m"),
 				addResourceLimitPatch(0, cpu, "700m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
@@ -632,7 +632,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{Quantity: resource.MustParse("40m")},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
 				addResourceRequestPatch(0, cpu, "40m"),
 				addResourceLimitPatch(0, cpu, "40m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
@@ -690,7 +690,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"100m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"100m\"}}"),
 				addResourceRequestPatch(0, cpu, "200m"),
 				addResourceLimitPatch(0, cpu, "200m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
@@ -726,7 +726,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"300m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"300m\"}}"),
 				addResourceRequestPatch(0, cpu, "200m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request"),
 			},
@@ -761,7 +761,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"150m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"150m\"}}"),
 				addResourceRequestPatch(0, cpu, "149m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request"),
 			},
@@ -796,7 +796,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"300m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{\"cpu\":\"300m\"}}"),
 				addResourceRequestPatch(0, cpu, "300m"),
 				addResourceLimitPatch(0, cpu, "900m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),
@@ -829,7 +829,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"100m\"},\"limits\":{}}"),
 				addResourceRequestPatch(0, cpu, "300m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request"),
 			},
@@ -897,7 +897,7 @@ func TestCalculatePatches_StartupBoost(t *testing.T) {
 			maxAllowedCpu:      resource.QuantityValue{},
 			featureGateEnabled: true,
 			expectPatches: []resource_admission.PatchRecord{
-				GetAddAnnotationPatch(annotations.StartupCPUBoostAnnotation, "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
+				GetAddAnnotationPatch(annotations.GetStartupCPUBoostAnnotationKey("container1"), "{\"requests\":{\"cpu\":\"1m\"},\"limits\":{\"cpu\":\"1m\"}}"),
 				addResourceRequestPatch(0, cpu, "300m"),
 				addResourceLimitPatch(0, cpu, "300m"),
 				GetAddAnnotationPatch(ResourceUpdatesAnnotation, "Pod resources updated by name: container 0: cpu request, cpu limit"),

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/util.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/util.go
@@ -18,6 +18,7 @@ package patch
 
 import (
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -38,7 +39,7 @@ func GetAddEmptyAnnotationsPatch() resource_admission.PatchRecord {
 func GetAddAnnotationPatch(annotationName, annotationValue string) resource_admission.PatchRecord {
 	return resource_admission.PatchRecord{
 		Op:    "add",
-		Path:  fmt.Sprintf("/metadata/annotations/%s", annotationName),
+		Path:  fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(annotationName, "/", "~1")),
 		Value: annotationValue,
 	}
 }
@@ -47,7 +48,7 @@ func GetAddAnnotationPatch(annotationName, annotationValue string) resource_admi
 func GetRemoveAnnotationPatch(annotationName string) resource_admission.PatchRecord {
 	return resource_admission.PatchRecord{
 		Op:   "remove",
-		Path: fmt.Sprintf("/metadata/annotations/%s", annotationName),
+		Path: fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(annotationName, "/", "~1")),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
@@ -69,7 +69,7 @@ func (m *matcher) GetMatchingVPA(ctx context.Context, pod *corev1.Pod) *vpa_type
 
 	var controllingVpa *vpa_types.VerticalPodAutoscaler
 	for _, vpaConfig := range configs {
-		if vpa_api_util.GetUpdateMode(vpaConfig) == vpa_types.UpdateModeOff && vpaConfig.Spec.StartupBoost == nil {
+		if vpa_api_util.GetUpdateMode(vpaConfig) == vpa_types.UpdateModeOff && !vpa_api_util.HasStartupBoost(vpaConfig) {
 			continue
 		}
 		if vpaConfig.Spec.TargetRef == nil {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
@@ -65,6 +65,7 @@ func TestGetMatchingVpa(t *testing.T) {
 		AddContainer(test.Container().WithName("i-am-container").Get())
 	podBuilder := podBuilderWithoutCreator.WithCreator(&sts.ObjectMeta, &sts.TypeMeta)
 	vpaBuilder := test.VerticalPodAutoscaler().WithContainer("i-am-container")
+	factor := int32(1)
 
 	testCases := []struct {
 		name            string
@@ -143,6 +144,35 @@ func TestGetMatchingVpa(t *testing.T) {
 			pod:           podBuilder.Get(),
 			vpas:          []*vpa_types.VerticalPodAutoscaler{},
 			expectedFound: false,
+		}, {
+			name: "vpa with update mode off but with startup boost is matched",
+			pod:  podBuilder.Get(),
+			vpas: []*vpa_types.VerticalPodAutoscaler{
+				vpaBuilder.WithName("off-with-boost-vpa").WithTargetRef(targetRef).WithUpdateMode(vpa_types.UpdateModeOff).WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor, nil, 0).Get(),
+			},
+			labelSelector:   "app = test",
+			expectedFound:   true,
+			expectedVpaName: "off-with-boost-vpa",
+			// Tests that UpdateModeOff is bypassed if the VPA has a pod-level startup boost defined.
+		}, {
+			name: "vpa with update mode off but with container-level startup boost is matched",
+			pod:  podBuilder.Get(),
+			vpas: []*vpa_types.VerticalPodAutoscaler{
+				vpaBuilder.WithName("off-with-container-boost-vpa").WithTargetRef(targetRef).WithUpdateMode(vpa_types.UpdateModeOff).WithContainerCPUStartupBoost("i-am-container", vpa_types.FactorStartupBoostType, &factor, nil, 0).Get(),
+			},
+			labelSelector:   "app = test",
+			expectedFound:   true,
+			expectedVpaName: "off-with-container-boost-vpa",
+			// Tests that UpdateModeOff is bypassed if the VPA has only a container-level startup boost defined.
+		}, {
+			name: "vpa with default update mode and startup boost is matched",
+			pod:  podBuilder.Get(),
+			vpas: []*vpa_types.VerticalPodAutoscaler{
+				vpaBuilder.WithName("auto-with-boost-vpa").WithTargetRef(targetRef).WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor, nil, 0).Get(),
+			},
+			labelSelector:   "app = test",
+			expectedFound:   true,
+			expectedVpaName: "auto-with-boost-vpa",
 		},
 	}
 

--- a/vertical-pod-autoscaler/pkg/updater/inplace/resource_updates.go
+++ b/vertical-pod-autoscaler/pkg/updater/inplace/resource_updates.go
@@ -18,6 +18,7 @@ package inplace
 
 import (
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -50,30 +51,44 @@ func (*resourcesInplaceUpdatesPatchCalculator) PatchResourceTarget() patch.Patch
 func (c *resourcesInplaceUpdatesPatchCalculator) CalculatePatches(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) ([]resource_admission.PatchRecord, error) {
 	result := []resource_admission.PatchRecord{}
 
-	var containersResources []vpa_api_util.ContainerResources
-	if vpa_api_util.GetUpdateMode(vpa) == vpa_types.UpdateModeOff {
-		// If update mode is "Off", we don't want to apply any recommendations,
-		// but we still want to unboost.
-		original, err := annotations.GetOriginalResourcesFromAnnotation(pod)
-		if err != nil {
-			return nil, err
-		}
-		containersResources = []vpa_api_util.ContainerResources{
-			{
-				Requests: original.Requests,
-				Limits:   original.Limits,
-			},
-		}
-	} else {
+	expiredAnnotations := vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa)
+
+	updateMode := vpa_api_util.GetUpdateMode(vpa)
+	var recommendedResources []vpa_api_util.ContainerResources
+	if updateMode != vpa_types.UpdateModeOff {
 		var err error
-		containersResources, _, err = c.recommendationProvider.GetContainersResourcesForPod(pod, vpa)
+		recommendedResources, _, err = c.recommendationProvider.GetContainersResourcesForPod(pod, vpa)
 		if err != nil {
 			return []resource_admission.PatchRecord{}, fmt.Errorf("failed to calculate resource patch for pod %s/%s: %v", pod.Namespace, pod.Name, err)
 		}
+	} else {
+		// If update mode is "Off", we don't want to apply any recommendations,
+		// but we still want to unboost.
+		recommendedResources = make([]vpa_api_util.ContainerResources, len(pod.Spec.Containers))
 	}
 
-	for i, containerResources := range containersResources {
-		newPatches := getContainerPatch(pod, i, containerResources)
+	for i, c := range pod.Spec.Containers {
+		var targetResources vpa_api_util.ContainerResources
+		annotationKey := annotations.GetStartupCPUBoostAnnotationKey(c.Name)
+		_, boosted := pod.Annotations[annotationKey]
+		expired := slices.Contains(expiredAnnotations, annotationKey)
+
+		switch {
+		case expired:
+			var err error
+			targetResources, err = getContainerResourcesForUnboost(pod, c, recommendedResources[i])
+			if err != nil {
+				return []resource_admission.PatchRecord{}, err
+			}
+		case boosted:
+			continue // currently boosted pod so we skip creating patches
+		case updateMode == vpa_types.UpdateModeOff:
+			continue // Nothing to do for pods when VPA is Off.
+		default:
+			targetResources = recommendedResources[i]
+		}
+
+		newPatches := getContainerPatch(pod, i, targetResources)
 		result = append(result, newPatches...)
 	}
 
@@ -103,4 +118,22 @@ func appendPatches(patches []resource_admission.PatchRecord, current corev1.Reso
 		patches = append(patches, patch.GetAddResourceRequirementValuePatch(containerIndex, fieldName, resource, request))
 	}
 	return patches
+}
+
+func getContainerResourcesForUnboost(pod *corev1.Pod, c corev1.Container, recommendedResources vpa_api_util.ContainerResources) (vpa_api_util.ContainerResources, error) {
+	original, err := annotations.GetOriginalResourcesFromAnnotation(pod, c.Name)
+	if err != nil {
+		return vpa_api_util.ContainerResources{}, err
+	}
+	if areResourcesEmpty(recommendedResources) && original != nil {
+		return vpa_api_util.ContainerResources{
+			Requests: original.Requests,
+			Limits:   original.Limits,
+		}, nil
+	}
+	return recommendedResources, nil
+}
+
+func areResourcesEmpty(resources vpa_api_util.ContainerResources) bool {
+	return len(resources.Requests) == 0 && len(resources.Limits) == 0
 }

--- a/vertical-pod-autoscaler/pkg/updater/inplace/resource_updates_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/inplace/resource_updates_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inplace
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
+)
+
+type fakeRecommendationProvider struct {
+	resources []vpa_api_util.ContainerResources
+	err       error
+}
+
+func (frp *fakeRecommendationProvider) GetContainersResourcesForPod(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) ([]vpa_api_util.ContainerResources, vpa_api_util.ContainerToAnnotationsMap, error) {
+	return frp.resources, nil, frp.err
+}
+
+func TestCalculatePatches_MultiContainerResourceUpdates(t *testing.T) {
+	now := metav1.Now()
+	past := metav1.Time{Time: now.Add(-5 * time.Minute)}
+	ten := int32(10)
+	thousand := int32(1000)
+
+	tests := []struct {
+		name               string
+		pod                *corev1.Pod
+		vpa                *vpa_types.VerticalPodAutoscaler
+		recommendResources []vpa_api_util.ContainerResources
+		recommendError     error
+		expectPatches      []resource_admission.PatchRecord
+		expectError        error
+	}{
+		{
+			name: "UpdateMode Off - Only unboost expired container",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.GetStartupCPUBoostAnnotationKey("c1"): "{\"requests\":{\"cpu\":\"100m\"}}",
+						annotations.GetStartupCPUBoostAnnotationKey("c2"): "{\"requests\":{\"cpu\":\"100m\"}}",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "c1", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+						{Name: "c2", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: past},
+					},
+				},
+			},
+			vpa: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{UpdateMode: &[]vpa_types.UpdateMode{vpa_types.UpdateModeOff}[0]},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{ContainerName: "c1", StartupBoost: &vpa_types.StartupBoost{CPU: &vpa_types.GenericStartupBoost{DurationSeconds: &ten}}},
+							{ContainerName: "c2", StartupBoost: &vpa_types.StartupBoost{CPU: &vpa_types.GenericStartupBoost{DurationSeconds: &thousand}}},
+						},
+					},
+				},
+			},
+			recommendResources: make([]vpa_api_util.ContainerResources, 2),
+			expectPatches: []resource_admission.PatchRecord{
+				{Op: "add", Path: "/spec/containers/0/resources/requests/cpu", Value: "100m"},
+			},
+		},
+		{
+			name: "UpdateMode Auto - ignores boosted unexpired containers naturally",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.GetStartupCPUBoostAnnotationKey("c1"): "{\"requests\":{\"cpu\":\"100m\"}}",
+						annotations.GetStartupCPUBoostAnnotationKey("c2"): "{\"requests\":{\"cpu\":\"100m\"}}",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "c1", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+						{Name: "c2", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: past},
+					},
+				},
+			},
+			vpa: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{UpdateMode: &[]vpa_types.UpdateMode{vpa_types.UpdateModeInPlaceOrRecreate}[0]},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{ContainerName: "c1", StartupBoost: &vpa_types.StartupBoost{CPU: &vpa_types.GenericStartupBoost{DurationSeconds: &ten}}},
+							{ContainerName: "c2", StartupBoost: &vpa_types.StartupBoost{CPU: &vpa_types.GenericStartupBoost{DurationSeconds: &thousand}}},
+						},
+					},
+				},
+			},
+			recommendResources: []vpa_api_util.ContainerResources{
+				{Requests: corev1.ResourceList{"cpu": resource.MustParse("200m")}},
+				{Requests: corev1.ResourceList{"cpu": resource.MustParse("200m")}},
+			},
+			expectPatches: []resource_admission.PatchRecord{
+				{Op: "add", Path: "/spec/containers/0/resources/requests/cpu", Value: "200m"},
+			},
+		},
+		{
+			name: "No Unboost - both containers unexpired so they stay boosted safely",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.GetStartupCPUBoostAnnotationKey("c1"): "{\"requests\":{\"cpu\":\"100m\"}}",
+						annotations.GetStartupCPUBoostAnnotationKey("c2"): "{\"requests\":{\"cpu\":\"100m\"}}",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "c1", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+						{Name: "c2", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: past},
+					},
+				},
+			},
+			vpa: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{UpdateMode: &[]vpa_types.UpdateMode{vpa_types.UpdateModeInPlaceOrRecreate}[0]},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{ContainerName: "c1", StartupBoost: &vpa_types.StartupBoost{CPU: &vpa_types.GenericStartupBoost{DurationSeconds: &thousand}}},
+							{ContainerName: "c2", StartupBoost: &vpa_types.StartupBoost{CPU: &vpa_types.GenericStartupBoost{DurationSeconds: &thousand}}},
+						},
+					},
+				},
+			},
+			recommendResources: []vpa_api_util.ContainerResources{
+				{Requests: corev1.ResourceList{"cpu": resource.MustParse("200m")}},
+				{Requests: corev1.ResourceList{"cpu": resource.MustParse("200m")}},
+			},
+			expectPatches: []resource_admission.PatchRecord{},
+		},
+		{
+			name: "Regular Recommendation - no startup boost annotations or config",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "c1", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+						{Name: "c2", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+					},
+				},
+			},
+			vpa: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{UpdateMode: &[]vpa_types.UpdateMode{vpa_types.UpdateModeInPlaceOrRecreate}[0]},
+				},
+			},
+			recommendResources: []vpa_api_util.ContainerResources{
+				{Requests: corev1.ResourceList{"cpu": resource.MustParse("300m")}},
+				{Requests: corev1.ResourceList{"cpu": resource.MustParse("300m")}},
+			},
+			expectPatches: []resource_admission.PatchRecord{
+				{Op: "add", Path: "/spec/containers/0/resources/requests/cpu", Value: "300m"},
+				{Op: "add", Path: "/spec/containers/1/resources/requests/cpu", Value: "300m"},
+			},
+		},
+		// Pod with UpdateMode Off and no startup boost is not going to end up here due to check in updater.go
+		// but this extra validation makes sure it yields no patches
+		{
+			name: "Regular Recommendation - UpdateMode Off - no startup boost annotations yields no patches",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "c1", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+						{Name: "c2", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("1m")}}},
+					},
+				},
+			},
+			vpa: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{UpdateMode: &[]vpa_types.UpdateMode{vpa_types.UpdateModeOff}[0]},
+				},
+			},
+			recommendResources: []vpa_api_util.ContainerResources{
+				{Requests: corev1.ResourceList{"cpu": resource.MustParse("300m")}},
+				{Requests: corev1.ResourceList{"cpu": resource.MustParse("300m")}},
+			},
+			expectPatches: []resource_admission.PatchRecord{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			frp := fakeRecommendationProvider{resources: tc.recommendResources, err: tc.recommendError}
+			calculator := resourcesInplaceUpdatesPatchCalculator{recommendationProvider: &frp}
+
+			patches, err := calculator.CalculatePatches(tc.pod, tc.vpa)
+			if tc.expectError != nil {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectPatches, patches)
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/updater/inplace/unboost_patch_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/inplace/unboost_patch_calculator.go
@@ -22,7 +22,6 @@ import (
 	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
@@ -40,10 +39,9 @@ func (*unboostAnnotationPatchCalculator) PatchResourceTarget() patch.PatchResour
 
 // CalculatePatches calculates the patch to remove the startup CPU boost annotation if the pod is ready to be unboosted.
 func (c *unboostAnnotationPatchCalculator) CalculatePatches(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) ([]resource_admission.PatchRecord, error) {
-	if vpa_api_util.IsPodReadyAndStartupBoostDurationPassed(pod, vpa) {
-		return []resource_admission.PatchRecord{
-			patch.GetRemoveAnnotationPatch(annotations.StartupCPUBoostAnnotation),
-		}, nil
+	var patches []resource_admission.PatchRecord
+	for _, annotationKey := range vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa) {
+		patches = append(patches, patch.GetRemoveAnnotationPatch(annotationKey))
 	}
-	return []resource_admission.PatchRecord{}, nil
+	return patches, nil
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -286,11 +286,10 @@ func (u *updater) RunOnce(ctx context.Context) {
 		if cpuStartupBoostFeatureEnabled && vpa_api_util.HasStartupBoost(vpa) {
 			// First, handle unboosting for pods that have finished their startup period.
 			for _, pod := range livePods {
-				if vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
-					if vpa_api_util.IsPodReadyAndStartupBoostDurationPassed(pod, vpa) {
-						podsToUnboost = append(podsToUnboost, pod)
-					}
-				} else {
+				if len(vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa)) > 0 {
+					podsToUnboost = append(podsToUnboost, pod)
+				}
+				if !vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
 					podsAvailableForUpdate = append(podsAvailableForUpdate, pod)
 				}
 			}

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -195,7 +195,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 			updateMode != vpa_types.UpdateModeAuto && //nolint:staticcheck
 			updateMode != vpa_types.UpdateModeInPlaceOrRecreate &&
 			updateMode != vpa_types.UpdateModeInPlace &&
-			vpa.Spec.StartupBoost == nil {
+			!vpa_api_util.HasStartupBoost(vpa) {
 			klog.V(3).InfoS("Skipping VPA object because its mode is not  \"InPlaceOrRecreate\", \"InPlace\", \"Recreate\" or \"Auto\" and it doesn't have startupBoost configured", "vpa", klog.KObj(vpa))
 			continue
 		}
@@ -283,7 +283,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 		podsToUnboost := make([]*corev1.Pod, 0)
 		withInPlaceUpdated := false
 
-		if cpuStartupBoostFeatureEnabled && vpa.Spec.StartupBoost != nil {
+		if cpuStartupBoostFeatureEnabled && vpa_api_util.HasStartupBoost(vpa) {
 			// First, handle unboosting for pods that have finished their startup period.
 			for _, pod := range livePods {
 				if vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/priority"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/restriction"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/utils"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 )
@@ -297,7 +298,7 @@ func testRunOnceBase(
 		pods[i].Labels = labels
 		if isCPUBoostTest {
 			pods[i].Annotations = map[string]string{
-				"startup-cpu-boost": "",
+				annotations.GetStartupCPUBoostAnnotationKey(containerName): "",
 			}
 			pods[i].Status.Conditions = []corev1.PodCondition{
 				{
@@ -742,7 +743,7 @@ func TestRunOnce_AutoUnboostThenEvict(t *testing.T) {
 
 	// Cycle 1: Unboost the cpu
 	for i := range pods {
-		pods[i].Annotations = map[string]string{"startup-cpu-boost": ""}
+		pods[i].Annotations = map[string]string{annotations.GetStartupCPUBoostAnnotationKey(containerName): ""}
 		pods[i].Status.Conditions = []corev1.PodCondition{
 			{
 				Type:   corev1.PodReady,
@@ -841,7 +842,7 @@ func TestRunOnce_AutoUnboostThenInPlace(t *testing.T) {
 
 	// Cycle 1: Unboost the cpu
 	for i := range pods {
-		pods[i].Annotations = map[string]string{"startup-cpu-boost": ""}
+		pods[i].Annotations = map[string]string{annotations.GetStartupCPUBoostAnnotationKey(containerName): ""}
 		pods[i].Status.Conditions = []corev1.PodCondition{
 			{
 				Type:   corev1.PodReady,

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -203,11 +203,10 @@ func (ip *PodsInPlaceRestrictionImpl) CanUnboost(pod *corev1.Pod, vpa *vpa_types
 	if pod.Status.Phase == corev1.PodPending {
 		return false
 	}
-	durationPassed := vpa_api_util.IsPodReadyAndStartupBoostDurationPassed(pod, vpa)
+	expiredAnnotations := vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa)
+	klog.V(2).InfoS("Pod ready, checking if containers can be unboosted", "pod", klog.KObj(pod))
 
-	klog.V(2).InfoS("Checking if pod can be unboosted", "pod", klog.KObj(pod), "durationPassed", durationPassed)
-
-	if !durationPassed {
+	if len(expiredAnnotations) == 0 {
 		return false
 	}
 	cr, present := ip.podToReplicaCreatorMap[getPodID(pod)]

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -204,11 +204,10 @@ func (ip *PodsInPlaceRestrictionImpl) CanUnboost(pod *corev1.Pod, vpa *vpa_types
 		return false
 	}
 	expiredAnnotations := vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa)
-	klog.V(2).InfoS("Pod ready, checking if containers can be unboosted", "pod", klog.KObj(pod))
-
 	if len(expiredAnnotations) == 0 {
 		return false
 	}
+	klog.V(2).InfoS("Pod ready, checking if containers can be unboosted", "pod", klog.KObj(pod))
 	cr, present := ip.podToReplicaCreatorMap[getPodID(pod)]
 	if present {
 		singleGroupStats, present := ip.creatorToSingleGroupStatsMap[cr]

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
@@ -302,7 +302,7 @@ func TestDisruptReplicatedByController(t *testing.T) {
 			pods: []podWithExpectations{
 				{
 					pod: generatePod().WithAnnotations(map[string]string{
-						annotations.StartupCPUBoostAnnotation: "",
+						annotations.GetStartupCPUBoostAnnotationKey("container1"): "",
 					}).Get(),
 					canEvict:        true,
 					evictionSuccess: true,

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	// StartupCPUBoostAnnotation is the annotation set on a pod when a CPU boost is applied.
+	// StartupCPUBoostAnnotationSuffix is the suffix for the annotation set on a pod when a CPU boost is applied.
 	// The value of the annotation is the original resource specification of the container.
-	StartupCPUBoostAnnotation = "startup-cpu-boost"
+	StartupCPUBoostAnnotationSuffix = "/cpu-startup-boost"
 )
 
 // OriginalResources contains the original resources of a container.
@@ -56,9 +56,14 @@ func GetOriginalResourcesAnnotationValue(container *corev1.Container) (string, e
 	return string(b), err
 }
 
-// GetOriginalResourcesFromAnnotation returns the original resources from the annotation.
-func GetOriginalResourcesFromAnnotation(pod *corev1.Pod) (*OriginalResources, error) {
-	val, ok := pod.Annotations[StartupCPUBoostAnnotation]
+// GetStartupCPUBoostAnnotationKey returns the annotation key for a given container.
+func GetStartupCPUBoostAnnotationKey(containerName string) string {
+	return containerName + StartupCPUBoostAnnotationSuffix
+}
+
+// GetOriginalResourcesFromAnnotation returns the original resources from the annotation for a specific container.
+func GetOriginalResourcesFromAnnotation(pod *corev1.Pod, containerName string) (*OriginalResources, error) {
+	val, ok := pod.Annotations[GetStartupCPUBoostAnnotationKey(containerName)]
 	if !ok {
 		return nil, nil
 	}

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	// StartupCPUBoostAnnotationSuffix is the suffix for the annotation set on a pod when a CPU boost is applied.
+	// StartupCPUBoostAnnotationPrefix is the prefix for the annotation set on a pod when a CPU boost is applied.
 	// The value of the annotation is the original resource specification of the container.
-	StartupCPUBoostAnnotationSuffix = "/cpu-startup-boost"
+	StartupCPUBoostAnnotationPrefix = "vpaCpuStartupBoost/"
 )
 
 // OriginalResources contains the original resources of a container.
@@ -58,7 +58,7 @@ func GetOriginalResourcesAnnotationValue(container *corev1.Container) (string, e
 
 // GetStartupCPUBoostAnnotationKey returns the annotation key for a given container.
 func GetStartupCPUBoostAnnotationKey(containerName string) string {
-	return containerName + StartupCPUBoostAnnotationSuffix
+	return StartupCPUBoostAnnotationPrefix + containerName
 }
 
 // GetOriginalResourcesFromAnnotation returns the original resources from the annotation for a specific container.

--- a/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/annotations/vpa_cpu_boost_test.go
@@ -123,7 +123,7 @@ func TestGetOriginalResourcesFromAnnotation(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						StartupCPUBoostAnnotation: `{"requests":{"cpu":"1","memory":"1Gi"},"limits":{"cpu":"2","memory":"2Gi"}}`,
+						GetStartupCPUBoostAnnotationKey("container1"): `{"requests":{"cpu":"1","memory":"1Gi"},"limits":{"cpu":"2","memory":"2Gi"}}`,
 					},
 				},
 			},
@@ -154,7 +154,7 @@ func TestGetOriginalResourcesFromAnnotation(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						StartupCPUBoostAnnotation: "invalid-json",
+						GetStartupCPUBoostAnnotationKey("container1"): "invalid-json",
 					},
 				},
 			},
@@ -165,7 +165,7 @@ func TestGetOriginalResourcesFromAnnotation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := GetOriginalResourcesFromAnnotation(tc.pod)
+			got, err := GetOriginalResourcesFromAnnotation(tc.pod, "container1")
 			if tc.expectErr {
 				assert.Error(t, err)
 				return

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -310,59 +310,54 @@ func CreateOrUpdateVpaCheckpoint(vpaCheckpointClient vpa_api.VerticalPodAutoscal
 	return nil
 }
 
-// IsPodReadyAndStartupBoostDurationPassed returns true if the pod is ready and all container startup boost durations have passed.
-// TODO(kamarabbas99): Instead of allowing the pod to be unboosted only after all containers have passed their boost duration, we
-// can allow unboosting as soon as any container has passed its boost duration. This will require changes in the
-// way we track unboost and unboosting logic in the updater.
-func IsPodReadyAndStartupBoostDurationPassed(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) bool {
-	if !PodHasCPUBoostInProgressAnnotation(pod) {
-		return false
+// GetExpiredStartupCPUBoostAnnotations returns the names of the containers that have passed their startup boost duration.
+func GetExpiredStartupCPUBoostAnnotations(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) []string {
+	var expiredAnnotations []string
+
+	_, readyCond := GetPodCondition(&pod.Status, corev1.PodReady)
+	if readyCond == nil || readyCond.Status != corev1.ConditionTrue {
+		return expiredAnnotations
+	}
+	readyTime := readyCond.LastTransitionTime.Time
+
+	for k := range pod.Annotations {
+		if containerName, found := strings.CutSuffix(k, annotations.StartupCPUBoostAnnotationSuffix); found {
+			boostDuration := getContainerCPUStartupBoostDuration(containerName, vpa)
+			if boostDuration == 0 || time.Since(readyTime) > time.Duration(boostDuration)*time.Second {
+				expiredAnnotations = append(expiredAnnotations, k)
+			}
+		}
 	}
 
-	if !IsPodReady(pod) {
-		return false
-	}
+	return expiredAnnotations
+}
 
-	var maxBoostDuration int32
+func getContainerCPUStartupBoostDuration(containerName string, vpa *vpa_types.VerticalPodAutoscaler) int32 {
+	var boostDuration int32
 	if vpa.Spec.StartupBoost != nil && vpa.Spec.StartupBoost.CPU != nil && vpa.Spec.StartupBoost.CPU.DurationSeconds != nil {
-		maxBoostDuration = *vpa.Spec.StartupBoost.CPU.DurationSeconds // Default to pod-level
+		boostDuration = *vpa.Spec.StartupBoost.CPU.DurationSeconds // Default to pod-level
 	}
 
 	if vpa.Spec.ResourcePolicy != nil {
-		for _, container := range pod.Spec.Containers {
-			crp := GetContainerResourcePolicy(container.Name, vpa.Spec.ResourcePolicy)
-
-			if crp == nil || crp.StartupBoost == nil || crp.StartupBoost.CPU == nil || crp.StartupBoost.CPU.DurationSeconds == nil {
-				continue
-			}
-
-			if *crp.StartupBoost.CPU.DurationSeconds > maxBoostDuration {
-				maxBoostDuration = *crp.StartupBoost.CPU.DurationSeconds
-			}
+		crp := GetContainerResourcePolicy(containerName, vpa.Spec.ResourcePolicy)
+		if crp != nil && crp.StartupBoost != nil && crp.StartupBoost.CPU != nil && crp.StartupBoost.CPU.DurationSeconds != nil {
+			boostDuration = *crp.StartupBoost.CPU.DurationSeconds
 		}
 	}
-
-	if maxBoostDuration == 0 {
-		return true
-	}
-
-	readyTime := time.Time{}
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			readyTime = cond.LastTransitionTime.Time
-			break
-		}
-	}
-	return time.Since(readyTime) > time.Duration(maxBoostDuration)*time.Second
+	return boostDuration
 }
 
-// PodHasCPUBoostInProgressAnnotation returns true if the pod has the CPU boost annotation.
+// PodHasCPUBoostInProgressAnnotation returns true if the pod has any CPU boost in progress annotation.
 func PodHasCPUBoostInProgressAnnotation(pod *corev1.Pod) bool {
 	if pod.Annotations == nil {
 		return false
 	}
-	_, found := pod.Annotations[annotations.StartupCPUBoostAnnotation]
-	return found
+	for k := range pod.Annotations {
+		if strings.HasSuffix(k, annotations.StartupCPUBoostAnnotationSuffix) {
+			return true
+		}
+	}
+	return false
 }
 
 // IsPodReady returns true if a pod is ready; false otherwise.

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -321,7 +321,7 @@ func GetExpiredStartupCPUBoostAnnotations(pod *corev1.Pod, vpa *vpa_types.Vertic
 	readyTime := readyCond.LastTransitionTime.Time
 
 	for k := range pod.Annotations {
-		if containerName, found := strings.CutSuffix(k, annotations.StartupCPUBoostAnnotationSuffix); found {
+		if containerName, found := strings.CutPrefix(k, annotations.StartupCPUBoostAnnotationPrefix); found {
 			boostDuration := getContainerCPUStartupBoostDuration(containerName, vpa)
 			if boostDuration == 0 || time.Since(readyTime) > time.Duration(boostDuration)*time.Second {
 				expiredAnnotations = append(expiredAnnotations, k)
@@ -353,7 +353,7 @@ func PodHasCPUBoostInProgressAnnotation(pod *corev1.Pod) bool {
 		return false
 	}
 	for k := range pod.Annotations {
-		if strings.HasSuffix(k, annotations.StartupCPUBoostAnnotationSuffix) {
+		if strings.HasPrefix(k, annotations.StartupCPUBoostAnnotationPrefix) {
 			return true
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -245,6 +245,21 @@ func GetUpdateMode(vpa *vpa_types.VerticalPodAutoscaler) vpa_types.UpdateMode {
 	return *vpa.Spec.UpdatePolicy.UpdateMode
 }
 
+// HasStartupBoost returns true if VPA has StartupBoost defined either globally or at container level.
+func HasStartupBoost(vpa *vpa_types.VerticalPodAutoscaler) bool {
+	if vpa.Spec.StartupBoost != nil {
+		return true
+	}
+	if vpa.Spec.ResourcePolicy != nil {
+		for _, containerPolicy := range vpa.Spec.ResourcePolicy.ContainerPolicies {
+			if containerPolicy.StartupBoost != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // GetContainerResourcePolicy returns the ContainerResourcePolicy for a given policy
 // and container name. It returns nil if there is no policy specified for the container.
 func GetContainerResourcePolicy(containerName string, policy *vpa_types.PodResourcePolicy) *vpa_types.ContainerResourcePolicy {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -400,7 +400,7 @@ func TestFindParentControllerForPod(t *testing.T) {
 	}
 }
 
-func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
+func TestGetExpiredStartupCPUBoostAnnotations(t *testing.T) {
 	now := metav1.Now()
 	past := metav1.Time{Time: now.Add(-2 * time.Minute)}
 	duration60 := int32(60)
@@ -410,26 +410,26 @@ func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
 		name     string
 		pod      *corev1.Pod
 		vpa      *vpa_types.VerticalPodAutoscaler
-		expected bool
+		expected []string
 	}{
 		{
 			name:     "No StartupBoost config",
 			pod:      &corev1.Pod{},
 			vpa:      &vpa_types.VerticalPodAutoscaler{},
-			expected: false,
+			expected: nil,
 		},
 		{
 			name:     "No duration in StartupBoost, no annotation",
 			pod:      &corev1.Pod{},
 			vpa:      test.VerticalPodAutoscaler().WithContainer(containerName).WithCPUStartupBoost(vpa_types.FactorStartupBoostType, nil, nil, 0).Get(),
-			expected: false,
+			expected: nil,
 		},
 		{
 			name: "No duration in StartupBoost, with annotation and pod ready",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"startup-cpu-boost": "",
+						"c1/cpu-startup-boost": "",
 					},
 				},
 				Status: corev1.PodStatus{
@@ -442,14 +442,14 @@ func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
 				},
 			},
 			vpa:      test.VerticalPodAutoscaler().WithContainer(containerName).WithCPUStartupBoost(vpa_types.FactorStartupBoostType, nil, nil, 0).Get(),
-			expected: true,
+			expected: []string{"c1/cpu-startup-boost"},
 		},
 		{
 			name: "Pod not ready",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"startup-cpu-boost": "",
+						"c1/cpu-startup-boost": "",
 					},
 				},
 				Status: corev1.PodStatus{
@@ -462,14 +462,14 @@ func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
 				},
 			},
 			vpa:      test.VerticalPodAutoscaler().WithContainer(containerName).WithCPUStartupBoost(vpa_types.FactorStartupBoostType, nil, nil, 60).Get(),
-			expected: false,
+			expected: nil,
 		},
 		{
 			name: "Duration passed",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"startup-cpu-boost": "",
+						"c1/cpu-startup-boost": "",
 					},
 				},
 				Status: corev1.PodStatus{
@@ -483,14 +483,14 @@ func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
 				},
 			},
 			vpa:      test.VerticalPodAutoscaler().WithContainer(containerName).WithCPUStartupBoost(vpa_types.FactorStartupBoostType, nil, nil, 60).Get(),
-			expected: true,
+			expected: []string{"c1/cpu-startup-boost"},
 		},
 		{
 			name: "Duration not passed",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"startup-cpu-boost": "",
+						"c1/cpu-startup-boost": "",
 					},
 				},
 				Status: corev1.PodStatus{
@@ -504,14 +504,15 @@ func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
 				},
 			},
 			vpa:      test.VerticalPodAutoscaler().WithContainer(containerName).WithCPUStartupBoost(vpa_types.FactorStartupBoostType, nil, nil, 60).Get(),
-			expected: false,
+			expected: nil,
 		},
 		{
 			name: "Container-level boost duration",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"startup-cpu-boost": "",
+						"c1/cpu-startup-boost": "",
+						"c2/cpu-startup-boost": "",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -554,14 +555,15 @@ func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: []string{"c2/cpu-startup-boost"},
 		},
 		{
 			name: "Container-level boost duration passed",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"startup-cpu-boost": "",
+						"c1/cpu-startup-boost": "",
+						"c2/cpu-startup-boost": "",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -604,14 +606,14 @@ func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: []string{"c1/cpu-startup-boost", "c2/cpu-startup-boost"},
 		},
 		{
 			name: "Pod-level boost duration is higher",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"startup-cpu-boost": "",
+						"c1/cpu-startup-boost": "",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -659,12 +661,13 @@ func TestIsPodReadyAndStartupBoostDurationPassed(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: []string{"c1/cpu-startup-boost"},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, IsPodReadyAndStartupBoostDurationPassed(tc.pod, tc.vpa))
+			actual := GetExpiredStartupCPUBoostAnnotations(tc.pod, tc.vpa)
+			assert.ElementsMatch(t, tc.expected, actual)
 		})
 	}
 }
@@ -685,7 +688,7 @@ func TestPodHasCPUBoostInProgressAnnotation(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"startup-cpu-boost": "",
+						"c1/cpu-startup-boost": "",
 					},
 				},
 			},

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -429,7 +429,7 @@ func TestGetExpiredStartupCPUBoostAnnotations(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"c1/cpu-startup-boost": "",
+						"vpaCpuStartupBoost/c1": "",
 					},
 				},
 				Status: corev1.PodStatus{
@@ -442,14 +442,14 @@ func TestGetExpiredStartupCPUBoostAnnotations(t *testing.T) {
 				},
 			},
 			vpa:      test.VerticalPodAutoscaler().WithContainer(containerName).WithCPUStartupBoost(vpa_types.FactorStartupBoostType, nil, nil, 0).Get(),
-			expected: []string{"c1/cpu-startup-boost"},
+			expected: []string{"vpaCpuStartupBoost/c1"},
 		},
 		{
 			name: "Pod not ready",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"c1/cpu-startup-boost": "",
+						"vpaCpuStartupBoost/c1": "",
 					},
 				},
 				Status: corev1.PodStatus{
@@ -469,7 +469,7 @@ func TestGetExpiredStartupCPUBoostAnnotations(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"c1/cpu-startup-boost": "",
+						"vpaCpuStartupBoost/c1": "",
 					},
 				},
 				Status: corev1.PodStatus{
@@ -483,14 +483,14 @@ func TestGetExpiredStartupCPUBoostAnnotations(t *testing.T) {
 				},
 			},
 			vpa:      test.VerticalPodAutoscaler().WithContainer(containerName).WithCPUStartupBoost(vpa_types.FactorStartupBoostType, nil, nil, 60).Get(),
-			expected: []string{"c1/cpu-startup-boost"},
+			expected: []string{"vpaCpuStartupBoost/c1"},
 		},
 		{
 			name: "Duration not passed",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"c1/cpu-startup-boost": "",
+						"vpaCpuStartupBoost/c1": "",
 					},
 				},
 				Status: corev1.PodStatus{
@@ -511,8 +511,8 @@ func TestGetExpiredStartupCPUBoostAnnotations(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"c1/cpu-startup-boost": "",
-						"c2/cpu-startup-boost": "",
+						"vpaCpuStartupBoost/c1": "",
+						"vpaCpuStartupBoost/c2": "",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -555,15 +555,15 @@ func TestGetExpiredStartupCPUBoostAnnotations(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{"c2/cpu-startup-boost"},
+			expected: []string{"vpaCpuStartupBoost/c2"},
 		},
 		{
 			name: "Container-level boost duration passed",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"c1/cpu-startup-boost": "",
-						"c2/cpu-startup-boost": "",
+						"vpaCpuStartupBoost/c1": "",
+						"vpaCpuStartupBoost/c2": "",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -606,14 +606,14 @@ func TestGetExpiredStartupCPUBoostAnnotations(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{"c1/cpu-startup-boost", "c2/cpu-startup-boost"},
+			expected: []string{"vpaCpuStartupBoost/c1", "vpaCpuStartupBoost/c2"},
 		},
 		{
 			name: "Pod-level boost duration is higher",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"c1/cpu-startup-boost": "",
+						"vpaCpuStartupBoost/c1": "",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -661,7 +661,7 @@ func TestGetExpiredStartupCPUBoostAnnotations(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{"c1/cpu-startup-boost"},
+			expected: []string{"vpaCpuStartupBoost/c1"},
 		},
 	}
 	for _, tc := range testCases {
@@ -688,7 +688,7 @@ func TestPodHasCPUBoostInProgressAnnotation(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"c1/cpu-startup-boost": "",
+						"vpaCpuStartupBoost/c1": "",
 					},
 				},
 			},

--- a/vertical-pod-autoscaler/test/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/common.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -263,7 +264,7 @@ func AnnotatePod(f *framework.Framework, podName, annotationName, annotationValu
 
 	patches = append(patches, utils.PatchRecord{
 		Op:    "add",
-		Path:  fmt.Sprintf("/metadata/annotations/%s", annotationName),
+		Path:  fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(annotationName, "/", "~1")),
 		Value: annotationValue,
 	})
 

--- a/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/test/e2e/utils"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 	podsecurity "k8s.io/pod-security-admission/api"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -40,7 +41,7 @@ import (
 
 const (
 	minimalCPULowerBound    = "0m"
-	minimalCPUUpperBound    = "100m"
+	minimalCPUUpperBound    = "120m"
 	minimalMemoryLowerBound = "0Mi"
 	minimalMemoryUpperBound = "300Mi"
 	// the initial values should be outside minimal bounds
@@ -360,7 +361,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 	var (
 		rc *ResourceConsumer
 	)
-	replicas := 3
+	replicas := 1
 
 	ginkgo.AfterEach(func() {
 		rc.CleanUp()
@@ -438,7 +439,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 				WithTargetRef(targetRef).
 				WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
 				WithContainer(containerName).
-				WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor, nil, 10).
+				WithContainerCPUStartupBoost(containerName, vpa_types.FactorStartupBoostType, &factor, nil, 10).
 				Get()
 
 			utils.InstallVPA(f, vpaCRD)
@@ -454,17 +455,127 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 				f.ClientSet,
 				f.ScalesGetter)
 
-			// Pods should be created with boosted CPU (10m * 20 = 200m)
-			err := waitForResourceRequestInRangeInPods(
-				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-				ParseQuantityOrDie("180m"), ParseQuantityOrDie("220m"))
+			ginkgo.By("Adding a second container to the deployment")
+			deployment, err := f.ClientSet.AppsV1().Deployments(ns).Get(context.TODO(), "hamster", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, apiv1.Container{
+				Name:    "container2",
+				Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+				Command: []string{"/agnhost", "pause"},
+				Resources: apiv1.ResourceRequirements{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU: ParseQuantityOrDie("20m"),
+					},
+				},
+			})
+			_, err = f.ClientSet.AppsV1().Deployments(ns).Update(context.TODO(), deployment, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+			// Wait for the new pods to roll out
+			err = waitForPodsMatch(f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"},
+				func(pod apiv1.Pod) bool {
+					return len(pod.Spec.Containers) == 2
+				})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verifying only the targeted container is boosted")
+			err = waitForResourceRequestsInRangeInPods(f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, []containerExpectation{
+				{Index: 0, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie("180m"), UpperBound: ParseQuantityOrDie("220m")},
+				{Index: 1, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie(minimalCPULowerBound), UpperBound: ParseQuantityOrDie(minimalCPUUpperBound)},
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verifying pods are unboosted in-place")
 			// Pods should be scaled back down in-place after they become Ready and
 			// StartupBoost.CPU.DurationSeconds has elapsed
-			err = waitForResourceRequestInRangeInPods(
-				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
-				ParseQuantityOrDie(minimalCPULowerBound), ParseQuantityOrDie(minimalCPUUpperBound))
+			err = waitForResourceRequestsInRangeInPods(f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, []containerExpectation{
+				{Index: 0, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie(minimalCPULowerBound), UpperBound: ParseQuantityOrDie(minimalCPUUpperBound)},
+				{Index: 1, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie(minimalCPULowerBound), UpperBound: ParseQuantityOrDie(minimalCPUUpperBound)},
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		f.It("with different durations for different containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), func() {
+			ns := f.Namespace.Name
+
+			ginkgo.By("Setting up a VPA CRD with CPUStartupBoost with different durations")
+			targetRef := &autoscaling.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "hamster",
+			}
+
+			container1Name := utils.GetHamsterContainerNameByIndex(0)
+			container2Name := utils.GetHamsterContainerNameByIndex(1)
+			factor := int32(20)
+			vpaCRD := test.VerticalPodAutoscaler().
+				WithName("hamster-vpa").
+				WithNamespace(f.Namespace.Name).
+				WithTargetRef(targetRef).
+				WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
+				WithContainer(container1Name).
+				WithContainer(container2Name).
+				WithContainerCPUStartupBoost(container1Name, vpa_types.FactorStartupBoostType, &factor, nil, 65).  // Short duration
+				WithContainerCPUStartupBoost(container2Name, vpa_types.FactorStartupBoostType, &factor, nil, 185). // Long duration
+				Get()
+
+			utils.InstallVPA(f, vpaCRD)
+
+			ginkgo.By("Setting up a hamster deployment with 1 container")
+			rc = NewDynamicResourceConsumer("hamster", ns, KindDeployment,
+				replicas,
+				1,             /*initCPUTotal*/
+				10,            /*initMemoryTotal*/
+				1,             /*initCustomMetric*/
+				initialCPU,    /*cpuRequest*/
+				initialMemory, /*memRequest*/
+				f.ClientSet,
+				f.ScalesGetter)
+
+			ginkgo.By("Adding a second container to the deployment")
+			deployment, err := f.ClientSet.AppsV1().Deployments(ns).Get(context.TODO(), "hamster", metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, apiv1.Container{
+				Name:    container2Name,
+				Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+				Command: []string{"/agnhost", "pause"},
+				Resources: apiv1.ResourceRequirements{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU: ParseQuantityOrDie("20m"),
+					},
+				},
+			})
+			_, err = f.ClientSet.AppsV1().Deployments(ns).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Wait for the new pods to roll out with 2 containers
+			err = waitForPodsMatch(f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"},
+				func(pod apiv1.Pod) bool {
+					return len(pod.Spec.Containers) == 2
+				})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verifying both containers are initially boosted")
+			err = waitForResourceRequestsInRangeInPods(f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, []containerExpectation{
+				{Index: 0, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie("180m"), UpperBound: ParseQuantityOrDie("220m")}, // 10m * 20
+				{Index: 1, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie("350m"), UpperBound: ParseQuantityOrDie("450m")}, // 20m * 20 = 400m
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verifying container 1 is unboosted first")
+			// Wait for the VPA updater to unboost container1 while container2 remains boosted.
+			err = waitForResourceRequestsInRangeInPods(f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, []containerExpectation{
+				{Index: 0, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie(minimalCPULowerBound), UpperBound: ParseQuantityOrDie(minimalCPUUpperBound)}, // Unboosted
+				{Index: 1, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie("350m"), UpperBound: ParseQuantityOrDie("450m")},                             // Still boosted
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verifying container 2 is unboosted later")
+			// At some point when duration of container2 passes, both containers will be unboosted.
+			err = waitForResourceRequestsInRangeInPods(f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, []containerExpectation{
+				{Index: 0, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie(minimalCPULowerBound), UpperBound: ParseQuantityOrDie(minimalCPUUpperBound)},
+				{Index: 1, ResourceName: apiv1.ResourceCPU, LowerBound: ParseQuantityOrDie(minimalCPULowerBound), UpperBound: ParseQuantityOrDie(minimalCPUUpperBound)},
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 	})
@@ -545,16 +656,37 @@ func waitForPodsMatch(f *framework.Framework, timeout time.Duration, listOptions
 	})
 }
 
-func waitForResourceRequestInRangeInPods(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, resourceName apiv1.ResourceName, lowerBound, upperBound resource.Quantity) error {
+type containerExpectation struct {
+	Index        int
+	ResourceName apiv1.ResourceName
+	LowerBound   resource.Quantity
+	UpperBound   resource.Quantity
+}
+
+func waitForResourceRequestsInRangeInPods(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, expectations []containerExpectation) error {
 	err := waitForPodsMatch(f, timeout, listOptions,
 		func(pod apiv1.Pod) bool {
-			resourceRequest, found := pod.Spec.Containers[0].Resources.Requests[resourceName]
-			framework.Logf("Comparing %v request %v against range of (%v, %v)", resourceName, resourceRequest, lowerBound, upperBound)
-			return found && resourceRequest.MilliValue() > lowerBound.MilliValue() && resourceRequest.MilliValue() < upperBound.MilliValue()
+			for _, exp := range expectations {
+				if exp.Index >= len(pod.Spec.Containers) {
+					return false
+				}
+				req, found := pod.Spec.Containers[exp.Index].Resources.Requests[exp.ResourceName]
+				framework.Logf("Pod %s container %d: Comparing %v request %v against range of (%v, %v)", pod.Name, exp.Index, exp.ResourceName, req, exp.LowerBound, exp.UpperBound)
+				if !found || req.MilliValue() < exp.LowerBound.MilliValue() || req.MilliValue() > exp.UpperBound.MilliValue() {
+					return false
+				}
+			}
+			return true
 		})
 
 	if err != nil {
-		return fmt.Errorf("error waiting for %s request in range of (%v,%v) for pods: %+v", resourceName, lowerBound, upperBound, listOptions)
+		return fmt.Errorf("error waiting for resource requests in range %+v for pods: %+v", expectations, listOptions)
 	}
 	return nil
+}
+
+func waitForResourceRequestInRangeInPods(f *framework.Framework, timeout time.Duration, listOptions metav1.ListOptions, resourceName apiv1.ResourceName, lowerBound, upperBound resource.Quantity) error {
+	return waitForResourceRequestsInRangeInPods(f, timeout, listOptions, []containerExpectation{
+		{Index: 0, ResourceName: resourceName, LowerBound: lowerBound, UpperBound: upperBound},
+	})
 }

--- a/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
@@ -392,7 +392,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 				WithTargetRef(targetRef).
 				WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
 				WithContainer(containerName).
-				WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor, nil, 10).
+				WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor, nil, 65).
 				Get()
 			utils.InstallVPA(f, vpaCRD)
 
@@ -439,7 +439,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 				WithTargetRef(targetRef).
 				WithUpdateMode(vpa_types.UpdateModeInPlaceOrRecreate).
 				WithContainer(containerName).
-				WithContainerCPUStartupBoost(containerName, vpa_types.FactorStartupBoostType, &factor, nil, 10).
+				WithContainerCPUStartupBoost(containerName, vpa_types.FactorStartupBoostType, &factor, nil, 65).
 				Get()
 
 			utils.InstallVPA(f, vpaCRD)

--- a/vertical-pod-autoscaler/test/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/updater.go
@@ -541,7 +541,7 @@ func setupPodsForCPUBoost(f *framework.Framework, hamsterCPU, hamsterMemory stri
 	for _, pod := range podList.Items {
 		original, err := annotations.GetOriginalResourcesAnnotationValue(&pod.Spec.Containers[0])
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		AnnotatePod(f, pod.Name, annotations.StartupCPUBoostAnnotation, original)
+		AnnotatePod(f, pod.Name, annotations.GetStartupCPUBoostAnnotationKey(pod.Spec.Containers[0].Name), original)
 	}
 	return podList
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind bug


 #### What this PR does / why we need it:
  - This PR introduces container-scoped CPU Startup Boost annotations in the Vertical Pod Autoscaler (VPA). Previously, a single pod-level annotation (`startup-cpu-boost`) was used, which didn't scale well for multi-container setups. By refactoring annotations to follow the format `vpaCpuStartupBoost/[containerName]`(note :- the '/' is literal character in annotation and  not path so I had to use '~1' as an escape sequence), we can now independently track and manage boost states for separate containers and revert back to each individual original requested cpu for each container instead. Currently we will only store original request and limit for one container. 
  - The updater was skipping pods with startup boost set only at container level.
  - fix full-vpa suite to properly test subset of container boosts 
 - nit change variable names to 'cpu startup boost' to be consistent.

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/autoscaler/issues/9471

#### Special notes for your reviewer:

I will update and merge the KEP changes if any once this approved.

#### Does this PR introduce a user-facing change?
The boost annotation will look different. But we havent had a release yet with startup boost.

```release-note
NONE
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: (https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost#aep-7862-cpu-startup-boost)
```
