### PR TITLE
Write pods with nominated node name to the cluster snapshot

### DIFF
--- a/cluster-autoscaler/core/podlistprocessor/filter_out_expendable.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_expendable.go
@@ -17,13 +17,9 @@ limitations under the License.
 package podlistprocessor
 
 import (
-	"fmt"
-
 	apiv1 "k8s.io/api/core/v1"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	core_utils "k8s.io/autoscaler/cluster-autoscaler/core/utils"
-	caerrors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	"k8s.io/klog/v2"
 )
 
 type filterOutExpendable struct {
@@ -36,33 +32,11 @@ func NewFilterOutExpendablePodListProcessor() *filterOutExpendable {
 
 // Process filters out pods which are expendable and adds pods which is waiting for lower priority pods preemption to the cluster snapshot
 func (p *filterOutExpendable) Process(autoscalingCtx *ca_context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
-	nodes, err := autoscalingCtx.AllNodeLister().List()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to list all nodes while filtering expendable pods: %v", err)
-	}
 	expendablePodsPriorityCutoff := autoscalingCtx.AutoscalingOptions.ExpendablePodsPriorityCutoff
 
-	unschedulablePods, waitingForLowerPriorityPreemption := core_utils.FilterOutExpendableAndSplit(pods, nodes, expendablePodsPriorityCutoff)
-	if err = p.addPreemptingPodsToSnapshot(waitingForLowerPriorityPreemption, autoscalingCtx); err != nil {
-		klog.Warningf("Failed to add preempting pods to snapshot: %v", err)
-		return nil, err
-	}
+	unschedulablePods := core_utils.FilterOutExpendablePods(pods, expendablePodsPriorityCutoff)
 
 	return unschedulablePods, nil
-}
-
-// addPreemptingPodsToSnapshot modifies the snapshot simulating scheduling of pods waiting for preemption.
-// this is not strictly correct as we are not simulating preemption itself but it matches
-// CA logic from before migration to scheduler framework. So let's keep it for now
-func (p *filterOutExpendable) addPreemptingPodsToSnapshot(pods []*apiv1.Pod, autoscalingCtx *ca_context.AutoscalingContext) error {
-	for _, p := range pods {
-		// TODO(DRA): Figure out if/how to use the predicate-checking SchedulePod() here instead - otherwise this doesn't work with DRA pods.
-		if err := autoscalingCtx.ClusterSnapshot.ForceAddPod(p, p.Status.NominatedNodeName); err != nil {
-			klog.Errorf("Failed to update snapshot with pod %s/%s waiting for preemption: %v", p.Namespace, p.Name, err)
-			return caerrors.ToAutoscalerError(caerrors.InternalError, err)
-		}
-	}
-	return nil
 }
 
 func (p *filterOutExpendable) CleanUp() {

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_expendable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_expendable_test.go
@@ -70,40 +70,6 @@ func TestFilterOutExpendable(t *testing.T) {
 			},
 			priorityCutoff: 3,
 		},
-		{
-			name: "single waiting-for-low-priority-preemption pod",
-			pods: []*apiv1.Pod{
-				test.BuildTestPod("p", 1000, 1, nominatedNodeName("node-1")),
-			},
-			nodes: []*apiv1.Node{
-				test.BuildTestNode("node-1", 2400, 2400),
-			},
-			wantPodsInSnapshot: []*apiv1.Pod{
-				test.BuildTestPod("p", 1000, 1, nominatedNodeName("node-1")),
-			},
-		},
-		{
-			name: "mixed expendable, non-expendable & waiting-for-low-priority-preemption pods",
-			pods: []*apiv1.Pod{
-				test.BuildTestPod("p1", 1000, 1, priority(3)),
-				test.BuildTestPod("p2", 1000, 1, priority(4)),
-				test.BuildTestPod("p3", 1000, 1, priority(1)),
-				test.BuildTestPod("p4", 1000, 1),
-				test.BuildTestPod("p5", 1000, 1, nominatedNodeName("node-1")),
-			},
-			priorityCutoff: 2,
-			wantPods: []*apiv1.Pod{
-				test.BuildTestPod("p1", 1000, 1, priority(3)),
-				test.BuildTestPod("p2", 1000, 1, priority(4)),
-				test.BuildTestPod("p4", 1000, 1),
-			},
-			wantPodsInSnapshot: []*apiv1.Pod{
-				test.BuildTestPod("p5", 1000, 1, nominatedNodeName("node-1")),
-			},
-			nodes: []*apiv1.Node{
-				test.BuildTestNode("node-1", 2400, 2400),
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -379,9 +379,10 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	} else {
 		metrics.UpdateMaxNodesCount(maxNodesCount)
 	}
-	nonExpendableScheduledPods := core_utils.FilterOutExpendablePods(podsBySchedulability.Scheduled, a.ExpendablePodsPriorityCutoff)
+	allocatedPods := slices.Concat(podsBySchedulability.Scheduled, podsBySchedulability.NominatedNode)
+	nonExpendableAllocatedPods := core_utils.FilterOutExpendablePods(allocatedPods, a.ExpendablePodsPriorityCutoff)
 
-	if err := a.ClusterSnapshot.SetClusterState(allNodes, nonExpendableScheduledPods, draSnapshot, csiSnapshot); err != nil {
+	if err := a.ClusterSnapshot.SetClusterState(allNodes, nonExpendableAllocatedPods, draSnapshot, csiSnapshot); err != nil {
 		return caerrors.ToAutoscalerError(caerrors.InternalError, err).AddPrefix("failed to initialize ClusterSnapshot: ")
 	}
 	// Initialize Pod Disruption Budget tracking
@@ -1391,9 +1392,9 @@ func listPods(podLister kube_util.PodLister, bypassedSchedulers, allowedSchedule
 	// Skip logging in case of the boring scenario, when all pods are scheduled.
 	if len(pods) != len(podsBySchedulability.Scheduled) {
 		ignoredDueToDisallowed := initialPodCount - len(pods)
-		ignored := len(pods) - len(podsBySchedulability.Scheduled) - len(podsBySchedulability.Unschedulable) - len(podsBySchedulability.Unprocessed)
-		klog.Infof("Found %d pods in the cluster: %d scheduled, %d unschedulable, %d unprocessed by scheduler, %d ignored by allowed schedulers (most likely using custom scheduler), %d ignored due to dissallowed schedulers",
-			initialPodCount, len(podsBySchedulability.Scheduled), len(podsBySchedulability.Unschedulable), len(podsBySchedulability.Unprocessed), ignored, ignoredDueToDisallowed)
+		ignored := len(pods) - len(podsBySchedulability.Scheduled) - len(podsBySchedulability.NominatedNode) - len(podsBySchedulability.Unschedulable) - len(podsBySchedulability.Unprocessed)
+		klog.Infof("Found %d pods in the cluster: %d scheduled, %d with nominated node, %d unschedulable, %d unprocessed by scheduler, %d ignored by allowed schedulers (most likely using custom scheduler), %d ignored due to dissallowed schedulers",
+			initialPodCount, len(podsBySchedulability.Scheduled), len(podsBySchedulability.NominatedNode), len(podsBySchedulability.Unschedulable), len(podsBySchedulability.Unprocessed), ignored, ignoredDueToDisallowed)
 	}
 	return
 }

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -3674,3 +3674,92 @@ func TestStaticAutoscalerRunOnceClearsRegistry(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, registry.GetCapacityBuffer(fakePodUID))
 }
+
+func TestStaticAutoscalerRunOnceWithNominatedNodeName(t *testing.T) {
+	readyNodeLister := kubernetes.NewTestNodeLister(nil)
+	allNodeLister := kubernetes.NewTestNodeLister(nil)
+	allPodListerMock := &podListerMock{}
+	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
+	daemonSetListerMock := &daemonSetListerMock{}
+	onScaleUpMock := &onScaleUpMock{}
+	onScaleDownMock := &onScaleDownMock{}
+
+	n1 := BuildTestNode("n1", 2000, 1000)
+	SetNodeReadyState(n1, true, time.Now())
+
+	p1 := BuildTestPod("p1", 1400, 0, WithNodeName("n1"))
+
+	p2 := BuildTestPod("p2", 1400, 0, MarkUnschedulable())
+	// p2 has NominatedNodeName set, so it should not trigger a scale up
+	p2.Status.NominatedNodeName = "n1"
+
+	provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleUp(func(id string, delta int) error {
+		return onScaleUpMock.ScaleUp(id, delta)
+	}).WithOnScaleDown(func(id string, name string) error {
+		return onScaleDownMock.ScaleDown(id, name)
+	}).Build()
+	provider.AddNodeGroup("ng1", 0, 10, 1)
+	provider.AddNode("ng1", n1)
+
+	assert.NotNil(t, provider)
+
+	// Create context with mocked lister registry.
+	options := config.AutoscalingOptions{
+		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+			ScaleDownUtilizationThreshold: 0.5,
+			MaxNodeProvisionTime:          10 * time.Second,
+		},
+		EstimatorName:                  estimator.BinpackingEstimatorName,
+		MaxNodesTotal:                  10,
+		MaxCoresTotal:                  10,
+		MaxMemoryTotal:                 100000,
+		MaxNodeGroupBinpackingDuration: 1 * time.Second,
+	}
+	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
+
+	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	assert.NoError(t, err)
+
+	setUpScaleDownActuator(&autoscalingCtx, options)
+
+	listerRegistry := kube_util.NewListerRegistry(allNodeLister, readyNodeLister, allPodListerMock,
+		podDisruptionBudgetListerMock, daemonSetListerMock,
+		nil, nil, nil, nil)
+	autoscalingCtx.ListerRegistry = listerRegistry
+
+	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
+		OkTotalUnreadyCount: 1,
+	}
+	clusterState := clusterstate.NewClusterStateRegistry(provider, clusterStateConfig, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults), processors.AsyncNodeGroupStateChecker)
+	sdPlanner, sdActuator := newScaleDownPlannerAndActuator(&autoscalingCtx, processors, clusterState, nil)
+	quotasTrackerFactory := newQuotasTrackerFactory(&autoscalingCtx, processors)
+	suOrchestrator := orchestrator.New()
+	suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, quotasTrackerFactory)
+
+	autoscaler := &StaticAutoscaler{
+		AutoscalingContext:    &autoscalingCtx,
+		clusterStateRegistry:  clusterState,
+		lastScaleUpTime:       time.Now(),
+		lastScaleDownFailTime: time.Now(),
+		scaleDownPlanner:      sdPlanner,
+		scaleDownActuator:     sdActuator,
+		scaleUpOrchestrator:   suOrchestrator,
+		processors:            processors,
+		loopStartNotifier:     loopstart.NewObserversList(nil),
+		processorCallbacks:    processorCallbacks,
+	}
+
+	// Scale up
+	readyNodeLister.SetNodes([]*apiv1.Node{n1})
+	allNodeLister.SetNodes([]*apiv1.Node{n1})
+	allPodListerMock.On("List").Return([]*apiv1.Pod{p1, p2}, nil).Once()
+	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
+
+	err = autoscaler.RunOnce(time.Now())
+	assert.NoError(t, err)
+
+	mock.AssertExpectationsForObjects(t, allPodListerMock,
+		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
+}

