### PR TITLE
Improve ScaleUpError status results to include PodsRemainUnschedulable info

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -950,12 +950,12 @@ func markAllGroupsAsUnschedulable(egs []*equivalence.PodGroup, reason status.Rea
 
 func markFailedGroupsAsUnschedulable(egs []*equivalence.PodGroup, failedGroups map[string]bool, reason status.Reasons) []*equivalence.PodGroup {
 	for _, eg := range egs {
-		if !eg.Schedulable {
+		// Skip if not schedulable, or if there are no groups to check
+		if !eg.Schedulable || len(eg.SchedulableGroups) == 0 {
 			continue
 		}
 
 		allFailed := true
-		hasFailedGroup := false
 
 		for _, sg := range eg.SchedulableGroups {
 			if !failedGroups[sg] {
@@ -963,14 +963,15 @@ func markFailedGroupsAsUnschedulable(egs []*equivalence.PodGroup, failedGroups m
 				continue
 			}
 
-			hasFailedGroup = true
 			if eg.SchedulingErrors == nil {
-				eg.SchedulingErrors = map[string]status.Reasons{}
+				eg.SchedulingErrors = make(map[string]status.Reasons)
 			}
 			eg.SchedulingErrors[sg] = reason
 		}
 
-		if hasFailedGroup && allFailed {
+		// Since we know len(eg.SchedulableGroups) > 0, allFailed is only true
+		// if every group in the list was present in failedGroups.
+		if allFailed {
 			eg.Schedulable = false
 		}
 	}

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -105,17 +105,29 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	podEquivalenceGroups := equivalence.BuildPodGroups(unschedulablePods)
 	metrics.UpdateDurationFromStart(metrics.BuildPodEquivalenceGroups, buildPodEquivalenceGroupsStart)
 
+	nodeGroups := o.autoscalingCtx.CloudProvider.NodeGroups()
 	upcomingNodes, aErr := o.UpcomingNodes(nodeInfos)
 	if aErr != nil {
-		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, aErr.AddPrefix("could not get upcoming nodes: "))
+		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
+		return status.UpdateScaleUpError(
+			&status.ScaleUpStatus{
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, map[string]status.Reasons{}, nodeInfos),
+			},
+			aErr.AddPrefix("could not get upcoming nodes: "),
+		)
 	}
 	klog.V(4).Infof("Upcoming %d nodes", len(upcomingNodes))
-	nodeGroups := o.autoscalingCtx.CloudProvider.NodeGroups()
 	if o.processors != nil && o.processors.NodeGroupListProcessor != nil {
 		var err error
 		nodeGroups, nodeInfos, err = o.processors.NodeGroupListProcessor.Process(o.autoscalingCtx, nodeGroups, nodeInfos, unschedulablePods)
 		if err != nil {
-			return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.ToAutoscalerError(errors.InternalError, err))
+			markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
+			return status.UpdateScaleUpError(
+				&status.ScaleUpStatus{
+					PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, map[string]status.Reasons{}, nodeInfos),
+				},
+				errors.ToAutoscalerError(errors.InternalError, err),
+			)
 		}
 	}
 
@@ -124,7 +136,13 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 
 	tracker, err := o.quotasTrackerFactory.NewQuotasTracker(o.autoscalingCtx, nodes)
 	if err != nil {
-		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("could not create quotas tracker: "))
+		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
+		return status.UpdateScaleUpError(
+			&status.ScaleUpStatus{
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, map[string]status.Reasons{}, nodeInfos),
+			},
+			errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("could not create quotas tracker: "),
+		)
 	}
 
 	now := time.Now()
