### PR TITLE
Implement scale-down prevention based on resource quotas

### DIFF
--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -28,11 +28,11 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/nodeevaltracker"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
-	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/unneeded"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/unremovable"
 	"k8s.io/autoscaler/cluster-autoscaler/processors"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
@@ -73,22 +73,21 @@ type Planner struct {
 	minUpdateInterval     time.Duration
 	eligibilityChecker    eligibilityChecker
 	nodeUtilizationMap    map[string]utilization.Info
-	resourceLimitsFinder  *resource.LimitsFinder
 	cc                    controllerReplicasCalculator
+	quotasTrackerFactory  *resourcequotas.TrackerFactory
 	scaleDownSetProcessor nodes.ScaleDownSetProcessor
 	scaleDownContext      *nodes.ScaleDownContext
 	maxNodeSkipEvalTime   *nodeevaltracker.MaxNodeSkipEvalTime
 }
 
 // New creates a new Planner object.
-func New(autoscalingCtx *ca_context.AutoscalingContext, processors *processors.AutoscalingProcessors, deleteOptions options.NodeDeleteOptions, drainabilityRules rules.Rules) *Planner {
-	resourceLimitsFinder := resource.NewLimitsFinder(processors.CustomResourcesProcessor)
+func New(autoscalingCtx *ca_context.AutoscalingContext, processors *processors.AutoscalingProcessors, deleteOptions options.NodeDeleteOptions, drainabilityRules rules.Rules, quotasTrackerFactory *resourcequotas.TrackerFactory) *Planner {
 	minUpdateInterval := autoscalingCtx.AutoscalingOptions.NodeGroupDefaults.ScaleDownUnneededTime
 	if minUpdateInterval == 0*time.Nanosecond {
 		minUpdateInterval = 1 * time.Nanosecond
 	}
 
-	unneededNodes := unneeded.NewNodes(processors.NodeGroupConfigProcessor, resourceLimitsFinder)
+	unneededNodes := unneeded.NewNodes(processors.NodeGroupConfigProcessor)
 	if autoscalingCtx.AutoscalingOptions.NodeDeletionCandidateTTL != 0 {
 		unneededNodes.LoadFromExistingTaints(autoscalingCtx, time.Now())
 	}
@@ -106,8 +105,8 @@ func New(autoscalingCtx *ca_context.AutoscalingContext, processors *processors.A
 		actuationInjector:     scheduling.NewHintingSimulator(),
 		eligibilityChecker:    eligibility.NewChecker(processors.NodeGroupConfigProcessor),
 		nodeUtilizationMap:    make(map[string]utilization.Info),
-		resourceLimitsFinder:  resourceLimitsFinder,
 		cc:                    newControllerReplicasCalculator(autoscalingCtx.ListerRegistry),
+		quotasTrackerFactory:  quotasTrackerFactory,
 		scaleDownSetProcessor: processors.ScaleDownSetProcessor,
 		scaleDownContext:      nodes.NewDefaultScaleDownContext(),
 		minUpdateInterval:     minUpdateInterval,
@@ -151,18 +150,20 @@ func (p *Planner) CleanUpUnneededNodes() {
 // to the Planner.
 func (p *Planner) NodesToDelete(_ time.Time) (empty, needDrain []*apiv1.Node) {
 	empty, needDrain = []*apiv1.Node{}, []*apiv1.Node{}
+
 	nodes, err := allNodes(p.autoscalingCtx.ClusterSnapshot)
 	if err != nil {
-		klog.Errorf("Nothing will scale down, failed to list nodes from ClusterSnapshot: %v", err)
+		klog.Errorf("Failed to list nodes for final limit check: %v", err)
 		return nil, nil
 	}
-	resourceLimiter, err := p.autoscalingCtx.CloudProvider.GetResourceLimiter()
+
+	tracker, err := p.quotasTrackerFactory.NewMinQuotasTracker(p.autoscalingCtx, nodes)
 	if err != nil {
-		klog.Errorf("Nothing will scale down, failed to create resource limiter: %v", err)
+		klog.Errorf("Failed to create tracker for final limit check: %v", err)
 		return nil, nil
 	}
-	p.scaleDownContext.ResourcesLeft = p.resourceLimitsFinder.LimitsLeft(p.autoscalingCtx, nodes, resourceLimiter, p.latestUpdate).DeepCopy()
-	p.scaleDownContext.ResourcesWithLimits = resourceLimiter.GetResources()
+	p.scaleDownContext.Tracker = tracker
+
 	emptyRemovableNodes, needDrainRemovableNodes, unremovableNodes := p.unneededNodes.RemovableAt(p.autoscalingCtx, *p.scaleDownContext, p.latestUpdate)
 	p.addUnremovableNodes(unremovableNodes)
 
@@ -307,6 +308,7 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 			klog.V(4).Infof("%d out of %d nodes skipped in scale down simulation: there are already %d unneeded nodes so no point in looking for more. Total atomic scale down nodes: %d", len(currentlyUnneededNodeNames)-i, len(currentlyUnneededNodeNames), len(removableList), atomicScaleDownNodesCount)
 			break
 		}
+
 		removable, unremovable := p.rs.SimulateNodeRemoval(node, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
 		if removable != nil {
 			_, inParallel, _ := p.autoscalingCtx.RemainingPdbTracker.CanRemovePods(removable.PodsToReschedule)

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -18,6 +18,8 @@ package planner
 
 import (
 	"fmt"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
+
 	"testing"
 	"time"
 
@@ -505,7 +507,8 @@ func TestUpdateClusterState(t *testing.T) {
 			assert.NoError(t, err)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, tc.nodes, tc.pods)
 			deleteOptions := options.NodeDeleteOptions{}
-			p := New(&autoscalingCtx, processors, deleteOptions, nil)
+			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
+			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(tc.eligible)}
 			if tc.isSimulationTimeout {
 				autoscalingCtx.AutoscalingOptions.ScaleDownSimulationTimeout = 1 * time.Second
@@ -526,6 +529,8 @@ func TestUpdateClusterState(t *testing.T) {
 		})
 	}
 }
+
+
 
 func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 	testCases := []struct {
@@ -703,7 +708,8 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			assert.NoError(t, err)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, nodes, nil)
 			deleteOptions := options.NodeDeleteOptions{}
-			p := New(&autoscalingCtx, processors, deleteOptions, nil)
+			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
+			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(nodeNames(nodes))}
 			p.minUpdateInterval = tc.updateInterval
 			p.unneededNodes.Update(&autoscalingCtx, previouslyUnneeded, time.Now())
@@ -838,7 +844,8 @@ func TestNewPlannerWithExistingDeletionCandidateNodes(t *testing.T) {
 			assert.NoError(t, err)
 
 			deleteOptions := options.NodeDeleteOptions{}
-			p := New(&autoscalingCtx, processors, deleteOptions, nil)
+			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
+			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
 
 			p.unneededNodes.AsList()
 		})
@@ -847,11 +854,13 @@ func TestNewPlannerWithExistingDeletionCandidateNodes(t *testing.T) {
 
 func TestNodesToDelete(t *testing.T) {
 	testCases := []struct {
-		name           string
-		nodes          map[string][]*apiv1.Node
-		removableNodes map[cloudprovider.NodeGroup][]simulator.NodeToBeRemoved
-		wantEmpty      []*apiv1.Node
-		wantDrain      []*apiv1.Node
+		name            string
+		nodes           map[string][]*apiv1.Node
+		removableNodes  map[cloudprovider.NodeGroup][]simulator.NodeToBeRemoved
+		wantEmpty       []*apiv1.Node
+		wantDrain       []*apiv1.Node
+		minLimits       map[string]int64
+		wantUnremovable map[string]simulator.UnremovableReason
 	}{
 		{
 			name:           "empty",
@@ -1016,6 +1025,56 @@ func TestNodesToDelete(t *testing.T) {
 				buildRemovableNode("atomic-partial-ng-partially-registered-1", 0).Node,
 			},
 		},
+		{
+			name: "min limits race condition protection",
+			nodes: map[string][]*apiv1.Node{
+				"ng1": {
+					BuildTestNode("node-3", 1000, 10),
+				},
+			},
+			removableNodes: map[cloudprovider.NodeGroup][]simulator.NodeToBeRemoved{
+				sizedNodeGroup("ng1", 3, false): {
+					buildRemovableNode("node-1", 0),
+					buildRemovableNode("node-2", 1),
+				},
+			},
+			wantEmpty: []*apiv1.Node{
+				buildRemovableNode("node-1", 0).Node,
+			},
+			wantDrain: []*apiv1.Node{},
+			minLimits: map[string]int64{
+				cloudprovider.ResourceNameCores:  2,
+				cloudprovider.ResourceNameMemory: 20,
+				"nodes":                          2,
+			},
+			wantUnremovable: map[string]simulator.UnremovableReason{
+				"node-2": simulator.MinimalResourceLimitExceeded,
+			},
+		},
+		{
+			name: "two nodes removable, quota allows both",
+			nodes: map[string][]*apiv1.Node{
+				"ng1": {
+					BuildTestNode("node-3", 1000, 10),
+				},
+			},
+			removableNodes: map[cloudprovider.NodeGroup][]simulator.NodeToBeRemoved{
+				sizedNodeGroup("ng1", 3, false): {
+					buildRemovableNode("node-1", 0),
+					buildRemovableNode("node-2", 0),
+				},
+			},
+			wantEmpty: []*apiv1.Node{
+				buildRemovableNode("node-1", 0).Node,
+				buildRemovableNode("node-2", 0).Node,
+			},
+			wantDrain: []*apiv1.Node{},
+			minLimits: map[string]int64{
+				cloudprovider.ResourceNameCores:  1,
+				cloudprovider.ResourceNameMemory: 10,
+				"nodes":                          1,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -1044,20 +1103,41 @@ func TestNodesToDelete(t *testing.T) {
 					ScaleDownUnneededTime: 10 * time.Minute,
 					ScaleDownUnreadyTime:  0 * time.Minute,
 				},
+				ScaleDownSimulationTimeout: 5 * time.Minute,
 			}
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOpts)
 			autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOpts, &fake.Clientset{}, nil, provider, nil, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, allNodes, nil)
 			deleteOptions := options.NodeDeleteOptions{}
-			p := New(&autoscalingCtx, processors, deleteOptions, nil)
+			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
+			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
 			p.latestUpdate = time.Now()
+
+			if tc.minLimits != nil {
+				resourceLimiter := cloudprovider.NewResourceLimiter(tc.minLimits, nil)
+				provider.SetResourceLimiter(resourceLimiter)
+			}
+
 			p.scaleDownContext.ActuationStatus = deletiontracker.NewNodeDeletionTracker(0 * time.Second)
 			p.unneededNodes.Update(&autoscalingCtx, allRemovables, time.Now().Add(-1*time.Hour))
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(nodeNames(allNodes))}
 			empty, drain := p.NodesToDelete(time.Now())
 			assert.ElementsMatch(t, tc.wantEmpty, empty)
 			assert.ElementsMatch(t, tc.wantDrain, drain)
+
+			if tc.wantUnremovable != nil {
+				unremovable := p.unremovableNodes.AsList()
+				unremovableMap := make(map[string]simulator.UnremovableReason)
+				for _, u := range unremovable {
+					unremovableMap[u.Node.Name] = u.Reason
+				}
+				for nodeName, expectedReason := range tc.wantUnremovable {
+					reason, found := unremovableMap[nodeName]
+					assert.True(t, found, "Node %s not found in unremovable list", nodeName)
+					assert.Equal(t, expectedReason, reason, "Reason mismatch for node %s", nodeName)
+				}
+			}
 		})
 	}
 }

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -530,8 +530,6 @@ func TestUpdateClusterState(t *testing.T) {
 	}
 }
 
