### PR TITLE
Don't call SchedulablePodGroups when only 1 node group gets created

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -844,12 +844,19 @@ func (o *ScaleUpOrchestrator) getRemainingPodsConsideringSkippedNodeGroups(egs [
 	return remaining
 }
 
-func (o *ScaleUpOrchestrator) buildNoOptionsAvailableStatus(egs []*equivalence.PodGroup, skipped map[string]status.Reasons, ngs []cloudprovider.NodeGroup, nodeInfos map[string]*framework.NodeInfo) *status.ScaleUpStatus {
+func (o *ScaleUpOrchestrator) noOptionsAvailableStatus(args scaleUpCtx) *status.ScaleUpStatus {
 	return &status.ScaleUpStatus{
 		Result:                  status.ScaleUpNoOptionsAvailable,
-		PodsRemainUnschedulable: o.GetRemainingPods(egs, ngs, skipped, nodeInfos),
-		ConsideredNodeGroups:    ngs,
+		PodsRemainUnschedulable: o.GetRemainingPods(args.podEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+		ConsideredNodeGroups:    args.nodeGroups,
 	}
+}
+
+func (o *ScaleUpOrchestrator) abortAllOrNothing(args scaleUpCtx) *status.ScaleUpStatus {
+	// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
+	klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
+	args.podEquivalenceGroups = markAllGroupsAsUnschedulable(args.podEquivalenceGroups, AllOrNothingReason)
+	return o.noOptionsAvailableStatus(args)
 }
 
 func findSkippedNodeGroupsSatisfyingPodPredicates(eg *equivalence.PodGroup, skipped map[string]status.Reasons) map[string]status.Reasons {
@@ -1025,11 +1032,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 
 	if len(options) == 0 {
 		klog.V(1).Info("No expansion options")
-		return scaleUpPlan{}, &status.ScaleUpStatus{
-			Result:                  status.ScaleUpNoOptionsAvailable,
-			PodsRemainUnschedulable: o.GetRemainingPods(args.podEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
-			ConsideredNodeGroups:    args.nodeGroups,
-		}, nil
+		return scaleUpPlan{}, o.noOptionsAvailableStatus(args), nil
 	}
 
 	// Pick some expansion option.
@@ -1037,11 +1040,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 	if bestOption == nil || bestOption.NodeCount <= 0 {
 		klog.Infof("Expander filtered out all options, valid options: %d", len(options))
 		args.podEquivalenceGroups = markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ExpansionOptionsFilteredOutReason)
-		return scaleUpPlan{}, &status.ScaleUpStatus{
-			Result:                  status.ScaleUpNoOptionsAvailable,
-			PodsRemainUnschedulable: o.GetRemainingPods(args.podEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
-			ConsideredNodeGroups:    args.nodeGroups,
-		}, nil
+		return scaleUpPlan{}, o.noOptionsAvailableStatus(args), nil
 	}
 	klog.V(1).Infof("Best option to resize: %s", bestOption.NodeGroup.Id())
 	if len(bestOption.Debug) > 0 {
@@ -1079,10 +1078,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 	if newNodes < bestOption.NodeCount {
 		klog.V(1).Infof("Only %d nodes can be added to %s due to resource quotas", newNodes, bestOption.NodeGroup.Id())
 		if args.allOrNothing {
-			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
-			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
-			markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, AllOrNothingReason)
-			return scaleUpPlan{}, o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, args.skippedNodeGroups, args.nodeGroups, args.nodeInfos), nil
+			return scaleUpPlan{}, o.abortAllOrNothing(args), nil
 		}
 	}
 
@@ -1091,10 +1087,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 	if !bestOption.NodeGroup.Exist() && !o.processors.AsyncNodeGroupStateChecker.IsUpcoming(bestOption.NodeGroup) {
 		if args.allOrNothing && bestOption.NodeGroup.MaxSize() < newNodes {
 			klog.V(1).Infof("Can only create a new node group with max %d nodes, need %d nodes", bestOption.NodeGroup.MaxSize(), newNodes)
-			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
-			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
-			markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, AllOrNothingReason)
-			return scaleUpPlan{}, o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, args.skippedNodeGroups, args.nodeGroups, args.nodeInfos), nil
+			return scaleUpPlan{}, o.abortAllOrNothing(args), nil
 		}
 		var scaleUpStatus *status.ScaleUpStatus
 		oldId := bestOption.NodeGroup.Id()
@@ -1132,10 +1125,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 	if totalCapacity < newNodes {
 		klog.V(1).Infof("Can only add %d nodes due to node group limits, need %d nodes", totalCapacity, newNodes)
 		if args.allOrNothing {
-			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
-			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
-			markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, AllOrNothingReason)
-			return scaleUpPlan{}, o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, args.skippedNodeGroups, args.nodeGroups, args.nodeInfos), nil
+			return scaleUpPlan{}, o.abortAllOrNothing(args), nil
 		}
 	}
 

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -155,160 +155,35 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 		o.processors.BinpackingLimiter.MarkProcessed(o.autoscalingCtx, nodegroupID)
 	}
 
