### PR TITLE
vpa: add missing */scale RBAC for admission controller

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrole.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-clusterrole.yaml
@@ -68,4 +68,12 @@ rules:
       - get
       - list
       - watch
+  # Allow access to scale subresources for resolving target selectors
+  - apiGroups:
+      - "*"
+    resources:
+      - "*/scale"
+    verbs:
+      - get
+      - watch
 {{- end -}}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Helm chart for the VPA admission controller is missing RBAC permissions for the `*/scale` subresource, which are already present in the standard deployment (`deploy/vpa-rbac.yaml`).

The admission controller relies on access to the scale subresource to resolve target selectors (via `status.labelSelector`) for VPA objects. Without this permission, it fails when working with custom resources (CRDs) that implement the scale subresource.

This PR adds `get` and `watch` permissions for `*/scale` to align the Helm chart RBAC with the standard deployment and restore expected functionality.

#### Which issue(s) this PR fixes:

Fixes #9485

#### Special notes for your reviewer:

- This change is scoped only to the admission controller ClusterRole.
- Permissions are limited to `get` and `watch`, matching the standard deployment and avoiding over-permissioning.
- This ensures consistent behavior between Helm and non-Helm installations.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```