### PR TITLE
VPA: Refactor validation to use field.ErrorList for structured errors

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
@@ -24,7 +24,10 @@ import (
 	"net/http"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
@@ -113,23 +116,32 @@ func (s *AdmissionServer) admit(ctx context.Context, data []byte) (*admissionv1.
 
 	var patches []resource.PatchRecord
 	var err error
+	var allErrs field.ErrorList
 	resource := metrics_admission.Unknown
 
 	admittedGroupResource := metav1.GroupResource{
 		Group:    ar.Request.Resource.Group,
 		Resource: ar.Request.Resource.Resource,
 	}
+	kind := ar.Request.RequestKind.Kind
+	name := ar.Request.Name
 
 	handler, ok := s.resourceHandlers[admittedGroupResource]
 	if ok {
-		patches, err = handler.GetPatches(ctx, ar.Request)
+		patches, allErrs = handler.GetPatches(ctx, ar.Request)
 		resource = handler.AdmissionResource()
 
-		if handler.DisallowIncorrectObjects() && err != nil {
+		if handler.DisallowIncorrectObjects() && len(allErrs) > 0 {
 			// we don't let in problematic objects - late validation
-			status := metav1.Status{}
-			status.Status = "Failure"
-			status.Message = err.Error()
+			err := apierrors.NewInvalid(
+				schema.GroupKind{
+					Group: admittedGroupResource.Group,
+					Kind:  kind,
+				},
+				name,
+				allErrs,
+			)
+			status := err.ErrStatus
 			response.Result = &status
 			response.Allowed = false
 		}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/handler.go
@@ -21,6 +21,7 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
 )
@@ -41,5 +42,5 @@ type Handler interface {
 	// DisallowIncorrectObjects returns whether incorrect objects (eg. unparsable, not passing validations) should be disallowed by Admission Server.
 	DisallowIncorrectObjects() bool
 	// GetPatches returns patches for given AdmissionRequest
-	GetPatches(context.Context, *admissionv1.AdmissionRequest) ([]PatchRecord, error)
+	GetPatches(context.Context, *admissionv1.AdmissionRequest) ([]PatchRecord, field.ErrorList)
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler.go
@@ -19,11 +19,11 @@ package pod
 import (
 	"context"
 	"encoding/json"
-	"errors"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 
 	resource_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
@@ -65,14 +65,14 @@ func (h *resourceHandler) DisallowIncorrectObjects() bool {
 }
 
 // GetPatches builds patches for Pod in given admission request.
-func (h *resourceHandler) GetPatches(ctx context.Context, ar *admissionv1.AdmissionRequest) ([]resource_admission.PatchRecord, error) {
+func (h *resourceHandler) GetPatches(ctx context.Context, ar *admissionv1.AdmissionRequest) ([]resource_admission.PatchRecord, field.ErrorList) {
 	if ar.Resource.Version != "v1" {
-		return nil, errors.New("only v1 Pods are supported")
+		return nil, field.ErrorList{field.Invalid(field.NewPath("."), ar.Resource.Version, "only v1 Pods are supported")}
 	}
 	raw, namespace := ar.Object.Raw, ar.Namespace
 	pod := corev1.Pod{}
 	if err := json.Unmarshal(raw, &pod); err != nil {
-		return nil, err
+		return nil, field.ErrorList{field.InternalError(field.NewPath("."), err)}
 	}
 	if len(pod.Name) == 0 {
 		pod.Name = pod.GenerateName + "%"
@@ -86,7 +86,7 @@ func (h *resourceHandler) GetPatches(ctx context.Context, ar *admissionv1.Admiss
 	}
 	pod, err := h.preProcessor.Process(pod)
 	if err != nil {
-		return nil, err
+		return nil, field.ErrorList{field.InternalError(field.NewPath("."), err)}
 	}
 
 	patches := []resource_admission.PatchRecord{}
@@ -96,7 +96,7 @@ func (h *resourceHandler) GetPatches(ctx context.Context, ar *admissionv1.Admiss
 	for _, c := range h.patchCalculators {
 		partialPatches, err := c.CalculatePatches(&pod, controllingVpa)
 		if err != nil {
-			return []resource_admission.PatchRecord{}, err
+			return []resource_admission.PatchRecord{}, field.ErrorList{field.InternalError(field.NewPath("."), err)}
 		}
 		patches = append(patches, partialPatches...)
 	}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/handler_test.go
@@ -92,7 +92,7 @@ func TestGetPatches(t *testing.T) {
 			namespace:            "default",
 			vpa:                  testVpa,
 			podPreProcessorError: nil,
-			expectError:          errors.New("unexpected end of JSON input"),
+			expectError:          errors.New(".: Internal error: unexpected end of JSON input"),
 		},
 		{
 			name:                 "invalid pod",
@@ -100,7 +100,7 @@ func TestGetPatches(t *testing.T) {
 			namespace:            "default",
 			vpa:                  testVpa,
 			podPreProcessorError: errors.New("bad pod"),
-			expectError:          errors.New("bad pod"),
+			expectError:          errors.New(".: Internal error: bad pod"),
 		},
 		{
 			name:                 "no vpa found",
@@ -120,7 +120,7 @@ func TestGetPatches(t *testing.T) {
 				[]resource_admission.PatchRecord{}, errors.New("Can't calculate this"),
 			}},
 			podPreProcessorError: nil,
-			expectError:          errors.New("Can't calculate this"),
+			expectError:          errors.New(".: Internal error: Can't calculate this"),
 			expectPatches:        []resource_admission.PatchRecord{},
 		},
 		{
@@ -136,7 +136,7 @@ func TestGetPatches(t *testing.T) {
 					[]resource_admission.PatchRecord{}, errors.New("Can't calculate this"),
 				}},
 			podPreProcessorError: nil,
-			expectError:          errors.New("Can't calculate this"),
+			expectError:          errors.New(".: Internal error: Can't calculate this"),
 			expectPatches:        []resource_admission.PatchRecord{},
 		},
 		{
@@ -183,7 +183,7 @@ func TestGetPatches(t *testing.T) {
 			fppp := &fakePodPreProcessor{tc.podPreProcessorError}
 			fvm := &fakeVpaMatcher{vpa: tc.vpa}
 			h := NewResourceHandler(fppp, fvm, tc.calculators)
-			patches, err := h.GetPatches(context.Background(), &admissionv1.AdmissionRequest{
+			patches, errs := h.GetPatches(context.Background(), &admissionv1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
 					Version: "v1",
 				},
@@ -193,11 +193,10 @@ func TestGetPatches(t *testing.T) {
 				},
 			})
 			if tc.expectError == nil {
-				assert.NoError(t, err)
+				assert.Empty(t, errs)
 			} else {
-				if assert.Error(t, err) {
-					assert.Equal(t, tc.expectError.Error(), err.Error())
-				}
+				assert.NotEmpty(t, errs)
+				assert.Equal(t, tc.expectError.Error(), errs[0].Error())
 			}
 			if assert.Equal(t, len(tc.expectPatches), len(patches), fmt.Sprintf("got %+v, want %+v", patches, tc.expectPatches)) {
 				for i, gotPatch := range patches {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -19,7 +19,6 @@ package vpa
 import (
 	"context"
 	"encoding/json"
-	"sort"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,22 +29,6 @@ import (
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
 )
-
-var (
-	possibleScalingModes = map[vpa_types.ContainerScalingMode]any{
-		vpa_types.ContainerScalingModeAuto: struct{}{},
-		vpa_types.ContainerScalingModeOff:  struct{}{},
-	}
-)
-
-func getPossibleScalingModes() []string {
-	modes := []string{}
-	for mode := range possibleScalingModes {
-		modes = append(modes, string(mode))
-	}
-	sort.Strings(modes)
-	return modes
-}
 
 // resourceHandler builds patches for VPAs.
 type resourceHandler struct {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/handler.go
@@ -19,18 +19,15 @@ package vpa
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
+	"sort"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	corev1 "k8s.io/api/core/v1"
-	apires "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
 )
 
@@ -40,6 +37,15 @@ var (
 		vpa_types.ContainerScalingModeOff:  struct{}{},
 	}
 )
+
+func getPossibleScalingModes() []string {
+	modes := []string{}
+	for mode := range possibleScalingModes {
+		modes = append(modes, string(mode))
+	}
+	sort.Strings(modes)
+	return modes
+}
 
 // resourceHandler builds patches for VPAs.
 type resourceHandler struct {
@@ -66,63 +72,12 @@ func (h *resourceHandler) DisallowIncorrectObjects() bool {
 	return true
 }
 
-// VPAValidationOptions contains the different settings for VPA validation
-type VPAValidationOptions struct {
-	// FIXME(adrian): IsVPACreate should be removed from here by splitting ValidateVPA() into ValidateVPACreate() and ValidateVPAUpdate() functions
-	IsVPACreate            bool
-	AllowCPUStartupBoost   bool
-	AllowInPlaceOrRecreate bool
-	AllowPerVPAConfig      bool
-}
-
-// GetValidationOptionsForVPA generates VPAValidationOptions for VPA
-func GetValidationOptionsForVPA(oldObj *vpa_types.VerticalPodAutoscaler) VPAValidationOptions {
-	opts := VPAValidationOptions{
-		IsVPACreate:            oldObj == nil,
-		AllowCPUStartupBoost:   allowCPUBoost(oldObj),
-		AllowInPlaceOrRecreate: features.Enabled(features.InPlaceOrRecreate),
-		AllowPerVPAConfig:      allowPerVPAConfig(oldObj),
-	}
-
-	return opts
-}
-
-func allowPerVPAConfig(oldObj *vpa_types.VerticalPodAutoscaler) bool {
-	if features.Enabled(features.PerVPAConfig) {
-		return true
-	}
-
-	if oldObj != nil && oldObj.Spec.UpdatePolicy != nil && oldObj.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil {
-		return true
-	}
-	if oldObj.Spec.ResourcePolicy != nil && oldObj.Spec.ResourcePolicy.ContainerPolicies != nil {
-		for _, policy := range oldObj.Spec.ResourcePolicy.ContainerPolicies {
-			if policy.OOMBumpUpRatio != nil || policy.OOMMinBumpUp != nil {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func allowCPUBoost(oldObj *vpa_types.VerticalPodAutoscaler) bool {
-	if features.Enabled(features.CPUStartupBoost) {
-		return true
-	}
-
-	if oldObj != nil && oldObj.Spec.StartupBoost != nil && oldObj.Spec.StartupBoost.CPU != nil {
-		return true
-	}
-	return false
-}
-
 // GetPatches builds patches for VPA in given admission request.
-func (h *resourceHandler) GetPatches(_ context.Context, ar *admissionv1.AdmissionRequest) ([]resource.PatchRecord, error) {
+func (h *resourceHandler) GetPatches(_ context.Context, ar *admissionv1.AdmissionRequest) ([]resource.PatchRecord, field.ErrorList) {
 	raw, isCreate := ar.Object.Raw, ar.Operation == admissionv1.Create
 	vpa, err := parseVPA(raw)
 	if err != nil {
-		return nil, err
+		return nil, field.ErrorList{field.InternalError(field.NewPath("."), err)}
 	}
 
 	oldVPA := &vpa_types.VerticalPodAutoscaler{}
@@ -131,20 +86,19 @@ func (h *resourceHandler) GetPatches(_ context.Context, ar *admissionv1.Admissio
 		oldRaw := ar.OldObject.Raw
 		oldVPA, err = parseVPA(oldRaw)
 		if err != nil {
-			return nil, err
+			return nil, field.ErrorList{field.InternalError(field.NewPath("."), err)}
 		}
 	}
 
-	opts := GetValidationOptionsForVPA(oldVPA)
+	opts := getValidationOptionsForVPA(oldVPA)
 
 	vpa, err = h.preProcessor.Process(vpa, isCreate)
 	if err != nil {
-		return nil, err
+		return nil, field.ErrorList{field.InternalError(field.NewPath("."), err)}
 	}
 
-	err = ValidateVPA(vpa, opts)
-	if err != nil {
-		return nil, err
+	if allErrs := validateVPA(vpa, opts); len(allErrs) > 0 {
+		return nil, allErrs
 	}
 
 	klog.V(4).InfoS("Processing vpa", "vpa", vpa)
@@ -167,177 +121,4 @@ func parseVPA(raw []byte) (*vpa_types.VerticalPodAutoscaler, error) {
 		return nil, err
 	}
 	return &vpa, nil
-}
-
-// ValidateVPA checks the correctness of VPA Spec and returns an error if there is a problem.
-func ValidateVPA(vpa *vpa_types.VerticalPodAutoscaler, opts VPAValidationOptions) error {
-	// check that perVPA is on if being used
-	if err := validatePerVPAFeatureFlag(vpa, opts); err != nil {
-		return err
-	}
-
-	if vpa.Spec.UpdatePolicy != nil {
-		mode := vpa.Spec.UpdatePolicy.UpdateMode
-		if mode == nil {
-			return errors.New("updateMode is required if UpdatePolicy is used")
-		}
-		if _, found := vpa_types.GetUpdateModes()[*mode]; !found {
-			return fmt.Errorf("unexpected UpdateMode value %s", *mode)
-		}
-		if *mode == vpa_types.UpdateModeInPlaceOrRecreate && !opts.AllowInPlaceOrRecreate {
-			return fmt.Errorf("in order to use UpdateMode %s, you must enable feature gate %s in the admission-controller args", vpa_types.UpdateModeInPlaceOrRecreate, features.InPlaceOrRecreate)
-		}
-		if minReplicas := vpa.Spec.UpdatePolicy.MinReplicas; minReplicas != nil && *minReplicas <= 0 {
-			return fmt.Errorf("minReplicas has to be positive, got %v", *minReplicas)
-		}
-	}
-
-	if vpa.Spec.ResourcePolicy != nil {
-		for _, policy := range vpa.Spec.ResourcePolicy.ContainerPolicies {
-			if policy.ContainerName == "" {
-				return errors.New("containerPolicies.ContainerName is required")
-			}
-
-			// Validate OOMBumpUpRatio
-			if policy.OOMBumpUpRatio != nil {
-				ratio := float64(policy.OOMBumpUpRatio.MilliValue()) / 1000.0
-				if ratio < 1.0 {
-					return fmt.Errorf("oomBumpUpRatio must be greater than or equal to 1.0, got %v", ratio)
-				}
-			}
-
-			// Validate OOMMinBumpUp
-			if policy.OOMMinBumpUp != nil {
-				minBump := policy.OOMMinBumpUp.Value()
-				if minBump < 0 {
-					return fmt.Errorf("oomMinBumpUp must be greater than or equal to 0, got %v bytes", minBump)
-				}
-			}
-
-			mode := policy.Mode
-			if mode != nil {
-				if _, found := possibleScalingModes[*mode]; !found {
-					return fmt.Errorf("unexpected Mode value %s", *mode)
-				}
-			}
-			for resource, minAllowed := range policy.MinAllowed {
-				if err := validateResourceResolution(resource, minAllowed); err != nil {
-					return fmt.Errorf("minAllowed: %v", err)
-				}
-				maxAllowed, found := policy.MaxAllowed[resource]
-				if found && maxAllowed.Cmp(minAllowed) < 0 {
-					return fmt.Errorf("max resource for %v is lower than min", resource)
-				}
-			}
-			for resource, max := range policy.MaxAllowed {
-				if err := validateResourceResolution(resource, max); err != nil {
-					return fmt.Errorf("maxAllowed: %v", err)
-				}
-			}
-			controlledValues := policy.ControlledValues
-			if mode != nil && controlledValues != nil {
-				if *mode == vpa_types.ContainerScalingModeOff && *controlledValues == vpa_types.ContainerControlledValuesRequestsAndLimits {
-					return errors.New("controlledValues shouldn't be specified if container scaling mode is off")
-				}
-			}
-			if err := validateStartupBoost(policy.StartupBoost, opts); err != nil {
-				return fmt.Errorf("invalid startupBoost in container %s: %v", policy.ContainerName, err)
-			}
-		}
-	}
-
-	if err := validateStartupBoost(vpa.Spec.StartupBoost, opts); err != nil {
-		return fmt.Errorf("invalid startupBoost: %v", err)
-	}
-
-	if opts.IsVPACreate && vpa.Spec.TargetRef == nil {
-		return errors.New("targetRef is required. If you're using v1beta1 version of the API, please migrate to v1")
-	}
-
-	if len(vpa.Spec.Recommenders) > 1 {
-		return errors.New("the current version of VPA object shouldn't specify more than one recommenders")
-	}
-
-	return nil
-}
-
-func validateStartupBoost(startupBoost *vpa_types.StartupBoost, opts VPAValidationOptions) error {
-	if startupBoost == nil {
-		return nil
-	}
-
-	if !opts.AllowCPUStartupBoost {
-		return fmt.Errorf("in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost)
-	}
-
-	cpuBoost := startupBoost.CPU
-	if cpuBoost == nil {
-		return nil
-	}
-	boostType := cpuBoost.Type
-	if boostType == "" {
-		return fmt.Errorf("startupBoost.cpu.type field is required and must be either %s or %s",
-			vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType)
-	}
-
-	switch boostType {
-	case vpa_types.FactorStartupBoostType:
-		if cpuBoost.Factor == nil {
-			return errors.New("startupBoost.cpu.factor is required when type is Factor")
-		}
-		if *cpuBoost.Factor < 1 {
-			return errors.New("invalid startupBoost.cpu.factor: must be >= 1 for type Factor")
-		}
-	case vpa_types.QuantityStartupBoostType:
-		if cpuBoost.Quantity == nil {
-			return errors.New("startupBoost.cpu.quantity is required when type is Quantity")
-		}
-		if err := validateCPUResolution(*cpuBoost.Quantity); err != nil {
-			return fmt.Errorf("invalid startupBoost.cpu.quantity: %v", err)
-		}
-	default:
-		return fmt.Errorf("startupBoost.cpu.type field is required and must be either %s or %s, got %v",
-			vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType, boostType)
-	}
-	return nil
-}
-
-func validateResourceResolution(name corev1.ResourceName, val apires.Quantity) error {
-	switch name {
-	case corev1.ResourceCPU:
-		return validateCPUResolution(val)
-	case corev1.ResourceMemory:
-		return validateMemoryResolution(val)
-	}
-	return nil
-}
-
-func validateCPUResolution(val apires.Quantity) error {
-	if _, precissionPreserved := val.AsScale(apires.Milli); !precissionPreserved {
-		return fmt.Errorf("CPU [%s] must be a whole number of milli CPUs", val.String())
-	}
-	return nil
-}
-
-func validateMemoryResolution(val apires.Quantity) error {
-	if _, precissionPreserved := val.AsScale(0); !precissionPreserved {
-		return fmt.Errorf("memory [%v] must be a whole number of bytes", val)
-	}
-	return nil
-}
-
-func validatePerVPAFeatureFlag(vpa *vpa_types.VerticalPodAutoscaler, opts VPAValidationOptions) error {
-	if vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil && !opts.AllowPerVPAConfig {
-		return fmt.Errorf("EvictAfterOOMSeconds is not supported when feature flag %s is disabled", features.PerVPAConfig)
-	}
-
-	if vpa.Spec.ResourcePolicy != nil {
-		for _, policy := range vpa.Spec.ResourcePolicy.ContainerPolicies {
-			perVPA := policy.OOMBumpUpRatio != nil || policy.OOMMinBumpUp != nil
-			if !opts.AllowPerVPAConfig && perVPA {
-				return fmt.Errorf("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag %s is disabled", features.PerVPAConfig)
-			}
-		}
-	}
-	return nil
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation.go
@@ -168,8 +168,8 @@ func validateVPASpecResourcePolicy(resourcePolicy *vpa_types.PodResourcePolicy, 
 		}
 
 		if policy.Mode != nil {
-			if _, found := possibleScalingModes[*policy.Mode]; !found {
-				allErrs = append(allErrs, field.NotSupported(policyPath.Child("mode"), *policy.Mode, getPossibleScalingModes()))
+			if _, found := vpa_types.GetScalingModes()[*policy.Mode]; !found {
+				allErrs = append(allErrs, field.NotSupported(policyPath.Child("mode"), *policy.Mode, vpa_types.GetPossibleScalingModes()))
 			}
 		}
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation.go
@@ -1,0 +1,286 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpa
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apires "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
+)
+
+// VPAValidationOptions contains the different settings for VPA validation
+type VPAValidationOptions struct {
+	IsVPACreate            bool
+	AllowCPUStartupBoost   bool
+	AllowInPlaceOrRecreate bool
+	AllowPerVPAConfig      bool
+}
+
+func getValidationOptionsForVPA(oldObj *vpa_types.VerticalPodAutoscaler) VPAValidationOptions {
+	opts := VPAValidationOptions{
+		IsVPACreate:            oldObj == nil,
+		AllowCPUStartupBoost:   allowCPUBoost(oldObj),
+		AllowInPlaceOrRecreate: features.Enabled(features.InPlaceOrRecreate),
+		AllowPerVPAConfig:      allowPerVPAConfig(oldObj),
+	}
+
+	return opts
+}
+
+func allowCPUBoost(oldObj *vpa_types.VerticalPodAutoscaler) bool {
+	if features.Enabled(features.CPUStartupBoost) {
+		return true
+	}
+
+	if oldObj == nil {
+		return false
+	}
+
+	if oldObj.Spec.StartupBoost != nil && oldObj.Spec.StartupBoost.CPU != nil {
+		return true
+	}
+
+	if oldObj.Spec.ResourcePolicy != nil && oldObj.Spec.ResourcePolicy.ContainerPolicies != nil {
+		for _, policy := range oldObj.Spec.ResourcePolicy.ContainerPolicies {
+			if policy.StartupBoost != nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func allowPerVPAConfig(oldObj *vpa_types.VerticalPodAutoscaler) bool {
+	if features.Enabled(features.PerVPAConfig) {
+		return true
+	}
+
+	if oldObj == nil {
+		return false
+	}
+
+	if oldObj.Spec.UpdatePolicy != nil && oldObj.Spec.UpdatePolicy.EvictAfterOOMSeconds != nil {
+		return true
+	}
+	if oldObj.Spec.ResourcePolicy != nil && oldObj.Spec.ResourcePolicy.ContainerPolicies != nil {
+		for _, policy := range oldObj.Spec.ResourcePolicy.ContainerPolicies {
+			if policy.OOMBumpUpRatio != nil || policy.OOMMinBumpUp != nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func validateVPA(vpa *vpa_types.VerticalPodAutoscaler, opts VPAValidationOptions) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, validateVPASpec(&vpa.Spec, field.NewPath("spec"), opts)...)
+	return allErrs
+}
+
+func validateVPASpec(spec *vpa_types.VerticalPodAutoscalerSpec, fldPath *field.Path, opts VPAValidationOptions) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// TODO: Add validation for spec.TargetRef
+	if spec.TargetRef == nil && opts.IsVPACreate {
+		allErrs = append(allErrs, field.Required(fldPath.Child("targetRef"), "If you're using v1beta1 version of the API, please migrate to v1"))
+	}
+
+	if spec.UpdatePolicy != nil {
+		allErrs = append(allErrs, validateVPASpecUpdatePolicy(spec.UpdatePolicy, fldPath.Child("updatePolicy"), opts)...)
+	}
+
+	if spec.ResourcePolicy != nil {
+		allErrs = append(allErrs, validateVPASpecResourcePolicy(spec.ResourcePolicy, fldPath.Child("resourcePolicy"), opts)...)
+	}
+
+	if spec.StartupBoost != nil {
+		allErrs = append(allErrs, validateVPASpecStartupBoost(spec.StartupBoost, fldPath.Child("startupBoost"), opts)...)
+	}
+
+	if len(spec.Recommenders) > 1 {
+		allErrs = append(allErrs, field.TooMany(fldPath.Child("recommenders"), len(spec.Recommenders), 1))
+	}
+
+	return allErrs
+}
+
+func validateVPASpecUpdatePolicy(updatePolicy *vpa_types.PodUpdatePolicy, fldPath *field.Path, opts VPAValidationOptions) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	mode := updatePolicy.UpdateMode
+	if mode == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("updateMode"), "updateMode is required if UpdatePolicy is used"))
+	} else {
+		if _, found := vpa_types.GetUpdateModes()[*mode]; !found {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("updateMode"), *mode, vpa_types.GetUpdateModesList()))
+		}
+
+		if *mode == vpa_types.UpdateModeInPlaceOrRecreate && !opts.AllowInPlaceOrRecreate {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("updateMode"), fmt.Sprintf("in order to use UpdateMode %s, you must enable feature gate %s in the admission-controller args", vpa_types.UpdateModeInPlaceOrRecreate, features.InPlaceOrRecreate)))
+		}
+	}
+	if minReplicas := updatePolicy.MinReplicas; minReplicas != nil && *minReplicas <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("minReplicas"), *minReplicas, "minReplicas has to be positive"))
+	}
+
+	if updatePolicy.EvictAfterOOMSeconds != nil {
+		if opts.AllowPerVPAConfig {
+			if *updatePolicy.EvictAfterOOMSeconds < 1 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("evictAfterOOMSeconds"), *updatePolicy.EvictAfterOOMSeconds, "must be greater than or equal to 1"))
+			}
+		} else {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("evictAfterOOMSeconds"), fmt.Sprintf("not supported when feature flag %s is disabled", features.PerVPAConfig)))
+		}
+	}
+
+	return allErrs
+}
+
+func validateVPASpecResourcePolicy(resourcePolicy *vpa_types.PodResourcePolicy, fldPath *field.Path, opts VPAValidationOptions) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for i, policy := range resourcePolicy.ContainerPolicies {
+		policyPath := fldPath.Child("containerPolicies").Index(i)
+		if policy.ContainerName == "" {
+			allErrs = append(allErrs, field.Required(policyPath.Child("containerName"), ""))
+		}
+
+		if policy.Mode != nil {
+			if _, found := possibleScalingModes[*policy.Mode]; !found {
+				allErrs = append(allErrs, field.NotSupported(policyPath.Child("mode"), *policy.Mode, getPossibleScalingModes()))
+			}
+		}
+
+		for resource, minAllowed := range policy.MinAllowed {
+			allErrs = append(allErrs, validateResourceResolution(policyPath.Child("minAllowed").Key(string(resource)), resource, minAllowed)...)
+			maxAllowed, found := policy.MaxAllowed[resource]
+			if found && maxAllowed.Cmp(minAllowed) < 0 {
+				allErrs = append(allErrs, field.Invalid(policyPath.Child("maxAllowed").Key(string(resource)), maxAllowed.String(), fmt.Sprintf("max resource for %v is lower than min of \"%v\"", resource, minAllowed.String())))
+			}
+		}
+
+		for resource, max := range policy.MaxAllowed {
+			allErrs = append(allErrs, validateResourceResolution(policyPath.Child("maxAllowed").Key(string(resource)), resource, max)...)
+		}
+
+		controlledValues := policy.ControlledValues
+		if policy.Mode != nil && controlledValues != nil {
+			if *policy.Mode == vpa_types.ContainerScalingModeOff && *controlledValues == vpa_types.ContainerControlledValuesRequestsAndLimits {
+				allErrs = append(allErrs, field.Forbidden(policyPath.Child("controlledValues"), "controlledValues shouldn't be specified if container scaling mode is off"))
+			}
+		}
+
+		if policy.OOMBumpUpRatio != nil {
+			if opts.AllowPerVPAConfig {
+				ratio := float64(policy.OOMBumpUpRatio.MilliValue()) / 1000.0
+				if ratio < 1.0 {
+					allErrs = append(allErrs, field.Invalid(policyPath.Child("oomBumpUpRatio"), ratio, "must be greater than or equal to 1.0"))
+				}
+			} else {
+				allErrs = append(allErrs, field.Forbidden(policyPath.Child("oomBumpUpRatio"), fmt.Sprintf("not supported when feature flag %s is disabled", features.PerVPAConfig)))
+			}
+		}
+
+		if policy.OOMMinBumpUp != nil {
+			if opts.AllowPerVPAConfig {
+				minBump := policy.OOMMinBumpUp.Value()
+				if minBump < 0 {
+					allErrs = append(allErrs, field.Invalid(policyPath.Child("oomMinBumpUp"), minBump, "must be greater than or equal to 0"))
+				}
+			} else {
+				allErrs = append(allErrs, field.Forbidden(policyPath.Child("oomMinBumpUp"), fmt.Sprintf("not supported when feature flag %s is disabled", features.PerVPAConfig)))
+			}
+		}
+
+		if policy.StartupBoost != nil {
+			allErrs = append(allErrs, validateVPASpecStartupBoost(policy.StartupBoost, policyPath.Child("startupBoost"), opts)...)
+		}
+	}
+
+	return allErrs
+}
+
+func validateVPASpecStartupBoost(startupBoost *vpa_types.StartupBoost, fldPath *field.Path, opts VPAValidationOptions) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if !opts.AllowCPUStartupBoost {
+		return append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost)))
+	}
+
+	cpuBoost := startupBoost.CPU
+	if cpuBoost == nil {
+		return allErrs
+	}
+	cpuPath := fldPath.Child("cpu")
+	boostType := cpuBoost.Type
+	if boostType == "" {
+		allErrs = append(allErrs, field.Required(cpuPath.Child("type"), fmt.Sprintf("must be either %s or %s", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType)))
+		return allErrs
+	}
+
+	switch boostType {
+	case vpa_types.FactorStartupBoostType:
+		if cpuBoost.Factor == nil {
+			allErrs = append(allErrs, field.Required(cpuPath.Child("factor"), "required when type is Factor"))
+		} else if *cpuBoost.Factor < 1 {
+			allErrs = append(allErrs, field.Invalid(cpuPath.Child("factor"), *cpuBoost.Factor, "must be >= 1 for type Factor"))
+		}
+	case vpa_types.QuantityStartupBoostType:
+		if cpuBoost.Quantity == nil {
+			allErrs = append(allErrs, field.Required(cpuPath.Child("quantity"), "required when type is Quantity"))
+		} else {
+			allErrs = append(allErrs, validateCPUResolution(*cpuBoost.Quantity, cpuPath.Child("quantity"))...)
+		}
+	default:
+		allErrs = append(allErrs, field.NotSupported(cpuPath.Child("type"), boostType, []string{string(vpa_types.FactorStartupBoostType), string(vpa_types.QuantityStartupBoostType)}))
+	}
+	return allErrs
+}
+
+func validateResourceResolution(fldPath *field.Path, name corev1.ResourceName, val apires.Quantity) field.ErrorList {
+	switch name {
+	case corev1.ResourceCPU:
+		return validateCPUResolution(val, fldPath)
+	case corev1.ResourceMemory:
+		return validateMemoryResolution(val, fldPath)
+	}
+	return nil
+}
+
+func validateCPUResolution(val apires.Quantity, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if _, precissionPreserved := val.AsScale(apires.Milli); !precissionPreserved {
+		allErrs = append(allErrs, field.Invalid(fldPath, val.String(), "must be a whole number of milli CPUs"))
+	}
+	return allErrs
+}
+
+func validateMemoryResolution(val apires.Quantity, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if _, precissionPreserved := val.AsScale(0); !precissionPreserved {
+		allErrs = append(allErrs, field.Invalid(fldPath, val.String(), "must be a whole number of bytes"))
+	}
+	return allErrs
+}

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation_test.go
@@ -38,6 +38,213 @@ const (
 	memory = corev1.ResourceMemory
 )
 
+func TestAllowCPUBoost(t *testing.T) {
+	tests := []struct {
+		name        string
+		oldObj      *vpa_types.VerticalPodAutoscaler
+		featureFlag bool
+		expected    bool
+	}{
+		{
+			name:        "feature enabled returns true",
+			oldObj:      nil,
+			featureFlag: true,
+			expected:    true,
+		},
+		{
+			name:        "feature disabled and oldObj nil returns false",
+			oldObj:      nil,
+			featureFlag: false,
+			expected:    false,
+		},
+		{
+			name: "feature disabled but top-level StartupBoost.CPU set returns true",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					StartupBoost: &vpa_types.StartupBoost{
+						CPU: &vpa_types.GenericStartupBoost{
+							Factor: ptr.To(int32(2)),
+						},
+					},
+				},
+			},
+			featureFlag: false,
+			expected:    true,
+		},
+		{
+			name: "feature disabled but container StartupBoost set returns true",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "app",
+								StartupBoost: &vpa_types.StartupBoost{
+									CPU: &vpa_types.GenericStartupBoost{
+										Factor: ptr.To(int32(2)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			featureFlag: false,
+			expected:    true,
+		},
+		{
+			name: "feature disabled and no startup boost configured returns false",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "app",
+							},
+						},
+					},
+				},
+			},
+			featureFlag: false,
+			expected:    false,
+		},
+		{
+			name: "feature disabled with empty container policies returns false",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{},
+					},
+				},
+			},
+			featureFlag: false,
+			expected:    false,
+		},
+		{
+			name: "feature disabled with ResourcePolicy nil returns false",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					StartupBoost: &vpa_types.StartupBoost{},
+				},
+			},
+			featureFlag: false,
+			expected:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.CPUStartupBoost, tc.featureFlag)
+			result := allowCPUBoost(tc.oldObj)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestAllowPerVPAConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		oldObj      *vpa_types.VerticalPodAutoscaler
+		featureFlag bool
+		expected    bool
+	}{
+		{
+			name:        "feature enabled returns true",
+			oldObj:      nil,
+			featureFlag: true,
+			expected:    true,
+		},
+		{
+			name:        "feature disabled and oldObj nil returns false",
+			oldObj:      nil,
+			featureFlag: false,
+			expected:    false,
+		},
+		{
+			name: "feature disabled but EvictAfterOOMSeconds set returns true",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						EvictAfterOOMSeconds: ptr.To(int32(600)),
+					},
+				},
+			},
+			featureFlag: false,
+			expected:    true,
+		},
+		{
+			name: "feature disabled but OOMBumpUpRatio set returns true",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName:  "app",
+								OOMBumpUpRatio: resource.NewQuantity(2, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			},
+			featureFlag: false,
+			expected:    true,
+		},
+		{
+			name: "feature disabled but OOMMinBumpUp set returns true",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "app",
+								OOMMinBumpUp:  resource.NewQuantity(100, resource.BinarySI),
+							},
+						},
+					},
+				},
+			},
+			featureFlag: false,
+			expected:    true,
+		},
+		{
+			name: "feature disabled and no per-vpa config returns false",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName: "app",
+							},
+						},
+					},
+				},
+			},
+			featureFlag: false,
+			expected:    false,
+		},
+		{
+			name: "feature disabled with empty container policies returns false",
+			oldObj: &vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{},
+					},
+				},
+			},
+			featureFlag: false,
+			expected:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.PerVPAConfig, tc.featureFlag)
+			result := allowPerVPAConfig(tc.oldObj)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestValidateVPA(t *testing.T) {
 	badUpdateMode := vpa_types.UpdateMode("bad")
 	validUpdateMode := vpa_types.UpdateModeOff
@@ -71,39 +278,51 @@ func TestValidateVPA(t *testing.T) {
 			name:        "empty create",
 			vpa:         vpa_types.VerticalPodAutoscaler{},
 			opts:        VPAValidationOptions{IsVPACreate: true},
-			expectError: errors.New("targetRef is required. If you're using v1beta1 version of the API, please migrate to v1"),
+			expectError: errors.New("spec.targetRef: Required value: If you're using v1beta1 version of the API, please migrate to v1"),
 		},
 		{
 			name: "no update mode",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{},
 				},
 			},
