### PR TITLE
Fix CA benchmark resource leak

### DIFF
--- a/.github/workflows/ca-benchmark.yaml
+++ b/.github/workflows/ca-benchmark.yaml
@@ -12,8 +12,6 @@ jobs:
   benchmark:
     name: Run and Compare Benchmarks
     runs-on: ubuntu-latest
-    # Do not block valid PRs on benchmark issues as we are still stabilizing.
-    continue-on-error: true
     steps:
       - name: Checkout PR
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -52,6 +50,8 @@ jobs:
 
       - name: Compare Results
         shell: bash
+        # Do not block valid PRs on benchmark issues as we are still stabilizing.
+        continue-on-error: true
         run: |
           echo "### Cluster Autoscaler Benchmark Results" >> $GITHUB_STEP_SUMMARY
           echo "Comparing PR branch against \`${{ github.event.pull_request.base.ref }}\`" >> $GITHUB_STEP_SUMMARY
@@ -61,7 +61,7 @@ jobs:
             echo '```' >> $GITHUB_STEP_SUMMARY
             $(go env GOPATH)/bin/benchstat base.txt pr.txt | tee benchstat.txt >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            
+          
             # Fail if any regression is > 10%
             grep -qE '\+[1-9][0-9].*%' benchstat.txt && { echo "Regression detected > 10%"; exit 1; } || true
           else

--- a/.github/workflows/ca-benchmark.yaml
+++ b/.github/workflows/ca-benchmark.yaml
@@ -39,13 +39,13 @@ jobs:
         shell: bash
         run: |
           cd base/cluster-autoscaler
-          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./core/bench/... -args -gc true | tee ../../base.txt
+          go test -v -bench=BenchmarkRunOnce -benchmem -count=6 ./core/bench/... -args -gc true | tee ../../base.txt
 
       - name: Run Benchmark (PR)
         shell: bash
         run: |
           cd pr/cluster-autoscaler
-          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./core/bench/... -args -gc true | tee ../../pr.txt
+          go test -v -bench=BenchmarkRunOnce -benchmem -count=6 ./core/bench/... -args -gc true | tee ../../pr.txt
 
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest

--- a/cluster-autoscaler/core/bench/benchmark_runonce_test.go
+++ b/cluster-autoscaler/core/bench/benchmark_runonce_test.go
@@ -133,38 +133,45 @@ func (s scenario) run(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		clusterFakes := newClusterFakes()
-		if err := s.setup(clusterFakes); err != nil {
-			b.Fatalf("setup failed: %v", err)
+		s.runIteration(b, i, f)
+	}
+}
+
+func (s scenario) runIteration(b *testing.B, i int, f *os.File) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clusterFakes := newClusterFakes()
+	if err := s.setup(clusterFakes); err != nil {
+		b.Fatalf("setup failed: %v", err)
+	}
+	autoscaler := newAutoscaler(ctx, b, s, clusterFakes)
+
+	// Manually trigger GC before the timed section to ensure a clean state
+	// for each iteration.
+	runtime.GC()
+
+	if f != nil && i == 0 {
+		if err := pprof.StartCPUProfile(f); err != nil {
+			b.Fatalf("Failed to start cpu profile: %v", err)
 		}
-		autoscaler := newAutoscaler(b, s, clusterFakes)
+	}
 
-		// Manually trigger GC before the timed section to ensure a clean state
-		// for each iteration.
-		runtime.GC()
+	b.StartTimer()
+	err := autoscaler.RunOnce(time.Now().Add(10 * time.Second))
+	b.StopTimer()
 
-		if f != nil && i == 0 {
-			if err := pprof.StartCPUProfile(f); err != nil {
-				b.Fatalf("Failed to start cpu profile: %v", err)
-			}
-		}
+	if f != nil && i == 0 {
+		pprof.StopCPUProfile()
+	}
 
-		b.StartTimer()
-		err := autoscaler.RunOnce(time.Now().Add(10 * time.Second))
-		b.StopTimer()
+	if err != nil {
+		b.Fatalf("RunOnce failed: %v", err)
+	}
 
-		if f != nil && i == 0 {
-			pprof.StopCPUProfile()
-		}
-
-		if err != nil {
-			b.Fatalf("RunOnce failed: %v", err)
-		}
-
-		if s.verify != nil {
-			if err := s.verify(clusterFakes); err != nil {
-				b.Fatalf("verify failed: %v", err)
-			}
+	if s.verify != nil {
+		if err := s.verify(clusterFakes); err != nil {
+			b.Fatalf("verify failed: %v", err)
 		}
 	}
 }
@@ -178,7 +185,7 @@ func newClusterFakes() *integration.FakeSet {
 }
 
 // newAutoscaler constructs a core.Autoscaler instance configured for the given scenario.
