### PR TITLE
Use application/json for CapacityBuffers client config

### DIFF
--- a/cluster-autoscaler/capacitybuffer/client/client.go
+++ b/cluster-autoscaler/capacitybuffer/client/client.go
@@ -106,7 +106,12 @@ func NewCapacityBufferClient(buffersClient capacitybuffer.Interface, kubernetesC
 
 // NewCapacityBufferClientFromConfig configures and returns a CapacityBufferClient.
 func NewCapacityBufferClientFromConfig(kubeConfig *rest.Config) (*CapacityBufferClient, error) {
-	buffersClient, err := capacitybuffer.NewForConfig(kubeConfig)
+	// Use a static JSON content type config for CapacityBuffer CRD data exchange
+	// to adhere to CRD requirements. The kubernetes and scale clients below continue
+	// to use the caller-provided content type since they use built-in types.
+	buffersConfig := rest.CopyConfig(kubeConfig)
+	buffersConfig.ContentType = "application/json"
+	buffersClient, err := capacitybuffer.NewForConfig(buffersConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create capacity buffer client for capacity buffer: %v", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind bug

#### What this PR does / why we need it:

The CapacityBuffer client implementation that we ship w/ CA inherits the global CA client REST configuration, which means that in order for it to work you have to set the global configuration to use JSON content-type for apiserver communications (`--kube-api-content-type=JSON`). This has the side-effect of de-optimizing data exchange for all CA-apiserver communications, which would otherwise benefit from using the default (`application/vnd.kubernetes.protobuf`).

This PR uses a static JSON config for the `CapacityBufferClient.buffersClient`, which makes sense as the k/k CRD spec requires it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8855

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Use application/json for CapacityBuffer client config
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