-			expectError: errors.New("updateMode is required if UpdatePolicy is used"),
+			expectError: errors.New("spec.updatePolicy.updateMode: Required value: updateMode is required if UpdatePolicy is used"),
 		},
 		{
 			name: "bad update mode",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode: &badUpdateMode,
 					},
 				},
 			},
-			expectError: errors.New("unexpected UpdateMode value bad"),
+			expectError: errors.New("spec.updatePolicy.updateMode: Unsupported value: \"bad\": supported values: \"InPlaceOrRecreate\", \"Initial\", \"Off\", \"Recreate\""),
 		},
 		{
 			name: "creating VPA with InPlaceOrRecreate update mode not allowed by disabled feature gate",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode: &inPlaceOrRecreateUpdateMode,
 					},
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowInPlaceOrRecreate: false},
-			expectError: fmt.Errorf("in order to use UpdateMode %s, you must enable feature gate %s in the admission-controller args", vpa_types.UpdateModeInPlaceOrRecreate, features.InPlaceOrRecreate),
+			expectError: fmt.Errorf("spec.updatePolicy.updateMode: Forbidden: in order to use UpdateMode %s, you must enable feature gate InPlaceOrRecreate in the admission-controller args", vpa_types.UpdateModeInPlaceOrRecreate),
 		},
 		{
 			name: "InPlaceOrRecreate update mode enabled by feature gate",
@@ -124,29 +343,41 @@ func TestValidateVPA(t *testing.T) {
 			name: "zero minReplicas",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						MinReplicas: &badMinReplicas,
 						UpdateMode:  &validUpdateMode,
 					},
 				},
 			},
