### PR TITLE
Add diagnostic watchdog system for loop monitoring

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	gce_localssdsize "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce/localssdsize"
+	"k8s.io/autoscaler/cluster-autoscaler/diagnostics"
 	kubelet_config "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	scheduler_config "k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
@@ -105,6 +106,8 @@ func NewDefaultNodeGroupDifferenceRatios() NodeGroupDifferenceRatios {
 
 // AutoscalingOptions contain various options to customize how autoscaling works
 type AutoscalingOptions struct {
+	// DiagnosticConfig holds configuration for the diagnostic system.
+	DiagnosticConfig diagnostics.Config
 	// NodeGroupDefaults are default values for per NodeGroup options.
 	// They will be used any time a specific value is not provided for a given NodeGroup.
 	NodeGroupDefaults NodeGroupAutoscalingOptions

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -19,6 +19,7 @@ package flags
 import (
 	"flag"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -28,6 +29,7 @@ import (
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce/localssdsize"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/diagnostics"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	scheduler_util "k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
@@ -109,6 +111,12 @@ var (
 	schedulerConfigFile         = flag.String(config.SchedulerConfigFileFlag, "", "scheduler-config allows changing configuration of in-tree scheduler plugins acting on PreFilter and Filter extension points")
 	nodeDeletionDelayTimeout    = flag.Duration("node-deletion-delay-timeout", 2*time.Minute, "Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node.")
 	nodeDeletionBatcherInterval = flag.Duration("node-deletion-batcher-interval", 0*time.Second, "How long CA ScaleDown gather nodes to delete them in batch.")
+	diagnosticDirectory         = flag.String("diagnostic-directory", "", "Directory to store diagnostic reports. Empty string disables the diagnostic system.")
+	diagnosticProfiles          = flag.String("diagnostic-profiles", "cpu", "Comma-separated list of profiles to collect (cpu, trace, heap, alloc).")
+	diagnosticMaxLoopTime       = flag.Duration("diagnostic-max-loop-time", 1*time.Minute, "Threshold for a single loop duration to trigger diagnostics.")
+	diagnosticMaxCollectionTime = flag.Duration("diagnostic-max-collection-time", 1*time.Minute, "Duration to collect diagnostic profiles.")
+	diagnosticCooldownPeriod    = flag.Duration("diagnostic-cooldown-period", 1*time.Hour, "Minimum time between two diagnostic collections.")
+	diagnosticTraceMaxMB        = flag.Uint64("diagnostic-trace-max-mb", 128, "Maximum size of the trace flight recorder window in megabytes.")
 	scanInterval                = flag.Duration("scan-interval", config.DefaultScanInterval, "How often cluster is reevaluated for scale up or down")
 	maxNodesTotal               = flag.Int("max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
 	coresTotal                  = flag.String("cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
@@ -302,11 +310,38 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		klog.Fatalf("Invalid value for --predicate-parallelism flag: %d", *predicateParallelism)
 	}
 
+	profiles := []string{}
+	if *diagnosticProfiles == "" && *diagnosticDirectory != "" {
+		klog.Warning("Diagnostic directory is set but diagnostic-profiles is empty. No profiles will be collected.")
+	} else if *diagnosticProfiles != "" {
+		for _, part := range strings.Split(*diagnosticProfiles, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				profiles = append(profiles, strings.ToLower(part))
+			}
+		}
+	}
+
+	validProfiles := []string{"cpu", "trace", "heap", "alloc"}
+	for _, p := range profiles {
+		if !slices.Contains(validProfiles, p) {
+			klog.Fatalf("Unknown diagnostic profile: %s. Valid options are: cpu, trace, heap, alloc", p)
+		}
+	}
+
 	if !ptr.Deref(enableDynamicResourceAllocation, false) {
 		klog.Fatalf("--enable-dynamic-resource-allocation flag must be true: %t", ptr.Deref(enableDynamicResourceAllocation, false))
 	}
 
 	return config.AutoscalingOptions{
+		DiagnosticConfig: diagnostics.Config{
+			Directory:         *diagnosticDirectory,
+			MaxLoopTime:       *diagnosticMaxLoopTime,
+			MaxCollectionTime: *diagnosticMaxCollectionTime,
+			CooldownPeriod:    *diagnosticCooldownPeriod,
+			EnabledProfiles:   profiles,
+			TraceMaxMB:        *diagnosticTraceMaxMB,
+		},
 		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
 			ScaleDownUtilizationThreshold:    *scaleDownUtilizationThreshold,
 			ScaleDownGpuUtilizationThreshold: *scaleDownGpuUtilizationThreshold,

--- a/cluster-autoscaler/diagnostics/file_sink.go
+++ b/cluster-autoscaler/diagnostics/file_sink.go
@@ -1,0 +1,54 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnostics
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+)
+
+// FileSink implements DiagnosticSink by saving reports to the local filesystem.
+type FileSink struct {
+	directory string
+}
+
+// NewFileSink creates a new FileSink that stores reports in the specified directory.
+func NewFileSink(directory string) (*FileSink, error) {
+	if err := os.MkdirAll(directory, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create diagnostics directory %s: %v", directory, err)
+	}
+	return &FileSink{directory: directory}, nil
+}
+
+// Store saves each profile in the report as a separate file.
+func (s *FileSink) Store(ctx context.Context, report *DiagnosticReport) error {
+	for profileType, data := range report.Profiles {
+		filename := fmt.Sprintf("%s.%s", report.ID, profileType)
+		path := filepath.Join(s.directory, filename)
+
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			klog.ErrorS(err, "Failed to save diagnostic profile", "path", path)
+			continue
+		}
+		klog.V(2).InfoS("Saved diagnostic profile", "path", path)
+	}
+	return nil
+}

--- a/cluster-autoscaler/diagnostics/interface.go
+++ b/cluster-autoscaler/diagnostics/interface.go
@@ -40,3 +40,12 @@ type ProfileCollector interface {
 	// For "cpu" and "trace", it should respect the context's deadline for collection duration.
 	Collect(ctx context.Context) ([]byte, error)
 }
+
+// CooldownObserver is an optional interface that collectors can implement to be
+// notified of the system's cooldown state changes.
+type CooldownObserver interface {
+	// OnCooldownStart is called when a cooldown period begins (usually after a collection).
+	OnCooldownStart()
+	// OnCooldownEnd is called when a cooldown period expires, meaning the system is ready to collect again.
+	OnCooldownEnd()
+}

--- a/cluster-autoscaler/diagnostics/interface.go
+++ b/cluster-autoscaler/diagnostics/interface.go
@@ -1,0 +1,42 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnostics
+
+import "context"
+
+// DiagnosticReport represents a collection of runtime profiles and associated metadata.
+type DiagnosticReport struct {
+	// ID is a unique identifier for the event that triggered this report.
+	ID string
+	// Profiles contains the collected profile data, keyed by profile type (e.g., "cpu", "trace", "heap").
+	Profiles map[string][]byte
+	// Metadata contains contextual tags related to the report.
+	Metadata map[string]string
+}
+
+// DiagnosticSink defines the interface for storing diagnostic reports.
+type DiagnosticSink interface {
+	// Store saves the diagnostic report.
+	Store(ctx context.Context, report *DiagnosticReport) error
+}
+
+// ProfileCollector defines the interface for collecting diagnostic profiles.
+type ProfileCollector interface {
+	// Collect gathers a profile.
+	// For "cpu" and "trace", it should respect the context's deadline for collection duration.
+	Collect(ctx context.Context) ([]byte, error)
+}

--- a/cluster-autoscaler/diagnostics/watchdog.go
+++ b/cluster-autoscaler/diagnostics/watchdog.go
@@ -1,0 +1,232 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnostics
+
+import (
+	"bytes"
+	"context"
+	"runtime/pprof"
+	"runtime/trace"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"k8s.io/klog/v2"
+)
+
+// Config holds configuration for the Manager.
+type Config struct {
+	// Directory is the path to store diagnostic reports. Empty string disables the diagnostic system.
+	Directory string
+	// MaxLoopTime is the threshold for a single loop duration to trigger diagnostics.
+	MaxLoopTime time.Duration
+	// MaxCollectionTime is the duration to collect CPU and Trace profiles.
+	MaxCollectionTime time.Duration
+	// CooldownPeriod is the minimum time between two diagnostic collections.
+	CooldownPeriod time.Duration
+	// EnabledProfiles is a list of profiles to collect (e.g., "cpu", "trace", "heap", "allocs").
+	EnabledProfiles []string
+
+	// TraceMaxMB is the maximum size of the flight recorder window in megabytes.
+	TraceMaxMB uint64
+}
+
+// Manager monitors loop durations and triggers diagnostic reports.
+type Manager struct {
+	sink       DiagnosticSink
+	config     Config
+	collectors map[string]ProfileCollector
+
+	mu           sync.Mutex
+	lastTrigger  time.Time
+	isCollecting bool
+}
+
+// NewManager creates a new Manager.
+func NewManager(sink DiagnosticSink, config Config) *Manager {
+	collectors := make(map[string]ProfileCollector)
+
+	for _, p := range config.EnabledProfiles {
+		switch p {
+		case "cpu":
+			collectors["cpu"] = &cpuCollector{}
+		case "trace":
+			if tc, err := newTraceCollector(config); err == nil {
+				collectors["trace"] = tc
+			}
+		case "heap":
+			collectors["heap"] = &heapCollector{}
+		case "allocs":
+			collectors["allocs"] = &allocsCollector{}
+		}
+	}
+
+	return &Manager{
+		sink:       sink,
+		config:     config,
+		collectors: collectors,
+	}
+}
+
+// NewManagerWithCollectors creates a new Manager with custom collectors.
+func NewManagerWithCollectors(sink DiagnosticSink, config Config, collectors map[string]ProfileCollector) *Manager {
+	return &Manager{
+		sink:       sink,
+		config:     config,
+		collectors: collectors,
+	}
+}
+
+type cpuCollector struct{}
+
+func (c *cpuCollector) Collect(ctx context.Context) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := pprof.StartCPUProfile(&buf); err != nil {
+		return nil, err
+	}
+	<-ctx.Done()
+	pprof.StopCPUProfile()
+	return buf.Bytes(), nil
+}
+
+type traceCollector struct {
+	flightRecorder *trace.FlightRecorder
+}
+
+func newTraceCollector(config Config) (*traceCollector, error) {
+	// Calculate minimum age to ensure we hold at least (MaxLoopTime + MaxCollectionTime).
+	// This guarantees that when WriteTo is called at the end of collection,
+	// the resulting trace contains the full history of the event.
+	minAge := config.MaxLoopTime + config.MaxCollectionTime
+	// Add a 10% safety buffer
+	minAge += minAge / 10
+
+	frConfig := trace.FlightRecorderConfig{
+		MaxBytes: config.TraceMaxMB * 1024 * 1024,
+		MinAge:   minAge,
+	}
+	fr := trace.NewFlightRecorder(frConfig)
+	if err := fr.Start(); err != nil {
+		klog.ErrorS(err, "Failed to start flight recorder", "frConfig", frConfig)
+		return nil, err
+	}
+	return &traceCollector{flightRecorder: fr}, nil
+}
+
+func (c *traceCollector) Collect(ctx context.Context) ([]byte, error) {
+	<-ctx.Done()
+	var buf bytes.Buffer
+	if _, err := c.flightRecorder.WriteTo(&buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+type heapCollector struct{}
+
+func (c *heapCollector) Collect(ctx context.Context) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := pprof.Lookup("heap").WriteTo(&buf, 0); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+type allocsCollector struct{}
+
+func (c *allocsCollector) Collect(ctx context.Context) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := pprof.Lookup("allocs").WriteTo(&buf, 0); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// RunWithDiagnostic executes the provided function. If it takes longer than MaxLoopTime,
+// diagnostic collection is triggered automatically in the background.
+func (dm *Manager) RunWithDiagnostic(ctx context.Context, runFn func()) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		select {
+		case <-time.After(dm.config.MaxLoopTime):
+			dm.mu.Lock()
+			now := time.Now()
+			if dm.isCollecting || now.Sub(dm.lastTrigger) < dm.config.CooldownPeriod {
+				dm.mu.Unlock()
+				return
+			}
+			dm.isCollecting = true
+			dm.lastTrigger = now
+			dm.mu.Unlock()
+
+			klog.InfoS("Diagnostic triggered diagnostic collection", "threshold", dm.config.MaxLoopTime)
+			go dm.collectAndStore(ctx)
+		case <-ctx.Done():
+		}
+	}()
+
+	runFn()
+}
+
+func (dm *Manager) collectAndStore(ctx context.Context) {
+	defer func() {
+		dm.mu.Lock()
+		dm.isCollecting = false
+		dm.mu.Unlock()
+	}()
+
+	report := &DiagnosticReport{
+		ID:       uuid.New().String(),
+		Profiles: make(map[string][]byte),
+		Metadata: make(map[string]string),
+	}
+
+	report.Metadata["threshold_exceeded"] = dm.config.MaxLoopTime.String()
+	report.Metadata["trigger_time"] = time.Now().Format(time.RFC3339)
+
+	// collectionCtx will be cancelled when either MaxCollectionTime expires
+	// or the monitored function completes (via ctx).
+	collectionCtx, collectionCancel := context.WithTimeout(ctx, dm.config.MaxCollectionTime)
+	defer collectionCancel()
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	for name, collector := range dm.collectors {
+		wg.Add(1)
+		go func(n string, c ProfileCollector) {
+			defer wg.Done()
+			data, err := c.Collect(collectionCtx)
+			if err != nil {
+				klog.ErrorS(err, "Failed to collect profile", "profile", n)
+				return
+			}
+			mu.Lock()
+			report.Profiles[n] = data
+			mu.Unlock()
+		}(name, collector)
+	}
+	wg.Wait()
+
+	// Use context.Background() for storage to ensure it persists even if the monitored loop has finished.
+	if err := dm.sink.Store(context.Background(), report); err != nil {
+		klog.ErrorS(err, "Failed to store diagnostic report", "reportID", report.ID)
+	} else {
+		klog.InfoS("Diagnostic report stored successfully", "reportID", report.ID)
+	}
+}

--- a/cluster-autoscaler/diagnostics/watchdog.go
+++ b/cluster-autoscaler/diagnostics/watchdog.go
@@ -75,19 +75,35 @@ func NewManager(sink DiagnosticSink, config Config) *Manager {
 		}
 	}
 
-	return &Manager{
-		sink:       sink,
-		config:     config,
-		collectors: collectors,
-	}
+	return NewManagerWithCollectors(sink, config, collectors)
 }
 
 // NewManagerWithCollectors creates a new Manager with custom collectors.
 func NewManagerWithCollectors(sink DiagnosticSink, config Config, collectors map[string]ProfileCollector) *Manager {
-	return &Manager{
+	dm := &Manager{
 		sink:       sink,
 		config:     config,
 		collectors: collectors,
+	}
+
+	dm.notifyCooldownEnd()
+
+	return dm
+}
+
+func (dm *Manager) notifyCooldownStart() {
+	for _, c := range dm.collectors {
+		if obs, ok := c.(CooldownObserver); ok {
+			obs.OnCooldownStart()
+		}
+	}
+}
+
+func (dm *Manager) notifyCooldownEnd() {
+	for _, c := range dm.collectors {
+		if obs, ok := c.(CooldownObserver); ok {
+			obs.OnCooldownEnd()
+		}
 	}
 }
 
@@ -105,6 +121,8 @@ func (c *cpuCollector) Collect(ctx context.Context) ([]byte, error) {
 
 type traceCollector struct {
 	flightRecorder *trace.FlightRecorder
+	mu             sync.Mutex
+	running        bool
 }
 
 func newTraceCollector(config Config) (*traceCollector, error) {
@@ -120,11 +138,30 @@ func newTraceCollector(config Config) (*traceCollector, error) {
 		MinAge:   minAge,
 	}
 	fr := trace.NewFlightRecorder(frConfig)
-	if err := fr.Start(); err != nil {
-		klog.ErrorS(err, "Failed to start flight recorder", "frConfig", frConfig)
-		return nil, err
-	}
 	return &traceCollector{flightRecorder: fr}, nil
+}
+
+func (c *traceCollector) OnCooldownEnd() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.running {
+		return
+	}
+	if err := c.flightRecorder.Start(); err != nil {
+		klog.ErrorS(err, "Failed to start flight recorder")
+		return
+	}
+	c.running = true
+}
+
+func (c *traceCollector) OnCooldownStart() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.running {
+		return
+	}
+	c.flightRecorder.Stop()
+	c.running = false
 }
 
 func (c *traceCollector) Collect(ctx context.Context) ([]byte, error) {
@@ -188,6 +225,16 @@ func (dm *Manager) collectAndStore(ctx context.Context) {
 	defer func() {
 		dm.mu.Lock()
 		dm.isCollecting = false
+		dm.notifyCooldownStart()
+
+		// Schedule the end of the cooldown period.
+		// Using the lastTrigger to ensure we respect the full period from the start of the event.
+		nextEnable := time.Until(dm.lastTrigger.Add(dm.config.CooldownPeriod))
+		time.AfterFunc(nextEnable, func() {
+			dm.mu.Lock()
+			defer dm.mu.Unlock()
+			dm.notifyCooldownEnd()
+		})
 		dm.mu.Unlock()
 	}()
 

--- a/cluster-autoscaler/diagnostics/watchdog_test.go
+++ b/cluster-autoscaler/diagnostics/watchdog_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnostics
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockSink struct {
+	mu      sync.Mutex
+	reports []*DiagnosticReport
+}
+
+func (m *mockSink) Store(ctx context.Context, report *DiagnosticReport) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reports = append(m.reports, report)
+	return nil
+}
+
+type mockCollector struct {
+	profileType string
+}
+
+func (m *mockCollector) Collect(ctx context.Context) ([]byte, error) {
+	return []byte("test-" + m.profileType + "-profile"), nil
+}
+
+func TestDiagnosticManager(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		sink := &mockSink{}
+		config := Config{
+			MaxLoopTime:       10 * time.Second,
+			MaxCollectionTime: 5 * time.Second,
+			CooldownPeriod:    60 * time.Second,
+			TraceMaxMB:        64,
+		}
+
+		collectors := map[string]ProfileCollector{
+			"cpu":  &mockCollector{profileType: "cpu"},
+			"heap": &mockCollector{profileType: "heap"},
+		}
+		dm := NewManagerWithCollectors(sink, config, collectors)
+		ctx := context.Background()
+
+		// Test 1: Loop duration below threshold
+		t.Log("Testing below threshold...")
+		dm.RunWithDiagnostic(ctx, func() {
+			time.Sleep(5 * time.Second)
+		})
+		synctest.Wait()
+
+		sink.mu.Lock()
+		assert.Equal(t, 0, len(sink.reports), "Should not collect if below threshold")
+		sink.mu.Unlock()
+
+		// Test 2: Loop duration above threshold
+		t.Log("Testing above threshold...")
+		dm.RunWithDiagnostic(ctx, func() {
+			time.Sleep(20 * time.Second)
+		})
+		// Wait for the background goroutines to finish collection
+		synctest.Wait()
+
+		sink.mu.Lock()
+		assert.Equal(t, 1, len(sink.reports), "Should collect if above threshold")
+		if len(sink.reports) == 1 {
+			report := sink.reports[0]
+			assert.Contains(t, report.Profiles, "cpu")
+			assert.Contains(t, report.Profiles, "heap")
+		}
+		sink.mu.Unlock()
+
+		// Test 3: Cooldown period
+		t.Log("Testing cooldown...")
+		// Trigger another one quickly - should be blocked by cooldown
+		dm.RunWithDiagnostic(ctx, func() {
+			time.Sleep(20 * time.Second)
+		})
+		synctest.Wait()
+
+		sink.mu.Lock()
+		assert.Equal(t, 1, len(sink.reports), "Should not collect during cooldown")
+		sink.mu.Unlock()
+
+		// Advance time past cooldown
+		time.Sleep(65 * time.Second)
+		dm.RunWithDiagnostic(ctx, func() {
+			time.Sleep(20 * time.Second)
+		})
+		synctest.Wait()
+
+		sink.mu.Lock()
+		assert.Equal(t, 2, len(sink.reports), "Should collect after cooldown")
+		sink.mu.Unlock()
+
+	})
+}
+
+func TestFileSink(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "diagnostics-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	sink, err := NewFileSink(tmpDir)
+	assert.NoError(t, err)
+
+	report := &DiagnosticReport{
+		ID: "test-report",
+		Profiles: map[string][]byte{
+			"cpu":  []byte("cpu-data"),
+			"heap": []byte("heap-data"),
+		},
+	}
+
+	err = sink.Store(context.Background(), report)
+	assert.NoError(t, err)
+
+	_, err = os.Stat(tmpDir + "/test-report.cpu")
+	assert.NoError(t, err)
+	_, err = os.Stat(tmpDir + "/test-report.heap")
+	assert.NoError(t, err)
+
+	data, err := os.ReadFile(tmpDir + "/test-report.cpu")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("cpu-data"), data)
+}

