### PR TITLE
fix(recommender): prevent memory leak and severely perturbs recommendations in LoadPods

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -490,12 +490,12 @@ func (feeder *clusterStateFeeder) LoadPods() {
 				klog.V(0).InfoS("Failed to add container", "container", container.ID, "error", err)
 			}
 		}
-		if podState := feeder.clusterState.Pods()[pod.ID]; podState != nil {
-			initContainerNames := make([]string, 0, len(pod.InitContainers))
-			for _, initContainer := range pod.InitContainers {
-				initContainerNames = append(initContainerNames, initContainer.ID.ContainerName)
-			}
-			podState.InitContainers = initContainerNames
+		initContainerNames := make([]string, 0, len(pod.InitContainers))
+		for _, initContainer := range pod.InitContainers {
+			initContainerNames = append(initContainerNames, initContainer.ID.ContainerName)
+		}
+		if err = feeder.clusterState.SetInitContainers(pod.ID, initContainerNames); err != nil {
+			klog.V(0).InfoS("Failed to set init containers", "pod", klog.KRef(pod.ID.Namespace, pod.ID.PodName), "error", err)
 		}
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -467,7 +467,8 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 func (feeder *clusterStateFeeder) LoadPods() {
 	podSpecs, err := feeder.specClient.GetPodSpecs()
 	if err != nil {
-		klog.ErrorS(err, "Cannot get SimplePodSpecs")
+		klog.ErrorS(err, "Cannot get SimplePodSpecs, skipping LoadPods cycle")
+		return
 	}
 	pods := make(map[model.PodID]*spec.BasicPodSpec)
 	for _, spec := range podSpecs {
@@ -489,9 +490,12 @@ func (feeder *clusterStateFeeder) LoadPods() {
 				klog.V(0).InfoS("Failed to add container", "container", container.ID, "error", err)
 			}
 		}
-		for _, initContainer := range pod.InitContainers {
-			podInitContainers := feeder.clusterState.Pods()[pod.ID].InitContainers
-			feeder.clusterState.Pods()[pod.ID].InitContainers = append(podInitContainers, initContainer.ID.ContainerName)
+		if podState := feeder.clusterState.Pods()[pod.ID]; podState != nil {
+			initContainerNames := make([]string, 0, len(pod.InitContainers))
+			for _, initContainer := range pod.InitContainers {
+				initContainerNames = append(initContainerNames, initContainer.ID.ContainerName)
+			}
+			podState.InitContainers = initContainerNames
 		}
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -108,6 +108,24 @@ func (cs *fakeClusterState) AddSample(sample *model.ContainerUsageSampleWithKey)
 
 func (cs *fakeClusterState) AddOrUpdatePod(podID model.PodID, _ labels.Set, _ corev1.PodPhase) {
 	cs.addedPods = append(cs.addedPods, podID)
+	if cs.stubbedPods == nil {
+		cs.stubbedPods = make(map[model.PodID]*model.PodState)
+	}
+	if cs.stubbedPods[podID] == nil {
+		cs.stubbedPods[podID] = &model.PodState{
+			ID:         podID,
+			Containers: make(map[string]*model.ContainerState),
+		}
+	}
+}
+
+func (cs *fakeClusterState) SetInitContainers(podID model.PodID, initContainers []string) error {
+	pod, podExists := cs.stubbedPods[podID]
+	if !podExists || pod == nil {
+		return model.NewKeyError(podID)
+	}
+	pod.InitContainers = append([]string(nil), initContainers...)
+	return nil
 }
 
 func (cs *fakeClusterState) Pods() map[model.PodID]*model.PodState {

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -483,6 +483,20 @@ func TestClusterStateFeeder_LoadPods_ContainerTracking(t *testing.T) {
 	assert.Equal(t, len(feeder.clusterState.Pods()[podWithInitContainersID].InitContainers), 2)
 	assert.Equal(t, len(feeder.clusterState.Pods()[podWithoutInitContainersID].Containers), 2)
 	assert.Equal(t, len(feeder.clusterState.Pods()[podWithoutInitContainersID].InitContainers), 0)
+
+	// Re-loading the same pods must not cause the init container list to grow.
+	// This guards against a regression where LoadPods appended to the existing
+	// slice on every invocation, leading to unbounded growth over time.
+	feeder.LoadPods()
+	feeder.LoadPods()
+
+	assert.Equal(t, len(feeder.clusterState.Pods()), 2)
+	assert.Equal(t, len(feeder.clusterState.Pods()[podWithInitContainersID].InitContainers), 2)
+	assert.ElementsMatch(t,
+		[]string{"init1", "init2"},
+		feeder.clusterState.Pods()[podWithInitContainersID].InitContainers,
+	)
+	assert.Equal(t, len(feeder.clusterState.Pods()[podWithoutInitContainersID].InitContainers), 0)
 }
 
 func TestClusterStateFeeder_LoadPods_MemorySaverMode(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -45,6 +45,7 @@ const (
 type ClusterState interface {
 	StateMapSize() int
 	AddOrUpdatePod(podID PodID, newLabels labels.Set, phase corev1.PodPhase)
+	SetInitContainers(podID PodID, initContainers []string) error
 	GetContainer(containerID ContainerID) *ContainerState
 	DeletePod(podID PodID)
 	AddOrUpdateContainer(containerID ContainerID, request Resources) error
@@ -175,6 +176,18 @@ func (cluster *clusterState) AddOrUpdatePod(podID PodID, newLabels labels.Set, p
 		cluster.addPodToItsVpa(pod)
 	}
 	pod.Phase = phase
+}
+
+// SetInitContainers sets the names of init containers that belong to the pod.
+// Requires the pod to be added to the clusterState first. Otherwise an error is
+// returned.
+func (cluster *clusterState) SetInitContainers(podID PodID, initContainers []string) error {
+	pod, podExists := cluster.pods[podID]
+	if !podExists || pod == nil {
+		return NewKeyError(podID)
+	}
+	pod.InitContainers = initContainers
+	return nil
 }
 
 // addPodToItsVpa increases the count of Pods associated with a VPA object.

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -339,6 +339,25 @@ func TestMissingKeys(t *testing.T) {
 
 	err = cluster.AddOrUpdateContainer(testContainerID, testRequest)
 	assert.EqualError(t, err, "KeyError: {namespace-1 pod-1}")
+
+	err = cluster.SetInitContainers(testPodID, []string{"init-container-1"})
+	assert.EqualError(t, err, "KeyError: {namespace-1 pod-1}")
+
+	cluster.pods[testPodID] = nil
+	err = cluster.SetInitContainers(testPodID, []string{"init-container-1"})
+	assert.EqualError(t, err, "KeyError: {namespace-1 pod-1}")
+}
+
+func TestSetInitContainers(t *testing.T) {
+	cluster := NewClusterState(testGcPeriod)
+	cluster.AddOrUpdatePod(testPodID, testLabels, corev1.PodRunning)
+
+	initContainers := []string{"init-container-1", "init-container-2"}
+	assert.NoError(t, cluster.SetInitContainers(testPodID, initContainers))
+	assert.Equal(t, []string{"init-container-1", "init-container-2"}, cluster.Pods()[testPodID].InitContainers)
+
+	assert.NoError(t, cluster.SetInitContainers(testPodID, []string{"init-container-3"}))
+	assert.Equal(t, []string{"init-container-3"}, cluster.Pods()[testPodID].InitContainers)
 }
 
 func addVpa(cluster ClusterState, id VpaID, annotations vpaAnnotationsMap, selector string, targetRef *autoscalingv1.CrossVersionObjectReference) *Vpa {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
prevent unbounded growth of pod InitContainers list and skip LoadPods cycle when GetPodSpecs fails to prevent severely perturbs recommendations in LoadPods, more details can see https://github.com/kubernetes/autoscaler/issues/9534


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/9534

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