-			expectError: errors.New("minReplicas has to be positive, got 0"),
+			expectError: errors.New("spec.updatePolicy.minReplicas: Invalid value: 0: minReplicas has to be positive"),
 		},
 		{
 			name: "no policy name",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{{}},
 					},
 				},
 			},
-			expectError: errors.New("containerPolicies.ContainerName is required"),
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].containerName: Required value"),
 		},
 		{
 			name: "invalid scaling mode",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -157,12 +388,16 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: errors.New("unexpected Mode value bad"),
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].mode: Unsupported value: \"bad\": supported values: \"Auto\", \"Off\""),
 		},
 		{
 			name: "more than one recommender",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode: &validUpdateMode,
 					},
@@ -172,12 +407,16 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: errors.New("the current version of VPA object shouldn't specify more than one recommenders"),
+			expectError: errors.New("spec.recommenders: Too many: 2: must have at most 1 item"),
 		},
 		{
 			name: "bad limits",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -193,12 +432,16 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: errors.New("max resource for cpu is lower than min"),
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].maxAllowed[cpu]: Invalid value: \"10\": max resource for cpu is lower than min of \"100\""),
 		},
 		{
 			name: "bad minAllowed cpu value",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -214,12 +457,16 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("minAllowed: CPU [%v] must be a whole number of milli CPUs", badCPUResource.String()),
+			expectError: fmt.Errorf("spec.resourcePolicy.containerPolicies[0].minAllowed[cpu]: Invalid value: \"%v\": must be a whole number of milli CPUs", badCPUResource.String()),
 		},
 		{
 			name: "bad minAllowed memory value",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -237,12 +484,16 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("minAllowed: memory [%v] must be a whole number of bytes", resource.MustParse("100m")),
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].minAllowed[memory]: Invalid value: \"100m\": must be a whole number of bytes"),
 		},
 		{
 			name: "bad maxAllowed cpu value",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -256,12 +507,16 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("maxAllowed: CPU [%s] must be a whole number of milli CPUs", badCPUResource.String()),
+			expectError: fmt.Errorf("spec.resourcePolicy.containerPolicies[0].maxAllowed[cpu]: Invalid value: \"%s\": must be a whole number of milli CPUs", badCPUResource.String()),
 		},
 		{
 			name: "bad maxAllowed memory value",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -277,12 +532,16 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: fmt.Errorf("maxAllowed: memory [%v] must be a whole number of bytes", resource.MustParse("500m")),
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].maxAllowed[memory]: Invalid value: \"500m\": must be a whole number of bytes"),
 		},
 		{
 			name: "scaling off with controlled values requests and limits",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -294,12 +553,16 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
-			expectError: errors.New("controlledValues shouldn't be specified if container scaling mode is off"),
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].controlledValues: Forbidden: controlledValues shouldn't be specified if container scaling mode is off"),
 		},
 		{
 			name: "all valid",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -326,6 +589,10 @@ func TestValidateVPA(t *testing.T) {
 			name: "top-level startupBoost with feature gate disabled",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					StartupBoost: &vpa_types.StartupBoost{
 						CPU: &vpa_types.GenericStartupBoost{
 							Factor: &validCPUBoostFactor,
@@ -334,12 +601,16 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: false},
-			expectError: fmt.Errorf("invalid startupBoost: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
+			expectError: fmt.Errorf("spec.startupBoost: Forbidden: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
 		},
 		{
 			name: "container startupBoost with feature gate disabled",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -355,12 +626,16 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: false},
-			expectError: fmt.Errorf("invalid startupBoost in container loot box: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
+			expectError: fmt.Errorf("spec.resourcePolicy.containerPolicies[0].startupBoost: Forbidden: in order to use startupBoost, you must enable feature gate %s in the admission-controller args", features.CPUStartupBoost),
 		},
 		{
 			name: "top-level startupBoost with bad factor",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					StartupBoost: &vpa_types.StartupBoost{
 						CPU: &vpa_types.GenericStartupBoost{
 							Type:   vpa_types.FactorStartupBoostType,
@@ -370,12 +645,16 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
-			expectError: errors.New("invalid startupBoost: invalid startupBoost.cpu.factor: must be >= 1 for type Factor"),
+			expectError: errors.New("spec.startupBoost.cpu.factor: Invalid value: 0: must be >= 1 for type Factor"),
 		},
 		{
 			name: "container startupBoost with bad factor",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -392,7 +671,7 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
-			expectError: errors.New("invalid startupBoost in container loot box: invalid startupBoost.cpu.factor: must be >= 1 for type Factor"),
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].startupBoost.cpu.factor: Invalid value: 0: must be >= 1 for type Factor"),
 		},
 		{
 			name: "top-level startupBoost with bad quantity",
@@ -411,7 +690,7 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
-			expectError: fmt.Errorf("invalid startupBoost: invalid startupBoost.cpu.quantity: CPU [%v] must be a whole number of milli CPUs", &badCPUBoostQuantity),
+			expectError: fmt.Errorf("spec.startupBoost.cpu.quantity: Invalid value: \"%v\": must be a whole number of milli CPUs", &badCPUBoostQuantity),
 		},
 		{
 			name: "container startupBoost with bad quantity",
@@ -437,12 +716,16 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
-			expectError: fmt.Errorf("invalid startupBoost in container loot box: invalid startupBoost.cpu.quantity: CPU [%v] must be a whole number of milli CPUs", &badCPUBoostQuantity),
+			expectError: fmt.Errorf("spec.resourcePolicy.containerPolicies[0].startupBoost.cpu.quantity: Invalid value: \"%v\": must be a whole number of milli CPUs", &badCPUBoostQuantity),
 		},
 		{
 			name: "top-level startupBoost with bad type",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					StartupBoost: &vpa_types.StartupBoost{
 						CPU: &vpa_types.GenericStartupBoost{
 							Type: badCPUBoostType,
@@ -451,12 +734,17 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
-			expectError: fmt.Errorf("invalid startupBoost: startupBoost.cpu.type field is required and must be either %s or %s, got %v", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType, badCPUBoostType),
+			expectError: fmt.Errorf("spec.startupBoost.cpu.type: Unsupported value: \"%v\": supported values: \"%s\", \"%s\"", badCPUBoostType, vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType),
 		},
 		{
 			name: "container startupBoost with bad type",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -472,24 +760,32 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
-			expectError: fmt.Errorf("invalid startupBoost in container loot box: startupBoost.cpu.type field is required and must be either %s or %s, got %v", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType, badCPUBoostType),
+			expectError: fmt.Errorf("spec.resourcePolicy.containerPolicies[0].startupBoost.cpu.type: Unsupported value: \"%v\": supported values: \"%s\", \"%s\"", badCPUBoostType, vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType),
 		},
 		{
 			name: "top-level startupBoost with empty type",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					StartupBoost: &vpa_types.StartupBoost{
 						CPU: &vpa_types.GenericStartupBoost{},
 					},
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
-			expectError: fmt.Errorf("invalid startupBoost: startupBoost.cpu.type field is required and must be either %s or %s", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType),
+			expectError: fmt.Errorf("spec.startupBoost.cpu.type: Required value: must be either %s or %s", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType),
 		},
 		{
 			name: "container startupBoost with empty type",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
 							{
@@ -503,7 +799,7 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowCPUStartupBoost: true},
-			expectError: fmt.Errorf("invalid startupBoost in container loot box: startupBoost.cpu.type field is required and must be either %s or %s", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType),
+			expectError: fmt.Errorf("spec.resourcePolicy.containerPolicies[0].startupBoost.cpu.type: Required value: must be either %s or %s", vpa_types.FactorStartupBoostType, vpa_types.QuantityStartupBoostType),
 		},
 		{
 			name: "top-level startupBoost with valid factor",
@@ -684,11 +980,93 @@ func TestValidateVPA(t *testing.T) {
 			opts: VPAValidationOptions{IsVPACreate: true, AllowPerVPAConfig: true},
 		},
 		{
+			name: "Invalid oomBumpUpRatio (negative value)",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode: &validUpdateMode,
+					},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName:  "*",
+								Mode:           &validScalingMode,
+								OOMBumpUpRatio: ptr.To(resource.MustParse("-1")),
+								OOMMinBumpUp:   ptr.To(resource.MustParse("104857600")),
+							},
+						},
+					},
+				},
+			},
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowPerVPAConfig: true},
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].oomBumpUpRatio: Invalid value: -1: must be greater than or equal to 1.0"),
+		},
+		{
+			name: "Invalid oomBumpUpRatio (less than 1)",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode: &validUpdateMode,
+					},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName:  "*",
+								Mode:           &validScalingMode,
+								OOMBumpUpRatio: ptr.To(resource.MustParse("0.5")),
+								OOMMinBumpUp:   ptr.To(resource.MustParse("104857600")),
+							},
+						},
+					},
+				},
+			},
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowPerVPAConfig: true},
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].oomBumpUpRatio: Invalid value: 0.5: must be greater than or equal to 1.0"),
+		},
+		{
+			name: "Invalid oomMinBumpUp (negative value)",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode: &validUpdateMode,
+					},
+					ResourcePolicy: &vpa_types.PodResourcePolicy{
+						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+							{
+								ContainerName:  "*",
+								Mode:           &validScalingMode,
+								OOMBumpUpRatio: ptr.To(resource.MustParse("2")),
+								OOMMinBumpUp:   ptr.To(resource.MustParse("-1")),
+							},
+						},
+					},
+				},
+			},
+			opts:        VPAValidationOptions{IsVPACreate: true, AllowPerVPAConfig: true},
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].oomMinBumpUp: Invalid value: -1: must be greater than or equal to 0"),
+		},
+		{
 			name: "per-vpa config disabled and used",
 			vpa: vpa_types.VerticalPodAutoscaler{
 				Spec: vpa_types.VerticalPodAutoscalerSpec{
 					UpdatePolicy: &vpa_types.PodUpdatePolicy{
 						UpdateMode: &validUpdateMode,
+					},
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
 					},
 					ResourcePolicy: &vpa_types.PodResourcePolicy{
 						ContainerPolicies: []vpa_types.ContainerResourcePolicy{
@@ -708,7 +1086,7 @@ func TestValidateVPA(t *testing.T) {
 				},
 			},
 			opts:        VPAValidationOptions{IsVPACreate: true, AllowPerVPAConfig: false},
-			expectError: errors.New("OOMBumpUpRatio and OOMMinBumpUp are not supported when feature flag PerVPAConfig is disabled"),
+			expectError: errors.New("spec.resourcePolicy.containerPolicies[0].oomMinBumpUp: Forbidden: not supported when feature flag PerVPAConfig is disabled"),
 		},
 	}
 	for _, tc := range tests {
@@ -720,14 +1098,58 @@ func TestValidateVPA(t *testing.T) {
 				featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.CPUStartupBoost, tc.opts.AllowCPUStartupBoost)
 			}
 			featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.PerVPAConfig, tc.opts.AllowPerVPAConfig)