--- a/cluster-autoscaler/diagnostics/watchdog_test.go
+++ b/cluster-autoscaler/diagnostics/watchdog_test.go
@@ -41,10 +41,60 @@ func (m *mockSink) Store(ctx context.Context, report *DiagnosticReport) error {
 
 type mockCollector struct {
 	profileType string
+	mu          sync.Mutex
+	startCalls  int
+	stopCalls   int
+}
+
+func (m *mockCollector) OnCooldownEnd() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.startCalls++
+}
+
+func (m *mockCollector) OnCooldownStart() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopCalls++
 }
 
 func (m *mockCollector) Collect(ctx context.Context) ([]byte, error) {
 	return []byte("test-" + m.profileType + "-profile"), nil
+}
+
+func TestManagerLifecycle(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		sink := &mockSink{}
+		config := Config{
+			MaxLoopTime:       10 * time.Second,
+			MaxCollectionTime: 5 * time.Second,
+			CooldownPeriod:    60 * time.Second,
+		}
+
+		collector := &mockCollector{profileType: "test"}
+		collectors := map[string]ProfileCollector{"test": collector}
+		dm := NewManagerWithCollectors(sink, config, collectors)
+
+		// 1. Verify initial start
+		assert.Equal(t, 1, collector.startCalls, "Should call OnCooldownEnd on creation")
+
+		// 2. Trigger collection
+		ctx := context.Background()
+		dm.RunWithDiagnostic(ctx, func() {
+			time.Sleep(20 * time.Second)
+		})
+		synctest.Wait()
+
+		// Verify stop was called after collection
+		assert.Equal(t, 1, collector.stopCalls, "Should call OnCooldownStart after collection")
+
+		// 3. Verify automatic resume after cooldown
+		// Advance time past the 60s cooldown
+		time.Sleep(65 * time.Second)
+		synctest.Wait()
+
+		assert.Equal(t, 2, collector.startCalls, "Should call OnCooldownEnd after cooldown expires via timer")
+	})
 }
 
 func TestDiagnosticManager(t *testing.T) {

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -39,7 +39,9 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/config/flags"
 	"k8s.io/autoscaler/cluster-autoscaler/core"
 	"k8s.io/autoscaler/cluster-autoscaler/debuggingsnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/diagnostics"
 	"k8s.io/autoscaler/cluster-autoscaler/loop"
+
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/version"
@@ -124,6 +126,23 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 		klog.Fatalf("Failed to autoscaler background components: %v", err)
 	}
 
