### PR TITLE
[cluster-autoscaler-release-1.34] fix: replace RemoveNodeInfo with tainted ghost node in scale-down simulation

### DIFF
--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -287,9 +287,6 @@ func (r *RemovalSimulator) replaceWithTaintedGhostNode(nodeName string, timestam
 		Effect: apiv1.TaintEffectNoSchedule,
 	})
 	ghostNodeInfo := framework.NewNodeInfo(taintedNode, nodeInfo.LocalResourceSlices)
-	if nodeInfo.CSINode != nil {
-		ghostNodeInfo.SetCSINode(nodeInfo.CSINode)
-	}
 	if err = r.clusterSnapshot.AddNodeInfo(ghostNodeInfo); err != nil {
 		return fmt.Errorf("couldn't add tainted ghost node for %s: %v", nodeName, err)
 	}

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/tpu"
 
 	"k8s.io/klog/v2"
@@ -236,8 +237,10 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
 			klog.Errorf("Simulating removal of %s/%s return error; %v", pod.Namespace, pod.Name, err)
 		}
 	}
-	// Remove the node from the snapshot, so that it doesn't interfere with topology spread constraint scheduling.
-	r.clusterSnapshot.RemoveNodeInfo(removedNode)
+
+	if err := r.replaceWithTaintedGhostNode(removedNode, timestamp); err != nil {
+		return err
+	}
 
 	newpods := make([]*apiv1.Pod, 0, len(pods))
 	for _, podptr := range pods {
@@ -252,6 +255,39 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
 	}
 	if len(statuses) != len(newpods) {
 		return fmt.Errorf("can reschedule only %d out of %d pods", len(statuses), len(newpods))
+	}
+
+	// After successful scheduling simulation, remove the tainted ghost node so that
+	// persisted snapshot state (used by subsequent simulations when canPersist=true)
+	// correctly reflects the node being gone.
+	return r.clusterSnapshot.RemoveNodeInfo(removedNode)
+}
+
+// replaceWithTaintedGhostNode replaces the given node in the snapshot with a
+// pod-less copy carrying the ToBeDeletedByClusterAutoscaler NoSchedule taint.
+// This mirrors what happens in reality during drain: the node is tainted but
+// stays in the cluster. Keeping it in the snapshot is critical for
+// PodTopologySpread constraints with the default nodeTaintsPolicy=Ignore,
+// where the scheduler still counts tainted nodes as topology domains even
+// though pods can't schedule on them. Removing the node entirely would
+// eliminate its domain from topology calculations, making the simulation
+// overly optimistic and causing scale-down/scale-up oscillation.
+func (r *RemovalSimulator) replaceWithTaintedGhostNode(nodeName string, timestamp time.Time) error {
+	nodeInfo, err := r.clusterSnapshot.GetNodeInfo(nodeName)
+	if err != nil {
+		return fmt.Errorf("couldn't get NodeInfo for removed node %s: %v", nodeName, err)
+	}
+	taintedNode := nodeInfo.Node().DeepCopy()
+	taintedNode.Spec.Taints = append(taintedNode.Spec.Taints, apiv1.Taint{
+		Key:    taints.ToBeDeletedTaint,
+		Value:  fmt.Sprint(timestamp.Unix()),
+		Effect: apiv1.TaintEffectNoSchedule,
+	})
+	if err = r.clusterSnapshot.RemoveNodeInfo(nodeName); err != nil {
+		return fmt.Errorf("couldn't remove NodeInfo for %s: %v", nodeName, err)
+	}
+	if err = r.clusterSnapshot.AddNodeInfo(framework.NewNodeInfo(taintedNode, nil)); err != nil {
+		return fmt.Errorf("couldn't add tainted ghost node for %s: %v", nodeName, err)
 	}
 	return nil
 }

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -277,15 +277,15 @@ func (r *RemovalSimulator) replaceWithTaintedGhostNode(nodeName string, timestam
 	if err != nil {
 		return fmt.Errorf("couldn't get NodeInfo for removed node %s: %v", nodeName, err)
 	}
+	if err = r.clusterSnapshot.RemoveNodeInfo(nodeName); err != nil {
+		return fmt.Errorf("couldn't remove NodeInfo for %s: %v", nodeName, err)
+	}
 	taintedNode := nodeInfo.Node().DeepCopy()
 	taintedNode.Spec.Taints = append(taintedNode.Spec.Taints, apiv1.Taint{
 		Key:    taints.ToBeDeletedTaint,
 		Value:  fmt.Sprint(timestamp.Unix()),
 		Effect: apiv1.TaintEffectNoSchedule,
 	})
-	if err = r.clusterSnapshot.RemoveNodeInfo(nodeName); err != nil {
-		return fmt.Errorf("couldn't remove NodeInfo for %s: %v", nodeName, err)
-	}
 	ghostNodeInfo := framework.NewNodeInfo(taintedNode, nodeInfo.LocalResourceSlices)
 	if nodeInfo.CSINode != nil {
 		ghostNodeInfo.SetCSINode(nodeInfo.CSINode)

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -286,7 +286,11 @@ func (r *RemovalSimulator) replaceWithTaintedGhostNode(nodeName string, timestam
 	if err = r.clusterSnapshot.RemoveNodeInfo(nodeName); err != nil {
 		return fmt.Errorf("couldn't remove NodeInfo for %s: %v", nodeName, err)
 	}
-	if err = r.clusterSnapshot.AddNodeInfo(framework.NewNodeInfo(taintedNode, nil)); err != nil {
+	ghostNodeInfo := framework.NewNodeInfo(taintedNode, nodeInfo.LocalResourceSlices)
+	if nodeInfo.CSINode != nil {
+		ghostNodeInfo.SetCSINode(nodeInfo.CSINode)
+	}
+	if err = r.clusterSnapshot.AddNodeInfo(ghostNodeInfo); err != nil {
 		return fmt.Errorf("couldn't add tainted ghost node for %s: %v", nodeName, err)
 	}
 	return nil

--- a/cluster-autoscaler/simulator/cluster_scheduling_test.go
+++ b/cluster-autoscaler/simulator/cluster_scheduling_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cluster-autoscaler/simulator/cluster_scheduling_test.go
+++ b/cluster-autoscaler/simulator/cluster_scheduling_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+// TestTopologySpreadTaintScheduling verifies scheduler behavior in
+// the post-taint state that motivates the ghost-node fix in SimulateNodeRemoval.
+//
+// The CAS simulation tests (SimulateNodeRemoval with default vs Honor policy)
+// live in cluster_test.go. This test validates the scheduler-side premise: that
+// after CAS taints a node with ToBeDeletedByClusterAutoscaler:NoSchedule, the
+// replacement pod cannot be placed (default policy) or can (Honor).
+func TestTopologySpreadTaintScheduling(t *testing.T) {
+	// --- Setup: 3 nodes with hostname topology, 1 TSC pod per node ---
+	node1 := BuildTestNode("node1", 1000, 2000000)
+	node2 := BuildTestNode("node2", 1000, 2000000)
+	node3 := BuildTestNode("node3", 1000, 2000000)
+	node1.Labels["kubernetes.io/hostname"] = "node1"
+	node2.Labels["kubernetes.io/hostname"] = "node2"
+	node3.Labels["kubernetes.io/hostname"] = "node3"
+	SetNodeReadyState(node1, true, time.Time{})
+	SetNodeReadyState(node2, true, time.Time{})
+	SetNodeReadyState(node3, true, time.Time{})
+
+	ownerRefs := GenerateOwnerReferences("rs", "ReplicaSet", "extensions/v1beta1", "")
+
+	// TSC with default nodeTaintsPolicy (nil → Ignore)
+	tscDefault := apiv1.TopologySpreadConstraint{
+		MaxSkew:           1,
+		TopologyKey:       "kubernetes.io/hostname",
+		WhenUnsatisfiable: apiv1.DoNotSchedule,
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "topo-app"},
+		},
+	}
+
+	// TSC with nodeTaintsPolicy=Honor (the fix)
+	honor := apiv1.NodeInclusionPolicyHonor
+	tscHonor := apiv1.TopologySpreadConstraint{
+		MaxSkew:           1,
+		TopologyKey:       "kubernetes.io/hostname",
+		WhenUnsatisfiable: apiv1.DoNotSchedule,
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "topo-app"},
+		},
+		NodeTaintsPolicy: &honor,
+	}
+
+	makePods := func(tsc apiv1.TopologySpreadConstraint) []*apiv1.Pod {
+		nodeNames := []string{"node1", "node2", "node3"}
+		pods := make([]*apiv1.Pod, len(nodeNames))
+		for i, nodeName := range nodeNames {
+			pod := BuildTestPod(fmt.Sprintf("pod%d", i+1), 100, 100000)
+			pod.Labels = map[string]string{"app": "topo-app"}
+			pod.OwnerReferences = ownerRefs
+			pod.Spec.NodeName = nodeName
+			pod.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{tsc}
+			pods[i] = pod
+		}
+		return pods
+	}
+
+	// -----------------------------------------------------------------------
+	// Post-taint state: replacement pod is UNSCHEDULABLE (default policy).
+	//
+	// In reality CAS taints node1 with NoSchedule, then drains it. After
+	// eviction, the cluster state is:
+	//   node1 (tainted, 0 matching pods)
+	//   node2 (1 matching pod)
+	//   node3 (1 matching pod)
+	//
+	// With default nodeTaintsPolicy=Ignore, PodTopologySpread still counts
+	// node1 as a domain with matchNum=0, so minMatchNum=0.
+	// Scheduling on node2: skew = (1+1) - 0 = 2 > maxSkew(1) → REJECT
+	// Scheduling on node3: skew = (1+1) - 0 = 2 > maxSkew(1) → REJECT
+	// Scheduling on node1: rejected by TaintToleration (NoSchedule)
+	//
+	// Result: pod is unschedulable on ALL nodes → CAS will trigger scale-up.
+	// -----------------------------------------------------------------------
+	t.Run("post_taint_scheduling_fails_with_default_nodeTaintsPolicy", func(t *testing.T) {
+		// Build tainted node1 (after CAS marks it ToBeDeleted)
+		taintedNode1 := node1.DeepCopy()
+		taintedNode1.Spec.Taints = []apiv1.Taint{{
+			Key:    "ToBeDeletedByClusterAutoscaler",
+			Effect: apiv1.TaintEffectNoSchedule,
+			Value:  fmt.Sprint(time.Now().Unix()),
+		}}
+
+		// Only pods on node2 and node3 survive (pod1 was evicted from node1)
+		podsDefault := makePods(tscDefault)
+		survivingPods := []*apiv1.Pod{podsDefault[1], podsDefault[2]}
+
+		snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+		allNodes := []*apiv1.Node{taintedNode1, node2, node3}
+		clustersnapshot.InitializeClusterSnapshotOrDie(t, snapshot, allNodes, survivingPods)
+
+		// Replacement pod created by the RS controller after eviction
+		replacementPod := BuildTestPod("pod1-replacement", 100, 100000)
+		replacementPod.Labels = map[string]string{"app": "topo-app"}
+		replacementPod.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{tscDefault}
+
+		_, schedErr := snapshot.SchedulePodOnAnyNodeMatching(replacementPod, func(ni *framework.NodeInfo) bool {
+			return true
+		})
+		assert.NotNil(t, schedErr,
+			"replacement pod should be UNSCHEDULABLE with default nodeTaintsPolicy=Ignore: "+
+				"tainted node1 is a phantom domain with 0 pods, inflating skew on all real candidates")
+	})
+
+	// -----------------------------------------------------------------------
+	// Post-taint state: scheduling SUCCEEDS with nodeTaintsPolicy=Honor.
+	//
+	// When the TSC has nodeTaintsPolicy=Honor, PodTopologySpread excludes
+	// node1 (untolerated NoSchedule taint) from domain counting entirely.
+	// Only 2 domains remain: node2(1), node3(1).
+	// Scheduling on node2: skew = (1+1) - 1 = 1 ≤ maxSkew(1) → ACCEPT
+	//
+	// This matches CAS's simulation behavior (RemoveNodeInfo), so the
+	// scale-down decision and real-world outcome are consistent.
+	// -----------------------------------------------------------------------
+	t.Run("post_taint_scheduling_succeeds_with_nodeTaintsPolicy_Honor", func(t *testing.T) {
+		taintedNode1 := node1.DeepCopy()
+		taintedNode1.Spec.Taints = []apiv1.Taint{{
+			Key:    "ToBeDeletedByClusterAutoscaler",
+			Effect: apiv1.TaintEffectNoSchedule,
+			Value:  fmt.Sprint(time.Now().Unix()),
+		}}
+
+		podsHonor := makePods(tscHonor)
+		survivingPods := []*apiv1.Pod{podsHonor[1], podsHonor[2]}
+
+		snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+		allNodes := []*apiv1.Node{taintedNode1, node2, node3}
+		clustersnapshot.InitializeClusterSnapshotOrDie(t, snapshot, allNodes, survivingPods)
+
+		replacementPod := BuildTestPod("pod1-replacement", 100, 100000)
+		replacementPod.Labels = map[string]string{"app": "topo-app"}
+		replacementPod.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{tscHonor}
+
+		nodeName, schedErr := snapshot.SchedulePodOnAnyNodeMatching(replacementPod, func(ni *framework.NodeInfo) bool {
+			return true
+		})
+		assert.Nil(t, schedErr,
+			"replacement pod should be SCHEDULABLE with nodeTaintsPolicy=Honor: "+
+				"tainted node1 is excluded from domain counting, matching CAS simulation")
+		assert.NotEmpty(t, nodeName, "should find a node to schedule on")
+	})
+
+}