-			err := ValidateVPA(&tc.vpa, tc.opts)
+			errs := validateVPA(&tc.vpa, tc.opts)
 			if tc.expectError == nil {
-				assert.NoError(t, err)
+				assert.Empty(t, errs)
 			} else {
-				if assert.Error(t, err) {
-					assert.Equal(t, tc.expectError.Error(), err.Error())
-				}
+				assert.NotEmpty(t, errs)
+				assert.Len(t, errs, 1)
+				assert.Equal(t, tc.expectError.Error(), errs[0].Error())
 			}
 		})
+	}
+}
+
+func TestVeryInvalidateVPA(t *testing.T) {
+	vpa := vpa_types.VerticalPodAutoscaler{
+		Spec: vpa_types.VerticalPodAutoscalerSpec{
+			ResourcePolicy: &vpa_types.PodResourcePolicy{
+				ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+					{
+						ContainerName: "loot box",
+						StartupBoost: &vpa_types.StartupBoost{
+							CPU: &vpa_types.GenericStartupBoost{},
+						},
+						ControlledResources: &[]corev1.ResourceName{"cpu", "memory", "broken"},
+					},
+				},
+			},
+			StartupBoost: &vpa_types.StartupBoost{},
+			UpdatePolicy: &vpa_types.PodUpdatePolicy{
+				MinReplicas:          ptr.To(int32(-1)),
+				UpdateMode:           ptr.To(vpa_types.UpdateMode("bad")),
+				EvictAfterOOMSeconds: ptr.To(int32(-1)),
+			},
+			Recommenders: []*vpa_types.VerticalPodAutoscalerRecommenderSelector{
+				{Name: "test1"},
+				{Name: "test2"},
+			},
+		},
+	}
+	expectFieldErrors := []string{
+		"spec.targetRef",
+		"spec.updatePolicy.updateMode",
+		"spec.updatePolicy.minReplicas",
+		"spec.updatePolicy.evictAfterOOMSeconds",
+		"spec.recommenders",
+		"spec.startupBoost",
+		"spec.resourcePolicy.containerPolicies[0].startupBoost",
+	}
+
+	errs := validateVPA(&vpa, VPAValidationOptions{IsVPACreate: true})
+
+	assert.Len(t, errs, 7)
+	for _, err := range errs {
+		assert.Contains(t, expectFieldErrors, err.Field)
 	}
 }

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/helpers.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/helpers.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package v1
 