-	// Calculate expansion options
-	schedulablePodGroups := map[string][]estimator.PodEquivalenceGroup{}
-	var options []expander.Option
-
-	// This code here runs a simulation to see which pods can be scheduled on which node groups.
-	for _, nodeGroup := range validNodeGroups {
-		schedulablePodGroups[nodeGroup.Id()] = o.SchedulablePodGroups(podEquivalenceGroups, nodeGroup, nodeInfos[nodeGroup.Id()])
-	}
-
-	for _, nodeGroup := range validNodeGroups {
-		option := o.ComputeExpansionOption(nodeGroup, schedulablePodGroups, nodeInfos, len(nodes), now, allOrNothing)
-		o.processors.BinpackingLimiter.MarkProcessed(o.autoscalingCtx, nodeGroup.Id())
-
-		if len(option.Pods) == 0 || option.NodeCount == 0 {
-			klog.V(4).Infof("No pod can fit to %s", nodeGroup.Id())
-		} else if allOrNothing && len(option.Pods) < len(unschedulablePods) {
-			klog.V(4).Infof("Some pods can't fit to %s, giving up due to all-or-nothing scale-up strategy", nodeGroup.Id())
-		} else {
-			options = append(options, option)
-		}
-
-		if o.processors.BinpackingLimiter.StopBinpacking(o.autoscalingCtx, options) {
-			break
-		}
-	}
-
-	// Finalize binpacking limiter.
-	o.processors.BinpackingLimiter.FinalizeBinpacking(o.autoscalingCtx, options)
-
-	if len(options) == 0 {
-		klog.V(1).Info("No expansion options")
-		return &status.ScaleUpStatus{
-			Result:                  status.ScaleUpNoOptionsAvailable,
-			PodsRemainUnschedulable: o.GetRemainingPods(podEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
-			ConsideredNodeGroups:    nodeGroups,
-		}, nil
-	}
-
-	// Pick some expansion option.
-	bestOption := o.autoscalingCtx.ExpanderStrategy.BestOption(options, nodeInfos)
-	if bestOption == nil || bestOption.NodeCount <= 0 {
-		klog.Infof("Expander filtered out all options, valid options: %d", len(options))
-		podEquivalenceGroups = markAllGroupsAsUnschedulable(podEquivalenceGroups, ExpansionOptionsFilteredOutReason)
-		return &status.ScaleUpStatus{
-			Result:                  status.ScaleUpNoOptionsAvailable,
-			PodsRemainUnschedulable: o.GetRemainingPods(podEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
-			ConsideredNodeGroups:    nodeGroups,
-		}, nil
-	}
-	klog.V(1).Infof("Best option to resize: %s", bestOption.NodeGroup.Id())
-	if len(bestOption.Debug) > 0 {
-		klog.V(1).Info(bestOption.Debug)
-	}
-	klog.V(1).Infof("Estimated %d nodes needed in %s", bestOption.NodeCount, bestOption.NodeGroup.Id())
-
-	// Cap new nodes to supported number of nodes in the cluster.
-	newNodes, aErr := o.GetCappedNewNodeCount(bestOption.NodeCount, len(nodes))
-	if aErr != nil {
-		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
-		return status.UpdateScaleUpError(
-			&status.ScaleUpStatus{
-				PodsTriggeredScaleUp:    bestOption.Pods,
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
-			},
-			aErr,
-		)
-	}
-
-	newNodes, aErr = o.applyLimits(newNodes, tracker, bestOption.NodeGroup, nodeInfos)
-	if aErr != nil {
-		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
-		return status.UpdateScaleUpError(
-			&status.ScaleUpStatus{
-				PodsTriggeredScaleUp:    bestOption.Pods,
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
-			},
-			aErr,
-		)
-	}
-
-	if newNodes < bestOption.NodeCount {
-		klog.V(1).Infof("Only %d nodes can be added to %s due to resource quotas", newNodes, bestOption.NodeGroup.Id())
-		if allOrNothing {
-			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
-			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
-			markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, AllOrNothingReason)
-			return o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, skippedNodeGroups, nodeGroups, nodeInfos), nil
-		}
-	}
-
-	// If necessary, create the node group. This is no longer simulation, an empty node group will be created by cloud provider if supported.
-	createNodeGroupResults := make([]nodegroups.CreateNodeGroupResult, 0)
-	if !bestOption.NodeGroup.Exist() && !o.processors.AsyncNodeGroupStateChecker.IsUpcoming(bestOption.NodeGroup) {
-		if allOrNothing && bestOption.NodeGroup.MaxSize() < newNodes {
-			klog.V(1).Infof("Can only create a new node group with max %d nodes, need %d nodes", bestOption.NodeGroup.MaxSize(), newNodes)
-			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
-			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
-			markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, AllOrNothingReason)
-			return o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, skippedNodeGroups, nodeGroups, nodeInfos), nil
-		}
-		var scaleUpStatus *status.ScaleUpStatus
-		oldId := bestOption.NodeGroup.Id()
-		if o.autoscalingCtx.AsyncNodeGroupsEnabled {
-			initializer := NewAsyncNodeGroupInitializer(bestOption, nodeInfos[oldId], o.scaleUpExecutor, o.taintConfig, daemonSets, o.processors.ScaleUpStatusProcessor, o.autoscalingCtx, allOrNothing)
-			createNodeGroupResults, scaleUpStatus, aErr = o.CreateNodeGroupAsync(bestOption, nodeInfos, schedulablePodGroups, podEquivalenceGroups, daemonSets, initializer)
-		} else {
-			createNodeGroupResults, scaleUpStatus, aErr = o.CreateNodeGroup(bestOption, nodeInfos, schedulablePodGroups, podEquivalenceGroups, daemonSets)
-		}
-		if aErr != nil {
-			return scaleUpStatus, aErr
-		}
-		nodeGroups = appendCreatedNodeGroups(nodeGroups, oldId, createNodeGroupResults)
-	}
-
-	scaleUpInfos, aErr := o.balanceScaleUps(now, bestOption.NodeGroup, newNodes, nodeInfos, schedulablePodGroups, tracker)
-	if aErr != nil {
-		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
-		return status.UpdateScaleUpError(
-			&status.ScaleUpStatus{
-				CreateNodeGroupResults:  createNodeGroupResults,
-				PodsTriggeredScaleUp:    bestOption.Pods,
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
-			},
-			aErr,
-		)
-	}
-
-	// Last check before scale-up. Node group capacity (both due to max size limits & current size) is only checked when balancing.
-	totalCapacity := 0
-	for _, sui := range scaleUpInfos {
-		totalCapacity += sui.NewSize - sui.CurrentSize
-	}
-	if totalCapacity < newNodes {
-		klog.V(1).Infof("Can only add %d nodes due to node group limits, need %d nodes", totalCapacity, newNodes)
-		if allOrNothing {
-			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
-			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
-			markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, AllOrNothingReason)
-			return o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, skippedNodeGroups, nodeGroups, nodeInfos), nil
-		}
+	plan, st, aErr := o.prepareScaleUp(scaleUpCtx{
+		validNodeGroups:      validNodeGroups,
+		podEquivalenceGroups: podEquivalenceGroups,
+		nodeInfos:            nodeInfos,
+		nodes:                nodes,
+		unschedulablePods:    unschedulablePods,
+		allOrNothing:         allOrNothing,
+		now:                  now,
+		nodeGroups:           nodeGroups,
+		skippedNodeGroups:    skippedNodeGroups,
+		tracker:              tracker,
+		daemonSets:           daemonSets,
+	})
+	if st != nil || aErr != nil {
+		return st, aErr
 	}
 
 	// Execute scale up.
