### PR TITLE
Graduation criteria for CapacityQuota API

### DIFF
--- a/cluster-autoscaler/proposals/granular-resource-limits.md
+++ b/cluster-autoscaler/proposals/granular-resource-limits.md
@@ -348,3 +348,32 @@ spec:
       cpu: 64
       memory: 128Gi
 ```
+
+## Graduation Criteria
+
+### Alpha (released in 1.35)
+
+- [x] Implement the API definition
+- [x] Refactor resource limits logic to support multiple sources of limits
+- [x] Integrate CapacityQuota API with the refactored resource limits logic
+
+### Beta
+
+- [ ] Add status subresource showing the current utilization of the limits
+- [ ] Implement the controller reconciling the CapacityQuota status
+- [ ] Implement E2E tests
+- [ ] Fix all major issues found during the alpha stage (if any)
+
+### GA (v1)
+
+- [ ] In beta for at least 1 minor k8s version
+- [ ] Waiting up to k8s 1.39 (inclusive) in beta for the Karpenter implementation.
+  In case of no implementation in order to avoid permanent beta (following the spirit
+  of [guidance for k8s REST APIs](https://kubernetes.io/blog/2020/08/21/moving-forward-from-beta/#avoiding-permanent-beta)) we will reevaluate the graduation criteria
+  with sig-autoscaling leads based on:
+    - existing adoption and feedback
+    - reasons for no implementation and immediate future plans
+- [ ] Graduation plan announced 1 month in advance on sig-autoscaling meeting to
+  allow time for feedback
+  - [ ] Reviewed and summarized all open issues about capacity quotas in
+    the https://github.com/kubernetes/autoscaler/ and https://github.com/kubernetes-sigs/karpenter repositories


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

#### What this PR does / why we need it:
This PR describes graduation criteria for CapacityQuota API

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/autoscaler/issues/8703.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