@@ -195,14 +213,26 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	// Cap new nodes to supported number of nodes in the cluster.
 	newNodes, aErr := o.GetCappedNewNodeCount(bestOption.NodeCount, len(nodes))
 	if aErr != nil {
-		return status.UpdateScaleUpError(&status.ScaleUpStatus{PodsTriggeredScaleUp: bestOption.Pods}, aErr)
+		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
+		return status.UpdateScaleUpError(
+			&status.ScaleUpStatus{
+				PodsTriggeredScaleUp:    bestOption.Pods,
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
+			},
+			aErr,
+		)
 	}
 
 	newNodes, aErr = o.applyLimits(newNodes, tracker, bestOption.NodeGroup, nodeInfos)
 	if aErr != nil {
+		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
 		return status.UpdateScaleUpError(
-			&status.ScaleUpStatus{PodsTriggeredScaleUp: bestOption.Pods},
-			aErr)
+			&status.ScaleUpStatus{
+				PodsTriggeredScaleUp:    bestOption.Pods,
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
+			},
+			aErr,
+		)
 	}
 
 	if newNodes < bestOption.NodeCount {
@@ -241,9 +271,15 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 
 	scaleUpInfos, aErr := o.balanceScaleUps(now, bestOption.NodeGroup, newNodes, nodeInfos, schedulablePodGroups)
 	if aErr != nil {
+		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
 		return status.UpdateScaleUpError(
-			&status.ScaleUpStatus{CreateNodeGroupResults: createNodeGroupResults, PodsTriggeredScaleUp: bestOption.Pods},
-			aErr)
+			&status.ScaleUpStatus{
+				CreateNodeGroupResults:  createNodeGroupResults,
+				PodsTriggeredScaleUp:    bestOption.Pods,
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
+			},
+			aErr,
+		)
 	}
 
 	// Last check before scale-up. Node group capacity (both due to max size limits & current size) is only checked when balancing.
@@ -265,11 +301,14 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	klog.V(1).Infof("Final scale-up plan: %v", scaleUpInfos)
 	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, nodeInfos, now, allOrNothing)
 	if aErr != nil {
+		failedGroupsMap := o.buildFailedGroupsMap(failedNodeGroups, scaleUpInfos)
+		markedEquivalenceGroups := markFailedGroupsAsUnschedulable(podEquivalenceGroups, failedGroupsMap, ScaleUpExecutionErrorReason)
 		return status.UpdateScaleUpError(
 			&status.ScaleUpStatus{
-				CreateNodeGroupResults: createNodeGroupResults,
-				FailedResizeNodeGroups: failedNodeGroups,
-				PodsTriggeredScaleUp:   bestOption.Pods,
+				CreateNodeGroupResults:  createNodeGroupResults,
+				FailedResizeNodeGroups:  failedNodeGroups,
+				PodsTriggeredScaleUp:    bestOption.Pods,
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
 			},
 			aErr,
 		)
@@ -907,6 +946,61 @@ func markAllGroupsAsUnschedulable(egs []*equivalence.PodGroup, reason status.Rea
 		}
 	}
 	return egs
