### PR TITLE
VPA: Add observedGeneration to status and conditions

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
@@ -625,6 +625,14 @@ spec:
                         message is a human-readable explanation containing details about
                         the transition
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
                       description: reason is the reason for the condition's last transition.
                       type: string
@@ -640,6 +648,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by this autoscaler.
+                format: int64
+                minimum: 0
+                type: integer
               recommendation:
                 description: |-
                   The most recently computed amount of resources recommended by the

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -625,6 +625,14 @@ spec:
                         message is a human-readable explanation containing details about
                         the transition
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
                       description: reason is the reason for the condition's last transition.
                       type: string
@@ -640,6 +648,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by this autoscaler.
+                format: int64
+                minimum: 0
+                type: integer
               recommendation:
                 description: |-
                   The most recently computed amount of resources recommended by the

--- a/vertical-pod-autoscaler/docs/api.md
+++ b/vertical-pod-autoscaler/docs/api.md
@@ -366,6 +366,7 @@ _Appears in:_
 | `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta)_ | lastTransitionTime is the last time the condition transitioned from<br />one status to another |  | Optional: \{\} <br /> |
 | `reason` _string_ | reason is the reason for the condition's last transition. |  | Optional: \{\} <br /> |
 | `message` _string_ | message is a human-readable explanation containing details about<br />the transition |  | Optional: \{\} <br /> |
+| `observedGeneration` _integer_ | observedGeneration represents the .metadata.generation that the condition was set based upon.<br />For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date<br />with respect to the current state of the instance. |  | Minimum: 0 <br />Optional: \{\} <br /> |
 
 
 #### VerticalPodAutoscalerConditionType
@@ -436,5 +437,6 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `recommendation` _[RecommendedPodResources](#recommendedpodresources)_ | The most recently computed amount of resources recommended by the<br />autoscaler for the controlled pods. |  | Optional: \{\} <br /> |
 | `conditions` _[VerticalPodAutoscalerCondition](#verticalpodautoscalercondition) array_ | Conditions is the set of conditions required for this autoscaler to scale its target,<br />and indicates whether or not those conditions are met. |  | Optional: \{\} <br /> |
+| `observedGeneration` _integer_ | observedGeneration is the most recent generation observed by this autoscaler. |  | Minimum: 0 <br />Optional: \{\} <br /> |
 
 

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -348,6 +348,11 @@ type VerticalPodAutoscalerStatus struct {
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	Conditions []VerticalPodAutoscalerCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
+
+	// observedGeneration is the most recent generation observed by this autoscaler.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty" protobuf:"varint,3,opt,name=observedGeneration"`
 }
 
 // RecommendedPodResources is the recommendation of resources computed by