--- a/cluster-autoscaler/core/utils/expendable.go
+++ b/cluster-autoscaler/core/utils/expendable.go
@@ -18,38 +18,7 @@ package utils
 
 import (
 	apiv1 "k8s.io/api/core/v1"
-	klog "k8s.io/klog/v2"
 )
-
-// FilterOutExpendableAndSplit filters out expendable pods and splits into:
-//   - waiting for lower priority pods preemption
-//   - other pods.
-func FilterOutExpendableAndSplit(unschedulableCandidates []*apiv1.Pod, nodes []*apiv1.Node, expendablePodsPriorityCutoff int) ([]*apiv1.Pod, []*apiv1.Pod) {
-	var unschedulableNonExpendable []*apiv1.Pod
-	var waitingForLowerPriorityPreemption []*apiv1.Pod
-
-	nodeNames := make(map[string]bool)
-	for _, node := range nodes {
-		nodeNames[node.Name] = true
-	}
-
-	for _, pod := range unschedulableCandidates {
-		if IsExpendablePod(pod, expendablePodsPriorityCutoff) {
-			klog.V(4).Infof("Pod %s has priority below %d (%d) and will scheduled when enough resources is free. Ignoring in scale up.", pod.Name, expendablePodsPriorityCutoff, *pod.Spec.Priority)
-		} else if nominatedNodeName := pod.Status.NominatedNodeName; nominatedNodeName != "" {
-			if nodeNames[nominatedNodeName] {
-				klog.V(4).Infof("Pod %s will be scheduled after low priority pods are preempted on %s. Ignoring in scale up.", pod.Name, nominatedNodeName)
-				waitingForLowerPriorityPreemption = append(waitingForLowerPriorityPreemption, pod)
-			} else {
-				klog.V(4).Infof("Pod %s has nominatedNodeName set to %s but node is gone", pod.Name, nominatedNodeName)
-				unschedulableNonExpendable = append(unschedulableNonExpendable, pod)
-			}
-		} else {
-			unschedulableNonExpendable = append(unschedulableNonExpendable, pod)
-		}
-	}
-	return unschedulableNonExpendable, waitingForLowerPriorityPreemption
-}
 
 // FilterOutExpendablePods filters out expendable pods.
 func FilterOutExpendablePods(pods []*apiv1.Pod, expendablePodsPriorityCutoff int) []*apiv1.Pod {

--- a/cluster-autoscaler/core/utils/expendable_test.go
+++ b/cluster-autoscaler/core/utils/expendable_test.go
@@ -25,48 +25,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 )
 
