### PR TITLE
Try fix dependabot grouping again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,16 @@ updates:
     - "ok-to-test"
     - "triage/accepted"
   groups:
+    non-kubernetes:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
     kubernetes:
       patterns:
         - "k8s.io/*"
-        - "k8s.io/**"
-    default:
-      group-by: dependency-name
-      exclude-patterns:
-        - "k8s.io/*"
-        - "k8s.io/**"
+        - "sigs.k8s.io/*"
 - package-ecosystem: docker
   directories:
     - "/vertical-pod-autoscaler/pkg/admission-controller"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Still not working! See https://github.com/kubernetes/autoscaler/pull/9628

Now I'm copying https://github.com/kubernetes-sigs/gateway-api/blob/ec7d5a2f6ff132f2b2465aff81dfcba862738a9c/.github/dependabot.yml

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/triage accepted
/area dependency 