### PR TITLE
chart(cluster-autoscaler): default serviceMonitor (metric)Relabelings to []

### DIFF
--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.57.0
+version: 9.57.1

--- a/cluster-autoscaler/charts/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/charts/cluster-autoscaler/README.md
@@ -550,10 +550,10 @@ vpa:
 | serviceMonitor.annotations | object | `{}` | Annotations to add to service monitor |
 | serviceMonitor.enabled | bool | `false` | If true, creates a Prometheus Operator ServiceMonitor. |
 | serviceMonitor.interval | string | `"10s"` | Interval that Prometheus scrapes Cluster Autoscaler metrics. |
-| serviceMonitor.metricRelabelings | object | `{}` | MetricRelabelConfigs to apply to samples before ingestion. |
+| serviceMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion. |
 | serviceMonitor.namespace | string | `"monitoring"` | Namespace which Prometheus is running in. |
 | serviceMonitor.path | string | `"/metrics"` | The path to scrape for metrics; autoscaler exposes `/metrics` (this is standard) |
-| serviceMonitor.relabelings | object | `{}` | RelabelConfigs to apply to metrics before scraping. |
+| serviceMonitor.relabelings | list | `[]` | RelabelConfigs to apply to metrics before scraping. |
 | serviceMonitor.selector | object | `{"release":"prometheus-operator"}` | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install. |
 | tolerations | list | `[]` | List of node taints to tolerate (requires Kubernetes >= 1.6). |
 | topologySpreadConstraints | list | `[]` | You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. (requires Kubernetes >= 1.19). |

--- a/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
@@ -468,10 +468,10 @@ serviceMonitor:
   annotations: {}
   ## [RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig)
   # serviceMonitor.relabelings -- RelabelConfigs to apply to metrics before scraping.
-  relabelings: {}
+  relabelings: []
   ## [RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig)
   # serviceMonitor.metricRelabelings -- MetricRelabelConfigs to apply to samples before ingestion.
-  metricRelabelings: {}
+  metricRelabelings: []
 
 # tolerations -- List of node taints to tolerate (requires Kubernetes >= 1.6).
 tolerations: []


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area cluster-autoscaler
/area helm-charts

#### What this PR does / why we need it:

The chart's `serviceMonitor.relabelings` and `serviceMonitor.metricRelabelings` defaults are `{}` (an empty map), but the `templates/servicemonitor.yaml` template renders them as YAML lists, and users naturally supply lists (per the linked Prometheus Operator `RelabelConfig` API).

When a user supplies a list, Helm cannot merge a list onto a map and emits this warning while silently dropping the user's value:

```
coalesce.go: warning: cannot overwrite table with non table for
cluster-autoscaler.serviceMonitor.relabelings (map[])
coalesce.go: warning: cannot overwrite table with non table for
cluster-autoscaler.serviceMonitor.metricRelabelings (map[])
```

Switching the defaults to `[]`:
- removes the warning,
- lets user-supplied lists merge cleanly into the rendered ServiceMonitor,
- aligns the value type with how the template uses it (and with the upstream Prometheus Operator `RelabelConfig` schema, which is a list).

The chart `version` is bumped to `9.57.1` (patch, bug fix), and `README.md` is regenerated via `helm-docs` so the rendered type column updates from `object`/`{}` to `list`/`[]`.

##### Reproduction (before this PR)

```yaml
# my-values.yaml
serviceMonitor:
  enabled: true
  metricRelabelings:
    - sourceLabels: [__name__]
      regex: 'go_.*'
      action: drop
```

```console
$ helm template myrelease cluster-autoscaler/charts/cluster-autoscaler -f my-values.yaml
coalesce.go:298: warning: cannot overwrite table with non table for cluster-autoscaler.serviceMonitor.metricRelabelings (map[])
...
    metricRelabelings:        # <-- empty; user value dropped
```

##### After this PR

```console
$ helm template myrelease cluster-autoscaler/charts/cluster-autoscaler -f my-values.yaml
# (no warnings)
...
    metricRelabelings:
      - action: drop
        regex: go_.*
        sourceLabels:
          - __name__
```

I also verified `helm lint`, `helm template` with `serviceMonitor.enabled=false` (default), and `helm template` with `serviceMonitor.enabled=true` and no overrides — all clean, with no spurious empty `relabelings:`/`metricRelabelings:` keys when defaults are used.

#### Which issue(s) this PR fixes:

Fixes #6357

#### Special notes for your reviewer:

- No template logic changed; only default values, the chart version, and the regenerated `README.md`.
- The template at `templates/servicemonitor.yaml` already truthy-checks `relabelings` / `metricRelabelings` before rendering, so the empty-list defaults remain a no-op when unset.

#### Does this PR introduce a user-facing change?

```release-note
`cluster-autoscaler` chart: `serviceMonitor.relabelings` and `serviceMonitor.metricRelabelings` now default to `[]` (was `{}`), removing the `cannot overwrite table with non table` Helm warning and allowing user-supplied list values to merge correctly.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```