-	klog.V(1).Infof("Final scale-up plan: %v", scaleUpInfos)
-	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, nodeInfos, now, allOrNothing)
+	klog.V(1).Infof("Final scale-up plan: %v", plan.scaleUpInfos)
+	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(plan.scaleUpInfos, nodeInfos, now, allOrNothing)
 	if aErr != nil {
-		failedGroupsMap := o.buildFailedGroupsMap(failedNodeGroups, scaleUpInfos)
+		failedGroupsMap := o.buildFailedGroupsMap(failedNodeGroups, plan.scaleUpInfos)
 		markedEquivalenceGroups := markFailedGroupsAsUnschedulable(podEquivalenceGroups, failedGroupsMap, ScaleUpExecutionErrorReason)
 		return status.UpdateScaleUpError(
 			&status.ScaleUpStatus{
-				CreateNodeGroupResults:  createNodeGroupResults,
+				CreateNodeGroupResults:  plan.createNodeGroupResults,
 				FailedResizeNodeGroups:  failedNodeGroups,
-				PodsTriggeredScaleUp:    bestOption.Pods,
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
+				PodsTriggeredScaleUp:    plan.bestOption.Pods,
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, plan.nodeGroups, skippedNodeGroups, nodeInfos),
 			},
 			aErr,
 		)
