### PR TITLE
Remove yaroslava-serdiuk from gce OWNERS file

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/OWNERS
+++ b/cluster-autoscaler/cloudprovider/gce/OWNERS
@@ -1,12 +1,10 @@
 approvers:
 - towca
 - x13n
-- yaroslava-serdiuk
 - BigDarkClown
 reviewers:
 - towca
 - x13n
-- yaroslava-serdiuk
 - BigDarkClown
 
 labels:


### PR DESCRIPTION
Removed 'yaroslava-serdiuk' from gce approvers and reviewers.

#### What type of PR is this?
/kind cleanup

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
