### PR TITLE
CapacityQuota status reconciler

### DIFF
--- a/cluster-autoscaler/resourcequotas/capacityquota/controller.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/controller.go
@@ -1,0 +1,253 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacityquota
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"k8s.io/autoscaler/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1"
+)
+
+const (
+	// ReconciledCondition is the condition specifying whether the CapacityQuota status has been reconciled.
+	ReconciledCondition = "Reconciled"
+	// ReconciliationSucceeded specifies that the CapacityQuota status has been reconciled successfully.
+	ReconciliationSucceeded = "ReconciliationSucceeded"
+	// ReconciliationFailed specifies that the CapacityQuota status has failed to reconcile.
+	ReconciliationFailed = "ReconciliationFailed"
+)
+
+// Reconciler reconciles a CapacityQuota object
+type Reconciler struct {
+	client     client.Client
+	nodeFilter resourcequotas.NodeFilter
+}
+
+// NewCapacityQuotaReconciler returns a new CapacityQuotaReconciler
+func NewCapacityQuotaReconciler(client client.Client, nodeFilter resourcequotas.NodeFilter) *Reconciler {
+	return &Reconciler{
+		client:     client,
+		nodeFilter: nodeFilter,
+	}
+}
+
+type invalidSelectorError struct {
+	err error
+}
+
+func (e *invalidSelectorError) Error() string {
+	return fmt.Sprintf("failed to parse selector: %s", e.err.Error())
+}
+
+func (e *invalidSelectorError) Unwrap() error {
+	return e.err
+}
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var cq v1alpha1.CapacityQuota
+	if err := r.client.Get(ctx, req.NamespacedName, &cq); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	originalCQ := cq.DeepCopy()
+
+	result, err := r.reconcileCapacityQuota(ctx, &cq)
+
+	if err != nil {
+		setReconciledCondition(&cq, metav1.ConditionFalse, ReconciliationFailed, err.Error())
+		if _, ok := errors.AsType[*invalidSelectorError](err); ok {
+			err = nil // Do not retry when the selector is invalid
+		}
+	} else {
+		setReconciledCondition(&cq, metav1.ConditionTrue, ReconciliationSucceeded, "CapacityQuota successfully reconciled")
+	}
+
+	if !apiequality.Semantic.DeepEqual(originalCQ.Status, cq.Status) {
+		if patchErr := r.client.Status().Patch(ctx, &cq, client.MergeFrom(originalCQ)); patchErr != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to patch status: %w", patchErr)
+		}
+	}
+
+	return result, err
+}
+
+func (r *Reconciler) reconcileCapacityQuota(ctx context.Context, cq *v1alpha1.CapacityQuota) (ctrl.Result, error) {
+	matchingNodes, err := r.getMatchingNodes(ctx, cq)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get matching nodes: %w", err)
+	}
+
+	cq.Status.Used = &v1alpha1.CapacityQuotaUsage{
+		Resources: calculateResourceUsage(cq, matchingNodes),
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) getMatchingNodes(ctx context.Context, cq *v1alpha1.CapacityQuota) ([]*corev1.Node, error) {
+	var nodeList corev1.NodeList
+	var listOpts []client.ListOption
+
+	if cq.Spec.Selector != nil {
+		selector, err := metav1.LabelSelectorAsSelector(cq.Spec.Selector)
+		if err != nil {
+			return nil, &invalidSelectorError{err: err}
+		}
+		listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: selector})
+	}
+
+	if err := r.client.List(ctx, &nodeList, listOpts...); err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	matchingNodes := make([]*corev1.Node, 0, len(nodeList.Items))
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if r.nodeFilter == nil || !r.nodeFilter.ExcludeFromTracking(node) {
+			matchingNodes = append(matchingNodes, node)
+		}
+	}
+
+	return matchingNodes, nil
+}
+
+func calculateResourceUsage(cq *v1alpha1.CapacityQuota, matchingNodes []*corev1.Node) v1alpha1.ResourceList {
+	used := make(v1alpha1.ResourceList)
+
+	for resName := range cq.Spec.Limits.Resources {
+		usage := resource.NewQuantity(0, resource.DecimalSI)
+		for _, node := range matchingNodes {
+			if resName == v1alpha1.ResourceNodes {
+				usage.Add(*resource.NewQuantity(1, resource.DecimalSI))
+			} else if quantity, ok := node.Status.Capacity[corev1.ResourceName(resName)]; ok {
+				usage.Add(quantity)
+			}
+		}
+		used[resName] = usage.DeepCopy()
+	}
+	return used
+}
+
+func setReconciledCondition(cq *v1alpha1.CapacityQuota, status metav1.ConditionStatus, reason, message string) {
+	newCondition := metav1.Condition{
+		Type:               ReconciledCondition,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: cq.Generation,
+	}
+
+	meta.SetStatusCondition(&cq.Status.Conditions, newCondition)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	nodePredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, oldOk := e.ObjectOld.(*corev1.Node)
+			newNode, newOk := e.ObjectNew.(*corev1.Node)
+			if !oldOk || !newOk {
+				return false
+			}
+
+			if !maps.Equal(oldNode.Labels, newNode.Labels) {
+				return true
+			}
+
+			if !maps.EqualFunc(oldNode.Status.Capacity, newNode.Status.Capacity, func(q1, q2 resource.Quantity) bool {
+				return q1.Equal(q2)
+			}) {
+				return true
+			}
+
+			return false
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.CapacityQuota{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.findCapacityQuotasForNode),
+			builder.WithPredicates(nodePredicate),
+		).
+		Complete(r)
+}
+
+func (r *Reconciler) findCapacityQuotasForNode(ctx context.Context, o client.Object) []reconcile.Request {
+	node, ok := o.(*corev1.Node)
+	if !ok {
+		return nil
+	}
+
+	var cqList v1alpha1.CapacityQuotaList
+	if err := r.client.List(ctx, &cqList); err != nil {
+		runtime.HandleError(fmt.Errorf("failed to list capacity quotas in map func: %w", err))
+		return nil
+	}
+
+	var requests []reconcile.Request
+	nodeLabels := labels.Set(node.GetLabels())
+
+	for _, cq := range cqList.Items {
+		if cq.Spec.Selector != nil {
+			selector, err := metav1.LabelSelectorAsSelector(cq.Spec.Selector)
+			if err != nil {
+				runtime.HandleError(err)
+				continue
+			}
+			// note: this works correctly for node updates both when a label is added and removed from a node.
+			// Intuitively, you may think that removing a label from the node so that it no longer matches a CapacityQuota
+			// will not trigger the reconciliation for that quota. This is not the case, since `EnqueueRequestsFromMapFunc`
+			// runs the provided function both on the old and the new object, and deduplicates the returned requests.
+			// Ref: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.24.1/pkg/handler#EnqueueRequestsFromMapFunc
+			if !selector.Matches(nodeLabels) {
+				continue
+			}
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: cq.Name,
+			},
+		})
+	}
+
+	return requests
+}