+}
+
+func markFailedGroupsAsUnschedulable(egs []*equivalence.PodGroup, failedGroups map[string]bool, reason status.Reasons) []*equivalence.PodGroup {
+	for _, eg := range egs {
+		if eg.Schedulable {
+			allFailed := true
+			hasFailedGroup := false
+			for _, sg := range eg.SchedulableGroups {
+				if failedGroups[sg] {
+					hasFailedGroup = true
+				} else {
+					allFailed = false
+				}
+			}
+			if hasFailedGroup {
+				if eg.SchedulingErrors == nil {
+					eg.SchedulingErrors = map[string]status.Reasons{}
+				}
+				for _, sg := range eg.SchedulableGroups {
+					if failedGroups[sg] {
+						eg.SchedulingErrors[sg] = reason
+					}
+				}
+				if allFailed {
+					eg.Schedulable = false
+				}
+			}
+		}
+	}
+	return egs
+}
+
+func (o *ScaleUpOrchestrator) buildFailedGroupsMap(failedNodeGroups []cloudprovider.NodeGroup, scaleUpInfos []nodegroupset.ScaleUpInfo) map[string]bool {
+	failedGroupsMap := make(map[string]bool)
+	for _, ng := range failedNodeGroups {
+		failedGroupsMap[ng.Id()] = true
+	}
+
+	// In sync mode, ExecuteScaleUps returns on first error.
+	// We need to consider all subsequent groups in the plan as failed too.
+	if !o.autoscalingCtx.ParallelScaleUp && len(failedNodeGroups) == 1 {
+		failedIdx := -1
+		for i, sui := range scaleUpInfos {
+			if sui.Group.Id() == failedNodeGroups[0].Id() {
+				failedIdx = i
+				break
+			}
+		}
+		if failedIdx >= 0 {
+			for i := failedIdx + 1; i < len(scaleUpInfos); i++ {
+				failedGroupsMap[scaleUpInfos[i].Group.Id()] = true
+			}
+		}
+	}
+	return failedGroupsMap
 }
 
 // GetPodsAwaitingEvaluation returns list of pods for which CA was unable to help

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -950,29 +950,28 @@ func markAllGroupsAsUnschedulable(egs []*equivalence.PodGroup, reason status.Rea
 
 func markFailedGroupsAsUnschedulable(egs []*equivalence.PodGroup, failedGroups map[string]bool, reason status.Reasons) []*equivalence.PodGroup {
 	for _, eg := range egs {
-		if eg.Schedulable {
-			allFailed := true
-			hasFailedGroup := false
-			for _, sg := range eg.SchedulableGroups {
-				if failedGroups[sg] {
-					hasFailedGroup = true
-				} else {
-					allFailed = false
-				}
+		if !eg.Schedulable {
+			continue
+		}
+
+		allFailed := true
+		hasFailedGroup := false
+
+		for _, sg := range eg.SchedulableGroups {
+			if !failedGroups[sg] {
+				allFailed = false
+				continue
 			}
-			if hasFailedGroup {
-				if eg.SchedulingErrors == nil {
-					eg.SchedulingErrors = map[string]status.Reasons{}
-				}
-				for _, sg := range eg.SchedulableGroups {
-					if failedGroups[sg] {
-						eg.SchedulingErrors[sg] = reason
-					}
-				}
-				if allFailed {
-					eg.Schedulable = false
-				}
+
+			hasFailedGroup = true
+			if eg.SchedulingErrors == nil {
+				eg.SchedulingErrors = map[string]status.Reasons{}
 			}
+			eg.SchedulingErrors[sg] = reason
+		}
+
+		if hasFailedGroup && allFailed {
+			eg.Schedulable = false
 		}
 	}
 	return egs

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaleup/equivalence"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
@@ -724,8 +725,8 @@ func TestCloudProviderFailingToScaleUpGroups(t *testing.T) {
 			{Name: "p2", Cpu: 1400, Node: "ng2-n1"},
 		},
 		ExtraPods: []PodConfig{
-			{Name: "p3", Cpu: 1400},
-			{Name: "p4", Cpu: 1400},
+			{Name: "p3", Cpu: 1400, Node: "group:ng1"},
+			{Name: "p4", Cpu: 1400, Node: "group:ng2"},
 		},
 		Options: &options,
 	}
@@ -742,39 +743,44 @@ func TestCloudProviderFailingToScaleUpGroups(t *testing.T) {
 		}
 	}
 	testCases := []struct {
-		desc                     string
-		parallel                 bool
-		onScaleUp                testprovider.OnScaleUpFunc
-		expectConcurrentErrors   bool
-		expectedTotalTargetSizes int
+		desc                            string
+		parallel                        bool
+		onScaleUp                       testprovider.OnScaleUpFunc
+		expectConcurrentErrors          bool
+		expectedTotalTargetSizes        int
+		expectedPodsRemainUnschedulable int
 	}{
 		{
-			desc:                     "synchronous scale up - two failures",
-			parallel:                 false,
-			onScaleUp:                failAlwaysScaleUp,
-			expectConcurrentErrors:   false,
-			expectedTotalTargetSizes: 3, // first error stops scale up process
+			desc:                            "synchronous scale up - two failures",
+			parallel:                        false,
+			onScaleUp:                       failAlwaysScaleUp,
+			expectConcurrentErrors:          false,
+			expectedTotalTargetSizes:        3, // first error stops scale up process
+			expectedPodsRemainUnschedulable: 1,
 		},
 		{
-			desc:                     "parallel scale up - two failures",
-			parallel:                 true,
-			onScaleUp:                failAlwaysScaleUp,
-			expectConcurrentErrors:   true,
-			expectedTotalTargetSizes: 4,
+			desc:                            "parallel scale up - two failures",
+			parallel:                        true,
+			onScaleUp:                       failAlwaysScaleUp,
+			expectConcurrentErrors:          false, // Only 1 group tried, so no concurrent errors
+			expectedTotalTargetSizes:        3,
+			expectedPodsRemainUnschedulable: 1,
 		},
 		{
-			desc:                     "synchronous scale up - one failure",
-			parallel:                 false,
-			onScaleUp:                failOnceScaleUp(),
-			expectConcurrentErrors:   false,
-			expectedTotalTargetSizes: 3,
+			desc:                            "synchronous scale up - one failure",
+			parallel:                        false,
+			onScaleUp:                       failOnceScaleUp(),
+			expectConcurrentErrors:          false,
+			expectedTotalTargetSizes:        3,
+			expectedPodsRemainUnschedulable: 1,
 		},
 		{
-			desc:                     "parallel scale up - one failure",
-			parallel:                 true,
-			onScaleUp:                failOnceScaleUp(),
-			expectConcurrentErrors:   false,
-			expectedTotalTargetSizes: 4,
+			desc:                            "parallel scale up - one failure",
+			parallel:                        true,
+			onScaleUp:                       failOnceScaleUp(),
+			expectConcurrentErrors:          false,
+			expectedTotalTargetSizes:        3,
+			expectedPodsRemainUnschedulable: 1,
 		},
 	}
 	for _, tc := range testCases {
@@ -786,6 +792,7 @@ func TestCloudProviderFailingToScaleUpGroups(t *testing.T) {
 			assert.Equal(t, errors.CloudProviderError, result.ScaleUpError.Type())
 			assert.Equal(t, tc.expectedTotalTargetSizes, result.GroupTargetSizes["ng1"]+result.GroupTargetSizes["ng2"])
 			assert.Equal(t, tc.expectConcurrentErrors, strings.Contains(result.ScaleUpError.Error(), "...and other errors"))
+			assert.Len(t, result.ScaleUpStatus.PodsRemainUnschedulable, tc.expectedPodsRemainUnschedulable)
 		})
 	}
 }
@@ -1283,7 +1290,12 @@ func buildTestPod(p PodConfig) *apiv1.Pod {
 		TolerateGpuForPod(pod)
 	}
 	if p.Node != "" {
-		pod.Spec.NodeName = p.Node
+		if strings.HasPrefix(p.Node, "group:") {
+			groupName := strings.TrimPrefix(p.Node, "group:")
+			pod.Spec.NodeSelector = map[string]string{nodeGroupLabel: groupName}
+		} else {
+			pod.Spec.NodeName = p.Node
+		}
 	}
 	return pod
 }
