### PR TITLE
CA: Fix CA e2e JUnit report overwrite 

### DIFF
--- a/cluster-autoscaler/hack/e2e/run-e2e-tests.sh
+++ b/cluster-autoscaler/hack/e2e/run-e2e-tests.sh
@@ -22,8 +22,13 @@ SCRIPT_DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
 CA_ROOT="$(readlink -f "${SCRIPT_DIR}/../..")"
 
 function print_help {
-  echo "Usage: run-e2e-tests.sh [FOCUS]"
+  echo "Usage: run-e2e-tests.sh [--report-prefix=PREFIX] [FOCUS]"
   echo "  FOCUS: Optional ginkgo focus string. Defaults to '\[sig-autoscaling\]'"
+  echo "  Flags:"
+  echo "    --report-prefix=PREFIX: Optional prefix for the JUnit report file name."
+  echo "                            When set, output becomes junit_\${PREFIX}01.xml,"
+  echo "                            so multiple invocations sharing the same ARTIFACTS"
+  echo "                            directory do not overwrite each other."
   echo "  Environment variables:"
   echo "    KUBECONFIG: Path to kubeconfig (default: ~/.kube/config)"
   echo "    ARTIFACTS: Directory for report artifacts (default: e2e/_artifacts)"
@@ -31,12 +36,29 @@ function print_help {
   echo "    TIMEOUT: Timeout for ginkgo tests (default: 400m)"
 }
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-    print_help
-    exit 0
-fi
+REPORT_PREFIX_FLAG=()
+FOCUS="\\[sig-autoscaling\\]"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    --report-prefix=*)
+      REPORT_PREFIX_FLAG=(--report-prefix="${1#*=}")
+      shift
+      ;;
+    --report-prefix)
+      echo "ERROR: use --report-prefix=PREFIX" >&2
+      exit 1
+      ;;
+    *)
+      FOCUS="$1"
+      shift
+      ;;
+  esac
+done
 
-FOCUS="${1:-"\\[sig-autoscaling\\]"}"
 # 400m allocates ~20 mins per each test case.
 TIMEOUT="${TIMEOUT:-400m}"
 
@@ -56,7 +78,7 @@ echo "Building e2e tests..."
 "${GOBIN}/ginkgo" build .
 
 echo "Running e2e tests with focus: ${FOCUS}"
-"${GOBIN}/ginkgo" -v --timeout="${TIMEOUT}" --focus="${FOCUS}" ./e2e.test -- --report-dir="${ARTIFACTS}" --disable-log-dump ${SKIP:-}
+"${GOBIN}/ginkgo" -v --timeout="${TIMEOUT}" --focus="${FOCUS}" ./e2e.test -- --report-dir="${ARTIFACTS}" "${REPORT_PREFIX_FLAG[@]}" --disable-log-dump ${SKIP:-}
 RESULT=$?
 
 popd >/dev/null

--- a/cluster-autoscaler/hack/e2e/run-e2e.sh
+++ b/cluster-autoscaler/hack/e2e/run-e2e.sh
@@ -48,7 +48,9 @@ CA_IMAGE="${REGISTRY}/cluster-autoscaler:${TAG}"
 
 echo "### STEP 1: Standard Autoscaling tests ###"
 ${CA_ROOT}/hack/e2e/deploy-ca-on-gce-for-e2e.sh "${CA_IMAGE}"
-${CA_ROOT}/hack/e2e/run-e2e-tests.sh "Standard Autoscaling${REMAINING_ARGS[0]:+.*${REMAINING_ARGS[0]}}"
+${CA_ROOT}/hack/e2e/run-e2e-tests.sh \
+  --report-prefix=standard_ \
+  "Standard Autoscaling${REMAINING_ARGS[0]:+.*${REMAINING_ARGS[0]}}"
 
 echo "### STEP 2: DRA Autoscaling tests ###"
 echo "Removing Cluster Autoscaler to reset its state..."
@@ -64,4 +66,6 @@ echo "Redeploying Cluster Autoscaler..."
 ${CA_ROOT}/hack/e2e/deploy-ca-on-gce-for-e2e.sh "${CA_IMAGE}"
 
 echo "Running DRA tests..."
-${CA_ROOT}/hack/e2e/run-e2e-tests.sh "DRA Autoscaling${REMAINING_ARGS[0]:+.*${REMAINING_ARGS[0]}}"
+${CA_ROOT}/hack/e2e/run-e2e-tests.sh \
+  --report-prefix=dra_ \
+  "DRA Autoscaling${REMAINING_ARGS[0]:+.*${REMAINING_ARGS[0]}}"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix e2e tests summary does not show all passed tests

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/9527

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
