### PR TITLE
Introduce relevance filter for ClusterSnapshot

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -372,6 +372,8 @@ type AutoscalingOptions struct {
 	CapacityQuotasEnabled             bool
 	// ScaleUpSimulationForSkippedNodeGroupsEnabled is used to enable/disable the scaleUpSimulation for the skipped node groups
 	ScaleUpSimulationForSkippedNodeGroupsEnabled bool
+	// RelevanceFilterEnabled tells if to prune irrelevant nodes from simulation snapshot.
+	RelevanceFilterEnabled bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -243,6 +243,7 @@ var (
 	maxNodeSkipEvalTimeTrackerEnabled            = flag.Bool("max-node-skip-eval-time-tracker-enabled", false, "Whether to enable the tracking of the maximum time of node being skipped during ScaleDown")
 	capacityQuotasEnabled                        = flag.Bool("capacity-quotas-enabled", false, "Whether to enable CapacityQuota CRD support.")
 	scaleUpSimulationForSkippedNodeGroupsEnabled = flag.Bool("scaleup-simulation-for-skipped-node-groups-enabled", false, "Whether to enable the scale up simulation for skipped node groups.")
+	relevanceFilterEnabled                       = flag.Bool("relevance-filter-enabled", false, "[Experimental] Whether to prune irrelevant nodes from simulation snapshot.")
 
 	// Deprecated flags
 	ignoreTaintsFlag = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
@@ -446,6 +447,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MaxNodeSkipEvalTimeTrackerEnabled:            *maxNodeSkipEvalTimeTrackerEnabled,
 		CapacityQuotasEnabled:                        *capacityQuotasEnabled,
 		ScaleUpSimulationForSkippedNodeGroupsEnabled: *scaleUpSimulationForSkippedNodeGroupsEnabled,
+		RelevanceFilterEnabled:                       *relevanceFilterEnabled,
 	}
 }
 

