### PR TITLE
Make async node group initializer handle concurrent scale-ups

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/async_initializer.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/async_initializer.go
@@ -39,9 +39,10 @@ import (
 // AsyncNodeGroupInitializer is a component of the Orchestrator responsible for initial
 // scale up of asynchronously created node groups.
 type AsyncNodeGroupInitializer struct {
-	// guards allTragetSizes
+	// guards allTragetSizes and processedTargetSizes
 	mutex                  sync.Mutex
 	allTargetSizes         map[string]int64
+	processedTargetSizes   map[string]int64
 	nodeGroup              cloudprovider.NodeGroup
 	triggeringPods         []*apiv1.Pod
 	nodeInfo               *framework.NodeInfo
@@ -66,6 +67,7 @@ func NewAsyncNodeGroupInitializer(
 ) *AsyncNodeGroupInitializer {
 	return &AsyncNodeGroupInitializer{
 		allTargetSizes:         map[string]int64{},
+		processedTargetSizes:   map[string]int64{},
 		nodeGroup:              option.NodeGroup,
 		triggeringPods:         option.Pods,
 		nodeInfo:               nodeInfo,
@@ -120,26 +122,14 @@ func (s *AsyncNodeGroupInitializer) InitializeNodeGroup(result nodegroups.AsyncN
 		nodeInfo = s.nodeInfo
 	}
 
-	nodeInfos := make(map[string]*framework.NodeInfo)
-	var scaleUpInfos []nodegroupset.ScaleUpInfo
-	for _, nodeGroup := range result.CreationResult.AllCreatedNodeGroups() {
-		upcomingId, ok := result.CreatedToUpcomingMapping[nodeGroup.Id()]
-		if !ok {
-			klog.Errorf("Couldn't retrieve initialization data for new node group %v. It won't get initialized. Available created to upcoming node group mapping: %v", nodeGroup.Id(), result.CreatedToUpcomingMapping)
-			continue
-		}
-		if targetSize := s.GetTargetSize(upcomingId); targetSize > 0 {
-			nodeInfos[nodeGroup.Id()] = nodeInfo
-			scaleUpInfo := nodegroupset.ScaleUpInfo{
-				Group:       nodeGroup,
-				CurrentSize: 0,
-				NewSize:     int(targetSize),
-				MaxSize:     nodeGroup.MaxSize(),
-			}
-			scaleUpInfos = append(scaleUpInfos, scaleUpInfo)
-		}
+	scaleUpInfos, nodeInfos := s.prepareScaleUps(result, nodeInfo)
+
+	if len(scaleUpInfos) == 0 {
+		klog.Infof("Scale-up for node group %s is already finished or no new scale-ups are needed.", s.nodeGroup.Id())
+		return
 	}
-	klog.Infof("Starting initial scale-up for async created node groups. Scale ups: %v", scaleUpInfos)
+
+	klog.Infof("Starting scale-up for async created node groups. Scale ups: %v", scaleUpInfos)
 	err, failedNodeGroups := s.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, nodeInfos, time.Now(), s.atomicScaleUp)
 	if err != nil {
 		var failedNodeGroupIds []string
@@ -161,6 +151,37 @@ func (s *AsyncNodeGroupInitializer) InitializeNodeGroup(result nodegroups.AsyncN
 		CreateNodeGroupResults: []nodegroups.CreateNodeGroupResult{result.CreationResult},
 		PodsTriggeredScaleUp:   s.triggeringPods,
 	}, nil)
+}
+
+func (s *AsyncNodeGroupInitializer) prepareScaleUps(result nodegroups.AsyncNodeGroupCreationResult, nodeInfo *framework.NodeInfo) ([]nodegroupset.ScaleUpInfo, map[string]*framework.NodeInfo) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	nodeInfos := make(map[string]*framework.NodeInfo)
+	var scaleUpInfos []nodegroupset.ScaleUpInfo
+
+	for _, nodeGroup := range result.CreationResult.AllCreatedNodeGroups() {
+		upcomingId, ok := result.CreatedToUpcomingMapping[nodeGroup.Id()]
+		if !ok {
+			klog.Errorf("Couldn't retrieve initialization data for new node group %v. It won't get initialized. Available created to upcoming node group mapping: %v", nodeGroup.Id(), result.CreatedToUpcomingMapping)
+			continue
+		}
+		targetSize := s.allTargetSizes[upcomingId]
+		currentSize := s.processedTargetSizes[upcomingId]
+
+		if delta := targetSize - currentSize; delta > 0 {
+			nodeInfos[nodeGroup.Id()] = nodeInfo
+			scaleUpInfo := nodegroupset.ScaleUpInfo{
+				Group:       nodeGroup,
+				CurrentSize: int(currentSize),
+				NewSize:     int(targetSize),
+				MaxSize:     nodeGroup.MaxSize(),
+			}
+			scaleUpInfos = append(scaleUpInfos, scaleUpInfo)
+			s.processedTargetSizes[upcomingId] = targetSize
+		}
+	}
+	return scaleUpInfos, nodeInfos
 }
 
 func (s *AsyncNodeGroupInitializer) emitScaleUpStatus(scaleUpStatus *status.ScaleUpStatus, err errors.AutoscalerError) {

--- a/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
@@ -129,3 +129,92 @@ func (f *fakeScaleUpStatusProcessor) Process(_ *ca_context.AutoscalingContext, s
 
 func (f *fakeScaleUpStatusProcessor) CleanUp() {
 }
+
+func TestPrepareScaleUps(t *testing.T) {
+	provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleUp(func(nodeGroup string, increase int) error {
+		return nil
+	}).Build()
+	upcomingNodeGroup := provider.BuildNodeGroup("upcoming-ng", 0, 100, 0, false, true, "T1", nil)
+	createdNodeGroup := provider.BuildNodeGroup("created-ng", 0, 100, 0, false, true, "T1", nil)
+	nodeInfo := framework.NewTestNodeInfo(BuildTestNode("t1", 100, 0))
+
+	testCases := []struct {
+		name              string
+		targetSize        int64
+		processedSize     int64
+		wantScaleUpInfos  []nodegroupset.ScaleUpInfo
+		wantProcessedSize int64
+	}{
+		{
+			name:          "first scale up",
+			targetSize:    3,
+			processedSize: 0,
+			wantScaleUpInfos: []nodegroupset.ScaleUpInfo{
+				{
+					Group:       createdNodeGroup,
+					CurrentSize: 0,
+					NewSize:     3,
+					MaxSize:     createdNodeGroup.MaxSize(),
+				},
+			},
+			wantProcessedSize: 3,
+		},
+		{
+			name:          "additional scale up",
+			targetSize:    5,
+			processedSize: 3,
+			wantScaleUpInfos: []nodegroupset.ScaleUpInfo{
+				{
+					Group:       createdNodeGroup,
+					CurrentSize: 3,
+					NewSize:     5,
+					MaxSize:     createdNodeGroup.MaxSize(),
+				},
+			},
+			wantProcessedSize: 5,
+		},
+		{
+			name:              "no new scale up",
+			targetSize:        3,
+			processedSize:     3,
+			wantScaleUpInfos:  nil,
+			wantProcessedSize: 3,
+		},
+	}
+
+	listers := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	options := config.AutoscalingOptions{AsyncNodeGroupsEnabled: true}
+	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
+	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	assert.NoError(t, err)
+	processors.AsyncNodeGroupStateChecker = &asyncnodegroups.MockAsyncNodeGroupStateChecker{IsUpcomingNodeGroup: map[string]bool{upcomingNodeGroup.Id(): true}}
+	executor := newScaleUpExecutor(&context, processors.ScaleStateNotifier, processors.AsyncNodeGroupStateChecker)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			option := expander.Option{NodeGroup: upcomingNodeGroup, Pods: []*apiv1.Pod{}}
+			scaleUpStatusProcessor := &fakeScaleUpStatusProcessor{}
+			initializer := NewAsyncNodeGroupInitializer(&option, nodeInfo, executor, taints.TaintConfig{}, nil, scaleUpStatusProcessor, &context, false)
+			initializer.SetTargetSize(upcomingNodeGroup.Id(), tc.targetSize)
+			initializer.processedTargetSizes[upcomingNodeGroup.Id()] = tc.processedSize
+
+			asyncResult := nodegroups.AsyncNodeGroupCreationResult{
+				CreationResult: nodegroups.CreateNodeGroupResult{MainCreatedNodeGroup: createdNodeGroup},
+				CreatedToUpcomingMapping: map[string]string{
+					createdNodeGroup.Id(): upcomingNodeGroup.Id(),
+				},
+			}
+
+			initializer.InitializeNodeGroup(asyncResult)
+
+			if len(tc.wantScaleUpInfos) > 0 {
+				assert.NotNil(t, scaleUpStatusProcessor.lastStatus)
+				assert.Equal(t, status.ScaleUpSuccessful, scaleUpStatusProcessor.lastStatus.Result)
+				assert.Equal(t, tc.wantScaleUpInfos, scaleUpStatusProcessor.lastStatus.ScaleUpInfos)
+			} else {
+				assert.Nil(t, scaleUpStatusProcessor.lastStatus)
+			}
+			assert.Equal(t, tc.wantProcessedSize, initializer.processedTargetSizes[upcomingNodeGroup.Id()])
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

It's required to handle scale-ups happening when a node group is being initialized. Thanks to this change, when the initial scale-up happens and another scale-up occurs concurrently, the concurrent scale-up can be queued on the cloud-provider side.

This change is valuable only when cloud-provider implements asynchronous node pool creations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