@@ -2273,4 +2285,121 @@ func matchNodeGroups(nodeGroups []string) func(*apiv1.Node) bool {
 	return func(n *apiv1.Node) bool {
 		return slices.Contains(nodeGroups, n.Labels[nodeGroupLabel])
 	}
+}
+
+func TestMarkFailedGroupsAsUnschedulable(t *testing.T) {
+	reason := NewRejectedReasons("stockout")
+
+	p1 := BuildTestPod("p1", 100, 100)
+	p2 := BuildTestPod("p2", 100, 100)
+	p3 := BuildTestPod("p3", 100, 100)
+
+	eg1 := &equivalence.PodGroup{
+		Pods:              []*apiv1.Pod{p1},
+		SchedulableGroups: []string{"ng1"},
+		Schedulable:       true,
+	}
+	eg2 := &equivalence.PodGroup{
+		Pods:              []*apiv1.Pod{p2},
+		SchedulableGroups: []string{"ng2"},
+		Schedulable:       true,
+	}
+	eg3 := &equivalence.PodGroup{
+		Pods:              []*apiv1.Pod{p3},
+		SchedulableGroups: []string{"ng1", "ng2"},
+		Schedulable:       true,
+	}
+
+	podEquivalenceGroups := []*equivalence.PodGroup{eg1, eg2, eg3}
+	failedGroups := map[string]bool{"ng2": true}
+
+	markFailedGroupsAsUnschedulable(podEquivalenceGroups, failedGroups, reason)
+
+	assert.True(t, eg1.Schedulable)
+	assert.False(t, eg2.Schedulable)
+	assert.True(t, eg3.Schedulable)
+
+	assert.Equal(t, reason, eg2.SchedulingErrors["ng2"])
+	assert.Equal(t, reason, eg3.SchedulingErrors["ng2"])
+	assert.NotContains(t, eg1.SchedulingErrors, "ng2")
+}
+
+func TestScaleUpPartialSuccessPopulatesPodsRemainUnschedulableParallel(t *testing.T) {
+	options := defaultOptions
+	options.ParallelScaleUp = true
+	options.BalanceSimilarNodeGroups = true
+	config := &ScaleUpTestConfig{
+		Groups: []NodeGroupConfig{
+			{Name: "ng1", MaxSize: 2},
+			{Name: "ng2", MaxSize: 2},
+		},
+		Nodes: []NodeConfig{
+			{Name: "ng1-n1", Cpu: 1000, Memory: 1000, Ready: true, Group: "ng1"},
+			{Name: "ng2-n1", Cpu: 1000, Memory: 1000, Ready: true, Group: "ng2"},
+		},
+		Pods: []PodConfig{
+			{Name: "fill-ng1", Cpu: 1000, Node: "ng1-n1"},
+			{Name: "fill-ng2", Cpu: 1000, Node: "ng2-n1"},
+		},
+		ExtraPods: []PodConfig{
+			{Name: "p1", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng1"},
+			{Name: "p2", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng2"},
+		},
+		OnScaleUp: func(group string, i int) error {
+			if group == "ng2" {
+				return fmt.Errorf("provider error for ng2")
+			}
+			return nil
+		},
+		ExpansionOptionToChoose: &GroupSizeChange{GroupName: "ng2", SizeChange: 1},
+		Options:                 &options,
+	}
+
+	result := runSimpleScaleUpTest(t, config)
+
+	assert.Equal(t, status.ScaleUpError, result.ScaleUpStatus.Result)
+	assert.Contains(t, result.ScaleUpStatus.PodsRemainUnschedulable, "p2")
+	assert.NotContains(t, result.ScaleUpStatus.PodsRemainUnschedulable, "p1")
+}
+
+func TestScaleUpPartialSuccessPopulatesPodsRemainUnschedulableSync(t *testing.T) {
+	options := defaultOptions
+	options.ParallelScaleUp = false
+	options.BalanceSimilarNodeGroups = true
+	config := &ScaleUpTestConfig{
+		Groups: []NodeGroupConfig{
+			{Name: "ng1", MaxSize: 2},
+			{Name: "ng2", MaxSize: 2},
+		},
+		Nodes: []NodeConfig{
+			{Name: "ng1-n1", Cpu: 1000, Memory: 1000, Ready: true, Group: "ng1"},
+			{Name: "ng2-n1", Cpu: 1000, Memory: 1000, Ready: true, Group: "ng2"},
+		},
+		Pods: []PodConfig{
+			{Name: "fill-ng1", Cpu: 1000, Node: "ng1-n1"},
+			{Name: "fill-ng2", Cpu: 1000, Node: "ng2-n1"},
+		},
+		ExtraPods: []PodConfig{
+			{Name: "p1_1", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng1"},
+			{Name: "p1_2", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng1"},
+			{Name: "p2_1", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng2"},
+			{Name: "p2_2", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng2"},
+		},
+		OnScaleUp: func(group string, i int) error {
+			if group == "ng2" {
+				return fmt.Errorf("provider error for ng2")
+			}
+			return nil
+		},
+		ExpansionOptionToChoose: &GroupSizeChange{GroupName: "ng2", SizeChange: 2},
+		Options:                 &options,
+	}
+
+	result := runSimpleScaleUpTest(t, config)
+
+	assert.Equal(t, status.ScaleUpError, result.ScaleUpStatus.Result)
+	assert.Contains(t, result.ScaleUpStatus.PodsRemainUnschedulable, "p2_1")
+	assert.Contains(t, result.ScaleUpStatus.PodsRemainUnschedulable, "p2_2")
+	assert.NotContains(t, result.ScaleUpStatus.PodsRemainUnschedulable, "p1_1")
+	assert.NotContains(t, result.ScaleUpStatus.PodsRemainUnschedulable, "p1_2")
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -725,8 +725,8 @@ func TestCloudProviderFailingToScaleUpGroups(t *testing.T) {
 			{Name: "p2", Cpu: 1400, Node: "ng2-n1"},
 		},
 		ExtraPods: []PodConfig{
-			{Name: "p3", Cpu: 1400, Node: "group:ng1"},
-			{Name: "p4", Cpu: 1400, Node: "group:ng2"},
+			{Name: "p3", Cpu: 1400},
+			{Name: "p4", Cpu: 1400},
 		},
 		Options: &options,
 	}
@@ -756,15 +756,15 @@ func TestCloudProviderFailingToScaleUpGroups(t *testing.T) {
 			onScaleUp:                       failAlwaysScaleUp,
 			expectConcurrentErrors:          false,
 			expectedTotalTargetSizes:        3, // first error stops scale up process
-			expectedPodsRemainUnschedulable: 1,
+			expectedPodsRemainUnschedulable: 2,
 		},
 		{
 			desc:                            "parallel scale up - two failures",
 			parallel:                        true,
 			onScaleUp:                       failAlwaysScaleUp,
-			expectConcurrentErrors:          false, // Only 1 group tried, so no concurrent errors
-			expectedTotalTargetSizes:        3,
-			expectedPodsRemainUnschedulable: 1,
+			expectConcurrentErrors:          true,
+			expectedTotalTargetSizes:        4,
+			expectedPodsRemainUnschedulable: 2,
 		},
 		{
 			desc:                            "synchronous scale up - one failure",
@@ -772,15 +772,15 @@ func TestCloudProviderFailingToScaleUpGroups(t *testing.T) {
 			onScaleUp:                       failOnceScaleUp(),
 			expectConcurrentErrors:          false,
 			expectedTotalTargetSizes:        3,
-			expectedPodsRemainUnschedulable: 1,
+			expectedPodsRemainUnschedulable: 2,
 		},
 		{
 			desc:                            "parallel scale up - one failure",
 			parallel:                        true,
 			onScaleUp:                       failOnceScaleUp(),
 			expectConcurrentErrors:          false,
-			expectedTotalTargetSizes:        3,
-			expectedPodsRemainUnschedulable: 1,
+			expectedTotalTargetSizes:        4,
+			expectedPodsRemainUnschedulable: 0,
 		},
 	}
 	for _, tc := range testCases {

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -1290,12 +1290,10 @@ func buildTestPod(p PodConfig) *apiv1.Pod {
 		TolerateGpuForPod(pod)
 	}
 	if p.Node != "" {
-		if strings.HasPrefix(p.Node, "group:") {
-			groupName := strings.TrimPrefix(p.Node, "group:")
-			pod.Spec.NodeSelector = map[string]string{nodeGroupLabel: groupName}
-		} else {
-			pod.Spec.NodeName = p.Node
-		}
+		pod.Spec.NodeName = p.Node
+	}
+	if p.NodeGroup != "" {
+		pod.Spec.NodeSelector = map[string]string{nodeGroupLabel: p.NodeGroup}
 	}
 	return pod
 }
@@ -2342,8 +2340,8 @@ func TestScaleUpPartialSuccessPopulatesPodsRemainUnschedulableParallel(t *testin
 			{Name: "fill-ng2", Cpu: 1000, Node: "ng2-n1"},
 		},
 		ExtraPods: []PodConfig{
-			{Name: "p1", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng1"},
-			{Name: "p2", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng2"},
+			{Name: "p1", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, NodeGroup: "ng1"},
+			{Name: "p2", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, NodeGroup: "ng2"},
 		},
 		OnScaleUp: func(group string, i int) error {
 			if group == "ng2" {
@@ -2380,10 +2378,10 @@ func TestScaleUpPartialSuccessPopulatesPodsRemainUnschedulableSync(t *testing.T)
 			{Name: "fill-ng2", Cpu: 1000, Node: "ng2-n1"},
 		},
 		ExtraPods: []PodConfig{
-			{Name: "p1_1", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng1"},
-			{Name: "p1_2", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng1"},
-			{Name: "p2_1", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng2"},
-			{Name: "p2_2", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, Node: "group:ng2"},
+			{Name: "p1_1", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, NodeGroup: "ng1"},
+			{Name: "p1_2", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, NodeGroup: "ng1"},
+			{Name: "p2_1", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, NodeGroup: "ng2"},
+			{Name: "p2_2", Cpu: 900, Memory: 0, Gpu: 0, ToleratesGpu: false, NodeGroup: "ng2"},
 		},
 		OnScaleUp: func(group string, i int) error {
 			if group == "ng2" {

--- a/cluster-autoscaler/core/scaleup/orchestrator/rejectedreasons.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/rejectedreasons.go
@@ -37,4 +37,7 @@ var (
 	// ExpansionOptionsFilteredOutReason means the node groups were considered as a scale-up candidates but got filtered
 	// out by the expander strategy.
 	ExpansionOptionsFilteredOutReason = NewRejectedReasons("expansion options filtered out and no longer considered")
+	// ScaleUpExecutionErrorReason means the node groups were considered as a scale-up candidates but the scale-up
+	// execution failed.
+	ScaleUpExecutionErrorReason = NewRejectedReasons("scale-up execution failed")
 )

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -70,6 +70,7 @@ type PodConfig struct {
 	Memory       int64
 	Gpu          int64
 	Node         string
+	NodeGroup    string
 	ToleratesGpu bool
 }
 


### PR DESCRIPTION
Improve ScaleUpError status results to include PodsRemainUnschedulable info

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, when a scale-up operation fails (e.g., due to cloud provider errors or quota limits), the `ScaleUpStatus` returned by the orchestrator does not always include the pods that remain unschedulable as a result of that failure. This can lead to inaccurate metrics and may cause SLOs (like ReactionTime) to ignore these pods.
This PR improves the `ScaleUpError` status results by populating the `PodsRemainUnschedulable` field in `ScaleUpStatus` across various failure paths in the scale-up loop:
- Failures during quotas tracker creation.
- Failures when applying limits or balancing scale-ups.
- Failures during the actual execution of scale-ups (`ExecuteScaleUps`).
To support this, the PR introduces `markFailedGroupsAsUnschedulable` to identify which pod equivalence groups failed to schedule on the failed node groups. It also handles both parallel and synchronous scale-up modes in `buildFailedGroupsMap`, ensuring that in sync mode, all subsequent groups in the plan after a failure are also considered failed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
The logic in `buildFailedGroupsMap` distinguishes between parallel and sync modes. In synchronous mode, since `ExecuteScaleUps` returns on the first error, we mark all subsequent node groups in the plan as failed too, as they were never attempted but couldn't proceed.
The logic in `buildFailedGroupsMap` distinguishes between parallel and sync modes. In synchronous mode, since `ExecuteScaleUps` returns on the first error, we mark all subsequent node groups in the plan as failed too, as they were never attempted but couldn't proceed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
