### PR TITLE
Add required ClusterRole apiGroups for Capacity(Buffers|Quotas)

### DIFF
--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.57.0
+version: 9.58.0

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/clusterrole.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/clusterrole.yaml
@@ -223,6 +223,22 @@ rules:
     - watch
     - update
     - patch
+  - apiGroups:
+    - autoscaling.x-k8s.io
+    resources:
+    - capacitybuffers
+    - capacityquotas
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - autoscaling.x-k8s.io
+    resources:
+    - capacitybuffers/status
+    verbs:
+    - update
+    - patch
 {{- if .Values.rbac.additionalRules }}
 {{ toYaml .Values.rbac.additionalRules | indent 2 }}
 {{- end }}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR updates the Cluster Autoscaler helm chart so that it delivers a ClusterRoles configuration that supports CapacityBuffer and CapacityQuota.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
