### PR TITLE
Implement O(1) PredicateEvaluator for inter pod affinity

### DIFF
--- a/cluster-autoscaler/builder/autoscaler.go
+++ b/cluster-autoscaler/builder/autoscaler.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/predicate"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store/streaming"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
@@ -151,14 +152,19 @@ func (b *AutoscalerBuilder) Build(ctx context.Context) (core.Autoscaler, *loop.L
 		return nil, nil, fmt.Errorf("informerFactory is missing: ensure WithInformerFactory() is called")
 	}
 
-	fwHandle, err := framework.NewHandle(ctx, b.informerFactory, autoscalingOptions.SchedulerConfig, autoscalingOptions.DynamicResourceAllocationEnabled, autoscalingOptions.CSINodeAwareSchedulingEnabled)
+	fwHandle, err := framework.NewHandle(ctx, b.informerFactory, autoscalingOptions.SchedulerConfig, autoscalingOptions.DynamicResourceAllocationEnabled, autoscalingOptions.CSINodeAwareSchedulingEnabled, autoscalingOptions.FastPredicatesEnabled)
 	if err != nil {
 		return nil, nil, err
 	}
 	deleteOptions := options.NewNodeDeleteOptions(autoscalingOptions)
 	drainabilityRules := rules.Default(deleteOptions)
 
-	var snapshotStore clustersnapshot.ClusterSnapshotStore = store.NewDeltaSnapshotStore(autoscalingOptions.ClusterSnapshotParallelism)
+	var snapshotStore clustersnapshot.ClusterSnapshotStore
+	if autoscalingOptions.FastPredicatesEnabled {
+		snapshotStore = streaming.NewStreamingSnapshotStore()
+	} else {
+		snapshotStore = store.NewDeltaSnapshotStore(autoscalingOptions.ClusterSnapshotParallelism)
+	}
 	opts := coreoptions.AutoscalerOptions{
 		AutoscalingOptions:     autoscalingOptions,
 		FrameworkHandle:        fwHandle,

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -327,6 +327,8 @@ type AutoscalingOptions struct {
 	ClusterSnapshotParallelism int
 	// PredicateParallelism is the number of goroutines to use for running scheduler predicates.
 	PredicateParallelism int
+	// FastPredicatesEnabled enables the fast predicates feature.
+	FastPredicatesEnabled bool
 	// CheckCapacityProcessorInstance is the name of the processor instance.
 	// Only ProvisioningRequests that define this name in their parameters with the key "processorInstance" will be processed by this CA instance.
 	// It only refers to check capacity ProvisioningRequests, but if not empty, best-effort atomic ProvisioningRequests processing is disabled in this instance.

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -234,6 +234,7 @@ var (
 	enableCSINodeAwareScheduling                 = flag.Bool("enable-csi-node-aware-scheduling", false, "Whether logic for handling CSINode objects is enabled.")
 	clusterSnapshotParallelism                   = flag.Int("cluster-snapshot-parallelism", 16, "Maximum parallelism of cluster snapshot creation.")
 	predicateParallelism                         = flag.Int("predicate-parallelism", 4, "Maximum parallelism of scheduler predicate checking.")
+	fastPredicatesEnabled                        = flag.Bool("fast-predicates-enabled", false, "Whether logic for fast predicate checking is enabled.")
 	checkCapacityProcessorInstance               = flag.String("check-capacity-processor-instance", "", "Name of the processor instance. Only ProvisioningRequests that define this name in their parameters with the key \"processorInstance\" will be processed by this CA instance. It only refers to check capacity ProvisioningRequests, but if not empty, best-effort atomic ProvisioningRequests processing is disabled in this instance. Not recommended: Until CA 1.35, ProvisioningRequests with this name as prefix in their class will be also processed.")
 	nodeDeletionCandidateTTL                     = flag.Duration("node-deletion-candidate-ttl", time.Duration(0), "Maximum time a node can be marked as removable before the marking becomes stale. This sets the TTL of Cluster-Autoscaler's state if the Cluste-Autoscaler deployment becomes inactive")
 	capacitybufferControllerEnabled              = flag.Bool("capacity-buffer-controller-enabled", false, "Whether to enable the default controller for capacity buffers or not")
@@ -425,6 +426,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		CSINodeAwareSchedulingEnabled:                *enableCSINodeAwareScheduling,
 		ClusterSnapshotParallelism:                   *clusterSnapshotParallelism,
 		PredicateParallelism:                         *predicateParallelism,
+		FastPredicatesEnabled:                        *fastPredicatesEnabled,
 		CheckCapacityProcessorInstance:               *checkCapacityProcessorInstance,
 		MaxInactivityTime:                            *maxInactivityTimeFlag,
 		MaxFailingTime:                               *maxFailingTimeFlag,

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -33,8 +33,10 @@ import (
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas/capacityquota"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/predicate"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store/streaming"
 	csinodeprovider "k8s.io/autoscaler/cluster-autoscaler/simulator/csi/provider"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
 	draprovider "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/provider"
@@ -100,14 +102,20 @@ func initializeDefaultOptions(ctx context.Context, opts *coreoptions.AutoscalerO
 		opts.AutoscalingKubeClients = ca_context.NewAutoscalingKubeClients(ctx, opts.AutoscalingOptions, opts.KubeClient, opts.InformerFactory)
 	}
 	if opts.FrameworkHandle == nil {
-		fwHandle, err := framework.NewHandle(ctx, opts.InformerFactory, opts.SchedulerConfig, opts.DynamicResourceAllocationEnabled, opts.CSINodeAwareSchedulingEnabled)
+		fwHandle, err := framework.NewHandle(ctx, opts.InformerFactory, opts.SchedulerConfig, opts.DynamicResourceAllocationEnabled, opts.CSINodeAwareSchedulingEnabled, opts.FastPredicatesEnabled)
 		if err != nil {
 			return err
 		}
 		opts.FrameworkHandle = fwHandle
 	}
 	if opts.ClusterSnapshot == nil {
-		opts.ClusterSnapshot = predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), opts.FrameworkHandle, opts.DynamicResourceAllocationEnabled, opts.PredicateParallelism, opts.CSINodeAwareSchedulingEnabled)
+		var snapshotStore clustersnapshot.ClusterSnapshotStore
+		if opts.FastPredicatesEnabled {
+			snapshotStore = streaming.NewStreamingSnapshotStore()
+		} else {
+			snapshotStore = store.NewBasicSnapshotStore()
+		}
+		opts.ClusterSnapshot = predicate.NewPredicateSnapshot(snapshotStore, opts.FrameworkHandle, opts.DynamicResourceAllocationEnabled, opts.PredicateParallelism, opts.CSINodeAwareSchedulingEnabled)
 	}
 	if opts.RemainingPdbTracker == nil {
 		opts.RemainingPdbTracker = pdb.NewBasicRemainingPdbTracker()

--- a/cluster-autoscaler/core/bench/benchmark_runonce_affinity_test.go
+++ b/cluster-autoscaler/core/bench/benchmark_runonce_affinity_test.go
@@ -1,0 +1,183 @@
+package bench
+
+import (
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/autoscaler/cluster-autoscaler/test/integration"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+const (
+	nodesCount  = 5000
+	podsPerNode = 10 // 50,000 pods total
+	surgeCount  = 100
+
+	expectedTotal = nodesCount + surgeCount
+)
+
+func BenchmarkRunOnceAffinitySurge_Default(b *testing.B) {
+	s := scenario{
+		setup:  setupAffinitySurge(nodesCount, podsPerNode, surgeCount, 50),
+		verify: verifyTotalTargetSizeMassive(expectedTotal),
+		config: func(opts *config.AutoscalingOptions) {
+			configureAffinitySurge(opts)
+			opts.FastPredicatesEnabled = false
+		},
+	}
+	s.run(b)
+}
+
+func BenchmarkRunOnceAffinitySurge_FastPredicates(b *testing.B) {
+	s := scenario{
+		setup:  setupAffinitySurge(nodesCount, podsPerNode, surgeCount, 50),
+		verify: verifyTotalTargetSizeMassive(expectedTotal),
+		config: func(opts *config.AutoscalingOptions) {
+			configureAffinitySurge(opts)
+			opts.FastPredicatesEnabled = true
+		},
+	}
+	s.run(b)
+}
+
+func configureAffinitySurge(opts *config.AutoscalingOptions) {
+	opts.MaxNodesPerScaleUp = 1000000
+	opts.ScaleUpFromZero = true
+	opts.MaxCoresTotal = 1000000000
+	opts.MaxMemoryTotal = 1000000000
+	opts.MaxNodesTotal = 1000000
+	opts.PredicateParallelism = 16
+	// Use high binpacking limits to avoid benchmarks being cut by internal timeouts.
+	opts.MaxBinpackingTime = 10 * time.Minute
+	opts.MaxNodeGroupBinpackingDuration = 10 * time.Minute
+}
+
+func setupAffinitySurge(nodesCount, podsPerNode, surgePodsCount, nodesPerGroup int) func(*integration.FakeSet) error {
+	go func() {
+		importHttp := true
+		if importHttp {
+			_ = http.ListenAndServe("localhost:6060", nil)
+		}
+	}()
+	return func(clusterFakes *integration.FakeSet) error {
+		clusterFakes.CloudProvider.SetResourceLimit(cloudprovider.ResourceNameCores, 0, 1000000000)
+		clusterFakes.CloudProvider.SetResourceLimit(cloudprovider.ResourceNameMemory, 0, 1000000000)
+
+		podGlobalIdx := 0
+		numGroups := nodesCount / nodesPerGroup
+
+		for i := 0; i < numGroups; i++ {
+			ngName := fmt.Sprintf("ng-affinity-%d", i)
+			nTemplate := BuildTestNode(fmt.Sprintf("%s-template", ngName), nodeCPU, nodeMem)
+			if nTemplate.Labels == nil {
+				nTemplate.Labels = make(map[string]string)
+			}
+			nTemplate.Labels["kubernetes.io/hostname"] = nTemplate.Name
+			SetNodeReadyState(nTemplate, true, time.Now())
+
+			clusterFakes.CloudProvider.AddNodeGroup(ngName,
+				testprovider.WithTemplate(framework.NewNodeInfo(nTemplate, nil)),
+				testprovider.WithNGSize(nodesPerGroup, 1000000),
+			)
+
+			ng := clusterFakes.CloudProvider.GetNodeGroup(ngName)
+			if err := ng.IncreaseSize(nodesPerGroup); err != nil {
+				return err
+			}
+			ngID := ng.Id()
+
+			for j := 0; j < nodesPerGroup; j++ {
+				nodeName := fmt.Sprintf("%s-node-%d", ngID, j)
+
+				node := BuildTestNode(nodeName, nodeCPU, nodeMem)
+				if node.Labels == nil {
+					node.Labels = make(map[string]string)
+				}
+				node.Labels["kubernetes.io/hostname"] = nodeName
+				SetNodeReadyState(node, true, time.Now())
+				clusterFakes.K8s.AddNode(node)
+
+				for p := 0; p < podsPerNode; p++ {
+					podName := fmt.Sprintf("filler-%s-pod-%d", ngID, podGlobalIdx)
+					pod := BuildTestPod(podName, 10, 10)
+					pod.Spec.NodeName = nodeName
+
+					// Create many small deployments using anti-affinity.
+					// Every 2 pods belong to the same "deployment".
+					deploymentID := podGlobalIdx / 2
+					appLabel := fmt.Sprintf("app-%d", deploymentID)
+
+					pod.Labels = map[string]string{"app": appLabel}
+					pod.Spec.Affinity = &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"app": appLabel},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+					}
+
+					clusterFakes.K8s.AddPod(pod)
+					podGlobalIdx++
+				}
+			}
+		}
+
+		for i := 0; i < surgePodsCount; i++ {
+			podName := fmt.Sprintf("surge-pod-%d", i)
+			pod := BuildTestPod(podName, nodeCPU, nodeMem, MarkUnschedulable())
+
+			// Surge pods also have anti-affinity
+			deploymentID := (podGlobalIdx + i) / 2
+			appLabel := fmt.Sprintf("app-%d", deploymentID)
+
+			pod.Labels = map[string]string{"app": appLabel}
+			pod.Spec.Affinity = &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": appLabel},
+							},
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			}
+
+			clusterFakes.K8s.AddPod(pod)
+		}
+
+		return nil
+	}
+}
+
+func verifyTotalTargetSizeMassive(expectedTotalTargetSize int) func(*integration.FakeSet) error {
+	return func(clusterFakes *integration.FakeSet) error {
+		total := 0
+		for _, ng := range clusterFakes.CloudProvider.NodeGroups() {
+			targetSize, err := ng.TargetSize()
+			if err != nil {
+				return err
+			}
+			total += targetSize
+		}
+		if total != expectedTotalTargetSize {
+			return fmt.Errorf("verify failed: expected total target size %d, got %d", expectedTotalTargetSize, total)
+		}
+		return nil
+	}
+}

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/predicate"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store/streaming"
 	csisnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/csi/snapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
@@ -408,7 +409,13 @@ func (a *Actuator) taintNode(node *apiv1.Node) error {
 }
 
 func (a *Actuator) createSnapshot(nodes []*apiv1.Node) (clustersnapshot.ClusterSnapshot, error) {
-	snapshot := predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), a.autoscalingCtx.FrameworkHandle, a.autoscalingCtx.DynamicResourceAllocationEnabled, a.autoscalingCtx.PredicateParallelism, a.autoscalingCtx.CSINodeAwareSchedulingEnabled)
+	var snapshotStore clustersnapshot.ClusterSnapshotStore
+	if a.autoscalingCtx.FastPredicatesEnabled {
+		snapshotStore = streaming.NewStreamingSnapshotStore()
+	} else {
+		snapshotStore = store.NewBasicSnapshotStore()
+	}
+	snapshot := predicate.NewPredicateSnapshot(snapshotStore, a.autoscalingCtx.FrameworkHandle, a.autoscalingCtx.DynamicResourceAllocationEnabled, a.autoscalingCtx.PredicateParallelism, a.autoscalingCtx.CSINodeAwareSchedulingEnabled)
 	pods, err := a.autoscalingCtx.AllPodLister().List()
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/core/static_autoscaler_csi_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_csi_test.go
@@ -223,7 +223,7 @@ func TestStaticAutoscalerCSI(t *testing.T) {
 			// Create a framework handle with informer-backed listers for StorageClass/PVC/CSIDriver.
 			client := clientsetfake.NewSimpleClientset(k8sObjects...)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			fwHandle, err := framework.NewHandle(context.Background(), informerFactory, nil, false, true)
+			fwHandle, err := framework.NewHandle(context.Background(), informerFactory, nil, false, true, false)
 			require.NoError(t, err)
 			stopCh := make(chan struct{})
 			t.Cleanup(func() { close(stopCh) })

--- a/cluster-autoscaler/proposals/fast_affinity.md
+++ b/cluster-autoscaler/proposals/fast_affinity.md
@@ -1,0 +1,107 @@
+# Fast Incremental Slice-Based Affinity
+
+## Overview
+This document describes a high-performance architecture for Pod Affinity and Anti-Affinity predicates, optimized for the scale and volatility of the Cluster Autoscaler (CA). This design replaces traditional $O(\text{PodsOnNode})$ selector matching with incremental indexing, a **Two-Way Label Index**, and extremely fast $O(1)$ slice lookups.
+
+The system is built on three architectural pillars:
+1.  **Incremental Indexing (Streaming Snapshot Store):** Internal data structures are updated reactively as pods and nodes change using the **Fort** pipeline library, rather than being re-calculated during the scheduling loop.
+2.  **Copy-on-Write (CoW) Semantics:** State is shared across simulation forks using CoW `PatchSet` objects, `BTreeMap` structures, and slice operations to avoid expensive allocations.
+3.  **Two-Way Label Indexing & Phased Evaluation:** The system splits computations into a thread-safe **Prepare** phase (serial) and an optimized **Check** phase (parallel), using bi-directional label indexing to eliminate redundant $O(\text{Terms} \times \text{Pods})$ operations.
+
+---
+
+## Pillar 1: Incremental Indexing (Streaming & Fort)
+
+Traditional schedulers often "pull" data (e.g., scanning all pods on a node) during the filtering phase. In this design, we "push" updates through a reactive indexing pipeline implemented in the `StreamingSnapshotStore`.
+
+### The Pipeline Flow
+- **Event-Driven Updates:** The `StreamingSnapshotStore` manages a set of `fort.ManualSharedInformer` instances. When pods or nodes are added/removed, they trigger updates in downstream indices.
+- **Affinity Term Registry:** All unique `AffinityTerms` are tracked in a global registry and assigned a unique integer ID.
+- **Lazy Term Registration:** When a new term is introduced by a pod, the system lazily backfills its presence across the cluster. To avoid $O(\text{Pods})$ overhead, it uses the **Two-Way Label Index** to only scan pods with matching labels.
+- **Topology Aggregation:** Pod updates propagate to **Presence Slices** (tracking pods satisfying terms) and **Forbidden Slices** (tracking anti-affinity constraints) for every topology domain (Node, Zone, Region). These are stored in a `fort.BTreeMap` indexed by `TopologyKey \x00 TopologyValue`.
+
+---
+
+## Pillar 2: Copy-on-Write (CoW) Simulation
+
+The Cluster Autoscaler frequently forks the cluster state to simulate "what-if" scenarios.
+
+### Efficient Forking & Zero-Allocation Iteration
+- **PatchSets:** Global registries, domain trackers, and label indices use `common.PatchSet`. When `Fork()` is called, these push a new empty layer onto the stack ($O(1)$).
+- **Slice Counting:** Topology domains track term presence using dense `[]int32` slices. Cloning a domain for modification is a single `copy()` instruction.
+- **Incremental Caching:** Match results are cached in a `PatchSet`-backed **Match Cache**. This cache is preserved across forks and only evaluates the *difference* when new terms are registered, ensuring evaluation remains $O(1)$ during simulation.
+
+---
+
+## Pillar 3: Phased Evaluation (Prepare & Check)
+
+To maximize parallel throughput, evaluation is split into two phases:
+
+### Phase 1: `PreparePod` (Serial PreFilter)
+Before entering the parallel per-node loop, `PreparePod` is called once per pod:
+1. It registers any novel terms the pod owns.
+2. It identifies which existing terms the pod matches (using the **Two-Way Label Index**).
+3. It returns a lightweight `PodAffinityContext` containing resolved integer IDs.
+
+### Phase 2: `FastCheckAffinity` (Parallel Filter)
+Inside the per-node loop, the evaluation drops to pure integer slice lookups:
+
+1.  **Incoming Anti-Affinity:**
+    ```go
+    // O(1) lookup per term I own.
+    for _, term := range podCtx.ownedAntiAffinity {
+        key := term.topologyKey + "\x00" + node.Labels[term.topologyKey]
+        if m, ok := presence.Get(key); ok {
+            if m[term.id] > 0 { // Simple slice bounds and value check
+                return Unschedulable
+            }
+        }
+    }
+    ```
+
+2.  **Incoming Affinity:**
+    ```go
+    // O(1) lookup per term I own.
+    for _, term := range podCtx.ownedAffinity {
+        key := term.topologyKey + "\x00" + node.Labels[term.topologyKey]
+        m, hasPresence := presence.Get(key)
+        if !hasPresence || m[term.id] <= 0 {
+            if !selfMatches(podCtx.matchIDs, term.id) { // Self-satisfaction fallback
+                return Unschedulable
+            }
+        }
+    }
+    ```
+
+3.  **Existing Anti-Affinity (Symmetry):**
+    ```go
+    // Check if WE violate any existing pod's anti-affinity rules.
+    for k, v := range node.Labels {
+        key := k + "\x00" + v
+        if f, ok := forbidden.Get(key); ok {
+            for _, matchID := range podCtx.matchIDs {
+                if f[matchID] > 0 && terms[matchID].antiAffinity {
+                    return Unschedulable
+                }
+            }
+        }
+    }
+    ```
+
+---
+
+## Comparison with Standard Kubernetes `InterPodAffinity`
+
+| Metric | Standard K8s `InterPodAffinity` | Fast Incremental Slice-Based |
+| :--- | :--- | :--- |
+| **Namespace Handling** | Correct. | Correct (uses `AffinityTerm`). |
+| **Symmetry Check** | $O(\text{PodsOnNode})$ matches. | $O(\text{MatchedTermsInSystem})$ array lookups. |
+| **Simulation** | Multi-step state management. | Native CoW via `PatchSet` and Slices. |
+| **Two-Way Indexing** | No (scans pods). | Yes (scans label buckets). |
+| **Scalability** | Degrades with pod density. | Performance depends on unique term types. |
+
+## Summary
+By combining `PatchSet` CoW indices with dense slice tracking, a Two-Way Label Index, and a phased evaluation lifecycle (`PreparePod` / `FastCheckAffinity`), the Cluster Autoscaler decouples the cost of affinity checks from the raw number of pods. It achieves the speed of a bitwise implementation while correctly supporting Kubernetes' complex, cross-namespace `AffinityTerm` logic.
+
+## Credits
+The initial prototype for the Fort reactive indexing pipeline was taken from [https://github.com/bwsalmon/kubernetes/pull/3](https://github.com/bwsalmon/kubernetes/pull/3).

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
 	schedulerinterface "k8s.io/kube-scheduler/framework"
+	"k8s.io/client-go/tools/cache"
 )
 
 // Forkable is an interface for objects that can be forked, reverted and committed.
@@ -125,6 +126,11 @@ type ClusterSnapshotStore interface {
 
 	// Clear resets the snapshot to an empty, unforked state.
 	Clear()
+
+	// GetPodInformer returns a SharedInformer for Pods.
+	GetPodInformer() cache.SharedInformer
+	// GetNodeInformer returns a SharedInformer for Nodes.
+	GetNodeInformer() cache.SharedInformer
 }
 
 // ErrNodeNotFound means that a node wasn't found in the snapshot.

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/evaluator.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/evaluator.go
@@ -1,0 +1,741 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store/fort"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/common"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
+)
+
+// affinityTermKey uniquely identifies an AffinityTerm by its criteria and topology.
+type affinityTermKey struct {
+	antiAffinity bool
+	termId       string
+}
+
+// termEntry stores a compiled AffinityTerm and its anti-affinity status.
+type termEntry struct {
+	term         *schedulerinterface.AffinityTerm
+	antiAffinity bool
+}
+
+// PodAffinityContext captures all information required to evaluate a pod's affinity
+// against nodes. It is designed to be extracted serially (PreFilter) and then used
+// concurrently across multiple nodes (Filter) without further map lookups.
+type PodAffinityContext struct {
+	pod               *apiv1.Pod
+	ownedAntiAffinity []termWithTopology
+	ownedAffinity     []termWithTopology
+	// matchIDs are the IDs of terms in the system that this pod matches.
+	matchIDs []int
+}
+
+// termWithTopology pairs a term ID with its target topology key.
+type termWithTopology struct {
+	id          int
+	topologyKey string
+}
+
+// matchCacheEntry stores the result of getMatchingTerms to avoid re-evaluating Matches().
+type matchCacheEntry struct {
+	matchIDs []int
+	// termsCount tracks the number of terms in the system when this entry was created,
+	// allowing for incremental cache updates as new terms are registered.
+	termsCount int
+}
+
+// PredicateEvaluator is a high-performance, namespace-aware evaluator for Pod Affinity
+// and Anti-Affinity predicates. It uses incremental indexing and Copy-on-Write (CoW)
+// data structures to sustain Cluster Autoscaler simulations at the 5,000+ node scale.
+//
+// Conceptually, it implements a "Two-Way Label Index" (indexed by term and pod labels)
+// to avoid O(N^2) matching, and relies on dense integer slices for fast per-node lookups.
+type PredicateEvaluator struct {
+	// lock is shared with the underlying ClusterSnapshotStore to ensure atomic mutations.
+	lock fort.LockGroup
+
+	podInformer  cache.SharedInformer
+	nodeInformer cache.SharedInformer
+
+	// Global registry of terms present in the system.
+	termRegistry *common.PatchSet[affinityTermKey, int]
+	// termsByID is an append-only slice of term definitions.
+	termsByID []termEntry
+	// termCounts tracks how many pods own each term.
+	termCounts []int
+
+	// Label-based indexing for terms to speed up matching new pods against the registry.
+	// key -> value -> []termID
+	termLabelIndex *common.PatchSet[string, []int]
+	// complexTerms contains IDs of terms that cannot be indexed by a simple label.
+	complexTerms []int
+
+	// Presence and Forbidden maps track which terms are satisfied or violated in each domain.
+	// (TopologyKey \x00 TopologyValue) -> []int32 (counts indexed by term ID)
+	presence  fort.BTreeMap[[]int32]
+	forbidden fort.BTreeMap[[]int32]
+
+	// hashDomainCounts tracks how many pods of a specific type (hash) exist in each domain.
+	// podHash\x00domain -> count
+	hashDomainCounts *common.PatchSet[string, int32]
+	// hashDomains provides a fast list of domains a pod type occupies.
+	hashDomains *common.PatchSet[string, []string]
+	// hashRepresentatives stores a sample pod for each unique pod type to run Matches() against.
+	hashRepresentatives *common.PatchSet[string, *apiv1.Pod]
+	// podLabelIndex indexes pod types by their labels to speed up backfilling new terms.
+	// key\x00value -> set[podHash]
+	podLabelIndex *common.PatchSet[string, sets.Set[string]]
+	// matchCache stores which terms each pod hash matches, preserved across forks.
+	matchCache *common.PatchSet[string, matchCacheEntry]
+
+	// podsWithNodes is the reactive joiner that powers the incremental updates.
+	podsWithNodes fort.CloneableSharedInformerQuery
+	registration  cache.ResourceEventHandlerRegistration
+}
+
+// NewPredicateEvaluator constructs a new evaluator and attaches it to the provided informers.
+func NewPredicateEvaluator(podInformer, nodeInformer cache.SharedInformer) *PredicateEvaluator {
+	var lock fort.LockGroup
+	if ci, ok := podInformer.(fort.CloneableSharedInformerQuery); ok {
+		lock = ci.GetLockGroup()
+	} else {
+		lock = fort.NewLockGroup()
+	}
+
+	e := &PredicateEvaluator{
+		lock:                lock,
+		podInformer:         podInformer,
+		nodeInformer:        nodeInformer,
+		termRegistry:        common.NewPatchSet[affinityTermKey, int](),
+		termLabelIndex:      common.NewPatchSet[string, []int](),
+		presence:            fort.NewBTreeMap[[]int32](),
+		forbidden:           fort.NewBTreeMap[[]int32](),
+		hashDomainCounts:    common.NewPatchSet[string, int32](),
+		hashDomains:         common.NewPatchSet[string, []string](),
+		hashRepresentatives: common.NewPatchSet[string, *apiv1.Pod](),
+		podLabelIndex:       common.NewPatchSet[string, sets.Set[string]](),
+		matchCache:          common.NewPatchSet[string, matchCacheEntry](),
+	}
+
+	// The pipeline joins pods with their nodes to maintain topology-aware indexing.
+	e.podsWithNodes = fort.QueryInformer(&fort.Join[framework.PodWithNode, *apiv1.Pod, *apiv1.Node]{
+		Lock: lock,
+		From: podInformer,
+		Join: nodeInformer,
+		On: func(p *apiv1.Pod, n *apiv1.Node) any {
+			if p != nil {
+				return p.Spec.NodeName
+			}
+			if n != nil {
+				return n.Name
+			}
+			return ""
+		},
+		Select: func(p *apiv1.Pod, n *apiv1.Node) (framework.PodWithNode, error) {
+			return framework.PodWithNode{Pod: p, Node: n}, nil
+		},
+	})
+
+	e.registration, _ = e.podsWithNodes.AddEventHandler(e)
+
+	return e
+}
+
+// PreparePod extracts the pod's affinity state in a thread-safe manner (PreFilter).
+// It registers any novel terms the pod owns and pre-calculates matching terms.
+func (e *PredicateEvaluator) PreparePod(pod *apiv1.Pod) *PodAffinityContext {
+	if pod == nil {
+		return nil
+	}
+
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	podInfo := framework.NewPodInfo(pod, nil)
+
+	// Extract selectors from spec to power the Two-Way Label Index.
+	var specAff, specAnti []apiv1.PodAffinityTerm
+	if pod.Spec.Affinity != nil {
+		if pod.Spec.Affinity.PodAffinity != nil {
+			specAff = pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		}
+		if pod.Spec.Affinity.PodAntiAffinity != nil {
+			specAnti = pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		}
+	}
+
+	// ensureTermRegistered handles lazy backfilling of new rules against existing pods.
+	prepareTerms := func(terms []schedulerinterface.AffinityTerm, specTerms []apiv1.PodAffinityTerm, anti bool) []termWithTopology {
+		var res []termWithTopology
+		for i := range terms {
+			t := &terms[i]
+			tk := affinityTermKey{antiAffinity: anti, termId: getTermId(t)}
+			var ls *metav1.LabelSelector
+			if i < len(specTerms) {
+				ls = specTerms[i].LabelSelector
+			}
+			id := e.ensureTermRegistered(t, tk, ls)
+			res = append(res, termWithTopology{id: id, topologyKey: t.TopologyKey})
+		}
+		return res
+	}
+
+	ownedAff := prepareTerms(podInfo.GetRequiredAffinityTerms(), specAff, false)
+	ownedAnti := prepareTerms(podInfo.GetRequiredAntiAffinityTerms(), specAnti, true)
+
+	// matchIDs allows the node loop to use integer slice lookups instead of Matches() string evaluations.
+	matchIDs := e.getMatchingTerms(pod)
+
+	return &PodAffinityContext{
+		pod:               pod,
+		ownedAffinity:     ownedAff,
+		ownedAntiAffinity: ownedAnti,
+		matchIDs:          matchIDs,
+	}
+}
+
+func (e *PredicateEvaluator) getPodMatchHash(pod *apiv1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	lblHash := framework.GetPodLabelSetHash(pod)
+	// We include namespace to correctly support cross-namespace affinity rules.
+	if lblHash == "" && len(pod.Labels) == 0 {
+		return pod.Namespace + "\x00"
+	}
+	return pod.Namespace + "\x00" + lblHash
+}
+
+// OnAdd updates all reactive indices when a pod is scheduled onto a node.
+func (e *PredicateEvaluator) OnAdd(obj any, isInInitialList bool) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.OnAddLocked(obj, isInInitialList)
+}
+
+func (e *PredicateEvaluator) OnAddLocked(obj any, _ bool) {
+	pwn := obj.(framework.PodWithNode)
+	if pwn.Pod == nil || pwn.Node == nil {
+		return
+	}
+
+	podInfo := framework.NewPodInfo(pwn.Pod, nil)
+	hash := e.getPodMatchHash(pwn.Pod)
+
+	// Tracking unique pod types (hashes) ensures backfilling doesn't become O(Pods).
+	if !e.hashRepresentatives.InCurrentPatch(hash) {
+		if _, found := e.hashRepresentatives.FindValue(hash); !found {
+			e.hashRepresentatives.SetCurrent(hash, pwn.Pod)
+
+			// Index the pod's labels to power the Two-Way Label Index during future rule registration.
+			for k, v := range pwn.Pod.Labels {
+				kv := k + "\x00" + v
+				hashes, found := e.podLabelIndex.FindValue(kv)
+				if !found || hashes == nil {
+					hashes = sets.New[string]()
+				} else {
+					hashes = hashes.Clone()
+				}
+				hashes.Insert(hash)
+				e.podLabelIndex.SetCurrent(kv, hashes)
+			}
+		}
+	}
+
+	// 1. Extract and register affinity terms owned by this pod.
+	var specAff, specAnti []apiv1.PodAffinityTerm
+	if pwn.Pod.Spec.Affinity != nil {
+		if pwn.Pod.Spec.Affinity.PodAffinity != nil {
+			specAff = pwn.Pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		}
+		if pwn.Pod.Spec.Affinity.PodAntiAffinity != nil {
+			specAnti = pwn.Pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		}
+	}
+
+	register := func(terms []schedulerinterface.AffinityTerm, specTerms []apiv1.PodAffinityTerm, anti bool) []int {
+		var ids []int
+		for i := range terms {
+			t := &terms[i]
+			tk := affinityTermKey{antiAffinity: anti, termId: getTermId(t)}
+			var ls *metav1.LabelSelector
+			if i < len(specTerms) {
+				ls = specTerms[i].LabelSelector
+			}
+			id := e.ensureTermRegistered(t, tk, ls)
+			e.termCounts[id]++
+			ids = append(ids, id)
+		}
+		return ids
+	}
+
+	ownedAffinity := podInfo.GetRequiredAffinityTerms()
+	ownedAntiAffinity := podInfo.GetRequiredAntiAffinityTerms()
+	allOwnedIDs := append(register(ownedAffinity, specAff, false), register(ownedAntiAffinity, specAnti, true)...)
+
+	// 2. Identify which terms in the system this pod satisfies.
+	matchingTerms := e.getMatchingTerms(pwn.Pod)
+
+	// 3. Update reactive topology indices for all domains the node belongs to.
+	for k, v := range pwn.Node.Labels {
+		domain := k + "\x00" + v
+		e.updateHashDomain(hash, domain, 1)
+		e.updatePresence(domain, matchingTerms, 1)
+	}
+
+	// 4. Update the Forbidden B-Tree for symmetry checks (anti-affinity).
+	e.updateForbidden(pwn.Node.Labels, allOwnedIDs, 1)
+}
+
+// ensureTermRegistered adds a term to the global registry and lazily backfills it.
+// It uses the podLabelIndex to only scan pod types that could possibly match, avoiding O(N).
+func (e *PredicateEvaluator) ensureTermRegistered(term *schedulerinterface.AffinityTerm, tk affinityTermKey, ls *metav1.LabelSelector) int {
+	if id, ok := e.termRegistry.FindValue(tk); ok {
+		return id
+	}
+
+	id := len(e.termsByID)
+	e.termRegistry.SetCurrent(tk, id)
+	e.termsByID = append(e.termsByID, termEntry{term: term, antiAffinity: tk.antiAffinity})
+	e.termCounts = append(e.termCounts, 0)
+
+	// Index the term definition to speed up future matching of incoming pods.
+	indexed := false
+	if ls != nil && len(ls.MatchExpressions) == 0 && len(ls.MatchLabels) > 0 {
+		for k, v := range ls.MatchLabels {
+			kv := k + "\x00" + v
+			ids, _ := e.termLabelIndex.FindValue(kv)
+			newIDs := append([]int(nil), ids...)
+			newIDs = append(newIDs, id)
+			e.termLabelIndex.SetCurrent(kv, newIDs)
+			indexed = true
+		}
+	}
+	if !indexed {
+		e.complexTerms = append(e.complexTerms, id)
+	}
+
+	// BACKFILL: Run the new rule against all existing pods in the cluster.
+	// We narrow down candidates using the podLabelIndex (The Two-Way Index).
+	var candidateHashes sets.Set[string]
+	if ls != nil && len(ls.MatchExpressions) == 0 && len(ls.MatchLabels) > 0 {
+		candidateHashes = sets.New[string]()
+		for k, v := range ls.MatchLabels {
+			kv := k + "\x00" + v
+			if hashes, ok := e.podLabelIndex.FindValue(kv); ok && hashes != nil {
+				for h := range hashes {
+					candidateHashes.Insert(h)
+				}
+			}
+			break
+		}
+	} else {
+		// Fallback for complex selectors: check all known unique pod types.
+		candidateHashes = sets.New[string]()
+		e.hashRepresentatives.ForEach(func(hash string, _ *apiv1.Pod) bool {
+			candidateHashes.Insert(hash)
+			return true
+		})
+	}
+
+	for hash := range candidateHashes {
+		rep, found := e.hashRepresentatives.FindValue(hash)
+		if found && rep != nil && term.Matches(rep, nil) {
+			domains, _ := e.hashDomains.FindValue(hash)
+			for _, domain := range domains {
+				hdKey := hash + "\x00" + domain
+				if count, ok := e.hashDomainCounts.FindValue(hdKey); ok && count > 0 {
+					e.updatePresence(domain, []int{id}, count)
+				}
+			}
+		}
+	}
+
+	return id
+}
+
+// updatePresence increments/decrements term satisfy counts in the presence B-Tree.
+func (e *PredicateEvaluator) updatePresence(domain string, matchingTerms []int, delta int32) {
+	if len(matchingTerms) == 0 {
+		return
+	}
+	m, _ := e.presence.Get(domain)
+	m = cloneCounts(m, len(e.termsByID))
+	for _, id := range matchingTerms {
+		m[id] += delta
+	}
+	e.presence.Set(domain, m)
+}
+
+// updateForbidden updates the anti-affinity violation counts in the forbidden B-Tree.
+func (e *PredicateEvaluator) updateForbidden(nodeLabels map[string]string, ownedIDs []int, delta int32) {
+	for _, id := range ownedIDs {
+		term := e.termsByID[id].term
+		if topoVal, ok := nodeLabels[term.TopologyKey]; ok {
+			key := term.TopologyKey + "\x00" + topoVal
+			f, _ := e.forbidden.Get(key)
+			f = cloneCounts(f, len(e.termsByID))
+			f[id] += delta
+			e.forbidden.Set(key, f)
+		}
+	}
+}
+
+// updateHashDomain manages the association between a pod type (hash) and a topology domain.
+func (e *PredicateEvaluator) updateHashDomain(hash, domain string, delta int32) int32 {
+	hdKey := hash + "\x00" + domain
+	count, _ := e.hashDomainCounts.FindValue(hdKey)
+	newCount := count + delta
+
+	if count == 0 && newCount > 0 {
+		domains, _ := e.hashDomains.FindValue(hash)
+		newDomains := make([]string, len(domains), len(domains)+1)
+		copy(newDomains, domains)
+		newDomains = append(newDomains, domain)
+		e.hashDomains.SetCurrent(hash, newDomains)
+	} else if count > 0 && newCount <= 0 {
+		// pop domain from hashDomains if it hits zero.
+		domains, _ := e.hashDomains.FindValue(hash)
+		newDomains := make([]string, 0, len(domains))
+		for _, d := range domains {
+			if d != domain {
+				newDomains = append(newDomains, d)
+			}
+		}
+		e.hashDomains.SetCurrent(hash, newDomains)
+		e.hashDomainCounts.DeleteCurrent(hdKey)
+		return 0
+	}
+
+	e.hashDomainCounts.SetCurrent(hdKey, newCount)
+	return newCount
+}
+
+func (e *PredicateEvaluator) OnUpdate(oldObj, newObj any) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.OnUpdateLocked(oldObj, newObj)
+}
+
+func (e *PredicateEvaluator) OnUpdateLocked(oldObj, newObj any) {
+	e.OnDeleteLocked(oldObj)
+	e.OnAddLocked(newObj, false)
+}
+
+func (e *PredicateEvaluator) OnDelete(obj any) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.OnDeleteLocked(obj)
+}
+
+func (e *PredicateEvaluator) OnDeleteLocked(obj any) {
+	pwn := obj.(framework.PodWithNode)
+	if pwn.Pod == nil || pwn.Node == nil {
+		return
+	}
+
+	podInfo := framework.NewPodInfo(pwn.Pod, nil)
+	hash := e.getPodMatchHash(pwn.Pod)
+	matchingTerms := e.getMatchingTerms(pwn.Pod)
+
+	ownedAffKeys := e.getKeys(podInfo.GetRequiredAffinityTerms(), false)
+	ownedAntiKeys := e.getKeys(podInfo.GetRequiredAntiAffinityTerms(), true)
+
+	var allOwnedIDs []int
+	for _, tk := range append(ownedAffKeys, ownedAntiKeys...) {
+		if id, ok := e.termRegistry.FindValue(tk); ok {
+			allOwnedIDs = append(allOwnedIDs, id)
+		}
+	}
+
+	// 1. Remove anti-affinity constraints.
+	e.updateForbidden(pwn.Node.Labels, allOwnedIDs, -1)
+
+	// 2. Remove term satisfaction presence.
+	for k, v := range pwn.Node.Labels {
+		domain := k + "\x00" + v
+		e.updatePresence(domain, matchingTerms, -1)
+		e.updateHashDomain(hash, domain, -1)
+	}
+
+	// 3. Clean up unique pod type tracking if the last pod of this type is gone.
+	totalHashCount := int32(0)
+	domains, _ := e.hashDomains.FindValue(hash)
+	for _, d := range domains {
+		hdKey := hash + "\x00" + d
+		if c, ok := e.hashDomainCounts.FindValue(hdKey); ok {
+			totalHashCount += c
+		}
+	}
+
+	if totalHashCount == 0 {
+		for k, v := range pwn.Pod.Labels {
+			kv := k + "\x00" + v
+			if hashes, ok := e.podLabelIndex.FindValue(kv); ok && hashes != nil {
+				hashes = hashes.Clone()
+				hashes.Delete(hash)
+				if len(hashes) == 0 {
+					e.podLabelIndex.DeleteCurrent(kv)
+				} else {
+					e.podLabelIndex.SetCurrent(kv, hashes)
+				}
+			}
+		}
+		e.hashRepresentatives.DeleteCurrent(hash)
+		e.hashDomains.DeleteCurrent(hash)
+		e.matchCache.DeleteCurrent(hash)
+	}
+
+	// 4. Update ref counts for owned terms.
+	for _, id := range allOwnedIDs {
+		e.termCounts[id]--
+	}
+}
+
+// Clear resets the evaluator to an empty base state.
+func (e *PredicateEvaluator) Clear() {
+	e.termRegistry = common.NewPatchSet[affinityTermKey, int]()
+	e.termsByID = nil
+	e.termCounts = nil
+	e.termLabelIndex = common.NewPatchSet[string, []int]()
+	e.complexTerms = nil
+	e.presence = fort.NewBTreeMap[[]int32]()
+	e.forbidden = fort.NewBTreeMap[[]int32]()
+	e.hashDomainCounts = common.NewPatchSet[string, int32]()
+	e.hashDomains = common.NewPatchSet[string, []string]()
+	e.hashRepresentatives = common.NewPatchSet[string, *apiv1.Pod]()
+	e.podLabelIndex = common.NewPatchSet[string, sets.Set[string]]()
+	e.matchCache = common.NewPatchSet[string, matchCacheEntry]()
+}
+
+// Fork creates a lightweight child evaluator sharing the parent's PatchSets.
+func (e *PredicateEvaluator) Fork(newPods, newNodes cache.SharedInformer) *PredicateEvaluator {
+	e.termRegistry.Fork()
+	e.termLabelIndex.Fork()
+	e.hashDomainCounts.Fork()
+	e.hashDomains.Fork()
+	e.hashRepresentatives.Fork()
+	e.podLabelIndex.Fork()
+	e.matchCache.Fork()
+
+	res := &PredicateEvaluator{
+		lock:                e.lock,
+		podInformer:         newPods,
+		nodeInformer:        newNodes,
+		termRegistry:        e.termRegistry,
+		termsByID:           e.termsByID[:len(e.termsByID):len(e.termsByID)], // CoW slice
+		termCounts:          make([]int, len(e.termCounts)),
+		termLabelIndex:      e.termLabelIndex,
+		complexTerms:        make([]int, len(e.complexTerms)),
+		presence:            e.presence.Clone(),
+		forbidden:           e.forbidden.Clone(),
+		hashDomainCounts:    e.hashDomainCounts,
+		hashDomains:         e.hashDomains,
+		hashRepresentatives: e.hashRepresentatives,
+		podLabelIndex:       e.podLabelIndex,
+		matchCache:          e.matchCache,
+	}
+	copy(res.termCounts, e.termCounts)
+	copy(res.complexTerms, e.complexTerms)
+
+	memo := make(map[cache.SharedInformer]cache.SharedInformer)
+	memo[e.podInformer] = newPods
+	memo[e.nodeInformer] = newNodes
+
+	res.podsWithNodes = fort.ClonePipeline(e.podsWithNodes, memo).(fort.CloneableSharedInformerQuery)
+	if ms, ok := res.podsWithNodes.(fort.ManualSharedInformer); ok {
+		res.registration, _ = ms.AddEventHandlerNoReplay(res)
+	} else {
+		res.registration, _ = res.podsWithNodes.AddEventHandler(res)
+	}
+
+	return res
+}
+
+func (e *PredicateEvaluator) Commit() {
+	e.termRegistry.Commit()
+	e.termLabelIndex.Commit()
+	e.hashDomainCounts.Commit()
+	e.hashDomains.Commit()
+	e.hashRepresentatives.Commit()
+	e.podLabelIndex.Commit()
+	e.matchCache.Commit()
+}
+
+func (e *PredicateEvaluator) Revert() {
+	e.termRegistry.Revert()
+	e.termLabelIndex.Revert()
+	e.hashDomainCounts.Revert()
+	e.hashDomains.Revert()
+	e.hashRepresentatives.Revert()
+	e.podLabelIndex.Revert()
+	e.matchCache.Revert()
+}
+
+// FastCheckAffinity executes the affinity checks for a pod on a node (Filter).
+// It relies entirely on pre-calculated context and integer slice lookups.
+func (e *PredicateEvaluator) FastCheckAffinity(podCtx *PodAffinityContext, node *apiv1.Node) clustersnapshot.SchedulingError {
+	if podCtx == nil || node == nil {
+		return nil
+	}
+
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+
+	// 1. Incoming Anti-Affinity: check if any existing pods violate OUR anti-affinity rules.
+	for _, twt := range podCtx.ownedAntiAffinity {
+		if topoVal, ok := node.Labels[twt.topologyKey]; ok {
+			key := twt.topologyKey + "\x00" + topoVal
+			if m, ok := e.presence.Get(key); ok {
+				if twt.id < len(m) && m[twt.id] > 0 {
+					return clustersnapshot.NewFailingPredicateError(podCtx.pod, "InterPodAffinity", []string{interpodaffinity.ErrReasonAntiAffinityRulesNotMatch}, "", "")
+				}
+			}
+		}
+	}
+
+	// 2. Incoming Affinity: check if any existing pods satisfy OUR affinity requirements.
+	for _, twt := range podCtx.ownedAffinity {
+		topoVal, ok := node.Labels[twt.topologyKey]
+		if !ok {
+			return clustersnapshot.NewFailingPredicateError(podCtx.pod, "InterPodAffinity", []string{interpodaffinity.ErrReasonAffinityRulesNotMatch}, "", "node lacks topology key")
+		}
+
+		key := twt.topologyKey + "\x00" + topoVal
+		m, hasPresence := e.presence.Get(key)
+		if !hasPresence || twt.id >= len(m) || m[twt.id] <= 0 {
+			// Affinity Fallback: a pod can satisfy its own affinity rule if it matches its own selector.
+			selfMatches := false
+			for _, mid := range podCtx.matchIDs {
+				if mid == twt.id {
+					selfMatches = true
+					break
+				}
+			}
+			if !selfMatches {
+				return clustersnapshot.NewFailingPredicateError(podCtx.pod, "InterPodAffinity", []string{interpodaffinity.ErrReasonAffinityRulesNotMatch}, "", "")
+			}
+		}
+	}
+
+	// 3. Existing Anti-Affinity (Symmetry): check if WE violate any existing pod's anti-affinity rules.
+	for k, v := range node.Labels {
+		key := k + "\x00" + v
+		if f, ok := e.forbidden.Get(key); ok {
+			for _, mid := range podCtx.matchIDs {
+				if mid < len(f) && f[mid] > 0 && e.termsByID[mid].antiAffinity {
+					return clustersnapshot.NewFailingPredicateError(podCtx.pod, "InterPodAffinity", []string{interpodaffinity.ErrReasonAntiAffinityRulesNotMatch}, "", "existing pod anti-affinity")
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// getMatchingTerms identifies which terms in the system a pod matches.
+// It is fully incremental: it caches previous results and only evaluates newly registered terms.
+func (e *PredicateEvaluator) getMatchingTerms(pod *apiv1.Pod) []int {
+	hash := e.getPodMatchHash(pod)
+	var res []int
+	startIndex := 0
+
+	// Check CoW cache first.
+	if hash != "" {
+		if val, ok := e.matchCache.FindValue(hash); ok {
+			if val.termsCount == len(e.termsByID) {
+				return val.matchIDs
+			}
+			res = append([]int(nil), val.matchIDs...)
+			startIndex = val.termsCount
+		}
+	}
+
+	// Incrementally evaluate newly added terms using the Two-Way Label Index.
+	if startIndex < len(e.termsByID) {
+		candidates := make(map[int]struct{})
+		for k, v := range pod.Labels {
+			kv := k + "\x00" + v
+			if ids, ok := e.termLabelIndex.FindValue(kv); ok && ids != nil {
+				for _, id := range ids {
+					if id >= startIndex {
+						candidates[id] = struct{}{}
+					}
+				}
+			}
+		}
+		for _, id := range e.complexTerms {
+			if id >= startIndex {
+				candidates[id] = struct{}{}
+			}
+		}
+
+		for id := startIndex; id < len(e.termsByID); id++ {
+			if _, ok := candidates[id]; ok {
+				if e.termsByID[id].term.Matches(pod, nil) {
+					res = append(res, id)
+				}
+			}
+		}
+
+		// Update the CoW cache for subsequent forks.
+		if hash != "" {
+			e.matchCache.SetCurrent(hash, matchCacheEntry{
+				matchIDs:   res,
+				termsCount: len(e.termsByID),
+			})
+		}
+	}
+
+	return res
+}
+
+func (e *PredicateEvaluator) getKeys(terms []schedulerinterface.AffinityTerm, anti bool) []affinityTermKey {
+	var keys []affinityTermKey
+	for i := range terms {
+		keys = append(keys, affinityTermKey{antiAffinity: anti, termId: getTermId(&terms[i])})
+	}
+	return keys
+}
+
+func getTermId(term *schedulerinterface.AffinityTerm) string {
+	return fmt.Sprintf("%v/%v/%v/%v", term.Selector, sets.List(term.Namespaces), term.NamespaceSelector, term.TopologyKey)
+}
+
+// cloneCounts performs a fast, zero-allocation-aware copy of a count slice.
+func cloneCounts(counts []int32, minLen int) []int32 {
+	l := len(counts)
+	if minLen > l {
+		l = minLen
+	}
+	if l == 0 {
+		return make([]int32, minLen)
+	}
+	res := make([]int32, l)
+	copy(res, counts)
+	return res
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/evaluator.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/evaluator.go
@@ -99,6 +99,11 @@ type PredicateEvaluator struct {
 	presence  fort.BTreeMap[[]int32]
 	forbidden fort.BTreeMap[[]int32]
 
+	// presenceModified and forbiddenModified track which slices were already
+	// cloned in the current fork to avoid redundant allocations.
+	presenceModified  map[string]bool
+	forbiddenModified map[string]bool
+
 	// hashDomainCounts tracks how many pods of a specific type (hash) exist in each domain.
 	// podHash\x00domain -> count
 	hashDomainCounts *common.PatchSet[string, int32]
@@ -134,6 +139,8 @@ func NewPredicateEvaluator(podInformer, nodeInformer cache.SharedInformer) *Pred
 		termLabelIndex:      common.NewPatchSet[string, []int](),
 		presence:            fort.NewBTreeMap[[]int32](),
 		forbidden:           fort.NewBTreeMap[[]int32](),
+		presenceModified:    make(map[string]bool),
+		forbiddenModified:   make(map[string]bool),
 		hashDomainCounts:    common.NewPatchSet[string, int32](),
 		hashDomains:         common.NewPatchSet[string, []string](),
 		hashRepresentatives: common.NewPatchSet[string, *apiv1.Pod](),
@@ -384,7 +391,10 @@ func (e *PredicateEvaluator) updatePresence(domain string, matchingTerms []int, 
 		return
 	}
 	m, _ := e.presence.Get(domain)
-	m = cloneCounts(m, len(e.termsByID))
+	if !e.presenceModified[domain] || len(m) < len(e.termsByID) {
+		m = cloneCounts(m, len(e.termsByID))
+		e.presenceModified[domain] = true
+	}
 	for _, id := range matchingTerms {
 		m[id] += delta
 	}
@@ -398,7 +408,10 @@ func (e *PredicateEvaluator) updateForbidden(nodeLabels map[string]string, owned
 		if topoVal, ok := nodeLabels[term.TopologyKey]; ok {
 			key := term.TopologyKey + "\x00" + topoVal
 			f, _ := e.forbidden.Get(key)
-			f = cloneCounts(f, len(e.termsByID))
+			if !e.forbiddenModified[key] || len(f) < len(e.termsByID) {
+				f = cloneCounts(f, len(e.termsByID))
+				e.forbiddenModified[key] = true
+			}
 			f[id] += delta
 			e.forbidden.Set(key, f)
 		}
@@ -525,6 +538,8 @@ func (e *PredicateEvaluator) Clear() {
 	e.complexTerms = nil
 	e.presence = fort.NewBTreeMap[[]int32]()
 	e.forbidden = fort.NewBTreeMap[[]int32]()
+	e.presenceModified = make(map[string]bool)
+	e.forbiddenModified = make(map[string]bool)
 	e.hashDomainCounts = common.NewPatchSet[string, int32]()
 	e.hashDomains = common.NewPatchSet[string, []string]()
 	e.hashRepresentatives = common.NewPatchSet[string, *apiv1.Pod]()
@@ -553,6 +568,8 @@ func (e *PredicateEvaluator) Fork(newPods, newNodes cache.SharedInformer) *Predi
 		complexTerms:        make([]int, len(e.complexTerms)),
 		presence:            e.presence.Clone(),
 		forbidden:           e.forbidden.Clone(),
+		presenceModified:    make(map[string]bool),
+		forbiddenModified:   make(map[string]bool),
 		hashDomainCounts:    e.hashDomainCounts,
 		hashDomains:         e.hashDomains,
 		hashRepresentatives: e.hashRepresentatives,

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/evaluator_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/evaluator_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store/streaming"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+)
+
+func TestPredicateEvaluator_AntiAffinity(t *testing.T) {
+	node := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				"topology": "zone1",
+			},
+		},
+	}
+
+	// Case 1: Incoming pod has anti-affinity against existing pod
+	t.Run("Incoming pod anti-affinity", func(t *testing.T) {
+		store := streaming.NewStreamingSnapshotStore()
+		podInformer := store.GetPodInformer()
+		nodeInformer := store.GetNodeInformer()
+		evaluator := NewPredicateEvaluator(podInformer, nodeInformer)
+
+		store.StoreNodeInfo(framework.NewNodeInfo(node, nil))
+
+		existingPod := &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p1",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "foo"},
+			},
+			Spec: apiv1.PodSpec{
+				NodeName: "node1",
+			},
+		}
+		store.StorePodInfo(framework.NewPodInfo(existingPod, nil), "node1")
+
+		incomingPod := &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p2",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "bar"},
+			},
+			Spec: apiv1.PodSpec{
+				Affinity: &apiv1.Affinity{
+					PodAntiAffinity: &apiv1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "foo"},
+								},
+								TopologyKey: "topology",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := evaluator.FastCheckAffinity(evaluator.PreparePod(incomingPod), node)
+		assert.Error(t, err) // Should fail because p1 is already there
+	})
+
+	// Case 2: Existing pod has anti-affinity against incoming pod
+	t.Run("Existing pod anti-affinity (symmetry)", func(t *testing.T) {
+		store := streaming.NewStreamingSnapshotStore()
+		podInformer := store.GetPodInformer()
+		nodeInformer := store.GetNodeInformer()
+		evaluator := NewPredicateEvaluator(podInformer, nodeInformer)
+
+		store.StoreNodeInfo(framework.NewNodeInfo(node, nil))
+
+		existingPodWithAntiAffinity := &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p1",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "foo"},
+			},
+			Spec: apiv1.PodSpec{
+				NodeName: "node1",
+				Affinity: &apiv1.Affinity{
+					PodAntiAffinity: &apiv1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "bar"},
+								},
+								TopologyKey: "topology",
+							},
+						},
+					},
+				},
+			},
+		}
+		store.StorePodInfo(framework.NewPodInfo(existingPodWithAntiAffinity, nil), "node1")
+
+		incomingPod := &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p2",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "bar"},
+			},
+		}
+
+
+		err := evaluator.FastCheckAffinity(evaluator.PreparePod(incomingPod), node)
+		assert.Error(t, err) // Should fail because existingPodWithAntiAffinity rejects bar
+	})
+
+	// Case 3: Namespace handling
+	t.Run("Namespace handling", func(t *testing.T) {
+		store := streaming.NewStreamingSnapshotStore()
+		podInformer := store.GetPodInformer()
+		nodeInformer := store.GetNodeInformer()
+		evaluator := NewPredicateEvaluator(podInformer, nodeInformer)
+
+		store.StoreNodeInfo(framework.NewNodeInfo(node, nil))
+
+		existingPod := &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p1",
+				Namespace: "other-ns",
+				Labels:    map[string]string{"app": "foo"},
+			},
+			Spec: apiv1.PodSpec{
+				NodeName: "node1",
+			},
+		}
+		store.StorePodInfo(framework.NewPodInfo(existingPod, nil), "node1")
+
+		// Incoming pod with anti-affinity but ONLY in "default" namespace
+		incomingPod := &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p2",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "bar"},
+			},
+			Spec: apiv1.PodSpec{
+				Affinity: &apiv1.Affinity{
+					PodAntiAffinity: &apiv1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "foo"},
+								},
+								TopologyKey: "topology",
+								Namespaces:  []string{"default"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := evaluator.FastCheckAffinity(evaluator.PreparePod(incomingPod), node)
+		assert.NoError(t, err) // Should pass because existing pod is in "other-ns"
+
+		// Change incoming pod to include "other-ns"
+		incomingPod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].Namespaces = []string{"other-ns"}
+		err = evaluator.FastCheckAffinity(evaluator.PreparePod(incomingPod), node)
+		assert.Error(t, err) // Should fail now
+	})
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
@@ -19,6 +19,7 @@ package predicate
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 
@@ -36,15 +37,21 @@ type SchedulerPluginRunner struct {
 	snapshot            clustersnapshot.ClusterSnapshot
 	defaultNodeOrdering clustersnapshot.NodeOrderMapping
 	parallelism         int
+	evaluator           *PredicateEvaluator
 }
 
 // NewSchedulerPluginRunner builds a SchedulerPluginRunner.
 func NewSchedulerPluginRunner(fwHandle *framework.Handle, snapshot clustersnapshot.ClusterSnapshot, parallelism int) *SchedulerPluginRunner {
+	var evaluator *PredicateEvaluator
+	if ps, ok := snapshot.(*PredicateSnapshot); ok {
+		evaluator = ps.evaluator
+	}
 	return &SchedulerPluginRunner{
 		fwHandle:            fwHandle,
 		snapshot:            snapshot,
 		defaultNodeOrdering: clustersnapshot.NewLastIndexOrderMapping(1),
 		parallelism:         parallelism,
+		evaluator:           evaluator,
 	}
 }
 