--- a/cluster-autoscaler/resourcequotas/capacityquota/controller.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/controller.go
@@ -18,9 +18,9 @@ package capacityquota
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -43,6 +43,12 @@ import (
 )
 
 const (
+	// ValidCondition is the condition specifying whethere the CapacityQuota is valid
+	ValidCondition = "Valid"
+	// ValidationSucceeded specifies that the CapacityQuota is valid
+	ValidationSucceeded = "ValidationSucceeded"
+	// ValidationFailed specifies that the CapacityQuota is invalid
+	ValidationFailed = "ValidationFailed"
 	// ReconciledCondition is the condition specifying whether the CapacityQuota status has been reconciled.
 	ReconciledCondition = "Reconciled"
 	// ReconciliationSucceeded specifies that the CapacityQuota status has been reconciled successfully.
@@ -55,26 +61,24 @@ const (
 type Reconciler struct {
 	client     client.Client
 	nodeFilter resourcequotas.NodeFilter
+	validators []Validator
+}
+
+// ReconcilerOptions are configuration options for CapacityQuota reconciler.
+type ReconcilerOptions struct {
+	NodeFilter       resourcequotas.NodeFilter
+	CustomValidators []Validator
 }
 
 // NewCapacityQuotaReconciler returns a new CapacityQuotaReconciler
-func NewCapacityQuotaReconciler(client client.Client, nodeFilter resourcequotas.NodeFilter) *Reconciler {
+func NewCapacityQuotaReconciler(client client.Client, opts ReconcilerOptions) *Reconciler {
+	validators := []Validator{&labelSelectorValidator{}}
+	validators = append(validators, opts.CustomValidators...)
 	return &Reconciler{
 		client:     client,
-		nodeFilter: nodeFilter,
+		nodeFilter: opts.NodeFilter,
+		validators: validators,
 	}
-}
-
-type invalidSelectorError struct {
-	err error
-}
-
-func (e *invalidSelectorError) Error() string {
-	return fmt.Sprintf("failed to parse selector: %s", e.err.Error())
-}
-
-func (e *invalidSelectorError) Unwrap() error {
-	return e.err
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -87,24 +91,64 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	originalCQ := cq.DeepCopy()
 
+	validationErrs := r.validateCapacityQuota(ctx, &cq)
+	if len(validationErrs) > 0 {
+		errMsg := formatValidationErrors(validationErrs)
+		setCondition(&cq, ValidCondition, metav1.ConditionFalse, ValidationFailed, errMsg)
+		setCondition(&cq, ReconciledCondition, metav1.ConditionFalse, ReconciliationFailed, "Validation failed")
+
+		if patchErr := r.patchStatus(ctx, originalCQ, &cq); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		return ctrl.Result{}, nil
+	}
+	setCondition(&cq, ValidCondition, metav1.ConditionTrue, ValidationSucceeded, "CapacityQuota is valid")
+
 	result, err := r.reconcileCapacityQuota(ctx, &cq)
 
 	if err != nil {
-		setReconciledCondition(&cq, metav1.ConditionFalse, ReconciliationFailed, err.Error())
-		if _, ok := errors.AsType[*invalidSelectorError](err); ok {
-			err = nil // Do not retry when the selector is invalid
-		}
+		setCondition(&cq, ReconciledCondition, metav1.ConditionFalse, ReconciliationFailed, err.Error())
 	} else {
-		setReconciledCondition(&cq, metav1.ConditionTrue, ReconciliationSucceeded, "CapacityQuota successfully reconciled")
+		setCondition(&cq, ReconciledCondition, metav1.ConditionTrue, ReconciliationSucceeded, "CapacityQuota successfully reconciled")
 	}
 
-	if !apiequality.Semantic.DeepEqual(originalCQ.Status, cq.Status) {
-		if patchErr := r.client.Status().Patch(ctx, &cq, client.MergeFrom(originalCQ)); patchErr != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to patch status: %w", patchErr)
-		}
+	if patchErr := r.patchStatus(ctx, originalCQ, &cq); patchErr != nil {
+		return ctrl.Result{}, patchErr
 	}
 
 	return result, err
+}
+
+func formatValidationErrors(errs []error) string {
+	errStrings := make([]string, len(errs))
+	for i, err := range errs {
+		errStrings[i] = err.Error()
+	}
+	return strings.Join(errStrings, "; ")
+}
+
+func (r *Reconciler) patchStatus(ctx context.Context, originalCQ, currentCQ *v1alpha1.CapacityQuota) error {
+	if !apiequality.Semantic.DeepEqual(originalCQ.Status, currentCQ.Status) {
+		if patchErr := r.client.Status().Patch(ctx, currentCQ, client.MergeFrom(originalCQ)); patchErr != nil {
+			return fmt.Errorf("failed to patch status: %w", patchErr)
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) validateCapacityQuota(ctx context.Context, cq *v1alpha1.CapacityQuota) []error {
+	var allErrs []error
+	for _, v := range r.validators {
+		if err := v.Validate(ctx, cq); err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return allErrs
 }
 
 func (r *Reconciler) reconcileCapacityQuota(ctx context.Context, cq *v1alpha1.CapacityQuota) (ctrl.Result, error) {
@@ -127,7 +171,7 @@ func (r *Reconciler) getMatchingNodes(ctx context.Context, cq *v1alpha1.Capacity
 	if cq.Spec.Selector != nil {
 		selector, err := metav1.LabelSelectorAsSelector(cq.Spec.Selector)
 		if err != nil {
-			return nil, &invalidSelectorError{err: err}
+			return nil, err
 		}
 		listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: selector})
 	}
@@ -164,9 +208,9 @@ func calculateResourceUsage(cq *v1alpha1.CapacityQuota, matchingNodes []*corev1.
 	return used
 }
 
-func setReconciledCondition(cq *v1alpha1.CapacityQuota, status metav1.ConditionStatus, reason, message string) {
+func setCondition(cq *v1alpha1.CapacityQuota, condType string, status metav1.ConditionStatus, reason, message string) {
 	newCondition := metav1.Condition{
-		Type:               ReconciledCondition,
+		Type:               condType,
 		Status:             status,
 		Reason:             reason,
 		Message:            message,

--- a/cluster-autoscaler/resourcequotas/capacityquota/testutil/testutil.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/testutil/testutil.go
@@ -1,0 +1,56 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1"
+)
+
+// QuotaOption is a functional option for configuring a CapacityQuota.
+type QuotaOption func(*v1alpha1.CapacityQuota)
+
+// NewCapacityQuota creates a new CapacityQuota with the given name and options.
+func NewCapacityQuota(name string, opts ...QuotaOption) *v1alpha1.CapacityQuota {
+	cq := &v1alpha1.CapacityQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	for _, opt := range opts {
+		opt(cq)
+	}
+	return cq
+}
+
+// WithLabelSelector configures the CapacityQuota's LabelSelector to match the given labels.
+func WithLabelSelector(labels map[string]string) QuotaOption {
+	return func(cq *v1alpha1.CapacityQuota) {
+		cq.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: labels,
+		}
+	}
+}
+
+// WithLimits configures the CapacityQuota's resource limits.
+func WithLimits(limits v1alpha1.ResourceList) QuotaOption {
+	return func(cq *v1alpha1.CapacityQuota) {
+		cq.Spec.Limits = v1alpha1.CapacityQuotaLimits{
+			Resources: limits,
+		}
+	}
+}

--- a/cluster-autoscaler/resourcequotas/capacityquota/validator.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/validator.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacityquota
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	cqv1alpha1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1"
+)
+
+// Validator checks whether CapacityQuota is valid.
+type Validator interface {
+	Validate(ctx context.Context, cq *cqv1alpha1.CapacityQuota) error
+}
+
+type labelSelectorValidator struct{}
+
+func (v *labelSelectorValidator) Validate(_ context.Context, cq *cqv1alpha1.CapacityQuota) error {
+	if _, err := metav1.LabelSelectorAsSelector(cq.Spec.Selector); err != nil {
+		return field.Invalid(field.NewPath("spec").Child("selector"), cq.Spec.Selector, err.Error())
+	}
+	return nil
+}

--- a/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
+++ b/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
@@ -281,12 +281,13 @@ var _ = Describe("CapacityQuota Controller", func() {
 			var fetchedCQ cqv1alpha1.CapacityQuota
 			g.Expect(crClient.Get(ctx, cqKey, &fetchedCQ)).To(Succeed())
 
-			g.Expect(meta.IsStatusConditionFalse(fetchedCQ.Status.Conditions, capacityquota.ReconciledCondition)).To(BeTrue())
-
-			cond := meta.FindStatusCondition(fetchedCQ.Status.Conditions, capacityquota.ReconciledCondition)
+			g.Expect(meta.IsStatusConditionFalse(fetchedCQ.Status.Conditions, capacityquota.ValidCondition)).To(BeTrue())
+			cond := meta.FindStatusCondition(fetchedCQ.Status.Conditions, capacityquota.ValidCondition)
 			g.Expect(cond).NotTo(BeNil())
-			g.Expect(cond.Reason).To(Equal(capacityquota.ReconciliationFailed))
-			g.Expect(cond.Message).To(ContainSubstring("failed to parse selector"))
+			g.Expect(cond.Reason).To(Equal("ValidationFailed"))
+			g.Expect(cond.Message).To(ContainSubstring("is not a valid label selector operator"))
+
+			g.Expect(meta.IsStatusConditionFalse(fetchedCQ.Status.Conditions, capacityquota.ReconciledCondition)).To(BeTrue())
 		}).Should(Succeed())
 	})
 })
@@ -295,6 +296,7 @@ func assertQuotaReconciled(ctx context.Context, g Gomega, cqKey types.Namespaced
 	var fetchedCQ cqv1alpha1.CapacityQuota
 	g.Expect(crClient.Get(ctx, cqKey, &fetchedCQ)).To(Succeed())
 
+	g.Expect(meta.IsStatusConditionTrue(fetchedCQ.Status.Conditions, capacityquota.ValidCondition)).To(BeTrue())
 	g.Expect(meta.IsStatusConditionTrue(fetchedCQ.Status.Conditions, capacityquota.ReconciledCondition)).To(BeTrue())
 	g.Expect(fetchedCQ.Status.Used).ToNot(BeNil())
 	g.Expect(apiequality.Semantic.DeepEqual(fetchedCQ.Status.Used.Resources, wantResources)).To(BeTrue())

--- a/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
+++ b/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cqv1alpha1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas/capacityquota"
+	cqtest "k8s.io/autoscaler/cluster-autoscaler/resourcequotas/capacityquota/testutil"
+	testutils "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
+)
+
+var _ = Describe("CapacityQuota Controller", func() {
+	SetDefaultEventuallyTimeout(5 * time.Second)
+	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
+
+	BeforeEach(func() {
+		By("creating a few initial nodes")
+		node1 := testutils.BuildTestNode("test-node-1", 2000, 8*units.GiB, testutils.WithNodeLabels(
+			map[string]string{"node-pool": "test-pool"},
+		))
+		Expect(crClient.Create(ctx, node1)).To(Succeed())
+		Expect(crClient.Status().Update(ctx, node1)).To(Succeed())
+
+		node2 := testutils.BuildTestNode("test-node-2", 4000, 16*units.GiB, testutils.WithNodeLabels(
+			map[string]string{"node-pool": "test-pool"},
+		))
+		Expect(crClient.Create(ctx, node2)).To(Succeed())
+		Expect(crClient.Status().Update(ctx, node2)).To(Succeed())
+
+		node3 := testutils.BuildTestNode("other-node-1", 8000, 32*units.GiB, testutils.WithNodeLabels(
+			map[string]string{"node-pool": "other-pool"},
+		))
+		Expect(crClient.Create(ctx, node3)).To(Succeed())
+		Expect(crClient.Status().Update(ctx, node3)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("cleaning up nodes")
+		err := crClient.DeleteAllOf(ctx, &corev1.Node{}, client.HasLabels{"node-pool"})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("cleaning up quotas")
+		err = crClient.DeleteAllOf(ctx, &cqv1alpha1.CapacityQuota{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should correctly sum capacities of matching nodes", func() {
+		By("creating a CapacityQuota")
+		cq := cqtest.NewCapacityQuota("test-quota-pool",
+			cqtest.WithLabelSelector(map[string]string{"node-pool": "test-pool"}),
+			cqtest.WithLimits(cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU:    resource.MustParse("10"),
+				cqv1alpha1.ResourceMemory: resource.MustParse("32Gi"),
+				cqv1alpha1.ResourceNodes:  resource.MustParse("5"),
+				"nvidia.com/gpu":          resource.MustParse("2"),
+			}),
+		)
+		Expect(crClient.Create(ctx, cq)).To(Succeed())
+
+		cqKey := types.NamespacedName{Name: "test-quota-pool"}
+
+		By("waiting for the CapacityQuota to be reconciled with correct usage")
+		Eventually(func(g Gomega) {
+			assertQuotaReconciled(ctx, g, cqKey, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU:    resource.MustParse("6"),
+				cqv1alpha1.ResourceMemory: resource.MustParse("24Gi"),
+				cqv1alpha1.ResourceNodes:  resource.MustParse("2"),
+				"nvidia.com/gpu":          resource.MustParse("0"),
+			})
+		}).Should(Succeed())
+	})
+
+	It("should correctly update capacities when a new matching node is added", func() {
+		By("creating a CapacityQuota")
+		cq := cqtest.NewCapacityQuota("test-quota-pool-add",
+			cqtest.WithLabelSelector(map[string]string{"node-pool": "test-pool"}),
+			cqtest.WithLimits(cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("10"),
+			}),
+		)
+		Expect(crClient.Create(ctx, cq)).To(Succeed())
+
+		cqKey := types.NamespacedName{Name: "test-quota-pool-add"}
+
+		By("waiting for initial reconciliation")
+		Eventually(func(g Gomega) {
+			assertQuotaReconciled(ctx, g, cqKey, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("6"),
+			})
+		}).Should(Succeed())
+
+		By("adding a new matching node")
+		newNode := testutils.BuildTestNode("test-node-3", 2000, 0, testutils.WithNodeLabels(
+			map[string]string{"node-pool": "test-pool"},
+		))
+		Expect(crClient.Create(ctx, newNode)).To(Succeed())
+		Expect(crClient.Status().Update(ctx, newNode)).To(Succeed())
+
+		By("ensuring quota was updated")
+		Eventually(func(g Gomega) {
+			assertQuotaReconciled(ctx, g, cqKey, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("8"),
+			})
+		}).Should(Succeed())
+	})
+
+	It("should correctly update capacities when a matching node is deleted", func() {
+		By("creating a CapacityQuota")
+		cq := cqtest.NewCapacityQuota("test-quota-pool-delete",
+			cqtest.WithLabelSelector(map[string]string{"node-pool": "test-pool"}),
+			cqtest.WithLimits(cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("10"),
+			}),
+		)
+		Expect(crClient.Create(ctx, cq)).To(Succeed())
+
+		cqKey := types.NamespacedName{Name: "test-quota-pool-delete"}
+
+		By("waiting for initial reconciliation")
+		Eventually(func(g Gomega) {
+			assertQuotaReconciled(ctx, g, cqKey, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("6"),
+			})
+		}).Should(Succeed())
+
+		By("deleting a matching node")
+		var fetchedNode corev1.Node
+		Expect(crClient.Get(ctx, types.NamespacedName{Name: "test-node-1"}, &fetchedNode)).To(Succeed())
+		Expect(crClient.Delete(ctx, &fetchedNode)).To(Succeed())
+
+		By("ensuring quota was updated")
+		Eventually(func(g Gomega) {
+			assertQuotaReconciled(ctx, g, cqKey, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("4"),
+			})
+		}).Should(Succeed())
+	})
+
+	It("should correctly update capacities when a node's label is removed, causing it to stop matching", func() {
+		By("creating the first CapacityQuota")
+		cq1 := cqtest.NewCapacityQuota("test-quota-pool-1",
+			cqtest.WithLabelSelector(map[string]string{"node-pool": "test-pool"}),
+			cqtest.WithLimits(cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("10"),
+			}),
+		)
+		Expect(crClient.Create(ctx, cq1)).To(Succeed())
+
+		By("creating the second CapacityQuota")
+		cq2 := cqtest.NewCapacityQuota("test-quota-pool-2",
+			cqtest.WithLabelSelector(map[string]string{"node-pool-2": "test-pool-2"}),
+			cqtest.WithLimits(cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("10"),
+			}),
+		)
+		Expect(crClient.Create(ctx, cq2)).To(Succeed())
+
+		cqKey1 := types.NamespacedName{Name: "test-quota-pool-1"}
+		cqKey2 := types.NamespacedName{Name: "test-quota-pool-2"}
+
+		By("creating a node that matches both quotas")
+		newNode := testutils.BuildTestNode("test-node-5", 5000, 0, testutils.WithNodeLabels(
+			map[string]string{
+				"node-pool":   "test-pool",
+				"node-pool-2": "test-pool-2",
+			},
+		))
+		Expect(crClient.Create(ctx, newNode)).To(Succeed())
+		Expect(crClient.Status().Update(ctx, newNode)).To(Succeed())
+
+		By("waiting for initial reconciliation")
+		Eventually(func(g Gomega) {
+			assertQuotaReconciled(ctx, g, cqKey1, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("11"),
+			})
+			assertQuotaReconciled(ctx, g, cqKey2, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("5"),
+			})
+		}).Should(Succeed())
+
+		By("removing the label from the node, so it no longer matches cq1")
+		var fetchedNode corev1.Node
+		Expect(crClient.Get(ctx, types.NamespacedName{Name: "test-node-5"}, &fetchedNode)).To(Succeed())
+		delete(fetchedNode.Labels, "node-pool")
+		Expect(crClient.Update(ctx, &fetchedNode)).To(Succeed())
+
+		By("ensuring cq1 drops the capacity of node5 (11 -> 6), while cq2 remains unchanged (5)")
+		Eventually(func(g Gomega) {
+			assertQuotaReconciled(ctx, g, cqKey1, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("6"),
+			})
+			assertQuotaReconciled(ctx, g, cqKey2, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("5"),
+			})
+		}).Should(Succeed())
+	})
+
+	It("should exclude nodes matching the configured NodeFilter", func() {
+		By("adding a virtual kubelet node that matches the quota's selector")
+		// the controller has been initialized with VirtualKubeletNodeFilter, so virtual kubelet nodes should be excluded
+		virtualKubeletNode := testutils.BuildTestNode("test-node-virtual", 1000000, 0, testutils.WithNodeLabels(
+			map[string]string{
+				"node-pool": "test-pool",
+				"type":      utils.VirtualKubeletNodeLabelValue,
+			},
+		))
+		Expect(crClient.Create(ctx, virtualKubeletNode)).To(Succeed())
+		Expect(crClient.Status().Update(ctx, virtualKubeletNode)).To(Succeed())
+
+		By("creating a CapacityQuota")
+		cq := cqtest.NewCapacityQuota("test-quota-pool-virtual",
+			cqtest.WithLabelSelector(map[string]string{"node-pool": "test-pool"}),
+			cqtest.WithLimits(cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("10"),
+			}),
+		)
+		Expect(crClient.Create(ctx, cq)).To(Succeed())
+
+		cqKey := types.NamespacedName{Name: "test-quota-pool-virtual"}
+
+		By("ensuring quota does not include the virtual node's capacity")
+		Eventually(func(g Gomega) {
+			assertQuotaReconciled(ctx, g, cqKey, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("6"),
+			})
+		}).Should(Succeed())
+	})
+
+	It("should report a failure condition if the selector is invalid", func() {
+		By("creating a CapacityQuota with an invalid selector")
+		cq := cqtest.NewCapacityQuota("test-quota-pool-invalid",
+			func(cq *cqv1alpha1.CapacityQuota) {
+				cq.Spec.Selector = &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "node-pool",
+							Operator: "InvalidOperator",
+						},
+					},
+				}
+			},
+			cqtest.WithLimits(cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("10"),
+			}),
+		)
+		Expect(crClient.Create(ctx, cq)).To(Succeed())
+
+		cqKey := types.NamespacedName{Name: "test-quota-pool-invalid"}
+
+		By("waiting for the CapacityQuota to be reconciled with a failed condition")
+		Eventually(func(g Gomega) {
+			var fetchedCQ cqv1alpha1.CapacityQuota
+			g.Expect(crClient.Get(ctx, cqKey, &fetchedCQ)).To(Succeed())
+
+			g.Expect(meta.IsStatusConditionFalse(fetchedCQ.Status.Conditions, capacityquota.ReconciledCondition)).To(BeTrue())
+
+			cond := meta.FindStatusCondition(fetchedCQ.Status.Conditions, capacityquota.ReconciledCondition)
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond.Reason).To(Equal(capacityquota.ReconciliationFailed))
+			g.Expect(cond.Message).To(ContainSubstring("failed to parse selector"))
+		}).Should(Succeed())
+	})
+})
+
+func assertQuotaReconciled(ctx context.Context, g Gomega, cqKey types.NamespacedName, wantResources cqv1alpha1.ResourceList) {
+	var fetchedCQ cqv1alpha1.CapacityQuota
+	g.Expect(crClient.Get(ctx, cqKey, &fetchedCQ)).To(Succeed())
+
+	g.Expect(meta.IsStatusConditionTrue(fetchedCQ.Status.Conditions, capacityquota.ReconciledCondition)).To(BeTrue())
+	g.Expect(fetchedCQ.Status.Used).ToNot(BeNil())
+	g.Expect(apiequality.Semantic.DeepEqual(fetchedCQ.Status.Used.Resources, wantResources)).To(BeTrue())
+}

