### PR TITLE
Add verify-go.sh script to validate go.mod and go.sum

### DIFF
--- a/vertical-pod-autoscaler/hack/verify-go.sh
+++ b/vertical-pod-autoscaler/hack/verify-go.sh
@@ -25,11 +25,11 @@ verify_go_mod() {
 
   if [[ ! -f "${module_dir}/go.mod" ]]; then
     echo "Error: ${module_dir}/go.mod does not exist"
-    exit 1
+    return 1
   fi
   if [[ ! -f "${module_dir}/go.sum" ]]; then
     echo "Error: ${module_dir}/go.sum does not exist"
-    exit 1
+    return 1
   fi
 
   echo "Verifying ${module_dir}/go.mod and ${module_dir}/go.sum"
@@ -39,7 +39,15 @@ verify_go_mod() {
   )
 }
 
-verify_go_mod "${SCRIPT_ROOT}"
-verify_go_mod "${SCRIPT_ROOT}/test"
+ret=0
 
-echo "go.mod and go.sum are up to date."
+verify_go_mod "${SCRIPT_ROOT}" || ret=$?
+verify_go_mod "${SCRIPT_ROOT}/test" || ret=$?
+
+if [[ $ret -eq 0 ]]
+then
+  echo "go.mod and go.sum are up to date."
+else
+  echo "go.mod and go.sum are out of date. Please run 'go mod tidy' in the affected directories"
+  exit 1
+fi

--- a/vertical-pod-autoscaler/hack/verify-go.sh
+++ b/vertical-pod-autoscaler/hack/verify-go.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+verify_go_mod() {
+  local module_dir="$1"
+
+  if [[ ! -f "${module_dir}/go.mod" ]]; then
+    echo "Error: ${module_dir}/go.mod does not exist"
+    exit 1
+  fi
+  if [[ ! -f "${module_dir}/go.sum" ]]; then
+    echo "Error: ${module_dir}/go.sum does not exist"
+    exit 1
+  fi
+
+  echo "Verifying ${module_dir}/go.mod and ${module_dir}/go.sum"
+  (
+    cd "${module_dir}"
+    go mod tidy -diff
+  )
+}
+
+verify_go_mod "${SCRIPT_ROOT}"
+verify_go_mod "${SCRIPT_ROOT}/test"
+
+echo "go.mod and go.sum are up to date."


### PR DESCRIPTION
Adds validation script that runs 'go mod tidy' and fails if go.mod or go.sum are modified, ensuring dependencies are properly tidied before merging PRs.

Follows existing verify-* script pattern and integrates automatically with verify-all.sh and CI workflows.

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9665

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
