### PR TITLE
Fix GPU detection for MIG and time-sliced NVIDIA resources

### DIFF
--- a/cluster-autoscaler/processors/customresources/gpu_processor.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor.go
@@ -114,8 +114,22 @@ func (p *GpuCustomResourcesProcessor) GetNodeGpuTarget(autoscalingCtx *ca_contex
 		klog.Errorf("Failed to build template for getting GPU estimation for node %v: %v", node.Name, err)
 		return CustomResourceTarget{}, errors.ToAutoscalerError(errors.CloudProviderError, err)
 	}
-	for _, gpuVendorResourceName := range gpu.GPUVendorResourceNames {
-		if gpuCapacity, found := template.Node().Status.Capacity[gpuVendorResourceName]; found {
+
+	// Keep backward compatibility by checking cloud provider GPU config first
+	// and then common legacy GPU resources.
+	gpuConfig := autoscalingCtx.CloudProvider.GetNodeGpuConfig(node)
+	if gpuConfig != nil && gpuConfig.ExtendedResourceName != "" {
+		if gpuCapacity, found := template.Node().Status.Capacity[gpuConfig.ExtendedResourceName]; found {
+			return CustomResourceTarget{gpuLabel, gpuCapacity.Value()}, nil
+		}
+	}
+	for _, legacyGpuResourceName := range []apiv1.ResourceName{gpu.ResourceNvidiaGPU, gpu.ResourceDirectX} {
+		if gpuCapacity, found := template.Node().Status.Capacity[legacyGpuResourceName]; found {
+			return CustomResourceTarget{gpuLabel, gpuCapacity.Value()}, nil
+		}
+	}
+	for resourceName, gpuCapacity := range template.Node().Status.Capacity {
+		if gpu.IsGPUResource(resourceName) {
 			return CustomResourceTarget{gpuLabel, gpuCapacity.Value()}, nil
 		}
 	}

--- a/cluster-autoscaler/processors/customresources/gpu_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor_test.go
@@ -25,9 +25,12 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
 
 const (
@@ -152,6 +155,38 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 	}
 	expectedReadiness[nodeNoGpuUnready.Name] = false
 
+	nodeSharedGpuReady := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nodeSharedGpuReady",
+			Labels:            gpuLabels,
+			CreationTimestamp: metav1.NewTime(start),
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+			Conditions:  []apiv1.NodeCondition{readyCondition},
+		},
+	}
+	nodeSharedGpuReady.Status.Allocatable["nvidia.com/gpu.shared"] = *resource.NewQuantity(4, resource.DecimalSI)
+	nodeSharedGpuReady.Status.Capacity["nvidia.com/gpu.shared"] = *resource.NewQuantity(4, resource.DecimalSI)
+	expectedReadiness[nodeSharedGpuReady.Name] = true
+
+	nodeMigGpuReady := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nodeMigGpuReady",
+			Labels:            gpuLabels,
+			CreationTimestamp: metav1.NewTime(start),
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+			Conditions:  []apiv1.NodeCondition{readyCondition},
+		},
+	}
+	nodeMigGpuReady.Status.Allocatable["nvidia.com/mig-1g.5gb"] = *resource.NewQuantity(7, resource.DecimalSI)
+	nodeMigGpuReady.Status.Capacity["nvidia.com/mig-1g.5gb"] = *resource.NewQuantity(7, resource.DecimalSI)
+	expectedReadiness[nodeMigGpuReady.Name] = true
+
 	nodeGPUReadyDra := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nodeGPUViaDra",
@@ -173,6 +208,8 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 		nodeDirectXReady,
 		nodeDirectXUnready,
 		nodeNoGpuReady,
+		nodeSharedGpuReady,
+		nodeMigGpuReady,
 		nodeGPUReadyDra,
 	}
 	initialAllNodes := []*apiv1.Node{
@@ -183,6 +220,8 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 		nodeDirectXUnready,
 		nodeNoGpuReady,
 		nodeNoGpuUnready,
+		nodeSharedGpuReady,
+		nodeMigGpuReady,
 		nodeGPUReadyDra,
 	}
 
@@ -209,4 +248,57 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 			assert.Equal(t, node.Status.Conditions[0].Status, apiv1.ConditionFalse, fmt.Sprintf("Unexpected ready condition value for node %s", node.Name))
 		}
 	}
