### PR TITLE
Skip envtest tests in `make test-unit`

### DIFF
--- a/.github/workflows/ca-test.yaml
+++ b/.github/workflows/ca-test.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/autoscaler/cluster-autoscaler
-        run: make test-ci
+        run: make test-all
         env:
           GO111MODULE: auto
           PROJECT_NAMES: ""

--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -69,6 +69,7 @@ this document:
   * [How can I run e2e tests?](#how-can-i-run-e2e-tests)
   * [How should I test my code before submitting PR?](#how-should-i-test-my-code-before-submitting-pr)
   * [How can I update CA dependencies (particularly k8s.io/kubernetes)?](#how-can-i-update-ca-dependencies-particularly-k8siokubernetes)
+  * [Tests fail with `unable to start control plane itself: failed to start the controlplane.`](#tests-fail-with-unable-to-start-control-plane-itself-failed-to-start-the-controlplane)
 <!--- TOC END -->
 
 # Basics
@@ -1454,3 +1455,12 @@ If you need to update vendor to an unreleased commit of Kubernetes, you can use 
 ```
 ./hack/submodule-k8s.sh <k8s commit sha> git@github.com:kubernetes/kubernetes.git
 ```
+
+### Tests fail with `unable to start control plane itself: failed to start the controlplane.`
+
+Some of our test utilize `controller-runtime`'s [envtest library](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest).
+Those tests run a local k8s API server and etcd instances. Running them requires having those binaries installed.
+
+To fix that, you can either:
+- Skip those tests by adding `-short` flag to `go test`.
+- Run `make setup-envtest` to install necessary binaries.

--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -58,12 +58,12 @@ test-build-tags:
 	done
 
 test-unit: clean build
-	go test -race ./... -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}
+	go test -short -race ./... -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}
 
 test-controllers: setup-envtest clean build
 	ginkgo --race --vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG} ./test/integration/controllers/...
 
-test-ci: setup-envtest
+test-all: setup-envtest
 	go test -race ./... -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}
 
 benchmark:
@@ -143,7 +143,7 @@ container: container-arch-$(GOARCH)
 container-arch-%: build-in-docker-arch-% make-image-arch-%
 	@echo "Full in-docker image ${TAG}${FOR_PROVIDER}-$* completed"
 
-test-in-docker: clean docker-builder
+test-in-docker: setup-envtest clean docker-builder
 	docker run ${RM_FLAG} -v `pwd`:/cluster-autoscaler/:Z autoscaling-builder:latest bash -c 'cd /cluster-autoscaler && go test -race ./... -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}'
 
 ## Location to install dependencies to


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:
Currently, running `make test-unit` or `make test-in-docker` without running `make setup-envtest` first can fail due to missing k8s binaries. Envtest tests require `make setup-envtest` to be called first, and they are generally slower than most of the unit tests. Therefore, they will be skipped when calling `make test-unit` and `make test-ci` has been renamed to `make test-all`. `make test-in-docker` will automatically run `setup-envtest`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