+import "sort"
+
 // GetUpdateModes returns all supported UpdateModes
 func GetUpdateModes() map[UpdateMode]any {
 	return map[UpdateMode]any{
@@ -25,4 +27,17 @@ func GetUpdateModes() map[UpdateMode]any {
 		UpdateModeAuto:              nil,
 		UpdateModeInPlaceOrRecreate: nil,
 	}
+}
+
+// GetUpdateModesList returns all supported UpdateModes as a slice of strings
+func GetUpdateModesList() []string {
+	modes := GetUpdateModes()
+	result := make([]string, 0, len(modes))
+	for mode := range modes {
+		if mode != UpdateModeAuto { // Skip the deprecated one
+			result = append(result, string(mode))
+		}
+	}
+	sort.Strings(result)
+	return result
 }

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/helpers.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/helpers.go
@@ -18,7 +18,7 @@ package v1
 
 import "sort"
 
-// GetUpdateModes returns all supported UpdateModes
+// GetUpdateModes returns all UpdateModes
 func GetUpdateModes() map[UpdateMode]any {
 	return map[UpdateMode]any{
 		UpdateModeOff:               nil,
@@ -30,6 +30,7 @@ func GetUpdateModes() map[UpdateMode]any {
 }
 
 // GetUpdateModesList returns all supported UpdateModes as a slice of strings
+// Note: This list will not return deprecated modes.
 func GetUpdateModesList() []string {
 	modes := GetUpdateModes()
 	result := make([]string, 0, len(modes))
@@ -37,6 +38,25 @@ func GetUpdateModesList() []string {
 		if mode != UpdateModeAuto { // Skip the deprecated one
 			result = append(result, string(mode))
 		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+// GetScalingModes returns all supported ScalingModes
+func GetScalingModes() map[ContainerScalingMode]any {
+	return map[ContainerScalingMode]any{
+		ContainerScalingModeAuto: nil,
+		ContainerScalingModeOff:  nil,
+	}
+}
+
+// GetPossibleScalingModes returns all supported ScalingModes as a slice of strings
+func GetPossibleScalingModes() []string {
+	modes := GetScalingModes()
+	result := make([]string, 0, len(modes))
+	for mode := range modes {
+		result = append(result, string(mode))
 	}
 	sort.Strings(result)
 	return result

--- a/vertical-pod-autoscaler/test/e2e/v1/admission_controller.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/admission_controller.go
@@ -1131,14 +1131,14 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
                 }
             }
         }`,
-				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: VerticalPodAutoscaler.autoscaling.k8s.io \"oom-test-vpa\" is invalid: .: Internal error: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'",
+				expectedErr: `admission webhook "vpa.k8s.io" denied the request: VerticalPodAutoscaler.autoscaling.k8s.io "oom-test-vpa" is invalid: .: Internal error: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'`,
 			},
 		}
 		for _, tc := range testCases {
 			ginkgo.By(fmt.Sprintf("Testing %s", tc.name))
 			err := InstallRawVPA(f, []byte(tc.vpaJSON))
 			gomega.Expect(err).To(gomega.HaveOccurred(), fmt.Sprintf("Invalid VPA object accepted, name: \"%s\"", tc.name))
-			gomega.Expect(err.Error()).To(gomega.MatchRegexp(tc.expectedErr))
+			gomega.Expect(err.Error()).To(gomega.Equal(tc.expectedErr))
 		}
 	})
 