--- a/cluster-autoscaler/test/integration/controllers/suite_test.go
+++ b/cluster-autoscaler/test/integration/controllers/suite_test.go
@@ -25,19 +25,26 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clockutil "k8s.io/utils/clock"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	capacitybuffer "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned"
+	cqv1alpha1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1"
 	cbapi "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	cbctrl "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/controller"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/fakepods"
 	cbmetrics "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
+	cqctrl "k8s.io/autoscaler/cluster-autoscaler/resourcequotas/capacityquota"
 )
 
 func TestControllers(t *testing.T) {
@@ -52,6 +59,7 @@ var cfg *rest.Config
 var testEnv *envtest.Environment
 var k8sClient *kubernetes.Clientset
 var buffersClient *capacitybuffer.Clientset
+var crClient client.Client
 var ctx context.Context
 var cancel context.CancelFunc
 var reconciliationCache *cbmetrics.ReconciliationCache
@@ -76,6 +84,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
+	scheme := runtime.NewScheme()
+	err = clientgoscheme.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = cqv1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	k8sClient, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
@@ -83,6 +97,24 @@ var _ = BeforeSuite(func() {
 	buffersClient, err = capacitybuffer.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(buffersClient).NotTo(BeNil())
+
+	crClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(crClient).NotTo(BeNil())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = cqctrl.NewCapacityQuotaReconciler(mgr.GetClient(), utils.VirtualKubeletNodeFilter{}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
 
 	client, err := cbclient.NewCapacityBufferClientFromConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())

--- a/cluster-autoscaler/test/integration/controllers/suite_test.go
+++ b/cluster-autoscaler/test/integration/controllers/suite_test.go
@@ -107,7 +107,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	err = cqctrl.NewCapacityQuotaReconciler(mgr.GetClient(), utils.VirtualKubeletNodeFilter{}).SetupWithManager(mgr)
+	err = cqctrl.NewCapacityQuotaReconciler(mgr.GetClient(), cqctrl.ReconcilerOptions{NodeFilter: utils.VirtualKubeletNodeFilter{}}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/cluster-autoscaler/utils/test/test_utils.go
+++ b/cluster-autoscaler/utils/test/test_utils.go
@@ -356,6 +356,13 @@ func IsReady(ready bool) NodeOption {
 	}
 }
 
+// WithNodeLabels sets labels for a Node.
+func WithNodeLabels(labels map[string]string) NodeOption {
+	return func(node *apiv1.Node) {
+		node.Labels = labels
+	}
+}
+
 // BuildTestNode creates a node with specified capacity.
 func BuildTestNode(name string, millicpuCapacity int64, memCapacity int64, opts ...NodeOption) *apiv1.Node {
 	node := &apiv1.Node{


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Implemented reconciler for CapacityQuota status. Controller has not been yet integrated with the autoscaler. It will be integrated in the next PR. Controller has been written in controller-runtime and tested with envtest.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/autoscaler/issues/8703

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
