### PR TITLE
fix(recommender): load bearer token from file into PrometheusBearerToken

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/config/config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config.go
@@ -282,6 +282,6 @@ func ValidateRecommenderConfig(config *RecommenderConfig) {
 			klog.ErrorS(err, "Unable to read bearer token file", "filename", config.PrometheusBearerTokenFile)
 			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
-		config.PrometheusBearerTokenFile = strings.TrimSpace(string(fileContent))
+		config.PrometheusBearerToken = strings.TrimSpace(string(fileContent))
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/config/config_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateRecommenderConfigLoadsBearerTokenFromFile(t *testing.T) {
+	t.Parallel()
+
+	config := DefaultRecommenderConfig()
+	tokenFilePath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenFilePath, []byte("\nmy-secret-token\n"), 0600); err != nil {
+		t.Fatalf("failed to create token file: %v", err)
+	}
+	config.PrometheusBearerTokenFile = tokenFilePath
+
+	ValidateRecommenderConfig(config)
+
+	if got, want := config.PrometheusBearerToken, "my-secret-token"; got != want {
+		t.Fatalf("PrometheusBearerToken = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

ValidateRecommenderConfig stores --prometheus-bearer-token-file content in the wrong field, leaving PrometheusBearerToken empty and causing unauthenticated 401 Prometheus requests , failed history loading, and worse recommendations.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/9532

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