--- a/vertical-pod-autoscaler/test/e2e/v1/admission_controller.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/admission_controller.go
@@ -1108,84 +1108,6 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
 			expectedErr string
 		}{
 			{
-				name: "Invalid oomBumpUpRatio (negative value)",
-				vpaJSON: `{
-            "apiVersion": "autoscaling.k8s.io/v1",
-            "kind": "VerticalPodAutoscaler",
-            "metadata": {"name": "oom-test-vpa"},
-            "spec": {
-                "targetRef": {
-                    "apiVersion": "apps/v1",
-                    "kind": "Deployment",
-                    "name": "oom-test"
-                },
-                "updatePolicy": {
-                    "updateMode": "Auto"
-                },
-                "resourcePolicy": {
-                    "containerPolicies": [{
-                        "containerName": "*",
-                        "oomBumpUpRatio": -1,
-                        "oomMinBumpUp": 104857600
-                    }]
-                }
-            }
-        }`,
-				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: oomBumpUpRatio must be greater than or equal to 1.0, got -1",
-			},
-			{
-				name: "Invalid oomBumpUpRatio (less than 1)",
-				vpaJSON: `{
-            "apiVersion": "autoscaling.k8s.io/v1",
-            "kind": "VerticalPodAutoscaler",
-            "metadata": {"name": "oom-test-vpa"},
-            "spec": {
-                "targetRef": {
-                    "apiVersion": "apps/v1",
-                    "kind": "Deployment",
-                    "name": "oom-test"
-                },
-                "updatePolicy": {
-                    "updateMode": "Auto"
-                },
-                "resourcePolicy": {
-                    "containerPolicies": [{
-                        "containerName": "*",
-                        "oomBumpUpRatio": 0.5,
-                        "oomMinBumpUp": 104857600
-                    }]
-                }
-            }
-        }`,
-				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: oomBumpUpRatio must be greater than or equal to 1.0, got 0.5",
-			},
-			{
-				name: "Invalid oomMinBumpUp (negative value)",
-				vpaJSON: `{
-            "apiVersion": "autoscaling.k8s.io/v1",
-            "kind": "VerticalPodAutoscaler",
-            "metadata": {"name": "oom-test-vpa"},
-            "spec": {
-                "targetRef": {
-                    "apiVersion": "apps/v1",
-                    "kind": "Deployment",
-                    "name": "oom-test"
-                },
-                "updatePolicy": {
-                    "updateMode": "Auto"
-                },
-                "resourcePolicy": {
-                    "containerPolicies": [{
-                        "containerName": "*",
-                        "oomBumpUpRatio": 2,
-                        "oomMinBumpUp": -1
-                    }]
-                }
-            }
-        }`,
-				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: oomMinBumpUp must be greater than or equal to 0, got -1 bytes",
-			},
-			{
 				name: "Invalid oomBumpUpRatio (string value)",
 				vpaJSON: `{
             "apiVersion": "autoscaling.k8s.io/v1",
@@ -1209,7 +1131,7 @@ var _ = AdmissionControllerE2eDescribe("Admission-controller", func() {
                 }
             }
         }`,
-				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: quantities must match the regular expression",
+				expectedErr: "admission webhook \"vpa.k8s.io\" denied the request: VerticalPodAutoscaler.autoscaling.k8s.io \"oom-test-vpa\" is invalid: .: Internal error: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'",
 			},
 		}
 		for _, tc := range testCases {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This improves the VPA's validation, returning all errors up front, rather than the first error encountered.
This also splits the valuation up across multiple functions, similar to what Kubernetes does.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This change was assisted by AI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improved VPA validation error messages now pinpoint exactly which fields are invalid, making it faster to diagnose and resolve configuration issues in your VerticalPodAutoscaler specs.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
