### PR TITLE
VPA: Group dependabot updates by k8s.io

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,14 @@ updates:
     - "area/vertical-pod-autoscaler"
     - "release-note-none"
     - "ok-to-test"
-  groups:
-    vpa-dependencies:
-      group-by: dependency-name
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+      default:
+        group-by: dependency-name
+        exclude-patterns:
+          - "k8s.io/*"
 - package-ecosystem: docker
   directories:
     - "/vertical-pod-autoscaler/pkg/admission-controller"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     - "area/vertical-pod-autoscaler"
     - "release-note-none"
     - "ok-to-test"
+    - "triage/accepted"
     groups:
       kubernetes:
         patterns:


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

See https://github.com/kubernetes/autoscaler/pull/9620

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/area dependency 
