### PR TITLE
VPA: Prevent OOM-induced feedback loop by capping recommendations at maxAllowed.memory

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -240,13 +240,65 @@ func (cluster *clusterState) AddOrUpdateContainer(containerID ContainerID, reque
 	if !podExists {
 		return NewKeyError(containerID.PodID)
 	}
-	if container, containerExists := pod.Containers[containerID.ContainerName]; !containerExists {
+
+	container, containerExists := pod.Containers[containerID.ContainerName]
+
+	if !containerExists {
 		cluster.findOrCreateAggregateContainerState(containerID)
-		pod.Containers[containerID.ContainerName] = NewContainerState(request, NewContainerStateAggregatorProxy(cluster, containerID))
+		// Initialize container state with aggregation logic
+		container = NewContainerState(request, NewContainerStateAggregatorProxy(cluster, containerID))
+
+		// Register container in cluster state
+		pod.Containers[containerID.ContainerName] = container
+
 	} else {
 		// Container aleady exists. Possibly update the request.
 		container.Request = request
 	}
+
+	// Resolve VPA controlling this pod via label selector
+	vpa := cluster.GetControllingVPA(pod)
+
+	// Default: no maxAllowed constraint
+	var maxAllowedMemory ResourceAmount = 0
+
+	// Apply VPA resource policy if present
+	if vpa != nil && vpa.ResourcePolicy != nil {
+
+		// Prefer exact container policy over wildcard
+		foundExact := false
+		for _, cp := range vpa.ResourcePolicy.ContainerPolicies {
+			if cp.ContainerName == containerID.ContainerName {
+				foundExact = true
+
+				// Extract maxAllowed.memory if specified
+				if cp.MaxAllowed != nil {
+					if mem, ok := cp.MaxAllowed[corev1.ResourceMemory]; ok {
+						maxAllowedMemory = ResourceAmount(mem.Value())
+					}
+				}
+				break
+			}
+		}
+
+		// Fallback to wildcard policy if no exact match exists
+		if !foundExact {
+			for _, cp := range vpa.ResourcePolicy.ContainerPolicies {
+				if cp.ContainerName == "*" {
+					if cp.MaxAllowed != nil {
+						if mem, ok := cp.MaxAllowed[corev1.ResourceMemory]; ok {
+							maxAllowedMemory = ResourceAmount(mem.Value())
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+
+	// Store maxAllowed memory for OOM-based recommendation capping
+	container.MaxMemory = maxAllowedMemory
+
 	return nil
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -212,18 +212,14 @@ func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory 
 	// Get max of the request and the recent usage-based memory peak.
 	// Omitting oomPeak here to protect against recommendation running too high on subsequent OOMs.
 	memoryUsed := ResourceAmountMax(requestedMemory, container.memoryPeak)
-
 	if container.MaxMemory > 0 && memoryUsed > container.MaxMemory {
 		memoryUsed = container.MaxMemory
 	}
-
 	memoryNeeded := ResourceAmountMax(memoryUsed+MemoryAmountFromBytes(container.GetOOMMinBumpUp()),
 		ScaleResource(memoryUsed, container.GetOOMBumpUpRatio()))
-
 	if container.MaxMemory > 0 && memoryNeeded > container.MaxMemory {
 		memoryNeeded = container.MaxMemory
 	}
-
 	oomMemorySample := ContainerUsageSample{
 		MeasureStart: timestamp,
 		Usage:        memoryNeeded,

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -57,6 +57,7 @@ type ContainerState struct {
 	WindowEnd time.Time
 	// Start of the latest memory usage sample that was aggregated.
 	lastMemorySampleStart time.Time
+	MaxMemory             ResourceAmount
 	// Aggregation to add usage samples to.
 	aggregator ContainerStateAggregator
 }
@@ -211,8 +212,17 @@ func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory 
 	// Get max of the request and the recent usage-based memory peak.
 	// Omitting oomPeak here to protect against recommendation running too high on subsequent OOMs.
 	memoryUsed := ResourceAmountMax(requestedMemory, container.memoryPeak)
+
+	if container.MaxMemory > 0 && memoryUsed > container.MaxMemory {
+		memoryUsed = container.MaxMemory
+	}
+
 	memoryNeeded := ResourceAmountMax(memoryUsed+MemoryAmountFromBytes(container.GetOOMMinBumpUp()),
 		ScaleResource(memoryUsed, container.GetOOMBumpUpRatio()))
+
+	if container.MaxMemory > 0 && memoryNeeded > container.MaxMemory {
+		memoryNeeded = container.MaxMemory
+	}
 
 	oomMemorySample := ContainerUsageSample{
 		MeasureStart: timestamp,

--- a/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util"
 )
@@ -336,5 +337,112 @@ func TestMemorySamplesWithCustomAggregationIntervalCount(t *testing.T) {
 	assert.True(t, c.AddSample(newUsageSample(testTimestamp.Add(2*interval), 10, ResourceMemory)))
 
 	test.mockCPUHistogram.AssertExpectations(t)
+	test.mockMemoryHistogram.AssertExpectations(t)
+}
+
+func TestRecordOOMCapsAtMaxMemory(t *testing.T) {
+	test := newContainerTest()
+
+	test.aggregateContainerState.OOMBumpUpRatio = 2.0
+	test.aggregateContainerState.OOMMinBumpUp = 0.0
+
+	test.container.MaxMemory = ResourceAmount(1000 * mb)
+
+	test.mockMemoryHistogram.On("AddSample",
+		mock.AnythingOfType("float64"),
+		1.0,
+		mock.Anything,
+	).Return()
+
+	err := test.container.RecordOOM(testTimestamp, ResourceAmount(1000*mb))
+	assert.NoError(t, err)
+
+	test.mockMemoryHistogram.AssertCalled(t, "AddSample",
+		mock.MatchedBy(func(val float64) bool {
+			return val == float64(1000*mb)
+		}),
+		1.0,
+		mock.Anything,
+	)
+}
+
+func TestRecordOOMWithoutMaxMemory(t *testing.T) {
+	test := newContainerTest()
+
+	test.aggregateContainerState.OOMBumpUpRatio = 2.0
+	test.aggregateContainerState.OOMMinBumpUp = 0.0
+
+	test.container.MaxMemory = 0
+
+	memoryAggregationWindowEnd :=
+		testTimestamp.Add(GetAggregationsConfig().MemoryAggregationIntervalDuration)
+
+	test.mockMemoryHistogram.On(
+		"AddSample",
+		2000.0*mb,
+		1.0,
+		memoryAggregationWindowEnd,
+	)
+
+	err := test.container.RecordOOM(
+		testTimestamp,
+		ResourceAmount(1000*mb),
+	)
+
+	assert.NoError(t, err)
+	test.mockMemoryHistogram.AssertExpectations(t)
+}
+
+func TestRecordOOMBelowMaxMemoryNotCapped(t *testing.T) {
+	test := newContainerTest()
+
+	test.aggregateContainerState.OOMBumpUpRatio = 1.2
+	test.aggregateContainerState.OOMMinBumpUp = 0.0
+
+	test.container.MaxMemory = ResourceAmount(3000 * mb)
+
+	memoryAggregationWindowEnd :=
+		testTimestamp.Add(GetAggregationsConfig().MemoryAggregationIntervalDuration)
+
+	test.mockMemoryHistogram.On(
+		"AddSample",
+		1200.0*mb,
+		1.0,
+		memoryAggregationWindowEnd,
+	)
+
+	err := test.container.RecordOOM(
+		testTimestamp,
+		ResourceAmount(1000*mb),
+	)
+
+	assert.NoError(t, err)
+	test.mockMemoryHistogram.AssertExpectations(t)
+}
+
+func TestRecordOOMAtMaxMemoryBoundary(t *testing.T) {
+	test := newContainerTest()
+
+	test.aggregateContainerState.OOMBumpUpRatio = 1.0
+	test.aggregateContainerState.OOMMinBumpUp = 0.0
+
+	test.container.MaxMemory = ResourceAmount(1000 * mb)
+
+	memoryAggregationWindowEnd :=
+		testTimestamp.Add(GetAggregationsConfig().MemoryAggregationIntervalDuration)
+
+	test.mockMemoryHistogram.On(
+		"AddSample",
+		1000.0*mb,
+		1.0,
+		memoryAggregationWindowEnd,
+	)
+
+	err := test.container.RecordOOM(
+		testTimestamp,
+		ResourceAmount(1000*mb),
+	)
+
+	assert.NoError(t, err)
 	test.mockMemoryHistogram.AssertExpectations(t)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Fixes a self-reinforcing feedback loop in VPA recommender OOM handling when `maxAllowed.memory` is configured below the workload’s actual peak memory usage.

Currently, when a pod is OOMKilled, the recommender generates a synthetic memory sample using OOM bump-up logic:

  memoryNeeded = max(requestedMemory, memoryPeak) * oom-bump-up-ratio

When `requestedMemory` is already capped by `maxAllowed.memory`, this produces synthetic samples that always exceed the configured limit. These samples persist in the histogram and disproportionately influence percentile-based recommendations (e.g., P99), causing `uncappedTarget` to remain significantly higher than any real observed usage.

This results in a non-converging feedback loop:
- Recommendation is capped at `maxAllowed`
- Pod OOMs again under the cap
- Synthetic sample is generated above the cap
- Histogram remains biased upward
- The cycle repeats indefinitely

In practice, this can cause `uncappedTarget` to remain significantly higher than actual observed memory usage for extended periods due to histogram decay characteristics.

#### Fix:

This PR enforces `maxAllowed.memory` as a hard upper bound during OOM processing.

Specifically:
- Introduces `MaxMemory` in `ContainerState`, populated from VPA `resourcePolicy.containerPolicies`
  - Exact container match is prioritized
  - Fallback to wildcard (`*`) policy is supported
- Applies capping at two stages:
  - `memoryUsed` (base value for scaling)
  - `memoryNeeded` (final synthetic sample)

This ensures that synthetic OOM samples never exceed the effective policy constraint.

#### Why this approach:

Instead of modifying the bump-up ratio or scaling behavior, this fix enforces existing policy constraints during OOM handling. This preserves the current algorithm while ensuring recommendations respect user-defined limits.

#### Result:

- Eliminates the OOM-induced feedback loop
- Ensures recommendations converge under capped configurations
- Prevents histogram pollution from unrealistic synthetic samples
- Preserves existing behavior when `maxAllowed.memory` is not set

#### Which issue(s) this PR fixes:

Fixes #9521

#### Special notes for your reviewer:

- This is a defensive fix: both intermediate (`memoryUsed`) and final (`memoryNeeded`) values are capped to prevent overshoot during computation
- Behavior is unchanged when no `maxAllowed.memory` is configured
- Exact container policy is prioritized over wildcard, consistent with existing VPA behavior
- This approach ensures synthetic samples respect policy limits rather than altering OOM scaling semantics

#### Does this PR introduce a user-facing change?

```release-note
VPA recommender now enforces `maxAllowed.memory` during OOM-based scaling, preventing runaway memory recommendations caused by repeated OOM events under capped configurations.
```