@@ -58,6 +65,11 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 
 	p.fwHandle.DelegatingLister.UpdateDelegate(p.snapshot)
 	defer p.fwHandle.DelegatingLister.ResetDelegate()
+
+	var podCtx *PodAffinityContext
+	if p.evaluator != nil {
+		podCtx = p.evaluator.PreparePod(pod)
+	}
 
 	state := schedulerimpl.NewCycleState()
 	// Run the PreFilter phase of the framework for the Pod. This allows plugins to precompute some things (for all Nodes in the cluster at once) and
@@ -114,6 +126,12 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 			return
 		}
 
+		if p.evaluator != nil {
+			if err := p.evaluator.FastCheckAffinity(podCtx, nodeInfo.Node()); err != nil {
+				return
+			}
+		}
+
 		// Run the Filter phase of the framework. Plugins retrieve the state they saved during PreFilter from CycleState, and answer whether the
 		// given Pod can be scheduled on the given Node.
 		filterStatus := p.fwHandle.Framework.RunFilterPlugins(context.TODO(), state, pod, nodeInfo)
@@ -131,7 +149,8 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 		// Filter didn't pass for some plugin, so this Node won't work - move on to the next one.
 	}
 
-	workqueue.ParallelizeUntil(ctx, p.parallelism, len(nodeInfosList), checkNode)
+	chunkSize := chunkSizeFor(len(nodeInfosList), p.parallelism)
+	workqueue.ParallelizeUntil(ctx, p.parallelism, len(nodeInfosList), checkNode, workqueue.WithChunkSize(chunkSize))
 
 	if foundNode != nil {
 		nodeOrdering.MarkMatch(foundIndex)
@@ -146,6 +165,14 @@ func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string
 	nodeInfo, err := p.snapshot.GetNodeInfo(nodeName)
 	if err != nil {
 		return nil, nil, clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("error obtaining NodeInfo for name %q: %v", nodeName, err))
+	}
+
+	var podCtx *PodAffinityContext
+	if p.evaluator != nil {
+		podCtx = p.evaluator.PreparePod(pod)
+		if err := p.evaluator.FastCheckAffinity(podCtx, nodeInfo.Node()); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	p.fwHandle.DelegatingLister.UpdateDelegate(p.snapshot)
@@ -200,4 +227,21 @@ func (p *SchedulerPluginRunner) failingFilterDebugInfo(filterName string, nodeIn
 	}
 
 	return strings.Join(infoParts, ", ")
+}
+
+// chunkSizeFor returns a chunk size for the given number of items to use for
+// parallel work. The size aims to produce good CPU utilization.
+// returns max(1, min(sqrt(n), n/Parallelism))
+func chunkSizeFor(n, parallelism int) int {
+	if parallelism <= 0 {
+		return 1
+	}
+	s := int(math.Sqrt(float64(n)))
+
+	if r := n/parallelism + 1; s > r {
+		s = r
+	} else if s < 1 {
+		s = 1
+	}
+	return s
 }

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
@@ -34,7 +34,7 @@ import (
 
 	testconfig "k8s.io/autoscaler/cluster-autoscaler/config/test"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store/streaming"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -170,7 +170,7 @@ func TestRunFiltersOnNode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(tt.customConfig)
+			pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(tt.customConfig, true)
 			assert.NoError(t, err)
 			err = snapshot.AddNodeInfo(framework.NewTestNodeInfo(tt.node, tt.scheduledPods...))
 			assert.NoError(t, err)
@@ -271,7 +271,7 @@ func TestRunFilterUntilPassingNode(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(tc.customConfig)
+			pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(tc.customConfig, true)
 			assert.NoError(t, err)
 
 			err = snapshot.AddNodeInfo(framework.NewTestNodeInfo(n1000))
@@ -305,7 +305,7 @@ func TestRunFilterUntilPassingNode_NodeOrdering(t *testing.T) {
 		return a.Node().Name > b.Node().Name
 	})
 
-	pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(nil)
+	pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(nil, true)
 	pluginRunner.parallelism = 1 // Parallelism being 1 is essential in this test to make sure we go through nodes in order.
 	assert.NoError(t, err)
 	assert.NoError(t, snapshot.AddNodeInfo(framework.NewTestNodeInfo(n1)))
@@ -361,7 +361,7 @@ func TestRunFilterUntilPassingNode_ExitEarlyWhenOrderingReturnNegativeOne(t *tes
 	n2 := BuildTestNode("n2", 1000, 2000000)
 	n3 := BuildTestNode("n3", 1000, 2000000)
 
-	pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(nil)
+	pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(nil, true)
 	pluginRunner.parallelism = 1
 	assert.NoError(t, err)
 	assert.NoError(t, snapshot.AddNodeInfo(framework.NewTestNodeInfo(n1)))
@@ -395,7 +395,7 @@ func TestRunFilterUntilPassingNode_PreferSmallestSteps(t *testing.T) {
 		return a.Node().Name < b.Node().Name
 	})
 
-	pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(nil)
+	pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(nil, true)
 	pluginRunner.parallelism = 16
 	assert.NoError(t, err)
 	assert.NoError(t, snapshot.AddNodeInfo(framework.NewTestNodeInfo(n1)))
@@ -456,7 +456,7 @@ func TestDebugInfo(t *testing.T) {
 	SetNodeReadyState(node1, true, time.Time{})
 
 	// with default predicate checker
-	defaultPluginRunner, clusterSnapshot, err := newTestPluginRunnerAndSnapshot(nil)
+	defaultPluginRunner, clusterSnapshot, err := newTestPluginRunnerAndSnapshot(nil, true)
 	assert.NoError(t, err)
 
 	err = clusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node1))
@@ -487,7 +487,7 @@ func TestDebugInfo(t *testing.T) {
 
 	customConfig, err := scheduler.ConfigFromPath(customConfigFile)
 	assert.NoError(t, err)
-	customPluginRunner, clusterSnapshot, err := newTestPluginRunnerAndSnapshot(customConfig)
+	customPluginRunner, clusterSnapshot, err := newTestPluginRunnerAndSnapshot(customConfig, true)
 	assert.NoError(t, err)
 
 	err = clusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node1))
@@ -497,7 +497,7 @@ func TestDebugInfo(t *testing.T) {
 	assert.Nil(t, predicateErr)
 }
 
