### PR TITLE
VPA: Fix admission validation for VPA resource updates

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -66,6 +66,57 @@ func (h *resourceHandler) DisallowIncorrectObjects() bool {
 	return true
 }
 
+// VPAValidationOptions contains the different settings for VPA validation
+type VPAValidationOptions struct {
+	// FIXME(adrian): IsVPACreate should be removed from here by splitting ValidateVPA() into ValidateVPACreate() and ValidateVPAUpdate() functions
+	IsVPACreate            bool
+	AllowCPUStartupBoost   bool
+	AllowInPlaceOrRecreate bool
+	AllowPerVPAConfig      bool
+}
+
+// GetValidationOptionsForVPA generates VPAValidationOptions for VPA
+func GetValidationOptionsForVPA(oldObj *vpa_types.VerticalPodAutoscaler) VPAValidationOptions {
+	opts := VPAValidationOptions{
+		IsVPACreate:            oldObj == nil,
+		AllowCPUStartupBoost:   allowCPUBoost(oldObj),
+		AllowInPlaceOrRecreate: features.Enabled(features.InPlaceOrRecreate),
+		AllowPerVPAConfig:      allowPerVPAConfig(oldObj),
+	}
+
+	return opts
+}
+
+func allowPerVPAConfig(oldObj *vpa_types.VerticalPodAutoscaler) bool {
+	if features.Enabled(features.PerVPAConfig) {
+		return true
+	}
+
+	if oldObj != nil && oldObj.Spec.UpdatePolicy != nil && oldObj.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil {
+		return true
+	}
+	if oldObj.Spec.ResourcePolicy != nil && oldObj.Spec.ResourcePolicy.ContainerPolicies != nil {
+		for _, policy := range oldObj.Spec.ResourcePolicy.ContainerPolicies {
+			if policy.OOMBumpUpRatio != nil || policy.OOMMinBumpUp != nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func allowCPUBoost(oldObj *vpa_types.VerticalPodAutoscaler) bool {
+	if features.Enabled(features.CPUStartupBoost) {
+		return true
+	}
+
+	if oldObj != nil && oldObj.Spec.StartupBoost != nil && oldObj.Spec.StartupBoost.CPU != nil {
+		return true
+	}
+	return false
+}
+
 // GetPatches builds patches for VPA in given admission request.
 func (h *resourceHandler) GetPatches(_ context.Context, ar *admissionv1.AdmissionRequest) ([]resource.PatchRecord, error) {
 	raw, isCreate := ar.Object.Raw, ar.Operation == admissionv1.Create
@@ -74,12 +125,24 @@ func (h *resourceHandler) GetPatches(_ context.Context, ar *admissionv1.Admissio
 		return nil, err
 	}
 
+	oldVPA := &vpa_types.VerticalPodAutoscaler{}
+
+	if ar.Operation == admissionv1.Update {
+		oldRaw := ar.OldObject.Raw
+		oldVPA, err = parseVPA(oldRaw)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	opts := GetValidationOptionsForVPA(oldVPA)
+
 	vpa, err = h.preProcessor.Process(vpa, isCreate)
 	if err != nil {
 		return nil, err
 	}
 
-	err = ValidateVPA(vpa, isCreate)
+	err = ValidateVPA(vpa, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -107,9 +170,9 @@ func parseVPA(raw []byte) (*vpa_types.VerticalPodAutoscaler, error) {
 }
 
 // ValidateVPA checks the correctness of VPA Spec and returns an error if there is a problem.
-func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
+func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, opts VPAValidationOptions) error {
 	// check that perVPA is on if being used
-	if err := validatePerVPAFeatureFlag(vpa); err != nil {
+	if err := validatePerVPAFeatureFlag(vpa, opts); err != nil {
 		return err
 	}
 
@@ -121,7 +184,7 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 		if _, found := vpa_types.GetUpdateModes()[*mode]; !found {
 			return fmt.Errorf("unexpected UpdateMode value %s", *mode)
 		}
-		if (*mode == vpa_types.UpdateModeInPlaceOrRecreate) && !features.Enabled(features.InPlaceOrRecreate) && isCreate {
+		if *mode == vpa_types.UpdateModeInPlaceOrRecreate && !opts.AllowInPlaceOrRecreate {
 			return fmt.Errorf("in order to use UpdateMode %s, you must enable feature gate %s in the admission-controller args", vpa_types.UpdateModeInPlaceOrRecreate, features.InPlaceOrRecreate)
 		}
 		if minReplicas := vpa.Spec.UpdatePolicy.MinReplicas; minReplicas != nil && *minReplicas <= 0 {
@@ -177,17 +240,17 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 					return errors.New("controlledValues shouldn't be specified if container scaling mode is off")
 				}
 			}
-			if err := validateStartupBoost(policy.StartupBoost, isCreate); err != nil {
+			if err := validateStartupBoost(policy.StartupBoost, opts); err != nil {
 				return fmt.Errorf("invalid startupBoost in container %s: %v", policy.ContainerName, err)
 			}
 		}
 	}
 
-	if err := validateStartupBoost(vpa.Spec.StartupBoost, isCreate); err != nil {
+	if err := validateStartupBoost(vpa.Spec.StartupBoost, opts); err != nil {
 		return fmt.Errorf("invalid startupBoost: %v", err)
 	}
 
-	if isCreate && vpa.Spec.TargetRef == nil {
+	if opts.IsVPACreate && vpa.Spec.TargetRef == nil {
 		return errors.New("targetRef is required. If you're using v1beta1 version of the API, please migrate to v1")
 	}
 
@@ -198,12 +261,12 @@ func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, isCreate bool) error {
 	return nil
 }
 
-func validateStartupBoost(startupBoost *vpa_types.StartupBoost, isCreate bool) error {
+func validateStartupBoost(startupBoost *vpa_types.StartupBoost, opts VPAValidationOptions) error {
 	if startupBoost == nil {
 		return nil
 	}
 
-	if !features.Enabled(features.CPUStartupBoost) && isCreate {
+	if !opts.AllowCPUStartupBoost {
 		return fmt.Errorf("in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost)
 	}
 
@@ -263,16 +326,15 @@ func validateMemoryResolution(val apires.Quantity) error {
 	return nil
 }
 
-func validatePerVPAFeatureFlag(vpa *vpa_types.VerticalPodAutoscaler) error {
-	featureFlagOn := features.Enabled(features.PerVPAConfig)
-	if !featureFlagOn && vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil {
+func validatePerVPAFeatureFlag(vpa *vpa_types.VerticalPodAutoscaler, opts VPAValidationOptions) error {
+	if vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil && !opts.AllowPerVPAConfig {
 		return fmt.Errorf("EvictAfterOOMSeconds is not supported when feature flag %s is disabled", features.PerVPAConfig)
 	}
 
 	if vpa.Spec.ResourcePolicy != nil {
 		for _, policy := range vpa.Spec.ResourcePolicy.ContainerPolicies {
 			perVPA := policy.OOMBumpUpRatio != nil || policy.OOMMinBumpUp != nil
-			if !featureFlagOn && perVPA {
+			if !opts.AllowPerVPAConfig && perVPA {
 				return fmt.Errorf("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag %s is disabled", features.PerVPAConfig)
 			}
 		}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler_test.go
@@ -58,13 +58,10 @@ func TestValidateVPA(t *testing.T) {
 	validCPUBoostTypeQuantity := vpa_types.QuantityStartupBoostType
 
 	tests := []struct {
-		name                                 string
-		vpa                                  vpa_types.VerticalPodAutoscaler
-		isCreate                             bool
-		expectError                          error
-		inPlaceOrRecreateFeatureGateDisabled bool
-		PerVPAConfigDisabled                 bool
-		cpuStartupBoostFeatureGateDisabled   bool
+		name        string
+		vpa         vpa_types.VerticalPodAutoscaler
+		expectError error
+		opts        VPAValidationOptions
 	}{
 		{
 			name: "empty update",
@@ -73,7 +70,7 @@ func TestValidateVPA(t *testing.T) {
 		{
 			name:        "empty create",
 			vpa:         vpa_types.VerticalPodAutoscaler{},
-			isCreate:    true,
+			opts:        VPAValidationOptions{IsVPACreate: true},
 			expectError: errors.New("targetRef is required. If you're using v1beta1 version of the API, please migrate to v1"),
 		},
 		{
@@ -105,22 +102,8 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:                             true,
-			inPlaceOrRecreateFeatureGateDisabled: true,
-			expectError:                          fmt.Errorf("in order to use UpdateMode %s, you must enable feature gate %s in the admission-controller args", vpa_types.UpdateModeInPlaceOrRecreate, features.InPlaceOrRecreate),
-		},
-		{
-			name: "updating VPA with InPlaceOrRecreate update mode allowed by disabled feature gate",
-			vpa: vpa_types.VerticalPodAutoscaler{
-				Spec: vpa_types.VerticalPodAutoscalerSpec{
-					UpdatePolicy: &vpa_types.PodUpdatePolicy{
-						UpdateMode: &inPlaceOrRecreateUpdateMode,
-					},
-				},
-			},
-			isCreate:                             false,
-			inPlaceOrRecreateFeatureGateDisabled: true,
-			expectError:                          nil,
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowInPlaceOrRecreate: false},
+			expectError: fmt.Errorf("in order to use UpdateMode %s, you must enable feature gate %s in the admission-controller args", vpa_types.UpdateModeInPlaceOrRecreate, features.InPlaceOrRecreate),
 		},
 		{
 			name: "InPlaceOrRecreate update mode enabled by feature gate",
@@ -129,8 +112,13 @@ func TestValidateVPA(t *testing.T) {
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode: &inPlaceOrRecreateUpdateMode,
 					},
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 				},
 			},
+			opts: VPAValidationOptions{IsVPACreate: true, AllowInPlaceOrRecreate: true},
 		},
 		{
 			name: "zero minReplicas",
@@ -345,9 +333,8 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:                           true,
-			cpuStartupBoostFeatureGateDisabled: true,
-			expectError:                        fmt.Errorf("invalid startupBoost: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: false},
+			expectError: fmt.Errorf("invalid startupBoost: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
 		},
 		{
 			name: "container startupBoost with feature gate disabled",
@@ -367,9 +354,8 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:                           true,
-			cpuStartupBoostFeatureGateDisabled: true,
-			expectError:                        fmt.Errorf("invalid startupBoost in container loot box: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: false},
+			expectError: fmt.Errorf("invalid startupBoost in container loot box: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
 		},
 		{
 			name: "top-level startupBoost with bad factor",
@@ -383,7 +369,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:    true,
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 			expectError: errors.New("invalid startupBoost: invalid startupBoost.cpu.factor: must be >= 1 for type Factor"),
 		},
 		{
@@ -405,7 +391,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:    true,
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 			expectError: errors.New("invalid startupBoost in container loot box: invalid startupBoost.cpu.factor: must be >= 1 for type Factor"),
 		},
 		{
@@ -424,7 +410,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:    true,
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 			expectError: fmt.Errorf("invalid startupBoost: invalid startupBoost.cpu.quantity: CPU [%v] must be a whole number of milli CPUs", &badCPUBoostQuantity),
 		},
 		{
@@ -450,7 +436,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:    true,
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 			expectError: fmt.Errorf("invalid startupBoost in container loot box: invalid startupBoost.cpu.quantity: CPU [%v] must be a whole number of milli CPUs", &badCPUBoostQuantity),
 		},
 		{
@@ -464,7 +450,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:    true,
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 			expectError: fmt.Errorf("invalid startupBoost: startupBoost.cpu.type field is required and must be either %s or %s, got %v", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType, badCPUBoostType),
 		},
 		{
@@ -485,7 +471,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:    true,
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 			expectError: fmt.Errorf("invalid startupBoost in container loot box: startupBoost.cpu.type field is required and must be either %s or %s, got %v", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType, badCPUBoostType),
 		},
 		{
@@ -497,7 +483,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:    true,
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 			expectError: fmt.Errorf("invalid startupBoost: startupBoost.cpu.type field is required and must be either %s or %s", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType),
 		},
 		{
@@ -516,7 +502,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate:    true,
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 			expectError: fmt.Errorf("invalid startupBoost in container loot box: startupBoost.cpu.type field is required and must be either %s or %s", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType),
 		},
 		{
@@ -535,7 +521,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate: true,
+			opts: VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 		},
 		{
 			name: "container startupBoost with valid factor",
@@ -560,7 +546,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate: true,
+			opts: VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 		},
 		{
 			name: "top-level startupBoost with valid quantity",
@@ -578,7 +564,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate: true,
+			opts: VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 		},
 		{
 			name: "container startupBoost with valid quantity",
@@ -603,7 +589,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate: true,
+			opts: VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 		},
 		{
 			name: "top-level and container startupBoost",
@@ -634,7 +620,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			isCreate: true,
+			opts: VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
 		},
 		{
 			name: "per-vpa config active and used",
@@ -642,6 +628,10 @@ func TestValidateVPA(t *testing.T) {
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode: &validUpdateMode,
+					},
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
 					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
@@ -660,12 +650,16 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			PerVPAConfigDisabled: false,
+			opts: VPAValidationOptions{IsVPACreate: true, AllowPerVPAConfig: true},
 		},
 		{
 			name: "per-vpa config active and used evictOOMThreshold",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode:           &validUpdateMode,
 						EvictAfterOOMSeconds: ptr.To(int32(600)),
@@ -687,7 +681,7 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			PerVPAConfigDisabled: false,
+			opts: VPAValidationOptions{IsVPACreate: true, AllowPerVPAConfig: true},
 		},
 		{
 			name: "per-vpa config disabled and used",
@@ -713,20 +707,20 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			PerVPAConfigDisabled: true,
-			expectError:          errors.New("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag PerVPAConfig is disabled"),
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowPerVPAConfig: false},
+			expectError: errors.New("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag PerVPAConfig is disabled"),
 		},
 	}
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("test case: %s", tc.name), func(t *testing.T) {
-			if tc.inPlaceOrRecreateFeatureGateDisabled {
+			if !tc.opts.AllowInPlaceOrRecreate || !tc.opts.AllowCPUStartupBoost {
 				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, features.MutableFeatureGate, version.MustParse("1.5"))
-				featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlaceOrRecreate, !tc.inPlaceOrRecreateFeatureGateDisabled)
+				featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.InPlaceOrRecreate, tc.opts.AllowInPlaceOrRecreate)
 			} else {
-				featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.CPUStartupBoost, !tc.cpuStartupBoostFeatureGateDisabled)
+				featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.CPUStartupBoost, tc.opts.AllowCPUStartupBoost)
 			}
-			featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.PerVPAConfig, !tc.PerVPAConfigDisabled)
-			err := ValidateVPA(&tc.vpa, tc.isCreate)
+			featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.PerVPAConfig, tc.opts.AllowPerVPAConfig)
+			err := ValidateVPA(&tc.vpa, tc.opts)
 			if tc.expectError == nil {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Previous there was a bug that allowed a user to use an alpha (off) feature by updating an existing VPA resource.
This changes the logic to be closer to what k/k does by:

- On create - allow if feature gate enabled
- On update - allow if feature gate is enabled or if the field exists already in the resource

This code could be cleaned up more, and I plan to do that in the future, but for now it's just to fix the bug in time for the next release.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where users could use alpha (off-by-default) features by updating an existing VPA resource, bypassing the feature gate check.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
