### PR TITLE
fixed validation for per-vpa config

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -109,7 +109,7 @@ func parseVPA(raw []byte) (*vpa_types.VerticalPodAutoscaler, error) {
 // ValidateVPA checks the correctness of VPA Spec and returns an error if there is a problem.
 func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 	// check that perVPA is on if being used
-	if err := validatePerVPAFeatureFlag(vpa); err != nil {
+	if err := validatePerVPAFeatureFlag(vpa, isCreate); err != nil {
 		return err
 	}
 
@@ -263,16 +263,16 @@ func validateMemoryResolution(val apires.Quantity) error {
 	return nil
 }
 
-func validatePerVPAFeatureFlag(vpa *vpa_types.VerticalPodAutoscaler) error {
+func validatePerVPAFeatureFlag(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 	featureFlagOn := features.Enabled(features.PerVPAConfig)
-	if !featureFlagOn && vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil {
+	if isCreate && !featureFlagOn && vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil {
 		return fmt.Errorf("EvictAfterOOMSeconds is not supported when feature flag %s is disabled", features.PerVPAConfig)
 	}
 
 	if vpa.Spec.ResourcePolicy != nil {
 		for _, policy := range vpa.Spec.ResourcePolicy.ContainerPolicies {
 			perVPA := policy.OOMBumpUpRatio != nil || policy.OOMMinBumpUp != nil
-			if !featureFlagOn && perVPA {
+			if !featureFlagOn && perVPA && isCreate {
 				return fmt.Errorf("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag %s is disabled", features.PerVPAConfig)
 			}
 		}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
@@ -640,6 +640,10 @@ func TestValidateVPA(t *testing.T) {
 			name: "per-vpa config active and used",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode: &validUpdateMode,
 					},
@@ -661,11 +665,16 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			PerVPAConfigDisabled: false,
+			isCreate:             true,
 		},
 		{
 			name: "per-vpa config active and used evictOOMThreshold",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode:           &validUpdateMode,
 						EvictAfterOOMSeconds: ptr.To(int32(600)),
@@ -688,6 +697,7 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			PerVPAConfigDisabled: false,
+			isCreate:             true,
 		},
 		{
 			name: "per-vpa config disabled and used",
@@ -714,6 +724,7 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			PerVPAConfigDisabled: true,
+			isCreate:             true,
 			expectError:          errors.New("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag PerVPAConfig is disabled"),
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
fixed validation for per-vpa config
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