+}
+
+func TestGetNodeGpuTargetFallsBackToNvidiaPrefixResourcesInTemplate(t *testing.T) {
+	processor := GpuCustomResourcesProcessor{}
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	autoscalingCtx := &ca_context.AutoscalingContext{CloudProvider: provider}
+
+	node := test.BuildTestNode("node-with-gpu-label", 1000, 1000)
+	node.Labels[GPULabel] = "nvidia-l4"
+
+	templateNode := test.BuildTestNode("template-with-shared-gpu", 1000, 1000)
+	templateNode.Status.Capacity["nvidia.com/gpu.shared"] = *resource.NewQuantity(4, resource.DecimalSI)
+
+	nodeGroup := provider.BuildNodeGroup("ng-with-shared-gpu", 1, 10, 1, true, false, "n1-standard-1", nil)
+	provider.SetMachineTemplates(map[string]*framework.NodeInfo{
+		nodeGroup.Id(): framework.NewNodeInfo(templateNode, nil),
+	})
+
+	gpuTarget, err := processor.GetNodeGpuTarget(autoscalingCtx, node, nodeGroup)
+	assert.Nil(t, err)
+	assert.Equal(t, CustomResourceTarget{ResourceType: "nvidia-l4", ResourceCount: 4}, gpuTarget)
+}
+
+func TestGetNodeGpuTargetUsesCloudProviderGpuResourceFromTemplate(t *testing.T) {
+	processor := GpuCustomResourcesProcessor{}
+	provider := testprovider.NewTestCloudProviderBuilder().
+		WithNodeGpuConfig(func(node *apiv1.Node) *cloudprovider.GpuConfig {
+			if _, found := node.Labels[GPULabel]; !found {
+				return nil
+			}
+			return &cloudprovider.GpuConfig{
+				Label:                GPULabel,
+				Type:                 node.Labels[GPULabel],
+				ExtendedResourceName: "example.com/custom-gpu",
+			}
+		}).
+		Build()
+	autoscalingCtx := &ca_context.AutoscalingContext{CloudProvider: provider}
+
+	node := test.BuildTestNode("node-with-custom-gpu-label", 1000, 1000)
+	node.Labels[GPULabel] = "custom-gpu-type"
+
+	templateNode := test.BuildTestNode("template-with-custom-gpu", 1000, 1000)
+	templateNode.Status.Capacity["example.com/custom-gpu"] = *resource.NewQuantity(3, resource.DecimalSI)
+
+	nodeGroup := provider.BuildNodeGroup("ng-with-custom-gpu", 1, 10, 1, true, false, "n1-standard-1", nil)
+	provider.SetMachineTemplates(map[string]*framework.NodeInfo{
+		nodeGroup.Id(): framework.NewNodeInfo(templateNode, nil),
+	})
+
+	gpuTarget, err := processor.GetNodeGpuTarget(autoscalingCtx, node, nodeGroup)
+	assert.Nil(t, err)
+	assert.Equal(t, CustomResourceTarget{ResourceType: "custom-gpu-type", ResourceCount: 3}, gpuTarget)
 }

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -18,6 +18,7 @@ package gpu
 
 import (
 	"fmt"
+	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -49,6 +50,21 @@ var GPUVendorResourceNames = []apiv1.ResourceName{
 	ResourceIntelGPU,
 	ResourceAMDGPU,
 	ResourceDirectX,
+}
+
+// IsGPUResource returns true if the resource name points to a known GPU resource.
+// In addition to exact known names, all nvidia.com/* resources are treated as GPU resources
+// to support MIG (nvidia.com/mig-*) and time-sliced GPUs (nvidia.com/gpu.shared).
+// NOTE: this intentionally matches any nvidia.com/ prefixed resource. If NVIDIA ever
+// publishes non-GPU extended resources under this prefix, they would be misclassified.
+func IsGPUResource(resourceName apiv1.ResourceName) bool {
+	for _, gpuVendorResourceName := range GPUVendorResourceNames {
+		if resourceName == gpuVendorResourceName {
+			return true
+		}
+	}
+
+	return strings.HasPrefix(string(resourceName), "nvidia.com/")
 }
 
 const (
@@ -134,12 +150,17 @@ func NodeHasGpu(GPULabel string, node *apiv1.Node) bool {
 }
 
 // NodeHasGpuAllocatable returns the GPU allocatable value and whether the node has GPU allocatable resources.
-// It checks all known GPU vendor resource names and returns the first non-zero allocatable GPU value found.
+// It checks known GPU vendor resource names first for deterministic results, then falls back to
+// prefix-based matching to support resources like NVIDIA MIG and time-sliced GPUs.
 func NodeHasGpuAllocatable(node *apiv1.Node) (gpuAllocatableValue int64, hasGpuAllocatable bool) {
-	for _, gpuVendorResourceName := range GPUVendorResourceNames {
-		gpuAllocatable, found := node.Status.Allocatable[gpuVendorResourceName]
-		if found && !gpuAllocatable.IsZero() {
-			return gpuAllocatable.Value(), true
+	for _, rn := range GPUVendorResourceNames {
+		if qty, found := node.Status.Allocatable[rn]; found && !qty.IsZero() {
+			return qty.Value(), true
+		}
+	}
+	for rn, qty := range node.Status.Allocatable {
+		if IsGPUResource(rn) && !qty.IsZero() {
+			return qty.Value(), true
 		}
 	}
 	return 0, false
@@ -148,8 +169,8 @@ func NodeHasGpuAllocatable(node *apiv1.Node) (gpuAllocatableValue int64, hasGpuA
 // PodRequestsGpu returns true if a given pod has GPU request.
 func PodRequestsGpu(pod *apiv1.Pod) bool {
 	podRequests := podutils.PodRequests(pod)
-	for _, gpuVendorResourceName := range GPUVendorResourceNames {
-		if _, found := podRequests[gpuVendorResourceName]; found {
+	for resourceName := range podRequests {
+		if IsGPUResource(resourceName) {
 			return true
 		}
 	}
@@ -157,15 +178,20 @@ func PodRequestsGpu(pod *apiv1.Pod) bool {
 }
 
 // DetectNodeGPUResourceName inspects the node's allocatable resources and returns the first
-// known GPU extended resource name that has non-zero allocatable. Falls back to Nvidia for
-// backward compatibility if none are found but a GPU label is present.
+// GPU extended resource name that has non-zero allocatable. It checks known vendor names first
+// for deterministic results, then falls back to prefix-based matching for NVIDIA MIG and
+// time-sliced GPUs. Returns Nvidia for backward compatibility if none are found.
 func DetectNodeGPUResourceName(node *apiv1.Node) apiv1.ResourceName {
 	for _, rn := range GPUVendorResourceNames {
 		if qty, ok := node.Status.Allocatable[rn]; ok && !qty.IsZero() {
 			return rn
 		}
 	}
-	// Fallback: preserve previous behavior (defaulting to Nvidia) if label existed
+	for rn, qty := range node.Status.Allocatable {
+		if IsGPUResource(rn) && !qty.IsZero() {
+			return rn
+		}
+	}
 	return ResourceNvidiaGPU
 }
 

--- a/cluster-autoscaler/utils/gpu/gpu_test.go
+++ b/cluster-autoscaler/utils/gpu/gpu_test.go
@@ -76,15 +76,80 @@ func TestNodeHasGpu(t *testing.T) {
 		},
 	}
 	assert.False(t, gpu.NodeHasGpu(GPULabel, nodeNoGpu))
+
+	nodeSharedGpuNoLabel := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "nodeSharedGpuNoLabel",
+			Labels: map[string]string{},
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{},
+			Allocatable: apiv1.ResourceList{},
+		},
+	}
+	nodeSharedGpuNoLabel.Status.Allocatable["nvidia.com/gpu.shared"] = *resource.NewQuantity(2, resource.DecimalSI)
+	nodeSharedGpuNoLabel.Status.Capacity["nvidia.com/gpu.shared"] = *resource.NewQuantity(2, resource.DecimalSI)
+	assert.True(t, gpu.NodeHasGpu(GPULabel, nodeSharedGpuNoLabel))
+}
+
+func TestIsGPUResource(t *testing.T) {
+	testCases := []struct {
+		name         string
+		resourceName apiv1.ResourceName
+		expected     bool
+	}{
+		{
+			name:         "known nvidia gpu resource",
+			resourceName: gpu.ResourceNvidiaGPU,
+			expected:     true,
+		},
+		{
+			name:         "known directx gpu resource",
+			resourceName: gpu.ResourceDirectX,
+			expected:     true,
+		},
+		{
+			name:         "nvidia mig resource",
+			resourceName: "nvidia.com/mig-1g.5gb",
+			expected:     true,
+		},
+		{
+			name:         "nvidia timesliced resource",
+			resourceName: "nvidia.com/gpu.shared",
+			expected:     true,
+		},
+		{
+			name:         "non gpu resource",
+			resourceName: "example.com/fpga",
+			expected:     false,
+		},
+		{
+			name:         "unknown nvidia.com resource matches by prefix",
+			resourceName: "nvidia.com/some-future-resource",
+			expected:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, gpu.IsGPUResource(tc.resourceName))
+		})
+	}
 }
 
 func TestPodRequestsGpu(t *testing.T) {
 	podNoGpu := test.BuildTestPod("podNoGpu", 0, 1000)
 	podWithGpu := test.BuildTestPod("pod1AnyGpu", 0, 1000)
+	podWithSharedGpu := test.BuildTestPod("podWithSharedGpu", 0, 1000)
+	podWithMIG := test.BuildTestPod("podWithMIG", 0, 1000)
 	podWithGpu.Spec.Containers[0].Resources.Requests[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	podWithSharedGpu.Spec.Containers[0].Resources.Requests["nvidia.com/gpu.shared"] = *resource.NewQuantity(1, resource.DecimalSI)
+	podWithMIG.Spec.Containers[0].Resources.Requests["nvidia.com/mig-1g.5gb"] = *resource.NewQuantity(1, resource.DecimalSI)
 
 	assert.False(t, gpu.PodRequestsGpu(podNoGpu))
 	assert.True(t, gpu.PodRequestsGpu(podWithGpu))
+	assert.True(t, gpu.PodRequestsGpu(podWithSharedGpu))
+	assert.True(t, gpu.PodRequestsGpu(podWithMIG))
 }
 
 func TestGetGpuInfoForMetrics(t *testing.T) {
@@ -280,6 +345,24 @@ func TestDetectNodeGPUResourceName(t *testing.T) {
 			expectedResourceName: gpu.ResourceAMDGPU,
 		},
 		{
+			name: "nvidia mig gpu",
+			node: &apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "node-with-nvidia-mig-gpu",
+					Labels: map[string]string{},
+				},
+				Status: apiv1.NodeStatus{
+					Capacity: apiv1.ResourceList{
+						"nvidia.com/mig-1g.5gb": *resource.NewQuantity(2, resource.DecimalSI),
+					},
+					Allocatable: apiv1.ResourceList{
+						"nvidia.com/mig-1g.5gb": *resource.NewQuantity(2, resource.DecimalSI),
+					},
+				},
+			},
+			expectedResourceName: "nvidia.com/mig-1g.5gb",
+		},
+		{
 			name: "test default gpu resource name",
 			node: &apiv1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -289,6 +372,26 @@ func TestDetectNodeGPUResourceName(t *testing.T) {
 				Status: apiv1.NodeStatus{
 					Capacity:    apiv1.ResourceList{},
 					Allocatable: apiv1.ResourceList{},
+				},
+			},
+			expectedResourceName: gpu.ResourceNvidiaGPU,
+		},
+		{
+			name: "known vendor name takes precedence over prefix match",
+			node: &apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "node-with-both-gpu-types",
+					Labels: map[string]string{},
+				},
+				Status: apiv1.NodeStatus{
+					Capacity: apiv1.ResourceList{
+						gpu.ResourceNvidiaGPU:   *resource.NewQuantity(1, resource.DecimalSI),
+						"nvidia.com/gpu.shared": *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Allocatable: apiv1.ResourceList{
+						gpu.ResourceNvidiaGPU:   *resource.NewQuantity(1, resource.DecimalSI),
+						"nvidia.com/gpu.shared": *resource.NewQuantity(4, resource.DecimalSI),
+					},
 				},
 			},
 			expectedResourceName: gpu.ResourceNvidiaGPU,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Nodes using NVIDIA MIG (nvidia.com/mig-*) or time-sliced GPUs (nvidia.com/gpu.shared) were incorrectly marked as unready by FilterOutNodesWithUnreadyResources because GPU detection only matched the hardcoded GPUVendorResourceNames list. This blocked autoscaling once okTotalUnreadyCount was exceeded.

This adds an IsGPUResource() predicate that matches known vendor names plus any nvidia.com/ prefixed resource, following the same heuristic already used in cloudprovider/gce/templates.go. Known vendor names are checked first for deterministic results.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8095

#### Special notes for your reviewer:

Existing GPU vendors (AMD, Intel, DirectX) are unaffected, they match by exact name before prefix matching runs. The nvidia.com/ prefix breadth is documented in IsGPUResource's doc comment.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix cluster-autoscaler incorrectly marking nodes with NVIDIA MIG or time-sliced GPU resources as unready, which blocked autoscaling.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
