### PR TITLE
TestRunFilterUntilPassingNode: handle parallelism race condition

### DIFF
--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
@@ -407,6 +407,7 @@ func TestRunFilterUntilPassingNode_PreferSmallestSteps(t *testing.T) {
 	// We use channels to block n1's evaluation until n2 has been visited, ensuring n2
 	// would finish first if not for the the logic that prefers smallest steps.
 	delayFirstNode := make(chan struct{})
+	firstNodeReached := make(chan struct{})
 	secondNodeVisited := make(chan struct{})
 	schedulingFinished := make(chan struct{})
 
@@ -417,10 +418,16 @@ func TestRunFilterUntilPassingNode_PreferSmallestSteps(t *testing.T) {
 			NodeOrdering: orderedIterator, // Needed to make the test deterministic.
 			IsNodeAcceptable: func(info *framework.NodeInfo) bool {
 				if info.Node().Name == "n1" {
+					close(firstNodeReached)
 					<-delayFirstNode
-				}
-				if info.Node().Name == "n2" {
-					close(secondNodeVisited)
+				} else {
+					// Block other nodes until n1's callback is in flight. Otherwise
+					// a passing node could call cancel() before the workqueue dispatches
+					// n1's chunk, causing n1 to be silently skipped and the test to flake
+					<-firstNodeReached
+					if info.Node().Name == "n2" {
+						close(secondNodeVisited)
+					}
 				}
 				return true // all nodes pass
 			},


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

This PR ensures that the `pluginRunner.RunFiltersUntilPassingNode` UT which guarantees out-of-order passing nodes still respect an ordered iterator, e.g.:

```
clustersnapshot.NewPriorityNodeOrderMapping(func(a, b *framework.NodeInfo) bool {
	return a.Node().Name < b.Node().Name
})
```

The current test is subject to a race condition if an "out of order" node (e.g., n2 before n1) returns passing before n1's chunk is even dispatched in high-parallel runtime scenarios.  We introduce a new blocking channel <-firstNodeReached so that n2 can't reach a terminal cancel() until n1's callback is actually in-flight, guaranteeing n1 is actually being evaluated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9604

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