-
-
 func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 	testCases := []struct {
 		name               string

--- a/cluster-autoscaler/core/scaledown/resource/limits.go
+++ b/cluster-autoscaler/core/scaledown/resource/limits.go
@@ -146,7 +146,7 @@ func (lf *LimitsFinder) customResourcesTotal(autoscalingCtx *ca_context.Autoscal
 		if !cacheHit {
 			resourceTargets, err = lf.crp.GetNodeResourceTargets(autoscalingCtx, node, nodeGroup)
 			if err != nil {
-				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("cannot get custom resource count for node %v when calculating cluster custom resource usage")
+				return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("cannot get custom resource count for node %v when calculating cluster custom resource usage", node.Name)
 			}
 			if nodeGroup != nil {
 				ngCache[nodeGroup.Id()] = resourceTargets
@@ -185,7 +185,7 @@ func (lf *LimitsFinder) DeltaForNode(autoscalingCtx *ca_context.AutoscalingConte
 	if cloudprovider.ContainsCustomResources(resourcesWithLimits) {
 		resourceTargets, err := lf.crp.GetNodeResourceTargets(autoscalingCtx, node, nodeGroup)
 		if err != nil {
-			return Delta{}, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to get node %v custom resources: %v", node.Name)
+			return Delta{}, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to get node %q custom resources: ", node.Name)
 		}
 		for _, resourceTarget := range resourceTargets {
 			resultScaleDownDelta[resourceTarget.ResourceType] = resourceTarget.ResourceCount

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes.go
@@ -25,8 +25,7 @@ import (
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
-	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
-	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils"
@@ -38,10 +37,10 @@ import (
 
 // Nodes tracks the state of cluster nodes that are not needed.
 type Nodes struct {
-	sdtg         scaleDownTimeGetter
-	limitsFinder *resource.LimitsFinder
-	cachedList   []*scaledown.UnneededNode
-	byName       map[string]*node
+	sdtg scaleDownTimeGetter
+
+	cachedList []*scaledown.UnneededNode
+	byName     map[string]*node
 }
 
 type node struct {
@@ -59,10 +58,9 @@ type scaleDownTimeGetter interface {
 }
 
 // NewNodes returns a new initialized Nodes object.
-func NewNodes(sdtg scaleDownTimeGetter, limitsFinder *resource.LimitsFinder) *Nodes {
+func NewNodes(sdtg scaleDownTimeGetter) *Nodes {
 	return &Nodes{
-		sdtg:         sdtg,
-		limitsFinder: limitsFinder,
+		sdtg: sdtg,
 	}
 }
 
@@ -290,25 +288,14 @@ func (n *Nodes) unremovableReason(autoscalingCtx *ca_context.AutoscalingContext,
 		return reason
 	}
 
-	resourceDelta, err := n.limitsFinder.DeltaForNode(autoscalingCtx, node, nodeGroup, scaleDownContext.ResourcesWithLimits)
+	checkResult, err := scaleDownContext.Tracker.ConsumeQuota(autoscalingCtx, nodeGroup, node, 1)
 	if err != nil {
-		klog.Errorf("Error getting node resources: %v", err)
+		klog.Errorf("Failed to check limits for %s: %v", node.Name, err)
 		return simulator.UnexpectedError
 	}
 
-	checkResult := scaleDownContext.ResourcesLeft.TryDecrementBy(resourceDelta)
 	if checkResult.Exceeded() {
-		klog.V(4).Infof("Skipping %s - minimal limit exceeded for %v", node.Name, checkResult.ExceededResources)
-		for _, resource := range checkResult.ExceededResources {
-			switch resource {
-			case cloudprovider.ResourceNameCores:
-				metrics.RegisterSkippedScaleDownCPU()
-			case cloudprovider.ResourceNameMemory:
-				metrics.RegisterSkippedScaleDownMemory()
-			default:
-				continue
-			}
-		}
+		klog.V(2).Infof("Skipping scale down of %s in this batch - would violate minimum limits", node.Name)
 		return simulator.MinimalResourceLimitExceeded
 	}
 

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
@@ -28,10 +28,11 @@ import (
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
-	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
 	nodeprocessors "k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
@@ -150,7 +151,7 @@ func TestUpdate(t *testing.T) {
 				unreadyTime:  defaultUnreadyTime,
 			}
 
-			nodes := NewNodes(fakeTimeGetter, nil)
+			nodes := NewNodes(fakeTimeGetter)
 			ctx := &ca_context.AutoscalingContext{CloudProvider: provider}
 
 			nodes.Update(ctx, tc.initialNodes, initialTimestamp)
@@ -266,14 +267,23 @@ func TestRemovableAt(t *testing.T) {
 				unneededTime: 0,
 				unreadyTime:  expectedThreshold,
 			}
-			n := NewNodes(fakeTimeGetter, &resource.LimitsFinder{})
+			n := NewNodes(fakeTimeGetter)
 
 			n.Update(&autoscalingCtx, removableNodes, time.Now().Add(-10*time.Minute)) //add -10 min to work correctly with unneeded time threshold
 
+			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
+				QuotaProvider:            resourcequotas.NewFakeProvider([]resourcequotas.Quota{}),
+				CustomResourcesProcessor: customresources.NewDefaultCustomResourcesProcessor(false, false),
+			})
+			var nodes []*apiv1.Node
+			for _, n := range removableNodes {
+				nodes = append(nodes, n.Node)
+			}
+			tracker, _ := factory.NewMinQuotasTracker(&autoscalingCtx, nodes)
+
 			gotEmptyToRemove, gotDrainToRemove, _ := n.RemovableAt(&autoscalingCtx, nodeprocessors.ScaleDownContext{
-				ActuationStatus:     as,
-				ResourcesLeft:       resource.Limits{},
-				ResourcesWithLimits: []string{},
+				ActuationStatus: as,
+				Tracker:         tracker,
 			}, time.Now())
 			if len(gotDrainToRemove) != tc.numDrainToRemove || len(gotEmptyToRemove) != tc.numEmptyToRemove {
 				t.Errorf("%s: getNodesToRemove() return %d, %d, want %d, %d", tc.name, len(gotEmptyToRemove), len(gotDrainToRemove), tc.numEmptyToRemove, tc.numDrainToRemove)
@@ -321,6 +331,7 @@ type unremovableTestCase struct {
 	thresholds            thresholdConfig
 	groupConfig           nodeGroupConfigTest
 	shouldTimeGetterError bool
+	quotas                []resourcequotas.Quota
 	expectedReason        simulator.UnremovableReason
 }
 
@@ -409,6 +420,22 @@ func TestRemovableAt_UnremovableReasons(t *testing.T) {
 			},
 			expectedReason: simulator.NodeGroupMinSizeReached,
 		},
+		{
+			name:       "MinimalResourceLimitExceeded",
+			nodeConfig: baseCase.nodeConfig,
+			thresholds: baseCase.thresholds,
+			groupConfig: baseCase.groupConfig,
+			quotas: []resourcequotas.Quota{
+				&resourcequotas.FakeQuota{
+					Name:        "quota1",
+					AppliesToFn: func(*apiv1.Node) bool { return true },
+					LimitsVal: map[string]int64{
+						resourcequotas.ResourceNodes: 1,
+					},
+				},
+			},
+			expectedReason: simulator.MinimalResourceLimitExceeded,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -439,16 +466,21 @@ func TestRemovableAt_UnremovableReasons(t *testing.T) {
 					unreadyTime:  tc.thresholds.unready,
 				}
 			}
-			n := NewNodes(timeGetter, &resource.LimitsFinder{})
+			n := NewNodes(timeGetter)
 
 			n.Update(&autoscalingCtx, nodesToProcess, now.Add(tc.nodeConfig.sinceOffset))
 
 			sdCtx := nodeprocessors.ScaleDownContext{
-				ActuationStatus:     &fakeActuationStatus{deletionCount: map[string]int{}},
-				ResourcesLeft:       nil,
-				ResourcesWithLimits: []string{},
+				ActuationStatus: &fakeActuationStatus{deletionCount: map[string]int{}},
 			}
 
+			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
+				QuotaProvider:            resourcequotas.NewFakeProvider(tc.quotas),
+				CustomResourcesProcessor: customresources.NewDefaultCustomResourcesProcessor(false, false),
+			})
+			tracker, _ := factory.NewMinQuotasTracker(&autoscalingCtx, []*apiv1.Node{node})
+
+			sdCtx.Tracker = tracker
 			gotEmptyToRemove, gotDrainToRemove, gotUnremovable := n.RemovableAt(&autoscalingCtx, sdCtx, now)
 
 			assert.Empty(t, gotEmptyToRemove, "Expected no empty nodes to be removable")
@@ -533,7 +565,7 @@ func TestNodeLoadFromExistingTaints(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			nodes := NewNodes(nil, nil)
+			nodes := NewNodes(nil)
 
 			allNodeLister := kube_util.NewTestNodeLister(nil)
 			allNodeLister.SetNodes(tc.allNodes)

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
@@ -421,9 +421,9 @@ func TestRemovableAt_UnremovableReasons(t *testing.T) {
 			expectedReason: simulator.NodeGroupMinSizeReached,
 		},
 		{
-			name:       "MinimalResourceLimitExceeded",
-			nodeConfig: baseCase.nodeConfig,
-			thresholds: baseCase.thresholds,
+			name:        "MinimalResourceLimitExceeded",
+			nodeConfig:  baseCase.nodeConfig,
+			thresholds:  baseCase.thresholds,
 			groupConfig: baseCase.groupConfig,
 			quotas: []resourcequotas.Quota{
 				&resourcequotas.FakeQuota{

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -191,14 +191,19 @@ func NewStaticAutoscaler(
 		processors.ScaleDownCandidatesNotifier.Register(ndlt)
 		processors.ScaleDownStatusProcessor = ndlt
 	}
-	scaleDownPlanner := planner.New(autoscalingCtx, processors, deleteOptions, drainabilityRules)
+	quotasTrackerFactory := resourcequotas.NewTrackerFactory(quotasTrackerOptions)
+	minQuotasTrackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
+		CustomResourcesProcessor: processors.CustomResourcesProcessor,
+		QuotaProvider:            resourcequotas.NewCloudMinProvider(cloudProvider),
+		NodeFilter:               quotasTrackerOptions.NodeFilter,
+	})
+
+	scaleDownPlanner := planner.New(autoscalingCtx, processors, deleteOptions, drainabilityRules, minQuotasTrackerFactory)
 	processorCallbacks.scaleDownPlanner = scaleDownPlanner
 
 	ndt := deletiontracker.NewNodeDeletionTracker(0 * time.Second)
 	scaleDownActuator := actuation.NewActuator(autoscalingCtx, processors.ScaleStateNotifier, ndt, deleteOptions, drainabilityRules, processors.NodeGroupConfigProcessor)
 	autoscalingCtx.ScaleDownActuator = scaleDownActuator
-
-	quotasTrackerFactory := resourcequotas.NewTrackerFactory(quotasTrackerOptions)
 	if scaleUpOrchestrator == nil {
 		scaleUpOrchestrator = orchestrator.New()
 	}

--- a/cluster-autoscaler/core/static_autoscaler_csi_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_csi_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	sdplanner "k8s.io/autoscaler/cluster-autoscaler/core/scaledown/planner"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/predicate"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
 	csinodeprovider "k8s.io/autoscaler/cluster-autoscaler/simulator/csi/provider"
@@ -289,7 +290,8 @@ func TestStaticAutoscalerCSI(t *testing.T) {
 			// internal removal simulator uses the same snapshot instance that RunOnce() initializes.
 			deleteOptions := options.NewNodeDeleteOptions(autoscaler.AutoscalingOptions)
 			drainabilityRules := rules.Default(deleteOptions)
-			newSDPlanner := sdplanner.New(autoscaler.AutoscalingContext, autoscaler.processors, deleteOptions, drainabilityRules)
+			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: autoscaler.processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(autoscaler.AutoscalingContext.CloudProvider)})
+			newSDPlanner := sdplanner.New(autoscaler.AutoscalingContext, autoscaler.processors, deleteOptions, drainabilityRules, factory)
 			autoscaler.scaleDownPlanner = newSDPlanner
 			autoscaler.processorCallbacks.scaleDownPlanner = newSDPlanner
 

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -336,7 +336,7 @@ func setupAutoscaler(config *autoscalerSetupConfig) (*StaticAutoscaler, error) {
 		nodeDeletionTracker = deletiontracker.NewNodeDeletionTracker(0 * time.Second)
 	}
 	autoscalingCtx.ScaleDownActuator = actuation.NewActuator(&autoscalingCtx, clusterState, nodeDeletionTracker, deleteOptions, drainabilityRules, processors.NodeGroupConfigProcessor)
-	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules)
+	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules, quotasTrackerFactory)
 
 	processorCallbacks.scaleDownPlanner = sdPlanner
 
@@ -3167,7 +3167,8 @@ func newScaleDownPlannerAndActuator(autoscalingCtx *ca_context.AutoscalingContex
 	if nodeDeletionTracker == nil {
 		nodeDeletionTracker = deletiontracker.NewNodeDeletionTracker(0 * time.Second)
 	}
-	planner := planner.New(autoscalingCtx, p, deleteOptions, nil)
+	quotasTrackerFactory := newQuotasTrackerFactory(autoscalingCtx, p)
+	planner := planner.New(autoscalingCtx, p, deleteOptions, nil, quotasTrackerFactory)
 	actuator := actuation.NewActuator(autoscalingCtx, cs, nodeDeletionTracker, deleteOptions, nil, p.NodeGroupConfigProcessor)
 	return planner, actuator
 }
@@ -3299,7 +3300,8 @@ func buildStaticAutoscaler(t *testing.T, provider cloudprovider.CloudProvider, a
 	deleteOptions := options.NewNodeDeleteOptions(autoscalingCtx.AutoscalingOptions)
 	drainabilityRules := rules.Default(deleteOptions)
 
-	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules)
+	quotasTrackerFactory := newQuotasTrackerFactory(&autoscalingCtx, processors)
+	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules, quotasTrackerFactory)
 
 	autoscaler := &StaticAutoscaler{
 		AutoscalingContext:   &autoscalingCtx,

--- a/cluster-autoscaler/processors/nodes/scale_down_context.go
+++ b/cluster-autoscaler/processors/nodes/scale_down_context.go
@@ -18,14 +18,13 @@ package nodes
 
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
-	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 )
 
 // ScaleDownContext keeps an updated version actuationStatus and resourcesLeft for the scaling down process
 type ScaleDownContext struct {
-	ActuationStatus     scaledown.ActuationStatus
-	ResourcesLeft       resource.Limits
-	ResourcesWithLimits []string
+	ActuationStatus scaledown.ActuationStatus
+	Tracker         *resourcequotas.Tracker
 }
 
 // NewDefaultScaleDownContext returns ScaleDownContext with passed MaxNodeCountToBeRemoved

--- a/cluster-autoscaler/resourcequotas/provider.go
+++ b/cluster-autoscaler/resourcequotas/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 
@@ -72,4 +73,72 @@ func (p *CombinedQuotasProvider) Quotas() ([]Quota, error) {
 		allQuotas = append(allQuotas, quotas...)
 	}
 	return allQuotas, nil
+}
+
+// minQuotaAdapter wraps cloudprovider.ResourceLimiter and returns GetMin values.
+type minQuotaAdapter struct {
+	limiter *cloudprovider.ResourceLimiter
+}
+
+func (a *minQuotaAdapter) ID() string                       { return a.limiter.ID() }
+func (a *minQuotaAdapter) AppliesTo(node *corev1.Node) bool { return a.limiter.AppliesTo(node) }
+func (a *minQuotaAdapter) Limits() map[string]int64 {
+	limits := make(map[string]int64)
+	for _, r := range a.limiter.GetResources() {
+		limits[r] = a.limiter.GetMin(r)
+	}
+	return limits
+}
+
+// maxQuotaAdapter wraps cloudprovider.ResourceLimiter and returns GetMax values.
+type maxQuotaAdapter struct {
+	limiter *cloudprovider.ResourceLimiter
+}
+
+func (a *maxQuotaAdapter) ID() string                       { return a.limiter.ID() }
+func (a *maxQuotaAdapter) AppliesTo(node *corev1.Node) bool { return a.limiter.AppliesTo(node) }
+func (a *maxQuotaAdapter) Limits() map[string]int64 {
+	limits := make(map[string]int64)
+	for _, r := range a.limiter.GetResources() {
+		limits[r] = a.limiter.GetMax(r)
+	}
+	return limits
+}
+
+// CloudMinProvider provides minimum quotas from cloud provider.
+type CloudMinProvider struct {
+	cloudProvider cloudprovider.CloudProvider
+}
+
+// Quotas returns the minimum quotas from the cloud provider.
+func (p *CloudMinProvider) Quotas() ([]Quota, error) {
+	rl, err := p.cloudProvider.GetResourceLimiter()
+	if err != nil {
+		return nil, err
+	}
+	return []Quota{&minQuotaAdapter{limiter: rl}}, nil
+}
+
+// NewCloudMinProvider returns a new CloudMinProvider.
+func NewCloudMinProvider(cloudProvider cloudprovider.CloudProvider) *CloudMinProvider {
+	return &CloudMinProvider{cloudProvider: cloudProvider}
+}
+
+// CloudMaxProvider provides maximum quotas from cloud provider.
+type CloudMaxProvider struct {
+	cloudProvider cloudprovider.CloudProvider
+}
+
+// Quotas returns the maximum quotas from the cloud provider.
+func (p *CloudMaxProvider) Quotas() ([]Quota, error) {
+	rl, err := p.cloudProvider.GetResourceLimiter()
+	if err != nil {
+		return nil, err
+	}
+	return []Quota{&maxQuotaAdapter{limiter: rl}}, nil
+}
+
+// NewCloudMaxProvider returns a new CloudMaxProvider.
+func NewCloudMaxProvider(cloudProvider cloudprovider.CloudProvider) *CloudMaxProvider {
+	return &CloudMaxProvider{cloudProvider: cloudProvider}
 }

--- a/cluster-autoscaler/resourcequotas/provider_test.go
+++ b/cluster-autoscaler/resourcequotas/provider_test.go
@@ -101,3 +101,81 @@ func TestCombinedQuotasProvider(t *testing.T) {
 		})
 	}
 }
+
+func TestMinQuotaAdapter(t *testing.T) {
+	maxLimits := map[string]int64{"cpu": 4, "memory": 16 * units.GiB}
+	minLimits := map[string]int64{"cpu": 1, "memory": 4 * units.GiB}
+	resourceLimiter := cloudprovider.NewResourceLimiter(minLimits, maxLimits)
+
+	adapter := &minQuotaAdapter{limiter: resourceLimiter}
+
+	if adapter.ID() != "cluster-wide" {
+		t.Errorf("got ID %q, want %q", adapter.ID(), "cluster-wide")
+	}
+	if !adapter.AppliesTo(nil) {
+		t.Error("AppliesTo(nil) returned false, want true")
+	}
+
+	if diff := cmp.Diff(minLimits, adapter.Limits()); diff != "" {
+		t.Errorf("Limits() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMaxQuotaAdapter(t *testing.T) {
+	maxLimits := map[string]int64{"cpu": 4, "memory": 16 * units.GiB}
+	minLimits := map[string]int64{"cpu": 1, "memory": 4 * units.GiB}
+	resourceLimiter := cloudprovider.NewResourceLimiter(minLimits, maxLimits)
+
+	adapter := &maxQuotaAdapter{limiter: resourceLimiter}
+
+	if adapter.ID() != "cluster-wide" {
+		t.Errorf("got ID %q, want %q", adapter.ID(), "cluster-wide")
+	}
+	if !adapter.AppliesTo(nil) {
+		t.Error("AppliesTo(nil) returned false, want true")
+	}
+
+	if diff := cmp.Diff(maxLimits, adapter.Limits()); diff != "" {
+		t.Errorf("Limits() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCloudMinProvider(t *testing.T) {
+	cloudProvider := test.NewTestCloudProviderBuilder().Build()
+	minLimits := map[string]int64{"cpu": 1, "memory": 4 * units.GiB}
+	resourceLimiter := cloudprovider.NewResourceLimiter(minLimits, nil)
+	cloudProvider.SetResourceLimiter(resourceLimiter)
+
+	quotasProvider := NewCloudMinProvider(cloudProvider)
+	quotas, err := quotasProvider.Quotas()
+	if err != nil {
+		t.Errorf("failed to get quotas: %v", err)
+	}
+	if len(quotas) != 1 {
+		t.Errorf("got %d quotas, expected 1", len(quotas))
+	}
+	quota := quotas[0]
+	if diff := cmp.Diff(minLimits, quota.Limits()); diff != "" {
+		t.Errorf("Limits() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCloudMaxProvider(t *testing.T) {
+	cloudProvider := test.NewTestCloudProviderBuilder().Build()
+	maxLimits := map[string]int64{"cpu": 4, "memory": 16 * units.GiB}
+	resourceLimiter := cloudprovider.NewResourceLimiter(nil, maxLimits)
+	cloudProvider.SetResourceLimiter(resourceLimiter)
+
+	quotasProvider := NewCloudMaxProvider(cloudProvider)
+	quotas, err := quotasProvider.Quotas()
+	if err != nil {
+		t.Errorf("failed to get quotas: %v", err)
+	}
+	if len(quotas) != 1 {
+		t.Errorf("got %d quotas, expected 1", len(quotas))
+	}
+	quota := quotas[0]
+	if diff := cmp.Diff(maxLimits, quota.Limits()); diff != "" {
+		t.Errorf("Limits() mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Update the scale down to use resourcequotas package as source of true, it will allow to implement scale down prevention mechanisms on cloudprovider side more flexibly.

#Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/autoscaler/issues/8703

#### Does this PR introduce a user-facing change?
```release-note
Refactored resource quota tracking to support BOTH minimum and maximum limits using a unified model. This allows for more flexible implementation of scale-down prevention based on resource quotas.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
-[Proposal]: https://github.com/kubernetes/autoscaler/blob/9db3d2536ebd1484a5ae24a601f2d147cb3217a3/cluster-autoscaler/proposals/granular-resource-limits.md
```