--- a/cluster-autoscaler/core/bench/benchmark_runonce_affinity_test.go
+++ b/cluster-autoscaler/core/bench/benchmark_runonce_affinity_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bench
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/expander"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/autoscaler/cluster-autoscaler/test/integration"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+var (
+	nodesCount        = flag.Int("nodes-count", 500, "Number of nodes in the cluster")
+	nodesPerNodeGroup = flag.Int("nodes-per-node-group", 50, "Number of nodes per node group")
+	podsPerNode       = flag.Int("pods-per-node", 10, "Number of pods per node")
+	surgeCount        = flag.Int("surge-count", 100, "Number of surge pods to schedule")
+)
+
+func BenchmarkRunOnceAffinitySurge_Hostname_Default(b *testing.B) {
+	s := scenario{
+		setup:  setupAffinitySurge(*nodesCount, *podsPerNode, *surgeCount, *nodesPerNodeGroup, apiv1.LabelHostname),
+		verify: verifyTotalTargetSizeEquals(*nodesCount + *surgeCount),
+		config: func(opts *config.AutoscalingOptions) {
+			configureAffinitySurge(opts)
+			opts.RelevanceFilterEnabled = false
+		},
+	}
+	s.run(b)
+}
+
+func BenchmarkRunOnceAffinitySurge_Hostname_RelevantOnly(b *testing.B) {
+	s := scenario{
+		setup:  setupAffinitySurge(*nodesCount, *podsPerNode, *surgeCount, *nodesPerNodeGroup, apiv1.LabelHostname),
+		verify: verifyTotalTargetSizeEquals(*nodesCount + *surgeCount),
+		config: func(opts *config.AutoscalingOptions) {
+			configureAffinitySurge(opts)
+			opts.RelevanceFilterEnabled = true
+		},
+	}
+	s.run(b)
+}
+
+// In the Zonal setup, each pod has an anti-affinity constraint against its
+// application partner. Across the entire set of surge pods, at least 1/2
+// of them are guaranteed to fit into at least one of the zones, even in
+// the worst case where all surge pods come in anti-affinity pairs.
+// By using the 'most-pods' expander, we guarantee that the chosen zone
+// will fit at least this amount.
+func BenchmarkRunOnceAffinitySurge_Zonal_Default(b *testing.B) {
+	s := scenario{
+		setup:  setupAffinitySurge(*nodesCount, *podsPerNode, *surgeCount, *nodesPerNodeGroup, apiv1.LabelTopologyZone),
+		verify: verifyTotalTargetSizeAtLeast(*nodesCount + (*surgeCount / 2)),
+		config: func(opts *config.AutoscalingOptions) {
+			configureAffinitySurge(opts)
+			opts.RelevanceFilterEnabled = false
+		},
+	}
+	s.run(b)
+}
+
+func BenchmarkRunOnceAffinitySurge_Zonal_RelevantOnly(b *testing.B) {
+	s := scenario{
+		setup:  setupAffinitySurge(*nodesCount, *podsPerNode, *surgeCount, *nodesPerNodeGroup, apiv1.LabelTopologyZone),
+		verify: verifyTotalTargetSizeAtLeast(*nodesCount + (*surgeCount / 2)),
+		config: func(opts *config.AutoscalingOptions) {
+			configureAffinitySurge(opts)
+			opts.RelevanceFilterEnabled = true
+		},
+	}
+	s.run(b)
+}
+
+func configureAffinitySurge(opts *config.AutoscalingOptions) {
+	opts.MaxNodesPerScaleUp = 1000000
+	opts.ScaleUpFromZero = true
+	opts.MaxCoresTotal = 1000000000
+	opts.MaxMemoryTotal = 1000000000
+	opts.MaxNodesTotal = 1000000
+	opts.PredicateParallelism = 16
+	opts.ExpanderNames = expander.MostPodsExpanderName
+	// Use high binpacking limits to avoid benchmarks being cut by internal timeouts.
+	opts.MaxBinpackingTime = 10 * time.Minute
+	opts.MaxNodeGroupBinpackingDuration = 10 * time.Minute
+}
+
+func setupAffinitySurge(nodesCount, podsPerNode, surgePodsCount, nodesPerGroup int, topologyKey string) func(*integration.FakeSet) error {
+	return func(clusterFakes *integration.FakeSet) error {
+		clusterFakes.CloudProvider.SetResourceLimit(cloudprovider.ResourceNameCores, 0, 1000000000)
+		clusterFakes.CloudProvider.SetResourceLimit(cloudprovider.ResourceNameMemory, 0, 1000000000)
+
+		numGroups := nodesCount / nodesPerGroup
+		totalPods := (nodesCount * podsPerNode) + surgePodsCount
+
+		// Use fixed seed for reproducibility
+		r := rand.New(rand.NewSource(42))
+
+		// Partition indices into scheduled and surge
+		indices := r.Perm(totalPods)
+		isSurge := make(map[int]bool)
+		for i := 0; i < surgePodsCount; i++ {
+			isSurge[indices[i]] = true
+		}
+
+		scheduledPodIdx := 0
+		surgePodIdx := 0
+
+		for i := 0; i < numGroups; i++ {
+			ngName := fmt.Sprintf("ng-affinity-%d", i)
+			zone := fmt.Sprintf("zone-%d", i%3)
+			instanceType := fmt.Sprintf("type-%d", i/3)
+
+			nTemplate := BuildTestNode(fmt.Sprintf("%s-template", ngName), nodeCPU, nodeMem)
+			if nTemplate.Labels == nil {
+				nTemplate.Labels = make(map[string]string)
+			}
+			nTemplate.Labels["kubernetes.io/hostname"] = nTemplate.Name
+			nTemplate.Labels["topology.kubernetes.io/zone"] = zone
+			nTemplate.Labels["node.kubernetes.io/instance-type"] = instanceType
+			SetNodeReadyState(nTemplate, true, time.Now())
+
+			clusterFakes.CloudProvider.AddNodeGroup(ngName,
+				testprovider.WithTemplate(framework.NewNodeInfo(nTemplate, nil)),
+				testprovider.WithNGSize(0, 1000000),
+			)
+
+			ng := clusterFakes.CloudProvider.GetNodeGroup(ngName)
+			if err := ng.IncreaseSize(nodesPerGroup); err != nil {
+				return err
+			}
+			ngID := ng.Id()
+
+			for j := 0; j < nodesPerGroup; j++ {
+				nodeName := fmt.Sprintf("%s-node-%d", ngID, j)
+
+				node := BuildTestNode(nodeName, nodeCPU, nodeMem)
+				if node.Labels == nil {
+					node.Labels = make(map[string]string)
+				}
+				node.Labels["kubernetes.io/hostname"] = nodeName
+				node.Labels["topology.kubernetes.io/zone"] = zone
+				node.Labels["node.kubernetes.io/instance-type"] = instanceType
+				SetNodeReadyState(node, true, time.Now())
+				clusterFakes.K8s.AddNode(node)
+				clusterFakes.CloudProvider.AddNode(ngID, node)
+
+				for k := 0; k < podsPerNode; k++ {
+					// Find the next non-surge pod index to schedule on this node
+					for isSurge[scheduledPodIdx+surgePodIdx] {
+						surgePodIdx++
+					}
+					podIdx := scheduledPodIdx + surgePodIdx
+
+					podName := fmt.Sprintf("scheduled-pod-%d", podIdx)
+					appLabels := map[string]string{"app": fmt.Sprintf("app-%d", podIdx/2)}
+					pod := BuildTestPod(podName, nodeCPU/int64(podsPerNode), nodeMem/int64(podsPerNode),
+						WithNodeName(nodeName),
+						WithLabels(appLabels),
+						WithPodAntiAffinity(appLabels, topologyKey),
+					)
+
+					clusterFakes.K8s.AddPod(pod)
+					scheduledPodIdx++
+				}
+			}
+		}
+
+		// Add remaining surge pods
+		for podIdx := 0; podIdx < totalPods; podIdx++ {
+			if isSurge[podIdx] {
+				podName := fmt.Sprintf("surge-pod-%d", podIdx)
+				appLabels := map[string]string{"app": fmt.Sprintf("app-%d", podIdx/2)}
+				pod := BuildTestPod(podName, nodeCPU, nodeMem,
+					MarkUnschedulable(),
+					WithLabels(appLabels),
+					WithPodAntiAffinity(appLabels, topologyKey),
+				)
+				clusterFakes.K8s.AddPod(pod)
+			}
+		}
+
+		return nil
+	}
+}
+
+func totalTargetSize(clusterFakes *integration.FakeSet) (int, error) {
+	total := 0
+	for _, ng := range clusterFakes.CloudProvider.NodeGroups() {
+		targetSize, err := ng.TargetSize()
+		if err != nil {
+			return 0, err
+		}
+		total += targetSize
+	}
+	return total, nil
+}
+
+func verifyTotalTargetSizeEquals(expected int) func(*integration.FakeSet) error {
+	return func(clusterFakes *integration.FakeSet) error {
+		total, err := totalTargetSize(clusterFakes)
+		if err != nil {
+			return err
+		}
+		if total != expected {
+			return fmt.Errorf("verify failed: expected total target size %d, got %d", expected, total)
+		}
+		return nil
+	}
+}
+
+func verifyTotalTargetSizeAtLeast(expectedMin int) func(*integration.FakeSet) error {
+	return func(clusterFakes *integration.FakeSet) error {
+		total, err := totalTargetSize(clusterFakes)
+		if err != nil {
+			return err
+		}
+		if total < expectedMin {
+			return fmt.Errorf("verify failed: expected total target size to be at least %d, got %d", expectedMin, total)
+		}
+		return nil
+	}
+}

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -129,6 +129,11 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 
 	now := time.Now()
 
