### PR TITLE
Scale up salvo feature - multiple scale ups per single CA loop

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -148,6 +148,10 @@ type AutoscalingOptions struct {
 	ScaleUpFromZero bool
 	// ParallelScaleUp defines whether CA can scale up node groups in parallel.
 	ParallelScaleUp bool
+	// SalvoScaleUp defines whether CA can scale up multiple node groups in a single CA loop.
+	SalvoScaleUp bool
+	// SalvoScaleUpBudget defines the maximum time CA spends on scale ups in a single CA loop.
+	SalvoScaleUpBudget time.Duration
 	// CloudConfig is the path to the cloud provider configuration file. Empty string for no configuration file.
 	CloudConfig string
 	// CloudProviderName sets the type of the cloud provider CA is about to run in. Allowed values: gce, aws

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -124,6 +124,8 @@ var (
 	okTotalUnreadyCount       = flag.Int("ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
 	scaleUpFromZero           = flag.Bool("scale-up-from-zero", true, "Should CA scale up when there are 0 ready nodes.")
 	parallelScaleUp           = flag.Bool("parallel-scale-up", false, "Whether to allow parallel node groups scale up. Experimental: may not work on some cloud providers, enable at your own risk.")
+	salvoScaleUp              = flag.Bool("salvo-scale-up", false, "Whether to allow multiple scale-ups in a single CA loop.")
+	salvoScaleUpBudget        = flag.Duration("salvo-scale-up-budget", 1*time.Minute, "Maximum time CA spends on subsequent scale ups in a single CA loop. Requires salvo-scale-up flag to be enabled.")
 	maxNodeProvisionTime      = flag.Duration("max-node-provision-time", 15*time.Minute, "The default maximum time CA waits for node to be provisioned - the value can be overridden per node group")
 	maxNodeStartupTime        = flag.Duration("max-node-startup-time", 15*time.Minute, "The maximum time from the moment the node is registered to the time the node is ready - the value can be overridden per node group")
 	maxPodEvictionTime        = flag.Duration("max-pod-eviction-time", 2*time.Minute, "Maximum time CA tries to evict a pod before giving up")
@@ -331,6 +333,8 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		OkTotalUnreadyCount:              *okTotalUnreadyCount,
 		ScaleUpFromZero:                  *scaleUpFromZero,
 		ParallelScaleUp:                  *parallelScaleUp,
+		SalvoScaleUp:                     *salvoScaleUp,
+		SalvoScaleUpBudget:               *salvoScaleUpBudget,
 		EstimatorName:                    *estimatorFlag,
 		ExpanderNames:                    *expanderFlag,
 		GRPCExpanderCert:                 *grpcExpanderCert,

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -17,9 +17,13 @@ limitations under the License.
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
+	"strings"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/fakepods"
@@ -63,8 +67,10 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	"k8s.io/utils/integer"
 
+	v1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 )
 
@@ -397,7 +403,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	metrics.UpdateDurationFromStart(metrics.UpdateState, stateUpdateStart)
 
 	scaleUpStatus := &status.ScaleUpStatus{Result: status.ScaleUpNotTried}
-	scaleUpStatusProcessorAlreadyCalled := false
+	scaleUpTriggered := false
 	scaleDownStatus := &scaledownstatus.ScaleDownStatus{Result: scaledownstatus.ScaleDownNotTried}
 
 	defer func() {
@@ -410,10 +416,10 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 
 		// This deferred processor execution allows the processors to handle a situation when a scale-(up|down)
 		// wasn't even attempted because e.g. the iteration exited earlier.
-		if !scaleUpStatusProcessorAlreadyCalled && a.processors != nil && a.processors.ScaleUpStatusProcessor != nil {
+		if !scaleUpTriggered && a.processors.ScaleUpStatusProcessor != nil {
 			a.processors.ScaleUpStatusProcessor.Process(a.AutoscalingContext, scaleUpStatus)
 		}
-		if a.processors != nil && a.processors.ScaleDownStatusProcessor != nil {
+		if a.processors.ScaleDownStatusProcessor != nil {
 			// Gather status before scaledown status processor invocation
 			nodeDeletionResults, nodeDeletionResultsAsOf := a.scaleDownActuator.DeletionResults()
 			scaleDownStatus.NodeDeleteResults = nodeDeletionResults
@@ -424,7 +430,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 			a.processors.ScaleDownStatusProcessor.Process(a.AutoscalingContext, scaleDownStatus)
 		}
 
-		if a.processors != nil && a.processors.AutoscalingStatusProcessor != nil {
+		if a.processors.AutoscalingStatusProcessor != nil {
 			err := a.processors.AutoscalingStatusProcessor.Process(a.AutoscalingContext, a.clusterStateRegistry, currentTime)
 			if err != nil {
 				klog.Errorf("AutoscalingStatusProcessor error: %v.", err)
@@ -482,8 +488,8 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	// them and not trigger another scale-up.
 	// The fake nodes are intentionally not added to the all nodes list, so that they are not considered as candidates for scale-down (which
 	// doesn't make sense as they're not real).
-	err = a.addUpcomingNodesToClusterSnapshot(upcomingCounts)
-	if err != nil {
+	templateNodeInfos := a.AutoscalingContext.TemplateNodeInfoRegistry.GetNodeInfos()
+	if _, err := a.addUpcomingNodesToClusterSnapshot(upcomingCounts, templateNodeInfos, "upcoming-%d"); err != nil {
 		klog.Errorf("Failed adding upcoming nodes to cluster snapshot: %v", err)
 		return caerrors.ToAutoscalerError(caerrors.InternalError, err)
 	}
@@ -522,30 +528,6 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 
 	// finally, filter out pods that are too "young" to safely be considered for a scale-up (delay is configurable)
 	unschedulablePodsToHelp = a.filterOutYoungPods(unschedulablePodsToHelp, currentTime)
-	preScaleUp := func() time.Time {
-		scaleUpStart := time.Now()
-		metrics.UpdateLastTime(metrics.ScaleUp, scaleUpStart)
-		return scaleUpStart
-	}
-
-	postScaleUp := func(scaleUpStart time.Time) {
-		metrics.UpdateDurationFromStart(metrics.ScaleUp, scaleUpStart)
-
-		if a.processors != nil && a.processors.ScaleUpStatusProcessor != nil {
-			a.processors.ScaleUpStatusProcessor.Process(autoscalingCtx, scaleUpStatus)
-			scaleUpStatusProcessorAlreadyCalled = true
-		}
-
-		if typedErr != nil {
-			klog.Errorf("Failed to scale up: %v", typedErr)
-			return
-		}
-		if scaleUpStatus.Result == status.ScaleUpSuccessful {
-			a.lastScaleUpTime = currentTime
-			// No scale down in this iteration.
-			scaleDownStatus.Result = scaledownstatus.ScaleDownInCooldown
-		}
-	}
 
 	shouldScaleUp := true
 
@@ -582,14 +564,34 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 
 	if shouldScaleUp || a.processors.ScaleUpEnforcer.ShouldForceScaleUp(unschedulablePodsToHelp) {
-		scaleUpStart := preScaleUp()
+		scaleUpTriggered = true
 		nodes := make([]*apiv1.Node, len(allNodeInfos))
 		for i, nodeInfo := range allNodeInfos {
 			nodes[i] = nodeInfo.Node()
 		}
-		nodeInfos := a.AutoscalingContext.TemplateNodeInfoRegistry.GetNodeInfos()
-		scaleUpStatus, typedErr = a.scaleUpOrchestrator.ScaleUp(unschedulablePodsToHelp, nodes, daemonsets, nodeInfos, false)
-		postScaleUp(scaleUpStart)
+
+		if a.AutoscalingContext.AutoscalingOptions.SalvoScaleUp {
+			scaleUpStatus, typedErr = a.runScaleUpSalvo(
+				currentTime,
+				unschedulablePodsToHelp,
+				daemonsets,
+				nodes,
+				templateNodeInfos,
+			)
+		} else {
+			_, scaleUpStatus, typedErr = a.runSingleScaleUp(
+				currentTime,
+				unschedulablePodsToHelp,
+				daemonsets,
+				nodes,
+				templateNodeInfos,
+			)
+		}
+
+		if scaleUpStatus.Result == status.ScaleUpSuccessful {
+			// No scale down in this iteration.
+			scaleDownStatus.Result = scaledownstatus.ScaleDownInCooldown
+		}
 	}
 
 	if typedErr = a.scaleDown(currentTime, allNodes, scaleDownActuationStatus, scaleDownStatus); typedErr != nil {
@@ -597,17 +599,127 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 
 	if a.EnforceNodeGroupMinSize {
-		scaleUpStart := preScaleUp()
+		scaleUpTriggered = true
 		nodes := make([]*apiv1.Node, len(allNodeInfos))
 		for i, nodeInfo := range allNodeInfos {
 			nodes[i] = nodeInfo.Node()
 		}
-		nodeInfos := a.AutoscalingContext.TemplateNodeInfoRegistry.GetNodeInfos()
-		scaleUpStatus, typedErr = a.scaleUpOrchestrator.ScaleUpToNodeGroupMinSize(nodes, nodeInfos)
-		postScaleUp(scaleUpStart)
+
+		scaleUpFn := func() (*status.ScaleUpStatus, caerrors.AutoscalerError) {
+			return a.scaleUpOrchestrator.ScaleUpToNodeGroupMinSize(nodes, templateNodeInfos)
+		}
+		_, scaleUpStatus, typedErr = a.instrumentedScaleUp(currentTime, scaleUpFn)
 	}
 
 	return nil
+}
+
+// instrumentedScaleUp handles a single ScaleUp orchestrator call with metrics and status reporting.
+// It accepts a generic scaleUpFn closure, allowing it to handle regular scale-ups or scaling up to node group min size.
+func (a *StaticAutoscaler) instrumentedScaleUp(
+	currentTime time.Time,
+	scaleUpFn func() (*status.ScaleUpStatus, caerrors.AutoscalerError),
+) ([]*apiv1.Pod, *status.ScaleUpStatus, caerrors.AutoscalerError) {
+	scaleUpStart := time.Now()
+	metrics.UpdateLastTime(metrics.ScaleUp, scaleUpStart)
+
+	scaleUpStatus, typedErr := scaleUpFn()
+	// Reference copy is sufficient since processors are not expected to modify the slice elements.
+	unfilteredPodsTriggeredScaleUp := scaleUpStatus.PodsTriggeredScaleUp
+
+	metrics.UpdateDurationFromStart(metrics.ScaleUp, scaleUpStart)
+
+	if a.processors.ScaleUpStatusProcessor != nil {
+		a.processors.ScaleUpStatusProcessor.Process(a.AutoscalingContext, scaleUpStatus)
+	}
+
+	if typedErr != nil {
+		klog.Errorf("Failed to scale up: %v", typedErr)
+		return unfilteredPodsTriggeredScaleUp, scaleUpStatus, typedErr
+	}
+	if scaleUpStatus.Result == status.ScaleUpSuccessful {
+		a.lastScaleUpTime = currentTime
+	}
+
+	return unfilteredPodsTriggeredScaleUp, scaleUpStatus, typedErr
+}
+
+func (a *StaticAutoscaler) runSingleScaleUp(
+	currentTime time.Time,
+	unschedulablePodsToHelp []*apiv1.Pod,
+	daemonsets []*v1.DaemonSet,
+	nodes []*apiv1.Node,
+	templateNodeInfos map[string]*framework.NodeInfo,
+) ([]*apiv1.Pod, *status.ScaleUpStatus, caerrors.AutoscalerError) {
+	scaleUpFn := func() (*status.ScaleUpStatus, caerrors.AutoscalerError) {
+		return a.scaleUpOrchestrator.ScaleUp(unschedulablePodsToHelp, nodes, daemonsets, templateNodeInfos, false)
+	}
+	return a.instrumentedScaleUp(currentTime, scaleUpFn)
+}
+
+func (a *StaticAutoscaler) runScaleUpSalvo(
+	currentTime time.Time,
+	unschedulablePodsToHelp []*apiv1.Pod,
+	daemonsets []*v1.DaemonSet,
+	nodes []*apiv1.Node,
+	templateNodeInfos map[string]*framework.NodeInfo,
+) (*status.ScaleUpStatus, caerrors.AutoscalerError) {
+	var scaleUpStatus *status.ScaleUpStatus
+	var typedErr caerrors.AutoscalerError
+	var handledPods []*apiv1.Pod
+
+	podsMap := make(map[types.UID]*apiv1.Pod)
+	for _, pod := range unschedulablePodsToHelp {
+		podsMap[pod.UID] = pod
+	}
+
+	budget := a.AutoscalingContext.AutoscalingOptions.SalvoScaleUpBudget
+	salvoCtx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	klog.Infof("Starting scale up salvo: %d pods to help, budget: %v", len(podsMap), budget)
+	i := 0
+	for ; ; i++ {
+		klog.V(4).Infof("Scale up salvo: iteration %d, pods left: %d", i, len(podsMap))
+		unschedulablePods := slices.Collect(maps.Values(podsMap))
+
+		handledPods, scaleUpStatus, typedErr = a.runSingleScaleUp(currentTime, unschedulablePods, daemonsets, nodes, templateNodeInfos)
+		if typedErr != nil {
+			klog.Infof("Scale up failed, finishing the scale up salvo: %v", typedErr)
+			break
+		}
+		if !scaleUpStatus.WasSuccessful() {
+			klog.Infof("Scale up not successful: %v, finishing the scale up salvo", scaleUpStatus.Result)
+			break
+		}
+		if len(handledPods) == 0 {
+			klog.Infof("Empty unfilteredPodsTriggeredScaleUp list - cannot update cluster snapshot, finishing the scale up salvo")
+			break
+		}
+
+		for _, pod := range handledPods {
+			delete(podsMap, pod.UID)
+		}
+
+		if len(podsMap) == 0 {
+			klog.Infof("All unschedulable pods have been helped, finishing the scale up salvo")
+			break
+		}
+
+		if err := salvoCtx.Err(); err != nil {
+			klog.Infof("Scale up budget of %v exhausted, finishing the scale up salvo", budget)
+			break
+		}
+
+		newNodes, err := a.addLatestScaleUpResultsToClusterSnapshot(i, scaleUpStatus, handledPods, templateNodeInfos)
+		if err != nil {
+			klog.Warningf("Failed to update cluster snapshot after scale up, finishing the scale up salvo: %v", err)
+			break
+		}
+		nodes = append(nodes, newNodes...)
+	}
+	klog.Infof("Finished scale up salvo after %d iterations, unschedulable pods left: %d", i, len(podsMap))
+	return scaleUpStatus, typedErr
 }
 
 func (a *StaticAutoscaler) updateSoftDeletionTaints(allNodes []*apiv1.Node) {
@@ -725,36 +837,86 @@ func (a *StaticAutoscaler) scaleDown(currentTime time.Time, allNodes []*apiv1.No
 	return nil
 }
 
-func (a *StaticAutoscaler) addUpcomingNodesToClusterSnapshot(upcomingCounts map[string]int) error {
+// addUpcomingNodesToClusterSnapshot generates upcoming node infos based on upcomingCounts and adds them to the ClusterSnapshot.
+func (a *StaticAutoscaler) addUpcomingNodesToClusterSnapshot(
+	upcomingCounts map[string]int,
+	templateNodeInfos map[string]*framework.NodeInfo,
+	suffixFmt string,
+) ([]*apiv1.Node, error) {
+	upcomingNodeInfosPerNg, err := getUpcomingNodeInfos(upcomingCounts, templateNodeInfos, suffixFmt)
+	if err != nil {
+		return nil, err
+	}
+
 	nodeGroups := a.nodeGroupsById()
 	upcomingNodeGroups := make(map[string]int)
 	upcomingNodesFromUpcomingNodeGroups := 0
-	nodeInfos := a.AutoscalingContext.TemplateNodeInfoRegistry.GetNodeInfos()
-	upcomingNodeInfosPerNg, err := getUpcomingNodeInfos(upcomingCounts, nodeInfos)
-	if err != nil {
-		return err
-	}
+	var newNodes []*apiv1.Node
+
 	for nodeGroupName, upcomingNodeInfos := range upcomingNodeInfosPerNg {
 		nodeGroup := nodeGroups[nodeGroupName]
 		if nodeGroup == nil {
-			return fmt.Errorf("failed to find node group: %s", nodeGroupName)
+			return nil, fmt.Errorf("failed to find node group: %s", nodeGroupName)
 		}
-		isUpcomingNodeGroup := a.processors.AsyncNodeGroupStateChecker.IsUpcoming(nodeGroup)
-		for _, upcomingNodeInfo := range upcomingNodeInfos {
-			err := a.ClusterSnapshot.AddNodeInfo(upcomingNodeInfo)
-			if err != nil {
-				return fmt.Errorf("failed to add upcoming node %s to cluster snapshot: %w", upcomingNodeInfo.Node().Name, err)
+		for i, upcomingNodeInfo := range upcomingNodeInfos {
+			if err := a.ClusterSnapshot.AddNodeInfo(upcomingNodeInfo); err != nil {
+				return nil, fmt.Errorf("Failed to add upcoming %d/%d node %q from node group %q to cluster snapshot: %w", i+1, len(upcomingNodeInfos), upcomingNodeInfo.Node().Name, nodeGroupName, err)
 			}
-			if isUpcomingNodeGroup {
-				upcomingNodesFromUpcomingNodeGroups++
-				upcomingNodeGroups[nodeGroup.Id()] += 1
-			}
+			newNodes = append(newNodes, upcomingNodeInfo.Node())
+		}
+		if a.processors.AsyncNodeGroupStateChecker.IsUpcoming(nodeGroup) {
+			upcomingNodesFromUpcomingNodeGroups += len(upcomingNodeInfos)
+			upcomingNodeGroups[nodeGroup.Id()] += len(upcomingNodeInfos)
 		}
 	}
 	if len(upcomingNodeGroups) > 0 {
 		klog.Infof("Injecting %d upcoming node groups with %d upcoming nodes: %v", len(upcomingNodeGroups), upcomingNodesFromUpcomingNodeGroups, upcomingNodeGroups)
 	}
-	return nil
+	return newNodes, nil
+}
+
+// addLatestScaleUpResultsToClusterSnapshot updates the ClusterSnapshot with upcoming nodes created in the latest scale up to prepare the state for the next scale up:
+//   - adds upcoming nodeInfos from the latest scale up to ClusterSnapshot
+//   - schedules the Pods that triggered the scale up on the latest nodeInfos
+//   - returns the new nodes
+func (a *StaticAutoscaler) addLatestScaleUpResultsToClusterSnapshot(idx int, scaleUpStatus *status.ScaleUpStatus, handledPods []*apiv1.Pod, templateNodeInfos map[string]*framework.NodeInfo) ([]*apiv1.Node, error) {
+	salvoSuffix := fmt.Sprintf("salvo-%d", idx)
+	upcomingCounts := make(map[string]int)
+
+	for _, suInfo := range scaleUpStatus.ScaleUpInfos {
+		nodesToInject := suInfo.NewSize - suInfo.CurrentSize
+		if nodesToInject <= 0 {
+			return nil, fmt.Errorf("Scale up salvo %d contains scale up info for node group %q with non-positive number of nodes to inject: %d. Current size: %d, new size: %d", idx, suInfo.Group.Id(), nodesToInject, suInfo.CurrentSize, suInfo.NewSize)
+		}
+
+		if _, ok := templateNodeInfos[suInfo.Group.Id()]; !ok {
+			return nil, fmt.Errorf("Failed to find template node info for node group %q", suInfo.Group.Id())
+		}
+		upcomingCounts[suInfo.Group.Id()] += nodesToInject
+	}
+
+	newNodes, err := a.addUpcomingNodesToClusterSnapshot(upcomingCounts, templateNodeInfos, "%d-"+salvoSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get upcoming node infos for salvo %d: %v", idx, err)
+	}
+
+	for _, pod := range handledPods {
+		nodeName, err := a.ClusterSnapshot.SchedulePodOnAnyNodeMatching(pod, clustersnapshot.SchedulingOptions{
+			IsNodeAcceptable: func(nodeInfo *framework.NodeInfo) bool {
+				return strings.HasSuffix(nodeInfo.Node().Name, salvoSuffix)
+			},
+		})
+		if err != nil {
+			nodeGroupIds := []string{}
+			for _, suInfo := range scaleUpStatus.ScaleUpInfos {
+				nodeGroupIds = append(nodeGroupIds, suInfo.Group.Id())
+			}
+			return nil, fmt.Errorf("Failed cluster snapshot update: couldn't schedule triggering pod %s on any of the nodes from scaled up node group(s) %v: %v", pod.Name, nodeGroupIds, err)
+		}
+		klog.V(5).Infof("Updated cluster snapshot: scheduled pod %s on node %s", pod.Name, nodeName)
+	}
+
+	return newNodes, nil
 }
 
 func (a *StaticAutoscaler) isScaleDownInCooldown(currentTime time.Time) bool {
@@ -1103,7 +1265,7 @@ func allPodsAreNew(pods []*apiv1.Pod, currentTime time.Time) bool {
 	return found && oldest.Add(unschedulablePodWithGpuTimeBuffer).After(currentTime)
 }
 
-func getUpcomingNodeInfos(upcomingCounts map[string]int, nodeInfos map[string]*framework.NodeInfo) (map[string][]*framework.NodeInfo, error) {
+func getUpcomingNodeInfos(upcomingCounts map[string]int, nodeInfos map[string]*framework.NodeInfo, suffixFmt string) (map[string][]*framework.NodeInfo, error) {
 	upcomingNodes := make(map[string][]*framework.NodeInfo)
 	for nodeGroup, numberOfNodes := range upcomingCounts {
 		nodeTemplate, found := nodeInfos[nodeGroup]
@@ -1112,20 +1274,20 @@ func getUpcomingNodeInfos(upcomingCounts map[string]int, nodeInfos map[string]*f
 			continue
 		}
 
-		if nodeTemplate.Node().Annotations == nil {
-			nodeTemplate.Node().Annotations = make(map[string]string)
-		}
-		nodeTemplate.Node().Annotations[annotations.NodeUpcomingAnnotation] = "true"
-
 		var nodes []*framework.NodeInfo
 		for i := 0; i < numberOfNodes; i++ {
 			// Ensure new nodes have different names because nodeName
 			// will be used as a map key. Also deep copy pods (daemonsets &
 			// any pods added by cloud provider on template).
-			freshNodeInfo, err := simulator.SanitizedNodeInfo(nodeTemplate, fmt.Sprintf("upcoming-%d", i))
+			freshNodeInfo, err := simulator.SanitizedNodeInfo(nodeTemplate, fmt.Sprintf(suffixFmt, i))
 			if err != nil {
 				return nil, err
 			}
+			if freshNodeInfo.Node().Annotations == nil {
+				freshNodeInfo.Node().Annotations = make(map[string]string)
+			}
+			freshNodeInfo.Node().Annotations[annotations.NodeUpcomingAnnotation] = "true"
+
 			nodes = append(nodes, freshNodeInfo)
 		}
 		upcomingNodes[nodeGroup] = nodes

--- a/cluster-autoscaler/core/static_autoscaler_salvo_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_salvo_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/estimator"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/annotations"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+const customNodeGroupLabel = "custom-nodegroup"
+
+func withNodeSelector(selector map[string]string) func(*apiv1.Pod) {
+	return func(pod *apiv1.Pod) {
+		pod.Spec.NodeSelector = selector
+	}
+}
+
+func TestStaticAutoscalerSalvoScaleUp(t *testing.T) {
+	setupSalvoTest := func(t *testing.T, salvoEnabled bool, salvoBudget time.Duration) (
+		*StaticAutoscaler,
+		*onScaleUpMock,
+	) {
+		n1 := BuildTestNode("n1", 1000, 1000)
+		n1.Labels = map[string]string{customNodeGroupLabel: "ng1"}
+		SetNodeReadyState(n1, true, time.Now())
+
+		n2 := BuildTestNode("n2", 1000, 1000)
+		n2.Labels = map[string]string{customNodeGroupLabel: "ng2"}
+		SetNodeReadyState(n2, true, time.Now())
+
+		tn1 := BuildTestNode("tn1", 1000, 1000)
+		tn1.Labels = map[string]string{customNodeGroupLabel: "ng1"}
+		tni1 := framework.NewTestNodeInfo(tn1)
+
+		tn2 := BuildTestNode("tn2", 1000, 1000)
+		tn2.Labels = map[string]string{customNodeGroupLabel: "ng2"}
+		tni2 := framework.NewTestNodeInfo(tn2)
+
+		mocks := newCommonMocks()
+		mocks.readyNodeLister.SetNodes([]*apiv1.Node{n1, n2})
+		mocks.allNodeLister.SetNodes([]*apiv1.Node{n1, n2})
+
+		busy1 := BuildTestPod("busy1", 1000, 1000, WithNodeName("n1"))
+		busy2 := BuildTestPod("busy2", 1000, 1000, WithNodeName("n2"))
+		p1 := BuildTestPod("p1", 1000, 1000, MarkUnschedulable(), withNodeSelector(map[string]string{customNodeGroupLabel: "ng1"}))
+		p2 := BuildTestPod("p2", 1000, 1000, MarkUnschedulable(), withNodeSelector(map[string]string{customNodeGroupLabel: "ng2"}))
+
+		mocks.allPodLister.On("List").Return([]*apiv1.Pod{busy1, busy2, p1, p2}, nil).Once()
+		mocks.daemonSetLister.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
+		mocks.podDisruptionBudgetLister.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
+
+		autoscaler, err := setupAutoscaler(&autoscalerSetupConfig{
+			nodeGroups: []*nodeGroup{
+				{name: "ng1", nodes: []*apiv1.Node{n1}, template: tni1, min: 1, max: 10},
+				{name: "ng2", nodes: []*apiv1.Node{n2}, template: tni2, min: 1, max: 10},
+			},
+			autoscalingOptions: config.AutoscalingOptions{
+				NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+					ScaleDownUnneededTime:         time.Minute,
+					ScaleDownUnreadyTime:          time.Minute,
+					ScaleDownUtilizationThreshold: 0.5,
+					MaxNodeProvisionTime:          10 * time.Second,
+				},
+				EstimatorName:           estimator.BinpackingEstimatorName,
+				EnforceNodeGroupMinSize: true,
+
+				MaxNodesTotal:                  10,
+				MaxCoresTotal:                  100,
+				MaxMemoryTotal:                 100000,
+				MaxNodeGroupBinpackingDuration: 1 * time.Second,
+				SalvoScaleUp:                   salvoEnabled,
+				SalvoScaleUpBudget:             salvoBudget,
+			},
+			clusterStateConfig: clusterstate.ClusterStateRegistryConfig{
+				OkTotalUnreadyCount: 1,
+			},
+			mocks:        mocks,
+			nodesDeleted: make(chan bool, 1),
+		})
+		assert.NoError(t, err)
+		autoscaler.initialized = true
+
+		return autoscaler, mocks.onScaleUp
+	}
+
+	t.Run("Salvo disabled - only single scale up is triggered", func(t *testing.T) {
+		autoscaler, onScaleUpMock := setupSalvoTest(t, false, 1*time.Minute)
+
+		// Legacy behavior expects exactly one scale-up matching ng1 or ng2
+		onScaleUpMock.On("ScaleUp", mock.MatchedBy(func(id string) bool {
+			return id == "ng1" || id == "ng2"
+		}), 1).Return(nil).Once()
+
+		err := autoscaler.RunOnce(time.Now())
+		assert.NoError(t, err)
+		mock.AssertExpectationsForObjects(t, onScaleUpMock)
+	})
+
+	t.Run("Salvo enabled - multiple sequential scale ups are triggered in a single loop", func(t *testing.T) {
+		autoscaler, onScaleUpMock := setupSalvoTest(t, true, 1*time.Minute)
+
+		// Both scale ups should be triggered sequentially in a single RunOnce loop
+		onScaleUpMock.On("ScaleUp", "ng1", 1).Return(nil).Once()
+		onScaleUpMock.On("ScaleUp", "ng2", 1).Return(nil).Once()
+
+		err := autoscaler.RunOnce(time.Now())
+		assert.NoError(t, err)
+		mock.AssertExpectationsForObjects(t, onScaleUpMock)
+
+		// Verify that virtual upcoming nodes were correctly injected for both node groups
+		nodeInfos, snapErr := autoscaler.AutoscalingContext.ClusterSnapshot.ListNodeInfos()
+		assert.NoError(t, snapErr)
+
+		var node1Info, node2Info *framework.NodeInfo
+		for _, ni := range nodeInfos {
+			if ni.Node().Annotations[annotations.NodeUpcomingAnnotation] == "true" {
+				if ni.Node().Labels[customNodeGroupLabel] == "ng1" {
+					node1Info = ni
+				} else if ni.Node().Labels[customNodeGroupLabel] == "ng2" {
+					node2Info = ni
+				}
+			}
+		}
+
+		// Because map iteration order is not deterministic, either ng1 or ng2 will be processed first.
+		// The final iteration intentionally skips snapshot injection, so exactly one of the two upcoming nodes will be present.
+		node1Present := node1Info != nil
+		node2Present := node2Info != nil
+		assert.True(t, node1Present != node2Present, "Expected exactly one upcoming node to be present in snapshot")
+
+		var presentNodeInfo *framework.NodeInfo
+		var expectedPodName string
+		if node1Present {
+			presentNodeInfo = node1Info
+			expectedPodName = "p1"
+		} else {
+			presentNodeInfo = node2Info
+			expectedPodName = "p2"
+		}
+
+		pods := presentNodeInfo.Pods()
+		assert.Len(t, pods, 1)
+		assert.Equal(t, expectedPodName, pods[0].Name)
+	})
+
+	t.Run("Salvo enabled - zero budget timeout halts the loop", func(t *testing.T) {
+		autoscaler, onScaleUpMock := setupSalvoTest(t, true, 0*time.Nanosecond)
+
+		// Only the first scale up should be triggered before the budget is exhausted
+		onScaleUpMock.On("ScaleUp", mock.Anything, 1).Return(nil).Once()
+
+		err := autoscaler.RunOnce(time.Now())
+		assert.NoError(t, err)
+		mock.AssertExpectationsForObjects(t, onScaleUpMock)
+	})
+}

--- a/cluster-autoscaler/processors/status/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_up_status_processor.go
@@ -17,6 +17,8 @@ limitations under the License.
 package status
 
 import (
+	"fmt"
+
 	apiv1 "k8s.io/api/core/v1"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -29,6 +31,7 @@ import (
 // ScaleUpStatus is the status of a scale-up attempt. This includes information
 // on if scale-up happened, description of scale-up operation performed and
 // status of pods that took part in the scale-up evaluation.
+// Objects referenced in ScaleUpStatus are meant to be read-only.
 type ScaleUpStatus struct {
 	Result                   ScaleUpResult
 	ScaleUpError             *errors.AutoscalerError
@@ -69,6 +72,27 @@ const (
 	// ScaleUpLimitedByMaxNodesTotal - the scale up wasn't attempted, because the cluster reached max nodes total
 	ScaleUpLimitedByMaxNodesTotal
 )
+
+func (r ScaleUpResult) String() string {
+	switch r {
+	case ScaleUpSuccessful:
+		return "ScaleUpSuccessful"
+	case ScaleUpError:
+		return "ScaleUpError"
+	case ScaleUpNoOptionsAvailable:
+		return "ScaleUpNoOptionsAvailable"
+	case ScaleUpNotNeeded:
+		return "ScaleUpNotNeeded"
+	case ScaleUpNotTried:
+		return "ScaleUpNotTried"
+	case ScaleUpInCooldown:
+		return "ScaleUpInCooldown"
+	case ScaleUpLimitedByMaxNodesTotal:
+		return "ScaleUpLimitedByMaxNodesTotal"
+	default:
+		return fmt.Sprintf("ScaleUpResultUnknown=%d", r)
+	}
+}
 
 // WasSuccessful returns true if the scale-up was successful.
 func (s *ScaleUpStatus) WasSuccessful() bool {

--- a/cluster-autoscaler/proposals/scale_up_salvo.md
+++ b/cluster-autoscaler/proposals/scale_up_salvo.md
@@ -1,0 +1,83 @@
+# Scale Up Salvo: Multiple Scale-Ups Per Cluster Autoscaler Loop
+
+## Background
+
+Traditionally, the Cluster Autoscaler (CA) runs in a single-threaded, synchronous loop. During each iteration of this loop, CA evaluates the set of unschedulable pods, determines the optimal node group(s) to scale up via its expander, and triggers a single scale-up request (resize) to the cloud provider. After triggering this scale-up, the loop finishes, and CA waits for the next iteration to evaluate any remaining or new unschedulable pods.
+
+However, this single-iteration model introduces significant scale-up latency when handling a large backlog of unschedulable pods. Because standard CA triggers only one scale-up request per loop, a massive backlog—even if homogeneous—often cannot be fully satisfied in a single iteration due to node group size limits or zonal balancing constraints. This forces remaining pods to wait for subsequent loop iterations, introducing artificial delays that could be avoided by executing consecutive scale-ups back-to-back.
+
+---
+
+## High-Level Proposal
+
+We introduce the **Scale Up Salvo** feature. When enabled, this feature allows the Cluster Autoscaler to execute multiple sequential scale-up evaluations and cloud provider resize requests within a single main loop iteration.
+
+Instead of immediately exiting the scale-up phase after the first group is provisioned, CA enters a _salvo loop_ where it:
+
+1. Runs a standard scale-up evaluation (`runSingleScaleUp`) to select and scale up the best node group for a subset of the unschedulable pods.
+2. Removes the pods that successfully triggered this scale-up from the active unschedulable pods backlog.
+3. Updates the in-memory `ClusterSnapshot` by injecting the faked "upcoming" nodes corresponding to the triggered scale-up, and virtually schedules the triggering pods on them.
+4. Evaluates and triggers the next scale-up on the remaining pods, taking into account the updated `ClusterSnapshot` (which ensures scheduling constraints against the newly triggered nodes are correctly respected). This process (repeating steps 1–3) continues until the backlog is cleared or the time budget is exhausted.
+
+This allows CA to trigger multiple distinct node group expansions in a single loop, reducing the time-to-provision for large backlogs.
+
+---
+
+## Configuration and Flags
+
+Two new command-line flags are introduced to configure the salvo behavior:
+
+- **`--salvo-scale-up`** (Default: `false`)
+  - Enables or disables the Scale Up Salvo feature. When set to `false` (default), CA preserves its legacy behavior of a single scale-up operation per loop.
+- **`--salvo-scale-up-budget`** (Default: `1m`)
+  - Specifies the maximum time duration CA is allowed to spend on subsequent scale-ups in a single loop. This prevents the salvo loop from starving other critical autoscaler operations (like scale-down evaluation or status reporting) under heavy pod backlogs. Requires `--salvo-scale-up` to be enabled.
+
+---
+
+## Detailed Design & Implementation
+
+The feature is implemented across `StaticAutoscaler` and the `ScaleUpStatusProcessor` tracking structure.
+
+### 1. Salvo Execution Loop (`runScaleUpSalvo`)
+
+When `--salvo-scale-up` is enabled, the autoscaler calls `runScaleUpSalvo` in `static_autoscaler.go`. The workflow is as follows:
+
+1.  **Track Unschedulable Pods:** Create an in-memory map of all unschedulable pods to help (`podsMap`).
+2.  **Time Budget Context:** Initialize a Go `context.Context` with a timeout matching the configured `--salvo-scale-up-budget`.
+3.  **Iteration Loop:**
+    - Convert the remaining `podsMap` back into a slice of unschedulable pods.
+    - Call `runSingleScaleUp` to let the scale-up orchestrator and expander select the best node group and resize it.
+    - If the scale-up fails or returns a status indicating that no scale-up was tried or needed, terminate the salvo.
+    - Remove the pods that successfully triggered a scale-up in this iteration from the remaining `podsMap`.
+    - **Update ClusterSnapshot:** Update the local `ClusterSnapshot` using the helper `addLatestScaleUpResultsToClusterSnapshot`. This makes the new upcoming nodes and virtually scheduled pods visible to subsequent iterations of the salvo loop. (Note: this update is intentionally skipped on the final iteration when the remaining backlog queue becomes empty to avoid unnecessary computations.)
+    - **Check Budget:** Verify if `salvoCtx.Err()` is non-nil (deadline exceeded). If so, terminate the salvo.
+
+### 2. Cluster Snapshot Synchronization
+
+To ensure subsequent iterations of the salvo loop do not attempt to scale up again for the same pods (or make incorrect decisions because they don't know about the newly triggered nodes), the `ClusterSnapshot` must be updated dynamically.
+
+The helper method `addLatestScaleUpResultsToClusterSnapshot` handles this update in-place:
+
+1.  **Inject Upcoming Nodes:** For each node group scale-up info in the status, it calculates the delta (`NewSize - CurrentSize`). It clones the node template, marks it with the `autoscaling.k8s.io/upcoming-node` annotation, and adds it to the `ClusterSnapshot` under a unique name suffixed with `salvo-<iteration_index>`.
+2.  **Virtual Pod Scheduling:** It calls `SchedulePodOnAnyNodeMatching` on the `ClusterSnapshot` to bind the triggering pods to these newly injected upcoming nodes. This mimics the scheduler and ensures that they do not remain in the "unschedulable pods" queue for the next iteration.
+
+### 3. Preserving Triggering Pods
+
+During standard execution, downstream status processors (such as `ScaleUpStatusProcessor`) process `ScaleUpStatus` and may filter the `ScaleUpStatus.PodsTriggeredScaleUp` slice (e.g., removing certain pods for custom metrics, logging, or special status reporting).
+
+However, the salvo loop requires the **exact, unfiltered set** of pods that actually triggered the cloud-provider scale-up in that iteration to:
+
+- Filter them out of the remaining unschedulable pods list.
+- Properly schedule them on the virtual upcoming nodes in the `ClusterSnapshot`.
+
+To resolve this, we preserve the original list by assigning the slice reference (`unfilteredPodsTriggeredScaleUp := scaleUpStatus.PodsTriggeredScaleUp`) immediately after the scale up orchestrator finishes and before any status processors run. This simple reference assignment is sufficient because status processors generally only filter the slice and do not perform in-place modifications on the underlying `Pod` objects, preserving the original list.
+
+The salvo loop then uses the `unfilteredPodsTriggeredScaleUp` list for snapshot synchronization and backlog filtering. This guarantees that both operations process the complete set of triggering pods, even if downstream processors filter the main `PodsTriggeredScaleUp` slice.
+
+---
+
+## Benefits
+
+1.  **Faster Backlog Resolution:** Instead of waiting for subsequent loop iterations (which takes tens of seconds or minutes each), CA can trigger multiple consecutive resizes immediately back-to-back. This is particularly helpful for large homogeneous backlogs that cannot be fully resolved in a single scale-up step due to size or zone-balancing limits.
+2.  **Consistent Simulator State:** Updating the local `ClusterSnapshot` dynamically ensures that subsequent iterations in the salvo loop evaluate remaining pods with a highly accurate view of the cluster's future state, respecting capacity limits and pod constraints.
+3.  **Operational Safety:** The budget timeout (`--salvo-scale-up-budget`) ensures the salvo loop finishes quickly and never hangs, keeping the main CA loop responsive and preventing starvation of other tasks like scale-down checks.


### PR DESCRIPTION
The Scale Up Salvo feature allows the Cluster Autoscaler to trigger multiple consecutive scale-up evaluations and cloud provider resize requests back-to-back within a single main loop iteration. This eliminates the multi-minute delay of legacy behavior, where CA had to wait for subsequent loop iterations to handle a large queue of unschedulable pods.

**The legacy single scale up per CA loop is still the default behavior**, this PR only introduces a new flag (false by default) which enabled the new multi-scale-up per loop behavior.

How it works
1. The Salvo Loop: CA enters an execution loop that sequentially calls the standard scale-up evaluation (runSingleScaleUp) for the unschedulable Pods from the chosen scale up pod shard.
2. Backlog Filtering: In each iteration, the pods that successfully trigger a node group scale-up are filtered out of the remaining unschedulable pods set.
3. Cluster Snapshot Sync: The newly triggered upcoming nodes are dynamically injected into the in-memory ClusterSnapshot (similarly to upcoming nodes at the beginning of CA loop), and the triggering pods are virtually scheduled onto them. This ensures subsequent iterations in the loop make scheduling decisions based on a highly accurate future state of the cluster.
4. Time Budget Guard: The loop continues until all pods are scheduled or the configured time budget (e.g., --salvo-scale-up-budget, default 1min) is exhausted, preventing the salvo loop from starving other parts of the logic.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces the Scale Up Salvo feature to enable the Cluster Autoscaler to perform multiple consecutive scale-up evaluations and cloud provider resize requests within a single main loop iteration, effectively reducing scale-up latency and time-to-provision for large numbers of unschedulable pods.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A new experimental salvo-scale-up flag can be enabled to allow multiple scale-ups in a single CA loop. Additional --salvo-scale-up-budget flag can be used to configure the maximum time CA spends on subsequent scale ups in a single CA loop.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