@@ -317,12 +192,12 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	o.clusterStateRegistry.Recalculate()
 	return &status.ScaleUpStatus{
 		Result:                  status.ScaleUpSuccessful,
-		ScaleUpInfos:            scaleUpInfos,
-		PodsRemainUnschedulable: o.GetRemainingPods(podEquivalenceGroups, nodeGroups, skippedNodeGroups, nodeInfos),
-		ConsideredNodeGroups:    nodeGroups,
-		CreateNodeGroupResults:  createNodeGroupResults,
-		PodsTriggeredScaleUp:    bestOption.Pods,
-		PodsAwaitEvaluation:     GetPodsAwaitingEvaluation(podEquivalenceGroups, bestOption.NodeGroup.Id()),
+		ScaleUpInfos:            plan.scaleUpInfos,
+		PodsRemainUnschedulable: o.GetRemainingPods(podEquivalenceGroups, plan.nodeGroups, skippedNodeGroups, nodeInfos),
+		ConsideredNodeGroups:    plan.nodeGroups,
+		CreateNodeGroupResults:  plan.createNodeGroupResults,
+		PodsTriggeredScaleUp:    plan.bestOption.Pods,
+		PodsAwaitEvaluation:     GetPodsAwaitingEvaluation(podEquivalenceGroups, plan.bestOption.NodeGroup.Id()),
 	}, nil
 }
 
@@ -1095,4 +970,179 @@ func appendCreatedNodeGroups(nodeGroups []cloudprovider.NodeGroup, bestOptionNod
 		}
 	}
 	return nodeGroups