+	if o.autoscalingCtx.RelevanceFilterEnabled {
+		cleanup := ApplyRelevanceFilter(o.autoscalingCtx.ClusterSnapshot, unschedulablePods)
+		defer cleanup()
+	}
+
 	// Filter out invalid node groups
 	validNodeGroups, skippedNodeGroups := o.filterValidScaleUpNodeGroups(nodeGroups, nodeInfos, tracker, len(nodes), now)
 
@@ -141,7 +146,6 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	schedulablePodGroups := map[string][]estimator.PodEquivalenceGroup{}
 	var options []expander.Option
 
-	// This code here runs a simulation to see which pods can be scheduled on which node groups.
 	for _, nodeGroup := range validNodeGroups {
 		schedulablePodGroups[nodeGroup.Id()] = o.SchedulablePodGroups(podEquivalenceGroups, nodeGroup, nodeInfos[nodeGroup.Id()])
 	}

--- a/cluster-autoscaler/core/scaleup/orchestrator/relevance.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/relevance.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"hash/fnv"
+	"sort"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/klog/v2"
+)
+
+// ApplyRelevanceFilter forks the cluster snapshot, removes nodes that are irrelevant to
+// the scheduling of pendingPods, and returns a function to revert the snapshot.
+// It is the caller's responsibility to call the returned revert function.
+func ApplyRelevanceFilter(snapshot clustersnapshot.ClusterSnapshot, pendingPods []*apiv1.Pod) func() {
+	allNodeInfos, err := snapshot.ListNodeInfos()
+	if err != nil {
+		klog.Errorf("Failed to list NodeInfos for relevance filter: %v", err)
+		return func() {}
+	}
+
+	relevantNodeInfos := FilterRelevantNodeInfos(pendingPods, allNodeInfos)
+	relevantMap := make(map[string]bool)
+	for _, ni := range relevantNodeInfos {
+		relevantMap[ni.Node().Name] = true
+	}
+
+	snapshot.Fork()
+
+	removedCount := 0
+	for _, ni := range allNodeInfos {
+		if !relevantMap[ni.Node().Name] {
+			if err := snapshot.RemoveNodeInfo(ni.Node().Name); err != nil {
+				klog.Errorf("Failed to remove irrelevant node %s from snapshot: %v", ni.Node().Name, err)
+			} else {
+				removedCount++
+			}
+		}
+	}
+
+	klog.V(4).Infof("Relevance Filter: Removed %d irrelevant nodes from ClusterSnapshot (kept %d/%d)", removedCount, len(relevantMap), len(allNodeInfos))
+
+	return func() {
+		snapshot.Revert()
+	}
+}
+
+// FilterRelevantNodeInfos returns a list of NodeInfos that have pods relevant to the scheduling of pendingPods.
+// Nodes are deemed relevant if they contain pods that match the affinity, anti-affinity, or topology spread constraints of the pending pods.
+func FilterRelevantNodeInfos(pendingPods []*apiv1.Pod, allNodeInfos []*framework.NodeInfo) []*framework.NodeInfo {
+	// TODO(x13n): De-duplicate pendingLabels and selectors to avoid redundant matching.
+	pendingLabels := make([]labels.Set, 0, len(pendingPods))
+	for _, p := range pendingPods {
+		pendingLabels = append(pendingLabels, labels.Set(p.Labels))
+	}
+
+	var pendingSelectors []labels.Selector
+	var selfMatchingHostnameSelectors []labels.Selector
+	hasTSC := false
+
+	for _, p := range pendingPods {
+		pLabels := labels.Set(p.Labels)
+		if p.Spec.Affinity != nil {
+			if p.Spec.Affinity.PodAffinity != nil {
+				for _, term := range p.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+					sel, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
+					if err != nil {
+						continue
+					}
+					if term.TopologyKey == apiv1.LabelHostname {
+						if sel.Matches(pLabels) {
+							selfMatchingHostnameSelectors = append(selfMatchingHostnameSelectors, sel)
+						}
+						continue
+					}
+					pendingSelectors = append(pendingSelectors, sel)
+				}
+			}
+			if p.Spec.Affinity.PodAntiAffinity != nil {
+				for _, term := range p.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+					// Hostname topology anti-affinities don't matter in ScaleUp (new nodes are empty).
+					if term.TopologyKey == apiv1.LabelHostname {
+						continue
+					}
+					if term.LabelSelector != nil {
+						if sel, err := metav1.LabelSelectorAsSelector(term.LabelSelector); err == nil {
+							pendingSelectors = append(pendingSelectors, sel)
+						}
+					}
+				}
+			}
+		}
+		for _, tsc := range p.Spec.TopologySpreadConstraints {
+			if tsc.TopologyKey == apiv1.LabelHostname {
+				continue
+			}
+			hasTSC = true
+			if tsc.LabelSelector != nil {
+				if sel, err := metav1.LabelSelectorAsSelector(tsc.LabelSelector); err == nil {
+					pendingSelectors = append(pendingSelectors, sel)
+				}
+			}
+		}
+	}
+
+	var relevant []*framework.NodeInfo
+	satisfiedSelfMatches := make([]bool, len(selfMatchingHostnameSelectors))
+	preservedSignatures := make(map[uint64]bool)
+
+	for _, ni := range allNodeInfos {
+		hasRelevantPod := false
+		for _, pi := range ni.Pods() {
+			p := pi.Pod
+			podLabels := labels.Set(p.Labels)
+
+			// 1. Regular non-hostname selectors
+			for _, sel := range pendingSelectors {
+				if sel.Matches(podLabels) {
+					hasRelevantPod = true
+					break
+				}
+			}
+			if hasRelevantPod {
+				break
+			}
+
+			// 2. Self-matching hostname selectors (at least one node per selector)
+			for i, sel := range selfMatchingHostnameSelectors {
+				if !satisfiedSelfMatches[i] && sel.Matches(podLabels) {
+					hasRelevantPod = true
+					satisfiedSelfMatches[i] = true
+				}
+			}
+
+			// 3. Does this node's pod have ANTI-affinity TO our pending pods?
+			if p.Spec.Affinity != nil && matchesAnyAntiOptimized(p.Spec.Affinity.PodAntiAffinity, pendingLabels) {
+				hasRelevantPod = true
+				break
+			}
+		}
+
+		// 4. Preserve representative nodes for TSC domains including across subsets of nodes.
+		// This is required to ensure no topology domains will be pruned.
+		isNeededForTSC := false
+		var sig uint64
+		if hasTSC {
+			sig = nodeSignature(ni.Node())
+			if !hasRelevantPod && !preservedSignatures[sig] {
+				isNeededForTSC = true
+			}
+		}
+
+		if hasRelevantPod || isNeededForTSC {
+			if hasTSC {
+				preservedSignatures[sig] = true
+			}
+			relevant = append(relevant, ni)
+		}
+	}
+	return relevant
+}
+
+func matchesAnyAntiOptimized(affinity *apiv1.PodAntiAffinity, labelsList []labels.Set) bool {
+	if affinity == nil {
+		return false
+	}
+	for _, term := range affinity.RequiredDuringSchedulingIgnoredDuringExecution {
+		// Hostname topology affinities don't actually matter in ScaleUp, so they can be effectively ignored.
+		if term.TopologyKey == apiv1.LabelHostname {
+			continue
+		}
+		if term.LabelSelector != nil {
+			if sel, err := metav1.LabelSelectorAsSelector(term.LabelSelector); err == nil {
+				for _, l := range labelsList {
+					if sel.Matches(l) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func nodeSignature(node *apiv1.Node) uint64 {
+	h := fnv.New64a()
+
+	// Sort labels to ensure deterministic order
+	keys := make([]string, 0, len(node.Labels))
+	for k := range node.Labels {
+		if k == apiv1.LabelHostname {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte{0}) // delimiter
+		h.Write([]byte(node.Labels[k]))
+		h.Write([]byte{0})
+	}
+
+	// Sort taints
+	taints := make([]apiv1.Taint, len(node.Spec.Taints))
+	copy(taints, node.Spec.Taints)
+	sort.Slice(taints, func(i, j int) bool {
+		return taints[i].Key < taints[j].Key
+	})
+
+	for _, t := range taints {
+		h.Write([]byte(t.Key))
+		h.Write([]byte{0})
+		h.Write([]byte(t.Value))
+		h.Write([]byte{0})
+		h.Write([]byte(t.Effect))
+		h.Write([]byte{0})
+	}
+
+	return h.Sum64()
+}

--- a/cluster-autoscaler/core/scaleup/orchestrator/relevance_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/relevance_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/testsnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestFilterRelevantNodeInfos(t *testing.T) {
+	podLabel := map[string]string{"app": "foo"}
+	pendingLabel := map[string]string{"app": "pending"}
+
+	testCases := []struct {
+		name          string
+		pendingPods   []*apiv1.Pod
+		allNodeInfos  []*framework.NodeInfo
+		expectedNodes []string
+	}{
+		{
+			name: "no affinities, node with pod is irrelevant",
+			pendingPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 100),
+			},
+			allNodeInfos: []*framework.NodeInfo{
+				framework.NewTestNodeInfo(BuildTestNode("n1", 1000, 1000), BuildTestPod("e1", 100, 100, WithLabels(podLabel))),
+			},
+			expectedNodes: []string{},
+		},
+		{
+			name: "pod affinity (pending to existing)",
+			pendingPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 100, WithPodAffinity(podLabel, "topology")),
+			},
+			allNodeInfos: []*framework.NodeInfo{
+				framework.NewTestNodeInfo(BuildTestNode("n1", 1000, 1000), BuildTestPod("e1", 100, 100, WithLabels(podLabel))),
+				framework.NewTestNodeInfo(BuildTestNode("n2", 1000, 1000)),
+			},
+			expectedNodes: []string{"n1"},
+		},
+		{
+			name: "pod anti-affinity (pending to existing)",
+			pendingPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 100, WithPodAntiAffinity(podLabel, "topology")),
+			},
+			allNodeInfos: []*framework.NodeInfo{
+				framework.NewTestNodeInfo(BuildTestNode("n1", 1000, 1000), BuildTestPod("e1", 100, 100, WithLabels(podLabel))),
+			},
+			expectedNodes: []string{"n1"},
+		},
+		{
+			name: "pod anti-affinity (existing to pending)",
+			pendingPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 100, WithLabels(pendingLabel)),
+			},
+			allNodeInfos: []*framework.NodeInfo{
+				framework.NewTestNodeInfo(BuildTestNode("n1", 1000, 1000), BuildTestPod("e1", 100, 100, WithPodAntiAffinity(pendingLabel, "topology"))),
+			},
+			expectedNodes: []string{"n1"},
+		},
+		{
+			name: "self-matching hostname affinity (keeps one node)",
+			pendingPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 100, WithLabels(podLabel), WithPodAffinity(podLabel, apiv1.LabelHostname)),
+			},
+			allNodeInfos: []*framework.NodeInfo{
+				framework.NewTestNodeInfo(BuildTestNode("n1", 1000, 1000), BuildTestPod("e1", 100, 100, WithLabels(podLabel))),
+				framework.NewTestNodeInfo(BuildTestNode("n2", 1000, 1000), BuildTestPod("e2", 100, 100, WithLabels(podLabel))),
+			},
+			expectedNodes: []string{"n1"}, // Only first one should be kept
+		},
+		{
+			name: "TSC preservation",
+			pendingPods: []*apiv1.Pod{
+				BuildTestPod("p1", 100, 100, WithHardTopologySpreadConstraint(1, "topology", podLabel)),
+			},
+			allNodeInfos: []*framework.NodeInfo{
+				framework.NewTestNodeInfo(BuildTestNode("n1", 1000, 1000, WithNodeLabel("topology", "zone1"))),
+				framework.NewTestNodeInfo(BuildTestNode("n2", 1000, 1000, WithNodeLabel("topology", "zone2"))),
+				framework.NewTestNodeInfo(BuildTestNode("n1-dup", 1000, 1000, WithNodeLabel("topology", "zone1"))),
+			},
+			expectedNodes: []string{"n1", "n2"}, // n1-dup has same signature as n1
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FilterRelevantNodeInfos(tc.pendingPods, tc.allNodeInfos)
+			gotNames := make([]string, 0, len(got))
+			for _, ni := range got {
+				gotNames = append(gotNames, ni.Node().Name)
+			}
+			assert.ElementsMatch(t, tc.expectedNodes, gotNames)
+		})
+	}
+}
+
+func TestApplyRelevanceFilter(t *testing.T) {
+	podLabel := map[string]string{"app": "foo"}
+	pendingPod := BuildTestPod("p1", 100, 100, WithPodAffinity(podLabel, "topology"))
+
+	n1 := BuildTestNode("n1", 1000, 1000)
+	ni1 := framework.NewTestNodeInfo(n1, BuildTestPod("e1", 100, 100, WithLabels(podLabel)))
+	n2 := BuildTestNode("n2", 1000, 1000)
+	ni2 := framework.NewTestNodeInfo(n2)
+
+	snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+	snapshot.AddNodeInfo(ni1)
+	snapshot.AddNodeInfo(ni2)
+
+	revert := ApplyRelevanceFilter(snapshot, []*apiv1.Pod{pendingPod})
+
+	// After filter, only n1 should be in snapshot
+	allInfos, _ := snapshot.ListNodeInfos()
+	assert.Equal(t, 1, len(allInfos))
+	assert.Equal(t, "n1", allInfos[0].Node().Name)
+
+	revert()
+
+	// After revert, both should be back
+	allInfos, _ = snapshot.ListNodeInfos()
+	assert.Equal(t, 2, len(allInfos))
+}

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -182,6 +182,20 @@ func WithMaxSkew(maxSkew int32, topologySpreadingKey string, minDomains int32) f
 	}
 }
 
