### PR TITLE
Enchance error handling for automatic reservations in GCE client

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client.go
@@ -80,6 +80,14 @@ const (
 	// be scaled up because the associated reservation is not compatible with the node group.
 	ErrorReservationIncompatible = "RESERVATION_INCOMPATIBLE"
 
+	// ErrorAutomaticReservationsNotAvailable happens if there is no automatic reservation with
+	// matching prespun instance properties, when using affinity ANY_RESERVATION_THEN_FAIL.
+	ErrorAutomaticReservationsNotAvailable = "AUTOMATIC_RESERVATIONS_NOT_AVAILABLE"
+
+	// ErrorAutomaticReservationsNoCapacity happens when trying to create an instance with
+	// affinity ANY_RESERVATION_THEN_FAIL but all reservations are full.
+	ErrorAutomaticReservationsNoCapacity = "AUTOMATIC_RESERVATIONS_NO_CAPACITY"
+
 	// ErrorUnsupportedTpuConfiguration is an error code for InstanceErrorInfo if the
 	// node group couldn't be scaled up because of invalid TPU configuration.
 	ErrorUnsupportedTpuConfiguration = "UNSUPPORTED_TPU_CONFIGURATION"
@@ -105,6 +113,8 @@ var (
 		regexp.MustCompile("Reservation (.*) is incorrect for the requested resources"),
 		regexp.MustCompile("Zone does not currently have sufficient capacity for the requested resources"),
 	}
+	automaticReservationsNoCapacityRegexp   = regexp.MustCompile("All automatic reservations in your project, or shared with your project, are fully consumed")
+	automaticReservationsNotAvailableRegexp = regexp.MustCompile("There is no automatic reservation matching the instance in your project")
 )
 
 // GceInstance extends cloudprovider.Instance with GCE specific numeric id.
@@ -613,6 +623,16 @@ func GetErrorInfo(errorCode, errorMessage, instanceStatus string, previousErrorI
 			ErrorClass: cloudprovider.OtherErrorClass,
 			ErrorCode:  ErrorUnsupportedTpuConfiguration,
 		}
+	} else if isAutomaticReservationNotAvailableError(errorMessage) {
+		return &cloudprovider.InstanceErrorInfo{
+			ErrorClass: cloudprovider.OtherErrorClass,
+			ErrorCode:  ErrorAutomaticReservationsNotAvailable,
+		}
+	} else if isAutomaticReservationsNoCapacity(errorMessage) {
+		return &cloudprovider.InstanceErrorInfo{
+			ErrorClass: cloudprovider.OtherErrorClass,
+			ErrorCode:  ErrorAutomaticReservationsNoCapacity,
+		}
 	} else if isInstanceStatusNotRunningYet(instanceStatus) {
 		if previousErrorInfo != nil {
 			// keep the current error
@@ -702,6 +722,14 @@ func isReservationCapacityExceeded(errorMessage string) bool {
 func isReservationIncompatible(errorMessage string) bool {
 	pattern := "No available resources in specified reservations"
 	return strings.Contains(errorMessage, pattern)
+}
+
+func isAutomaticReservationNotAvailableError(errorMessage string) bool {
+	return automaticReservationsNotAvailableRegexp.MatchString(errorMessage)
+}
+
+func isAutomaticReservationsNoCapacity(errorMessage string) bool {
+	return automaticReservationsNoCapacityRegexp.MatchString(errorMessage)
 }
 
 func isInvalidReservationError(errorMessage string) bool {

--- a/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/autoscaling_gce_client_test.go
@@ -241,6 +241,18 @@ func TestErrors(t *testing.T) {
 			expectedErrorCode:  ErrorUnsupportedTpuConfiguration,
 			expectedErrorClass: cloudprovider.OtherErrorClass,
 		},
+		{
+			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "There is no automatic reservation matching the instance in your project, or shared with it. To create an instance, create a new automatic reservation or share an existing one from another project.",
+			expectedErrorCode:  ErrorAutomaticReservationsNotAvailable,
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
+		{
+			errorCodes:         []string{"CONDITION_NOT_MET"},
+			errorMessage:       "All automatic reservations in your project, or shared with your project, are fully consumed. To create an instance, create a new automatic reservation or increase the size of an existing one.",
+			expectedErrorCode:  ErrorAutomaticReservationsNoCapacity,
+			expectedErrorClass: cloudprovider.OtherErrorClass,
+		},
 	}
 	for _, tc := range testCases {
 		for _, errorCode := range tc.errorCodes {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Adds handling of new errors produced by GCE when automatic reservations are used.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