+}
+
+type scaleUpCtx struct {
+	validNodeGroups      []cloudprovider.NodeGroup
+	podEquivalenceGroups []*equivalence.PodGroup
+	nodeInfos            map[string]*framework.NodeInfo
+	nodes                []*apiv1.Node
+	unschedulablePods    []*apiv1.Pod
+	allOrNothing         bool
+	now                  time.Time
+	nodeGroups           []cloudprovider.NodeGroup
+	skippedNodeGroups    map[string]status.Reasons
+	tracker              *resourcequotas.Tracker
+	daemonSets           []*appsv1.DaemonSet
+}
+
+type scaleUpPlan struct {
+	scaleUpInfos           []nodegroupset.ScaleUpInfo
+	createNodeGroupResults []nodegroups.CreateNodeGroupResult
+	bestOption             *expander.Option
+	nodeGroups             []cloudprovider.NodeGroup
+}
+
+func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *status.ScaleUpStatus, errors.AutoscalerError) {
+	// Calculate expansion options
+	schedulablePodGroups := map[string][]estimator.PodEquivalenceGroup{}
+	var options []expander.Option
+
+	// This code here runs a simulation to see which pods can be scheduled on which node groups.
+	for _, nodeGroup := range args.validNodeGroups {
+		schedulablePodGroups[nodeGroup.Id()] = o.SchedulablePodGroups(args.podEquivalenceGroups, nodeGroup, args.nodeInfos[nodeGroup.Id()])
+	}
+
+	for _, nodeGroup := range args.validNodeGroups {
+		option := o.ComputeExpansionOption(nodeGroup, schedulablePodGroups, args.nodeInfos, len(args.nodes), args.now, args.allOrNothing)
+		o.processors.BinpackingLimiter.MarkProcessed(o.autoscalingCtx, nodeGroup.Id())
+
+		if len(option.Pods) == 0 || option.NodeCount == 0 {
+			klog.V(4).Infof("No pod can fit to %s", nodeGroup.Id())
+		} else if args.allOrNothing && len(option.Pods) < len(args.unschedulablePods) {
+			klog.V(4).Infof("Some pods can't fit to %s, giving up due to all-or-nothing scale-up strategy", nodeGroup.Id())
+		} else {
+			options = append(options, option)
+		}
+
+		if o.processors.BinpackingLimiter.StopBinpacking(o.autoscalingCtx, options) {
+			break
+		}
+	}
+
+	// Finalize binpacking limiter.
+	o.processors.BinpackingLimiter.FinalizeBinpacking(o.autoscalingCtx, options)
+
+	if len(options) == 0 {
+		klog.V(1).Info("No expansion options")
+		return scaleUpPlan{}, &status.ScaleUpStatus{
+			Result:                  status.ScaleUpNoOptionsAvailable,
+			PodsRemainUnschedulable: o.GetRemainingPods(args.podEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+			ConsideredNodeGroups:    args.nodeGroups,
+		}, nil
+	}
+
+	// Pick some expansion option.
+	bestOption := o.autoscalingCtx.ExpanderStrategy.BestOption(options, args.nodeInfos)
+	if bestOption == nil || bestOption.NodeCount <= 0 {
+		klog.Infof("Expander filtered out all options, valid options: %d", len(options))
+		args.podEquivalenceGroups = markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ExpansionOptionsFilteredOutReason)
+		return scaleUpPlan{}, &status.ScaleUpStatus{
+			Result:                  status.ScaleUpNoOptionsAvailable,
+			PodsRemainUnschedulable: o.GetRemainingPods(args.podEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+			ConsideredNodeGroups:    args.nodeGroups,
+		}, nil
+	}
+	klog.V(1).Infof("Best option to resize: %s", bestOption.NodeGroup.Id())
+	if len(bestOption.Debug) > 0 {
+		klog.V(1).Info(bestOption.Debug)
+	}
+	klog.V(1).Infof("Estimated %d nodes needed in %s", bestOption.NodeCount, bestOption.NodeGroup.Id())
+
+	// Cap new nodes to supported number of nodes in the cluster.
+	newNodes, aErr := o.GetCappedNewNodeCount(bestOption.NodeCount, len(args.nodes))
+	if aErr != nil {
+		markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ScaleUpExecutionErrorReason)
+		st, err := status.UpdateScaleUpError(
+			&status.ScaleUpStatus{
+				PodsTriggeredScaleUp:    bestOption.Pods,
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+			},
+			aErr,
+		)
+		return scaleUpPlan{}, st, err
+	}
+
+	newNodes, aErr = o.applyLimits(newNodes, args.tracker, bestOption.NodeGroup, args.nodeInfos)
+	if aErr != nil {
+		markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ScaleUpExecutionErrorReason)
+		st, err := status.UpdateScaleUpError(
+			&status.ScaleUpStatus{
+				PodsTriggeredScaleUp:    bestOption.Pods,
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+			},
+			aErr,
+		)
+		return scaleUpPlan{}, st, err
+	}
+
+	if newNodes < bestOption.NodeCount {
+		klog.V(1).Infof("Only %d nodes can be added to %s due to resource quotas", newNodes, bestOption.NodeGroup.Id())
+		if args.allOrNothing {
+			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
+			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
+			markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, AllOrNothingReason)
+			return scaleUpPlan{}, o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, args.skippedNodeGroups, args.nodeGroups, args.nodeInfos), nil
+		}
+	}
+
+	// If necessary, create the node group. This is no longer simulation, an empty node group will be created by cloud provider if supported.
+	createNodeGroupResults := make([]nodegroups.CreateNodeGroupResult, 0)
+	if !bestOption.NodeGroup.Exist() && !o.processors.AsyncNodeGroupStateChecker.IsUpcoming(bestOption.NodeGroup) {
+		if args.allOrNothing && bestOption.NodeGroup.MaxSize() < newNodes {
+			klog.V(1).Infof("Can only create a new node group with max %d nodes, need %d nodes", bestOption.NodeGroup.MaxSize(), newNodes)
+			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
+			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
+			markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, AllOrNothingReason)
+			return scaleUpPlan{}, o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, args.skippedNodeGroups, args.nodeGroups, args.nodeInfos), nil
+		}
+		var scaleUpStatus *status.ScaleUpStatus
+		oldId := bestOption.NodeGroup.Id()
+		if o.autoscalingCtx.AsyncNodeGroupsEnabled {
+			initializer := NewAsyncNodeGroupInitializer(bestOption, args.nodeInfos[oldId], o.scaleUpExecutor, o.taintConfig, args.daemonSets, o.processors.ScaleUpStatusProcessor, o.autoscalingCtx, args.allOrNothing)
+			createNodeGroupResults, scaleUpStatus, aErr = o.CreateNodeGroupAsync(bestOption, args.nodeInfos, schedulablePodGroups, args.podEquivalenceGroups, args.daemonSets, initializer)
+		} else {
+			createNodeGroupResults, scaleUpStatus, aErr = o.CreateNodeGroup(bestOption, args.nodeInfos, schedulablePodGroups, args.podEquivalenceGroups, args.daemonSets)
+		}
+		if aErr != nil {
+			return scaleUpPlan{}, scaleUpStatus, aErr
+		}
+		args.nodeGroups = appendCreatedNodeGroups(args.nodeGroups, oldId, createNodeGroupResults)
+	}
+
+	scaleUpInfos, aErr := o.balanceScaleUps(args.now, bestOption.NodeGroup, newNodes, args.nodeInfos, schedulablePodGroups, args.tracker)
+	if aErr != nil {
+		markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ScaleUpExecutionErrorReason)
+		st, err := status.UpdateScaleUpError(
+			&status.ScaleUpStatus{
+				CreateNodeGroupResults:  createNodeGroupResults,
+				PodsTriggeredScaleUp:    bestOption.Pods,
+				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+			},
+			aErr,
+		)
+		return scaleUpPlan{}, st, err
+	}
+
+	// Last check before scale-up. Node group capacity (both due to max size limits & current size) is only checked when balancing.
+	totalCapacity := 0
+	for _, sui := range scaleUpInfos {
+		totalCapacity += sui.NewSize - sui.CurrentSize
+	}
+	if totalCapacity < newNodes {
+		klog.V(1).Infof("Can only add %d nodes due to node group limits, need %d nodes", totalCapacity, newNodes)
+		if args.allOrNothing {
+			// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
+			klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
+			markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, AllOrNothingReason)
+			return scaleUpPlan{}, o.buildNoOptionsAvailableStatus(markedEquivalenceGroups, args.skippedNodeGroups, args.nodeGroups, args.nodeInfos), nil
+		}
+	}
+
+	return scaleUpPlan{
+		scaleUpInfos:           scaleUpInfos,
+		createNodeGroupResults: createNodeGroupResults,
+		bestOption:             bestOption,
+		nodeGroups:             args.nodeGroups,
+	}, nil, nil
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"slices"
 	"strings"
 	"time"
 