+// WithHardTopologySpreadConstraint sets a hard topology spread constraint to the pod.
+func WithHardTopologySpreadConstraint(maxSkew int32, topologyKey string, matchLabels map[string]string) func(*apiv1.Pod) {
+	return func(pod *apiv1.Pod) {
+		pod.Spec.TopologySpreadConstraints = append(pod.Spec.TopologySpreadConstraints, apiv1.TopologySpreadConstraint{
+			MaxSkew:           maxSkew,
+			TopologyKey:       topologyKey,
+			WhenUnsatisfiable: apiv1.DoNotSchedule,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: matchLabels,
+			},
+		})
+	}
+}
+
 // WithCreationTimestamp sets creation timestamp to the pod.
 func WithCreationTimestamp(timestamp time.Time) func(*apiv1.Pod) {
 	return func(pod *apiv1.Pod) {
@@ -219,8 +233,27 @@ func WithNodeNamesAffinity(nodeNames ...string) func(*apiv1.Pod) {
 	}
 }
 
-// WithPodHostnameAntiAffinity sets pod's anti-affinity for pods matching the given labels at hostname topology level.
-func WithPodHostnameAntiAffinity(labels map[string]string) func(*apiv1.Pod) {
+// WithPodAffinity sets pod's affinity for pods matching the given labels at the provided topology level.
+func WithPodAffinity(labels map[string]string, topologyKey string) func(*apiv1.Pod) {
+	return func(pod *apiv1.Pod) {
+		if pod.Spec.Affinity == nil {
+			pod.Spec.Affinity = &apiv1.Affinity{}
+		}
+		pod.Spec.Affinity.PodAffinity = &apiv1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: labels,
+					},
+					TopologyKey: topologyKey,
+				},
+			},
+		}
+	}
+}
+
+// WithPodAntiAffinity sets pod's anti-affinity for pods matching the given labels at the provided topology level.
+func WithPodAntiAffinity(labels map[string]string, topologyKey string) func(*apiv1.Pod) {
 	return func(pod *apiv1.Pod) {
 		if pod.Spec.Affinity == nil {
 			pod.Spec.Affinity = &apiv1.Affinity{}
@@ -231,11 +264,16 @@ func WithPodHostnameAntiAffinity(labels map[string]string) func(*apiv1.Pod) {
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: labels,
 					},
-					TopologyKey: "kubernetes.io/hostname",
+					TopologyKey: topologyKey,
 				},
 			},
 		}
 	}