+	runAutoscalerOnce := func(ctx context.Context, lastRun time.Time) {
+		loop.RunAutoscalerOnce(autoscaler, healthCheck, lastRun)
+	}
+
+	if autoscalingOpts.DiagnosticConfig.Directory != "" {
+		sink, err := diagnostics.NewFileSink(autoscalingOpts.DiagnosticConfig.Directory)
+		if err != nil {
+			klog.Fatalf("Failed to create diagnostic sink: %v", err)
+		}
+		diagnosticManager := diagnostics.NewManager(sink, autoscalingOpts.DiagnosticConfig)
+		runAutoscalerOnce = func(ctx context.Context, lastRun time.Time) {
+			diagnosticManager.RunWithDiagnostic(ctx, func() {
+				loop.RunAutoscalerOnce(autoscaler, healthCheck, lastRun)
+			})
+		}
+	}
+
 	err = mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		// Autoscale ad infinitum.
 		if autoscalingOpts.FrequentLoopsEnabled {
@@ -139,7 +158,7 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 				default:
 					trigger.Wait(previousRun)
 					previousRun, lastRun = lastRun, time.Now()
-					loop.RunAutoscalerOnce(autoscaler, healthCheck, lastRun)
+					runAutoscalerOnce(ctx, lastRun)
 				}
 			}
 		} else {
@@ -149,7 +168,7 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 					// TODO: handle graceful shutdown with context
 					return nil
 				case <-time.After(autoscalingOpts.ScanInterval):
-					loop.RunAutoscalerOnce(autoscaler, healthCheck, time.Now())
+					runAutoscalerOnce(ctx, time.Now())
 				}
 			}
 		}


### PR DESCRIPTION
Introduces a diagnostic system that monitors cluster-autoscaler loop durations and automatically collects runtime profiles when a configurable threshold is exceeded.

Key features:
- Watchdog Manager: Monitors the main loop and triggers collection in the background if a run exceeds MaxLoopTime.
- Profile Collection: Support for CPU, Execution Trace (via Flight Recorder), Heap, and Allocation profiling.
- Flexible Configuration: New flags to configure thresholds, collection duration, cooldown periods, and enabled profiles.
- Dependency Injection: Modular design using a ProfileCollector interface, enabling clean testing and future extension.
- File Sink: Automatically saves collected reports and profiles to a specified local directory for offline analysis.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9530 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a diagnostic watchdog system that automatically collects CPU, trace, and memory profiles when the autoscaler loop duration exceeds a configured threshold.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
