### PR TITLE
CA: remove dead CreateNodeNameToInfoMap helper

### DIFF
--- a/cluster-autoscaler/utils/scheduler/scheduler.go
+++ b/cluster-autoscaler/utils/scheduler/scheduler.go
@@ -37,43 +37,6 @@ const (
 	schedulerConfigInvalidErr  = "invalid KubeSchedulerConfiguration"
 )
 
-// CreateNodeNameToInfoMap obtains a list of pods and pivots that list into a map where the keys are node names
-// and the values are the aggregated information for that node. Pods waiting lower priority pods preemption
-// (pod.Status.NominatedNodeName is set) are also added to list of pods for a node.
-func CreateNodeNameToInfoMap(pods []*apiv1.Pod, nodes []*apiv1.Node) map[string]*framework.NodeInfo {
-	nodeNameToNodeInfo := make(map[string]*framework.NodeInfo)
-	for _, pod := range pods {
-		nodeName := pod.Spec.NodeName
-		if nodeName == "" {
-			nodeName = pod.Status.NominatedNodeName
-		}
-		if _, ok := nodeNameToNodeInfo[nodeName]; !ok {
-			nodeNameToNodeInfo[nodeName] = framework.NewNodeInfo(nil, nil)
-		}
-		nodeNameToNodeInfo[nodeName].AddPod(framework.NewPodInfo(pod, nil))
-	}
-
-	for _, node := range nodes {
-		if _, ok := nodeNameToNodeInfo[node.Name]; !ok {
-			nodeNameToNodeInfo[node.Name] = framework.NewNodeInfo(nil, nil)
-		}
-		nodeNameToNodeInfo[node.Name].SetNode(node)
-	}
-
-	// Some pods may be out of sync with node lists. Removing incomplete node infos.
-	keysToRemove := make([]string, 0)
-	for key, nodeInfo := range nodeNameToNodeInfo {
-		if nodeInfo.Node() == nil {
-			keysToRemove = append(keysToRemove, key)
-		}
-	}
-	for _, key := range keysToRemove {
-		delete(nodeNameToNodeInfo, key)
-	}
-
-	return nodeNameToNodeInfo
-}
-
 func isHugePageResourceName(name apiv1.ResourceName) bool {
 	return strings.HasPrefix(string(name), apiv1.ResourceHugePagesPrefix)
 }

--- a/cluster-autoscaler/utils/scheduler/scheduler.go
+++ b/cluster-autoscaler/utils/scheduler/scheduler.go
@@ -23,7 +23,6 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	schedulerinterface "k8s.io/kube-scheduler/framework"
 	scheduler_config "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	scheduler_scheme "k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"

--- a/cluster-autoscaler/utils/scheduler/scheduler_test.go
+++ b/cluster-autoscaler/utils/scheduler/scheduler_test.go
@@ -25,7 +25,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	testconfig "k8s.io/autoscaler/cluster-autoscaler/config/test"
-	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 

--- a/cluster-autoscaler/utils/scheduler/scheduler_test.go
+++ b/cluster-autoscaler/utils/scheduler/scheduler_test.go
@@ -34,31 +34,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateNodeNameToInfoMap(t *testing.T) {
-	p1 := BuildTestPod("p1", 1500, 200000)
-	p1.Spec.NodeName = "node1"
-	p2 := BuildTestPod("p2", 3000, 200000)
-	p2.Spec.NodeName = "node2"
-	p3 := BuildTestPod("p3", 3000, 200000)
-	p3.Spec.NodeName = "node3"
-
-	var priority int32 = 100
-	podWaitingForPreemption := BuildTestPod("w1", 1500, 200000)
-	podWaitingForPreemption.Spec.Priority = &priority
-	podWaitingForPreemption.Status.NominatedNodeName = "node1"
-
-	n1 := BuildTestNode("node1", 2000, 2000000)
-	n2 := BuildTestNode("node2", 2000, 2000000)
-
-	res := CreateNodeNameToInfoMap([]*apiv1.Pod{p1, p2, p3, podWaitingForPreemption}, []*apiv1.Node{n1, n2})
-	assert.Equal(t, 2, len(res))
-	assert.Equal(t, p1, res["node1"].Pods()[0].Pod)
-	assert.Equal(t, podWaitingForPreemption, res["node1"].Pods()[1].Pod)
-	assert.Equal(t, n1, res["node1"].Node())
-	assert.Equal(t, p2, res["node2"].Pods()[0].Pod)
-	assert.Equal(t, n2, res["node2"].Node())
-}
-
 func TestResourceList(t *testing.T) {
 	tests := []struct {
 		resource *schedulerimpl.Resource


### PR DESCRIPTION
The function has been unused since Feb 2020 (6 years), when the last usage in simulator/cluster.go was removed in PR #2890 (commit d11b39603d6b93d091331c1266f782be64d4323d).

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