@@ -480,23 +481,38 @@ func (o *ScaleUpOrchestrator) processCreateNodeGroupResult(
 	}
 
 	initialOption.NodeGroup = result.MainCreatedNodeGroup
+	newId := result.MainCreatedNodeGroup.Id()
 
-	// If possible replace candidate node-info with node info based on crated node group. The latter
-	// one should be more in line with nodes which will be created by node group.
+	// Use candidate template and scheduling results as a fallback
+	nodeInfos[newId] = nodeInfos[initialOptionId]
+	schedulablePodGroups[newId] = schedulablePodGroups[initialOptionId]
+
+	// If possible, replace candidate node-info with node info based on created node group.
+	// The latter should be more in line with nodes which will be created by node group.
 	mainCreatedNodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(result.MainCreatedNodeGroup, daemonSets, o.taintConfig)
 	if aErr == nil {
-		nodeInfos[result.MainCreatedNodeGroup.Id()] = mainCreatedNodeInfo
-		schedulablePodGroups[result.MainCreatedNodeGroup.Id()] = o.SchedulablePodGroups(podEquivalenceGroups, result.MainCreatedNodeGroup, mainCreatedNodeInfo)
+		nodeInfos[newId] = mainCreatedNodeInfo
 	} else {
-		klog.Warningf("Cannot build node info for newly created main node group %v; balancing similar node groups may not work; err=%v", result.MainCreatedNodeGroup.Id(), aErr)
-		// Use node info based on expansion candidate but update Id which likely changed when node group was created.
-		nodeInfos[result.MainCreatedNodeGroup.Id()] = nodeInfos[initialOptionId]
-		schedulablePodGroups[result.MainCreatedNodeGroup.Id()] = schedulablePodGroups[initialOptionId]
+		klog.Warningf("Cannot build node info for newly created main node group %v; balancing similar node groups may not work; err=%v", newId, aErr)
 	}