-func newAutoscaler(b *testing.B, s scenario, clusterFakes *integration.FakeSet) core.Autoscaler {
+func newAutoscaler(ctx context.Context, b *testing.B, s scenario, clusterFakes *integration.FakeSet) core.Autoscaler {
 	opts := defaultCAOptions()
 	if s.config != nil {
 		s.config(&opts)
@@ -190,7 +197,7 @@ func newAutoscaler(b *testing.B, s scenario, clusterFakes *integration.FakeSet) 
 	ftkc := &fastTaintingKubeClient{taintedNodes: make(map[string]bool)}
 	ftkc.registerReactors(clusterFakes.KubeClient)
 
-	kubeClients := ca_context.NewAutoscalingKubeClients(context.Background(), opts, clusterFakes.KubeClient, clusterFakes.InformerFactory)
+	kubeClients := ca_context.NewAutoscalingKubeClients(ctx, opts, clusterFakes.KubeClient, clusterFakes.InformerFactory)
 	kubeClients.Recorder = &noOpRecorder{}
 
 	wrappedCloudProvider := &fastScaleUpCloudProvider{
@@ -204,7 +211,7 @@ func newAutoscaler(b *testing.B, s scenario, clusterFakes *integration.FakeSet) 
 		WithAutoscalingKubeClients(kubeClients).
 		WithInformerFactory(clusterFakes.InformerFactory).
 		WithCloudProvider(wrappedCloudProvider).
-		WithPodObserver(clusterFakes.PodObserver).Build(context.Background())
+		WithPodObserver(clusterFakes.PodObserver).Build(ctx)
 	if err != nil {
 		b.Fatalf("Failed to build: %v", err)
 	}

--- a/cluster-autoscaler/core/bench/benchmark_runonce_test.go
+++ b/cluster-autoscaler/core/bench/benchmark_runonce_test.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
+	"runtime/trace"
 	"sync"
 	"testing"
 	"time"
@@ -85,6 +86,7 @@ const (
 
 var (
 	runOnceCpuProfile = flag.String("profile-cpu", "", "If set, the benchmark writes a CPU profile to this file, covering the RunOnce execution during the first iteration.")
+	runOnceTrace      = flag.String("trace", "", "If set, the benchmark writes an execution trace to this file, covering the RunOnce execution during the first iteration.")
 	withGC            = flag.Bool("gc", false, "If set to false, the benchmark disables garbage collection to stabilize the runtime.")
 )
 
@@ -122,22 +124,30 @@ func (s scenario) run(b *testing.B) {
 		defer debug.SetGCPercent(oldGC)
 	}
 
-	var f *os.File
+	var fProf, fTrace *os.File
 	if *runOnceCpuProfile != "" {
 		var err error
-		f, err = os.Create(*runOnceCpuProfile)
+		fProf, err = os.Create(*runOnceCpuProfile)
 		if err != nil {
 			b.Fatalf("Failed to create cpu profile file: %v", err)
 		}
-		defer f.Close()
+		defer fProf.Close()
+	}
+	if *runOnceTrace != "" {
+		var err error
+		fTrace, err = os.Create(*runOnceTrace)
+		if err != nil {
+			b.Fatalf("Failed to create trace file: %v", err)
+		}
+		defer fTrace.Close()
 	}
 
 	for i := 0; i < b.N; i++ {
-		s.runIteration(b, i, f)
+		s.runIteration(b, i, fProf, fTrace)
 	}
 }
 
-func (s scenario) runIteration(b *testing.B, i int, f *os.File) {
+func (s scenario) runIteration(b *testing.B, i int, fProf, fTrace *os.File) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -151,9 +161,16 @@ func (s scenario) runIteration(b *testing.B, i int, f *os.File) {
 	// for each iteration.
 	runtime.GC()
 
-	if f != nil && i == 0 {
-		if err := pprof.StartCPUProfile(f); err != nil {
-			b.Fatalf("Failed to start cpu profile: %v", err)
+	if i == 0 {
+		if fProf != nil {
+			if err := pprof.StartCPUProfile(fProf); err != nil {
+				b.Fatalf("Failed to start cpu profile: %v", err)
+			}
+		}
+		if fTrace != nil {
+			if err := trace.Start(fTrace); err != nil {
+				b.Fatalf("Failed to start trace: %v", err)
+			}
 		}
 	}
 
@@ -161,8 +178,13 @@ func (s scenario) runIteration(b *testing.B, i int, f *os.File) {
 	err := autoscaler.RunOnce(time.Now().Add(10 * time.Second))
 	b.StopTimer()
 
-	if f != nil && i == 0 {
-		pprof.StopCPUProfile()
+	if i == 0 {
+		if fProf != nil {
+			pprof.StopCPUProfile()
+		}
+		if fTrace != nil {
+			trace.Stop()
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Each iteration of BenchmarkRunOnce was creating new instances of
InformerFactory and PodObserver with context.Background(), leading
to a goroutine and memory leak that caused exit code 143
after long runs (found in #9596). 

This change introduces a cancellable context for each iteration
to ensure all background goroutines are properly terminated.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
