### PR TITLE
VPA: fix helm set args

### DIFF
--- a/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
@@ -124,18 +124,20 @@ done
 # Add feature gates if specified
 RECOM_ARGS_IDX=0
 if [ -n "${FEATURE_GATES:-}" ]; then
+  # Escape commas so Helm --set treats the value as a single assignment
+  ESCAPED_FEATURE_GATES="${FEATURE_GATES//,/\\,}"
   # Add feature gates to each enabled component
   for COMPONENT in ${COMPONENTS}; do
     case ${COMPONENT} in
       recommender)
-        HELM_SET_ARGS+=("--set" "recommender.extraArgs[${RECOM_ARGS_IDX}]=--feature-gates=${FEATURE_GATES}")
+        HELM_SET_ARGS+=("--set" "recommender.extraArgs[${RECOM_ARGS_IDX}]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         RECOM_ARGS_IDX=$((RECOM_ARGS_IDX + 1))
         ;;
       updater)
-        HELM_SET_ARGS+=("--set" "updater.extraArgs[0]=--feature-gates=${FEATURE_GATES}")
+        HELM_SET_ARGS+=("--set" "updater.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         ;;
       admission-controller)
-        HELM_SET_ARGS+=("--set" "admissionController.extraArgs[0]=--feature-gates=${FEATURE_GATES}")
+        HELM_SET_ARGS+=("--set" "admissionController.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         ;;
     esac
   done


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Before that if you would run:
```bash
ubuntu:~/autoscaler/vertical-pod-autoscaler(fix-script-helm)$ export ENABLE_ALL_FEATURE_GATES=true
ubuntu:~/autoscaler/vertical-pod-autoscaler(fix-script-helm)$ ./hack/dev-deploy-locally.sh
```
You would get only the Alpha features enabled:
```bash
 ubuntu:~/autoscaler/vertical-pod-autoscaler(fix-script-helm)$ k get deployments.apps -n kube-system vpa-updater -o yaml | grep args -A 3
      - args:
        - --v=4
        - --stderrthreshold=info
        - --feature-gates=AllAlpha=true
 ```
Now you would get both:
```bash
ubuntu:~/autoscaler/vertical-pod-autoscaler(fix-script-helm)$ k get deployments.apps -n kube-system vpa-updater -o yaml | grep args -A 3
      - args:
        - --v=4
        - --stderrthreshold=info
        - --feature-gates=AllAlpha=true,AllBeta=true
 ```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