--- a/cluster-autoscaler/simulator/cluster_scheduling_test.go
+++ b/cluster-autoscaler/simulator/cluster_scheduling_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cluster-autoscaler/simulator/cluster_scheduling_test.go
+++ b/cluster-autoscaler/simulator/cluster_scheduling_test.go
@@ -53,7 +53,7 @@ func TestTopologySpreadTaintScheduling(t *testing.T) {
 	ownerRefs := GenerateOwnerReferences("rs", "ReplicaSet", "extensions/v1beta1", "")
 
 	// TSC with default nodeTaintsPolicy (nil → Ignore)
-	tscDefault := apiv1.TopologySpreadConstraint{
+	defaultTSC := apiv1.TopologySpreadConstraint{
 		MaxSkew:           1,
 		TopologyKey:       "kubernetes.io/hostname",
 		WhenUnsatisfiable: apiv1.DoNotSchedule,
@@ -62,23 +62,16 @@ func TestTopologySpreadTaintScheduling(t *testing.T) {
 		},
 	}
 
-	// TSC with nodeTaintsPolicy=Honor (the fix)
+	// TSC with nodeTaintsPolicy=Honor
 	honor := apiv1.NodeInclusionPolicyHonor
-	tscHonor := apiv1.TopologySpreadConstraint{
-		MaxSkew:           1,
-		TopologyKey:       "kubernetes.io/hostname",
-		WhenUnsatisfiable: apiv1.DoNotSchedule,
-		LabelSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{"app": "topo-app"},
-		},
-		NodeTaintsPolicy: &honor,
-	}
+	honorTSC := defaultTSC
+	honorTSC.NodeTaintsPolicy = &honor
 
 	makePods := func(tsc apiv1.TopologySpreadConstraint) []*apiv1.Pod {
 		nodeNames := []string{"node1", "node2", "node3"}
 		pods := make([]*apiv1.Pod, len(nodeNames))
 		for i, nodeName := range nodeNames {
-			pod := BuildTestPod(fmt.Sprintf("pod%d", i+1), 100, 100000)
+			pod := BuildTestPod(fmt.Sprintf("tsc-pod-%s", nodeName), 100, 100000)
 			pod.Labels = map[string]string{"app": "topo-app"}
 			pod.OwnerReferences = ownerRefs
 			pod.Spec.NodeName = nodeName
@@ -88,90 +81,64 @@ func TestTopologySpreadTaintScheduling(t *testing.T) {
 		return pods
 	}
 
-	// -----------------------------------------------------------------------
-	// Post-taint state: replacement pod is UNSCHEDULABLE (default policy).
-	//
-	// In reality CAS taints node1 with NoSchedule, then drains it. After
-	// eviction, the cluster state is:
-	//   node1 (tainted, 0 matching pods)
-	//   node2 (1 matching pod)
-	//   node3 (1 matching pod)
-	//
-	// With default nodeTaintsPolicy=Ignore, PodTopologySpread still counts
-	// node1 as a domain with matchNum=0, so minMatchNum=0.
-	// Scheduling on node2: skew = (1+1) - 0 = 2 > maxSkew(1) → REJECT
-	// Scheduling on node3: skew = (1+1) - 0 = 2 > maxSkew(1) → REJECT
-	// Scheduling on node1: rejected by TaintToleration (NoSchedule)
-	//
-	// Result: pod is unschedulable on ALL nodes → CAS will trigger scale-up.
-	// -----------------------------------------------------------------------
-	t.Run("post_taint_scheduling_fails_with_default_nodeTaintsPolicy", func(t *testing.T) {
-		// Build tainted node1 (after CAS marks it ToBeDeleted)
-		taintedNode1 := node1.DeepCopy()
-		taintedNode1.Spec.Taints = []apiv1.Taint{{
-			Key:    "ToBeDeletedByClusterAutoscaler",
-			Effect: apiv1.TaintEffectNoSchedule,
-			Value:  fmt.Sprint(time.Now().Unix()),
-		}}
+	tests := []struct {
+		name          string
+		tsc           apiv1.TopologySpreadConstraint
+		expectFailure bool
+	}{
+		{
+			// With default nodeTaintsPolicy=Ignore, PodTopologySpread still counts
+			// tainted node1 as a domain with matchNum=0, so minMatchNum=0.
+			// Scheduling on node2: skew = (1+1) - 0 = 2 > maxSkew(1) → REJECT
+			// Scheduling on node3: skew = (1+1) - 0 = 2 > maxSkew(1) → REJECT
+			// Scheduling on node1: rejected by TaintToleration (NoSchedule)
+			name:          "post-taint scheduling fails with default nodeTaintsPolicy",
+			tsc:           defaultTSC,
+			expectFailure: true,
+		},
+		{
+			// With nodeTaintsPolicy=Honor, PodTopologySpread excludes tainted
+			// node1 from domain counting. Only 2 domains: node2(1), node3(1).
+			// Scheduling on node2: skew = (1+1) - 1 = 1 ≤ maxSkew(1) → ACCEPT
+			name:          "post-taint scheduling succeeds with nodeTaintsPolicy Honor",
+			tsc:           honorTSC,
+			expectFailure: false,
+		},
+	}
 
-		// Only pods on node2 and node3 survive (pod1 was evicted from node1)
-		podsDefault := makePods(tscDefault)
-		survivingPods := []*apiv1.Pod{podsDefault[1], podsDefault[2]}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			taintedNode1 := node1.DeepCopy()
+			taintedNode1.Spec.Taints = []apiv1.Taint{{
+				Key:    "ToBeDeletedByClusterAutoscaler",
+				Effect: apiv1.TaintEffectNoSchedule,
+				Value:  fmt.Sprint(time.Now().Unix()),
+			}}
 
-		snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-		allNodes := []*apiv1.Node{taintedNode1, node2, node3}
-		clustersnapshot.InitializeClusterSnapshotOrDie(t, snapshot, allNodes, survivingPods)
+			// Only pods on node2 and node3 survive (pod on node1 was evicted).
+			pods := makePods(tc.tsc)
+			survivingPods := []*apiv1.Pod{pods[1], pods[2]}
 
-		// Replacement pod created by the RS controller after eviction
-		replacementPod := BuildTestPod("pod1-replacement", 100, 100000)
-		replacementPod.Labels = map[string]string{"app": "topo-app"}
-		replacementPod.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{tscDefault}
+			snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+			allNodes := []*apiv1.Node{taintedNode1, node2, node3}
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, snapshot, allNodes, survivingPods)
 
-		_, schedErr := snapshot.SchedulePodOnAnyNodeMatching(replacementPod, func(ni *framework.NodeInfo) bool {
-			return true
+			replacementPod := BuildTestPod("replacement-pod", 100, 100000)
+			replacementPod.Labels = map[string]string{"app": "topo-app"}
+			replacementPod.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{tc.tsc}
+
+			nodeName, schedErr := snapshot.SchedulePodOnAnyNodeMatching(replacementPod, func(ni *framework.NodeInfo) bool {
+				return true
+			})
+
+			if tc.expectFailure {
+				assert.NotNil(t, schedErr,
+					"replacement pod should be UNSCHEDULABLE: tainted node1 is a phantom domain with 0 pods")
+			} else {
+				assert.Nil(t, schedErr,
+					"replacement pod should be SCHEDULABLE: tainted node1 is excluded from domain counting")
+				assert.NotEmpty(t, nodeName, "should find a node to schedule on")
+			}
 		})
-		assert.NotNil(t, schedErr,
-			"replacement pod should be UNSCHEDULABLE with default nodeTaintsPolicy=Ignore: "+
-				"tainted node1 is a phantom domain with 0 pods, inflating skew on all real candidates")
-	})
-
-	// -----------------------------------------------------------------------
-	// Post-taint state: scheduling SUCCEEDS with nodeTaintsPolicy=Honor.
-	//
-	// When the TSC has nodeTaintsPolicy=Honor, PodTopologySpread excludes
-	// node1 (untolerated NoSchedule taint) from domain counting entirely.
-	// Only 2 domains remain: node2(1), node3(1).
-	// Scheduling on node2: skew = (1+1) - 1 = 1 ≤ maxSkew(1) → ACCEPT
-	//
-	// This matches CAS's simulation behavior (RemoveNodeInfo), so the
-	// scale-down decision and real-world outcome are consistent.
-	// -----------------------------------------------------------------------
-	t.Run("post_taint_scheduling_succeeds_with_nodeTaintsPolicy_Honor", func(t *testing.T) {
-		taintedNode1 := node1.DeepCopy()
-		taintedNode1.Spec.Taints = []apiv1.Taint{{
-			Key:    "ToBeDeletedByClusterAutoscaler",
-			Effect: apiv1.TaintEffectNoSchedule,
-			Value:  fmt.Sprint(time.Now().Unix()),
-		}}
-
-		podsHonor := makePods(tscHonor)
-		survivingPods := []*apiv1.Pod{podsHonor[1], podsHonor[2]}
-
-		snapshot := testsnapshot.NewTestSnapshotOrDie(t)
-		allNodes := []*apiv1.Node{taintedNode1, node2, node3}
-		clustersnapshot.InitializeClusterSnapshotOrDie(t, snapshot, allNodes, survivingPods)
-
-		replacementPod := BuildTestPod("pod1-replacement", 100, 100000)
-		replacementPod.Labels = map[string]string{"app": "topo-app"}
-		replacementPod.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{tscHonor}
-
-		nodeName, schedErr := snapshot.SchedulePodOnAnyNodeMatching(replacementPod, func(ni *framework.NodeInfo) bool {
-			return true
-		})
-		assert.Nil(t, schedErr,
-			"replacement pod should be SCHEDULABLE with nodeTaintsPolicy=Honor: "+
-				"tainted node1 is excluded from domain counting, matching CAS simulation")
-		assert.NotEmpty(t, nodeName, "should find a node to schedule on")
-	})
-
+	}
 }

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -186,11 +188,6 @@ func TestFindNodesToRemove(t *testing.T) {
 	blocker2 := BuildTestPod("blocker2", 100, 100000)
 	blocker2.Spec.NodeName = "topo-n3"
 
-	topoNodeToRemove := NodeToBeRemoved{
-		Node:             topoNode1,
-		PodsToReschedule: []*apiv1.Pod{pod5},
-	}
-
 	tests := []findNodesToRemoveTestConfig{
 		{
 			name:       "just an empty node, should be removed",
@@ -228,12 +225,12 @@ func TestFindNodesToRemove(t *testing.T) {
 			toRemove:   []NodeToBeRemoved{emptyNodeToRemove, drainableNodeToRemove},
 		},
 		{
-			name:       "topology spread constraint test - one node should be removable",
+			name:       "topology spread constraint test - node unremovable due to phantom zone",
 			pods:       []*apiv1.Pod{pod5, pod6, pod7, blocker1, blocker2},
 			allNodes:   []*apiv1.Node{topoNode1, topoNode2, topoNode3},
 			candidates: []string{topoNode1.Name, topoNode2.Name, topoNode3.Name},
-			toRemove:   []NodeToBeRemoved{topoNodeToRemove},
 			unremovable: []*UnremovableNode{
+				{Node: topoNode1, Reason: NoPlaceToMovePods},
 				{Node: topoNode2, Reason: BlockedByPod, BlockingPod: &drain.BlockingPod{Pod: blocker1, Reason: drain.NotReplicated}},
 				{Node: topoNode3, Reason: BlockedByPod, BlockingPod: &drain.BlockingPod{Pod: blocker2, Reason: drain.NotReplicated}},
 			},

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -302,17 +302,21 @@ func TestSimulateNodeRemoval(t *testing.T) {
 	registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, rsLister, nil)
 
 	ownerRefs := GenerateOwnerReferences("rs", "ReplicaSet", "extensions/v1beta1", "")
-	buildReplicaSetPod := func(name, nodeName string, cpu, memory int64) *apiv1.Pod {
-		pod := BuildTestPod(name, cpu, memory)
-		pod.OwnerReferences = ownerRefs
-		pod.Spec.NodeName = nodeName
-		return pod
-	}
-	buildStandalonePod := func(name, nodeName string, cpu, memory int64) *apiv1.Pod {
-		pod := BuildTestPod(name, cpu, memory)
-		pod.Spec.NodeName = nodeName
-		return pod
-	}
+
+	// Pods for the basic drain/capacity test cases.
+	drainableReplicaPodA := BuildTestPod("drainable-rs-pod-a", 100, 100000)
+	drainableReplicaPodA.OwnerReferences = ownerRefs
+	drainableReplicaPodA.Spec.NodeName = drainableNode.Name
+
+	drainableReplicaPodB := BuildTestPod("drainable-rs-pod-b", 100, 100000)
+	drainableReplicaPodB.OwnerReferences = ownerRefs
+	drainableReplicaPodB.Spec.NodeName = drainableNode.Name
+
+	standalonePodOnNonDrainable := BuildTestPod("standalone-on-non-drainable", 100, 100000)
+	standalonePodOnNonDrainable.Spec.NodeName = nonDrainableNode.Name
+
+	largePodOnFull := BuildTestPod("large-pod-on-full", 1000, 100000)
+	largePodOnFull.Spec.NodeName = fullNode.Name
 
 	clusterSnapshot := testsnapshot.NewTestSnapshotOrDie(t)
 
@@ -355,6 +359,20 @@ func TestSimulateNodeRemoval(t *testing.T) {
 	honorTSC := defaultTSC
 	honorTSC.NodeTaintsPolicy = &honorPolicy
 
+	// Pods for topology-spread test cases (default policy).
+	defaultPodN1 := buildTopoPod("default-tsc-pod-n1", topoNode1.Name, defaultTSC)
+	defaultPodN2 := buildTopoPod("default-tsc-pod-n2", topoNode2.Name, defaultTSC)
+	defaultPodN3 := buildTopoPod("default-tsc-pod-n3", topoNode3.Name, defaultTSC)
+	blockerN2 := BuildTestPod("blocker-n2", 100, 100000)
+	blockerN2.Spec.NodeName = topoNode2.Name
+	blockerN3 := BuildTestPod("blocker-n3", 100, 100000)
+	blockerN3.Spec.NodeName = topoNode3.Name
+
+	// Pods for topology-spread test cases (Honor policy).
+	honorPodN1 := buildTopoPod("honor-tsc-pod-n1", topoNode1.Name, honorTSC)
+	honorPodN2 := buildTopoPod("honor-tsc-pod-n2", topoNode2.Name, honorTSC)
+	honorPodN3 := buildTopoPod("honor-tsc-pod-n3", topoNode3.Name, honorTSC)
+
 	tests := []simulateNodeRemovalTestConfig{
 		{
 			name:        "just an empty node, should be removed",
@@ -363,92 +381,60 @@ func TestSimulateNodeRemoval(t *testing.T) {
 			toRemove:    &NodeToBeRemoved{Node: emptyNode},
 			unremovable: nil,
 		},
-		func() simulateNodeRemovalTestConfig {
-			drainableReplicaPodA := buildReplicaSetPod("drainable-rs-pod-a", drainableNode.Name, 100, 100000)
-			drainableReplicaPodB := buildReplicaSetPod("drainable-rs-pod-b", drainableNode.Name, 100, 100000)
-			return simulateNodeRemovalTestConfig{
-				name:     "just a drainable node, but nowhere for pods to go to",
-				pods:     []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB},
-				nodeName: drainableNode.Name,
-				allNodes: []*apiv1.Node{drainableNode},
-				toRemove: nil,
-				unremovable: &UnremovableNode{
-					Node:   drainableNode,
-					Reason: NoPlaceToMovePods,
-				},
-			}
-		}(),
-		func() simulateNodeRemovalTestConfig {
-			drainableReplicaPodA := buildReplicaSetPod("drainable-rs-pod-a", drainableNode.Name, 100, 100000)
-			drainableReplicaPodB := buildReplicaSetPod("drainable-rs-pod-b", drainableNode.Name, 100, 100000)
-			existingStandalonePod := buildStandalonePod("existing-standalone-pod", nonDrainableNode.Name, 100, 100000)
-			return simulateNodeRemovalTestConfig{
-				name:        "drainable node, and a mostly empty node that can take its pods",
-				pods:        []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB, existingStandalonePod},
-				nodeName:    drainableNode.Name,
-				allNodes:    []*apiv1.Node{drainableNode, nonDrainableNode},
-				toRemove:    &NodeToBeRemoved{Node: drainableNode, PodsToReschedule: []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB}},
-				unremovable: nil,
-			}
-		}(),
-		func() simulateNodeRemovalTestConfig {
-			drainableReplicaPodA := buildReplicaSetPod("drainable-rs-pod-a", drainableNode.Name, 100, 100000)
-			drainableReplicaPodB := buildReplicaSetPod("drainable-rs-pod-b", drainableNode.Name, 100, 100000)
-			existingLargePod := buildStandalonePod("existing-large-pod", fullNode.Name, 1000, 100000)
-			return simulateNodeRemovalTestConfig{
-				name:        "drainable node, and a full node that cannot fit anymore pods",
-				pods:        []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB, existingLargePod},
-				nodeName:    drainableNode.Name,
-				allNodes:    []*apiv1.Node{drainableNode, fullNode},
-				toRemove:    nil,
-				unremovable: &UnremovableNode{Node: drainableNode, Reason: NoPlaceToMovePods},
-			}
-		}(),
-		func() simulateNodeRemovalTestConfig {
-			drainableReplicaPodA := buildReplicaSetPod("drainable-rs-pod-a", drainableNode.Name, 100, 100000)
-			drainableReplicaPodB := buildReplicaSetPod("drainable-rs-pod-b", drainableNode.Name, 100, 100000)
-			existingStandalonePod := buildStandalonePod("existing-standalone-pod", nonDrainableNode.Name, 100, 100000)
-			existingLargePod := buildStandalonePod("existing-large-pod", fullNode.Name, 1000, 100000)
-			return simulateNodeRemovalTestConfig{
-				name:        "4 nodes, 1 empty, 1 drainable",
-				pods:        []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB, existingStandalonePod, existingLargePod},
-				nodeName:    emptyNode.Name,
-				allNodes:    []*apiv1.Node{emptyNode, drainableNode, fullNode, nonDrainableNode},
-				toRemove:    &NodeToBeRemoved{Node: emptyNode},
-				unremovable: nil,
-			}
-		}(),
-		func() simulateNodeRemovalTestConfig {
-			constrainedPodOnNode1 := buildTopoPod("default-policy-pod-topo-n1", topoNode1.Name, defaultTSC)
-			constrainedPodOnNode2 := buildTopoPod("default-policy-pod-topo-n2", topoNode2.Name, defaultTSC)
-			constrainedPodOnNode3 := buildTopoPod("default-policy-pod-topo-n3", topoNode3.Name, defaultTSC)
-			blockerOnNode2 := buildStandalonePod("blocker-n2", topoNode2.Name, 100, 100000)
-			blockerOnNode3 := buildStandalonePod("blocker-n3", topoNode3.Name, 100, 100000)
-			return simulateNodeRemovalTestConfig{
-				name:     "topology spread constraint test - node unremovable due to phantom zone",
-				pods:     []*apiv1.Pod{constrainedPodOnNode1, constrainedPodOnNode2, constrainedPodOnNode3, blockerOnNode2, blockerOnNode3},
-				allNodes: []*apiv1.Node{topoNode1, topoNode2, topoNode3},
-				nodeName: topoNode1.Name,
-				toRemove: nil,
-				unremovable: &UnremovableNode{
-					Node:   topoNode1,
-					Reason: NoPlaceToMovePods,
-				},
-			}
-		}(),
-		func() simulateNodeRemovalTestConfig {
-			honorConstrainedPodOnNode1 := buildTopoPod("honor-policy-pod-topo-n1", topoNode1.Name, honorTSC)
-			honorConstrainedPodOnNode2 := buildTopoPod("honor-policy-pod-topo-n2", topoNode2.Name, honorTSC)
-			honorConstrainedPodOnNode3 := buildTopoPod("honor-policy-pod-topo-n3", topoNode3.Name, honorTSC)
-			return simulateNodeRemovalTestConfig{
-				name:        "topology spread constraint test - node removable with nodeTaintsPolicy Honor",
-				pods:        []*apiv1.Pod{honorConstrainedPodOnNode1, honorConstrainedPodOnNode2, honorConstrainedPodOnNode3},
-				allNodes:    []*apiv1.Node{topoNode1, topoNode2, topoNode3},
-				nodeName:    topoNode1.Name,
-				toRemove:    &NodeToBeRemoved{Node: topoNode1, PodsToReschedule: []*apiv1.Pod{honorConstrainedPodOnNode1}},
-				unremovable: nil,
-			}
-		}(),
+		{
+			name:     "just a drainable node, but nowhere for pods to go to",
+			pods:     []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB},
+			nodeName: drainableNode.Name,
+			allNodes: []*apiv1.Node{drainableNode},
+			toRemove: nil,
+			unremovable: &UnremovableNode{
+				Node:   drainableNode,
+				Reason: NoPlaceToMovePods,
+			},
+		},
+		{
+			name:        "drainable node, and a mostly empty node that can take its pods",
+			pods:        []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB, standalonePodOnNonDrainable},
+			nodeName:    drainableNode.Name,
+			allNodes:    []*apiv1.Node{drainableNode, nonDrainableNode},
+			toRemove:    &NodeToBeRemoved{Node: drainableNode, PodsToReschedule: []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB}},
+			unremovable: nil,
+		},
+		{
+			name:        "drainable node, and a full node that cannot fit anymore pods",
+			pods:        []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB, largePodOnFull},
+			nodeName:    drainableNode.Name,
+			allNodes:    []*apiv1.Node{drainableNode, fullNode},
+			toRemove:    nil,
+			unremovable: &UnremovableNode{Node: drainableNode, Reason: NoPlaceToMovePods},
+		},
+		{
+			name:        "4 nodes, 1 empty, 1 drainable",
+			pods:        []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB, standalonePodOnNonDrainable, largePodOnFull},
+			nodeName:    emptyNode.Name,
+			allNodes:    []*apiv1.Node{emptyNode, drainableNode, fullNode, nonDrainableNode},
+			toRemove:    &NodeToBeRemoved{Node: emptyNode},
+			unremovable: nil,
+		},
+		{
+			name:     "topology spread constraint test - node unremovable due to phantom zone",
+			pods:     []*apiv1.Pod{defaultPodN1, defaultPodN2, defaultPodN3, blockerN2, blockerN3},
+			allNodes: []*apiv1.Node{topoNode1, topoNode2, topoNode3},
+			nodeName: topoNode1.Name,
+			toRemove: nil,
+			unremovable: &UnremovableNode{
+				Node:   topoNode1,
+				Reason: NoPlaceToMovePods,
+			},
+		},
+		{
+			name:        "topology spread constraint test - node removable with nodeTaintsPolicy Honor",
+			pods:        []*apiv1.Pod{honorPodN1, honorPodN2, honorPodN3},
+			allNodes:    []*apiv1.Node{topoNode1, topoNode2, topoNode3},
+			nodeName:    topoNode1.Name,
+			toRemove:    &NodeToBeRemoved{Node: topoNode1, PodsToReschedule: []*apiv1.Pod{honorPodN1}},
+			unremovable: nil,
+		},
 		{
 			name:        "candidate not in clusterSnapshot should be marked unremovable",
 			nodeName:    noExistNode.Name,

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -376,6 +376,30 @@ func TestSimulateNodeRemoval(t *testing.T) {
 	blocker2 := BuildTestPod("blocker2", 100, 100000)
 	blocker2.Spec.NodeName = "topo-n3"
 
+	// Same constraint but with NodeTaintsPolicy: Honor — ghost node's taint
+	// excludes it from domain counting, so removal succeeds even with maxSkew=1.
+	honorPolicy := apiv1.NodeInclusionPolicyHonor
+	honorTopoConstraint := topoConstraint
+	honorTopoConstraint.NodeTaintsPolicy = &honorPolicy
+
+	pod8 := BuildTestPod("p8", 100, 100000)
+	pod8.Labels = map[string]string{"app": "topo-app"}
+	pod8.OwnerReferences = ownerRefs
+	pod8.Spec.NodeName = "topo-n1"
+	pod8.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{honorTopoConstraint}
+
+	pod9 := BuildTestPod("p9", 100, 100000)
+	pod9.Labels = map[string]string{"app": "topo-app"}
+	pod9.OwnerReferences = ownerRefs
+	pod9.Spec.NodeName = "topo-n2"
+	pod9.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{honorTopoConstraint}
+
+	pod10 := BuildTestPod("p10", 100, 100000)
+	pod10.Labels = map[string]string{"app": "topo-app"}
+	pod10.OwnerReferences = ownerRefs
+	pod10.Spec.NodeName = "topo-n3"
+	pod10.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{honorTopoConstraint}
+
 	tests := []simulateNodeRemovalTestConfig{
 		{
 			name:        "just an empty node, should be removed",
@@ -420,11 +444,22 @@ func TestSimulateNodeRemoval(t *testing.T) {
 			unremovable: nil,
 		},
 		{
-			name:        "topology spread constraint test - one node should be removable",
-			pods:        []*apiv1.Pod{pod5, pod6, pod7, blocker1, blocker2},
+			name:     "topology spread constraint test - node unremovable due to phantom zone",
+			pods:     []*apiv1.Pod{pod5, pod6, pod7, blocker1, blocker2},
+			allNodes: []*apiv1.Node{topoNode1, topoNode2, topoNode3},
+			nodeName: topoNode1.Name,
+			toRemove: nil,
+			unremovable: &UnremovableNode{
+				Node:   topoNode1,
+				Reason: NoPlaceToMovePods,
+			},
+		},
+		{
+			name:        "topology spread constraint test - node removable with nodeTaintsPolicy Honor",
+			pods:        []*apiv1.Pod{pod8, pod9, pod10},
 			allNodes:    []*apiv1.Node{topoNode1, topoNode2, topoNode3},
 			nodeName:    topoNode1.Name,
-			toRemove:    &NodeToBeRemoved{Node: topoNode1, PodsToReschedule: []*apiv1.Pod{pod5}},
+			toRemove:    &NodeToBeRemoved{Node: topoNode1, PodsToReschedule: []*apiv1.Pod{pod8}},
 			unremovable: nil,
 		},
 		{

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package simulator
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -28,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -272,15 +270,12 @@ func TestSimulateNodeRemoval(t *testing.T) {
 
 	// two small pods backed by ReplicaSet
 	drainableNode := BuildTestNode("n2", 1000, 2000000)
-	drainableNodeInfo := framework.NewTestNodeInfo(drainableNode)
 
 	// one small pod, not backed by anything
 	nonDrainableNode := BuildTestNode("n3", 1000, 2000000)
-	nonDrainableNodeInfo := framework.NewTestNodeInfo(nonDrainableNode)
 
 	// one very large pod
 	fullNode := BuildTestNode("n4", 1000, 2000000)
-	fullNodeInfo := framework.NewTestNodeInfo(fullNode)
 
 	// noExistNode it doesn't have any node info in the cluster snapshot.
 	noExistNode := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n5"}}
@@ -307,24 +302,17 @@ func TestSimulateNodeRemoval(t *testing.T) {
 	registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, rsLister, nil)
 
 	ownerRefs := GenerateOwnerReferences("rs", "ReplicaSet", "extensions/v1beta1", "")
-
-	pod1 := BuildTestPod("p1", 100, 100000)
-	pod1.OwnerReferences = ownerRefs
-	pod1.Spec.NodeName = "n2"
-	drainableNodeInfo.AddPod(&framework.PodInfo{Pod: pod1})
-
-	pod2 := BuildTestPod("p2", 100, 100000)
-	pod2.OwnerReferences = ownerRefs
-	pod2.Spec.NodeName = "n2"
-	drainableNodeInfo.AddPod(&framework.PodInfo{Pod: pod2})
-
-	pod3 := BuildTestPod("p3", 100, 100000)
-	pod3.Spec.NodeName = "n3"
-	nonDrainableNodeInfo.AddPod(&framework.PodInfo{Pod: pod3})
-
-	pod4 := BuildTestPod("p4", 1000, 100000)
-	pod4.Spec.NodeName = "n4"
-	fullNodeInfo.AddPod(&framework.PodInfo{Pod: pod4})
+	buildReplicaSetPod := func(name, nodeName string, cpu, memory int64) *apiv1.Pod {
+		pod := BuildTestPod(name, cpu, memory)
+		pod.OwnerReferences = ownerRefs
+		pod.Spec.NodeName = nodeName
+		return pod
+	}
+	buildStandalonePod := func(name, nodeName string, cpu, memory int64) *apiv1.Pod {
+		pod := BuildTestPod(name, cpu, memory)
+		pod.Spec.NodeName = nodeName
+		return pod
+	}
 
 	clusterSnapshot := testsnapshot.NewTestSnapshotOrDie(t)
 
@@ -339,66 +327,33 @@ func TestSimulateNodeRemoval(t *testing.T) {
 	SetNodeReadyState(topoNode2, true, time.Time{})
 	SetNodeReadyState(topoNode3, true, time.Time{})
 
+	// buildTopoPod creates a topology-spread-constrained pod on a given node.
+	buildTopoPod := func(name, nodeName string, tsc apiv1.TopologySpreadConstraint) *apiv1.Pod {
+		pod := BuildTestPod(name, 100, 100000)
+		pod.Labels = map[string]string{"app": "topo-app"}
+		pod.OwnerReferences = ownerRefs
+		pod.Spec.NodeName = nodeName
+		pod.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{tsc}
+		return pod
+	}
+
 	minDomains := int32(2)
 	maxSkew := int32(1)
-	topoConstraint := apiv1.TopologySpreadConstraint{
+	defaultTSC := apiv1.TopologySpreadConstraint{
 		MaxSkew:           maxSkew,
 		TopologyKey:       "kubernetes.io/hostname",
 		WhenUnsatisfiable: apiv1.DoNotSchedule,
 		MinDomains:        &minDomains,
 		LabelSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"app": "topo-app",
-			},
+			MatchLabels: map[string]string{"app": "topo-app"},
 		},
 	}
 
-	pod5 := BuildTestPod("p5", 100, 100000)
-	pod5.Labels = map[string]string{"app": "topo-app"}
-	pod5.OwnerReferences = ownerRefs
-	pod5.Spec.NodeName = "topo-n1"
-	pod5.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{topoConstraint}
-
-	pod6 := BuildTestPod("p6", 100, 100000)
-	pod6.Labels = map[string]string{"app": "topo-app"}
-	pod6.OwnerReferences = ownerRefs
-	pod6.Spec.NodeName = "topo-n2"
-	pod6.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{topoConstraint}
-
-	pod7 := BuildTestPod("p7", 100, 100000)
-	pod7.Labels = map[string]string{"app": "topo-app"}
-	pod7.OwnerReferences = ownerRefs
-	pod7.Spec.NodeName = "topo-n3"
-	pod7.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{topoConstraint}
-
-	blocker1 := BuildTestPod("blocker1", 100, 100000)
-	blocker1.Spec.NodeName = "topo-n2"
-	blocker2 := BuildTestPod("blocker2", 100, 100000)
-	blocker2.Spec.NodeName = "topo-n3"
-
-	// Same constraint but with NodeTaintsPolicy: Honor — ghost node's taint
-	// excludes it from domain counting, so removal succeeds even with maxSkew=1.
+	// NodeTaintsPolicy: Honor — ghost node's taint excludes it from domain
+	// counting, so removal succeeds even with maxSkew=1.
 	honorPolicy := apiv1.NodeInclusionPolicyHonor
-	honorTopoConstraint := topoConstraint
-	honorTopoConstraint.NodeTaintsPolicy = &honorPolicy
-
-	pod8 := BuildTestPod("p8", 100, 100000)
-	pod8.Labels = map[string]string{"app": "topo-app"}
-	pod8.OwnerReferences = ownerRefs
-	pod8.Spec.NodeName = "topo-n1"
-	pod8.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{honorTopoConstraint}
-
-	pod9 := BuildTestPod("p9", 100, 100000)
-	pod9.Labels = map[string]string{"app": "topo-app"}
-	pod9.OwnerReferences = ownerRefs
-	pod9.Spec.NodeName = "topo-n2"
-	pod9.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{honorTopoConstraint}
-
-	pod10 := BuildTestPod("p10", 100, 100000)
-	pod10.Labels = map[string]string{"app": "topo-app"}
-	pod10.OwnerReferences = ownerRefs
-	pod10.Spec.NodeName = "topo-n3"
-	pod10.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{honorTopoConstraint}
+	honorTSC := defaultTSC
+	honorTSC.NodeTaintsPolicy = &honorPolicy
 
 	tests := []simulateNodeRemovalTestConfig{
 		{
@@ -408,60 +363,92 @@ func TestSimulateNodeRemoval(t *testing.T) {
 			toRemove:    &NodeToBeRemoved{Node: emptyNode},
 			unremovable: nil,
 		},
-		{
-			name:     "just a drainable node, but nowhere for pods to go to",
-			pods:     []*apiv1.Pod{pod1, pod2},
-			nodeName: drainableNode.Name,
-			allNodes: []*apiv1.Node{drainableNode},
-			toRemove: nil,
-			unremovable: &UnremovableNode{
-				Node:   drainableNode,
-				Reason: NoPlaceToMovePods,
-			},
-		},
-		{
-			name:        "drainable node, and a mostly empty node that can take its pods",
-			pods:        []*apiv1.Pod{pod1, pod2, pod3},
-			nodeName:    drainableNode.Name,
-			allNodes:    []*apiv1.Node{drainableNode, nonDrainableNode},
-			toRemove:    &NodeToBeRemoved{Node: drainableNode, PodsToReschedule: []*apiv1.Pod{pod1, pod2}},
-			unremovable: nil,
-		},
-		{
-			name:        "drainable node, and a full node that cannot fit anymore pods",
-			pods:        []*apiv1.Pod{pod1, pod2, pod4},
-			nodeName:    drainableNode.Name,
-			allNodes:    []*apiv1.Node{drainableNode, fullNode},
-			toRemove:    nil,
-			unremovable: &UnremovableNode{Node: drainableNode, Reason: NoPlaceToMovePods},
-		},
-		{
-			name:        "4 nodes, 1 empty, 1 drainable",
-			pods:        []*apiv1.Pod{pod1, pod2, pod3, pod4},
-			nodeName:    emptyNode.Name,
-			allNodes:    []*apiv1.Node{emptyNode, drainableNode, fullNode, nonDrainableNode},
-			toRemove:    &NodeToBeRemoved{Node: emptyNode},
-			unremovable: nil,
-		},
-		{
-			name:     "topology spread constraint test - node unremovable due to phantom zone",
-			pods:     []*apiv1.Pod{pod5, pod6, pod7, blocker1, blocker2},
-			allNodes: []*apiv1.Node{topoNode1, topoNode2, topoNode3},
-			nodeName: topoNode1.Name,
-			toRemove: nil,
-			unremovable: &UnremovableNode{
-				Node:   topoNode1,
-				Reason: NoPlaceToMovePods,
-			},
-		},
-		{
-			name:        "topology spread constraint test - node removable with nodeTaintsPolicy Honor",
-			pods:        []*apiv1.Pod{pod8, pod9, pod10},
-			allNodes:    []*apiv1.Node{topoNode1, topoNode2, topoNode3},
-			nodeName:    topoNode1.Name,
-			toRemove:    &NodeToBeRemoved{Node: topoNode1, PodsToReschedule: []*apiv1.Pod{pod8}},
-			unremovable: nil,
-		},
+		func() simulateNodeRemovalTestConfig {
+			drainableReplicaPodA := buildReplicaSetPod("drainable-rs-pod-a", drainableNode.Name, 100, 100000)
+			drainableReplicaPodB := buildReplicaSetPod("drainable-rs-pod-b", drainableNode.Name, 100, 100000)
+			return simulateNodeRemovalTestConfig{
+				name:     "just a drainable node, but nowhere for pods to go to",
+				pods:     []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB},
+				nodeName: drainableNode.Name,
+				allNodes: []*apiv1.Node{drainableNode},
+				toRemove: nil,
+				unremovable: &UnremovableNode{
+					Node:   drainableNode,
+					Reason: NoPlaceToMovePods,
+				},
+			}
+		}(),
+		func() simulateNodeRemovalTestConfig {
+			drainableReplicaPodA := buildReplicaSetPod("drainable-rs-pod-a", drainableNode.Name, 100, 100000)
+			drainableReplicaPodB := buildReplicaSetPod("drainable-rs-pod-b", drainableNode.Name, 100, 100000)
+			existingStandalonePod := buildStandalonePod("existing-standalone-pod", nonDrainableNode.Name, 100, 100000)
+			return simulateNodeRemovalTestConfig{
+				name:        "drainable node, and a mostly empty node that can take its pods",
+				pods:        []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB, existingStandalonePod},
+				nodeName:    drainableNode.Name,
+				allNodes:    []*apiv1.Node{drainableNode, nonDrainableNode},
+				toRemove:    &NodeToBeRemoved{Node: drainableNode, PodsToReschedule: []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB}},
+				unremovable: nil,
+			}
+		}(),
+		func() simulateNodeRemovalTestConfig {
+			drainableReplicaPodA := buildReplicaSetPod("drainable-rs-pod-a", drainableNode.Name, 100, 100000)
+			drainableReplicaPodB := buildReplicaSetPod("drainable-rs-pod-b", drainableNode.Name, 100, 100000)
+			existingLargePod := buildStandalonePod("existing-large-pod", fullNode.Name, 1000, 100000)
+			return simulateNodeRemovalTestConfig{
+				name:        "drainable node, and a full node that cannot fit anymore pods",
+				pods:        []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB, existingLargePod},
+				nodeName:    drainableNode.Name,
+				allNodes:    []*apiv1.Node{drainableNode, fullNode},
+				toRemove:    nil,
+				unremovable: &UnremovableNode{Node: drainableNode, Reason: NoPlaceToMovePods},
+			}
+		}(),
+		func() simulateNodeRemovalTestConfig {
+			drainableReplicaPodA := buildReplicaSetPod("drainable-rs-pod-a", drainableNode.Name, 100, 100000)
+			drainableReplicaPodB := buildReplicaSetPod("drainable-rs-pod-b", drainableNode.Name, 100, 100000)
+			existingStandalonePod := buildStandalonePod("existing-standalone-pod", nonDrainableNode.Name, 100, 100000)
+			existingLargePod := buildStandalonePod("existing-large-pod", fullNode.Name, 1000, 100000)
+			return simulateNodeRemovalTestConfig{
+				name:        "4 nodes, 1 empty, 1 drainable",
+				pods:        []*apiv1.Pod{drainableReplicaPodA, drainableReplicaPodB, existingStandalonePod, existingLargePod},
+				nodeName:    emptyNode.Name,
+				allNodes:    []*apiv1.Node{emptyNode, drainableNode, fullNode, nonDrainableNode},
+				toRemove:    &NodeToBeRemoved{Node: emptyNode},
+				unremovable: nil,
+			}
+		}(),
+		func() simulateNodeRemovalTestConfig {
+			constrainedPodOnNode1 := buildTopoPod("default-policy-pod-topo-n1", topoNode1.Name, defaultTSC)
+			constrainedPodOnNode2 := buildTopoPod("default-policy-pod-topo-n2", topoNode2.Name, defaultTSC)
+			constrainedPodOnNode3 := buildTopoPod("default-policy-pod-topo-n3", topoNode3.Name, defaultTSC)
+			blockerOnNode2 := buildStandalonePod("blocker-n2", topoNode2.Name, 100, 100000)
+			blockerOnNode3 := buildStandalonePod("blocker-n3", topoNode3.Name, 100, 100000)
+			return simulateNodeRemovalTestConfig{
+				name:     "topology spread constraint test - node unremovable due to phantom zone",
+				pods:     []*apiv1.Pod{constrainedPodOnNode1, constrainedPodOnNode2, constrainedPodOnNode3, blockerOnNode2, blockerOnNode3},
+				allNodes: []*apiv1.Node{topoNode1, topoNode2, topoNode3},
+				nodeName: topoNode1.Name,
+				toRemove: nil,
+				unremovable: &UnremovableNode{
+					Node:   topoNode1,
+					Reason: NoPlaceToMovePods,
+				},
+			}
+		}(),
+		func() simulateNodeRemovalTestConfig {
+			honorConstrainedPodOnNode1 := buildTopoPod("honor-policy-pod-topo-n1", topoNode1.Name, honorTSC)
+			honorConstrainedPodOnNode2 := buildTopoPod("honor-policy-pod-topo-n2", topoNode2.Name, honorTSC)
+			honorConstrainedPodOnNode3 := buildTopoPod("honor-policy-pod-topo-n3", topoNode3.Name, honorTSC)
+			return simulateNodeRemovalTestConfig{
+				name:        "topology spread constraint test - node removable with nodeTaintsPolicy Honor",
+				pods:        []*apiv1.Pod{honorConstrainedPodOnNode1, honorConstrainedPodOnNode2, honorConstrainedPodOnNode3},
+				allNodes:    []*apiv1.Node{topoNode1, topoNode2, topoNode3},
+				nodeName:    topoNode1.Name,
+				toRemove:    &NodeToBeRemoved{Node: topoNode1, PodsToReschedule: []*apiv1.Pod{honorConstrainedPodOnNode1}},
+				unremovable: nil,
+			}
+		}(),
 		{
 			name:        "candidate not in clusterSnapshot should be marked unremovable",
 			nodeName:    noExistNode.Name,
@@ -481,7 +468,6 @@ func TestSimulateNodeRemoval(t *testing.T) {
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, clusterSnapshot, test.allNodes, test.pods)
 			r := NewRemovalSimulator(registry, clusterSnapshot, testDeleteOptions(), nil, false)
 			toRemove, unremovable := r.SimulateNodeRemoval(test.nodeName, destinations, time.Now(), nil)
-			fmt.Printf("Test scenario: %s, toRemove=%v, unremovable=%v\n", test.name, toRemove, unremovable)
 			assert.Equal(t, test.toRemove, toRemove)
 			assert.Equal(t, test.unremovable, unremovable)
 		})


### PR DESCRIPTION
This is a manual cherry-pick of #9288, with https://github.com/kubernetes/autoscaler/commit/c10792bf161ed67fe835a5b55f3c4d1a789286ce adapting it to the older version. Replaces failed automated cherry-pick https://github.com/kubernetes/autoscaler/pull/9552.

/assign jackfrancis

```release-note
Pods with hard TopologySpreadConstraints using the default nodeTaintsPolicy will no longer cause scale-down/scale-up oscillation. The scale-down simulation now faithfully models the drain taint, matching real scheduler behavior. Pods using nodeTaintsPolicy: Honor are unaffected and continue to scale down correctly.
```
