### PR TITLE
extend DO nodeInfoTemplate with GPU information + more precision for CPU resources

### DIFF
--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager.go
@@ -151,7 +151,6 @@ func (m *Manager) Refresh() error {
 			continue
 		}
 		nodePoolTemplateResponse, _, err := m.client.GetNodePoolTemplate(ctx, m.clusterID, nodePool.Name)
-		klog.V(4).Infof("fetched template response - %+v", nodePoolTemplateResponse)
 		if err != nil {
 			return err
 		}

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_manager.go
@@ -151,7 +151,7 @@ func (m *Manager) Refresh() error {
 			continue
 		}
 		nodePoolTemplateResponse, _, err := m.client.GetNodePoolTemplate(ctx, m.clusterID, nodePool.Name)
-		klog.V(4).Infof("fetched template response - %v", nodePoolTemplateResponse)
+		klog.V(4).Infof("fetched template response - %+v", nodePoolTemplateResponse)
 		if err != nil {
 			return err
 		}

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group.go
@@ -315,11 +315,11 @@ func toInstanceStatus(nodeState *godo.KubernetesNodeStatus) *cloudprovider.Insta
 }
 
 func toNodeInfoTemplate(resp *godo.KubernetesNodePoolTemplate) (*framework.NodeInfo, error) {
-	allocatable, err := parseToQuanitity(resp.Template.Allocatable.CPU, resp.Template.Allocatable.Pods, resp.Template.Allocatable.Memory)
+	allocatable, err := parseToQuantity(resp.Template.Allocatable.CpuMilliCores, resp.Template.Allocatable.Pods, resp.Template.Allocatable.Memory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create allocatable resources - %s", err)
 	}
-	capacity, err := parseToQuanitity(resp.Template.Capacity.CPU, resp.Template.Capacity.Pods, resp.Template.Capacity.Memory)
+	capacity, err := parseToQuantity(resp.Template.Capacity.CpuMilliCores, resp.Template.Capacity.Pods, resp.Template.Capacity.Memory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create capacity resources - %s", err)
 	}
@@ -330,6 +330,18 @@ func toNodeInfoTemplate(resp *godo.KubernetesNodePoolTemplate) (*framework.NodeI
 	l := map[string]string{
 		apiv1.LabelOSStable:   cloudprovider.DefaultOS,
 		apiv1.LabelArchStable: cloudprovider.DefaultArch,
+	}
+
+	if resp.Template.Gpu != nil {
+		resourceName := fmt.Sprintf("%s.com/gpu", resp.Template.Gpu.Vendor)
+		gpuResourceName := apiv1.ResourceName(resourceName)
+		gpuResourceQuantity, err := resource.ParseQuantity(fmt.Sprintf("%d", resp.Template.Gpu.Count))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse gpu quantity - %s", err)
+		}
+
+		allocatable[gpuResourceName] = gpuResourceQuantity
+		capacity[gpuResourceName] = gpuResourceQuantity
 	}
 
 	l = cloudprovider.JoinStringMaps(l, resp.Template.Labels)
@@ -351,8 +363,8 @@ func toNodeInfoTemplate(resp *godo.KubernetesNodePoolTemplate) (*framework.NodeI
 	return framework.NewNodeInfo(node, nil), nil
 }
 
-func parseToQuanitity(cpu int64, pods int64, memory string) (apiv1.ResourceList, error) {
-	c := resource.NewQuantity(cpu, resource.DecimalSI)
+func parseToQuantity(cpuMilliCores int64, pods int64, memory string) (apiv1.ResourceList, error) {
+	c := resource.NewMilliQuantity(cpuMilliCores, resource.DecimalSI)
 	p := resource.NewQuantity(pods, resource.DecimalSI)
 	m, err := resource.ParseQuantity(memory)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -452,6 +454,250 @@ func TestGenerateWorkerName(t *testing.T) {
 		assert.Equal(t, 2, len(parts), "incorrect number of components for generated worker name")
 		assert.Equal(t, prefix, parts[0], "unexpected prefix in generated worker name")
 		assert.Equal(t, expectedLength, len(parts[1]), "incorrect suffix length for generated worker name")
+	})
+}
+
+func TestParseToQuantity(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		rl, err := parseToQuantity(3800, 110, "8Gi")
+		require.NoError(t, err)
+
+		expCPU := resource.NewMilliQuantity(3800, resource.DecimalSI)
+		expPods := resource.NewQuantity(110, resource.DecimalSI)
+		expMem := resource.MustParse("8Gi")
+
+		assert.True(t, expCPU.Equal(rl[apiv1.ResourceCPU]))
+		assert.True(t, expPods.Equal(rl[apiv1.ResourcePods]))
+		assert.True(t, expMem.Equal(rl[apiv1.ResourceMemory]))
+
+		// compare with regular CPU quantity
+		rl, err = parseToQuantity(4000, 110, "8Gi")
+		require.NoError(t, err)
+		fullCPU := resource.NewQuantity(4, resource.DecimalSI)
+		assert.True(t, fullCPU.Equal(rl[apiv1.ResourceCPU]))
+	})
+
+	t.Run("invalid memory string", func(t *testing.T) {
+		_, err := parseToQuantity(100, 10, "not-a-valid-quantity")
+		assert.Error(t, err)
+	})
+}
+
+func TestToNodeInfoTemplate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "my-pool",
+				Labels: map[string]string{
+					"pool": "primary",
+				},
+				Taints: []string{"dedicated=test:NoSchedule"},
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 8000,
+					Pods:          110,
+					Memory:        "32Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 7800,
+					Pods:          110,
+					Memory:        "31Gi",
+				},
+			},
+		}
+
+		ni, err := toNodeInfoTemplate(resp)
+		require.NoError(t, err)
+		require.NotNil(t, ni)
+
+		node := ni.Node()
+		require.NotNil(t, node)
+
+		assert.True(t, strings.HasPrefix(node.Name, "my-pool-"))
+		assert.Len(t, strings.TrimPrefix(node.Name, "my-pool-"), generatedWorkerNameSuffixLength)
+
+		assert.Equal(t, cloudprovider.DefaultOS, node.Labels[apiv1.LabelOSStable])
+		assert.Equal(t, cloudprovider.DefaultArch, node.Labels[apiv1.LabelArchStable])
+		assert.Equal(t, "primary", node.Labels["pool"])
+
+		require.Len(t, node.Spec.Taints, 1)
+		assert.Equal(t, "dedicated", node.Spec.Taints[0].Key)
+		assert.Equal(t, "test", node.Spec.Taints[0].Value)
+		assert.Equal(t, apiv1.TaintEffectNoSchedule, node.Spec.Taints[0].Effect)
+
+		assert.Equal(t, apiv1.NodeRunning, node.Status.Phase)
+
+		capCPU := resource.NewMilliQuantity(8000, resource.DecimalSI)
+		allCPU := resource.NewMilliQuantity(7800, resource.DecimalSI)
+		assert.True(t, capCPU.Equal(node.Status.Capacity[apiv1.ResourceCPU]))
+		assert.True(t, allCPU.Equal(node.Status.Allocatable[apiv1.ResourceCPU]))
+
+		memCap := resource.MustParse("32Gi")
+		memAll := resource.MustParse("31Gi")
+		assert.True(t, memCap.Equal(node.Status.Capacity[apiv1.ResourceMemory]))
+		assert.True(t, memAll.Equal(node.Status.Allocatable[apiv1.ResourceMemory]))
+
+		podsCap := resource.NewQuantity(110, resource.DecimalSI)
+		assert.True(t, podsCap.Equal(node.Status.Capacity[apiv1.ResourcePods]))
+		assert.True(t, podsCap.Equal(node.Status.Allocatable[apiv1.ResourcePods]))
+
+		assert.NotEmpty(t, node.Status.Conditions)
+	})
+
+	t.Run("template labels override defaults", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "pool",
+				Labels: map[string]string{
+					apiv1.LabelOSStable: "windows",
+				},
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 2000,
+					Pods:          30,
+					Memory:        "4Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 1900,
+					Pods:          30,
+					Memory:        "4Gi",
+				},
+			},
+		}
+
+		ni, err := toNodeInfoTemplate(resp)
+		require.NoError(t, err)
+		assert.Equal(t, "windows", ni.Node().Labels[apiv1.LabelOSStable])
+		assert.Equal(t, cloudprovider.DefaultArch, ni.Node().Labels[apiv1.LabelArchStable])
+	})
+
+	t.Run("success with NVIDIA GPU", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "gpu-pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 4000,
+					Pods:          110,
+					Memory:        "16Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 3800,
+					Pods:          110,
+					Memory:        "15Gi",
+				},
+				Gpu: &godo.KubernetesNodePoolGPUResources{
+					Vendor: "nvidia",
+					Model:  "a100",
+					Count:  4,
+				},
+			},
+		}
+
+		ni, err := toNodeInfoTemplate(resp)
+		require.NoError(t, err)
+
+		node := ni.Node()
+		gpuName := apiv1.ResourceName("nvidia.com/gpu")
+		expGPU := resource.MustParse("4")
+		assert.True(t, expGPU.Equal(node.Status.Capacity[gpuName]))
+		assert.True(t, expGPU.Equal(node.Status.Allocatable[gpuName]))
+	})
+
+	t.Run("success with AMD GPU", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "amd-gpu-pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 8000,
+					Pods:          110,
+					Memory:        "32Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 7900,
+					Pods:          110,
+					Memory:        "31Gi",
+				},
+				Gpu: &godo.KubernetesNodePoolGPUResources{
+					Vendor: "amd",
+					Model:  "mi300x",
+					Count:  8,
+				},
+			},
+		}
+
+		ni, err := toNodeInfoTemplate(resp)
+		require.NoError(t, err)
+
+		node := ni.Node()
+		gpuName := apiv1.ResourceName("amd.com/gpu")
+		expGPU := resource.MustParse("8")
+		assert.True(t, expGPU.Equal(node.Status.Capacity[gpuName]))
+		assert.True(t, expGPU.Equal(node.Status.Allocatable[gpuName]))
+	})
+
+	t.Run("allocatable parse error", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 1000,
+					Pods:          10,
+					Memory:        "1Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 900,
+					Pods:          10,
+					Memory:        "NOT_VALID",
+				},
+			},
+		}
+
+		_, err := toNodeInfoTemplate(resp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create allocatable resources")
+	})
+
+	t.Run("capacity parse error", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 1000,
+					Pods:          10,
+					Memory:        "NOT_VALID",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 900,
+					Pods:          10,
+					Memory:        "1Gi",
+				},
+			},
+		}
+
+		_, err := toNodeInfoTemplate(resp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create capacity resources")
+	})
+
+	t.Run("taints parse error", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 1000,
+					Pods:          10,
+					Memory:        "1Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 900,
+					Pods:          10,
+					Memory:        "1Gi",
+				},
+				Taints: []string{"this-is-not-a-valid-taint-string-format"},
+			},
+		}
+
+		_, err := toNodeInfoTemplate(resp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse taints")
 	})
 }
 

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_node_group_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
@@ -452,6 +454,250 @@ func TestGenerateWorkerName(t *testing.T) {
 		assert.Equal(t, 2, len(parts), "incorrect number of components for generated worker name")
 		assert.Equal(t, prefix, parts[0], "unexpected prefix in generated worker name")
 		assert.Equal(t, expectedLength, len(parts[1]), "incorrect suffix length for generated worker name")
+	})
+}
+
+func TestParseToQuantity(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		rl, err := parseToQuantity(3800, 110, "8Gi")
+		require.NoError(t, err)
+
+		expCPU := resource.NewMilliQuantity(3800, resource.DecimalSI)
+		expPods := resource.NewQuantity(110, resource.DecimalSI)
+		expMem := resource.MustParse("8Gi")
+
+		assert.True(t, expCPU.Equal(rl[apiv1.ResourceCPU]))
+		assert.True(t, expPods.Equal(rl[apiv1.ResourcePods]))
+		assert.True(t, expMem.Equal(rl[apiv1.ResourceMemory]))
+
+		// compare with regular CPU quantity
+		rl, err = parseToQuantity(4000, 110, "8Gi")
+		require.NoError(t, err)
+		fullCPU := resource.NewQuantity(4, resource.DecimalSI)
+		assert.True(t, fullCPU.Equal(rl[apiv1.ResourceCPU]))
+	})
+
+	t.Run("invalid memory string", func(t *testing.T) {
+		_, err := parseToQuantity(100, 10, "not-a-valid-quantity")
+		assert.Error(t, err)
+	})
+}
+
+func TestToNodeInfoTemplate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "my-pool",
+				Labels: map[string]string{
+					"pool": "primary",
+				},
+				Taints: []string{"dedicated=test:NoSchedule"},
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 8000,
+					Pods:          110,
+					Memory:        "32Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 7800,
+					Pods:          110,
+					Memory:        "31Gi",
+				},
+			},
+		}
+
+		ni, err := toNodeInfoTemplate(resp)
+		require.NoError(t, err)
+		require.NotNil(t, ni)
+
+		node := ni.Node()
+		require.NotNil(t, node)
+
+		assert.True(t, strings.HasPrefix(node.Name, "my-pool-"))
+		assert.Len(t, strings.TrimPrefix(node.Name, "my-pool-"), generatedWorkerNameSuffixLength)
+
+		assert.Equal(t, cloudprovider.DefaultOS, node.Labels[apiv1.LabelOSStable])
+		assert.Equal(t, cloudprovider.DefaultArch, node.Labels[apiv1.LabelArchStable])
+		assert.Equal(t, "primary", node.Labels["pool"])
+
+		require.Len(t, node.Spec.Taints, 1)
+		assert.Equal(t, "dedicated", node.Spec.Taints[0].Key)
+		assert.Equal(t, "test", node.Spec.Taints[0].Value)
+		assert.Equal(t, apiv1.TaintEffectNoSchedule, node.Spec.Taints[0].Effect)
+
+		assert.Equal(t, apiv1.NodeRunning, node.Status.Phase)
+
+		capCPU := resource.NewMilliQuantity(8000, resource.DecimalSI)
+		allCPU := resource.NewMilliQuantity(7800, resource.DecimalSI)
+		assert.True(t, capCPU.Equal(node.Status.Capacity[apiv1.ResourceCPU]))
+		assert.True(t, allCPU.Equal(node.Status.Allocatable[apiv1.ResourceCPU]))
+
+		memCap := resource.MustParse("32Gi")
+		memAll := resource.MustParse("31Gi")
+		assert.True(t, memCap.Equal(node.Status.Capacity[apiv1.ResourceMemory]))
+		assert.True(t, memAll.Equal(node.Status.Allocatable[apiv1.ResourceMemory]))
+
+		podsCap := resource.NewQuantity(110, resource.DecimalSI)
+		assert.True(t, podsCap.Equal(node.Status.Capacity[apiv1.ResourcePods]))
+		assert.True(t, podsCap.Equal(node.Status.Allocatable[apiv1.ResourcePods]))
+
+		assert.NotEmpty(t, node.Status.Conditions)
+	})
+
+	t.Run("template labels override defaults", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "pool",
+				Labels: map[string]string{
+					apiv1.LabelOSStable: "windows",
+				},
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 2000,
+					Pods:          30,
+					Memory:        "4Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 1900,
+					Pods:          30,
+					Memory:        "4Gi",
+				},
+			},
+		}
+
+		ni, err := toNodeInfoTemplate(resp)
+		require.NoError(t, err)
+		assert.Equal(t, "windows", ni.Node().Labels[apiv1.LabelOSStable])
+		assert.Equal(t, cloudprovider.DefaultArch, ni.Node().Labels[apiv1.LabelArchStable])
+	})
+
+	t.Run("success with NVIDIA GPU", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "gpu-pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 4000,
+					Pods:          110,
+					Memory:        "16Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 3800,
+					Pods:          110,
+					Memory:        "15Gi",
+				},
+				Gpu: &godo.KubernetesNodePoolGPUResources{
+					Vendor: "nvidia",
+					Model:  "a100",
+					Count:  4,
+				},
+			},
+		}
+
+		ni, err := toNodeInfoTemplate(resp)
+		require.NoError(t, err)
+
+		node := ni.Node()
+		gpuName := apiv1.ResourceName("nvidia.com/gpu")
+		expGPU := resource.MustParse("4")
+		assert.True(t, expGPU.Equal(node.Status.Capacity[gpuName]))
+		assert.True(t, expGPU.Equal(node.Status.Allocatable[gpuName]))
+	})
+
+	t.Run("success with AMD GPU", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "amd-gpu-pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 8000,
+					Pods:          110,
+					Memory:        "32Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 7900,
+					Pods:          110,
+					Memory:        "31Gi",
+				},
+				Gpu: &godo.KubernetesNodePoolGPUResources{
+					Vendor: "amd",
+					Model:  "mi300x",
+					Count:  8,
+				},
+			},
+		}
+
+		ni, err := toNodeInfoTemplate(resp)
+		require.NoError(t, err)
+
+		node := ni.Node()
+		gpuName := apiv1.ResourceName("amd.com/gpu")
+		expGPU := resource.MustParse("8")
+		assert.True(t, expGPU.Equal(node.Status.Capacity[gpuName]))
+		assert.True(t, expGPU.Equal(node.Status.Allocatable[gpuName]))
+	})
+
+	t.Run("allocatable parse error", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 1000,
+					Pods:          10,
+					Memory:        "1Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 900,
+					Pods:          10,
+					Memory:        "NOT_VALID",
+				},
+			},
+		}
+
+		_, err := toNodeInfoTemplate(resp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create allocatable resources")
+	})
+
+	t.Run("capacity parse error", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 1000,
+					Pods:          10,
+					Memory:        "NOT_VALID",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 900,
+					Pods:          10,
+					Memory:        "1Gi",
+				},
+			},
+		}
+
+		_, err := toNodeInfoTemplate(resp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create capacity resources")
+	})
+
+	t.Run("taints parse error", func(t *testing.T) {
+		resp := &godo.KubernetesNodePoolTemplate{
+			Template: &godo.KubernetesNodeTemplate{
+				Name: "pool",
+				Capacity: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 1000,
+					Pods:          10,
+					Memory:        "1Gi",
+				},
+				Allocatable: &godo.KubernetesNodePoolResources{
+					CpuMilliCores: 900,
+					Pods:          10,
+					Memory:        "1Gi",
+				},
+				Taints: []string{"this-is-not-a-valid-taint-string-format"},
+			},
+		}
+
+		_, err := toNodeInfoTemplate(resp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse taints")
 	})
 }
 

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/smithy-go v1.24.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0
-	github.com/digitalocean/godo v1.169.0
+	github.com/digitalocean/godo v1.188.0
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.76.1
 	github.com/aws/smithy-go v1.24.0
 	github.com/cenkalti/backoff/v4 v4.3.0
