### PR TITLE
Migrate scale up to new resourcequotas signatures

### DIFF
--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -153,7 +153,7 @@ func initializeDefaultOptions(ctx context.Context, opts *coreoptions.AutoscalerO
 		opts.ExpanderStrategy = expanderStrategy
 	}
 	if opts.QuotasTrackerOptions.QuotaProvider == nil {
-		providers := []resourcequotas.Provider{resourcequotas.NewCloudQuotasProvider(opts.CloudProvider)}
+		providers := []resourcequotas.Provider{resourcequotas.NewCloudMaxProvider(opts.CloudProvider)}
 
 		if opts.CapacityQuotasEnabled {
 			// register informer here to disable lazy initialization

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -122,7 +122,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	// Initialise binpacking limiter.
 	o.processors.BinpackingLimiter.InitBinpacking(o.autoscalingCtx, nodeGroups)
 
-	tracker, err := o.quotasTrackerFactory.NewQuotasTracker(o.autoscalingCtx, nodes)
+	tracker, err := o.quotasTrackerFactory.NewMaxQuotasTracker(o.autoscalingCtx, nodes)
 	if err != nil {
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("could not create quotas tracker: "))
 	}
@@ -294,7 +294,7 @@ func (o *ScaleUpOrchestrator) applyLimits(newNodes int, tracker *resourcequotas.
 		klog.Errorf("No node info for: %s", nodeGroup.Id())
 		return 0, errors.NewAutoscalerError(errors.CloudProviderError, "No node info for best expansion option!")
 	}
-	checkResult, err := tracker.CheckDelta(o.autoscalingCtx, nodeGroup, nodeInfo.Node(), newNodes)
+	checkResult, err := tracker.CheckQuota(o.autoscalingCtx, nodeGroup, nodeInfo.Node(), newNodes)
 	if err != nil {
 		return 0, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("failed to check resource quotas: ")
 	}
@@ -317,7 +317,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 	nodeGroups := o.autoscalingCtx.CloudProvider.NodeGroups()
 	scaleUpInfos := make([]nodegroupset.ScaleUpInfo, 0)
 
-	tracker, err := o.quotasTrackerFactory.NewQuotasTracker(o.autoscalingCtx, nodes)
+	tracker, err := o.quotasTrackerFactory.NewMaxQuotasTracker(o.autoscalingCtx, nodes)
 	if err != nil {
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("could not create quotas tracker: "))
 	}
@@ -356,7 +356,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 		}
 
 		newNodeCount := ng.MinSize() - targetSize
