### PR TITLE
Group dependabot VPA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,18 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: "/vertical-pod-autoscaler"
+  directories:
+    - "/vertical-pod-autoscaler"
+    - "/vertical-pod-autoscaler/test/"
   schedule:
     interval: daily
   labels:
     - "area/vertical-pod-autoscaler"
     - "release-note-none"
     - "ok-to-test"
+  groups:
+    vpa-dependencies:
+      group-by: dependency-name
 - package-ecosystem: docker
   directories:
     - "/vertical-pod-autoscaler/pkg/admission-controller"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Currently these dependabot PRs don't work (see https://github.com/kubernetes/autoscaler/pull/9582), since the test directory isn't updated, so the tests all fail with this:
```
go: updates to go.mod needed; to update it:
	go mod tidy
```

I'm hoping that by grouping them like this, dependabot will make a single PR that covers both go.mod files

I copied this example, I don't know if it's right: https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-updates-across-directories-in-a-monorepo


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
