### PR TITLE
VPA test flaking: wait for OOM bump recommendation in e2e

### DIFF
--- a/vertical-pod-autoscaler/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/e2e/v1/recommender.go
@@ -453,12 +453,6 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 			Get()
 		utils.InstallVPA(f, vpaCRD)
 
-		ginkgo.By("Waiting for recommendation to be filled")
-		vpa, err := utils.WaitForRecommendationPresent(vpaClientSet, vpaCRD)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(vpa.Status.Recommendation.ContainerRecommendations).Should(gomega.HaveLen(1))
-
-		currentMemory := vpa.Status.Recommendation.ContainerRecommendations[0].Target.Memory().Value()
 		oomReplicationControllerRequestLimit := int64(1024 * 1024 * 1024)                          // from runOomingReplicationController
 		defaultBumpMemory := float64(oomReplicationControllerRequestLimit) * defaultOOMBumpUpRatio // DefaultOOMBumpUpRatio
 		customBumpMemory := float64(oomReplicationControllerRequestLimit) * oomBumpUpRatio         // Custom ratio from VPA config
@@ -467,8 +461,16 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 		gomega.Expect(customBumpMemory).Should(gomega.BeNumerically(">", defaultBumpMemory),
 			fmt.Sprintf("Custom OOM bump ratio (%fx) should be greater than default (%fx)", float64(oomBumpUpRatio), defaultOOMBumpUpRatio))
 
-		// Verify that the actual recommendation is at least the custom bump ratio
-		gomega.Expect(currentMemory).Should(gomega.BeNumerically(">=", int64(customBumpMemory)),
+		ginkgo.By("Waiting for recommendation to reflect the OOM bump")
+		var currentMemory int64
+		_, err := utils.WaitForVPAMatch(vpaClientSet, vpaCRD, func(vpa *vpa_types.VerticalPodAutoscaler) bool {
+			if vpa.Status.Recommendation == nil || len(vpa.Status.Recommendation.ContainerRecommendations) != 1 {
+				return false
+			}
+			currentMemory = vpa.Status.Recommendation.ContainerRecommendations[0].Target.Memory().Value()
+			return currentMemory >= int64(customBumpMemory)
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Memory recommendation should be at least custom bump up ratio (%dx). Got: %d bytes (%.2fx), Expected: >= %d bytes (%dx)",
 				oomBumpUpRatio,
 				currentMemory,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fix VPA test flaking : the PerVPAConfig OOM bump e2e previously waited only for any recommendation to appear, which could catch a pre-OOM recommendation before the recommender observed the pod OOM status update.so need wait until the recommendation reaches the expected custom OOM bump value before asserting.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/9509

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