-		checkResult, err := tracker.CheckDelta(o.autoscalingCtx, ng, nodeInfo.Node(), newNodeCount)
+		checkResult, err := tracker.CheckQuota(o.autoscalingCtx, ng, nodeInfo.Node(), newNodeCount)
 		if err != nil {
 			klog.Warningf("ScaleUpToNodeGroupMinSize: failed to check resource quotas: %v", err)
 			continue
@@ -674,7 +674,7 @@ func (o *ScaleUpOrchestrator) IsNodeGroupReadyToScaleUp(nodeGroup cloudprovider.
 
 // IsNodeGroupResourceExceeded returns nil if node group resource limits are not exceeded, otherwise a reason is provided.
 func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfo *framework.NodeInfo, numNodes int) status.Reasons {
-	checkResult, err := tracker.CheckDelta(o.autoscalingCtx, nodeGroup, nodeInfo.Node(), numNodes)
+	checkResult, err := tracker.CheckQuota(o.autoscalingCtx, nodeGroup, nodeInfo.Node(), numNodes)
 	if err != nil {
 		klog.Errorf("Skipping node group %s; error checking resource quotas: %v", nodeGroup.Id(), err)
 		return NotReadyReason

--- a/cluster-autoscaler/resourcequotas/factory.go
+++ b/cluster-autoscaler/resourcequotas/factory.go
@@ -55,13 +55,6 @@ func (f *TrackerFactory) NewMaxQuotasTracker(autoscalingCtx *context.Autoscaling
 	return f.newQuotasTracker(autoscalingCtx, nodes, false /* isMinEnforcement */)
 }
 
-// NewQuotasTracker builds a new Tracker for maximum limits enforcement.
-//
-// Deprecated: Use NewMaxQuotasTracker instead.
-func (f *TrackerFactory) NewQuotasTracker(autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node) (*Tracker, error) {
-	return f.NewMaxQuotasTracker(autoscalingCtx, nodes)
-}
-
 // NewMinQuotasTracker builds a new Tracker for minimum limits enforcement.
 //
 // NewMinQuotasTracker calculates resources used by the nodes for every

--- a/cluster-autoscaler/resourcequotas/factory_test.go
+++ b/cluster-autoscaler/resourcequotas/factory_test.go
@@ -225,7 +225,7 @@ func TestNewMaxQuotasTracker(t *testing.T) {
 			}
 			factory := NewTrackerFactory(TrackerOptions{
 				CustomResourcesProcessor: crp,
-				QuotaProvider:            NewCloudQuotasProvider(cloudProvider),
+				QuotaProvider:            NewCloudMaxProvider(cloudProvider),
 				NodeFilter:               tc.nodeFilter,
 			})
 			tracker, err := factory.NewMaxQuotasTracker(ctx, tc.nodes)
@@ -233,7 +233,7 @@ func TestNewMaxQuotasTracker(t *testing.T) {
 				t.Errorf("failed to create tracker: %v", err)
 			}
 			var ng cloudprovider.NodeGroup
-			result, err := tracker.CheckDelta(ctx, ng, tc.newNode, tc.nodeDelta)
+			result, err := tracker.CheckQuota(ctx, ng, tc.newNode, tc.nodeDelta)
 			if err != nil {
 				t.Errorf("failed to check delta: %v", err)
 			}
@@ -242,7 +242,7 @@ func TestNewMaxQuotasTracker(t *testing.T) {
 				cmpopts.EquateEmpty(),
 			}
 			if diff := cmp.Diff(tc.wantResult, result, opts...); diff != "" {
-				t.Errorf("CheckDelta() mismatch (-want +got):\n%s", diff)
+				t.Errorf("CheckQuota() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/cluster-autoscaler/resourcequotas/tracker.go
+++ b/cluster-autoscaler/resourcequotas/tracker.go
@@ -99,16 +99,6 @@ func (t *Tracker) ConsumeQuota(
 	return result, nil
 }
 
-// ApplyDelta checks if a delta is within limits and applies it. Delta is applied only if it can be applied entirely.
-// See CheckDelta documentation for more information.
-//
-// Deprecated: Use ConsumeQuota instead.
-func (t *Tracker) ApplyDelta(
-	autoscalingCtx *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup, node *corev1.Node, nodeDelta int,
-) (*CheckDeltaResult, error) {
-	return t.ConsumeQuota(autoscalingCtx, nodeGroup, node, nodeDelta)
-}
-
 // CheckQuota checks if a delta is within limits and returns a struct containing information
 // about exceeded quotas, if any, and how many nodes could be added/removed without violating the quotas,
 // which is less than or equal to nodeDelta.
@@ -130,21 +120,6 @@ func (t *Tracker) CheckQuota(
 	}
 	matchingQuotas := t.matchingQuotaStatuses(node)
 	return t.checkQuota(delta, matchingQuotas, nodeDelta), nil
-}
-
-// CheckDelta checks if a delta is within limits and returns a struct containing information
-// about exceeded quotas, if any, and how many nodes could be added without violating the quotas,
-// which is less than or equal to nodeDelta.
-//
-// nodeDelta is the number of nodes that we try to add to the cluster. Resources used by each node
-// are taken from the template node passed via the node parameter. nodeGroup is required to fetch
-// the custom resources, such as GPU.
-//
-// Deprecated: Use CheckQuota instead.
-func (t *Tracker) CheckDelta(
-	autoscalingCtx *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup, node *corev1.Node, nodeDelta int,
-) (*CheckDeltaResult, error) {
-	return t.CheckQuota(autoscalingCtx, nodeGroup, node, nodeDelta)
 }
 
 func (t *Tracker) checkQuota(delta resourceList, matchingQuotas []*quotaStatus, nodeDelta int) *CheckDeltaResult {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

ResourceQuota package was changed in  #9598, since now it's working with minimums that overall signatures were changed to improve readability. Methods like ApplyDelta, CheckDelta now are ConsumeQuota, CheckQuota. And the tracker can work only in mode: Max | Min

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/autoscaler/issues/8703

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