-func TestFilterOutExpendableAndSplit(t *testing.T) {
-	var priority1 int32 = 1
-	var priority100 int32 = 100
-
-	p1 := BuildTestPod("p1", 1000, 200000)
-	p1.Spec.Priority = &priority1
-	p2 := BuildTestPod("p2", 1000, 200000)
-	p2.Spec.Priority = &priority100
-	n1 := BuildTestNode("node1", 10, 10)
-	n2 := BuildTestNode("node2", 10, 10)
-
-	podWaitingForPreemption1 := BuildTestPod("w1", 1000, 200000)
-	podWaitingForPreemption1.Spec.Priority = &priority1
-	podWaitingForPreemption1.Status.NominatedNodeName = "node1"
-	podWaitingForPreemption2 := BuildTestPod("w2", 1000, 200000)
-	podWaitingForPreemption2.Spec.Priority = &priority100
-	podWaitingForPreemption2.Status.NominatedNodeName = "node2"
-
-	res1, res2 := FilterOutExpendableAndSplit([]*apiv1.Pod{p1, p2, podWaitingForPreemption1, podWaitingForPreemption2}, []*apiv1.Node{n1, n2}, 0)
-	assert.Equal(t, 2, len(res1))
-	assert.Equal(t, p1, res1[0])
-	assert.Equal(t, p2, res1[1])
-	assert.Equal(t, 2, len(res2))
-	assert.Equal(t, podWaitingForPreemption1, res2[0])
-	assert.Equal(t, podWaitingForPreemption2, res2[1])
-
-	res1, res2 = FilterOutExpendableAndSplit([]*apiv1.Pod{p1, p2, podWaitingForPreemption1, podWaitingForPreemption2}, []*apiv1.Node{n1, n2}, 10)
-	assert.Equal(t, 1, len(res1))
-	assert.Equal(t, p2, res1[0])
-	assert.Equal(t, 1, len(res2))
-	assert.Equal(t, podWaitingForPreemption2, res2[0])
-
-	// if node2 is missing podWaitingForPreemption2 should be treated as standard pod not one waiting for preemption
-	res1, res2 = FilterOutExpendableAndSplit([]*apiv1.Pod{p1, p2, podWaitingForPreemption1, podWaitingForPreemption2}, []*apiv1.Node{n1}, 0)
-	assert.Equal(t, 3, len(res1))
-	assert.Equal(t, p1, res1[0])
-	assert.Equal(t, p2, res1[1])
-	assert.Equal(t, podWaitingForPreemption2, res1[2])
-	assert.Equal(t, 1, len(res2))
-	assert.Equal(t, podWaitingForPreemption1, res2[0])
-}
-
 func TestFilterOutExpendablePods(t *testing.T) {
 	p1 := BuildTestPod("p1", 1500, 200000)
 	p2 := BuildTestPod("p2", 3000, 200000)

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
@@ -27,6 +27,7 @@ import (
 	drasnapshot "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/snapshot"
 	drautils "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/klogx"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/dynamic-resource-allocation/resourceclaim"
 	schedulerinterface "k8s.io/kube-scheduler/framework"
@@ -47,6 +48,7 @@ type PredicateSnapshot struct {
 
 // NewPredicateSnapshot builds a PredicateSnapshot.
 func NewPredicateSnapshot(snapshotStore clustersnapshot.ClusterSnapshotStore, fwHandle *framework.Handle, draEnabled bool, parallelism int, enableCSINodeAwareScheduling bool) *PredicateSnapshot {
+	parallelism = max(parallelism, 1)
 	snapshot := &PredicateSnapshot{
 		ClusterSnapshotStore:         snapshotStore,
 		draEnabled:                   draEnabled,
@@ -64,7 +66,7 @@ func NewPredicateSnapshot(snapshotStore clustersnapshot.ClusterSnapshotStore, fw
 }
 
 // SetClusterState resets the snapshot to an unforked state and replaces the contents of the snapshot
-// with the provided data. scheduledPods are correlated to their Nodes based on spec.NodeName.
+// with the provided data. scheduledPods are correlated to their Nodes based on spec.NodeName or status.NominatedNodeName.
 // The provided draSnapshot and csiSnapshot are treated as the source of truth and are eagerly
 // loaded into the created NodeInfo/PodInfo objects.
 func (s *PredicateSnapshot) SetClusterState(nodes []*apiv1.Node, scheduledPods []*apiv1.Pod, draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) error {
@@ -101,16 +103,8 @@ func (s *PredicateSnapshot) SetClusterState(nodes []*apiv1.Node, scheduledPods [
 		nodeNameToIdx[node.Name] = i
 	}
 
-	if s.parallelism > 1 {
-		if err := s.setClusterStatePodsParallelized(nodeInfos, nodeNameToIdx, scheduledPods); err != nil {
-			return err
-		}
-	} else {
-		// TODO(macsko): Migrate to setClusterStatePodsParallelized for parallelism == 1
-		// after making sure the implementation is always correct in CA 1.33.
-		if err := s.setClusterStatePodsSequential(nodeInfos, nodeNameToIdx, scheduledPods); err != nil {
-			return err
-		}
+	if err := s.setClusterStatePods(nodeInfos, nodeNameToIdx, scheduledPods); err != nil {
+		return err
 	}
 
 	// We build NodeInfo objects with all their pods before adding them to the store.
@@ -125,29 +119,17 @@ func (s *PredicateSnapshot) SetClusterState(nodes []*apiv1.Node, scheduledPods [
 	return nil
 }
 
-func (s *PredicateSnapshot) setClusterStatePodsSequential(nodeInfos []*framework.NodeInfo, nodeNameToIdx map[string]int, scheduledPods []*apiv1.Pod) error {
-	for _, pod := range scheduledPods {
-		if nodeIdx, ok := nodeNameToIdx[pod.Spec.NodeName]; ok {
-			var claims []*resourceapi.ResourceClaim
-			if s.draEnabled && s.draSnapshot != nil {
-				var err error
-				claims, err = s.draSnapshot.PodClaims(pod)
-				if err != nil {
-					return fmt.Errorf("couldn't obtain pod %s/%s claims: %v", pod.Namespace, pod.Name, err)
-				}
-			}
-			podInfo := framework.NewPodInfo(pod, claims)
-			nodeInfos[nodeIdx].AddPodInfo(podInfo)
-		}
-	}
-	return nil
-}
-
-func (s *PredicateSnapshot) setClusterStatePodsParallelized(nodeInfos []*framework.NodeInfo, nodeNameToIdx map[string]int, scheduledPods []*apiv1.Pod) error {
+func (s *PredicateSnapshot) setClusterStatePods(nodeInfos []*framework.NodeInfo, nodeNameToIdx map[string]int, scheduledPods []*apiv1.Pod) error {
+	loggingQuota := klogx.PodsLoggingQuota()
 	podInfosForNode := make([][]*framework.PodInfo, len(nodeInfos))
 	for _, pod := range scheduledPods {
-		nodeIdx, ok := nodeNameToIdx[pod.Spec.NodeName]
+		nodeName := pod.Spec.NodeName
+		if nodeName == "" {
+			nodeName = pod.Status.NominatedNodeName
+		}
+		nodeIdx, ok := nodeNameToIdx[nodeName]
 		if !ok {
+			klogx.V(1).UpTo(loggingQuota).Warningf("SetClusterState: node %q bound or nominated by pod \"%s/%s\" does not exist in the snapshot", nodeName, pod.Namespace, pod.Name)
 			continue
 		}
 
@@ -164,6 +146,7 @@ func (s *PredicateSnapshot) setClusterStatePodsParallelized(nodeInfos []*framewo
 		podInfosForNode[nodeIdx] = append(podInfosForNode[nodeIdx], podInfo)
 	}
 
+	klogx.V(1).Over(loggingQuota).Warningf("Other %d pods were bound to or nominated non-existing node", -loggingQuota.Left())
 	ctx := context.Background()
 	workqueue.ParallelizeUntil(ctx, s.parallelism, len(nodeInfos), func(nodeIdx int) {
 		nodeInfo := nodeInfos[nodeIdx]

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -1493,6 +1493,29 @@ func TestSetClusterState(t *testing.T) {
 
 				compareStates(t, snapshotState{nodes: newNodes, podsByNode: newPodsByNode, draSnapshot: drasnapshot.NewEmptySnapshot(), csiSnapshot: csisnapshot.NewSnapshot(newCSINodeMap)}, getSnapshotState(t, snapshot))
 			})
+		t.Run(fmt.Sprintf("%s: clear base %d nodes %d pods and set a new state with nominated nodes", name, nodeCount, podCount),
+			func(t *testing.T) {
+				snapshot := startSnapshot(t, snapshotFactory, state)
+				compareStates(t, state, getSnapshotState(t, snapshot))
+
+				newNodes, newPods := clustersnapshot.CreateTestNodes(13), clustersnapshot.CreateTestPods(37)
+				newPodsByNode := clustersnapshot.AssignTestPodsToNodes(newPods, newNodes)
+
+				for _, pod := range newPods {
+					pod.Status.NominatedNodeName = pod.Spec.NodeName
+					pod.Spec.NodeName = ""
+				}
+
+				// Create CSI nodes for new nodes
+				newCSINodeMap := map[string]*storagev1.CSINode{}
+				for _, node := range newNodes {
+					newCSINodeMap[node.Name] = BuildCSINode(node)
+				}
+
+				assert.NoError(t, snapshot.SetClusterState(newNodes, newPods, nil, csisnapshot.NewSnapshot(newCSINodeMap)))
+
+				compareStates(t, snapshotState{nodes: newNodes, podsByNode: newPodsByNode, draSnapshot: drasnapshot.NewEmptySnapshot(), csiSnapshot: csisnapshot.NewSnapshot(newCSINodeMap)}, getSnapshotState(t, snapshot))
+			})
 		t.Run(fmt.Sprintf("%s: clear fork %d nodes %d pods %d extra nodes %d extra pods", name, nodeCount, podCount, extraNodeCount, extraPodCount),
 			func(t *testing.T) {
 				snapshot := startSnapshot(t, snapshotFactory, state)

--- a/cluster-autoscaler/utils/klogx/klogx.go
+++ b/cluster-autoscaler/utils/klogx/klogx.go
@@ -95,3 +95,11 @@ func (v Verbose) Info(args ...interface{}) {
 		v.v.Info(args...)
 	}
 }
+
+// Warningf is a wrapper for klog.Warningf that logs if the Quota allows for it.
+func (v Verbose) Warningf(format string, args ...interface{}) {
+	if v.enabled {
+		// klog.Verbose does not implement Warningf
+		klog.Warningf(format, args...)
+	}
+}

--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -63,6 +63,7 @@ type PodsBySchedulability struct {
 	Scheduled     []*apiv1.Pod
 	Unschedulable []*apiv1.Pod
 	Unprocessed   []*apiv1.Pod
+	NominatedNode []*apiv1.Pod
 }
 
 // NewListerRegistry returns a registry providing various listers to list pods or nodes matching conditions
@@ -176,7 +177,7 @@ func ScheduledPods(allPods []*apiv1.Pod) []*apiv1.Pod {
 }
 
 // ArrangePodsBySchedulability is a helper method that arranges pods by schedulability:
-// scheduled, unschedulable, and unprocessed by any any bypassed schedulers.
+// scheduled, with nominated node, unschedulable, and unprocessed by any bypassed schedulers.
 func ArrangePodsBySchedulability(allPods []*apiv1.Pod, bypassedSchedulers map[string]bool) (podsBySchedulability PodsBySchedulability) {
 	for _, pod := range allPods {
 		if isScheduled(pod) {
@@ -184,6 +185,8 @@ func ArrangePodsBySchedulability(allPods []*apiv1.Pod, bypassedSchedulers map[st
 			continue
 		} else if isDeleted(pod) {
 			continue
+		} else if pod.Status.NominatedNodeName != "" {
+			podsBySchedulability.NominatedNode = append(podsBySchedulability.NominatedNode, pod)
 		} else {
 			_, condition := podv1.GetPodCondition(&pod.Status, apiv1.PodScheduled)
 			if condition != nil && condition.Status == apiv1.ConditionFalse && condition.Reason == apiv1.PodReasonUnschedulable {


### PR DESCRIPTION


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Previously, this was done by filterOutExpendable pod list processor. That was fine, as pod's NominatedNodeName was tightly coupled to the preemption. With KEP-5278, the scheduler sets NominatedNodeName after reserving the resources for the pod on the node, but before the actual binding the pod to the node. This change decouples adding pods with NominatedNodeName from filtering out expendable pods, and instead saves them in the `SetClusterState` call.

Additionally, in the previous implementation, if a pod with NominatedNodeName had a custom scheduler configured, and hasn't been yet processed by the scheduler, CA ignores it. That means that that pod is not saved in the cluster snapshot, so CA considers reserved resources as free, which might result in missing scale ups.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Pods with status.nominatedNodeName will not trigger scale up even if the target node does not exist
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5278-nominated-node-name-for-expectation
```