-	if initialOptionId != result.MainCreatedNodeGroup.Id() {
+
+	// schedulablePodGroups entry will only be used for balancing similar node groups.
+	// If there are no extra node groups created, balancing won't happen anyway,
+	// so we can just patch the node group id for reporting correctness
+	// and skip expensive SchedulablePodGroups computation.
+	if aErr == nil && len(result.ExtraCreatedNodeGroups) > 0 {
+		// Remove reference to initial id to prevent stale/duplicate entries in scheduling error reports
+		deletePodEquivalenceGroupsId(podEquivalenceGroups, initialOptionId)
+		schedulablePodGroups[newId] = o.SchedulablePodGroups(podEquivalenceGroups, result.MainCreatedNodeGroup, mainCreatedNodeInfo)
+	} else {
+		patchPodEquivalenceGroupsId(podEquivalenceGroups, initialOptionId, newId)
+	}
+
+	if initialOptionId != newId {
 		delete(nodeInfos, initialOptionId)
 		delete(schedulablePodGroups, initialOptionId)
 	}
+
 	for _, nodeGroup := range result.ExtraCreatedNodeGroups {
 		nodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(nodeGroup, daemonSets, o.taintConfig)
 		if aErr != nil {
@@ -842,6 +858,30 @@ func (o *ScaleUpOrchestrator) getRemainingPodsConsideringSkippedNodeGroups(egs [
 		}
 	}
 	return remaining
+}
+
+func patchPodEquivalenceGroupsId(podEquivalenceGroups []*equivalence.PodGroup, oldId, newId string) {
+	if oldId == newId {
+		return
+	}
+	for _, eg := range podEquivalenceGroups {
+		if i := slices.Index(eg.SchedulableGroups, oldId); i != -1 {
+			eg.SchedulableGroups[i] = newId
+		}
+		if err, found := eg.SchedulingErrors[oldId]; found {
+			eg.SchedulingErrors[newId] = err
+			delete(eg.SchedulingErrors, oldId)
+		}
+	}
+}
+
+func deletePodEquivalenceGroupsId(podEquivalenceGroups []*equivalence.PodGroup, id string) {
+	for _, eg := range podEquivalenceGroups {
+		if i := slices.Index(eg.SchedulableGroups, id); i != -1 {
+			eg.SchedulableGroups = slices.Delete(eg.SchedulableGroups, i, i+1)
+		}
+		delete(eg.SchedulingErrors, id)
+	}
 }
 
 func (o *ScaleUpOrchestrator) noOptionsAvailableStatus(args scaleUpCtx) *status.ScaleUpStatus {

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -1901,6 +1901,7 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	expandedGroups := make(chan string, 10)
 
 	p1 := BuildTestPod("p1", 80, 0)
+	p2 := BuildTestPod("p2", 99999, 0) // unschedulable pod
 
 	fakeClient := &fake.Clientset{}
 
@@ -1944,11 +1945,22 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	})
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{p1}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{p1, p2}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
 	assert.NoError(t, err)
 	assert.True(t, scaleUpStatus.WasSuccessful())
 	assert.Equal(t, "autoprovisioned-T1", utils.GetStringFromChan(createdGroups))
 	assert.Equal(t, "autoprovisioned-T1-1", utils.GetStringFromChan(expandedGroups))
+
+	// Verify stale node group ID cleanup
+	foundP2 := false
+	for _, remainUnschedulable := range scaleUpStatus.PodsRemainUnschedulable {
+		if remainUnschedulable.Pod.Name == "p2" {
+			foundP2 = true
+			assert.NotContains(t, remainUnschedulable.RejectedNodeGroups, "T1")
+			assert.Contains(t, remainUnschedulable.RejectedNodeGroups, "autoprovisioned-T1")
+		}
+	}
+	assert.True(t, foundP2, "p2 was not found in PodsRemainUnschedulable")
 }
 
 func TestScaleUpBalanceAutoprovisionedNodeGroups(t *testing.T) {
@@ -1958,6 +1970,7 @@ func TestScaleUpBalanceAutoprovisionedNodeGroups(t *testing.T) {
 	p1 := BuildTestPod("p1", 80, 0)
 	p2 := BuildTestPod("p2", 80, 0)
 	p3 := BuildTestPod("p3", 80, 0)
+	p4 := BuildTestPod("p4", 99999, 0) // unschedulable pod
 
 	fakeClient := &fake.Clientset{}
 
@@ -2002,7 +2015,7 @@ func TestScaleUpBalanceAutoprovisionedNodeGroups(t *testing.T) {
 	})
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{p1, p2, p3}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{p1, p2, p3, p4}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
 	assert.NoError(t, err)
 	assert.True(t, scaleUpStatus.WasSuccessful())
 	assert.Equal(t, "autoprovisioned-T1", utils.GetStringFromChan(createdGroups))
@@ -2013,6 +2026,17 @@ func TestScaleUpBalanceAutoprovisionedNodeGroups(t *testing.T) {
 	assert.True(t, expandedGroupMap["autoprovisioned-T1-1"])
 	assert.True(t, expandedGroupMap["autoprovisioned-T1-1-1"])
 	assert.True(t, expandedGroupMap["autoprovisioned-T1-2-1"])
+
+	// Verify stale node group ID cleanup
+	foundP4 := false
+	for _, remainUnschedulable := range scaleUpStatus.PodsRemainUnschedulable {
+		if remainUnschedulable.Pod.Name == "p4" {
+			foundP4 = true
+			assert.NotContains(t, remainUnschedulable.RejectedNodeGroups, "T1")
+			assert.Contains(t, remainUnschedulable.RejectedNodeGroups, "autoprovisioned-T1")
+		}
+	}
+	assert.True(t, foundP4, "p4 was not found in PodsRemainUnschedulable")
 }
 
 func TestScaleUpToMeetNodeGroupMinSize(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR introduces an optimization to scale-up process by skipping the expensive `SchedulablePodGroups` simulation when only 1 node group is created, as the result is only used by `balanceScaleUps` (which doesn't matter when we get 1 node group created). 

Instead of the expensive call, we're now only patching the node group ID directly (also fixed the stale/duplicate `podEquivalenceGroups.SchedulableGroups` entries)  for reporting correctness.

To keep the `schedulablePodGroups` (which now won't be recalculated in 1 node group cases) in a more contained scope and prevent future uses depending on the now skipped calculations, the PR includes a refactor that extracted the scale-up planning logic into a separate `planScaleUp` method.



#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:
Commits are split into logical parts, 1st only moving the code without meaningful changes. PTAL

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