@@ -429,6 +434,13 @@ type VerticalPodAutoscalerCondition struct {
 	// the transition
 	// +optional
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
+
+	// observedGeneration represents the .metadata.generation that the condition was set based upon.
+	// For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the instance.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"bytes,6,opt,name=observedGeneration"`
 }
 
 // +genclient

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -574,6 +574,11 @@ func (in *VerticalPodAutoscalerStatus) DeepCopyInto(out *VerticalPodAutoscalerSt
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ObservedGeneration != nil {
+		in, out := &in.ObservedGeneration, &out.ObservedGeneration
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -325,6 +325,7 @@ func (cluster *clusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 	vpa.SetUpdateMode(apiObject.Spec.UpdatePolicy)
 	vpa.SetResourcePolicy(apiObject.Spec.ResourcePolicy)
 	vpa.SetAPIVersion(apiObject.GetObjectKind().GroupVersionKind().Version)
+	vpa.Generation = apiObject.Generation
 	return nil
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -40,12 +40,14 @@ type vpaConditionsMap map[vpa_types.VerticalPodAutoscalerConditionType]vpa_types
 
 func (conditionsMap *vpaConditionsMap) Set(
 	conditionType vpa_types.VerticalPodAutoscalerConditionType,
+	observedGeneration int64,
 	status bool, reason string, message string) *vpaConditionsMap {
 	oldCondition, alreadyPresent := (*conditionsMap)[conditionType]
 	condition := vpa_types.VerticalPodAutoscalerCondition{
-		Type:    conditionType,
-		Reason:  reason,
-		Message: message,
+		Type:               conditionType,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: observedGeneration,
 	}
 	if status {
 		condition.Status = corev1.ConditionTrue
@@ -93,7 +95,7 @@ func (vpa *Vpa) ConditionActive(conditionType vpa_types.VerticalPodAutoscalerCon
 func (vpa *Vpa) SetCondition(conditionType vpa_types.VerticalPodAutoscalerConditionType, status bool, reason string, message string) {
 	vpa.mutex.Lock()
 	defer vpa.mutex.Unlock()
-	vpa.conditions.Set(conditionType, status, reason, message)
+	vpa.conditions.Set(conditionType, vpa.Generation, status, reason, message)
 }
 
 // DeleteCondition deletes a condition in a thread-safe manner.
@@ -142,14 +144,14 @@ func (vpa *Vpa) updateConditionsLocked(podsMatched bool) {
 	} else {
 		reason = "NoPodsMatched"
 		msg = "No pods match this VPA object"
-		vpa.conditions.Set(vpa_types.NoPodsMatched, true, reason, msg)
+		vpa.conditions.Set(vpa_types.NoPodsMatched, vpa.Generation, true, reason, msg)
 	}
 
 	// Can safely call hasRecommendationLocked() - no deadlock risk
 	if vpa.hasRecommendationLocked() {
-		vpa.conditions.Set(vpa_types.RecommendationProvided, true, "", "")
+		vpa.conditions.Set(vpa_types.RecommendationProvided, vpa.Generation, true, "", "")
 	} else {
-		vpa.conditions.Set(vpa_types.RecommendationProvided, false, reason, msg)
+		vpa.conditions.Set(vpa_types.RecommendationProvided, vpa.Generation, false, reason, msg)
 	}
 }
 
@@ -208,6 +210,9 @@ type Vpa struct {
 
 	// mutex protects concurrent access to conditions and recommendation fields
 	mutex sync.RWMutex
+
+	// Generation is the generation of the VPA object observed by the recommender.
+	Generation int64
 }
 
 // NewVpa returns a new Vpa with a given ID and pod selector. Doesn't set the
@@ -228,6 +233,7 @@ func NewVpa(id VpaID, selector labels.Selector, created time.Time) *Vpa {
 		// to the version requested by the client server side.
 		APIVersion: vpa_types.SchemeGroupVersion.Version,
 		PodCount:   0,
+		Generation: 0,
 	}
 	return vpa
 }
@@ -378,6 +384,7 @@ func (vpa *Vpa) AsStatus() *vpa_types.VerticalPodAutoscalerStatus {
 	if vpa.recommendation != nil {
 		status.Recommendation = vpa.recommendation
 	}
+	status.ObservedGeneration = &vpa.Generation
 	return status
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -40,14 +40,12 @@ type vpaConditionsMap map[vpa_types.VerticalPodAutoscalerConditionType]vpa_types
 
 func (conditionsMap *vpaConditionsMap) Set(
 	conditionType vpa_types.VerticalPodAutoscalerConditionType,
-	observedGeneration int64,
 	status bool, reason string, message string) *vpaConditionsMap {
 	oldCondition, alreadyPresent := (*conditionsMap)[conditionType]
 	condition := vpa_types.VerticalPodAutoscalerCondition{
-		Type:               conditionType,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: observedGeneration,
+		Type:    conditionType,
+		Reason:  reason,
+		Message: message,
 	}
 	if status {
 		condition.Status = corev1.ConditionTrue
@@ -95,7 +93,7 @@ func (vpa *Vpa) ConditionActive(conditionType vpa_types.VerticalPodAutoscalerCon
 func (vpa *Vpa) SetCondition(conditionType vpa_types.VerticalPodAutoscalerConditionType, status bool, reason string, message string) {
 	vpa.mutex.Lock()
 	defer vpa.mutex.Unlock()
-	vpa.conditions.Set(conditionType, vpa.Generation, status, reason, message)
+	vpa.conditions.Set(conditionType, status, reason, message)
 }
 
 // DeleteCondition deletes a condition in a thread-safe manner.
@@ -144,14 +142,14 @@ func (vpa *Vpa) updateConditionsLocked(podsMatched bool) {
 	} else {
 		reason = "NoPodsMatched"
 		msg = "No pods match this VPA object"
-		vpa.conditions.Set(vpa_types.NoPodsMatched, vpa.Generation, true, reason, msg)
+		vpa.conditions.Set(vpa_types.NoPodsMatched, true, reason, msg)
 	}
 
 	// Can safely call hasRecommendationLocked() - no deadlock risk
 	if vpa.hasRecommendationLocked() {
-		vpa.conditions.Set(vpa_types.RecommendationProvided, vpa.Generation, true, "", "")
+		vpa.conditions.Set(vpa_types.RecommendationProvided, true, "", "")
 	} else {
-		vpa.conditions.Set(vpa_types.RecommendationProvided, vpa.Generation, false, reason, msg)
+		vpa.conditions.Set(vpa_types.RecommendationProvided, false, reason, msg)
 	}
 }
 

--- a/vertical-pod-autoscaler/test/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/recommender.go
@@ -41,6 +41,7 @@ import (
 	klog "k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 	podsecurity "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 )
 
 func init() {
@@ -239,6 +240,28 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 	ginkgo.It("serves recommendation", func() {
 		ginkgo.By("Waiting for recommendation to be filled")
 		_, err := utils.WaitForRecommendationPresent(vpaClientSet, vpaCRD)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	// FIXME: Move this to an integration test once we have integration test available
+	ginkgo.It("sets observedGeneration and conditions.observedGeneration", func() {
+		ginkgo.By("Waiting for observedGeneration to be updated")
+
+		_, err := utils.WaitForVPAMatch(vpaClientSet, vpaCRD, func(vpa *vpa_types.VerticalPodAutoscaler) bool {
+			return vpa.Generation > 0 && ptr.Deref(vpa.Status.ObservedGeneration, 0) == vpa.Generation
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Waiting for conditions.observedGeneration to be updated")
+		_, err = utils.WaitForVPAMatch(vpaClientSet, vpaCRD, func(vpa *vpa_types.VerticalPodAutoscaler) bool {
+			for _, cond := range vpa.Status.Conditions {
+				if cond.ObservedGeneration == 0 || cond.ObservedGeneration != vpa.Generation {
+					return false
+				}
+			}
+			return true
+		})
+
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 

--- a/vertical-pod-autoscaler/test/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/recommender.go
@@ -41,7 +41,6 @@ import (
 	klog "k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 	podsecurity "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/ptr"
 )
 
 func init() {
@@ -240,28 +239,6 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 	ginkgo.It("serves recommendation", func() {
 		ginkgo.By("Waiting for recommendation to be filled")
 		_, err := utils.WaitForRecommendationPresent(vpaClientSet, vpaCRD)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	})
-
-	// FIXME: Move this to an integration test once we have integration test available
-	ginkgo.It("sets observedGeneration and conditions.observedGeneration", func() {
-		ginkgo.By("Waiting for observedGeneration to be updated")
-
-		_, err := utils.WaitForVPAMatch(vpaClientSet, vpaCRD, func(vpa *vpa_types.VerticalPodAutoscaler) bool {
-			return vpa.Generation > 0 && ptr.Deref(vpa.Status.ObservedGeneration, 0) == vpa.Generation
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		ginkgo.By("Waiting for conditions.observedGeneration to be updated")
-		_, err = utils.WaitForVPAMatch(vpaClientSet, vpaCRD, func(vpa *vpa_types.VerticalPodAutoscaler) bool {
-			for _, cond := range vpa.Status.Conditions {
-				if cond.ObservedGeneration == 0 || cond.ObservedGeneration != vpa.Generation {
-					return false
-				}
-			}
-			return true
-		})
-
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 

--- a/vertical-pod-autoscaler/test/integration/recommender/recommender_test.go
+++ b/vertical-pod-autoscaler/test/integration/recommender/recommender_test.go
@@ -28,15 +28,16 @@ import (
 
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	recommender_config "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/config"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/test/e2e/utils"
 )
 
 /*
 Tests in this file are for illustrative purposes only.
-Once we start writing integreation tests, we can build out the nessesary scaffolding to support them, possibly even reusing the e2e scaffolding
+Once we start writing integration tests, we can build out the necessary scaffolding to support them, possibly even reusing the e2e scaffolding
 */
 
 func TestRemovingGC(t *testing.T) {
-	t.Parallel()
 	recommenderConfig := recommender_config.DefaultRecommenderConfig()
 	recommenderConfig.CheckpointsGCInterval = 1 * time.Second // Short interval for testing
 
@@ -80,7 +81,7 @@ func TestRemovingGC(t *testing.T) {
 	}
 	t.Logf("Verified VPA Checkpoint exists: %s", fetched.Name)
 
-	// // Wait for deletion
+	// Wait for deletion
 	err = wait.PollUntilContextTimeout(tCtx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		cp, err := vpaClient.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns.Name).Get(ctx, checkpointName, metav1.GetOptions{})
 		if err != nil {
@@ -105,5 +106,61 @@ func TestRemovingGC(t *testing.T) {
 
 	if len(list.Items) > 0 {
 		t.Fatalf("Expected no remaining VPA Checkpoints, but found %d", len(list.Items))
+	}
+}
+
+func TestObservedGeneration(t *testing.T) {
+	recommenderConfig := recommender_config.DefaultRecommenderConfig()
+
+	tCtx, closeFn, rm, informers, c, vpaClient := recommenderSetup(t, recommenderConfig)
+	defer closeFn()
+	ns := framework.CreateNamespaceOrDie(c, "observed-generation", t)
+	defer framework.DeleteNamespaceOrDie(c, ns, t)
+	stopControllers := runControllerAndInformers(tCtx, rm, informers)
+	defer stopControllers()
+
+	vpaCRD := test.VerticalPodAutoscaler().
+		WithName("hamster-vpa").
+		WithNamespace(ns.Name).
+		WithTargetRef(utils.HamsterTargetRef). // Fake targetRef to satisfy validation
+		WithContainer("fake-container").
+		Get()
+
+	_, err := vpaClient.AutoscalingV1().VerticalPodAutoscalers(ns.Name).Create(tCtx, vpaCRD, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create VPA: %v", err)
+	}
+
+	var lastVPA *vpav1.VerticalPodAutoscaler
+	err = wait.PollUntilContextTimeout(tCtx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		vpa, err := vpaClient.AutoscalingV1().VerticalPodAutoscalers(ns.Name).Get(ctx, vpaCRD.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		lastVPA = vpa
+
+		if len(vpa.Status.Conditions) == 0 || vpa.Status.ObservedGeneration == nil {
+			// Neither Status.Conditions nor Status.ObservedGeneration have been updated yet - keep waiting
+			return false, nil
+		}
+
+		for _, condition := range vpa.Status.Conditions {
+			if condition.ObservedGeneration != vpa.Generation {
+				return false, nil
+			}
+		}
+		if *vpa.Status.ObservedGeneration != vpa.Generation {
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		if lastVPA != nil {
+			t.Fatalf("Timed out. Last status: conditions=%v, observedGeneration=%v, generation=%d: %v", lastVPA.Status.Conditions, lastVPA.Status.ObservedGeneration, lastVPA.Generation, err)
+		} else {
+			t.Fatalf("Timed out waiting for VPA status to update, but never successfully fetched the VPA: %v", err)
+		}
 	}
 }

--- a/vertical-pod-autoscaler/test/integration/recommender/recommender_test.go
+++ b/vertical-pod-autoscaler/test/integration/recommender/recommender_test.go
@@ -139,17 +139,7 @@ func TestObservedGeneration(t *testing.T) {
 		}
 		lastVPA = vpa
 
-		if len(vpa.Status.Conditions) == 0 || vpa.Status.ObservedGeneration == nil {
-			// Neither Status.Conditions nor Status.ObservedGeneration have been updated yet - keep waiting
-			return false, nil
-		}
-
-		for _, condition := range vpa.Status.Conditions {
-			if condition.ObservedGeneration != vpa.Generation {
-				return false, nil
-			}
-		}
-		if *vpa.Status.ObservedGeneration != vpa.Generation {
+		if vpa.Status.ObservedGeneration == nil || *vpa.Status.ObservedGeneration != vpa.Generation {
 			return false, nil
 		}
 
@@ -158,7 +148,7 @@ func TestObservedGeneration(t *testing.T) {
 
 	if err != nil {
 		if lastVPA != nil {
-			t.Fatalf("Timed out. Last status: conditions=%v, observedGeneration=%v, generation=%d: %v", lastVPA.Status.Conditions, lastVPA.Status.ObservedGeneration, lastVPA.Generation, err)
+			t.Fatalf("Timed out. Last status: observedGeneration=%v, generation=%d: %v", lastVPA.Status.ObservedGeneration, lastVPA.Generation, err)
 		} else {
 			t.Fatalf("Timed out waiting for VPA status to update, but never successfully fetched the VPA: %v", err)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Doing to VPA what Jordan suggested we do to HPA: https://github.com/kubernetes/kubernetes/pull/138228#issuecomment-4246418112

This also moves us closer to the standardised conditions: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1623-standardize-conditions

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Does a change like this need feature gateing? I assume not since it has a CRD that gets applied to the cluster.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
VPA now stores a observedGeneration in both status and condition fields.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc liggitt 
