### PR TITLE
Fix typos in VPA updater metrics description

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
@@ -72,7 +72,7 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Name:      "vpas_with_evictable_pods_total",
-			Help:      "Number of VPA objects with at least one Pod matching evicition criteria.",
+			Help:      "Number of VPA objects with at least one Pod matching eviction criteria.",
 		}, []string{"vpa_size_log2", "update_mode"},
 	)
 

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
@@ -56,7 +56,7 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Name:      "evictable_pods_total",
-			Help:      "Number of Pods matching evicition criteria.",
+			Help:      "Number of Pods matching eviction criteria.",
 		}, []string{"vpa_size_log2", "update_mode"},
 	)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Cleans up small typo in prometheus metric evictable_pods_total.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A