-	github.com/digitalocean/godo v1.169.0
+	github.com/digitalocean/godo v1.188.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-querystring v1.1.0

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -179,8 +179,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.169.0 h1:Wp9UrtIAgpFEEuY4ifWwq8JHJh7mFKPBXnkRv2Wf0Bw=
-github.com/digitalocean/godo v1.169.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.188.0 h1:QDxgjWnJYRf3JStAY9KM0xUqPC1YfXkPQWUMRRzraCk=
+github.com/digitalocean/godo v1.188.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -173,8 +173,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.169.0 h1:Wp9UrtIAgpFEEuY4ifWwq8JHJh7mFKPBXnkRv2Wf0Bw=
-github.com/digitalocean/godo v1.169.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.188.0 h1:QDxgjWnJYRf3JStAY9KM0xUqPC1YfXkPQWUMRRzraCk=
+github.com/digitalocean/godo v1.188.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
Motivation for this change is to support scale from zero use-cases consistently across AMD and NVIDIA.

The extension of the respective API endpoint was mapped in godo [v1.188.0](https://github.com/digitalocean/godo/releases/tag/v1.188.0), hence bumping the godo version in this PR too.


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR maps vendor specific GPU resources in the node template info, to support scale from zero use-cases across AMD and NVIDIA. NVIDIA scale from zero was already supported before, as there is support based on labels in the cluster-autoscaler. The label based approach, however, does not support AMD.

Additionally, it switches to the usage of `cpuMilliCores` from `cpu` in order to make more precise calculations based on actual CPU `allocatables` and not only. 

#### Which issue(s) this PR fixes:

No GH issue exists for that.

#### Special notes for your reviewer:

Verified change for AMD and NVIDIA scale from zero.

#### Does this PR introduce a user-facing change?

```release-note
Added support for scale from zero use case for AMD GPU Nodes in DigitalOcean provider.
Changed CPU allocatable calculation to base cpuMilliCores in favor of full CPUs to be more precise in DigitalOcean provider.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

There is no change required from users, hence not adding sth in that section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DigitalOcean node resource reporting by preserving milliCPU values.
  * Added accurate GPU capacity and allocatable resource reporting for NVIDIA and AMD devices.
  * Added validation for invalid CPU, memory, GPU, capacity, and taint quantities.
  * Reduced unnecessary diagnostic logging during node pool template refreshes.

* **Tests**
  * Expanded coverage for resource parsing, node labels, taints, and GPU configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->