-func newTestPluginRunnerAndSnapshot(schedConfig *config.KubeSchedulerConfiguration) (*SchedulerPluginRunner, clustersnapshot.ClusterSnapshot, error) {
+func newTestPluginRunnerAndSnapshot(schedConfig *config.KubeSchedulerConfiguration, fastPredicatesEnabled bool) (*SchedulerPluginRunner, clustersnapshot.ClusterSnapshot, error) {
 	if schedConfig == nil {
 		defaultConfig, err := scheduler_config_latest.Default()
 		if err != nil {
@@ -506,11 +506,11 @@ func newTestPluginRunnerAndSnapshot(schedConfig *config.KubeSchedulerConfigurati
 		schedConfig = defaultConfig
 	}
 
-	fwHandle, err := framework.NewHandle(context.Background(), informers.NewSharedInformerFactory(clientsetfake.NewSimpleClientset(), 0), schedConfig, true, false)
+	fwHandle, err := framework.NewHandle(context.Background(), informers.NewSharedInformerFactory(clientsetfake.NewSimpleClientset(), 0), schedConfig, true, false, fastPredicatesEnabled)
 	if err != nil {
 		return nil, nil, err
 	}
-	snapshot := NewPredicateSnapshot(store.NewBasicSnapshotStore(), fwHandle, true, 1, false)
+	snapshot := NewPredicateSnapshot(streaming.NewStreamingSnapshotStore(), fwHandle, fastPredicatesEnabled, 1, false)
 	return NewSchedulerPluginRunner(fwHandle, snapshot, 1), snapshot, nil
 }
 
@@ -535,33 +535,45 @@ func BenchmarkRunFiltersUntilPassingNode(b *testing.B) {
 	lastNode := BuildTestNode(lastNodeName, 1000, 1000)
 	nodes = append(nodes, lastNode)
 
-	pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(nil)
-	assert.NoError(b, err)
-
-	for _, node := range nodes {
-		err := snapshot.AddNodeInfo(framework.NewTestNodeInfo(node, podsOnNodes[node.Name]...))
-		assert.NoError(b, err)
-	}
-
-	testCases := []struct {
-		parallelism int
+	testConfigs := []struct {
+		name                  string
+		fastPredicatesEnabled bool
 	}{
-		{parallelism: 1},
-		{parallelism: 2},
-		{parallelism: 4},
-		{parallelism: 8},
-		{parallelism: 16},
+		{name: "Before (Default Plugins)", fastPredicatesEnabled: false},
+		{name: "After (Fast O(1) Predicates)", fastPredicatesEnabled: true},
 	}
 
-	for _, tc := range testCases {
-		b.Run(fmt.Sprintf("parallelism-%d", tc.parallelism), func(b *testing.B) {
-			pluginRunner.parallelism = tc.parallelism
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				_, _, err := pluginRunner.RunFiltersUntilPassingNode(pod, clustersnapshot.SchedulingOptions{
-					NodeOrdering: clustersnapshot.NewLastIndexOrderMapping(1),
-				})
+	for _, config := range testConfigs {
+		b.Run(config.name, func(b *testing.B) {
+			pluginRunner, snapshot, err := newTestPluginRunnerAndSnapshot(nil, config.fastPredicatesEnabled)
+			assert.NoError(b, err)
+
+			for _, node := range nodes {
+				err := snapshot.AddNodeInfo(framework.NewTestNodeInfo(node, podsOnNodes[node.Name]...))
 				assert.NoError(b, err)
+			}
+
+			testCases := []struct {
+				parallelism int
+			}{
+				{parallelism: 1},
+				{parallelism: 2},
+				{parallelism: 4},
+				{parallelism: 8},
+				{parallelism: 16},
+			}
+
+			for _, tc := range testCases {
+				b.Run(fmt.Sprintf("parallelism-%d", tc.parallelism), func(b *testing.B) {
+					pluginRunner.parallelism = tc.parallelism
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						_, _, err := pluginRunner.RunFiltersUntilPassingNode(pod, clustersnapshot.SchedulingOptions{
+							NodeOrdering: clustersnapshot.NewLastIndexOrderMapping(1),
+						})
+						assert.NoError(b, err)
+					}
+				})
 			}
 		})
 	}

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
@@ -43,6 +43,9 @@ type PredicateSnapshot struct {
 	parallelism                  int
 	draSnapshot                  *drasnapshot.Snapshot
 	csiSnapshot                  *csisnapshot.Snapshot
+
+	evaluator      *PredicateEvaluator
+	evaluatorStack []*PredicateEvaluator
 }
 
 // NewPredicateSnapshot builds a PredicateSnapshot.
@@ -55,6 +58,13 @@ func NewPredicateSnapshot(snapshotStore clustersnapshot.ClusterSnapshotStore, fw
 		draSnapshot:                  drasnapshot.NewEmptySnapshot(),
 		csiSnapshot:                  csisnapshot.NewEmptySnapshot(),
 	}
+
+	podInformer := snapshotStore.GetPodInformer()
+	nodeInformer := snapshotStore.GetNodeInformer()
+	if podInformer != nil && nodeInformer != nil {
+		snapshot.evaluator = NewPredicateEvaluator(podInformer, nodeInformer)
+	}
+
 	// Plugin runner really only needs a framework.SharedLister for running the plugins, but it also needs to run the provided Node-matching functions
 	// which operate on *framework.NodeInfo. The only object that allows obtaining *framework.NodeInfos is PredicateSnapshot, so we have an ugly circular
 	// dependency between PluginRunner and PredicateSnapshot.
@@ -401,6 +411,10 @@ func (s *PredicateSnapshot) Clear() {
 	s.ClusterSnapshotStore.Clear()
 	s.draSnapshot = drasnapshot.NewEmptySnapshot()
 	s.csiSnapshot = csisnapshot.NewEmptySnapshot()
+
+	if s.evaluator != nil {
+		s.evaluator.Clear()
+	}
 }
 
 // Fork creates a fork of snapshot state. All modifications can later be reverted to moment of forking via Revert().
@@ -408,6 +422,11 @@ func (s *PredicateSnapshot) Fork() {
 	s.ClusterSnapshotStore.Fork()
 	s.draSnapshot.Fork()
 	s.csiSnapshot.Fork()
+
+	if s.evaluator != nil {
+		s.evaluatorStack = append(s.evaluatorStack, s.evaluator)
+		s.evaluator = s.evaluator.Fork(s.ClusterSnapshotStore.GetPodInformer(), s.ClusterSnapshotStore.GetNodeInformer())
+	}
 }
 
 // Revert reverts snapshot state to moment of forking.
@@ -415,6 +434,12 @@ func (s *PredicateSnapshot) Revert() {
 	s.ClusterSnapshotStore.Revert()
 	s.draSnapshot.Revert()
 	s.csiSnapshot.Revert()
+
+	if len(s.evaluatorStack) > 0 {
+		s.evaluator.Revert()
+		s.evaluator = s.evaluatorStack[len(s.evaluatorStack)-1]
+		s.evaluatorStack = s.evaluatorStack[:len(s.evaluatorStack)-1]
+	}
 }
 
 // Commit commits changes done after forking.
@@ -424,6 +449,11 @@ func (s *PredicateSnapshot) Commit() error {
 	}
 	s.draSnapshot.Commit()
 	s.csiSnapshot.Commit()
+
+	if len(s.evaluatorStack) > 0 {
+		s.evaluator.Commit()
+		s.evaluatorStack = s.evaluatorStack[:len(s.evaluatorStack)-1]
+	}
 	return nil
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_benchmark_test.go
@@ -33,7 +33,7 @@ func BenchmarkAddNodeInfo(b *testing.B) {
 	for snapshotName, snapshotFactory := range snapshots {
 		for _, tc := range testCases {
 			nodes := clustersnapshot.CreateTestNodes(tc)
-			clusterSnapshot, err := snapshotFactory()
+			clusterSnapshot, err := snapshotFactory(b)
 			assert.NoError(b, err)
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s: AddNodeInfo() %d", snapshotName, tc), func(b *testing.B) {
@@ -59,7 +59,7 @@ func BenchmarkListNodeInfos(b *testing.B) {
 	for snapshotName, snapshotFactory := range snapshots {
 		for _, tc := range testCases {
 			nodes := clustersnapshot.CreateTestNodes(tc)
-			clusterSnapshot, err := snapshotFactory()
+			clusterSnapshot, err := snapshotFactory(b)
 			assert.NoError(b, err)
 			err = clusterSnapshot.SetClusterState(nodes, nil, nil, nil)
 			if err != nil {
@@ -89,7 +89,7 @@ func BenchmarkAddPods(b *testing.B) {
 			nodes := clustersnapshot.CreateTestNodes(tc)
 			pods := clustersnapshot.CreateTestPods(tc * 30)
 			clustersnapshot.AssignTestPodsToNodes(pods, nodes)
-			clusterSnapshot, err := snapshotFactory()
+			clusterSnapshot, err := snapshotFactory(b)
 			assert.NoError(b, err)
 			err = clusterSnapshot.SetClusterState(nodes, nil, nil, nil)
 			assert.NoError(b, err)
@@ -125,7 +125,7 @@ func BenchmarkForkAddRevert(b *testing.B) {
 			for _, ptc := range podTestCases {
 				pods := clustersnapshot.CreateTestPods(ntc * ptc)
 				clustersnapshot.AssignTestPodsToNodes(pods, nodes)
-				clusterSnapshot, err := snapshotFactory()
+				clusterSnapshot, err := snapshotFactory(b)
 				assert.NoError(b, err)
 				err = clusterSnapshot.SetClusterState(nodes, pods, nil, nil)
 				assert.NoError(b, err)

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
@@ -316,7 +316,7 @@ func BenchmarkScheduleRevert(b *testing.B) {
 			for cfgName, cfg := range configurations {
 				b.Run(cfgName, func(b *testing.B) {
 					for i := 0; i < b.N; i++ {
-						snapshot, err := snapshotFactory()
+						snapshot, err := snapshotFactory(b)
 						if err != nil {
 							b.Errorf("Failed to create a snapshot: %v", err)
 						}

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package predicate
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"math/rand"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store/streaming"
 	csisnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/csi/snapshot"
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
@@ -45,20 +47,18 @@ import (
 	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
-var snapshots = map[string]func() (clustersnapshot.ClusterSnapshot, error){
-	"basic": func() (clustersnapshot.ClusterSnapshot, error) {
-		fwHandle, err := framework.NewTestFrameworkHandle()
-		if err != nil {
-			return nil, err
-		}
+var snapshots = map[string]func(t testing.TB) (clustersnapshot.ClusterSnapshot, error){
+	"basic": func(t testing.TB) (clustersnapshot.ClusterSnapshot, error) {
+		fwHandle := framework.NewTestFrameworkHandleOrDie(t)
 		return NewPredicateSnapshot(store.NewBasicSnapshotStore(), fwHandle, true, 1, true), nil
 	},
-	"delta": func() (clustersnapshot.ClusterSnapshot, error) {
-		fwHandle, err := framework.NewTestFrameworkHandle()
-		if err != nil {
-			return nil, err
-		}
+	"delta": func(t testing.TB) (clustersnapshot.ClusterSnapshot, error) {
+		fwHandle := framework.NewTestFrameworkHandleOrDie(t)
 		return NewPredicateSnapshot(store.NewDeltaSnapshotStore(16), fwHandle, true, 1, true), nil
+	},
+	"streaming": func(t testing.TB) (clustersnapshot.ClusterSnapshot, error) {
+		fwHandle := framework.NewTestFrameworkHandleOrDie(t)
+		return NewPredicateSnapshot(streaming.NewStreamingSnapshotStore(), fwHandle, true, 1, true), nil
 	},
 }
 
@@ -156,8 +156,8 @@ func getSnapshotState(t *testing.T, snapshot clustersnapshot.ClusterSnapshot) sn
 	return snapshotState{nodes: extractNodes(nodes), podsByNode: pods, draSnapshot: snapshot.DraSnapshot(), csiSnapshot: snapshot.CsiSnapshot()}
 }
 
-func startSnapshot(t *testing.T, snapshotFactory func() (clustersnapshot.ClusterSnapshot, error), state snapshotState) clustersnapshot.ClusterSnapshot {
-	snapshot, err := snapshotFactory()
+func startSnapshot(t *testing.T, snapshotFactory func(t testing.TB) (clustersnapshot.ClusterSnapshot, error), state snapshotState) clustersnapshot.ClusterSnapshot {
+	snapshot, err := snapshotFactory(t)
 	assert.NoError(t, err)
 	var pods []*apiv1.Pod
 	for _, nodePods := range state.podsByNode {
@@ -1564,7 +1564,7 @@ func TestNode404(t *testing.T) {
 		for _, op := range ops {
 			t.Run(fmt.Sprintf("%s: %s empty", name, op.name),
 				func(t *testing.T) {
-					snapshot, err := snapshotFactory()
+					snapshot, err := snapshotFactory(t)
 					assert.NoError(t, err)
 
 					// Empty snapshot - shouldn't be able to operate on nodes that are not here.
@@ -1574,7 +1574,7 @@ func TestNode404(t *testing.T) {
 
 			t.Run(fmt.Sprintf("%s: %s fork", name, op.name),
 				func(t *testing.T) {
-					snapshot, err := snapshotFactory()
+					snapshot, err := snapshotFactory(t)
 					assert.NoError(t, err)
 
 					node := BuildTestNode("node", 10, 100)
@@ -1602,7 +1602,7 @@ func TestNode404(t *testing.T) {
 
 			t.Run(fmt.Sprintf("%s: %s base", name, op.name),
 				func(t *testing.T) {
-					snapshot, err := snapshotFactory()
+					snapshot, err := snapshotFactory(t)
 					assert.NoError(t, err)
 
 					node := BuildTestNode("node", 10, 100)
@@ -1644,7 +1644,7 @@ func TestNodeAlreadyExists(t *testing.T) {
 		for _, op := range ops {
 			t.Run(fmt.Sprintf("%s: %s base", name, op.name),
 				func(t *testing.T) {
-					snapshot, err := snapshotFactory()
+					snapshot, err := snapshotFactory(t)
 					assert.NoError(t, err)
 
 					err = snapshot.AddNodeInfo(framework.NewTestNodeInfoWithCSI(node, csiNode))
@@ -1657,7 +1657,7 @@ func TestNodeAlreadyExists(t *testing.T) {
 
 			t.Run(fmt.Sprintf("%s: %s base, forked", name, op.name),
 				func(t *testing.T) {
-					snapshot, err := snapshotFactory()
+					snapshot, err := snapshotFactory(t)
 					assert.NoError(t, err)
 
 					err = snapshot.AddNodeInfo(framework.NewTestNodeInfoWithCSI(node, csiNode))
@@ -1673,7 +1673,7 @@ func TestNodeAlreadyExists(t *testing.T) {
 
 			t.Run(fmt.Sprintf("%s: %s fork", name, op.name),
 				func(t *testing.T) {
-					snapshot, err := snapshotFactory()
+					snapshot, err := snapshotFactory(t)
 					assert.NoError(t, err)
 
 					snapshot.Fork()
@@ -1687,7 +1687,7 @@ func TestNodeAlreadyExists(t *testing.T) {
 				})
 			t.Run(fmt.Sprintf("%s: %s committed", name, op.name),
 				func(t *testing.T) {
-					snapshot, err := snapshotFactory()
+					snapshot, err := snapshotFactory(t)
 					assert.NoError(t, err)
 
 					snapshot.Fork()
@@ -1828,7 +1828,7 @@ func TestPVCUsedByPods(t *testing.T) {
 	for snapshotName, snapshotFactory := range snapshots {
 		for _, tc := range testcase {
 			t.Run(fmt.Sprintf("%s with snapshot (%s)", tc.desc, snapshotName), func(t *testing.T) {
-				snapshot, err := snapshotFactory()
+				snapshot, err := snapshotFactory(t)
 				assert.NoError(t, err)
 				csiNode := BuildCSINode(tc.node)
 				err = snapshot.AddNodeInfo(framework.NewTestNodeInfoWithCSI(tc.node, csiNode, tc.pods...))
@@ -1900,7 +1900,7 @@ func TestPVCClearAndFork(t *testing.T) {
 
 	for snapshotName, snapshotFactory := range snapshots {
 		t.Run(fmt.Sprintf("fork and revert snapshot with pvc pods with snapshot: %s", snapshotName), func(t *testing.T) {
-			snapshot, err := snapshotFactory()
+			snapshot, err := snapshotFactory(t)
 			assert.NoError(t, err)
 			csiNode := BuildCSINode(node)
 			err = snapshot.AddNodeInfo(framework.NewTestNodeInfoWithCSI(node, csiNode, pod1))
@@ -1927,7 +1927,7 @@ func TestPVCClearAndFork(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("clear snapshot with pvc pods with snapshot: %s", snapshotName), func(t *testing.T) {
-			snapshot, err := snapshotFactory()
+			snapshot, err := snapshotFactory(t)
 			assert.NoError(t, err)
 			csiNode := BuildCSINode(node)
 			err = snapshot.AddNodeInfo(framework.NewTestNodeInfoWithCSI(node, csiNode, pod1))
@@ -2038,7 +2038,7 @@ func TestSetClusterStateConcurrentDRA(t *testing.T) {
 
 	draSnap := drasnapshot.NewSnapshot(claimsMap, nil, nil, nil)
 
-	fwHandle, err := framework.NewTestFrameworkHandle()
+	fwHandle, err := framework.NewTestFrameworkHandle(context.Background())
 	assert.NoError(t, err)
 
 	// Set parallelism to 8 to ensure the workqueue utilizes multiple goroutines.

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -22,6 +22,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	schedulerinterface "k8s.io/kube-scheduler/framework"
 	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -261,6 +262,16 @@ func (snapshot *BasicSnapshotStore) Commit() error {
 func (snapshot *BasicSnapshotStore) Clear() {
 	baseData := newInternalBasicSnapshotData()
 	snapshot.data = []*internalBasicSnapshotData{baseData}
+}
+
+// GetPodInformer returns a SharedInformer for Pods.
+func (snapshot *BasicSnapshotStore) GetPodInformer() cache.SharedInformer {
+	return nil
+}
+
+// GetNodeInformer returns a SharedInformer for Nodes.
+func (snapshot *BasicSnapshotStore) GetNodeInformer() cache.SharedInformer {
+	return nil
 }
 
 // implementation of SharedLister interface

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	schedulerinterface "k8s.io/kube-scheduler/framework"
 )
@@ -450,4 +451,14 @@ func (snapshot *DeltaSnapshotStore) Commit() error {
 // Time: O(1)
 func (snapshot *DeltaSnapshotStore) Clear() {
 	snapshot.data = newInternalDeltaSnapshotData()
+}
+
+// GetPodInformer returns a SharedInformer for Pods.
+func (snapshot *DeltaSnapshotStore) GetPodInformer() cache.SharedInformer {
+	return nil
+}
+
+// GetNodeInformer returns a SharedInformer for Nodes.
+func (snapshot *DeltaSnapshotStore) GetNodeInformer() cache.SharedInformer {
+	return nil
 }

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/advanced_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/advanced_test.go
@@ -1,0 +1,185 @@
+package fort
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestClone_DiamondDAG(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+
+	// Diamond Structure:
+	//      Source
+	//      /    \
+	//   Left    Right (both FlatMap over Source)
+	//      \    /
+	//       Join  (Joins Left and Right)
+
+	left := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map:  func(i int) ([]int, error) { return []int{i}, nil },
+		Over: source,
+	})
+	right := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map:  func(i int) ([]int, error) { return []int{i}, nil },
+		Over: source,
+	})
+
+	joined := QueryInformer(&Join[int, int, int]{
+		Lock:   lock,
+		Select: func(l, r int) (int, error) { return l + r, nil },
+		From:   left,
+		Join:   right,
+		On:     func(l, r int) any { return l },
+	})
+
+	// Clone the diamond
+	ns := source.Clone(nil).(ManualSharedInformer)
+	memo := map[cache.SharedInformer]cache.SharedInformer{
+		source: ns,
+	}
+
+	nj := ClonePipeline(joined, memo).(CloneableSharedInformerQuery)
+
+	// A Join query is a Select over a joiner.
+	// nj (Select) -> joiner -> [nLeft, nRight]
+	joinerInf := nj.GetSources()[0].(CloneableSharedInformerQuery)
+	sources := joinerInf.GetSources()
+	nLeft := sources[0].(CloneableSharedInformerQuery)
+	nRight := sources[1].(CloneableSharedInformerQuery)
+
+	if nLeft.GetSources()[0] != ns || nRight.GetSources()[0] != ns {
+		t.Errorf("Cloned diamond stages should all point to the same cloned source")
+	}
+}
+
+func TestGrouper_MultiAggregation(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+
+	type Aggs struct {
+		Count    int64
+		Sum      int64
+		Any      int
+		Distinct []int
+	}
+
+	grouper := QueryInformer(&GroupBy[*Aggs, int]{
+		Lock: lock,
+		Select: func(fields []GroupField) (*Aggs, error) {
+			rawDistincts := fields[3].([]any)
+			distincts := make([]int, len(rawDistincts))
+			for i, d := range rawDistincts {
+				distincts[i] = d.(int)
+			}
+			return &Aggs{
+				Count:    fields[0].(int64),
+				Sum:      fields[1].(int64),
+				Any:      fields[2].(int),
+				Distinct: distincts,
+			}, nil
+		},
+		From: source,
+		GroupBy: func(i int) (any, []GroupField) {
+			return 0, []GroupField{
+				Count(),
+				Sum(int64(i)),
+				AnyValue(i),
+				Distinct(i),
+			}
+		},
+	})
+
+	var latest *Aggs
+	grouper.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { latest = obj.(*Aggs) },
+		UpdateFunc: func(old, new any) { latest = new.(*Aggs) },
+	})
+
+	source.OnAdd(10, true)
+	source.OnAdd(20, false)
+	source.OnAdd(10, false)
+
+	if latest.Count != 3 {
+		t.Errorf("Expected count 3, got %d", latest.Count)
+	}
+	if latest.Sum != 40 {
+		t.Errorf("Expected sum 40, got %d", latest.Sum)
+	}
+	if len(latest.Distinct) != 2 {
+		t.Errorf("Expected 2 distinct values, got %v", latest.Distinct)
+	}
+
+	source.OnDelete(10)
+	if latest.Count != 2 || latest.Sum != 30 {
+		t.Errorf("After delete: expected count 2 sum 30, got count %d sum %d", latest.Count, latest.Sum)
+	}
+}
+
+func TestDefaultKeyFunc_Robustness(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  any
+	}{
+		{"nil", nil},
+		{"string", "hello"},
+		{"int", 123},
+		{"slice", []int{1, 2, 3}},
+		{"map", map[string]int{"a": 1}},
+		{"struct", struct{ A int }{42}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := DefaultKeyFunc(tc.obj)
+			if err != nil {
+				t.Errorf("DefaultKeyFunc failed for %s: %v", tc.name, err)
+			}
+			if key == "" {
+				t.Errorf("DefaultKeyFunc returned empty key for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestBTreeMap_CloneIsolation(t *testing.T) {
+	m := NewBTreeMap[[]int]()
+	m.Set("k1", []int{1})
+
+	m2 := m.Clone()
+	
+	// Modify original slice (this is why we need COW in the handlers)
+	v, _ := m.Get("k1")
+	v[0] = 99 
+
+	v2, _ := m2.Get("k1")
+	if v2[0] != 99 {
+		t.Errorf("BTreeMap clone somehow isolated a shallow mutation without COW?")
+	}
+}
+
+func TestBTreeMap_COWManualIsolation(t *testing.T) {
+	m := NewBTreeMap[[]int]()
+	m.Set("k1", []int{1})
+
+	m2 := m.Clone()
+	
+	// Proper COW update
+	v, _ := m.Get("k1")
+	newV := append([]int(nil), v...)
+	newV[0] = 99
+	m.Set("k1", newV)
+
+	v1, _ := m.Get("k1")
+	v2, _ := m2.Get("k1")
+
+	if v1[0] != 99 {
+		t.Errorf("Original not updated")
+	}
+	if v2[0] != 1 {
+		t.Errorf("Clone not isolated")
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/btree/btree.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/btree/btree.go
@@ -1,0 +1,856 @@
+// Copyright 2014-2022 Google Inc.
+// Copyright 2025 The Kubernetes Authors.
+//
+// This file is derived from github.com/google/btree and has been
+// modified for use in the Kubernetes util package.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package btree implements in-memory B-Trees of arbitrary degree.
+//
+// btree implements an in-memory B-Tree for use as an ordered data structure.
+// It is not meant for persistent storage solutions.
+//
+// It has a flatter structure than an equivalent red-black or other binary tree,
+// which in some cases yields better memory usage and/or performance.
+// See some discussion on the matter here:
+//
+//	http://google-opensource.blogspot.com/2013/01/c-containers-that-save-memory-and-time.html
+//
+// Note, though, that this project is in no way related to the C++ B-Tree
+// implementation written about there.
+//
+// Within this tree, each node contains a slice of items and a (possibly nil)
+// slice of children.  For basic numeric values or raw structs, this can cause
+// efficiency differences when compared to equivalent C++ template code that
+// stores values in arrays within the node:
+//   - Due to the overhead of storing values as interfaces (each
+//     value needs to be stored as the value itself, then 2 words for the
+//     interface pointing to that value and its type), resulting in higher
+//     memory use.
+//   - Since interfaces can point to values anywhere in memory, values are
+//     most likely not stored in contiguous blocks, resulting in a higher
+//     number of cache misses.
+//
+// These issues don't tend to matter, though, when working with strings or other
+// heap-allocated structures, since C++-equivalent structures also must store
+// pointers and also distribute their values across the heap.
+//
+// This implementation is designed to be a drop-in replacement to gollrb.LLRB
+// trees, (http://github.com/petar/gollrb), an excellent and probably the most
+// widely used ordered tree implementation in the Go ecosystem currently.
+// Its functions, therefore, exactly mirror those of
+// llrb.LLRB where possible.  Unlike gollrb, though, we currently don't
+// support storing multiple equivalent values.
+package btree
+
+import (
+	"cmp"
+	"sort"
+	"sync"
+)
+
+// DefaultFreeListSize is the default capacity of a BTree node free list.
+const DefaultFreeListSize = 32
+
+// FreeList represents a free list of btree nodes. By default each
+// BTree has its own FreeList, but multiple BTrees can share the same
+// FreeList, in particular when they're created with Clone.
+// Two Btrees using the same freelist are safe for concurrent write access.
+type FreeList[T any] struct {
+	mu       sync.Mutex
+	freelist []*node[T]
+}
+
+// NewFreeList creates a new free list.
+// size is the maximum size of the returned free list.
+func NewFreeList[T any](size int) *FreeList[T] {
+	return &FreeList[T]{freelist: make([]*node[T], 0, size)}
+}
+
+func (f *FreeList[T]) newNode() (n *node[T]) {
+	f.mu.Lock()
+	index := len(f.freelist) - 1
+	if index < 0 {
+		f.mu.Unlock()
+		return new(node[T])
+	}
+	n = f.freelist[index]
+	f.freelist[index] = nil
+	f.freelist = f.freelist[:index]
+	f.mu.Unlock()
+	return
+}
+
+func (f *FreeList[T]) freeNode(n *node[T]) (out bool) {
+	f.mu.Lock()
+	if len(f.freelist) < cap(f.freelist) {
+		f.freelist = append(f.freelist, n)
+		out = true
+	}
+	f.mu.Unlock()
+	return
+}
+
+// ItemIterator allows callers of {A/De}scend* to iterate in-order over portions of
+// the tree.  When this function returns false, iteration will stop and the
+// associated Ascend* function will immediately return.
+type ItemIterator[T any] func(item T) bool
+
+// Less returns a default LessFunc that uses the '<' operator for types that support it.
+func Less[T cmp.Ordered]() LessFunc[T] {
+	return func(a, b T) bool { return a < b }
+}
+
+// NewOrdered creates a new B-Tree for ordered types.
+func NewOrdered[T cmp.Ordered](degree int) *BTree[T] {
+	return New[T](degree, Less[T]())
+}
+
+// New creates a new B-Tree with the given degree.
+//
+// New(2), for example, will create a 2-3-4 tree (each node contains 1-3 items
+// and 2-4 children).
+//
+// The passed-in LessFunc determines how objects of type T are ordered.
+func New[T any](degree int, less LessFunc[T]) *BTree[T] {
+	return NewWithFreeList(degree, less, NewFreeList[T](DefaultFreeListSize))
+}
+
+// NewWithFreeList creates a new B-Tree that uses the given node free list.
+func NewWithFreeList[T any](degree int, less LessFunc[T], f *FreeList[T]) *BTree[T] {
+	if degree <= 1 {
+		panic("bad degree")
+	}
+	return &BTree[T]{
+		degree: degree,
+		cow:    &copyOnWriteContext[T]{freelist: f, less: less},
+	}
+}
+
+// items stores items in a node.
+type items[T any] []T
+
+// insertAt inserts a value into the given index, pushing all subsequent values
+// forward.
+func (s *items[T]) insertAt(index int, item T) {
+	var zero T
+	*s = append(*s, zero)
+	if index < len(*s) {
+		copy((*s)[index+1:], (*s)[index:])
+	}
+	(*s)[index] = item
+}
+
+// removeAt removes a value at a given index, pulling all subsequent values
+// back.
+func (s *items[T]) removeAt(index int) T {
+	item := (*s)[index]
+	copy((*s)[index:], (*s)[index+1:])
+	var zero T
+	(*s)[len(*s)-1] = zero
+	*s = (*s)[:len(*s)-1]
+	return item
+}
+
+// pop removes and returns the last element in the list.
+func (s *items[T]) pop() (out T) {
+	index := len(*s) - 1
+	out = (*s)[index]
+	var zero T
+	(*s)[index] = zero
+	*s = (*s)[:index]
+	return
+}
+
+// truncate truncates this instance at index so that it contains only the
+// first index items. index must be less than or equal to length.
+func (s *items[T]) truncate(index int) {
+	var toClear items[T]
+	*s, toClear = (*s)[:index], (*s)[index:]
+	var zero T
+	for i := 0; i < len(toClear); i++ {
+		toClear[i] = zero
+	}
+}
+
+// find returns the index where the given item should be inserted into this
+// list.  'found' is true if the item already exists in the list at the given
+// index.
+func (s items[T]) find(item T, less func(T, T) bool) (index int, found bool) {
+	i := sort.Search(len(s), func(i int) bool {
+		return less(item, s[i])
+	})
+	if i > 0 && !less(s[i-1], item) {
+		return i - 1, true
+	}
+	return i, false
+}
+
+// node is an internal node in a tree.
+//
+// It must at all times maintain the invariant that either
+//   - len(children) == 0, len(items) unconstrained
+//   - len(children) == len(items) + 1
+type node[T any] struct {
+	items    items[T]
+	children items[*node[T]]
+	cow      *copyOnWriteContext[T]
+}
+
+func (n *node[T]) mutableFor(cow *copyOnWriteContext[T]) *node[T] {
+	if n.cow == cow {
+		return n
+	}
+	out := cow.newNode()
+	if cap(out.items) >= len(n.items) {
+		out.items = out.items[:len(n.items)]
+	} else {
+		out.items = make(items[T], len(n.items), cap(n.items))
+	}
+	copy(out.items, n.items)
+	// Copy children
+	if cap(out.children) >= len(n.children) {
+		out.children = out.children[:len(n.children)]
+	} else {
+		out.children = make(items[*node[T]], len(n.children), cap(n.children))
+	}
+	copy(out.children, n.children)
+	return out
+}
+
+func (n *node[T]) mutableChild(i int) *node[T] {
+	c := n.children[i].mutableFor(n.cow)
+	n.children[i] = c
+	return c
+}
+
+// split splits the given node at the given index.  The current node shrinks,
+// and this function returns the item that existed at that index and a new node
+// containing all items/children after it.
+func (n *node[T]) split(i int) (T, *node[T]) {
+	item := n.items[i]
+	next := n.cow.newNode()
+	next.items = append(next.items, n.items[i+1:]...)
+	n.items.truncate(i)
+	if len(n.children) > 0 {
+		next.children = append(next.children, n.children[i+1:]...)
+		n.children.truncate(i + 1)
+	}
+	return item, next
+}
+
+// maybeSplitChild checks if a child should be split, and if so splits it.
+// Returns whether or not a split occurred.
+func (n *node[T]) maybeSplitChild(i, maxItems int) bool {
+	if len(n.children[i].items) < maxItems {
+		return false
+	}
+	first := n.mutableChild(i)
+	item, second := first.split(maxItems / 2)
+	n.items.insertAt(i, item)
+	n.children.insertAt(i+1, second)
+	return true
+}
+
+// insert inserts an item into the subtree rooted at this node, making sure
+// no nodes in the subtree exceed maxItems items.  Should an equivalent item be
+// be found/replaced by insert, it will be returned.
+func (n *node[T]) insert(item T, maxItems int) (_ T, _ bool) {
+	i, found := n.items.find(item, n.cow.less)
+	if found {
+		out := n.items[i]
+		n.items[i] = item
+		return out, true
+	}
+	if len(n.children) == 0 {
+		n.items.insertAt(i, item)
+		return
+	}
+	if n.maybeSplitChild(i, maxItems) {
+		inTree := n.items[i]
+		switch {
+		case n.cow.less(item, inTree):
+			// no change, we want first split node
+		case n.cow.less(inTree, item):
+			i++ // we want second split node
+		default:
+			out := n.items[i]
+			n.items[i] = item
+			return out, true
+		}
+	}
+	return n.mutableChild(i).insert(item, maxItems)
+}
+
+// get finds the given key in the subtree and returns it.
+func (n *node[T]) get(key T) (_ T, _ bool) {
+	i, found := n.items.find(key, n.cow.less)
+	if found {
+		return n.items[i], true
+	} else if len(n.children) > 0 {
+		return n.children[i].get(key)
+	}
+	return
+}
+
+// min returns the first item in the subtree.
+func min[T any](n *node[T]) (_ T, found bool) {
+	if n == nil {
+		return
+	}
+	for len(n.children) > 0 {
+		n = n.children[0]
+	}
+	if len(n.items) == 0 {
+		return
+	}
+	return n.items[0], true
+}
+
+// max returns the last item in the subtree.
+func max[T any](n *node[T]) (_ T, found bool) {
+	if n == nil {
+		return
+	}
+	for len(n.children) > 0 {
+		n = n.children[len(n.children)-1]
+	}
+	if len(n.items) == 0 {
+		return
+	}
+	return n.items[len(n.items)-1], true
+}
+
+// toRemove details what item to remove in a node.remove call.
+type toRemove int
+
+const (
+	removeItem toRemove = iota // removes the given item
+	removeMin                  // removes smallest item in the subtree
+	removeMax                  // removes largest item in the subtree
+)
+
+// remove removes an item from the subtree rooted at this node.
+func (n *node[T]) remove(item T, minItems int, typ toRemove) (_ T, _ bool) {
+	var i int
+	var found bool
+	switch typ {
+	case removeMax:
+		if len(n.children) == 0 {
+			return n.items.pop(), true
+		}
+		i = len(n.items)
+	case removeMin:
+		if len(n.children) == 0 {
+			return n.items.removeAt(0), true
+		}
+		i = 0
+	case removeItem:
+		i, found = n.items.find(item, n.cow.less)
+		if len(n.children) == 0 {
+			if found {
+				return n.items.removeAt(i), true
+			}
+			return
+		}
+	default:
+		panic("invalid type")
+	}
+	// If we get to here, we have children.
+	if len(n.children[i].items) <= minItems {
+		return n.growChildAndRemove(i, item, minItems, typ)
+	}
+	child := n.mutableChild(i)
+	// Either we had enough items to begin with, or we've done some
+	// merging/stealing, because we've got enough now and we're ready to return
+	// stuff.
+	if found {
+		// The item exists at index 'i', and the child we've selected can give us a
+		// predecessor, since if we've gotten here it's got > minItems items in it.
+		out := n.items[i]
+		// We use our special-case 'remove' call with typ=maxItem to pull the
+		// predecessor of item i (the rightmost leaf of our immediate left child)
+		// and set it into where we pulled the item from.
+		var zero T
+		n.items[i], _ = child.remove(zero, minItems, removeMax)
+		return out, true
+	}
+	// Final recursive call.  Once we're here, we know that the item isn't in this
+	// node and that the child is big enough to remove from.
+	return child.remove(item, minItems, typ)
+}
+
+// growChildAndRemove grows child 'i' to make sure it's possible to remove an
+// item from it while keeping it at minItems, then calls remove to actually
+// remove it.
+//
+// Most documentation says we have to do two sets of special casing:
+//  1. item is in this node
+//  2. item is in child
+//
+// In both cases, we need to handle the two subcases:
+//
+//	A) node has enough values that it can spare one
+//	B) node doesn't have enough values
+//
+// For the latter, we have to check:
+//
+//	a) left sibling has node to spare
+//	b) right sibling has node to spare
+//	c) we must merge
+//
+// To simplify our code here, we handle cases #1 and #2 the same:
+// If a node doesn't have enough items, we make sure it does (using a,b,c).
+// We then simply redo our remove call, and the second time (regardless of
+// whether we're in case 1 or 2), we'll have enough items and can guarantee
+// that we hit case A.
+func (n *node[T]) growChildAndRemove(i int, item T, minItems int, typ toRemove) (T, bool) {
+	if i > 0 && len(n.children[i-1].items) > minItems {
+		// Steal from left child
+		child := n.mutableChild(i)
+		stealFrom := n.mutableChild(i - 1)
+		stolenItem := stealFrom.items.pop()
+		child.items.insertAt(0, n.items[i-1])
+		n.items[i-1] = stolenItem
+		if len(stealFrom.children) > 0 {
+			child.children.insertAt(0, stealFrom.children.pop())
+		}
+	} else if i < len(n.items) && len(n.children[i+1].items) > minItems {
+		// steal from right child
+		child := n.mutableChild(i)
+		stealFrom := n.mutableChild(i + 1)
+		stolenItem := stealFrom.items.removeAt(0)
+		child.items = append(child.items, n.items[i])
+		n.items[i] = stolenItem
+		if len(stealFrom.children) > 0 {
+			child.children = append(child.children, stealFrom.children.removeAt(0))
+		}
+	} else {
+		if i >= len(n.items) {
+			i--
+		}
+		child := n.mutableChild(i)
+		// merge with right child
+		mergeItem := n.items.removeAt(i)
+		mergeChild := n.children.removeAt(i + 1)
+		child.items = append(child.items, mergeItem)
+		child.items = append(child.items, mergeChild.items...)
+		child.children = append(child.children, mergeChild.children...)
+		n.cow.freeNode(mergeChild)
+	}
+	return n.remove(item, minItems, typ)
+}
+
+type direction int
+
+const (
+	descend = direction(-1)
+	ascend  = direction(+1)
+)
+
+type optionalItem[T any] struct {
+	item  T
+	valid bool
+}
+
+func optional[T any](item T) optionalItem[T] {
+	return optionalItem[T]{item: item, valid: true}
+}
+func empty[T any]() optionalItem[T] {
+	return optionalItem[T]{}
+}
+
+// iterate provides a simple method for iterating over elements in the tree.
+//
+// When ascending, the 'start' should be less than 'stop' and when descending,
+// the 'start' should be greater than 'stop'. Setting 'includeStart' to true
+// will force the iterator to include the first item when it equals 'start',
+// thus creating a "greaterOrEqual" or "lessThanEqual" rather than just a
+// "greaterThan" or "lessThan" queries.
+func (n *node[T]) iterate(dir direction, start, stop optionalItem[T], includeStart bool, hit bool, iter ItemIterator[T]) (bool, bool) {
+	var ok, found bool
+	var index int
+	switch dir {
+	case ascend:
+		if start.valid {
+			index, _ = n.items.find(start.item, n.cow.less)
+		}
+		for i := index; i < len(n.items); i++ {
+			if len(n.children) > 0 {
+				if hit, ok = n.children[i].iterate(dir, start, stop, includeStart, hit, iter); !ok {
+					return hit, false
+				}
+			}
+			if !includeStart && !hit && start.valid && !n.cow.less(start.item, n.items[i]) {
+				hit = true
+				continue
+			}
+			hit = true
+			if stop.valid && !n.cow.less(n.items[i], stop.item) {
+				return hit, false
+			}
+			if !iter(n.items[i]) {
+				return hit, false
+			}
+		}
+		if len(n.children) > 0 {
+			if hit, ok = n.children[len(n.children)-1].iterate(dir, start, stop, includeStart, hit, iter); !ok {
+				return hit, false
+			}
+		}
+	case descend:
+		if start.valid {
+			index, found = n.items.find(start.item, n.cow.less)
+			if !found {
+				index = index - 1
+			}
+		} else {
+			index = len(n.items) - 1
+		}
+		for i := index; i >= 0; i-- {
+			if start.valid && !n.cow.less(n.items[i], start.item) {
+				if !includeStart || hit || n.cow.less(start.item, n.items[i]) {
+					continue
+				}
+			}
+			if len(n.children) > 0 {
+				if hit, ok = n.children[i+1].iterate(dir, start, stop, includeStart, hit, iter); !ok {
+					return hit, false
+				}
+			}
+			if stop.valid && !n.cow.less(stop.item, n.items[i]) {
+				return hit, false //	continue
+			}
+			hit = true
+			if !iter(n.items[i]) {
+				return hit, false
+			}
+		}
+		if len(n.children) > 0 {
+			if hit, ok = n.children[0].iterate(dir, start, stop, includeStart, hit, iter); !ok {
+				return hit, false
+			}
+		}
+	}
+	return hit, true
+}
+
+// BTree is a generic implementation of a B-Tree.
+//
+// BTree stores items of type T in an ordered structure, allowing easy insertion,
+// removal, and iteration.
+//
+// Write operations are not safe for concurrent mutation by multiple
+// goroutines, but Read operations are.
+type BTree[T any] struct {
+	degree int
+	length int
+	root   *node[T]
+	cow    *copyOnWriteContext[T]
+}
+
+// LessFunc determines how to order a type 'T'.  It should implement a strict
+// ordering, and should return true if within that ordering, 'a' < 'b'.
+type LessFunc[T any] func(a, b T) bool
+
+// copyOnWriteContext pointers determine node ownership... a tree with a write
+// context equivalent to a node's write context is allowed to modify that node.
+// A tree whose write context does not match a node's is not allowed to modify
+// it, and must create a new, writable copy (IE: it's a Clone).
+//
+// When doing any write operation, we maintain the invariant that the current
+// node's context is equal to the context of the tree that requested the write.
+// We do this by, before we descend into any node, creating a copy with the
+// correct context if the contexts don't match.
+//
+// Since the node we're currently visiting on any write has the requesting
+// tree's context, that node is modifiable in place.  Children of that node may
+// not share context, but before we descend into them, we'll make a mutable
+// copy.
+type copyOnWriteContext[T any] struct {
+	freelist *FreeList[T]
+	less     LessFunc[T]
+}
+
+// Clone clones the btree, lazily.  Clone should not be called concurrently,
+// but the original tree (t) and the new tree (t2) can be used concurrently
+// once the Clone call completes.
+//
+// The internal tree structure of b is marked read-only and shared between t and
+// t2.  Writes to both t and t2 use copy-on-write logic, creating new nodes
+// whenever one of b's original nodes would have been modified.  Read operations
+// should have no performance degredation.  Write operations for both t and t2
+// will initially experience minor slow-downs caused by additional allocs and
+// copies due to the aforementioned copy-on-write logic, but should converge to
+// the original performance characteristics of the original tree.
+func (t *BTree[T]) Clone() (t2 *BTree[T]) {
+	// Create two entirely new copy-on-write contexts.
+	// This operation effectively creates three trees:
+	//   the original, shared nodes (old b.cow)
+	//   the new b.cow nodes
+	//   the new out.cow nodes
+	cow1, cow2 := *t.cow, *t.cow
+	out := *t
+	t.cow = &cow1
+	out.cow = &cow2
+	return &out
+}
+
+// maxItems returns the max number of items to allow per node.
+func (t *BTree[T]) maxItems() int {
+	return t.degree*2 - 1
+}
+
+// minItems returns the min number of items to allow per node (ignored for the
+// root node).
+func (t *BTree[T]) minItems() int {
+	return t.degree - 1
+}
+
+func (c *copyOnWriteContext[T]) newNode() (n *node[T]) {
+	n = c.freelist.newNode()
+	n.cow = c
+	return
+}
+
+type freeType int
+
+const (
+	ftFreelistFull freeType = iota // node was freed (available for GC, not stored in freelist)
+	ftStored                       // node was stored in the freelist for later use
+	ftNotOwned                     // node was ignored by COW, since it's owned by another one
+)
+
+// freeNode frees a node within a given COW context, if it's owned by that
+// context.  It returns what happened to the node (see freeType const
+// documentation).
+func (c *copyOnWriteContext[T]) freeNode(n *node[T]) freeType {
+	if n.cow == c {
+		// clear to allow GC
+		n.items.truncate(0)
+		n.children.truncate(0)
+		n.cow = nil
+		if c.freelist.freeNode(n) {
+			return ftStored
+		}
+		return ftFreelistFull
+	}
+	return ftNotOwned
+}
+
+// ReplaceOrInsert adds the given item to the tree.  If an item in the tree
+// already equals the given one, it is removed from the tree and returned,
+// and the second return value is true.  Otherwise, (zeroValue, false)
+//
+// nil cannot be added to the tree (will panic).
+func (t *BTree[T]) ReplaceOrInsert(item T) (_ T, _ bool) {
+	if t.root == nil {
+		t.root = t.cow.newNode()
+		t.root.items = append(t.root.items, item)
+		t.length++
+		return
+	}
+	t.root = t.root.mutableFor(t.cow)
+	if len(t.root.items) >= t.maxItems() {
+		item2, second := t.root.split(t.maxItems() / 2)
+		oldroot := t.root
+		t.root = t.cow.newNode()
+		t.root.items = append(t.root.items, item2)
+		t.root.children = append(t.root.children, oldroot, second)
+	}
+	out, outb := t.root.insert(item, t.maxItems())
+	if !outb {
+		t.length++
+	}
+	return out, outb
+}
+
+// Delete removes an item equal to the passed in item from the tree, returning
+// it.  If no such item exists, returns (zeroValue, false).
+func (t *BTree[T]) Delete(item T) (T, bool) {
+	return t.deleteItem(item, removeItem)
+}
+
+// DeleteMin removes the smallest item in the tree and returns it.
+// If no such item exists, returns (zeroValue, false).
+func (t *BTree[T]) DeleteMin() (T, bool) {
+	var zero T
+	return t.deleteItem(zero, removeMin)
+}
+
+// DeleteMax removes the largest item in the tree and returns it.
+// If no such item exists, returns (zeroValue, false).
+func (t *BTree[T]) DeleteMax() (T, bool) {
+	var zero T
+	return t.deleteItem(zero, removeMax)
+}
+
+func (t *BTree[T]) deleteItem(item T, typ toRemove) (_ T, _ bool) {
+	if t.root == nil || len(t.root.items) == 0 {
+		return
+	}
+	t.root = t.root.mutableFor(t.cow)
+	out, outb := t.root.remove(item, t.minItems(), typ)
+	if len(t.root.items) == 0 && len(t.root.children) > 0 {
+		oldroot := t.root
+		t.root = t.root.children[0]
+		t.cow.freeNode(oldroot)
+	}
+	if outb {
+		t.length--
+	}
+	return out, outb
+}
+
+// AscendRange calls the iterator for every value in the tree within the range
+// [greaterOrEqual, lessThan), until iterator returns false.
+func (t *BTree[T]) AscendRange(greaterOrEqual, lessThan T, iterator ItemIterator[T]) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(ascend, optional[T](greaterOrEqual), optional[T](lessThan), true, false, iterator)
+}
+
+// AscendLessThan calls the iterator for every value in the tree within the range
+// [first, pivot), until iterator returns false.
+func (t *BTree[T]) AscendLessThan(pivot T, iterator ItemIterator[T]) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(ascend, empty[T](), optional(pivot), false, false, iterator)
+}
+
+// AscendGreaterOrEqual calls the iterator for every value in the tree within
+// the range [pivot, last], until iterator returns false.
+func (t *BTree[T]) AscendGreaterOrEqual(pivot T, iterator ItemIterator[T]) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(ascend, optional[T](pivot), empty[T](), true, false, iterator)
+}
+
+// Ascend calls the iterator for every value in the tree within the range
+// [first, last], until iterator returns false.
+func (t *BTree[T]) Ascend(iterator ItemIterator[T]) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(ascend, empty[T](), empty[T](), false, false, iterator)
+}
+
+// DescendRange calls the iterator for every value in the tree within the range
+// [lessOrEqual, greaterThan), until iterator returns false.
+func (t *BTree[T]) DescendRange(lessOrEqual, greaterThan T, iterator ItemIterator[T]) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(descend, optional[T](lessOrEqual), optional[T](greaterThan), true, false, iterator)
+}
+
+// DescendLessOrEqual calls the iterator for every value in the tree within the range
+// [pivot, first], until iterator returns false.
+func (t *BTree[T]) DescendLessOrEqual(pivot T, iterator ItemIterator[T]) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(descend, optional[T](pivot), empty[T](), true, false, iterator)
+}
+
+// DescendGreaterThan calls the iterator for every value in the tree within
+// the range [last, pivot), until iterator returns false.
+func (t *BTree[T]) DescendGreaterThan(pivot T, iterator ItemIterator[T]) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(descend, empty[T](), optional[T](pivot), false, false, iterator)
+}
+
+// Descend calls the iterator for every value in the tree within the range
+// [last, first], until iterator returns false.
+func (t *BTree[T]) Descend(iterator ItemIterator[T]) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(descend, empty[T](), empty[T](), false, false, iterator)
+}
+
+// Get looks for the key item in the tree, returning it.  It returns
+// (zeroValue, false) if unable to find that item.
+func (t *BTree[T]) Get(key T) (_ T, _ bool) {
+	if t.root == nil {
+		return
+	}
+	return t.root.get(key)
+}
+
+// Min returns the smallest item in the tree, or (zeroValue, false) if the tree is empty.
+func (t *BTree[T]) Min() (_ T, _ bool) {
+	return min(t.root)
+}
+
+// Max returns the largest item in the tree, or (zeroValue, false) if the tree is empty.
+func (t *BTree[T]) Max() (_ T, _ bool) {
+	return max(t.root)
+}
+
+// Has returns true if the given key is in the tree.
+func (t *BTree[T]) Has(key T) bool {
+	_, ok := t.Get(key)
+	return ok
+}
+
+// Len returns the number of items currently in the tree.
+func (t *BTree[T]) Len() int {
+	return t.length
+}
+
+// Clear removes all items from the btree.  If addNodesToFreelist is true,
+// t's nodes are added to its freelist as part of this call, until the freelist
+// is full.  Otherwise, the root node is simply dereferenced and the subtree
+// left to Go's normal GC processes.
+//
+// This can be much faster
+// than calling Delete on all elements, because that requires finding/removing
+// each element in the tree and updating the tree accordingly.  It also is
+// somewhat faster than creating a new tree to replace the old one, because
+// nodes from the old tree are reclaimed into the freelist for use by the new
+// one, instead of being lost to the garbage collector.
+//
+// This call takes:
+//
+//	O(1): when addNodesToFreelist is false, this is a single operation.
+//	O(1): when the freelist is already full, it breaks out immediately
+//	O(freelist size):  when the freelist is empty and the nodes are all owned
+//	    by this tree, nodes are added to the freelist until full.
+//	O(tree size):  when all nodes are owned by another tree, all nodes are
+//	    iterated over looking for nodes to add to the freelist, and due to
+//	    ownership, none are.
+func (t *BTree[T]) Clear(addNodesToFreelist bool) {
+	if t.root != nil && addNodesToFreelist {
+		t.root.reset(t.cow)
+	}
+	t.root, t.length = nil, 0
+}
+
+// reset returns a subtree to the freelist.  It breaks out immediately if the
+// freelist is full, since the only benefit of iterating is to fill that
+// freelist up.  Returns true if parent reset call should continue.
+func (n *node[T]) reset(c *copyOnWriteContext[T]) bool {
+	for _, child := range n.children {
+		if !child.reset(c) {
+			return false
+		}
+	}
+	return c.freeNode(n) != ftFreelistFull
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/btree_indexer.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/btree_indexer.go
@@ -1,0 +1,242 @@
+package fort
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store/fort/btree"
+	"k8s.io/client-go/tools/cache"
+)
+
+// CloneableIndexer extends cache.Indexer with a fast Clone operation.
+type CloneableIndexer interface {
+	cache.Indexer
+	Clone() CloneableIndexer
+}
+
+// BTreeMap is a generic fast-cloneable map with string keys.
+// It uses a B-Tree to provide O(1) structural cloning via Copy-on-Write (COW).
+// 
+// IMPORTANT: The B-Tree structure itself is COW, meaning that tree.Clone() 
+// is very fast and doesn't duplicate the data. However, the VALUES stored inside 
+// the tree are NOT automatically deep-copied. 
+//
+// If you store complex types like slices, maps, or pointers to structs, you 
+// MUST perform a manual COW (e.g., shallow-clone the slice) BEFORE updating 
+// a value in the tree. This ensures that existing snapshots of the tree 
+// remain immutable and consistent.
+type BTreeMap[V any] interface {
+	Get(key string) (V, bool)
+	Set(key string, val V)
+	Delete(key string)
+	List() []V
+	ListKeys() []string
+	// Clone performs an O(1) structural clone.
+	Clone() BTreeMap[V]
+	Len() int
+}
+
+type btreeMapItem[V any] struct {
+	key string
+	val V
+}
+
+func btreeMapItemLess[V any](a, b btreeMapItem[V]) bool {
+	return a.key < b.key
+}
+
+type btreeMap[V any] struct {
+	mu   sync.RWMutex
+	tree *btree.BTree[btreeMapItem[V]]
+}
+
+// NewBTreeMap creates a new B-Tree based cloneable map.
+func NewBTreeMap[V any]() BTreeMap[V] {
+	return &btreeMap[V]{
+		tree: btree.New(32, btreeMapItemLess[V]),
+	}
+}
+
+func (m *btreeMap[V]) Get(key string) (V, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	it, ok := m.tree.Get(btreeMapItem[V]{key: key})
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return it.val, true
+}
+
+func (m *btreeMap[V]) Set(key string, val V) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tree.ReplaceOrInsert(btreeMapItem[V]{key: key, val: val})
+}
+
+func (m *btreeMap[V]) Delete(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tree.Delete(btreeMapItem[V]{key: key})
+}
+
+func (m *btreeMap[V]) List() []V {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	res := make([]V, 0, m.tree.Len())
+	m.tree.Ascend(func(item btreeMapItem[V]) bool {
+		res = append(res, item.val)
+		return true
+	})
+	return res
+}
+
+func (m *btreeMap[V]) ListKeys() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	res := make([]string, 0, m.tree.Len())
+	m.tree.Ascend(func(item btreeMapItem[V]) bool {
+		res = append(res, item.key)
+		return true
+	})
+	return res
+}
+
+func (m *btreeMap[V]) Clone() BTreeMap[V] {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return &btreeMap[V]{
+		// tree.Clone() is O(1) structural copy.
+		tree: m.tree.Clone(),
+	}
+}
+
+func (m *btreeMap[V]) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.tree.Len()
+}
+
+// btreeIndexer implements CloneableIndexer (cache.Indexer) using a B-Tree for storage.
+type btreeIndexer struct {
+	keyFunc cache.KeyFunc
+	data    BTreeMap[any]
+	lastRV  string
+}
+
+// NewBTreeIndexer creates a new fast-cloneable indexer.
+func NewBTreeIndexer(keyFunc cache.KeyFunc) CloneableIndexer {
+	return &btreeIndexer{
+		keyFunc: keyFunc,
+		data:    NewBTreeMap[any](),
+	}
+}
+
+func (i *btreeIndexer) Clone() CloneableIndexer {
+	return &btreeIndexer{
+		keyFunc: i.keyFunc,
+		data:    i.data.Clone(), // O(1) structural clone.
+		lastRV:  i.lastRV,
+	}
+}
+
+func (i *btreeIndexer) Add(obj any) error {
+	key, err := i.keyFunc(obj)
+	if err != nil {
+		return err
+	}
+	i.data.Set(key, obj)
+	return nil
+}
+
+func (i *btreeIndexer) Update(obj any) error {
+	return i.Add(obj)
+}
+
+func (i *btreeIndexer) Delete(obj any) error {
+	key, err := i.keyFunc(obj)
+	if err != nil {
+		return err
+	}
+	i.data.Delete(key)
+	return nil
+}
+
+func (i *btreeIndexer) List() []any {
+	return i.data.List()
+}
+
+func (i *btreeIndexer) ListKeys() []string {
+	return i.data.ListKeys()
+}
+
+func (i *btreeIndexer) Get(obj any) (item any, exists bool, err error) {
+	key, err := i.keyFunc(obj)
+	if err != nil {
+		return nil, false, err
+	}
+	return i.GetByKey(key)
+}
+
+func (i *btreeIndexer) GetByKey(key string) (item any, exists bool, err error) {
+	val, ok := i.data.Get(key)
+	return val, ok, nil
+}
+
+func (i *btreeIndexer) Replace(objs []any, rv string) error {
+	i.data = NewBTreeMap[any]()
+	i.lastRV = rv
+	for _, obj := range objs {
+		if err := i.Add(obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (i *btreeIndexer) Resync() error {
+	return nil
+}
+
+func (i *btreeIndexer) LastStoreSyncResourceVersion() string {
+	return i.lastRV
+}
+
+func (i *btreeIndexer) Bookmark(rv string) {
+	i.lastRV = rv
+}
+
+// Indexer methods stubs - currently not used by Fort queries.
+// If indexing support is needed, these must be implemented using B-Trees as well.
+
+func (i *btreeIndexer) Index(indexName string, obj any) ([]any, error) {
+	return nil, fmt.Errorf("Index not implemented in BTreeIndexer")
+}
+
+func (i *btreeIndexer) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	return nil, fmt.Errorf("IndexKeys not implemented in BTreeIndexer")
+}
+
+func (i *btreeIndexer) ListIndexFuncValues(indexName string) []string {
+	return nil
+}
+
+func (i *btreeIndexer) ByIndex(indexName, indexedValue string) ([]any, error) {
+	return nil, fmt.Errorf("ByIndex not implemented in BTreeIndexer")
+}
+
+func (i *btreeIndexer) GetIndexerResyncPeriod(indexName string) time.Duration {
+	return 0
+}
+
+func (i *btreeIndexer) GetIndexers() cache.Indexers {
+	return nil
+}
+
+func (i *btreeIndexer) AddIndexers(newIndexers cache.Indexers) error {
+	if len(newIndexers) > 0 {
+		return fmt.Errorf("AddIndexers not implemented in BTreeIndexer")
+	}
+	return nil
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/chaining_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/chaining_test.go
@@ -1,0 +1,172 @@
+package fort
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestChaining_FlatMapToJoin(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	type TaggedValue struct {
+		ID  int
+		Tag string
+	}
+
+	// 1. FlatMap source into tagged values
+	tagged := QueryInformer(&FlatMap[*TaggedValue, int]{
+		Lock: lock,
+		Map: func(i int) ([]*TaggedValue, error) {
+			return []*TaggedValue{
+				{ID: i, Tag: "A"},
+				{ID: i, Tag: "B"},
+			}, nil
+		},
+		Over: source,
+	})
+
+	// 2. Join tagged values with themselves on ID
+	joined := QueryInformer(&Join[string, *TaggedValue, *TaggedValue]{
+		Lock: lock,
+		Select: func(l, r *TaggedValue) (string, error) {
+			return fmt.Sprintf("%d:%s-%s", l.ID, l.Tag, r.Tag), nil
+		},
+		From: tagged,
+		Join: tagged,
+		On: func(l, r *TaggedValue) any {
+			if l != nil {
+				return [1]int{l.ID}
+			}
+			return [1]int{r.ID}
+		},
+		Where: func(l, r *TaggedValue) bool {
+			return l.Tag < r.Tag // Only A-B pairs
+		},
+	})
+
+	var results []string
+	joined.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { results = append(results, obj.(string)) },
+	})
+
+	source.OnAdd(1, true)
+	// Expected: "1:A-B"
+	if len(results) != 1 || results[0] != "1:A-B" {
+		t.Errorf("Expected [1:A-B], got %v", results)
+	}
+}
+
+func TestChaining_JoinToGroupByToFlatMap(t *testing.T) {
+	lock := NewLockGroup()
+	users := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	orders := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	type User struct {
+		ID   int
+		Name string
+	}
+	type Order struct {
+		ID     int
+		UserID int
+		Amount int
+	}
+
+	// 1. Join Users and Orders
+	userOrders := QueryInformer(&Join[UserOrder, *User, *Order]{
+		Lock: lock,
+		Select: func(u *User, o *Order) (UserOrder, error) {
+			return UserOrder{UserName: u.Name, Amount: o.Amount}, nil
+		},
+		From: users,
+		Join: orders,
+		On: func(u *User, o *Order) any {
+			if u != nil {
+				return [1]int{u.ID}
+			}
+			return [1]int{o.UserID}
+		},
+	})
+
+	// 2. GroupBy User to get Totals
+	type UserTotal struct {
+		UserName string
+		Total    int64
+	}
+	userTotals := QueryInformer(&GroupBy[UserTotal, UserOrder]{
+		Lock: lock,
+		Select: func(fields []GroupField) (UserTotal, error) {
+			return UserTotal{
+				UserName: fields[0].(string),
+				Total:    fields[1].(int64),
+			}, nil
+		},
+		From: userOrders,
+		GroupBy: func(uo UserOrder) (any, []GroupField) {
+			return [1]string{uo.UserName},
+				[]GroupField{
+					AnyValue(uo.UserName),
+					Sum(int64(uo.Amount)),
+				}
+		},
+	})
+
+	// 3. FlatMap Totals into Alerts (if Total > 100)
+	type Alert struct {
+		User    string
+		Message string
+	}
+	alerts := QueryInformer(&FlatMap[*Alert, UserTotal]{
+		Lock: lock,
+		Map: func(ut UserTotal) ([]*Alert, error) {
+			if ut.Total > 100 {
+				return []*Alert{{User: ut.UserName, Message: "High Spending"}}, nil
+			}
+			return nil, nil
+		},
+		Over: userTotals,
+	})
+
+	var activeAlerts []*Alert
+	alerts.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { activeAlerts = append(activeAlerts, obj.(*Alert)) },
+		UpdateFunc: func(old, new any) {
+			for i, a := range activeAlerts {
+				if a.User == new.(*Alert).User {
+					activeAlerts[i] = new.(*Alert)
+					return
+				}
+			}
+		},
+		DeleteFunc: func(obj any) {
+			val := obj.(*Alert)
+			for i, a := range activeAlerts {
+				if a.User == val.User {
+					activeAlerts = append(activeAlerts[:i], activeAlerts[i+1:]...)
+					return
+				}
+			}
+		},
+	})
+
+	// Pushing data
+	users.OnAdd(&User{ID: 1, Name: "Bob"}, true)
+	orders.OnAdd(&Order{ID: 101, UserID: 1, Amount: 50}, true)
+	if len(activeAlerts) != 0 {
+		t.Errorf("Expected 0 alerts for Bob, got %v", activeAlerts)
+	}
+
+	// Update Bob's total to 150
+	orders.OnAdd(&Order{ID: 102, UserID: 1, Amount: 100}, false)
+	if len(activeAlerts) != 1 || activeAlerts[0].User != "Bob" {
+		t.Errorf("Expected 1 alert for Bob, got %v", activeAlerts)
+	}
+
+	// Reduce Bob's spending (Update order 102)
+	orders.OnUpdate(&Order{ID: 102, UserID: 1, Amount: 100}, &Order{ID: 102, UserID: 1, Amount: 10})
+	if len(activeAlerts) != 0 {
+		t.Errorf("Expected alerts to be cleared for Bob, got %v", activeAlerts)
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/clone_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/clone_test.go
@@ -1,0 +1,118 @@
+package fort
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestClone_FlatMap(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	query := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map:  func(i int) ([]int, error) { return []int{i * 10}, nil },
+		Over: source,
+	})
+
+	newSource := source.Clone(nil).(ManualSharedInformer)
+	cloned := query.Clone([]cache.SharedInformer{newSource})
+
+	var result int
+	cloned.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { result = obj.(int) },
+	})
+
+	newSource.OnAdd(5, true)
+	if result != 50 {
+		t.Errorf("Cloned FlatMap failed: expected 50, got %d", result)
+	}
+}
+
+func TestClone_Join(t *testing.T) {
+	lock := NewLockGroup()
+	s1 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	s2 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	onFunc := func(l, r int) any { return [1]int{0} }
+	query := QueryInformer(&Join[int, int, int]{
+		Lock: lock,
+		Select: func(l, r int) (int, error) { return l + r, nil },
+		From:   s1,
+		Join:   s2,
+		On:     onFunc,
+	})
+
+	ns1 := s1.Clone(nil).(ManualSharedInformer)
+	ns2 := s2.Clone(nil).(ManualSharedInformer)
+	
+	nj := newJoiner[int, int](ns1.GetLockGroup(), ns1, ns2, onFunc)
+	cloned := query.Clone([]cache.SharedInformer{nj})
+
+	var result int
+	cloned.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { result = obj.(int) },
+	})
+
+	ns1.OnAdd(10, true)
+	ns2.OnAdd(20, true)
+	if result != 30 {
+		t.Errorf("Cloned Join failed: expected 30, got %d", result)
+	}
+}
+
+func TestClone_GroupBy(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	query := QueryInformer(&GroupBy[int, int]{
+		Lock:    lock,
+		Select:  func(fields []GroupField) (int, error) { return int(fields[0].(int64)), nil },
+		From:    source,
+		GroupBy: func(i int) (any, []GroupField) { return [1]int{0}, []GroupField{Count()} },
+	})
+
+	newSource := source.Clone(nil).(ManualSharedInformer)
+	cloned := query.Clone([]cache.SharedInformer{newSource})
+
+	var result int
+	cloned.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { result = obj.(int) },
+		UpdateFunc: func(old, new any) { result = new.(int) },
+	})
+
+	newSource.OnAdd(1, true)
+	newSource.OnAdd(2, false)
+	if result != 2 {
+		t.Errorf("Cloned GroupBy failed: expected 2, got %d", result)
+	}
+}
+
+func TestClone_Chained(t *testing.T) {
+	lock := NewLockGroup()
+	s1 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	
+	q1 := QueryInformer(&Select[int, int]{
+		Lock:   lock,
+		Select: func(i int) (int, error) { return i + 1, nil },
+		From:   s1,
+	})
+	q2 := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map:  func(i int) ([]int, error) { return []int{i, i * 2}, nil },
+		Over: q1,
+	})
+
+	ns1 := s1.Clone(nil).(ManualSharedInformer)
+	nq1 := q1.Clone([]cache.SharedInformer{ns1})
+	nq2 := q2.Clone([]cache.SharedInformer{nq1})
+
+	var results []int
+	nq2.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { results = append(results, obj.(int)) },
+	})
+
+	ns1.OnAdd(10, true) 
+	if len(results) != 2 || results[0] != 11 || results[1] != 22 {
+		t.Errorf("Cloned chain failed: %v", results)
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/consistency_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/consistency_test.go
@@ -1,0 +1,148 @@
+package fort
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestClone_ConsistencyUnderUpdate(t *testing.T) {
+	// Root source uses a keyFunc that handles integers.
+	keyFunc := func(obj any) (string, error) {
+		return string(rune(obj.(int))), nil
+	}
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, keyFunc)
+	
+	// Pipeline: source -> flatMap -> grouper
+	fm := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map: func(i int) ([]int, error) {
+			res := make([]int, 10)
+			for j := 0; j < 10; j++ {
+				res[j] = i*1000 + j
+			}
+			return res, nil
+		},
+		Over: source,
+	})
+
+	grouper := QueryInformer(&GroupBy[int64, int]{
+		Lock: lock,
+		Select: func(fields []GroupField) (int64, error) {
+			return fields[0].(int64), nil
+		},
+		From: fm,
+		GroupBy: func(i int) (any, []GroupField) {
+			return 0, []GroupField{Sum(int64(i))}
+		},
+	})
+
+	// Start a goroutine that constantly updates the source
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		val := 1
+		source.OnAdd(val, true)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				newVal := val + 1
+				source.OnUpdate(val, newVal)
+				val = newVal
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Give the pipeline a moment to warm up before first clone
+	time.Sleep(100 * time.Millisecond)
+
+	// Perform multiple clones while updates are happening
+	for i := 0; i < 10; i++ {
+		// 1. Lock original pipeline
+		locks := SnapshotLockDomain(grouper)
+		
+		// 2. Clone the chain
+		// IMPORTANT: For the clone to have state, we must connect it to the snapshot sources.
+		ns := source.Clone(nil)
+		nfm := fm.Clone([]cache.SharedInformer{ns})
+		ncloned := grouper.Clone([]cache.SharedInformer{nfm})
+		
+		// 3. Unlock original (let updates continue)
+		locks.Unlock()
+
+		// 4. Test cloned pipeline's integrity independently
+		var results []int64
+		var resLock sync.Mutex
+		ncloned.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) { 
+				resLock.Lock()
+				results = append(results, obj.(int64)) 
+				resLock.Unlock()
+			},
+			UpdateFunc: func(old, new any) { 
+				resLock.Lock()
+				results = append(results, new.(int64)) 
+				resLock.Unlock()
+			},
+		})
+		
+		// The clone should be immediately populated because AddEventHandler 
+		// replays the state of the (snapshot) indexer.
+		success := false
+		for attempt := 0; attempt < 100; attempt++ {
+			resLock.Lock()
+			if len(results) > 0 && results[len(results)-1] > 0 {
+				success = true
+				resLock.Unlock()
+				break
+			}
+			resLock.Unlock()
+			time.Sleep(1 * time.Millisecond)
+		}
+
+		if !success {
+			t.Errorf("Iteration %d: Cloned pipeline failed to populate state. Got %v", i, results)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+}
+
+func TestClone_AtomicSnapshot(t *testing.T) {
+	source := NewManualSharedInformer()
+	query := QueryInformer(&Select[int, int]{
+		Select: func(i int) (int, error) { return i, nil },
+		From:   source,
+	})
+
+	source.OnAdd(1, true)
+
+	locks := SnapshotLockDomain(query)
+	
+	// Start an update in background
+	updated := make(chan struct{})
+	go func() {
+		source.OnUpdate(1, 2)
+		close(updated)
+	}()
+
+	// The update should be blocked by the lock
+	select {
+	case <-updated:
+		t.Errorf("Update should have been blocked by SnapshotLockDomain")
+	case <-time.After(50 * time.Millisecond):
+		// Success: update is blocked
+	}
+
+	locks.Unlock()
+	<-updated // Now it should finish
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/corner_case_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/corner_case_test.go
@@ -1,0 +1,314 @@
+package fort
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestFlatMap_CornerCases(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	
+	// Test 1: Returning empty slice should delete existing items
+	flatMap := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map: func(i int) ([]int, error) {
+			if i == 0 {
+				return []int{}, nil
+			}
+			return []int{i, i * 10}, nil
+		},
+		Over: source,
+	})
+
+	var results []int
+	flatMap.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { results = append(results, obj.(int)) },
+		DeleteFunc: func(obj any) {
+			val := obj.(int)
+			for i, v := range results {
+				if v == val {
+					results = append(results[:i], results[i+1:]...)
+					break
+				}
+			}
+		},
+	})
+
+	source.OnAdd(1, true) // results: [1, 10]
+	if len(results) != 2 {
+		t.Errorf("Expected 2 items, got %v", results)
+	}
+
+	source.OnUpdate(1, 0) // results: []
+	if len(results) != 0 {
+		t.Errorf("Expected 0 items after empty update, got %v", results)
+	}
+
+	// Test 2: Error in Map function
+	source.OnUpdate(0, 5) // results: [5, 50]
+	
+	errFlatMap := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map: func(i int) ([]int, error) {
+			return nil, errors.New("map error")
+		},
+		Over: source,
+	})
+	
+	errFlatMap.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+	source.OnUpdate(5, 6) // Should not crash
+}
+
+func TestJoiner_CornerCases(t *testing.T) {
+	lock := NewLockGroup()
+	s1 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	s2 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	joined := QueryInformer(&Join[int, int, int]{
+		Lock: lock,
+		Select: func(l, r int) (int, error) { return l + r, nil },
+		From:   s1,
+		Join:   s2,
+		On:     func(l, r int) any { return [1]int{0} }, // All items join
+	})
+
+	var results []int
+	joined.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { results = append(results, obj.(int)) },
+		DeleteFunc: func(obj any) {
+			val := obj.(int)
+			for i, v := range results {
+				if v == val {
+					results = append(results[:i], results[i+1:]...)
+					break
+				}
+			}
+		},
+	})
+
+	// 1. One side empty
+	s1.OnAdd(1, true)
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results when one side is empty")
+	}
+
+	// 2. Multi-match deletion
+	s2.OnAdd(10, true) // results: [11]
+	s1.OnAdd(2, false) // results: [11, 12]
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %v", results)
+	}
+
+	s2.OnDelete(10) // Should delete both 11 and 12
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results after multi-match delete, got %v", results)
+	}
+}
+
+func TestGrouper_CornerCases(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	grouper := QueryInformer(&GroupBy[int64, int]{
+		Lock:   lock,
+		Select: func(fields []GroupField) (int64, error) { return fields[1].(int64), nil },
+		From:   source,
+		GroupBy: func(i int) (any, []GroupField) {
+			return 0, []GroupField{AnyValue(i), Sum(int64(i))}
+		},
+	})
+
+	var latestSum int64
+	var count int
+	grouper.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { latestSum = obj.(int64); count++ },
+		UpdateFunc: func(old, new any) { latestSum = new.(int64) },
+		DeleteFunc: func(obj any) { count-- },
+	})
+
+	// 1. Empty source - handled by informer replay (0 items)
+	if count != 0 {
+		t.Errorf("Expected count 0 for empty source")
+	}
+
+	// 2. Sum reaching zero but items still in group
+	source.OnAdd(10, true)  // Sum: 10
+	source.OnAdd(-10, false) // Sum: 0
+	if latestSum != 0 || count != 1 {
+		t.Errorf("Expected sum 0 and count 1, got sum %d count %d", latestSum, count)
+	}
+
+	// 3. AnyValue consistency
+	source.OnDelete(10)
+	source.OnDelete(-10)
+	if count != 0 {
+		t.Errorf("Expected group deleted")
+	}
+}
+
+func TestGrouper_AnyValueConsistency(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	grouper := QueryInformer(&GroupBy[int, int]{
+		Lock:   lock,
+		Select: func(fields []GroupField) (int, error) { return fields[0].(int), nil },
+		From:   source,
+		GroupBy: func(i int) (any, []GroupField) {
+			return 0, []GroupField{AnyValue(i)}
+		},
+	})
+
+	var result int
+	grouper.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { result = obj.(int) },
+		UpdateFunc: func(old, new any) { result = new.(int) },
+	})
+
+	source.OnAdd(100, true)
+	if result != 100 {
+		t.Errorf("Expected 100, got %d", result)
+	}
+
+	source.OnAdd(200, false)
+	// result should be 100 or 200 (implementation detail, but must be one of them)
+	if result != 100 && result != 200 {
+		t.Errorf("Expected 100 or 200, got %d", result)
+	}
+
+	oldResult := result
+	source.OnDelete(oldResult)
+	
+	// Now result must be the OTHER one
+	expected := 100
+	if oldResult == 100 {
+		expected = 200
+	}
+	if result != expected {
+		t.Errorf("Expected %d after deleting %d, got %d", expected, oldResult, result)
+	}
+}
+
+func TestGrouper_FilterTransitions(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	grouper := QueryInformer(&GroupBy[int64, int]{
+		Lock:   lock,
+		Select: func(fields []GroupField) (int64, error) { return fields[0].(int64), nil },
+		From:   source,
+		Where:  func(i int) bool { return i > 0 }, // Only positive
+		GroupBy: func(i int) (any, []GroupField) {
+			return 0, []GroupField{Sum(int64(i))}
+		},
+	})
+
+	var latestSum int64
+	var count int
+	grouper.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { latestSum = obj.(int64); count++ },
+		UpdateFunc: func(old, new any) { latestSum = new.(int64) },
+		DeleteFunc: func(obj any) { count-- },
+	})
+
+	// 1. Add item that fails filter
+	source.OnAdd(-10, true)
+	if count != 0 {
+		t.Errorf("Expected 0 groups, got %d", count)
+	}
+
+	// 2. Update item to pass filter (-10 -> 5)
+	source.OnUpdate(-10, 5)
+	if count != 1 || latestSum != 5 {
+		t.Errorf("Expected 1 group with sum 5, got count %d sum %d", count, latestSum)
+	}
+
+	// 3. Update item to fail filter (5 -> -5)
+	source.OnUpdate(5, -5)
+	if count != 0 {
+		t.Errorf("Expected 0 groups after item filtered out, got %d", count)
+	}
+}
+
+func TestClone_Unsynced(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	query := QueryInformer(&Select[int, int]{
+		Lock:   lock,
+		Select: func(i int) (int, error) { return i, nil },
+		From:   source,
+	})
+
+	// Clone BEFORE sync
+	ns := source.Clone(nil)
+	nq := query.Clone([]cache.SharedInformer{ns})
+
+	if nq.HasSynced() {
+		t.Errorf("Cloned query should not be synced if parent wasn't")
+	}
+
+	source.SetHasSynced()
+	// Clones have their own lifecycle but inherit the fact that they are NOT synced yet.
+	// We need to trigger sync on the clones if we want them synced.
+	if nq.HasSynced() {
+		t.Errorf("Clone should require its own SetHasSynced or sync from source")
+	}
+}
+
+func TestClone_DistinctCOWIntegrity(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	grouper := QueryInformer(&GroupBy[[]any, int]{
+		Lock: lock,
+		Select: func(fields []GroupField) ([]any, error) {
+			return fields[0].([]any), nil
+		},
+		From: source,
+		GroupBy: func(i int) (any, []GroupField) {
+			return 0, []GroupField{Distinct(i)}
+		},
+	})
+
+	source.OnAdd(1, true)
+
+	// Clone
+	ns := source.Clone(nil)
+	nq := grouper.Clone([]cache.SharedInformer{ns})
+
+	var cloneResults []any
+	nq.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { cloneResults = obj.([]any) },
+		UpdateFunc: func(old, new any) { cloneResults = new.([]any) },
+	})
+
+	// Initial state of clone should have [1]
+	if len(cloneResults) != 1 || cloneResults[0] != 1 {
+		t.Errorf("Expected [1] in clone, got %v", cloneResults)
+	}
+
+	// Add to ORIGINAL source
+	source.OnAdd(2, false)
+
+	// Clone should still have [1] (COW isolation)
+	if len(cloneResults) != 1 || cloneResults[0] != 1 {
+		t.Errorf("Clone isolation failed! Clone results changed to %v after original update", cloneResults)
+	}
+}
+
+func TestBTreeMap_EmptyKeys(t *testing.T) {
+	m := NewBTreeMap[int]()
+	m.Set("", 42)
+	val, ok := m.Get("")
+	if !ok || val != 42 {
+		t.Errorf("BTreeMap failed with empty key")
+	}
+
+	m.Delete("")
+	if m.Len() != 0 {
+		t.Errorf("BTreeMap Delete failed with empty key")
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/example.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/example.go
@@ -1,0 +1,218 @@
+package fort
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+type TPod struct {
+	NodeName string
+	Label    string
+}
+
+type TService struct {
+	Name     string
+	SomeData string
+}
+
+type TServiceNode struct {
+	Node    string
+	Service string
+	Count   int64
+}
+
+func (s *TService) Matches(pod *TPod) bool {
+	if len(pod.Label) == 0 || len(s.SomeData) == 0 {
+		return false
+	}
+	return pod.Label[0] == s.SomeData[0]
+}
+
+type TNode struct {
+	Name    string
+	Domains []string
+}
+
+type TNodeDomain struct {
+	Name   string
+	Domain string
+}
+
+type TServiceDomain struct {
+	Service string
+	Domain  string
+	Count   int64
+}
+
+type DomainCount struct {
+	Domain string
+	Count  int64
+}
+
+type TServiceInfo struct {
+	Service      string
+	DomainCounts []DomainCount
+}
+
+type PodSpreadLiteInfo struct {
+	ServiceNodes   CloneableSharedInformerQuery
+	NodeDomains    CloneableSharedInformerQuery
+	ServiceDomains CloneableSharedInformerQuery
+	ServiceInfo    CloneableSharedInformerQuery
+
+	PodUpdates     ManualSharedInformer
+	ServiceUpdates ManualSharedInformer
+	NodeUpdates    ManualSharedInformer
+}
+
+func NewPodSpreadLiteInfo(podInformer, serviceInformer, nodeInformer ManualSharedInformer) *PodSpreadLiteInfo {
+	d := &PodSpreadLiteInfo{
+		PodUpdates:     podInformer,
+		ServiceUpdates: serviceInformer,
+		NodeUpdates:    nodeInformer,
+	}
+
+	lock := podInformer.GetLockGroup()
+
+	// Compute the number of pods on each node that match each service.
+	d.ServiceNodes = QueryInformer(&GroupByJoin[*TServiceNode, *TPod, *TService]{
+		Lock: lock,
+		Select: func(fields []GroupField) (*TServiceNode, error) {
+			return &TServiceNode{
+				Service: fields[0].(string),
+				Node:    fields[1].(string),
+				Count:   fields[2].(int64),
+			}, nil
+		},
+
+		From: podInformer,
+		Join: serviceInformer,
+
+		Where: func(pod *TPod, service *TService) bool {
+			return service.Matches(pod)
+		},
+
+		GroupBy: func(pod *TPod, service *TService) (any, []GroupField) {
+			return [2]string{service.Name, pod.NodeName},
+				[]GroupField{
+					AnyValue(service.Name),
+					AnyValue(pod.NodeName),
+					Count(),
+				}
+		},
+	})
+
+	// Create one entry for each node / domain pair.
+	d.NodeDomains = QueryInformer(&FlatMap[*TNodeDomain, *TNode]{
+		Lock: lock,
+		Map: func(node *TNode) ([]*TNodeDomain, error) {
+			ret := []*TNodeDomain{}
+			for _, d := range node.Domains {
+				ret = append(ret, &TNodeDomain{Name: node.Name, Domain: d})
+			}
+			return ret, nil
+		},
+		Over: nodeInformer,
+	})
+
+	// Join the service/node pod counts with the node/domain pairs.
+	d.ServiceDomains = QueryInformer(&GroupByJoin[*TServiceDomain, *TServiceNode, *TNodeDomain]{
+		Lock: lock,
+		Select: func(fields []GroupField) (*TServiceDomain, error) {
+			return &TServiceDomain{
+				Service: fields[0].(string),
+				Domain:  fields[1].(string),
+				Count:   fields[2].(int64),
+			}, nil
+		},
+		From: d.ServiceNodes,
+		Join: d.NodeDomains,
+		On: func(service *TServiceNode, node *TNodeDomain) any {
+			if service != nil {
+				return [1]string{service.Node}
+			} else {
+				return [1]string{node.Name}
+			}
+		},
+		GroupBy: func(service *TServiceNode, node *TNodeDomain) (any, []GroupField) {
+			return [2]string{service.Service, node.Domain},
+				[]GroupField{
+					AnyValue(service.Service),
+					AnyValue(node.Domain),
+					Sum(service.Count),
+				}
+		},
+	})
+
+	// Flatten the results into one entry per service, with a sub array of domains and their counts.
+	d.ServiceInfo = QueryInformer(&GroupBy[*TServiceInfo, *TServiceDomain]{
+		Lock: lock,
+		Select: func(fields []GroupField) (*TServiceInfo, error) {
+			rawDistincts := fields[1].([]any)
+			domainCounts := make([]DomainCount, len(rawDistincts))
+			for i, d := range rawDistincts {
+				domainCounts[i] = d.(DomainCount)
+			}
+			return &TServiceInfo{
+				Service:      fields[0].(string),
+				DomainCounts: domainCounts,
+			}, nil
+		},
+		From: d.ServiceDomains,
+		GroupBy: func(serviceDomain *TServiceDomain) (any, []GroupField) {
+			return [1]string{serviceDomain.Service},
+				[]GroupField{
+					AnyValue(serviceDomain.Service),
+					Distinct(DomainCount{Domain: serviceDomain.Domain, Count: serviceDomain.Count}),
+				}
+		},
+	})
+
+	return d
+}
+
+func (d *PodSpreadLiteInfo) Clone() *PodSpreadLiteInfo {
+	nd := &PodSpreadLiteInfo{}
+
+	// To create a consistent snapshot of the entire query DAG, we must first 
+	// acquire an exclusive lock on the entire Domain. 
+	// SnapshotLockDomain identifies the shared LockGroup from the provided informers.
+	locks := SnapshotLockDomain(d.ServiceNodes, d.NodeDomains, d.ServiceDomains, d.ServiceInfo)
+	defer locks.Unlock()
+
+	// 1. Manually clone the leaf sources.
+	nd.PodUpdates = d.PodUpdates.Clone(nil).(ManualSharedInformer)
+	nd.ServiceUpdates = d.ServiceUpdates.Clone(nil).(ManualSharedInformer)
+	nd.NodeUpdates = d.NodeUpdates.Clone(nil).(ManualSharedInformer)
+
+	// 2. Prepare a memo map with the leaf replacements. 
+	// This map ensures that intermediate query stages are only cloned once,
+	// correctly handling "Diamond DAGs" where multiple queries share a source.
+	memo := map[cache.SharedInformer]cache.SharedInformer{
+		d.PodUpdates:     nd.PodUpdates,
+		d.ServiceUpdates: nd.ServiceUpdates,
+		d.NodeUpdates:    nd.NodeUpdates,
+	}
+
+	// 3. Use ClonePipeline to recursively perform O(1) structural clones of all
+	// intermediate query stages, attaching them to the new sources.
+	nd.ServiceNodes = ClonePipeline(d.ServiceNodes, memo).(CloneableSharedInformerQuery)
+	nd.NodeDomains = ClonePipeline(d.NodeDomains, memo).(CloneableSharedInformerQuery)
+	nd.ServiceDomains = ClonePipeline(d.ServiceDomains, memo).(CloneableSharedInformerQuery)
+	nd.ServiceInfo = ClonePipeline(d.ServiceInfo, memo).(CloneableSharedInformerQuery)
+
+	return nd
+}
+
+func (p *TPod) String() string {
+	return fmt.Sprintf("Pod(%s, %s)", p.NodeName, p.Label)
+}
+
+func (s *TService) String() string {
+	return fmt.Sprintf("Service(%s, %s)", s.Name, s.SomeData)
+}
+
+func (n *TNode) String() string {
+	return fmt.Sprintf("Node(%s, %v)", n.Name, n.Domains)
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/example_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/example_test.go
@@ -1,0 +1,267 @@
+package fort
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestPodSpreadLiteInfo(t *testing.T) {
+	lock := NewLockGroup()
+	podSource := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	serviceSource := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	nodeSource := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+
+	ps := NewPodSpreadLiteInfo(podSource, serviceSource, nodeSource)
+
+	// Results tracker
+	var latestResults map[string]*TServiceInfo = make(map[string]*TServiceInfo)
+	ps.ServiceInfo.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			si := obj.(*TServiceInfo)
+			latestResults[si.Service] = si
+		},
+		UpdateFunc: func(old, new any) {
+			si := new.(*TServiceInfo)
+			latestResults[si.Service] = si
+		},
+		DeleteFunc: func(obj any) {
+			si := obj.(*TServiceInfo)
+			delete(latestResults, si.Service)
+		},
+	})
+
+	// 1. Setup Infrastructure
+	// Node 1 in Zone A
+	// Node 2 in Zone B
+	// Node 3 in Zone A
+	nodeSource.OnAdd(&TNode{Name: "n1", Domains: []string{"zone-a"}}, true)
+	nodeSource.OnAdd(&TNode{Name: "n2", Domains: []string{"zone-b"}}, true)
+	nodeSource.OnAdd(&TNode{Name: "n3", Domains: []string{"zone-a"}}, true)
+
+	// Service S1 (data 'A') matches pods with label starting with 'A'
+	serviceSource.OnAdd(&TService{Name: "s1", SomeData: "Alpha"}, true)
+
+	// 2. Add Pods
+	// Pod 1 on Node 1, Label 'Apple' (matches s1)
+	// Pod 2 on Node 2, Label 'Ant' (matches s1)
+	// Pod 3 on Node 3, Label 'Banana' (does NOT match s1)
+	podSource.OnAdd(&TPod{NodeName: "n1", Label: "Apple"}, true)
+	podSource.OnAdd(&TPod{NodeName: "n2", Label: "Ant"}, true)
+	podSource.OnAdd(&TPod{NodeName: "n3", Label: "Banana"}, true)
+
+	// Expectation for s1:
+	// zone-a: 1 pod (on n1)
+	// zone-b: 1 pod (on n2)
+	validate := func(results map[string]*TServiceInfo, serviceName string, expected map[string]int64) {
+		si, ok := results[serviceName]
+		if !ok {
+			t.Fatalf("Service %s not found in results", serviceName)
+		}
+		if len(si.DomainCounts) != len(expected) {
+			t.Errorf("Expected %d domains, got %d", len(expected), len(si.DomainCounts))
+		}
+		for _, dc := range si.DomainCounts {
+			exp, ok := expected[dc.Domain]
+			if !ok {
+				t.Errorf("Unexpected domain %s in results", dc.Domain)
+				continue
+			}
+			if dc.Count != exp {
+				t.Errorf("Domain %s: expected count %d, got %d", dc.Domain, exp, dc.Count)
+			}
+		}
+	}
+
+	expectedS1 := map[string]int64{"zone-a": 1, "zone-b": 1}
+	validate(latestResults, "s1", expectedS1)
+
+	// 3. Update Pod 3 to match s1 (Banana -> Avocado)
+	podSource.OnUpdate(&TPod{NodeName: "n3", Label: "Banana"}, &TPod{NodeName: "n3", Label: "Avocado"})
+	// Now zone-a should have 2 pods (n1 and n3)
+	validate(latestResults, "s1", map[string]int64{"zone-a": 2, "zone-b": 1})
+
+	// 4. Test Cloning
+	t.Log("Testing Clone...")
+	psClone := ps.Clone()
+	
+	var cloneResults map[string]*TServiceInfo = make(map[string]*TServiceInfo)
+	psClone.ServiceInfo.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			si := obj.(*TServiceInfo)
+			cloneResults[si.Service] = si
+		},
+		UpdateFunc: func(old, new any) {
+			si := new.(*TServiceInfo)
+			cloneResults[si.Service] = si
+		},
+	})
+
+	// Initial clone state should match current state
+	validate(cloneResults, "s1", map[string]int64{"zone-a": 2, "zone-b": 1})
+
+	// Add new pod to original
+	podSource.OnAdd(&TPod{NodeName: "n1", Label: "Apricot"}, false)
+	// Original state: zone-a: 3, zone-b: 1
+	validate(latestResults, "s1", map[string]int64{"zone-a": 3, "zone-b": 1})
+	// Clone state should still be: zone-a: 2, zone-b: 1
+	validate(cloneResults, "s1", map[string]int64{"zone-a": 2, "zone-b": 1})
+
+	// Update clone independent of original
+	psClone.PodUpdates.OnAdd(&TPod{NodeName: "n2", Label: "Axe"}, false)
+	// Clone state: zone-a: 2, zone-b: 2
+	validate(cloneResults, "s1", map[string]int64{"zone-a": 2, "zone-b": 2})
+	// Original state should still be: zone-a: 3, zone-b: 1
+	validate(latestResults, "s1", map[string]int64{"zone-a": 3, "zone-b": 1})
+}
+
+func TestPodSpreadLiteInfo_MultiDomainNode(t *testing.T) {
+	lock := NewLockGroup()
+	podSource := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	serviceSource := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	nodeSource := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+
+	ps := NewPodSpreadLiteInfo(podSource, serviceSource, nodeSource)
+
+	var latest *TServiceInfo
+	ps.ServiceInfo.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { latest = obj.(*TServiceInfo) },
+		UpdateFunc: func(old, new any) { latest = new.(*TServiceInfo) },
+	})
+
+	// Node in two domains (e.g. Zone and Rack)
+	nodeSource.OnAdd(&TNode{Name: "n1", Domains: []string{"zone-a", "rack-1"}}, true)
+	serviceSource.OnAdd(&TService{Name: "s1", SomeData: "A"}, true)
+	podSource.OnAdd(&TPod{NodeName: "n1", Label: "Apple"}, true)
+
+	if latest == nil || len(latest.DomainCounts) != 2 {
+		t.Fatalf("Expected 2 domains, got %v", latest)
+	}
+
+	// Sort domain counts for consistent comparison
+	sort.Slice(latest.DomainCounts, func(i, j int) bool {
+		return latest.DomainCounts[i].Domain < latest.DomainCounts[j].Domain
+	})
+
+	expected := []DomainCount{
+		{Domain: "rack-1", Count: 1},
+		{Domain: "zone-a", Count: 1},
+	}
+	if !reflect.DeepEqual(latest.DomainCounts, expected) {
+		t.Errorf("Unexpected domain counts: %v", latest.DomainCounts)
+	}
+}
+
+func TestPodSpreadLiteInfo_LargeDataset(t *testing.T) {
+	lock := NewLockGroup()
+	podSource := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	serviceSource := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	nodeSource := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+
+	ps := NewPodSpreadLiteInfo(podSource, serviceSource, nodeSource)
+
+	var latestResults map[string]*TServiceInfo = make(map[string]*TServiceInfo)
+	ps.ServiceInfo.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { si := obj.(*TServiceInfo); latestResults[si.Service] = si },
+		UpdateFunc: func(old, new any) { si := new.(*TServiceInfo); latestResults[si.Service] = si },
+	})
+
+	numZones := 5
+	numNodesPerZone := 10
+	numServices := 10
+	podsPerNodePerService := 2 // Each node will have 2 pods for each matching service
+
+	// 1. Setup Nodes (50 total)
+	for z := 0; z < numZones; z++ {
+		zoneName := fmt.Sprintf("zone-%d", z)
+		for n := 0; n < numNodesPerZone; n++ {
+			nodeName := fmt.Sprintf("node-%d-%d", z, n)
+			nodeSource.OnAdd(&TNode{Name: nodeName, Domains: []string{zoneName}}, true)
+		}
+	}
+
+	// 2. Setup Services (10 total)
+	// Service 's-i' matches pods with labels starting with char(ord('A') + i)
+	for i := 0; i < numServices; i++ {
+		serviceName := fmt.Sprintf("s-%d", i)
+		matchChar := string(rune('A' + i))
+		serviceSource.OnAdd(&TService{Name: serviceName, SomeData: matchChar}, true)
+	}
+
+	// 3. Setup Pods (50 nodes * 10 services * 2 pods = 1000 pods)
+	for z := 0; z < numZones; z++ {
+		for n := 0; n < numNodesPerZone; n++ {
+			nodeName := fmt.Sprintf("node-%d-%d", z, n)
+			for i := 0; i < numServices; i++ {
+				matchChar := string(rune('A' + i))
+				for p := 0; p < podsPerNodePerService; p++ {
+					podLabel := fmt.Sprintf("%s-pod-%d", matchChar, p)
+					podSource.OnAdd(&TPod{NodeName: nodeName, Label: podLabel}, true)
+				}
+			}
+		}
+	}
+
+	// 4. Validate Results
+	// Total expected pods for EACH service: 50 nodes * 2 pods = 100
+	// Per zone: 10 nodes * 2 pods = 20
+	if len(latestResults) != numServices {
+		t.Errorf("Expected %d services, got %d", numServices, len(latestResults))
+	}
+
+	for i := 0; i < numServices; i++ {
+		serviceName := fmt.Sprintf("s-%d", i)
+		si, ok := latestResults[serviceName]
+		if !ok {
+			t.Fatalf("Service %s missing", serviceName)
+		}
+		if len(si.DomainCounts) != numZones {
+			t.Errorf("Service %s: expected %d zones, got %d", serviceName, numZones, len(si.DomainCounts))
+		}
+		total := int64(0)
+		for _, dc := range si.DomainCounts {
+			if dc.Count != 20 {
+				t.Errorf("Service %s, Zone %s: expected 20 pods, got %d", serviceName, dc.Domain, dc.Count)
+			}
+			total += dc.Count
+		}
+		if total != 100 {
+			t.Errorf("Service %s: expected total 100 pods, got %d", serviceName, total)
+		}
+	}
+
+	// 5. Verify Clone Isolation under Large Dataset
+	psClone := ps.Clone()
+	var cloneResults map[string]*TServiceInfo = make(map[string]*TServiceInfo)
+	psClone.ServiceInfo.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { si := obj.(*TServiceInfo); cloneResults[si.Service] = si },
+		UpdateFunc: func(old, new any) { si := new.(*TServiceInfo); cloneResults[si.Service] = si },
+	})
+
+	// Add more pods to ORIGINAL only
+	podSource.OnAdd(&TPod{NodeName: "node-0-0", Label: "A-extra"}, false)
+	
+	// Original service 's-0' in 'zone-0' should have 21 pods
+	if latestResults["s-0"].DomainCounts[0].Count != 21 {
+		// Note: DomainCounts order might not be fixed, find zone-0
+		count := int64(0)
+		for _, dc := range latestResults["s-0"].DomainCounts {
+			if dc.Domain == "zone-0" { count = dc.Count; break }
+		}
+		if count != 21 {
+			t.Errorf("Original zone-0 expected 21 pods, got %d", count)
+		}
+	}
+
+	// Clone service 's-0' in 'zone-0' should still have 20 pods
+	count := int64(0)
+	for _, dc := range cloneResults["s-0"].DomainCounts {
+		if dc.Domain == "zone-0" { count = dc.Count; break }
+	}
+	if count != 20 {
+		t.Errorf("Clone zone-0 expected 20 pods (isolated), got %d", count)
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/flatmap.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/flatmap.go
@@ -1,0 +1,192 @@
+package fort
+
+import (
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// flatMapper implements FlatMap query by applying a 1:N mapping function to each 
+// object from a source informer. It embeds baseInformer for event management.
+// When an input object is updated, flatMapper reconciles the old and new sets 
+// of mapped outputs to emit minimal downstream events.
+type flatMapper[Out, In any] struct {
+	*baseInformer
+	mapper       FlatMapFunc[Out, In]
+	registration cache.ResourceEventHandlerRegistration
+	source       cache.SharedInformer
+	indexer      CloneableIndexer
+}
+
+var _ ManualSharedInformer = &flatMapper[int, int]{}
+
+func newFlatMapper[Out, In any](lock LockGroup, mapper FlatMapFunc[Out, In], from cache.SharedInformer) *flatMapper[Out, In] {
+	return newFlatMapperWithHandler(mapper, from, NewManualSharedInformerWithOptions(lock, DefaultKeyFunc))
+}
+
+func newFlatMapperWithHandler[Out, In any](mapper FlatMapFunc[Out, In], from cache.SharedInformer, handler ManualSharedInformer) *flatMapper[Out, In] {
+	m := &flatMapper[Out, In]{
+		baseInformer: newBaseInformer(handler.GetLockGroup(), handler.GetKeyFunc()),
+		mapper:       mapper,
+		source:       from,
+		indexer:      NewBTreeIndexer(handler.GetKeyFunc()),
+	}
+	m.baseInformer.parent = m
+
+	m.registration, _ = from.AddEventHandler(m)
+
+	go func() {
+		for {
+			if m.registration.HasSynced() {
+				m.SetHasSynced()
+				return
+			}
+			select {
+			case <-time.After(10 * time.Millisecond):
+			case <-m.IsStoppedChan():
+				return
+			}
+		}
+	}()
+
+	return m
+}
+
+func (m *flatMapper[Out, In]) GetStore() cache.Store {
+	return m.indexer
+}
+
+func (m *flatMapper[Out, In]) GetIndexer() cache.Indexer {
+	return m.indexer
+}
+
+func (m *flatMapper[O, I]) OnAddLocked(obj any, isInitial bool) {
+	input := obj.(I)
+	results, _ := m.mapper(input)
+	for _, r := range results {
+		m.indexer.Add(r)
+		m.dispatchAdd(r, isInitial)
+	}
+}
+
+func (m *flatMapper[O, I]) OnUpdateLocked(oldObj, newObj any) {
+	oldInput := oldObj.(I)
+	newInput := newObj.(I)
+	oldResults, _ := m.mapper(oldInput)
+	newResults, _ := m.mapper(newInput)
+
+	keyFunc := m.GetKeyFunc()
+	oldKeys := make(map[string]O)
+	for _, r := range oldResults {
+		key, _ := keyFunc(r)
+		oldKeys[key] = r
+	}
+
+	newKeys := make(map[string]O)
+	for _, r := range newResults {
+		key, _ := keyFunc(r)
+		newKeys[key] = r
+	}
+
+	for key, oldR := range oldKeys {
+		if newR, ok := newKeys[key]; ok {
+			m.indexer.Update(newR)
+			m.dispatchUpdate(oldR, newR)
+			delete(newKeys, key)
+		} else {
+			m.indexer.Delete(oldR)
+			m.dispatchDelete(oldR)
+		}
+	}
+	for _, newR := range newKeys {
+		m.indexer.Add(newR)
+		m.dispatchAdd(newR, false)
+	}
+}
+
+func (m *flatMapper[O, I]) OnDeleteLocked(oldObj any) {
+	input := oldObj.(I)
+	results, _ := m.mapper(input)
+	for _, r := range results {
+		m.indexer.Delete(r)
+		m.dispatchDelete(r)
+	}
+}
+
+func (m *flatMapper[Out, In]) dispatchAdd(obj Out, isInitial bool) {
+	for _, h := range m.handlers {
+		m.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnAdd(obj, isInitial) }, 
+			func(l LockedResourceEventHandler) { l.OnAddLocked(obj, isInitial) })
+	}
+}
+
+func (m *flatMapper[Out, In]) dispatchUpdate(oldObj, newObj Out) {
+	for _, h := range m.handlers {
+		m.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnUpdate(oldObj, newObj) }, 
+			func(l LockedResourceEventHandler) { l.OnUpdateLocked(oldObj, newObj) })
+	}
+}
+
+func (m *flatMapper[Out, In]) dispatchDelete(obj Out) {
+	for _, h := range m.handlers {
+		m.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnDelete(obj) }, 
+			func(l LockedResourceEventHandler) { l.OnDeleteLocked(obj) })
+	}
+}
+
+func (m *flatMapper[Out, In]) Clone(newSources []cache.SharedInformer) CloneableSharedInformerQuery {
+	var newSource cache.SharedInformer
+	if len(newSources) > 0 {
+		newSource = newSources[0]
+	} else {
+		newSource = m.source
+	}
+
+	newLock := newSource.(CloneableSharedInformerQuery).GetLockGroup()
+
+	cloned := &flatMapper[Out, In]{
+		baseInformer: m.baseInformer.clone(),
+		mapper:       m.mapper,
+		source:       newSource,
+		indexer:      m.indexer.Clone(),
+	}
+	cloned.baseInformer.lock = newLock
+	cloned.baseInformer.parent = cloned
+
+	if ms, ok := newSource.(ManualSharedInformer); ok {
+		cloned.registration, _ = ms.AddEventHandlerNoReplay(cloned)
+	} else {
+		cloned.registration, _ = newSource.AddEventHandler(cloned)
+	}
+
+	return cloned
+}
+
+func (m *flatMapper[Out, In]) GetController() cache.Controller {
+	return nil
+}
+
+func (m *flatMapper[Out, In]) Run(stopCh <-chan struct{}) {
+	defer m.SetIsStopped()
+	defer func() {
+		if m.source != nil && m.registration != nil {
+			_ = m.source.RemoveEventHandler(m.registration)
+		}
+	}()
+	<-stopCh
+}
+
+func (m *flatMapper[Out, In]) SetWatchErrorHandler(handler cache.WatchErrorHandler) error {
+	return m.source.SetWatchErrorHandler(handler)
+}
+
+func (m *flatMapper[Out, In]) SetWatchErrorHandlerWithContext(handler cache.WatchErrorHandlerWithContext) error {
+	return m.source.SetWatchErrorHandlerWithContext(handler)
+}
+
+func (m *flatMapper[Out, In]) GetSources() []cache.SharedInformer {
+	return []cache.SharedInformer{m.source}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/flatmap_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/flatmap_test.go
@@ -1,0 +1,71 @@
+package fort
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestFlatMap_UpdateAndDelete(t *testing.T) {
+	keyFunc := func(obj any) (string, error) {
+		return obj.(string), nil
+	}
+	lock := NewLockGroup()
+	handler := NewManualSharedInformerWithOptions(lock, keyFunc)
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	type Item struct {
+		ID   int
+		Vals []string
+	}
+
+	m := &FlatMap[string, Item]{
+		Lock: lock,
+		Map: func(item Item) ([]string, error) {
+			return item.Vals, nil
+		},
+		Over: source,
+	}
+	flatMap := newFlatMapperWithHandler[string, Item](m.Map, m.Over, handler)
+
+	results := make(map[string]int)
+	flatMap.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			results[obj.(string)]++
+		},
+		UpdateFunc: func(old, new any) {
+			// If it's the same key, we don't need to do much in this test's result map
+			// since it's just a count.
+		},
+		DeleteFunc: func(obj any) {
+			results[obj.(string)]--
+			if results[obj.(string)] == 0 {
+				delete(results, obj.(string))
+			}
+		},
+	})
+
+	i1 := Item{ID: 1, Vals: []string{"a", "b"}}
+	source.OnAdd(i1, true)
+
+	if len(results) != 2 || results["a"] != 1 || results["b"] != 1 {
+		t.Errorf("Initial flatmap failed: %v", results)
+	}
+
+	// Update i1: remove "a", add "c"
+	i1Updated := Item{ID: 1, Vals: []string{"b", "c"}}
+	source.OnUpdate(i1, i1Updated)
+
+	if len(results) != 2 || results["b"] != 1 || results["c"] != 1 {
+		t.Errorf("Update flatmap failed: %v", results)
+	}
+	if _, ok := results["a"]; ok {
+		t.Errorf("Expected 'a' to be deleted")
+	}
+
+	// Delete i1
+	source.OnDelete(i1Updated)
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results after delete, got %v", results)
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/fort_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/fort_test.go
@@ -1,0 +1,258 @@
+package fort
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+type User struct {
+	ID   int
+	Name string
+}
+
+type Order struct {
+	ID     int
+	UserID int
+	Amount int
+}
+
+type UserOrder struct {
+	UserName string
+	Amount   int
+}
+
+func TestSelectJoinGroupBy(t *testing.T) {
+	lock := NewLockGroup()
+	users := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	orders := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	// Query pipeline setup
+	userOrders := QueryInformer(&Join[UserOrder, *User, *Order]{
+		Lock: lock,
+		Select: func(u *User, o *Order) (UserOrder, error) {
+			return UserOrder{UserName: u.Name, Amount: o.Amount}, nil
+		},
+		From: users,
+		Join: orders,
+		On: func(u *User, o *Order) any {
+			if u != nil {
+				return [1]int{u.ID}
+			}
+			return [1]int{o.UserID}
+		},
+		Where: func(u *User, o *Order) bool {
+			return u.ID == o.UserID
+		},
+	})
+
+	type UserTotal struct {
+		UserName string
+		Total    int64
+	}
+	userTotals := QueryInformer(&GroupBy[UserTotal, UserOrder]{
+		Lock: lock,
+		Select: func(fields []GroupField) (UserTotal, error) {
+			return UserTotal{
+				UserName: fields[0].(string),
+				Total:    fields[1].(int64),
+			}, nil
+		},
+		From: userOrders,
+		GroupBy: func(uo UserOrder) (any, []GroupField) {
+			return [1]string{uo.UserName},
+				[]GroupField{
+					AnyValue(uo.UserName),
+					Sum(int64(uo.Amount)),
+				}
+		},
+	})
+
+	var totalResults []UserTotal
+	userTotals.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			newT := obj.(UserTotal)
+			for i, r := range totalResults {
+				if r.UserName == newT.UserName {
+					totalResults[i] = newT
+					return
+				}
+			}
+			totalResults = append(totalResults, newT)
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			newT := newObj.(UserTotal)
+			for i, r := range totalResults {
+				if r.UserName == newT.UserName {
+					totalResults[i] = newT
+					return
+				}
+			}
+			totalResults = append(totalResults, newT)
+		},
+	})
+
+	// Pushing data as pointers to ensure unique identity
+	users.OnAdd(&User{ID: 1, Name: "Alice"}, true)
+	orders.OnAdd(&Order{ID: 101, UserID: 1, Amount: 50}, true)
+	orders.OnAdd(&Order{ID: 102, UserID: 1, Amount: 30}, false)
+
+	if len(totalResults) != 1 {
+		t.Errorf("Expected 1 total result, got %d", len(totalResults))
+	} else if totalResults[0].Total != 80 {
+		t.Errorf("Expected total 80, got %d", totalResults[0].Total)
+	}
+}
+
+func TestFlatMap(t *testing.T) {
+	type TaggedItem struct {
+		ID  int
+		Tag string
+	}
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	m := QueryInformer(&FlatMap[*TaggedItem, int]{
+		Lock: lock,
+		Map: func(i int) ([]*TaggedItem, error) {
+			return []*TaggedItem{
+				{ID: i, Tag: "even"},
+				{ID: i, Tag: "odd"},
+			}, nil
+		},
+		Over: source,
+	})
+
+	var results []*TaggedItem
+	m.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			results = append(results, obj.(*TaggedItem))
+		},
+	})
+
+	source.OnAdd(1, true)
+	if len(results) != 2 {
+		t.Errorf("Expected 2 tagged items, got %d", len(results))
+	}
+}
+
+func TestJoinUpdatesAndDeletes(t *testing.T) {
+	lock := NewLockGroup()
+	left := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	right := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	joined := QueryInformer(&Join[UserOrder, *User, *Order]{
+		Lock: lock,
+		Select: func(u *User, o *Order) (UserOrder, error) {
+			return UserOrder{UserName: u.Name, Amount: o.Amount}, nil
+		},
+		From: left,
+		Join: right,
+		On: func(u *User, o *Order) any {
+			if u != nil {
+				return [1]int{u.ID}
+			}
+			return [1]int{o.UserID}
+		},
+		Where: func(u *User, o *Order) bool {
+			return u.ID == o.UserID
+		},
+	})
+
+	var results []UserOrder
+	joined.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { results = append(results, obj.(UserOrder)) },
+		UpdateFunc: func(old, new any) {
+			for i, r := range results {
+				if r.UserName == old.(UserOrder).UserName && r.Amount == old.(UserOrder).Amount {
+					results[i] = new.(UserOrder)
+					return
+				}
+			}
+		},
+		DeleteFunc: func(obj any) {
+			val := obj.(UserOrder)
+			for i, r := range results {
+				if r.UserName == val.UserName && r.Amount == val.Amount {
+					results = append(results[:i], results[i+1:]...)
+					return
+				}
+			}
+		},
+	})
+
+	u1 := &User{ID: 1, Name: "Alice"}
+	o1 := &Order{ID: 101, UserID: 1, Amount: 50}
+	o2 := &Order{ID: 102, UserID: 1, Amount: 100}
+
+	left.OnAdd(u1, true)
+	right.OnAdd(o1, true)
+	right.OnAdd(o2, false)
+
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+
+	// Update order amount
+	right.OnUpdate(o1, &Order{ID: 101, UserID: 1, Amount: 60})
+	found := false
+	for _, r := range results {
+		if r.Amount == 60 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Updated amount 60 not found in results")
+	}
+
+	// Delete user -> should delete all joined results
+	left.OnDelete(u1)
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results after left delete, got %d", len(results))
+	}
+}
+
+func TestGroupByAggregations(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	type CategoryTotal struct {
+		Category string
+		Sum      int64
+		Count    int64
+	}
+
+	query := QueryInformer(&GroupBy[CategoryTotal, *UserOrder]{
+		Lock: lock,
+		Select: func(fields []GroupField) (CategoryTotal, error) {
+			return CategoryTotal{
+				Category: fields[0].(string),
+				Sum:      fields[1].(int64),
+				Count:    fields[2].(int64),
+			}, nil
+		},
+		From: source,
+		GroupBy: func(uo *UserOrder) (any, []GroupField) {
+			return [1]string{uo.UserName},
+				[]GroupField{
+					AnyValue(uo.UserName),
+					Sum(int64(uo.Amount)),
+					Count(),
+				}
+		},
+	})
+
+	var latest CategoryTotal
+	query.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { latest = obj.(CategoryTotal) },
+		UpdateFunc: func(old, new any) { latest = new.(CategoryTotal) },
+	})
+
+	source.OnAdd(&UserOrder{UserName: "Alice", Amount: 10}, true)
+	source.OnAdd(&UserOrder{UserName: "Alice", Amount: 20}, false)
+
+	if latest.Sum != 30 || latest.Count != 2 {
+		t.Errorf("Expected Sum 30 Count 2, got %+v", latest)
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/grouper.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/grouper.go
@@ -1,0 +1,441 @@
+package fort
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// grouper implements GroupBy query. It aggregates objects from a source informer
+// into groups identified by a comparable key and evaluates aggregate fields.
+// It embeds baseInformer to handle event routing and state propagation.
+type grouper[Out, In any] struct {
+	*baseInformer
+	sel     GroupSelectFunc[Out]
+	groupBy SingleGroupByFunc[In]
+	where   SingleFilterFunc[In]
+	source  cache.SharedInformer
+
+	registration cache.ResourceEventHandlerRegistration
+
+	groups BTreeMap[*groupState[Out]]
+}
+
+var _ ManualSharedInformer = &grouper[int, int]{}
+
+// groupState maintains the current aggregation state for a single group.
+type groupState[Out any] struct {
+	count   int
+	fields  []any
+	lastOut Out
+	anyValues map[int]map[any]int
+}
+
+func (s *groupState[Out]) clone() *groupState[Out] {
+	ns := *s
+	ns.fields = append([]any(nil), s.fields...)
+	if s.anyValues != nil {
+		ns.anyValues = make(map[int]map[any]int, len(s.anyValues))
+		for k, v := range s.anyValues {
+			inner := make(map[any]int, len(v))
+			for ik, iv := range v {
+				inner[ik] = iv
+			}
+			ns.anyValues[k] = inner
+		}
+	}
+	return &ns
+}
+
+func newGrouper[Out, In any](lock LockGroup, sel GroupSelectFunc[Out], groupBy SingleGroupByFunc[In], from cache.SharedInformer, where SingleFilterFunc[In]) *grouper[Out, In] {
+	return newGrouperWithHandler(sel, groupBy, from, where, NewManualSharedInformerWithOptions(lock, DefaultKeyFunc))
+}
+
+func newGrouperWithHandler[Out, In any](sel GroupSelectFunc[Out], groupBy SingleGroupByFunc[In], from cache.SharedInformer, where SingleFilterFunc[In], handler ManualSharedInformer) *grouper[Out, In] {
+	g := &grouper[Out, In]{
+		baseInformer: newBaseInformer(handler.GetLockGroup(), handler.GetKeyFunc()),
+		sel:          sel,
+		groupBy:      groupBy,
+		where:        where,
+		source:       from,
+		groups:       NewBTreeMap[*groupState[Out]](),
+	}
+	g.baseInformer.parent = g
+
+	g.registration, _ = from.AddEventHandler(g)
+
+	// Sync propagation goroutine.
+	go func() {
+		for {
+			if g.registration.HasSynced() {
+				g.SetHasSynced()
+				return
+			}
+			select {
+			case <-time.After(10 * time.Millisecond):
+			case <-g.IsStoppedChan():
+				return
+			}
+		}
+	}()
+
+	return g
+}
+
+func (g *grouper[Out, In]) GetIndexer() cache.Indexer {
+	return &grouperIndexer[Out]{groups: g.groups}
+}
+
+func (g *grouper[Out, In]) GetStore() cache.Store {
+	return &grouperIndexer[Out]{groups: g.groups}
+}
+
+func (g *grouper[Out, In]) OnAddLocked(obj any, isInitial bool) {
+	input := obj.(In)
+	if g.where != nil && !g.where(input) {
+		return
+	}
+
+	key, fields := g.groupBy(input)
+	keyStr := DefaultKey(key)
+
+	state, ok := g.groups.Get(keyStr)
+	var oldOut Out
+	var newState *groupState[Out]
+	if ok {
+		oldOut = state.lastOut
+		newState = state.clone()
+	} else {
+		newState = &groupState[Out]{}
+	}
+
+	newFields := g.evaluateFields(fields, newState, input, true)
+	newOut, _ := g.sel(newFields)
+	newState.lastOut = newOut
+	g.groups.Set(keyStr, newState)
+
+	if ok {
+		g.dispatchUpdate(oldOut, newOut)
+	} else {
+		g.dispatchAdd(newOut, isInitial)
+	}
+}
+
+func (g *grouper[Out, In]) OnUpdateLocked(oldObj, newObj any) {
+	oldInput := oldObj.(In)
+	newInput := newObj.(In)
+
+	oldPass := g.where == nil || g.where(oldInput)
+	newPass := g.where == nil || g.where(newInput)
+
+	if !oldPass && !newPass {
+		return
+	}
+	if !oldPass && newPass {
+		g.OnAddLocked(newObj, false)
+		return
+	}
+	if oldPass && !newPass {
+		g.OnDeleteLocked(oldObj)
+		return
+	}
+
+	oldKey, oldFields := g.groupBy(oldInput)
+	newKey, newFields := g.groupBy(newInput)
+
+	if oldKey == newKey {
+		keyStr := DefaultKey(oldKey)
+		state, ok := g.groups.Get(keyStr)
+		if !ok {
+			g.OnAddLocked(newObj, false)
+			return
+		}
+
+		oldOut := state.lastOut
+		newState := state.clone()
+
+		g.evaluateFields(oldFields, newState, oldInput, false)
+		resFields := g.evaluateFields(newFields, newState, newInput, true)
+		
+		newOut, _ := g.sel(resFields)
+		newState.lastOut = newOut
+		g.groups.Set(keyStr, newState)
+		g.dispatchUpdate(oldOut, newOut)
+	} else {
+		g.OnDeleteLocked(oldObj)
+		g.OnAddLocked(newObj, false)
+	}
+}
+
+func (g *grouper[Out, In]) OnDeleteLocked(obj any) {
+	input := obj.(In)
+	if g.where != nil && !g.where(input) {
+		return
+	}
+
+	key, fields := g.groupBy(input)
+	keyStr := DefaultKey(key)
+
+	state, ok := g.groups.Get(keyStr)
+	if !ok {
+		return
+	}
+
+	oldOut := state.lastOut
+	newState := state.clone()
+
+	newFields := g.evaluateFields(fields, newState, input, false)
+
+	if newState.count == 0 {
+		g.groups.Delete(keyStr)
+		g.dispatchDelete(oldOut)
+	} else {
+		newOut, _ := g.sel(newFields)
+		newState.lastOut = newOut
+		g.groups.Set(keyStr, newState)
+		g.dispatchUpdate(oldOut, newOut)
+	}
+}
+
+func (g *grouper[Out, In]) dispatchAdd(obj Out, isInitial bool) {
+	for _, h := range g.handlers {
+		g.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnAdd(obj, isInitial) }, 
+			func(l LockedResourceEventHandler) { l.OnAddLocked(obj, isInitial) })
+	}
+}
+
+func (g *grouper[Out, In]) dispatchUpdate(oldObj, newObj Out) {
+	for _, h := range g.handlers {
+		g.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnUpdate(oldObj, newObj) }, 
+			func(l LockedResourceEventHandler) { l.OnUpdateLocked(oldObj, newObj) })
+	}
+}
+
+func (g *grouper[Out, In]) dispatchDelete(obj Out) {
+	for _, h := range g.handlers {
+		g.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnDelete(obj) }, 
+			func(l LockedResourceEventHandler) { l.OnDeleteLocked(obj) })
+	}
+}
+
+func (g *grouper[Out, In]) evaluateFields(fields []GroupField, state *groupState[Out], input In, adding bool) []GroupField {
+	if state.fields == nil {
+		state.fields = make([]any, len(fields))
+	}
+
+	if adding {
+		state.count++
+	} else {
+		state.count--
+	}
+
+	res := make([]GroupField, len(fields))
+	for i, f := range fields {
+		gf := f.(*groupField)
+		if gf.count {
+			res[i] = int64(state.count)
+		} else if gf.sum != nil {
+			if state.fields[i] == nil {
+				state.fields[i] = int64(0)
+			}
+			val := *gf.sum
+			if adding {
+				state.fields[i] = state.fields[i].(int64) + val
+			} else {
+				state.fields[i] = state.fields[i].(int64) - val
+			}
+			res[i] = state.fields[i]
+		} else if gf.distinct != nil {
+			if state.fields[i] == nil {
+				state.fields[i] = make(map[any]int)
+			}
+			m := state.fields[i].(map[any]int)
+			newM := make(map[any]int, len(m))
+			for k, v := range m {
+				newM[k] = v
+			}
+			
+			if adding {
+				newM[gf.distinct]++
+			} else {
+				newM[gf.distinct]--
+				if newM[gf.distinct] == 0 {
+					delete(newM, gf.distinct)
+				}
+			}
+			state.fields[i] = newM
+			
+			var distincts []any
+			for k := range newM {
+				distincts = append(distincts, k)
+			}
+			res[i] = distincts
+		} else if gf.anyValue != nil {
+			if state.anyValues == nil {
+				state.anyValues = make(map[int]map[any]int)
+			}
+			m := state.anyValues[i]
+			if m == nil {
+				m = make(map[any]int)
+				state.anyValues[i] = m
+			}
+			if adding {
+				m[gf.anyValue]++
+			} else {
+				m[gf.anyValue]--
+				if m[gf.anyValue] == 0 {
+					delete(m, gf.anyValue)
+				}
+			}
+			var picked any
+			for k := range m {
+				picked = k
+				break
+			}
+			state.fields[i] = picked
+			res[i] = picked
+		} else if gf.key != nil {
+			res[i] = gf.key
+		}
+	}
+	return res
+}
+
+func (g *grouper[Out, In]) Clone(newSources []cache.SharedInformer) CloneableSharedInformerQuery {
+	ns := newSources[0]
+	newLock := ns.(CloneableSharedInformerQuery).GetLockGroup()
+	
+	ng := &grouper[Out, In]{
+		baseInformer: g.baseInformer.clone(),
+		sel:          g.sel,
+		groupBy:      g.groupBy,
+		where:        g.where,
+		source:       ns,
+		groups:       g.groups.Clone(),
+	}
+	ng.baseInformer.lock = newLock
+	ng.baseInformer.parent = ng
+
+	if ms, ok := ns.(ManualSharedInformer); ok {
+		ng.registration, _ = ms.AddEventHandlerNoReplay(ng)
+	} else {
+		ng.registration, _ = ns.AddEventHandler(ng)
+	}
+
+	return ng
+}
+
+func (g *grouper[Out, In]) GetController() cache.Controller {
+	return nil
+}
+
+func (g *grouper[Out, In]) Run(stopCh <-chan struct{}) {
+	defer g.SetIsStopped()
+	defer func() {
+		if g.source != nil && g.registration != nil {
+			_ = g.source.RemoveEventHandler(g.registration)
+		}
+	}()
+	<-stopCh
+}
+
+func (g *grouper[Out, In]) SetWatchErrorHandler(handler cache.WatchErrorHandler) error {
+	return g.source.SetWatchErrorHandler(handler)
+}
+
+func (g *grouper[Out, In]) SetWatchErrorHandlerWithContext(handler cache.WatchErrorHandlerWithContext) error {
+	return g.source.SetWatchErrorHandlerWithContext(handler)
+}
+
+func (g *grouper[Out, In]) GetSources() []cache.SharedInformer {
+	return []cache.SharedInformer{g.source}
+}
+
+// grouperIndexer implements cache.Store by wrapping the grouper's internal 
+// groups B-Tree. It avoids maintaining a redundant index of Out objects.
+type grouperIndexer[Out any] struct {
+	groups  BTreeMap[*groupState[Out]]
+	keyFunc cache.KeyFunc
+}
+
+func (i *grouperIndexer[Out]) Clone() CloneableIndexer {
+	return &grouperIndexer[Out]{
+		groups:  i.groups.Clone(),
+		keyFunc: i.keyFunc,
+	}
+}
+
+func (i *grouperIndexer[Out]) Add(obj any) error    { return fmt.Errorf("not supported") }
+func (i *grouperIndexer[Out]) Update(obj any) error { return fmt.Errorf("not supported") }
+func (i *grouperIndexer[Out]) Delete(obj any) error { return fmt.Errorf("not supported") }
+
+func (i *grouperIndexer[Out]) List() []any {
+	states := i.groups.List()
+	res := make([]any, len(states))
+	for idx, s := range states {
+		res[idx] = s.lastOut
+	}
+	return res
+}
+
+func (i *grouperIndexer[Out]) ListKeys() []string {
+	return i.groups.ListKeys()
+}
+
+func (i *grouperIndexer[Out]) Get(obj any) (item any, exists bool, err error) {
+	key, err := i.keyFunc(obj)
+	if err != nil {
+		return nil, false, err
+	}
+	return i.GetByKey(key)
+}
+
+func (i *grouperIndexer[Out]) GetByKey(key string) (item any, exists bool, err error) {
+	state, ok := i.groups.Get(key)
+	if !ok {
+		return nil, false, nil
+	}
+	return state.lastOut, true, nil
+}
+
+func (i *grouperIndexer[Out]) Replace(objs []any, rv string) error {
+	return fmt.Errorf("not supported")
+}
+
+func (i *grouperIndexer[Out]) Resync() error {
+	return nil
+}
+
+func (i *grouperIndexer[Out]) Bookmark(rv string) {}
+
+func (i *grouperIndexer[Out]) LastStoreSyncResourceVersion() string {
+	return ""
+}
+
+func (i *grouperIndexer[Out]) Index(indexName string, obj any) ([]any, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+func (i *grouperIndexer[Out]) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+func (i *grouperIndexer[Out]) ListIndexFuncValues(indexName string) []string {
+	return nil
+}
+
+func (i *grouperIndexer[Out]) ByIndex(indexName, indexedValue string) ([]any, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+func (i *grouperIndexer[Out]) GetIndexers() cache.Indexers {
+	return nil
+}
+
+func (i *grouperIndexer[Out]) AddIndexers(newIndexers cache.Indexers) error {
+	return fmt.Errorf("not supported")
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/grouper_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/grouper_test.go
@@ -1,0 +1,132 @@
+package fort
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestGrouper_UpdateAndDelete(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	type Data struct {
+		ID       int
+		Category string
+		Value    int64
+	}
+	type Aggregated struct {
+		Category string
+		Sum      int64
+	}
+
+	grouped := QueryInformer(&GroupBy[Aggregated, Data]{
+		Lock: lock,
+		Select: func(fields []GroupField) (Aggregated, error) {
+			return Aggregated{
+				Category: fields[0].(string),
+				Sum:      fields[1].(int64),
+			}, nil
+		},
+		From: source,
+		GroupBy: func(d Data) (any, []GroupField) {
+			return [1]string{d.Category},
+				[]GroupField{
+					AnyValue(d.Category),
+					Sum(d.Value),
+				}
+		},
+	})
+
+	results := make(map[string]int64)
+	grouped.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			res := obj.(Aggregated)
+			results[res.Category] = res.Sum
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			res := newObj.(Aggregated)
+			results[res.Category] = res.Sum
+		},
+		DeleteFunc: func(obj any) {
+			res := obj.(Aggregated)
+			delete(results, res.Category)
+		},
+	})
+
+	d1 := Data{ID: 1, Category: "A", Value: 10}
+	d2 := Data{ID: 2, Category: "A", Value: 20}
+	
+	source.OnAdd(d1, true)
+	if results["A"] != 10 {
+		t.Errorf("Expected 10, got %d", results["A"])
+	}
+
+	source.OnAdd(d2, false)
+	if results["A"] != 30 {
+		t.Errorf("Expected 30, got %d", results["A"])
+	}
+
+	// Update d1
+	d1Updated := Data{ID: 1, Category: "A", Value: 15}
+	source.OnUpdate(d1, d1Updated)
+	if results["A"] != 35 {
+		t.Errorf("Expected 35 after update, got %d", results["A"])
+	}
+
+	// Change category of d2
+	d2Updated := Data{ID: 2, Category: "B", Value: 20}
+	source.OnUpdate(d2, d2Updated)
+	if results["A"] != 15 {
+		t.Errorf("Expected 15 for A, got %d", results["A"])
+	}
+	if results["B"] != 20 {
+		t.Errorf("Expected 20 for B, got %d", results["B"])
+	}
+
+	// Delete d1
+	source.OnDelete(d1Updated)
+	if _, ok := results["A"]; ok {
+		t.Errorf("Category A should have been deleted")
+	}
+}
+
+func TestGrouper_Where(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	type Data struct {
+		Val int
+	}
+
+	grouped := QueryInformer(&GroupBy[int, Data]{
+		Lock: lock,
+		Select: func(fields []GroupField) (int, error) {
+			return int(fields[0].(int64)), nil
+		},
+		From: source,
+		Where: func(d Data) bool {
+			return d.Val > 10
+		},
+		GroupBy: func(d Data) (any, []GroupField) {
+			return [1]string{"constant"}, []GroupField{Count()}
+		},
+	})
+
+	var count int
+	grouped.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { count = obj.(int) },
+		UpdateFunc: func(old, new any) { count = new.(int) },
+		DeleteFunc: func(obj any) { count = 0 },
+	})
+
+	source.OnAdd(Data{Val: 5}, true)
+	if count != 0 {
+		t.Errorf("Expected 0, got %d", count)
+	}
+
+	source.OnAdd(Data{Val: 15}, false)
+	if count != 1 {
+		t.Errorf("Expected 1, got %d", count)
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/interface.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/interface.go
@@ -1,0 +1,323 @@
+package fort
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+type explicitKeyProvider interface {
+	ExplicitKey() string
+}
+
+// DefaultKey is a robust key function that handles both K8s objects and primitive types.
+// It ensures that even non-meta objects can be indexed without returning errors.
+func DefaultKey(obj any) string {
+	if obj == nil {
+		return "<nil>"
+	}
+	switch v := obj.(type) {
+	case string:
+		return v
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case [2]string:
+		return v[0] + "\x00" + v[1]
+	case [3]string:
+		return v[0] + "\x00" + v[1] + "\x00" + v[2]
+	case explicitKeyProvider:
+		return v.ExplicitKey()
+	}
+
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		klog.Warningf("DefaultKey: unexpected type %T, falling back to string conversion: %v", obj, err)
+		return fmt.Sprintf("%v", obj)
+	}
+	return key
+}
+
+// DefaultKeyFunc wraps DefaultKey to satisfy the cache.KeyFunc signature.
+func DefaultKeyFunc(obj any) (string, error) {
+	return DefaultKey(obj), nil
+}
+
+// UnwrapDeleted returns the underlying object if it's wrapped in a DeletedFinalStateUnknown container.
+func UnwrapDeleted(obj any) any {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		return d.Obj
+	}
+	return obj
+}
+
+// LockGroup manages a shared RWMutex for a connected set of query informers (a "Domain").
+// In Fort, an entire query Directed Acyclic Graph (DAG)—from leaf sources to final aggregates—
+// should share a single LockGroup. This shared lock ensures transactional consistency
+// across the domain during complex updates and snapshots.
+// When a source informer receives an event, the entire propagation through the DAG
+// happens under this lock, ensuring that at any point, a reader sees a consistent
+// state across all stages of the pipeline.
+type LockGroup interface {
+	RLock()
+	RUnlock()
+	Lock()
+	Unlock()
+}
+
+type lockGroup struct {
+	sync.RWMutex
+}
+
+// NewLockGroup creates a new shared mutex domain.
+func NewLockGroup() LockGroup {
+	return &lockGroup{}
+}
+
+// CloneableSharedInformerQuery is a shared informer defined by a query that supports
+// high-performance cloning. Clones are "born hydrated," meaning they inherit the
+// full current state of their parent via O(1) Copy-on-Write (COW) structural
+// cloning of the underlying B-Trees. This allows creating consistent snapshots
+// of complex query pipelines nearly instantaneously, regardless of dataset size.
+type CloneableSharedInformerQuery interface {
+	cache.SharedInformer
+	// Clone creates a new instance of the query using the provided new sources.
+	// The cloned informer starts with the exact same data state as the parent
+	// at the moment of cloning.
+	//
+	// REQUIRES: The caller MUST hold the shared LockGroup of the parent.
+	// For most query types, an RLock is sufficient, but ManualSharedInformer
+	// and queries that use structural COW cloning (B-Trees) require an
+	// exclusive Lock to safely clone their underlying indexers.
+	Clone(newSources []cache.SharedInformer) CloneableSharedInformerQuery
+	// GetLockGroup returns the shared lock used by this informer domain.
+	GetLockGroup() LockGroup
+	// SetName sets the name for debug logging.
+	SetName(name string)
+	// GetSources returns the upstream informers providing data to this query.
+	GetSources() []cache.SharedInformer
+	// IsStoppedChan returns a channel that is closed when the informer is stopped.
+	IsStoppedChan() <-chan struct{}
+	// GetKeyFunc returns the key function used by this informer.
+	GetKeyFunc() cache.KeyFunc
+	// GetIndexer returns the underlying indexer.
+	GetIndexer() cache.Indexer
+	// GetStore returns the underlying store.
+	GetStore() cache.Store
+}
+
+// QueryInformer generates a new SharedInformer by running the given query spec.
+func QueryInformer(query QuerySpec) CloneableSharedInformerQuery {
+	return query.Build()
+}
+
+// QuerySpec defines the interface for building a query informer from a declarative specification.
+type QuerySpec interface {
+	Build() CloneableSharedInformerQuery
+}
+
+// Select defines a simple transformation and filtering query.
+type Select[Out, In any] struct {
+	Lock   LockGroup
+	Select SingleSelectFunc[Out, In]
+	From   cache.SharedInformer
+	Where  SingleFilterFunc[In]
+}
+
+type SingleSelectFunc[Out, Left any] func(value Left) (Out, error)
+type SingleFilterFunc[In any] func(in In) bool
+
+// JoinValue represents a pair of joined objects.
+type JoinValue[Left, Right any] struct {
+	Left  Left
+	Right Right
+}
+
+// Join defines a many-to-many join between two informers.
+type Join[Out, Left, Right any] struct {
+	Lock   LockGroup
+	Select JoinSelectFunc[Out, Left, Right]
+	From   cache.SharedInformer
+	Join   cache.SharedInformer
+	// On defines the join key. If nil, a full Cartesian join is performed.
+	On     JoinOnFunc[Left, Right]
+	Where  JoinFilterFunc[Left, Right]
+}
+
+type JoinSelectFunc[Out, Left, Right any] func(left Left, right Right) (Out, error)
+type JoinFilterFunc[Left, Right any] func(left Left, right Right) bool
+
+// JoinOnFunc defines the key used for joining two objects.
+type JoinOnFunc[Left, Right any] func(left Left, right Right) any
+
+// GroupBy defines an aggregation query over a single informer.
+type GroupBy[Out, In any] struct {
+	Lock    LockGroup
+	Select  GroupSelectFunc[Out]
+	From    cache.SharedInformer
+	Where   SingleFilterFunc[In]
+	GroupBy SingleGroupByFunc[In]
+}
+
+type GroupSelectFunc[Out any] func(fields []GroupField) (Out, error)
+type SingleGroupByFunc[In any] func(in In) (any, []GroupField)
+
+// GroupByJoin defines an aggregation query over the results of a join.
+type GroupByJoin[Out, Left, Right any] struct {
+	Lock    LockGroup
+	Select  GroupSelectFunc[Out]
+	From    cache.SharedInformer
+	Join    cache.SharedInformer
+	On      JoinOnFunc[Left, Right]
+	Where   JoinFilterFunc[Left, Right]
+	GroupBy JoinGroupByFunc[Left, Right]
+}
+
+type JoinGroupByFunc[Left, Right any] func(left Left, right Right) (any, []GroupField)
+
+// GroupField represents an individual aggregate field in a GroupBy query.
+type GroupField interface{}
+
+type groupField struct {
+	key      any
+	count    bool
+	sum      *int64
+	distinct any
+	anyValue any
+}
+
+// Aggregate builders.
+
+func GroupKey(key any) GroupField {
+	return &groupField{key: key}
+}
+
+func Count() GroupField {
+	return &groupField{count: true}
+}
+
+func Sum(val int64) GroupField {
+	return &groupField{sum: &val}
+}
+
+func Distinct(val any) GroupField {
+	return &groupField{distinct: val}
+}
+
+func AnyValue(val any) GroupField {
+	return &groupField{anyValue: val}
+}
+
+// FlatMap defines a one-to-many transformation query.
+type FlatMap[Out, In any] struct {
+	Lock LockGroup
+	Map  FlatMapFunc[Out, In]
+	Over cache.SharedInformer
+}
+
+type FlatMapFunc[Out, In any] func(obj In) ([]Out, error)
+
+// LockedResourceEventHandler allows processing events without re-acquiring the LockGroup.
+// Internal query stages use this to propagate events across the shared-lock domain.
+type LockedResourceEventHandler interface {
+	OnAddLocked(obj any, isInInitialList bool)
+	OnUpdateLocked(oldObj, newObj any)
+	OnDeleteLocked(oldObj any)
+}
+
+// ManualSharedInformer allows manual triggering of events.
+// It is primarily used for testing and for providing hydrated snapshot sources.
+type ManualSharedInformer interface {
+	CloneableSharedInformerQuery
+	cache.ResourceEventHandler
+	LockedResourceEventHandler
+
+	SetIsStopped()
+	SetHasSynced()
+	GetKeyFunc() cache.KeyFunc
+	TriggerWatchError(err error)
+
+	// Clear removes all objects from the informer and notifies handlers.
+	Clear()
+
+	// AddEventHandlerNoReplay registers a handler without replaying current state.
+	// Used during pipeline cloning to prevent redundant O(N) hydration.
+	AddEventHandlerNoReplay(h cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error)
+}
+
+// SnapshotLockDomain acquires an exclusive Lock on the domain (LockGroup),
+// enabling a consistent and safe snapshot. Exclusive lock is REQUIRED because
+// B-Tree structural cloning is not thread-safe for concurrent read-only clones.
+func SnapshotLockDomain(informers ...CloneableSharedInformerQuery) DomainLock {
+	if len(informers) == 0 {
+		return &domainLock{}
+	}
+	lock := informers[0].GetLockGroup()
+	lock.Lock()
+	return &domainLock{lock: lock, exclusive: true}
+}
+
+// DomainLock provides a handle to release a domain-level lock.
+type DomainLock interface {
+	Unlock()
+}
+
+type domainLock struct {
+	lock      LockGroup
+	exclusive bool
+}
+
+func (ls *domainLock) Unlock() {
+	if ls.lock != nil {
+		if ls.exclusive {
+			ls.lock.Unlock()
+		} else {
+			ls.lock.RUnlock()
+		}
+	}
+}
+
+// ClonePipeline recursively clones a query DAG starting from root, replacing leaf sources.
+// It ensures that shared branches in the DAG are only cloned once (memoization).
+//
+// REQUIRES: The caller MUST hold an exclusive lock on the LockGroup of the root informer
+// (and thus the entire domain) before calling this, as it triggers structural B-Tree clones.
+func ClonePipeline(root cache.SharedInformer, memo map[cache.SharedInformer]cache.SharedInformer) cache.SharedInformer {
+	return clonePipelineRecursive(root, memo, 0)
+}
+
+const maxCloneDepth = 100
+
+func clonePipelineRecursive(root cache.SharedInformer, memo map[cache.SharedInformer]cache.SharedInformer, depth int) cache.SharedInformer {
+	if depth > maxCloneDepth {
+		panic(fmt.Sprintf("Recursive clone depth exceeded %d (possible cycle in query DAG)", maxCloneDepth))
+	}
+
+	if repl, ok := memo[root]; ok {
+		return repl
+	}
+
+	q, ok := root.(CloneableSharedInformerQuery)
+	if !ok {
+		return root
+	}
+
+	sources := q.GetSources()
+	if len(sources) == 0 {
+		// This is a leaf that was not in the initial memo map.
+		return root
+	}
+
+	newSources := make([]cache.SharedInformer, len(sources))
+	for i, s := range sources {
+		newSources[i] = clonePipelineRecursive(s, memo, depth+1)
+	}
+
+	res := q.Clone(newSources)
+	memo[root] = res
+	return res
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/joiner.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/joiner.go
@@ -1,0 +1,448 @@
+package fort
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// joiner implements a many-to-many join between two source informers.
+// It maintains internal B-Trees of join sets to allow fast multi-match lookups.
+// It embeds baseInformer to handle downstream event propagation.
+type joiner[L, R any] struct {
+	*baseInformer
+	on      JoinOnFunc[L, R]
+
+	leftSource  cache.SharedInformer
+	rightSource cache.SharedInformer
+
+	leftRegistration  cache.ResourceEventHandlerRegistration
+	rightRegistration cache.ResourceEventHandlerRegistration
+
+	left  BTreeMap[[]L]
+	right BTreeMap[[]R]
+}
+
+var _ ManualSharedInformer = &joiner[int, int]{}
+
+func newJoiner[L, R any](lock LockGroup, leftSource, rightSource cache.SharedInformer, on JoinOnFunc[L, R]) *joiner[L, R] {
+	return newJoinerWithHandler(leftSource, rightSource, on, NewManualSharedInformerWithOptions(lock, DefaultKeyFunc))
+}
+
+func newJoinerWithHandler[L, R any](leftSource, rightSource cache.SharedInformer, on JoinOnFunc[L, R], handler ManualSharedInformer) *joiner[L, R] {
+	j := &joiner[L, R]{
+		baseInformer: newBaseInformer(handler.GetLockGroup(), handler.GetKeyFunc()),
+		on:          on,
+		leftSource:  leftSource,
+		rightSource: rightSource,
+		left:        NewBTreeMap[[]L](),
+		right:       NewBTreeMap[[]R](),
+	}
+	j.baseInformer.parent = j
+
+	j.leftRegistration, _ = leftSource.AddEventHandler(leftHandler[L, R]{j})
+	j.rightRegistration, _ = rightSource.AddEventHandler(rightHandler[L, R]{j})
+
+	go func() {
+		for {
+			if j.leftRegistration.HasSynced() && j.rightRegistration.HasSynced() {
+				j.SetHasSynced()
+				return
+			}
+			select {
+			case <-time.After(10 * time.Millisecond):
+			case <-j.IsStoppedChan():
+				return
+			}
+		}
+	}()
+
+	return j
+}
+
+func (j *joiner[L, R]) GetIndexer() cache.Indexer {
+	return nil
+}
+
+func (j *joiner[L, R]) GetStore() cache.Store {
+	return nil
+}
+
+func (j *joiner[L, R]) OnAddLocked(obj any, init bool) {}
+func (j *joiner[L, R]) OnUpdateLocked(old, new any)  {}
+func (j *joiner[L, R]) OnDeleteLocked(obj any)       {}
+
+type leftHandler[L, R any] struct{ j *joiner[L, R] }
+
+func (h leftHandler[L, R]) OnAdd(obj any, init bool) {
+	h.j.GetLockGroup().Lock()
+	defer h.j.GetLockGroup().Unlock()
+	h.OnAddLocked(obj, init)
+}
+func (h leftHandler[L, R]) OnAddLocked(obj any, init bool) { h.j.onLeftAdd(obj.(L), init) }
+func (h leftHandler[L, R]) OnUpdate(old, new any) {
+	h.j.GetLockGroup().Lock()
+	defer h.j.GetLockGroup().Unlock()
+	h.OnUpdateLocked(old, new)
+}
+func (h leftHandler[L, R]) OnUpdateLocked(old, new any) { h.j.onLeftUpdate(old.(L), new.(L)) }
+func (h leftHandler[L, R]) OnDelete(obj any) {
+	h.j.GetLockGroup().Lock()
+	defer h.j.GetLockGroup().Unlock()
+	h.OnDeleteLocked(obj)
+}
+func (h leftHandler[L, R]) OnDeleteLocked(obj any) { h.j.onLeftDelete(obj.(L)) }
+
+type rightHandler[L, R any] struct{ j *joiner[L, R] }
+
+func (h rightHandler[L, R]) OnAdd(obj any, init bool) {
+	h.j.GetLockGroup().Lock()
+	defer h.j.GetLockGroup().Unlock()
+	h.OnAddLocked(obj, init)
+}
+func (h rightHandler[L, R]) OnAddLocked(obj any, init bool) { h.j.onRightAdd(obj.(R), init) }
+func (h rightHandler[L, R]) OnUpdate(old, new any) {
+	h.j.GetLockGroup().Lock()
+	defer h.j.GetLockGroup().Unlock()
+	h.OnUpdateLocked(old, new)
+}
+func (h rightHandler[L, R]) OnUpdateLocked(old, new any) { h.j.onRightUpdate(old.(R), new.(R)) }
+func (h rightHandler[L, R]) OnDelete(obj any) {
+	h.j.GetLockGroup().Lock()
+	defer h.j.GetLockGroup().Unlock()
+	h.OnDeleteLocked(obj)
+}
+func (h rightHandler[L, R]) OnDeleteLocked(obj any) { h.j.onRightDelete(obj.(R)) }
+
+func objectsEqual(a, b any) bool {
+	ka := DefaultKey(a)
+	kb := DefaultKey(b)
+	return ka == kb
+}
+
+func (j *joiner[L, R]) onLeftAdd(left L, isInitial bool) {
+	key := j.on(left, *new(R))
+	keyStr := DefaultKey(key)
+
+	items, _ := j.left.Get(keyStr)
+	newItems := append(append([]L(nil), items...), left)
+	j.left.Set(keyStr, newItems)
+
+	if rights, ok := j.right.Get(keyStr); ok {
+		for _, right := range rights {
+			j.dispatchAdd(JoinValue[L, R]{Left: left, Right: right}, isInitial)
+		}
+	}
+}
+
+func (j *joiner[L, R]) onLeftUpdate(oldLeft, newLeft L) {
+	oldKey := j.on(oldLeft, *new(R))
+	newKey := j.on(newLeft, *new(R))
+
+	if oldKey == newKey {
+		keyStr := DefaultKey(oldKey)
+		if rights, ok := j.right.Get(keyStr); ok {
+			for _, right := range rights {
+				j.dispatchUpdate(JoinValue[L, R]{Left: oldLeft, Right: right}, JoinValue[L, R]{Left: newLeft, Right: right})
+			}
+		}
+		slice, _ := j.left.Get(keyStr)
+		newSlice := append([]L(nil), slice...)
+		for i, v := range newSlice {
+			if objectsEqual(v, oldLeft) {
+				newSlice[i] = newLeft
+				break
+			}
+		}
+		j.left.Set(keyStr, newSlice)
+	} else {
+		j.onLeftDelete(oldLeft)
+		j.onLeftAdd(newLeft, false)
+	}
+}
+
+func (j *joiner[L, R]) onLeftDelete(left L) {
+	key := j.on(left, *new(R))
+	keyStr := DefaultKey(key)
+
+	if rights, ok := j.right.Get(keyStr); ok {
+		for _, right := range rights {
+			j.dispatchDelete(JoinValue[L, R]{Left: left, Right: right})
+		}
+	}
+	slice, _ := j.left.Get(keyStr)
+	newSlice := make([]L, 0, len(slice))
+	for _, v := range slice {
+		if !objectsEqual(v, left) {
+			newSlice = append(newSlice, v)
+		}
+	}
+	if len(newSlice) == 0 {
+		j.left.Delete(keyStr)
+	} else {
+		j.left.Set(keyStr, newSlice)
+	}
+}
+
+func (j *joiner[L, R]) onRightAdd(right R, isInitial bool) {
+	key := j.on(*new(L), right)
+	keyStr := DefaultKey(key)
+
+	items, _ := j.right.Get(keyStr)
+	newItems := append(append([]R(nil), items...), right)
+	j.right.Set(keyStr, newItems)
+
+	if lefts, ok := j.left.Get(keyStr); ok {
+		for _, left := range lefts {
+			j.dispatchAdd(JoinValue[L, R]{Left: left, Right: right}, isInitial)
+		}
+	}
+}
+
+func (j *joiner[L, R]) onRightUpdate(oldRight, newRight R) {
+	oldKey := j.on(*new(L), oldRight)
+	newKey := j.on(*new(L), newRight)
+
+	if oldKey == newKey {
+		keyStr := DefaultKey(oldKey)
+		if lefts, ok := j.left.Get(keyStr); ok {
+			for _, left := range lefts {
+				j.dispatchUpdate(JoinValue[L, R]{Left: left, Right: oldRight}, JoinValue[L, R]{Left: left, Right: newRight})
+			}
+		}
+		slice, _ := j.right.Get(keyStr)
+		newSlice := append([]R(nil), slice...)
+		for i, v := range newSlice {
+			if objectsEqual(v, oldRight) {
+				newSlice[i] = newRight
+				break
+			}
+		}
+		j.right.Set(keyStr, newSlice)
+	} else {
+		j.onRightDelete(oldRight)
+		j.onRightAdd(newRight, false)
+	}
+}
+
+func (j *joiner[L, R]) onRightDelete(right R) {
+	key := j.on(*new(L), right)
+	keyStr := DefaultKey(key)
+
+	if lefts, ok := j.left.Get(keyStr); ok {
+		for _, left := range lefts {
+			j.dispatchDelete(JoinValue[L, R]{Left: left, Right: right})
+		}
+	}
+	slice, _ := j.right.Get(keyStr)
+	newSlice := make([]R, 0, len(slice))
+	for _, v := range slice {
+		if !objectsEqual(v, right) {
+			newSlice = append(newSlice, v)
+		}
+	}
+	if len(newSlice) == 0 {
+		j.right.Delete(keyStr)
+	} else {
+		j.right.Set(keyStr, newSlice)
+	}
+}
+
+func (j *joiner[L, R]) dispatchAdd(obj JoinValue[L, R], isInitial bool) {
+	for _, h := range j.handlers {
+		j.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnAdd(obj, isInitial) }, 
+			func(l LockedResourceEventHandler) { l.OnAddLocked(obj, isInitial) })
+	}
+}
+
+func (j *joiner[L, R]) dispatchUpdate(oldObj, newObj JoinValue[L, R]) {
+	for _, h := range j.handlers {
+		j.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnUpdate(oldObj, newObj) }, 
+			func(l LockedResourceEventHandler) { l.OnUpdateLocked(oldObj, newObj) })
+	}
+}
+
+func (j *joiner[L, R]) dispatchDelete(obj JoinValue[L, R]) {
+	for _, h := range j.handlers {
+		j.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnDelete(obj) }, 
+			func(l LockedResourceEventHandler) { l.OnDeleteLocked(obj) })
+	}
+}
+
+func (j *joiner[L, R]) Clone(newSources []cache.SharedInformer) CloneableSharedInformerQuery {
+	nl := newSources[0]
+	nr := newSources[1]
+	newLock := nl.(CloneableSharedInformerQuery).GetLockGroup()
+	
+	nj := &joiner[L, R]{
+		baseInformer: j.baseInformer.clone(),
+		on:          j.on,
+		leftSource:  nl,
+		rightSource: nr,
+		left:        j.left.Clone(),
+		right:       j.right.Clone(),
+	}
+	nj.baseInformer.lock = newLock
+	nj.baseInformer.parent = nj
+
+	if ms, ok := nl.(ManualSharedInformer); ok {
+		nj.leftRegistration, _ = ms.AddEventHandlerNoReplay(leftHandler[L, R]{nj})
+	} else {
+		nj.leftRegistration, _ = nl.AddEventHandler(leftHandler[L, R]{nj})
+	}
+	if ms, ok := nr.(ManualSharedInformer); ok {
+		nj.rightRegistration, _ = ms.AddEventHandlerNoReplay(rightHandler[L, R]{nj})
+	} else {
+		nj.rightRegistration, _ = nr.AddEventHandler(rightHandler[L, R]{nj})
+	}
+
+	return nj
+}
+
+func (j *joiner[L, R]) GetController() cache.Controller {
+	return nil
+}
+
+func (j *joiner[L, R]) Run(stopCh <-chan struct{}) {
+	defer j.SetIsStopped()
+	defer func() {
+		if j.leftSource != nil && j.leftRegistration != nil {
+			_ = j.leftSource.RemoveEventHandler(j.leftRegistration)
+		}
+		if j.rightSource != nil && j.rightRegistration != nil {
+			_ = j.rightSource.RemoveEventHandler(j.rightRegistration)
+		}
+	}()
+	<-stopCh
+}
+
+func (j *joiner[L, R]) SetWatchErrorHandler(handler cache.WatchErrorHandler) error {
+	_ = j.leftSource.SetWatchErrorHandler(handler)
+	_ = j.rightSource.SetWatchErrorHandler(handler)
+	return nil
+}
+
+func (j *joiner[L, R]) SetWatchErrorHandlerWithContext(handler cache.WatchErrorHandlerWithContext) error {
+	_ = j.leftSource.SetWatchErrorHandlerWithContext(handler)
+	_ = j.rightSource.SetWatchErrorHandlerWithContext(handler)
+	return nil
+}
+
+func (j *joiner[L, R]) GetSources() []cache.SharedInformer {
+	return []cache.SharedInformer{j.leftSource, j.rightSource}
+}
+
+// joinerIndexer implements cache.Store by computing join results on the fly 
+// from the left and right B-Trees. This avoids the O(N^2) memory cost of 
+// storing all joined pairs explicitly, at the cost of O(N) lookup in GetByKey.
+type joinerIndexer[L, R any] struct {
+	left    BTreeMap[[]L]
+	right   BTreeMap[[]R]
+	keyFunc cache.KeyFunc
+}
+
+func (i *joinerIndexer[L, R]) Clone() CloneableIndexer {
+	return &joinerIndexer[L, R]{
+		left:    i.left.Clone(),
+		right:   i.right.Clone(),
+		keyFunc: i.keyFunc,
+	}
+}
+
+func (i *joinerIndexer[L, R]) Add(obj any) error    { return fmt.Errorf("not supported") }
+func (i *joinerIndexer[L, R]) Update(obj any) error { return fmt.Errorf("not supported") }
+func (i *joinerIndexer[L, R]) Delete(obj any) error { return fmt.Errorf("not supported") }
+
+func (i *joinerIndexer[L, R]) List() []any {
+	var res []any
+	for _, key := range i.left.ListKeys() {
+		lefts, _ := i.left.Get(key)
+		rights, ok := i.right.Get(key)
+		if ok {
+			for _, l := range lefts {
+				for _, r := range rights {
+					res = append(res, JoinValue[L, R]{Left: l, Right: r})
+				}
+			}
+		}
+	}
+	return res
+}
+
+func (i *joinerIndexer[L, R]) ListKeys() []string {
+	var res []string
+	for _, key := range i.left.ListKeys() {
+		lefts, _ := i.left.Get(key)
+		rights, ok := i.right.Get(key)
+		if ok {
+			for _, l := range lefts {
+				for _, r := range rights {
+					val := JoinValue[L, R]{Left: l, Right: r}
+					keyStr, _ := i.keyFunc(val)
+					res = append(res, keyStr)
+				}
+			}
+		}
+	}
+	return res
+}
+
+func (i *joinerIndexer[L, R]) Get(obj any) (item any, exists bool, err error) {
+	key, err := i.keyFunc(obj)
+	if err != nil {
+		return nil, false, err
+	}
+	return i.GetByKey(key)
+}
+
+func (i *joinerIndexer[L, R]) GetByKey(key string) (item any, exists bool, err error) {
+	for _, obj := range i.List() {
+		objKey, _ := i.keyFunc(obj)
+		if objKey == key {
+			return obj, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func (i *joinerIndexer[L, R]) Replace(objs []any, rv string) error {
+	return fmt.Errorf("not supported")
+}
+
+func (i *joinerIndexer[L, R]) Resync() error {
+	return nil
+}
+
+func (i *joinerIndexer[L, R]) Bookmark(rv string) {}
+
+func (i *joinerIndexer[L, R]) LastStoreSyncResourceVersion() string {
+	return ""
+}
+
+func (i *joinerIndexer[L, R]) Index(indexName string, obj any) ([]any, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+func (i *joinerIndexer[L, R]) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+func (i *joinerIndexer[L, R]) ListIndexFuncValues(indexName string) []string {
+	return nil
+}
+
+func (i *joinerIndexer[L, R]) ByIndex(indexName, indexedValue string) ([]any, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+func (i *joinerIndexer[L, R]) GetIndexers() cache.Indexers {
+	return nil
+}
+
+func (i *joinerIndexer[L, R]) AddIndexers(newIndexers cache.Indexers) error {
+	return fmt.Errorf("not supported")
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/joiner_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/joiner_test.go
@@ -1,0 +1,122 @@
+package fort
+
+import (
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestJoiner_OnUpdate(t *testing.T) {
+	lock := NewLockGroup()
+	left := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	right := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	type L struct{ ID int; Val string }
+	type R struct{ ID int; Val string }
+	type Joined struct{ LVal, RVal string }
+
+	joinedInformer := QueryInformer(&Join[Joined, L, R]{
+		Lock: lock,
+		Select: func(l L, r R) (Joined, error) {
+			return Joined{LVal: l.Val, RVal: r.Val}, nil
+		},
+		From: left,
+		Join: right,
+		On: func(l L, r R) any {
+			if l.ID != 0 { return [1]int{l.ID} }
+			return [1]int{r.ID}
+		},
+	})
+
+	var results []Joined
+	joinedInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			results = append(results, obj.(Joined))
+		},
+		UpdateFunc: func(old, new any) {
+			oldJ := old.(Joined)
+			newJ := new.(Joined)
+			for i, r := range results {
+				if r == oldJ {
+					results[i] = newJ
+					return
+				}
+			}
+		},
+		DeleteFunc: func(obj any) {
+			target := obj.(Joined)
+			for i, r := range results {
+				if r == target {
+					results = append(results[:i], results[i+1:]...)
+					break
+				}
+			}
+		},
+	})
+
+	l1 := L{ID: 1, Val: "L1"}
+	r1 := R{ID: 1, Val: "R1"}
+
+	left.OnAdd(l1, true)
+	right.OnAdd(r1, true)
+
+	if len(results) != 1 || results[0].LVal != "L1" || results[0].RVal != "R1" {
+		t.Errorf("Initial join failed: %v", results)
+	}
+
+	// Update left item
+	l1Updated := L{ID: 1, Val: "L1-Updated"}
+	left.OnUpdate(l1, l1Updated)
+
+	if len(results) != 1 || results[0].LVal != "L1-Updated" {
+		t.Errorf("Update join failed: %v", results)
+	}
+
+	// Change key of left item (should break join)
+	l1NewKey := L{ID: 2, Val: "L1-NewKey"}
+	left.OnUpdate(l1Updated, l1NewKey)
+
+	if len(results) != 0 {
+		t.Errorf("Join should have been broken after key change, got: %v", results)
+	}
+}
+
+func TestJoiner_Where(t *testing.T) {
+	lock := NewLockGroup()
+	left := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	right := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	type Item struct{ ID int; Val int }
+	
+	joinedInformer := QueryInformer(&Join[int, Item, Item]{
+		Lock:   lock,
+		Select: func(l, r Item) (int, error) { return l.ID + r.ID, nil },
+		From:   left,
+		Join:   right,
+		On: func(l, r Item) any {
+			if l.ID != 0 { return [1]int{l.ID} }
+			return [1]int{r.ID}
+		},
+		Where: func(l, r Item) bool {
+			return l.Val > 10 && r.Val > 10
+		},
+	})
+
+	var count int
+	joinedInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) { count++ },
+		DeleteFunc: func(obj any) { count-- },
+	})
+
+	left.OnAdd(Item{ID: 1, Val: 15}, true)
+	right.OnAdd(Item{ID: 1, Val: 5}, true) // Fails Where
+
+	if count != 0 {
+		t.Errorf("Expected 0, got %d", count)
+	}
+
+	right.OnUpdate(Item{ID: 1, Val: 5}, Item{ID: 1, Val: 20}) // Now matches Where
+	if count != 1 {
+		t.Errorf("Expected 1 after right update, got %d", count)
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/manual.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/manual.go
@@ -1,0 +1,403 @@
+package fort
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// baseInformer implements common SharedInformer logic (registration, sync propagation, 
+// error handling) without providing its own storage.
+// It is designed to be embedded in specialized informers (manualInformer, queries).
+type baseInformer struct {
+	name string
+
+	lock LockGroup
+
+	handlers      map[int]cache.ResourceEventHandler
+	nextHandlerId int
+
+	synced        chan struct{}
+	isStoppedChan chan struct{}
+
+	hasSynced bool
+	isStopped bool
+
+	lastSyncResourceVersion string
+
+	transform cache.TransformFunc
+
+	keyFunc cache.KeyFunc
+
+	watchErrorHandler            cache.WatchErrorHandler
+	watchErrorHandlerWithContext cache.WatchErrorHandlerWithContext
+
+	// parent is the outer informer that embeds this baseInformer.
+	// It allows baseInformer to delegate store-related calls (like GetStore()) 
+	// back to the specialized implementation, ensuring that even if a query 
+	// doesn't use standard BTree storage, baseInformer's registration 
+	// logic (like atomic replay) still works correctly.
+	parent ManualSharedInformer
+}
+
+// manualInformer implements ManualSharedInformer using a shared LockGroup 
+// and a standard B-Tree indexer for storage. It is the primary "leaf" source 
+// for Fort query pipelines.
+type manualInformer struct {
+	*baseInformer
+	indexer CloneableIndexer
+}
+
+var _ ManualSharedInformer = &manualInformer{}
+
+func (p *baseInformer) GetLockGroup() LockGroup {
+	return p.lock
+}
+
+func (p *baseInformer) AddEventHandler(h cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return p.AddEventHandlerWithOptions(h, cache.HandlerOptions{})
+}
+
+func (p *baseInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+	return p.AddEventHandler(handler)
+}
+
+func (p *baseInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
+	return p.addEventHandler(handler, true)
+}
+
+func (p *baseInformer) AddEventHandlerNoReplay(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return p.addEventHandler(handler, false)
+}
+
+type manualInformerRegistration struct {
+	informer ManualSharedInformer
+	id       int
+}
+
+var _ cache.ResourceEventHandlerRegistration = &manualInformerRegistration{}
+
+func (r *manualInformerRegistration) HasSynced() bool {
+	return r.informer.HasSynced()
+}
+
+// addEventHandler registers a handler, optionally replaying the entire current state.
+func (p *baseInformer) addEventHandler(handler cache.ResourceEventHandler, replay bool) (cache.ResourceEventHandlerRegistration, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.isStopped {
+		return nil, fmt.Errorf("was not added to shared informer because it has stopped already")
+	}
+
+	p.nextHandlerId++
+	r := &manualInformerRegistration{
+		informer: p.parent,
+		id:       p.nextHandlerId,
+	}
+	p.handlers[p.nextHandlerId] = handler
+
+	if replay {
+		// Atomic replay of current state to ensure the new handler is fully hydrated.
+		if store := p.parent.GetStore(); store != nil {
+			list := store.List()
+			for _, obj := range list {
+				p.dispatchEvent(handler, 
+					func(h cache.ResourceEventHandler) { h.OnAdd(obj, true) }, 
+					func(l LockedResourceEventHandler) { l.OnAddLocked(obj, true) })
+			}
+		}
+	}
+
+	return r, nil
+}
+
+// dispatchEvent selects the appropriate handler method based on whether the handler
+// supports the Locked interface. 
+func (p *baseInformer) dispatchEvent(h cache.ResourceEventHandler, std func(cache.ResourceEventHandler), locked func(LockedResourceEventHandler)) {
+	defer utilruntime.HandleCrash()
+	if m, ok := h.(LockedResourceEventHandler); ok {
+		locked(m)
+	} else {
+		std(h)
+	}
+}
+
+func (p *baseInformer) RemoveEventHandler(r cache.ResourceEventHandlerRegistration) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	pr := r.(*manualInformerRegistration)
+	delete(p.handlers, pr.id)
+	return nil
+}
+
+func (p *baseInformer) Run(stopCh <-chan struct{}) {
+	defer p.SetIsStopped()
+	<-stopCh
+}
+
+func (p *baseInformer) RunWithContext(ctx context.Context) {
+	p.Run(ctx.Done())
+}
+
+func (p *baseInformer) LastSyncResourceVersion() string {
+	return p.lastSyncResourceVersion
+}
+
+func (p *baseInformer) SetWatchErrorHandler(handler cache.WatchErrorHandler) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.watchErrorHandler = handler
+	return nil
+}
+
+func (p *baseInformer) SetWatchErrorHandlerWithContext(handler cache.WatchErrorHandlerWithContext) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.watchErrorHandlerWithContext = handler
+	return nil
+}
+
+func (p *baseInformer) TriggerWatchError(err error) {
+	p.lock.RLock()
+	h := p.watchErrorHandler
+	hc := p.watchErrorHandlerWithContext
+	p.lock.RUnlock()
+
+	if h != nil {
+		h(nil, err)
+	}
+	if hc != nil {
+		hc(context.TODO(), nil, err)
+	}
+}
+
+func (p *baseInformer) SetTransform(handler cache.TransformFunc) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.transform != nil {
+		return fmt.Errorf("Setting transform when it is already set.")
+	}
+	p.transform = handler
+	return nil
+}
+
+func (p *baseInformer) HasSynced() bool {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.hasSynced
+}
+
+func (p *baseInformer) IsStopped() bool {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.isStopped
+}
+
+func (p *baseInformer) IsStoppedChan() <-chan struct{} {
+	return p.isStoppedChan
+}
+
+func (p *baseInformer) SetHasSynced() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.hasSynced {
+		return
+	}
+
+	p.hasSynced = true
+	close(p.synced)
+}
+
+func (p *baseInformer) SetIsStopped() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.isStopped {
+		return
+	}
+	p.isStopped = true
+	close(p.isStoppedChan)
+}
+
+func (p *baseInformer) GetKeyFunc() cache.KeyFunc {
+	return p.keyFunc
+}
+
+func (p *baseInformer) GetIndexer() cache.Indexer {
+	panic("GetIndexer not implemented")
+}
+
+func (p *baseInformer) GetStore() cache.Store {
+	panic("GetStore not implemented")
+}
+
+func (p *baseInformer) GetController() cache.Controller {
+	return nil
+}
+
+func (p *baseInformer) OnAdd(obj any, isInInitialList bool) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.parent.OnAddLocked(obj, isInInitialList)
+}
+
+func (p *baseInformer) OnUpdate(oldObj, newObj any) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.parent.OnUpdateLocked(oldObj, newObj)
+}
+
+func (p *baseInformer) OnDelete(oldObj any) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.parent.OnDeleteLocked(oldObj)
+}
+
+func (p *baseInformer) Clear() {
+	panic("Clear not implemented")
+}
+
+func (p *manualInformer) GetStore() cache.Store {
+	return p.indexer
+}
+
+func (p *manualInformer) GetIndexer() cache.Indexer {
+	return p.indexer
+}
+
+func (p *manualInformer) Clear() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	list := p.indexer.List()
+	for _, obj := range list {
+		p.OnDeleteLocked(obj)
+	}
+}
+
+func (p *manualInformer) OnAddLocked(obj any, isInInitialList bool) {
+	transformed := obj
+	if p.transform != nil {
+		transformed, _ = p.transform(obj)
+	}
+
+	p.indexer.Add(transformed)
+
+	for _, h := range p.handlers {
+		p.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnAdd(transformed, isInInitialList) }, 
+			func(l LockedResourceEventHandler) { l.OnAddLocked(transformed, isInInitialList) })
+	}
+}
+
+func (p *manualInformer) OnUpdateLocked(oldObj, newObj any) {
+	oldTransformed := oldObj
+	newTransformed := newObj
+	if p.transform != nil {
+		oldTransformed, _ = p.transform(oldObj)
+		newTransformed, _ = p.transform(newObj)
+	}
+
+	oldKey, _ := p.keyFunc(oldTransformed)
+	newKey, _ := p.keyFunc(newTransformed)
+
+	if oldKey != newKey {
+		p.OnDeleteLocked(oldObj)
+		p.OnAddLocked(newObj, false)
+		return
+	}
+
+	p.indexer.Update(newTransformed)
+
+	for _, h := range p.handlers {
+		p.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnUpdate(oldTransformed, newTransformed) }, 
+			func(l LockedResourceEventHandler) { l.OnUpdateLocked(oldTransformed, newTransformed) })
+	}
+}
+
+func (p *manualInformer) OnDeleteLocked(oldObj any) {
+	unwrapped := UnwrapDeleted(oldObj)
+	transformed := unwrapped
+	if p.transform != nil {
+		transformed, _ = p.transform(unwrapped)
+	}
+
+	p.indexer.Delete(transformed)
+
+	for _, h := range p.handlers {
+		p.dispatchEvent(h, 
+			func(h cache.ResourceEventHandler) { h.OnDelete(transformed) }, 
+			func(l LockedResourceEventHandler) { l.OnDeleteLocked(transformed) })
+	}
+}
+
+func (p *manualInformer) Clone(_ []cache.SharedInformer) CloneableSharedInformerQuery {
+	res := &manualInformer{
+		baseInformer: p.baseInformer.clone(),
+		indexer:      p.indexer.Clone(),
+	}
+	res.baseInformer.parent = res
+	return res
+}
+
+func (p *baseInformer) clone() *baseInformer {
+	newB := &baseInformer{
+		name:                    p.name,
+		handlers:                map[int]cache.ResourceEventHandler{},
+		transform:               p.transform,
+		isStopped:               p.isStopped,
+		hasSynced:               p.hasSynced,
+		lastSyncResourceVersion: p.lastSyncResourceVersion,
+		keyFunc:                 p.keyFunc,
+		lock:                    NewLockGroup(),
+		synced:                  make(chan struct{}),
+		isStoppedChan:           make(chan struct{}),
+	}
+	if p.hasSynced {
+		close(newB.synced)
+	}
+	if p.isStopped {
+		close(newB.isStoppedChan)
+	}
+	return newB
+}
+
+func (p *baseInformer) SetName(name string) {
+	p.name = name
+}
+
+func (p *baseInformer) GetSources() []cache.SharedInformer {
+	return nil
+}
+
+func newBaseInformer(lock LockGroup, keyFunc cache.KeyFunc) *baseInformer {
+	return &baseInformer{
+		handlers:      map[int]cache.ResourceEventHandler{},
+		keyFunc:       keyFunc,
+		lock:          lock,
+		synced:        make(chan struct{}),
+		isStoppedChan: make(chan struct{}),
+	}
+}
+
+// NewManualSharedInformer creates a ManualSharedInformer with a default lock and keyfunc.
+func NewManualSharedInformer() ManualSharedInformer {
+	return NewManualSharedInformerWithOptions(NewLockGroup(), DefaultKeyFunc)
+}
+
+// NewManualSharedInformerWithOptions creates a ManualSharedInformer with specific options.
+func NewManualSharedInformerWithOptions(lock LockGroup, keyFunc cache.KeyFunc) ManualSharedInformer {
+	res := &manualInformer{
+		baseInformer: newBaseInformer(lock, keyFunc),
+		indexer:      NewBTreeIndexer(keyFunc),
+	}
+	res.baseInformer.parent = res
+	return res
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/memory_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/memory_test.go
@@ -1,0 +1,205 @@
+package fort
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func getMemory() uint64 {
+	var m runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	return m.Alloc
+}
+
+type MemItem struct {
+	ID int
+	Val int
+}
+
+func TestMemoryOverhead_SourceOnly(t *testing.T) {
+	const numItems = 100_000
+	
+	before := getMemory()
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	
+	for i := 0; i < numItems; i++ {
+		source.OnAdd(&MemItem{ID: i, Val: i}, true)
+	}
+	
+	after := getMemory()
+	overhead := int64(after) - int64(before)
+	if overhead < 0 { overhead = 0 }
+	fmt.Printf("Memory: Source only (%d items): %.2f MB (%.1f bytes/item)\n", 
+		numItems, float64(overhead)/1024/1024, float64(overhead)/float64(numItems))
+	
+	runtime.KeepAlive(source)
+}
+
+func TestMemoryOverhead_Select(t *testing.T) {
+	const numItems = 100_000
+	
+	before := getMemory()
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	
+	sel := QueryInformer(&Select[*MemItem, *MemItem]{
+		Lock: lock,
+		Select: func(i *MemItem) (*MemItem, error) { 
+			return &MemItem{ID: i.ID, Val: i.Val + 1}, nil 
+		},
+		From: source,
+	})
+	
+	sel.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+
+	for i := 0; i < numItems; i++ {
+		source.OnAdd(&MemItem{ID: i, Val: i}, true)
+	}
+	
+	after := getMemory()
+	overhead := int64(after) - int64(before)
+	if overhead < 0 { overhead = 0 }
+	fmt.Printf("Memory: Source + Select (%d items): %.2f MB (%.1f bytes/item)\n", 
+		numItems, float64(overhead)/1024/1024, float64(overhead)/float64(numItems))
+	
+	runtime.KeepAlive(source)
+	runtime.KeepAlive(sel)
+}
+
+func TestMemoryOverhead_FlatMap(t *testing.T) {
+	const numItems = 100_000
+	
+	before := getMemory()
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	
+	// 1:2 mapping
+	fm := QueryInformer(&FlatMap[*MemItem, *MemItem]{
+		Lock: lock,
+		Map: func(i *MemItem) ([]*MemItem, error) { 
+			return []*MemItem{i, {ID: i.ID + 1000000, Val: i.Val}}, nil 
+		},
+		Over: source,
+	})
+	
+	fm.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+
+	for i := 0; i < numItems; i++ {
+		source.OnAdd(&MemItem{ID: i, Val: i}, true)
+	}
+	
+	after := getMemory()
+	overhead := int64(after) - int64(before)
+	if overhead < 0 { overhead = 0 }
+	fmt.Printf("Memory: Source + FlatMap 1:2 (%d items): %.2f MB (%.1f bytes/item)\n", 
+		numItems, float64(overhead)/1024/1024, float64(overhead)/float64(numItems))
+	
+	runtime.KeepAlive(source)
+	runtime.KeepAlive(fm)
+}
+
+func TestMemoryOverhead_Join(t *testing.T) {
+	const numItems = 100_000
+	
+	before := getMemory()
+	lock := NewLockGroup()
+	s1 := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	s2 := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	
+	join := QueryInformer(&Join[*MemItem, *MemItem, *MemItem]{
+		Lock: lock,
+		Select: func(l, r *MemItem) (*MemItem, error) { 
+			return &MemItem{ID: l.ID, Val: l.Val + r.Val}, nil 
+		},
+		From: s1,
+		Join: s2,
+		On: func(l, r *MemItem) any {
+			if l != nil { return l.ID }
+			return r.ID
+		},
+	})
+	
+	join.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+
+	for i := 0; i < numItems; i++ {
+		s1.OnAdd(&MemItem{ID: i, Val: i}, true)
+		s2.OnAdd(&MemItem{ID: i, Val: i}, true)
+	}
+	
+	after := getMemory()
+	overhead := int64(after) - int64(before)
+	if overhead < 0 { overhead = 0 }
+	fmt.Printf("Memory: 2 Sources + Join (%d items each): %.2f MB (%.1f bytes/joined-result)\n", 
+		numItems, float64(overhead)/1024/1024, float64(overhead)/float64(numItems))
+	
+	runtime.KeepAlive(s1)
+	runtime.KeepAlive(s2)
+	runtime.KeepAlive(join)
+}
+
+func TestMemoryOverhead_GroupBy(t *testing.T) {
+	const numItems = 100_000
+	const numGroups = 1000
+	
+	before := getMemory()
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	
+	grouper := QueryInformer(&GroupBy[int64, *MemItem]{
+		Lock: lock,
+		Select: func(fields []GroupField) (int64, error) { return fields[0].(int64), nil },
+		From: source,
+		GroupBy: func(i *MemItem) (any, []GroupField) {
+			return i.ID % numGroups, []GroupField{Count()}
+		},
+	})
+	
+	grouper.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+
+	for i := 0; i < numItems; i++ {
+		source.OnAdd(&MemItem{ID: i, Val: i}, true)
+	}
+	
+	after := getMemory()
+	overhead := int64(after) - int64(before)
+	if overhead < 0 { overhead = 0 }
+	fmt.Printf("Memory: Source + GroupBy (%d items, %d groups): %.2f MB (%.1f bytes/item)\n", 
+		numItems, numGroups, float64(overhead)/1024/1024, float64(overhead)/float64(numItems))
+	
+	runtime.KeepAlive(source)
+	runtime.KeepAlive(grouper)
+}
+
+func TestMemoryOverhead_Clones(t *testing.T) {
+	const numItems = 10_000
+	const numClones = 1000
+	
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	for i := 0; i < numItems; i++ {
+		source.OnAdd(&MemItem{ID: i, Val: i}, true)
+	}
+	
+	before := getMemory()
+	clones := make([]cache.SharedInformer, numClones)
+	for i := 0; i < numClones; i++ {
+		lock.RLock()
+		clones[i] = source.Clone(nil)
+		lock.RUnlock()
+	}
+	
+	after := getMemory()
+	overhead := int64(after) - int64(before)
+	if overhead < 0 { overhead = 0 }
+	fmt.Printf("Memory: %d Clones of 10k items: %.2f MB (%.1f bytes/clone)\n", 
+		numClones, float64(overhead)/1024/1024, float64(overhead)/float64(numClones))
+	
+	// Prevent GC from collecting clones before measurement
+	runtime.KeepAlive(clones)
+	runtime.KeepAlive(source)
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/perf_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/perf_test.go
@@ -1,0 +1,139 @@
+package fort
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+type perfItem struct {
+	ID    int
+	Value int
+}
+
+func BenchmarkThroughput(b *testing.B) {
+	sizes := []int{100, 1000, 10000}
+	depths := []int{1, 3, 5}
+
+	for _, depth := range depths {
+		for _, size := range sizes {
+			b.Run(fmt.Sprintf("Depth%d/Size%d", depth, size), func(b *testing.B) {
+				lock := NewLockGroup()
+				source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+				
+				var current CloneableSharedInformerQuery = source
+				for i := 0; i < depth; i++ {
+					// Add a transformation layer
+					current = QueryInformer(&Select[perfItem, perfItem]{
+						Lock: lock,
+						Select: func(in perfItem) (perfItem, error) {
+							return perfItem{ID: in.ID, Value: in.Value + 1}, nil
+						},
+						From: current,
+					})
+				}
+
+				// Pre-hydrate
+				for i := 0; i < size; i++ {
+					source.OnAdd(perfItem{ID: i, Value: 0}, true)
+				}
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					id := i % size
+					source.OnUpdate(perfItem{ID: id, Value: i}, perfItem{ID: id, Value: i + 1})
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkCloningPerformance(b *testing.B) {
+	sizes := []int{100, 1000, 10000}
+	
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
+			lock := NewLockGroup()
+			source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+			
+			// Complex-ish pipeline: source -> select -> grouper
+			fm := QueryInformer(&FlatMap[int, perfItem]{
+				Lock: lock,
+				Map: func(in perfItem) ([]int, error) {
+					return []int{in.Value, in.Value * 2}, nil
+				},
+				Over: source,
+			})
+
+			grouper := QueryInformer(&GroupBy[int64, int]{
+				Lock: lock,
+				Select: func(fields []GroupField) (int64, error) {
+					return fields[0].(int64), nil
+				},
+				From: fm,
+				GroupBy: func(i int) (any, []GroupField) {
+					return 0, []GroupField{Sum(int64(i))}
+				},
+			})
+
+			// Hydrate
+			for i := 0; i < size; i++ {
+				source.OnAdd(perfItem{ID: i, Value: i}, true)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// We must hold the lock to clone
+				lock.RLock()
+				ns := source.Clone(nil)
+				nfm := fm.Clone([]cache.SharedInformer{ns})
+				_ = grouper.Clone([]cache.SharedInformer{nfm})
+				lock.RUnlock()
+			}
+		})
+	}
+}
+
+func BenchmarkJoinPerformance(b *testing.B) {
+	sizes := []int{100, 1000, 5000}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
+			lock := NewLockGroup()
+			s1 := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+			s2 := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+
+			joined := QueryInformer(&Join[int, perfItem, perfItem]{
+				Lock: lock,
+				Select: func(l, r perfItem) (int, error) {
+					return l.Value + r.Value, nil
+				},
+				From: s1,
+				Join: s2,
+				On: func(l, r perfItem) any {
+					if l.ID != 0 {
+						return [1]int{l.ID}
+					}
+					return [1]int{r.ID}
+				},
+			})
+
+			// To keep results alive
+			joined.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+
+			// Hydrate both sides
+			for i := 0; i < size; i++ {
+				s1.OnAdd(perfItem{ID: i, Value: i}, true)
+				s2.OnAdd(perfItem{ID: i, Value: i}, true)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				id := i % size
+				// Update one side - triggers join recalculation
+				s1.OnUpdate(perfItem{ID: id, Value: i}, perfItem{ID: id, Value: i + 1})
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/real_informer_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/real_informer_test.go
@@ -1,0 +1,113 @@
+package fort
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	fcache "k8s.io/client-go/tools/cache/testing"
+)
+
+func TestIntegration_RealInformerToQuery(t *testing.T) {
+	lw := fcache.NewFakeControllerSource()
+	inf := cache.NewSharedInformer(lw, &corev1.Pod{}, 0)
+	
+	lock := NewLockGroup()
+	query := QueryInformer(&Select[string, *corev1.Pod]{
+		Lock: lock,
+		From: inf,
+		Select: func(p *corev1.Pod) (string, error) { return p.Name, nil },
+	})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go inf.Run(stopCh)
+	go query.Run(stopCh)
+
+	// Wait for sync
+	cache.WaitForCacheSync(stopCh, inf.HasSynced)
+
+	// Live update
+	lw.Add(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-live"}})
+
+	// Verify propagation
+	found := false
+	for i := 0; i < 50; i++ {
+		list := query.GetStore().List()
+		if len(list) == 1 && list[0].(string) == "pod-live" {
+			found = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !found {
+		t.Errorf("Query failed to receive live update from real informer")
+	}
+}
+
+func TestIntegration_QueryToRealInformer(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	
+	// Create a Fort query
+	query := QueryInformer(&Select[int, int]{
+		Lock: lock,
+		From: source,
+		Select: func(i int) (int, error) { return i * 10, nil },
+	})
+
+	// Verify compatibility with standard ResourceEventHandler
+	var received int
+	var mu sync.Mutex
+	query.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			mu.Lock()
+			defer mu.Unlock()
+			received = obj.(int)
+		},
+	})
+
+	source.OnAdd(5, true)
+	
+	if received != 50 {
+		t.Errorf("Standard event handler failed to receive event from query informer")
+	}
+}
+
+func TestIntegration_RealInformerHydration(t *testing.T) {
+	lw := fcache.NewFakeControllerSource()
+	inf := cache.NewSharedInformer(lw, &corev1.Pod{}, 0)
+	
+	// Add data BEFORE starting
+	lw.Add(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}})
+	
+	lock := NewLockGroup()
+	query := QueryInformer(&Select[string, *corev1.Pod]{
+		Lock: lock,
+		From: inf,
+		Select: func(p *corev1.Pod) (string, error) { return p.Name, nil },
+	})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go inf.Run(stopCh)
+	go query.Run(stopCh)
+
+	// Verify query is born hydrated
+	found := false
+	for i := 0; i < 50; i++ {
+		if query.HasSynced() && len(query.GetStore().List()) == 1 {
+			found = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !found {
+		t.Errorf("Query failed to hydrate from real informer")
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/repro_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/repro_test.go
@@ -1,0 +1,94 @@
+package fort
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestManualInformer_UpdateKeyChangeBug(t *testing.T) {
+	lock := NewLockGroup()
+	// Use a keyfunc that depends on the value
+	keyFunc := func(obj any) (string, error) {
+		return obj.(string), nil
+	}
+	inf := NewManualSharedInformerWithOptions(lock, keyFunc)
+
+	inf.OnAdd("A", true)
+	if len(inf.GetStore().List()) != 1 {
+		t.Errorf("Expected 1 item")
+	}
+
+	// Update "A" to "B". Key changes from "A" to "B".
+	inf.OnUpdate("A", "B")
+
+	items := inf.GetStore().List()
+	if len(items) != 1 {
+		t.Errorf("Expected 1 item after update, but got %d (leak of old key!)", len(items))
+		for _, item := range items {
+			t.Logf("Item: %v", item)
+		}
+	}
+}
+
+func TestClonePipeline_CyclePanic(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	
+	q1 := &Select[int, int]{Lock: lock, From: source, Select: func(i int) (int, error) { return i, nil }}
+	i1 := q1.Build()
+	
+	// Create a cycle by forcing sources
+	i1.(*flatMapper[int, int]).source = i1 
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic on recursive clone cycle")
+		}
+	}()
+
+	memo := make(map[cache.SharedInformer]cache.SharedInformer)
+	ClonePipeline(i1, memo)
+}
+
+func TestOperator_RegistrationLeak(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+
+	// Build a small pipeline
+	query := QueryInformer(&Select[int, int]{
+		Lock:   lock,
+		From:   source,
+		Select: func(i int) (int, error) { return i, nil },
+	})
+
+	// Get internal informer to check handlers count
+	si := source.(*manualInformer)
+
+	si.lock.RLock()
+	initialHandlers := len(si.handlers)
+	si.lock.RUnlock()
+	
+	for i := 0; i < 100; i++ {
+		// Clone
+		cl := query.Clone([]cache.SharedInformer{source})
+		
+		// Run and stop immediately to unregister
+		stopCh := make(chan struct{})
+		go cl.Run(stopCh)
+		close(stopCh)
+		
+		// Give a tiny bit of time for the goroutine to cleanup
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	si.lock.RLock()
+	finalHandlers := len(si.handlers)
+	si.lock.RUnlock()
+	if finalHandlers > initialHandlers {
+		t.Errorf("Registration leak detected! Handlers count grew from %d to %d", initialHandlers, finalHandlers)
+	}
+}
+
+

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/scale_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/scale_test.go
@@ -1,0 +1,142 @@
+package fort
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// TestScale_MillionEntries performs high-scale performance benchmarking
+// with 1,000,000 objects in a multi-stage query pipeline.
+func TestScale_MillionEntries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping high-scale test in short mode")
+	}
+
+	const numItems = 1_000_000
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	
+	// Pipeline: Source -> FlatMap (1:2 distinct strings) -> GroupBy (i % 1000)
+	// Using strings ensures no identity collisions in the FlatMap output indexer.
+	fm := QueryInformer(&FlatMap[string, int]{
+		Lock: lock,
+		Map: func(i int) ([]string, error) {
+			return []string{
+				fmt.Sprintf("item-%d-a", i),
+				fmt.Sprintf("item-%d-b", i),
+			}, nil
+		},
+		Over: source,
+	})
+
+	type GroupResult struct {
+		Name  string
+		Count int64
+	}
+
+	grouper := QueryInformer(&GroupBy[*GroupResult, string]{
+		Lock: lock,
+		Select: func(fields []GroupField) (*GroupResult, error) {
+			return &GroupResult{
+				Name:  fields[0].(string),
+				Count: fields[1].(int64),
+			}, nil
+		},
+		From: fm,
+		GroupBy: func(s string) (any, []GroupField) {
+			// Extract original index for grouping: "item-123-a" -> 123
+			parts := strings.Split(s, "-")
+			idx, _ := strconv.Atoi(parts[1])
+			groupName := fmt.Sprintf("group-%d", idx%1000)
+			return groupName, []GroupField{AnyValue(groupName), Count()}
+		},
+	})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go fm.Run(stopCh)
+	go grouper.Run(stopCh)
+
+	// 1. Ingestion Phase
+	fmt.Printf("Ingesting %d items...\n", numItems)
+	start := time.Now()
+	for i := 0; i < numItems; i++ {
+		source.OnAdd(i, false)
+		if i > 0 && i%200_000 == 0 {
+			fmt.Printf("  ... %d items ingested (avg %.2fµs/item)\n", i, float64(time.Since(start).Microseconds())/float64(i))
+		}
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("Ingestion complete: %v (%.2fµs/item)\n", elapsed, float64(elapsed.Microseconds())/numItems)
+
+	// 2. Memory Measurement
+	var m runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	fmt.Printf("Memory allocated: %.2f MB\n", float64(m.Alloc)/1024/1024)
+
+	// 3. Cloning Phase (The core performance feature)
+	fmt.Println("Performing high-scale clones...")
+	start = time.Now()
+	numClones := 100
+	for i := 0; i < numClones; i++ {
+		locks := SnapshotLockDomain(grouper)
+		ns := source.Clone(nil)
+		nfm := fm.Clone([]cache.SharedInformer{ns})
+		_ = grouper.Clone([]cache.SharedInformer{nfm})
+		locks.Unlock()
+	}
+	elapsed = time.Since(start)
+	fmt.Printf("Cloning (Source+FlatMap+Grouper) latency at 1M items: %v per snapshot\n", elapsed/time.Duration(numClones))
+
+	// 4. Update Latency Phase
+	fmt.Println("Measuring update latency at scale...")
+	start = time.Now()
+	numUpdates := 1000
+	for i := 0; i < numUpdates; i++ {
+		// Update item-i to item-(i+numItems)
+		source.OnUpdate(i, i+numItems)
+	}
+	elapsed = time.Since(start)
+	fmt.Printf("Update latency at scale: %.2fµs/update (full pipeline propagation)\n", float64(elapsed.Microseconds())/float64(numUpdates))
+
+	// 5. Verification
+	fmt.Println("Verifying final aggregation state...")
+	var list []any
+	found := false
+	for i := 0; i < 100; i++ {
+		list = grouper.GetStore().List()
+		if len(list) == 1000 {
+			found = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	
+	if !found {
+		t.Errorf("Expected 1000 groups, got %d", len(list))
+	} else {
+		// Each group should have exactly (numItems * 2 / 1000) = 2000 items
+		// We need to find the item in the list because we don't know the exact key DefaultKeyFunc generated for the pointer.
+		var foundZero bool
+		for _, it := range list {
+			res := it.(*GroupResult)
+			if res.Name == "group-0" {
+				foundZero = true
+				if res.Count != 2000 {
+					t.Errorf("Expected group-0 to have 2000 items, got %d", res.Count)
+				}
+				break
+			}
+		}
+		if !foundZero {
+			t.Errorf("group-0 not found in results")
+		}
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/spec.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/spec.go
@@ -1,0 +1,121 @@
+package fort
+
+import "k8s.io/client-go/tools/cache"
+
+func getLock(lock LockGroup, source cache.SharedInformer) LockGroup {
+	if lock != nil {
+		return lock
+	}
+	if q, ok := source.(CloneableSharedInformerQuery); ok {
+		return q.GetLockGroup()
+	}
+	return NewLockGroup()
+}
+
+func getSourceKeyFunc(source cache.SharedInformer) cache.KeyFunc {
+	if q, ok := source.(CloneableSharedInformerQuery); ok {
+		return q.GetKeyFunc()
+	}
+	return DefaultKeyFunc
+}
+
+func (q *Select[Out, In]) Build() CloneableSharedInformerQuery {
+	lock := getLock(q.Lock, q.From)
+	inf := newFlatMapper[Out, In](lock, func(value In) ([]Out, error) {
+		if q.Where == nil || q.Where(value) {
+			out, err := q.Select(value)
+			if err != nil {
+				return nil, err
+			}
+			return []Out{out}, nil
+		}
+		return nil, nil
+	}, q.From)
+	inf.SetName("select-query")
+	return inf
+}
+
+func (q *Join[Out, Left, Right]) Build() CloneableSharedInformerQuery {
+	lock := getLock(q.Lock, q.From)
+	on := q.On
+	if on == nil {
+		on = func(l Left, r Right) any { return 0 }
+	}
+
+	kl := getSourceKeyFunc(q.From)
+	kr := getSourceKeyFunc(q.Join)
+
+	joinKeyFunc := func(obj any) (string, error) {
+		jv := obj.(JoinValue[Left, Right])
+		l, _ := kl(jv.Left)
+		r, _ := kr(jv.Right)
+		return l + " // " + r, nil
+	}
+
+	sq := &Select[Out, JoinValue[Left, Right]]{
+		Lock: lock,
+		Select: func(joined JoinValue[Left, Right]) (Out, error) {
+			return q.Select(joined.Left, joined.Right)
+		},
+		From: newJoinerWithHandler(q.From, q.Join, on, NewManualSharedInformerWithOptions(lock, joinKeyFunc)),
+		Where: func(joined JoinValue[Left, Right]) bool {
+			if q.Where == nil {
+				return true
+			}
+			return q.Where(joined.Left, joined.Right)
+		},
+	}
+	inf := sq.Build()
+	inf.SetName("join-query")
+	return inf
+}
+
+func (q *GroupBy[Out, In]) Build() CloneableSharedInformerQuery {
+	lock := getLock(q.Lock, q.From)
+	inf := newGrouper[Out, In](lock, q.Select, q.GroupBy, q.From, q.Where)
+	inf.SetName("groupBy-query")
+	return inf
+}
+
+func (q *GroupByJoin[Out, Left, Right]) Build() CloneableSharedInformerQuery {
+	lock := getLock(q.Lock, q.From)
+	on := q.On
+	if on == nil {
+		on = func(l Left, r Right) any { return 0 }
+	}
+
+	kl := getSourceKeyFunc(q.From)
+	kr := getSourceKeyFunc(q.Join)
+
+	joinKeyFunc := func(obj any) (string, error) {
+		jv := obj.(JoinValue[Left, Right])
+		l, _ := kl(jv.Left)
+		r, _ := kr(jv.Right)
+		return l + " // " + r, nil
+	}
+
+	g := &GroupBy[Out, JoinValue[Left, Right]]{
+		Lock:   lock,
+		Select: q.Select,
+		From:   newJoinerWithHandler(q.From, q.Join, on, NewManualSharedInformerWithOptions(lock, joinKeyFunc)),
+		Where: func(joined JoinValue[Left, Right]) bool {
+			if q.Where == nil {
+				return true
+			}
+			return q.Where(joined.Left, joined.Right)
+		},
+		GroupBy: func(joined JoinValue[Left, Right]) (any, []GroupField) {
+			return q.GroupBy(joined.Left, joined.Right)
+		},
+	}
+	inf := g.Build()
+	inf.SetName("groupByJoin-query")
+	return inf
+}
+
+func (q *FlatMap[Out, In]) Build() CloneableSharedInformerQuery {
+	lock := getLock(q.Lock, q.Over)
+	inf := newFlatMapper[Out, In](lock, q.Map, q.Over)
+	inf.SetName("flatMap-query")
+	return inf
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/stress_concurrency_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/stress_concurrency_test.go
@@ -1,0 +1,165 @@
+package fort
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// TestStress_ConcurrentUpdateAndClone executes high-frequency updates from multiple goroutines
+// while periodically taking clones. It verifies that all clones are internally consistent
+// and isolated from subsequent updates in the original pipeline.
+func TestStress_ConcurrentUpdateAndClone(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+
+	// Build a non-trivial pipeline: Source -> FlatMap -> GroupBy
+	// FlatMap: 1 int -> [val, val*10]
+	// GroupBy: sum of all values
+	fm := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map:  func(i int) ([]int, error) { return []int{i, i * 10}, nil },
+		Over: source,
+	})
+
+	type Agg struct {
+		Count int64
+		Sum   int64
+	}
+	grouper := QueryInformer(&GroupBy[*Agg, int]{
+		Lock: lock,
+		Select: func(fields []GroupField) (*Agg, error) {
+			return &Agg{
+				Count: fields[0].(int64),
+				Sum:   fields[1].(int64),
+			}, nil
+		},
+		From: fm,
+		GroupBy: func(i int) (any, []GroupField) {
+			return "total", []GroupField{Count(), Sum(int64(i))}
+		},
+	})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go fm.Run(stopCh)
+	go grouper.Run(stopCh)
+
+	const numUpdaters = 5
+	const updatesPerUpdater = 500
+	const numCloners = 2
+	const clonesPerCloner = 20
+
+	var wg sync.WaitGroup
+	
+	// 1. Updaters: push random data
+	wg.Add(numUpdaters)
+	for i := 0; i < numUpdaters; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < updatesPerUpdater; j++ {
+				val := rand.Intn(100) + 1 // 1..100
+				source.OnAdd(val, false)
+				if j%10 == 0 {
+					source.OnDelete(val)
+				}
+				time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
+			}
+		}(i)
+	}
+
+	// 2. Cloners: periodically take snapshots and verify isolation
+	wg.Add(numCloners)
+	for i := 0; i < numCloners; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < clonesPerCloner; j++ {
+				// Atomically capture the original state and take a clone
+				locks := SnapshotLockDomain(grouper)
+				
+				// Capture current state from original using List() for identity-agnostic check
+				var origCount int64
+				origList := grouper.GetStore().List()
+				if len(origList) > 0 {
+					origCount = origList[0].(*Agg).Count
+				}
+				
+				// Create clone
+				ns := source.Clone(nil)
+				nfm := fm.Clone([]cache.SharedInformer{ns})
+				ng := grouper.Clone([]cache.SharedInformer{nfm})
+				
+				locks.Unlock()
+
+				// Verify Clone Isolation: The clone should eventually match the 
+				// captured state, and should NOT change even as 'source' continues to churn.
+				
+				// Since clones are born hydrated with their B-Tree states, 
+				// but their handlers are populated via replay, we wait a bit for hydration.
+				var cloneCount int64
+				found := false
+				for attempt := 0; attempt < 100; attempt++ {
+					cloneList := ng.GetStore().List()
+					if len(cloneList) > 0 {
+						cloneCount = cloneList[0].(*Agg).Count
+						// If we captured an origCount, the clone must eventually reach at least that state.
+						if cloneCount >= origCount {
+							found = true
+							break
+						}
+					} else if origCount == 0 {
+						found = true
+						break
+					}
+					time.Sleep(1 * time.Millisecond)
+				}
+				
+				if !found {
+					t.Errorf("Cloner %d: Clone failed to hydrate or was inconsistent. Orig count: %d, Clone count: %d", id, origCount, cloneCount)
+				}
+
+				// Isolation check: capture current clone state, wait, check again.
+				initialCount := cloneCount
+				time.Sleep(10 * time.Millisecond)
+				cloneListFinal := ng.GetStore().List()
+				if len(cloneListFinal) > 0 {
+					finalCount := cloneListFinal[0].(*Agg).Count
+					if finalCount != initialCount {
+						t.Errorf("Cloner %d: Isolation failure! Clone state changed from %d to %d", id, initialCount, finalCount)
+					}
+				}
+
+				time.Sleep(10 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestStress_MassiveCloning verifies that taking thousands of clones rapidly
+// does not cause memory leaks or deadlocks.
+func TestStress_MassiveCloning(t *testing.T) {
+	lock := NewLockGroup()
+	source := NewManualSharedInformerWithOptions(lock, DefaultKeyFunc)
+	query := QueryInformer(&Select[int, int]{
+		Lock: lock,
+		Select: func(i int) (int, error) { return i, nil },
+		From: source,
+	})
+
+	for i := 0; i < 1000; i++ {
+		source.OnAdd(i, false)
+		
+		func() {
+			locks := SnapshotLockDomain(query)
+			defer locks.Unlock()
+			
+			ns := source.Clone(nil)
+			_ = query.Clone([]cache.SharedInformer{ns})
+		}()
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/stress_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/stress_test.go
@@ -1,0 +1,243 @@
+package fort
+
+import (
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestStress_ComplexPipeline(t *testing.T) {
+	lock := NewLockGroup()
+	// Root sources
+	sourceA := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc) // Emits RawA
+	sourceB := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc) // Emits RawB
+
+	type RawA struct {
+		ID   int
+		Vals []int // Will be expanded by FlatMap
+	}
+	type RawB struct {
+		ID    int
+		Value int
+	}
+
+	type ExpandedA struct {
+		ID  int
+		Val int
+	}
+
+	type Joined struct {
+		ID    int
+		AVal  int
+		BVal  int
+		Total int
+	}
+
+	type Aggregated struct {
+		ID    int
+		Sum   int64
+		Count int64
+	}
+
+	// 1. FlatMap: RawA -> []ExpandedA
+	// Each RawA generates multiple ExpandedA objects.
+	flatMapA := QueryInformer(&FlatMap[ExpandedA, RawA]{
+		Lock: lock,
+		Map: func(a RawA) ([]ExpandedA, error) {
+			res := make([]ExpandedA, len(a.Vals))
+			for i, v := range a.Vals {
+				res[i] = ExpandedA{ID: a.ID, Val: v}
+			}
+			return res, nil
+		},
+		Over: sourceA,
+	})
+
+	// 2. Join: ExpandedA + RawB -> Joined
+	// Joins on ID.
+	joinedInformer := QueryInformer(&Join[Joined, ExpandedA, RawB]{
+		Lock: lock,
+		Select: func(a ExpandedA, b RawB) (Joined, error) {
+			return Joined{
+				ID:    a.ID,
+				AVal:  a.Val,
+				BVal:  b.Value,
+				Total: a.Val + b.Value,
+			}, nil
+		},
+		From: flatMapA,
+		Join: sourceB,
+		On: func(a ExpandedA, b RawB) any {
+			if a.ID != 0 {
+				return [1]int{a.ID}
+			}
+			return [1]int{b.ID}
+		},
+	})
+
+	// 3. GroupBy: Joined -> Aggregated
+	// Groups by ID, calculates Sum of Total and Count of items.
+	finalAggregator := QueryInformer(&GroupBy[Aggregated, Joined]{
+		Lock: lock,
+		Select: func(fields []GroupField) (Aggregated, error) {
+			return Aggregated{
+				ID:    fields[0].(int),
+				Sum:   fields[1].(int64),
+				Count: fields[2].(int64),
+			}, nil
+		},
+		From: joinedInformer,
+		GroupBy: func(j Joined) (any, []GroupField) {
+			return j.ID, []GroupField{
+				AnyValue(j.ID),
+				Sum(int64(j.Total)),
+				Count(),
+			}
+		},
+	})
+
+	// Track final results
+	var resLock sync.Mutex
+	finalResults := make(map[int]Aggregated)
+	finalAggregator.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			agg := obj.(Aggregated)
+			resLock.Lock()
+			finalResults[agg.ID] = agg
+			resLock.Unlock()
+		},
+		UpdateFunc: func(old, new any) {
+			agg := new.(Aggregated)
+			resLock.Lock()
+			finalResults[agg.ID] = agg
+			resLock.Unlock()
+		},
+		DeleteFunc: func(obj any) {
+			agg := obj.(Aggregated)
+			resLock.Lock()
+			delete(finalResults, agg.ID)
+			resLock.Unlock()
+		},
+	})
+
+	// --- Stress Phase ---
+	numIDs := 100
+	valsPerID := 10
+	
+	// Pre-populate source B
+	for i := 1; i <= numIDs; i++ {
+		sourceB.OnAdd(RawB{ID: i, Value: 100}, true)
+	}
+
+	// Push RawA data
+	for i := 1; i <= numIDs; i++ {
+		vals := make([]int, valsPerID)
+		for j := 0; j < valsPerID; j++ {
+			vals[j] = j + 1
+		}
+		sourceA.OnAdd(RawA{ID: i, Vals: vals}, false)
+	}
+
+	// Validate results
+	resLock.Lock()
+	if len(finalResults) != numIDs {
+		t.Errorf("Expected %d groups, got %d", numIDs, len(finalResults))
+	}
+	for id, agg := range finalResults {
+		expectedSum := int64(1055)
+		if agg.Sum != expectedSum {
+			t.Errorf("ID %d: expected sum %d, got %d", id, expectedSum, agg.Sum)
+		}
+		if agg.Count != int64(valsPerID) {
+			t.Errorf("ID %d: expected count %d, got %d", id, valsPerID, agg.Count)
+		}
+	}
+	resLock.Unlock()
+
+	// --- Update Phase (Churn) ---
+	for i := 1; i <= numIDs; i++ {
+		sourceB.OnUpdate(RawB{ID: i, Value: 100}, RawB{ID: i, Value: 200})
+	}
+
+	resLock.Lock()
+	for id, agg := range finalResults {
+		expectedSum := int64(2055)
+		if agg.Sum != expectedSum {
+			t.Errorf("AFTER UPDATE ID %d: expected sum %d, got %d", id, expectedSum, agg.Sum)
+		}
+	}
+	resLock.Unlock()
+
+	// --- Delete Phase ---
+	for i := 1; i <= numIDs/2; i++ {
+		vals := make([]int, valsPerID)
+		for j := 0; j < valsPerID; j++ {
+			vals[j] = j + 1
+		}
+		sourceA.OnDelete(RawA{ID: i, Vals: vals})
+	}
+
+	resLock.Lock()
+	if len(finalResults) != numIDs/2 {
+		t.Errorf("AFTER DELETE: Expected %d groups, got %d", numIDs/2, len(finalResults))
+	}
+	resLock.Unlock()
+}
+
+func BenchmarkPipeline(b *testing.B) {
+	lock := NewLockGroup()
+	sourceA := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	sourceB := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	type RawA struct { ID int; Vals []int }
+	type RawB struct { ID int; Value int }
+	type ExpandedA struct { ID int; Val int }
+	type Joined struct { ID, AVal, BVal, Total int }
+	type Aggregated struct { ID int; Sum int64 }
+
+	flatMapA := QueryInformer(&FlatMap[ExpandedA, RawA]{
+		Lock: lock,
+		Map: func(a RawA) ([]ExpandedA, error) {
+			res := make([]ExpandedA, len(a.Vals))
+			for i, v := range a.Vals { res[i] = ExpandedA{ID: a.ID, Val: v} }
+			return res, nil
+		},
+		Over: sourceA,
+	})
+
+	joinedInformer := QueryInformer(&Join[Joined, ExpandedA, RawB]{
+		Lock: lock,
+		Select: func(a ExpandedA, b RawB) (Joined, error) {
+			return Joined{ID: a.ID, AVal: a.Val, BVal: b.Value, Total: a.Val + b.Value}, nil
+		},
+		From: flatMapA,
+		Join: sourceB,
+		On: func(a ExpandedA, b RawB) any {
+			if a.ID != 0 { return [1]int{a.ID} }
+			return [1]int{b.ID}
+		},
+	})
+
+	finalAggregator := QueryInformer(&GroupBy[Aggregated, Joined]{
+		Lock: lock,
+		Select: func(fields []GroupField) (Aggregated, error) {
+			return Aggregated{ID: fields[0].(int), Sum: fields[1].(int64)}, nil
+		},
+		From: joinedInformer,
+		GroupBy: func(j Joined) (any, []GroupField) {
+			return j.ID, []GroupField{AnyValue(j.ID), Sum(int64(j.Total))}
+		},
+	})
+
+	finalAggregator.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+
+	sourceB.OnAdd(RawB{ID: 1, Value: 100}, true)
+	vals := []int{1, 2, 3, 4, 5}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sourceA.OnAdd(RawA{ID: 1, Vals: vals}, false)
+		sourceA.OnDelete(RawA{ID: 1, Vals: vals})
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/sync_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/sync_test.go
@@ -1,0 +1,87 @@
+package fort
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestSyncPropagation_Chained(t *testing.T) {
+	lock := NewLockGroup()
+	s1 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	
+	// Chain: s1 -> flatMap -> grouper
+	flatMap := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map: func(i int) ([]int, error) { return []int{i}, nil },
+		Over: s1,
+	})
+
+	grouper := QueryInformer(&GroupBy[int, int]{
+		Lock: lock,
+		Select: func(fields []GroupField) (int, error) { return int(fields[0].(int64)), nil },
+		From: flatMap,
+		GroupBy: func(i int) (any, []GroupField) { return [1]int{0}, []GroupField{Count()} },
+	})
+
+	if grouper.HasSynced() {
+		t.Errorf("Grouper should not be synced yet")
+	}
+
+	s1.SetHasSynced()
+
+	// Wait a bit for goroutines to propagate sync
+	success := false
+	for i := 0; i < 10; i++ {
+		if grouper.HasSynced() {
+			success = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !success {
+		t.Errorf("Sync signal did not propagate through the chain to grouper")
+	}
+}
+
+func TestSyncPropagation_Join(t *testing.T) {
+	lock := NewLockGroup()
+	s1 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	s2 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	joined := QueryInformer(&Join[int, int, int]{
+		Lock:   lock,
+		Select: func(l, r int) (int, error) { return l + r, nil },
+		From:   s1,
+		Join:   s2,
+		On: func(l, r int) any { return [1]int{0} },
+	})
+
+	if joined.HasSynced() {
+		t.Errorf("Joined should not be synced yet")
+	}
+
+	s1.SetHasSynced()
+	time.Sleep(10 * time.Millisecond)
+
+	if joined.HasSynced() {
+		t.Errorf("Joined should not be synced when only one source is synced")
+	}
+
+	s2.SetHasSynced()
+	
+	success := false
+	for i := 0; i < 10; i++ {
+		if joined.HasSynced() {
+			success = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !success {
+		t.Errorf("Joined did not sync after both sources synced")
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/fort/watch_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/fort/watch_test.go
@@ -1,0 +1,100 @@
+package fort
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestWatchErrorHandlerPropagation_Chained(t *testing.T) {
+	lock := NewLockGroup()
+	s1 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	
+	// Chain: s1 -> flatMap -> grouper
+	flatMap := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map: func(i int) ([]int, error) { return []int{i}, nil },
+		Over: s1,
+	})
+
+	grouper := QueryInformer(&GroupBy[int, int]{
+		Lock: lock,
+		Select: func(fields []GroupField) (int, error) { return int(fields[0].(int64)), nil },
+		From: flatMap,
+		GroupBy: func(i int) (any, []GroupField) { return [1]int{0}, []GroupField{Count()} },
+	})
+
+	var observedErr error
+	errHandler := func(r *cache.Reflector, err error) {
+		observedErr = err
+	}
+
+	grouper.SetWatchErrorHandler(errHandler)
+
+	testErr := errors.New("upstream watch failure")
+	s1.TriggerWatchError(testErr)
+
+	if observedErr != testErr {
+		t.Errorf("Expected error %v, got %v", testErr, observedErr)
+	}
+}
+
+func TestWatchErrorHandlerPropagation_Join(t *testing.T) {
+	lock := NewLockGroup()
+	s1 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	s2 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+
+	joined := QueryInformer(&Join[int, int, int]{
+		Lock: lock,
+		Select: func(l, r int) (int, error) { return l + r, nil },
+		From:   s1,
+		Join:   s2,
+		On: func(l, r int) any { return [1]int{0} },
+	})
+
+	var observedErr error
+	errHandler := func(r *cache.Reflector, err error) {
+		observedErr = err
+	}
+
+	joined.SetWatchErrorHandler(errHandler)
+
+	testErr1 := errors.New("left source failure")
+	s1.TriggerWatchError(testErr1)
+	if observedErr != testErr1 {
+		t.Errorf("Expected error from left source, got %v", observedErr)
+	}
+
+	testErr2 := errors.New("right source failure")
+	s2.TriggerWatchError(testErr2)
+	if observedErr != testErr2 {
+		t.Errorf("Expected error from right source, got %v", observedErr)
+	}
+}
+
+func TestWatchErrorHandlerWithContextPropagation(t *testing.T) {
+	lock := NewLockGroup()
+	s1 := NewManualSharedInformerWithOptions(lock, cache.MetaNamespaceKeyFunc)
+	
+	flatMap := QueryInformer(&FlatMap[int, int]{
+		Lock: lock,
+		Map: func(i int) ([]int, error) { return []int{i}, nil },
+		Over: s1,
+	})
+
+	var observedErr error
+	errHandler := func(ctx context.Context, r *cache.Reflector, err error) {
+		observedErr = err
+	}
+
+	flatMap.SetWatchErrorHandlerWithContext(errHandler)
+
+	testErr := errors.New("contextual error")
+	s1.TriggerWatchError(testErr)
+
+	if observedErr != testErr {
+		t.Errorf("Expected contextual error %v, got %v", testErr, observedErr)
+	}
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/store/streaming/store.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/streaming/store.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store/fort"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
+)
+
+type StreamingSnapshotStore struct {
+	lock fort.LockGroup
+
+	nodesInformer fort.ManualSharedInformer
+	podsInformer  fort.ManualSharedInformer
+
+	// Cache for NodeInfo objects
+	nodeInfoCache fort.BTreeMap[*framework.NodeInfo]
+
+	// Index: PVC Key -> Count of pods using it
+	pvcUsage fort.CloneableSharedInformerQuery
+
+	// Stack for Fork/Revert
+	forkStack []snapshotState
+}
+
+type snapshotState struct {
+	nodes         fort.ManualSharedInformer
+	pods          fort.ManualSharedInformer
+	nodeInfoCache fort.BTreeMap[*framework.NodeInfo]
+	pvcUsage      fort.CloneableSharedInformerQuery
+}
+
+func NewStreamingSnapshotStore() *StreamingSnapshotStore {
+	lock := fort.NewLockGroup()
+	nodes := fort.NewManualSharedInformerWithOptions(lock, fort.DefaultKeyFunc)
+	pods := fort.NewManualSharedInformerWithOptions(lock, fort.DefaultKeyFunc)
+	nodes.SetHasSynced()
+	pods.SetHasSynced()
+
+	// Track PVC usage
+	pvcUsage := fort.QueryInformer(&fort.FlatMap[string, *apiv1.Pod]{
+		Lock: lock,
+		Over: pods,
+		Map: func(p *apiv1.Pod) ([]string, error) {
+			res := []string{}
+			for _, v := range p.Spec.Volumes {
+				if v.PersistentVolumeClaim != nil {
+					res = append(res, fmt.Sprintf("%s/%s", p.Namespace, v.PersistentVolumeClaim.ClaimName))
+				}
+			}
+			return res, nil
+		},
+	})
+
+	// Count occurrences of each PVC key
+	pvcCounts := fort.QueryInformer(&fort.GroupBy[int, string]{
+		Lock: lock,
+		From: pvcUsage,
+		GroupBy: func(pvcKey string) (any, []fort.GroupField) {
+			return pvcKey, []fort.GroupField{fort.Count()}
+		},
+		Select: func(fields []fort.GroupField) (int, error) {
+			return int(fields[0].(int64)), nil
+		},
+	})
+
+	s := &StreamingSnapshotStore{
+		lock:          lock,
+		nodesInformer: nodes,
+		podsInformer:  pods,
+		nodeInfoCache: fort.NewBTreeMap[*framework.NodeInfo](),
+		pvcUsage:      pvcCounts,
+	}
+	return s
+}
+
+func (s *StreamingSnapshotStore) GetPodInformer() cache.SharedInformer {
+	return s.podsInformer
+}
+
+func (s *StreamingSnapshotStore) GetNodeInformer() cache.SharedInformer {
+	return s.nodesInformer
+}
+
+// Implement ClusterSnapshotStore interface
+
+func (s *StreamingSnapshotStore) NodeInfos() schedulerinterface.NodeInfoLister {
+	return s
+}
+
+func (s *StreamingSnapshotStore) StorageInfos() schedulerinterface.StorageInfoLister {
+	return s
+}
+
+func (s *StreamingSnapshotStore) IsPVCUsedByPods(key string) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	count, ok, _ := s.pvcUsage.GetStore().GetByKey(key)
+	return ok && count.(int) > 0
+}
+
+func (s *StreamingSnapshotStore) List() ([]schedulerinterface.NodeInfo, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	items := s.nodeInfoCache.List()
+	res := make([]schedulerinterface.NodeInfo, 0, len(items))
+	for _, ni := range items {
+		res = append(res, ni)
+	}
+	return res, nil
+}
+
+func (s *StreamingSnapshotStore) HavePodsWithAffinityList() ([]schedulerinterface.NodeInfo, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	items := s.nodeInfoCache.List()
+	res := make([]schedulerinterface.NodeInfo, 0)
+	for _, ni := range items {
+		if len(ni.PodsWithAffinity) > 0 {
+			res = append(res, ni)
+		}
+	}
+	return res, nil
+}
+
+func (s *StreamingSnapshotStore) HavePodsWithRequiredAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	items := s.nodeInfoCache.List()
+	res := make([]schedulerinterface.NodeInfo, 0)
+	for _, ni := range items {
+		if len(ni.PodsWithRequiredAntiAffinity) > 0 {
+			res = append(res, ni)
+		}
+	}
+	return res, nil
+}
+
+func (s *StreamingSnapshotStore) Get(nodeName string) (schedulerinterface.NodeInfo, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	ni, ok := s.nodeInfoCache.Get(nodeName)
+	if !ok {
+		return nil, clustersnapshot.ErrNodeNotFound
+	}
+	return ni, nil
+}
+
+func (s *StreamingSnapshotStore) Fork() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.forkStack = append(s.forkStack, snapshotState{
+		nodes:         s.nodesInformer,
+		pods:          s.podsInformer,
+		nodeInfoCache: s.nodeInfoCache,
+		pvcUsage:      s.pvcUsage,
+	})
+
+	s.nodesInformer = s.nodesInformer.Clone(nil).(fort.ManualSharedInformer)
+	s.podsInformer = s.podsInformer.Clone(nil).(fort.ManualSharedInformer)
+	s.nodeInfoCache = s.nodeInfoCache.Clone()
+
+	memo := make(map[cache.SharedInformer]cache.SharedInformer)
+	memo[s.forkStack[len(s.forkStack)-1].pods] = s.podsInformer
+	s.pvcUsage = fort.ClonePipeline(s.pvcUsage, memo).(fort.CloneableSharedInformerQuery)
+}
+func (s *StreamingSnapshotStore) Revert() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if len(s.forkStack) == 0 {
+		return
+	}
+
+	last := s.forkStack[len(s.forkStack)-1]
+	s.forkStack = s.forkStack[:len(s.forkStack)-1]
+
+	s.nodesInformer = last.nodes
+	s.podsInformer = last.pods
+	s.nodeInfoCache = last.nodeInfoCache
+	s.pvcUsage = last.pvcUsage
+}
+
+func (s *StreamingSnapshotStore) Commit() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if len(s.forkStack) == 0 {
+		return nil
+	}
+
+	s.forkStack = s.forkStack[:len(s.forkStack)-1]
+	return nil
+}
+
+func (s *StreamingSnapshotStore) StorePodInfo(podInfo *framework.PodInfo, nodeName string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	pod := podInfo.Pod
+	s.podsInformer.OnAddLocked(pod, false)
+
+	// Update cache
+	if ni, ok := s.nodeInfoCache.Get(nodeName); ok {
+		newNi := ni.DeepCopy()
+		newNi.AddPod(framework.NewPodInfo(pod, podInfo.NeededResourceClaims))
+		s.nodeInfoCache.Set(nodeName, newNi)
+	} else {
+		return clustersnapshot.ErrNodeNotFound
+	}
+	return nil
+}
+
+func (s *StreamingSnapshotStore) RemovePodInfo(namespace string, podName string, nodeName string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	key := fmt.Sprintf("%s/%s", namespace, podName)
+	obj, exists, _ := s.podsInformer.GetStore().GetByKey(key)
+	if exists {
+		s.podsInformer.OnDeleteLocked(obj)
+
+		// Update cache
+		if ni, ok := s.nodeInfoCache.Get(nodeName); ok {
+			newNi := ni.DeepCopy()
+			newNi.RemovePod(klog.Background(), obj.(*apiv1.Pod))
+			s.nodeInfoCache.Set(nodeName, newNi)
+		} else {
+			return clustersnapshot.ErrNodeNotFound
+		}
+	} else {
+		return fmt.Errorf("pod %s/%s not found", namespace, podName)
+	}
+	return nil
+}
+
+func (s *StreamingSnapshotStore) StoreNodeInfo(nodeInfo *framework.NodeInfo) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, ok := s.nodeInfoCache.Get(nodeInfo.Node().Name); ok {
+		return fmt.Errorf("node %s already exists", nodeInfo.Node().Name)
+	}
+
+	s.nodesInformer.OnAddLocked(nodeInfo.Node(), false)
+
+	// Create a new NodeInfo and add all pods from nodeInfo to it.
+	newNi := framework.NewNodeInfo(nodeInfo.Node(), nodeInfo.LocalResourceSlices)
+	if nodeInfo.CSINode != nil {
+		newNi.SetCSINode(nodeInfo.CSINode)
+	}
+
+	for _, podInfo := range nodeInfo.Pods() {
+		pod := podInfo.Pod
+		s.podsInformer.OnAddLocked(pod, false)
+		newNi.AddPod(framework.NewPodInfo(pod, podInfo.NeededResourceClaims))
+	}
+
+	s.nodeInfoCache.Set(nodeInfo.Node().Name, newNi)
+	return nil
+}
+
+func (s *StreamingSnapshotStore) RemoveNodeInfo(nodeName string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	obj, exists, _ := s.nodesInformer.GetStore().GetByKey(nodeName)
+	if exists {
+		// Remove all pods of this node from podsInformer
+		if ni, ok := s.nodeInfoCache.Get(nodeName); ok {
+			for _, podInfo := range ni.Pods() {
+				s.podsInformer.OnDeleteLocked(podInfo.Pod)
+			}
+		}
+
+		s.nodesInformer.OnDeleteLocked(obj)
+		s.nodeInfoCache.Delete(nodeName)
+	} else {
+		return clustersnapshot.ErrNodeNotFound
+	}
+	return nil
+}
+
+func (s *StreamingSnapshotStore) Clear() {
+	s.lock.Lock()
+	s.forkStack = nil
+	s.nodeInfoCache = fort.NewBTreeMap[*framework.NodeInfo]()
+	s.lock.Unlock()
+
+	s.nodesInformer.Clear()
+	s.podsInformer.Clear()
+
+	// pvcUsage is already linked to podsInformer, so it will be cleared automatically via events.
+}

--- a/cluster-autoscaler/simulator/clustersnapshot/testsnapshot/test_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/testsnapshot/test_snapshot.go
@@ -17,6 +17,8 @@ limitations under the License.
 package testsnapshot
 
 import (
+	"context"
+
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/predicate"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
@@ -53,7 +55,7 @@ func NewTestSnapshotAndHandle() (clustersnapshot.ClusterSnapshot, *framework.Han
 
 // NewCustomTestSnapshotAndHandle returns an instance of ClusterSnapshot with a specific ClusterSnapshotStore that can be used in tests.
 func NewCustomTestSnapshotAndHandle(snapshotStore clustersnapshot.ClusterSnapshotStore) (clustersnapshot.ClusterSnapshot, *framework.Handle, error) {
-	testFwHandle, err := framework.NewTestFrameworkHandle()
+	testFwHandle, err := framework.NewTestFrameworkHandle(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cluster-autoscaler/simulator/common/patchset.go
+++ b/cluster-autoscaler/simulator/common/patchset.go
@@ -189,6 +189,37 @@ func (p *PatchSet[K, V]) AsMap() map[K]V {
 	return patchSetMap
 }
 
+// ForEach iterates through the current effective state of the PatchSet, calling the provided
+// function f for each key-value pair. If f returns false, iteration stops.
+// This is significantly more memory-efficient than AsMap() as it avoids allocating a new map.
+func (p *PatchSet[K, V]) ForEach(f func(K, V) bool) {
+	if !p.cacheInSync {
+		// Rebuild cache directly without intermediate map allocation
+		for k := range p.cache {
+			delete(p.cache, k)
+		}
+		for _, patch := range p.patches {
+			for key, value := range patch.modified {
+				v := value
+				p.cache[key] = &v
+			}
+			for key := range patch.deleted {
+				delete(p.cache, key)
+			}
+		}
+		p.cacheInSync = true
+	}
+
+	for key, value := range p.cache {
+		if value != nil {
+			if !f(key, *value) {
+				return
+			}
+		}
+	}
+}
+
+
 // SetCurrent adds or updates a key-value pair in the topmost patch layer.
 func (p *PatchSet[K, V]) SetCurrent(key K, value V) {
 	if len(p.patches) == 0 {

--- a/cluster-autoscaler/simulator/framework/handle.go
+++ b/cluster-autoscaler/simulator/framework/handle.go
@@ -41,13 +41,16 @@ type Handle struct {
 }
 
 // NewHandle builds a framework Handle based on the provided informers and scheduler config.
-func NewHandle(ctx context.Context, informerFactory informers.SharedInformerFactory, schedConfig *schedulerconfig.KubeSchedulerConfiguration, draEnabled bool, csiEnabled bool) (*Handle, error) {
+func NewHandle(ctx context.Context, informerFactory informers.SharedInformerFactory, schedConfig *schedulerconfig.KubeSchedulerConfiguration, draEnabled bool, csiEnabled bool, fastPredicatesEnabled bool) (*Handle, error) {
 	if schedConfig == nil {
 		var err error
 		schedConfig, err = schedulerconfiglatest.Default()
 		if err != nil {
 			return nil, fmt.Errorf("couldn't create scheduler config: %v", err)
 		}
+	}
+	if fastPredicatesEnabled {
+		DisableInterPodAffinity(schedConfig)
 	}
 	if len(schedConfig.Profiles) != 1 {
 		return nil, fmt.Errorf("unexpected scheduler config: expected one scheduler profile only (found %d profiles)", len(schedConfig.Profiles))
@@ -89,4 +92,23 @@ func NewHandle(ctx context.Context, informerFactory informers.SharedInformerFact
 		Framework:        framework,
 		DelegatingLister: sharedLister,
 	}, nil
+}
+
+// DisableInterPodAffinity disables InterPodAffinity plugin in the given configuration.
+func DisableInterPodAffinity(cfg *schedulerconfig.KubeSchedulerConfiguration) {
+	if cfg == nil {
+		return
+	}
+	for i := range cfg.Profiles {
+		profile := &cfg.Profiles[i]
+		if profile.Plugins == nil {
+			profile.Plugins = &schedulerconfig.Plugins{}
+		}
+		profile.Plugins.PreFilter.Disabled = append(profile.Plugins.PreFilter.Disabled,
+			schedulerconfig.Plugin{Name: "InterPodAffinity"},
+		)
+		profile.Plugins.Filter.Disabled = append(profile.Plugins.Filter.Disabled,
+			schedulerconfig.Plugin{Name: "InterPodAffinity"},
+		)
+	}
 }

--- a/cluster-autoscaler/simulator/framework/infos.go
+++ b/cluster-autoscaler/simulator/framework/infos.go
@@ -23,6 +23,8 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sort"
+	"strings"
 	schedulerinterface "k8s.io/kube-scheduler/framework"
 	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -178,3 +180,34 @@ func NewNodeInfo(node *apiv1.Node, slices []*resourceapi.ResourceSlice, pods ...
 	}
 	return result
 }
+
+// PodWithNode is a pair of Pod and Node.
+type PodWithNode struct {
+	Pod  *apiv1.Pod
+	Node *apiv1.Node
+}
+
+func (p PodWithNode) ExplicitKey() string {
+	return p.Node.Name + "\x00" + p.Pod.Namespace + "\x00" + p.Pod.Name
+}
+
+// GetPodLabelSetHash returns a deterministic hash of the pod's labels.
+func GetPodLabelSetHash(pod *apiv1.Pod) string {
+	if pod == nil || len(pod.Labels) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(pod.Labels))
+	for k := range pod.Labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	for _, k := range keys {
+		sb.WriteString(k)
+		sb.WriteString("=")
+		sb.WriteString(pod.Labels[k])
+		sb.WriteString(",")
+	}
+	return sb.String()
+}
+

--- a/cluster-autoscaler/simulator/framework/test_utils.go
+++ b/cluster-autoscaler/simulator/framework/test_utils.go
@@ -67,6 +67,7 @@ func NodeInfoCmpOptions() []cmp.Option {
 // testFailer is an abstraction that covers both *testing.T and *testing.B.
 type testFailer interface {
 	Fatalf(format string, args ...any)
+	Cleanup(func())
 }
 
 // NewTestNodeInfo returns a new NodeInfo without any DRA information - only to be used in test code.
@@ -91,12 +92,12 @@ func NewTestNodeInfoWithCSI(node *apiv1.Node, csiNode *storagev1.CSINode, pods .
 }
 
 // NewTestFrameworkHandle creates a Handle that can be used in tests.
-func NewTestFrameworkHandle() (*Handle, error) {
+func NewTestFrameworkHandle(ctx context.Context) (*Handle, error) {
 	defaultConfig, err := scheduler_config_latest.Default()
 	if err != nil {
 		return nil, err
 	}
-	fwHandle, err := NewHandle(context.Background(), informers.NewSharedInformerFactory(clientsetfake.NewSimpleClientset(), 0), defaultConfig, true, true)
+	fwHandle, err := NewHandle(ctx, informers.NewSharedInformerFactory(clientsetfake.NewSimpleClientset(), 0), defaultConfig, true, true, false)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,9 @@ func NewTestFrameworkHandle() (*Handle, error) {
 
 // NewTestFrameworkHandleOrDie creates a Handle that can be used in tests.
 func NewTestFrameworkHandleOrDie(t testFailer) *Handle {
-	handle, err := NewTestFrameworkHandle()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	handle, err := NewTestFrameworkHandle(ctx)
 	if err != nil {
 		t.Fatalf("TestFrameworkHandleOrDie: couldn't create test framework handle: %v", err)
 	}


### PR DESCRIPTION
This change introduces a high-performance ClusterSnapshot implementation that replaces traditional O(PodsOnNode) selector matching with incremental indexing, Copy-on-Write (CoW) simulation, and phased evaluation.

Key architectural pillars:
- Incremental Indexing: Leverages the 'fort' pipeline library and StreamingSnapshotStore to update indices reactively as pods and nodes change.
- CoW Simulation: Uses PatchSet-backed BTreeMap structures and slice operations to efficiently share state across simulation forks with O(1) cost.
- Phased Evaluation: Splits computation into a serial 'PreparePod' phase and a parallel 'FastCheckAffinity' phase using bi-directional label indexing.

Other changes:
- Support for complex namespace logic and AffinityTerm mapping.
- Native integration with StreamingSnapshotStore via event propagation.
- Disable legacy scheduler plugin when the fast path is enabled.
- Introduced a new BenchmarkRunOnceAffinitySurge with heavy pod anti-affinity use to measure the improvement.

Performance Gain (BenchmarkRunOnceAffinitySurge - 5000 nodes, 50,000 pods):
- Before (Default): 164.4s/op
- After (Fast O(1)): 9.36s/op
- Speedup: 17.56x

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Anti affinity is the most expensive part of scheduler logic used by Cluster Autoscaler.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Large part is AI generated, needs careful review.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A new, experimental --fast-predicates-enabled flag can be used to enable alternative implementation of pod anti-affinity checks.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