+}
+
+// WithPodHostnameAntiAffinity sets pod's anti-affinity for pods matching the given labels at hostname topology level.
+func WithPodHostnameAntiAffinity(labels map[string]string) func(*apiv1.Pod) {
+	return WithPodAntiAffinity(labels, apiv1.LabelHostname)
 }
 
 // BuildTestPodWithEphemeralStorage creates a pod with cpu, memory and ephemeral storage resources.
@@ -353,6 +391,16 @@ type NodeOption func(*apiv1.Node)
 func IsReady(ready bool) NodeOption {
 	return func(node *apiv1.Node) {
 		SetNodeReadyState(node, ready, time.Now())
+	}
+}
+
+// WithNodeLabel adds a label to the node.
+func WithNodeLabel(key, value string) NodeOption {
+	return func(node *apiv1.Node) {
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+		}
+		node.Labels[key] = value
 	}
 }
 


### PR DESCRIPTION
This feature results in visible (up to almost 10x) loop time reduction in the provided anti-affinity surge benchmark, depending on the topology used.

$ go test -v ./core/bench -bench BenchmarkRunOnceAffinitySurge -run ^$ -benchtime=1x
goos: linux
goarch: amd64
pkg: k8s.io/autoscaler/cluster-autoscaler/core/bench cpu: AMD EPYC 7B13
BenchmarkRunOnceAffinitySurge_Hostname_Default
BenchmarkRunOnceAffinitySurge_Hostname_Default-64                      1        606368983108 ns/op
BenchmarkRunOnceAffinitySurge_Hostname_RelevantOnly
BenchmarkRunOnceAffinitySurge_Hostname_RelevantOnly-64                 1        72663479496 ns/op
BenchmarkRunOnceAffinitySurge_Zonal_Default
BenchmarkRunOnceAffinitySurge_Zonal_Default-64                         1        605389016837 ns/op
BenchmarkRunOnceAffinitySurge_Zonal_RelevantOnly
BenchmarkRunOnceAffinitySurge_Zonal_RelevantOnly-64                    1        313136394981 ns/op

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Performance improvement.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new, experimental --relevance-filter-enabled flag, pruning irrelevant nodes before scale up simulations, significantly improving performance at scale when computationally complex scheduling predicates are used (inter pod affinity, topology spreading).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @tetianakh @towca 
/hold to add unit tests beyond the benchmark
