### PR TITLE
Update the buffer proposal to reflect the current state.

### DIFF
--- a/cluster-autoscaler/proposals/buffers.md
+++ b/cluster-autoscaler/proposals/buffers.md
@@ -9,9 +9,9 @@
 - [x] Implement the API definition
 - [x] Implement the buffer controller and fake pod processing logic in the cluster autoscaler
 
-## Beta graduation criteria (planned for 1.35)
+## Beta graduation criteria (1.35)
 
-- [ ] Implement integration with k8s resource quotas
+- [x] Implement integration with k8s resource quotas
 
 ## V1 graduation criteria (planned for TBD)
 


### PR DESCRIPTION
Beta graduation was implemented in: https://github.com/kubernetes/autoscaler/pull/9062

#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:
Update the proposal with the current state

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
This does not change the proposal, it reflects the changes that were done already in the code.

#### Does this PR introduce a user-facing change?
```release-note

NONE

```