### PR TITLE
Add owner reference to capacity buffer pods.

### DIFF
--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -184,6 +184,7 @@ func (p *CapacityBufferPodListProcessor) updateBufferStatus(buffer *v1beta1.Capa
 func makeFakePods(buffer *v1beta1.CapacityBuffer, samplePodTemplate *apiv1.PodTemplateSpec, podCount int, forceSafeToEvictFakePods bool) ([]*apiv1.Pod, error) {
 	var fakePods []*apiv1.Pod
 	samplePod := pod.GetPodFromTemplate(samplePodTemplate)
+	withOwnerReference(samplePod, buffer)
 	samplePod.Spec.NodeName = ""
 	samplePod = withCapacityBufferFakePodAnnotation(samplePod)
 	if forceSafeToEvictFakePods {
@@ -197,6 +198,16 @@ func makeFakePods(buffer *v1beta1.CapacityBuffer, samplePodTemplate *apiv1.PodTe
 		fakePods = append(fakePods, fakePod)
 	}
 	return fakePods, nil
+}
+
+func withOwnerReference(pod *apiv1.Pod, buffer *v1beta1.CapacityBuffer) {
+	pod.OwnerReferences = append(pod.OwnerReferences, metav1.OwnerReference{
+		APIVersion: capacitybuffer.CapacityBufferApiVersion,
+		Kind:       capacitybuffer.CapacityBufferKind,
+		Name:       buffer.Name,
+		UID:        buffer.UID,
+		Controller: new(true),
+	})
 }
 
 func withCapacityBufferFakePodAnnotation(pod *apiv1.Pod) *apiv1.Pod {

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
@@ -191,8 +191,9 @@ func TestPodListProcessor(t *testing.T) {
 			fakeKubernetesClient := fakeclient.NewSimpleClientset(test.objectsInKubernetesClient...)
 			fakeBuffersClient := buffersfake.NewSimpleClientset(test.objectsInBuffersClient...)
 			fakeCapacityBuffersClient, _ := client.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, nil, nil)
+			capacityBuffersRegistry := fakepods.NewRegistry(nil)
 
-			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, fakepods.NewRegistry(nil), test.forceSafeToEvict)
+			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, capacityBuffersRegistry, test.forceSafeToEvict)
 			resUnschedulablePods, err := processor.Process(nil, test.unschedulablePods)
 			assert.Equal(t, err != nil, test.expectError)
 
@@ -205,6 +206,20 @@ func TestPodListProcessor(t *testing.T) {
 					safeToEvict, err := strconv.ParseBool(pod.Annotations[drain.PodSafeToEvictKey])
 					assert.Equal(t, err == nil && safeToEvict, test.forceSafeToEvict)
 					fakePodsNames[pod.Name] = true
+
+					// Verify owner reference
+					cb := capacityBuffersRegistry.GetCapacityBuffer(pod.UID)
+					if assert.NotNil(t, cb) {
+						assert.Equal(t, []metav1.OwnerReference{
+							{
+								APIVersion: capacitybuffer.CapacityBufferApiVersion,
+								Kind:       capacitybuffer.CapacityBufferKind,
+								Name:       cb.Name,
+								UID:        cb.UID,
+								Controller: new(true),
+							},
+						}, pod.OwnerReferences)
+					}
 				}
 			}
 			assert.Equal(t, test.expectedUnschedFakePodsCount, numberOfFakePods)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This will improve the CA loop time massively, because when there are many unschedulable capacity pods, CA will try to simulate every single one of them. But if we add ownerreference as controller, HintingSimulator have built-in optimization to avoid attempting scheduling all the other pods when similar one is already unschedulable.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

Link to logic that determine similar unschedulable pods:
https://github.com/walidghallab/autoscaler/blob/a9fc0de2bb5355dad5e7a02a22dc482f480b2d42/cluster-autoscaler/simulator/scheduling/similar_pods.go#L70-L84

Hinting simulator optimization:
https://github.com/walidghallab/autoscaler/blob/a9fc0de2bb5355dad5e7a02a22dc482f480b2d42/cluster-autoscaler/simulator/scheduling/hinting_simulator.go#L116-L119

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improve performance of capacity buffers pods when they are unschedulable including during their scale-ups and when CA can't create nodes for them.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
