### PR TITLE
feat: add cert-manager integration with vpa helm chart

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -26,7 +26,7 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 | omerap12 | <kubernetes-sig-autoscaling@googlegroups.com> |  |
 
 ## Webhook Management
-The admission controller requires a `MutatingWebhookConfiguration` and TLS certificates. This chart supports two mutually exclusive modes:
+The admission controller requires a `MutatingWebhookConfiguration` and TLS certificates. This chart supports three mutually exclusive modes:
 
 ### Helm-managed (default)
 ```yaml
@@ -51,6 +51,22 @@ In this mode:
 - The VPA admission controller creates and manages the webhook itself
 Important: You are responsible for creating the TLS secret before or after installing the chart. The admission controller will only create the `MutatingWebhookConfiguration` once the secret exists.
 If the secret is created after the Helm install, you must restart the admission controller pod to trigger webhook registration.
+
+### cert-manager managed
+```yaml
+admissionController:
+  registerWebhook: false
+  certGen:
+    enabled: false
+  certManager:
+    enabled: true
+```
+In this mode:
+- Helm creates the MutatingWebhookConfiguration
+- cert-manager issues and renews TLS certificates automatically
+- cert-manager's cainjector injects the CA into the webhook configuration
+
+By default, you must provide an existing `Issuer` or `ClusterIssuer` via `admissionController.certManager.issuerRef`. Alternatively, enable `admissionController.certManager.createSelfSignedIssuer.enabled: true` to let the chart create a namespaced self-signed issuer automatically.
 
 ## Custom Resource Definitions
 
@@ -107,6 +123,19 @@ helm upgrade <release-name> <chart> \
 | admissionController.certGen.resources | object | `{}` | The resources block for the certgen pod |
 | admissionController.certGen.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The securityContext block for the certgen container(s) |
 | admissionController.certGen.tolerations | list | `[]` |  |
+| admissionController.certManager.annotations | object | `{}` | Annotations to add to all cert-manager resources created by Chart. |
+| admissionController.certManager.createSelfSignedIssuer | object | `{"duration":"8760h","enabled":false,"renewBefore":"720h"}` | Optionally create a SelfSigned Issuer for CA generation. When enabled, a namespaced SelfSigned Issuer is created in the VPA namespace to issue the intermediate CA certificate, which in turn signs the webhook TLS certificate. |
+| admissionController.certManager.createSelfSignedIssuer.duration | string | `"8760h"` | Lifetime of the intermediate CA certificate. |
+| admissionController.certManager.createSelfSignedIssuer.renewBefore | string | `"720h"` | Time before expiry to renew the CA certificate. |
+| admissionController.certManager.duration | string | `"168h"` | Lifetime of the webhook TLS certificate. |
+| admissionController.certManager.enabled | bool | `false` | If true, cert-manager manages the webhook certificate lifecycle. cert-manager must be installed in the cluster, see https://cert-manager.io/docs/installation. Mutually exclusive with certGen.enabled, registerWebhook, and tls.create. |
+| admissionController.certManager.issuerRef | object | `{"group":"cert-manager.io","kind":"ClusterIssuer","name":""}` | Reference to an existing issuer for signing the webhook TLS certificate. Required when createSelfSignedIssuer.enabled is false. |
+| admissionController.certManager.issuerRef.group | string | `"cert-manager.io"` | API group of the issuer. |
+| admissionController.certManager.issuerRef.kind | string | `"ClusterIssuer"` | Kind of the issuer (ClusterIssuer or Issuer). |
+| admissionController.certManager.issuerRef.name | string | `""` | Name of the issuer. |
+| admissionController.certManager.privateKey.algorithm | string | `"RSA"` | Key algorithm for certificates (RSA, ECDSA, Ed25519). |
+| admissionController.certManager.privateKey.size | int | `2048` | Key size for RSA or ECDSA. Ignored for Ed25519. |
+| admissionController.certManager.renewBefore | string | `"24h"` | Time before expiry to renew the TLS certificate. |
 | admissionController.enabled | bool | `true` |  |
 | admissionController.extraArgs | list | `[]` |  |
 | admissionController.extraEnv | list | `[]` |  |

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md.gotmpl
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md.gotmpl
@@ -23,7 +23,7 @@ helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
 {{ template "chart.requirementsSection" . }}
 
 ## Webhook Management
-The admission controller requires a `MutatingWebhookConfiguration` and TLS certificates. This chart supports two mutually exclusive modes:
+The admission controller requires a `MutatingWebhookConfiguration` and TLS certificates. This chart supports three mutually exclusive modes:
 
 ### Helm-managed (default)
 ```yaml
@@ -48,6 +48,22 @@ In this mode:
 - The VPA admission controller creates and manages the webhook itself
 Important: You are responsible for creating the TLS secret before or after installing the chart. The admission controller will only create the `MutatingWebhookConfiguration` once the secret exists.
 If the secret is created after the Helm install, you must restart the admission controller pod to trigger webhook registration.
+
+### cert-manager managed
+```yaml
+admissionController:
+  registerWebhook: false
+  certGen:
+    enabled: false
+  certManager:
+    enabled: true
+```
+In this mode:
+- Helm creates the MutatingWebhookConfiguration
+- cert-manager issues and renews TLS certificates automatically
+- cert-manager's cainjector injects the CA into the webhook configuration
+
+By default, you must provide an existing `Issuer` or `ClusterIssuer` via `admissionController.certManager.issuerRef`. Alternatively, enable `admissionController.certManager.createSelfSignedIssuer.enabled: true` to let the chart create a namespaced self-signed issuer automatically.
 
 ## Custom Resource Definitions
 

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/NOTES.txt
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/NOTES.txt
@@ -29,6 +29,16 @@ Webhook Configuration:
    Mode: Helm-managed (recommended)
    - Webhook registered by: Helm (MutatingWebhookConfiguration)
    - Certificates managed by: certgen job
+{{- else if .Values.admissionController.certManager.enabled }}
+   Mode: cert-manager
+   - Webhook registered by: Helm (MutatingWebhookConfiguration)
+   - Certificates managed by: cert-manager (automatic renewal)
+   - CA injected by: cert-manager cainjector
+{{- if or .Values.admissionController.volumes .Values.admissionController.volumeMounts }}
+
+   ⚠️  NOTE: admissionController.volumes and admissionController.volumeMounts are
+   managed by the chart in cert-manager mode. Any custom values set there have no effect.
+{{- end }}
 {{- else if .Values.admissionController.tls.create }}
    Mode: Helm-managed with Helm-generated certificates
    - Webhook registered by: Helm (MutatingWebhookConfiguration)
@@ -45,6 +55,7 @@ Webhook Configuration:
    - admissionController.certGen.enabled: true (recommended)
    - admissionController.tls.create: true
    - admissionController.registerWebhook: true (application-managed)
+   - admissionController.certManager.enabled: true 
 {{- end }}
 {{- end }}
 

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
@@ -82,6 +82,25 @@ admissionController webhook
 {{- end }}
 
 {{/*
+admissionController certManager
+*/}}
+{{- define "vertical-pod-autoscaler.admissionController.certManager.certName" -}}
+{{ include "vertical-pod-autoscaler.fullname" . }}-webhook-cert
+{{- end }}
+
+{{- define "vertical-pod-autoscaler.admissionController.certManager.issuerName" -}}
+{{ include "vertical-pod-autoscaler.fullname" . }}-selfsigned
+{{- end }}
+
+{{- define "vertical-pod-autoscaler.admissionController.certManager.caName" -}}
+{{ include "vertical-pod-autoscaler.fullname" . }}-webhook-ca
+{{- end }}
+
+{{- define "vertical-pod-autoscaler.admissionController.certManager.caIssuerName" -}}
+{{ include "vertical-pod-autoscaler.fullname" . }}-ca
+{{- end }}
+
+{{/*
 admissionController certGen
 */}}
 {{- define "vertical-pod-autoscaler.admissionController.certGen.fullname" -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certmanager.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-certmanager.yaml
@@ -1,0 +1,101 @@
+{{- if and .Values.admissionController.enabled .Values.admissionController.certManager.enabled -}}
+{{- $algorithm := .Values.admissionController.certManager.privateKey.algorithm | default "RSA" }}
+{{- $size := int (.Values.admissionController.certManager.privateKey.size | default 2048) }}
+{{- if .Values.admissionController.certManager.createSelfSignedIssuer.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "vertical-pod-autoscaler.admissionController.certManager.issuerName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
+  {{- with .Values.admissionController.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "vertical-pod-autoscaler.admissionController.certManager.caName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
+  {{- with .Values.admissionController.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  isCA: true
+  secretName: {{ include "vertical-pod-autoscaler.admissionController.certManager.caName" . }}
+  commonName: {{ include "vertical-pod-autoscaler.admissionController.certManager.caName" . }}
+  privateKey:
+    algorithm: {{ $algorithm }}
+    {{- if ne $algorithm "Ed25519" }}
+    size: {{ $size }}
+    {{- end }}
+  issuerRef:
+    name: {{ include "vertical-pod-autoscaler.admissionController.certManager.issuerName" . }}
+    kind: Issuer
+    group: cert-manager.io
+  duration: {{ .Values.admissionController.certManager.createSelfSignedIssuer.duration }}
+  renewBefore: {{ .Values.admissionController.certManager.createSelfSignedIssuer.renewBefore }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "vertical-pod-autoscaler.admissionController.certManager.caIssuerName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
+  {{- with .Values.admissionController.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ca:
+    secretName: {{ include "vertical-pod-autoscaler.admissionController.certManager.caName" . }}
+---
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "vertical-pod-autoscaler.admissionController.certManager.certName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
+  {{- with .Values.admissionController.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "vertical-pod-autoscaler.admissionController.tls.secretName" . }}
+  dnsNames:
+    - {{ .Values.admissionController.service.name }}
+    - {{ .Values.admissionController.service.name }}.{{ .Release.Namespace }}
+    - {{ .Values.admissionController.service.name }}.{{ .Release.Namespace }}.svc
+    - {{ .Values.admissionController.service.name }}.{{ .Release.Namespace }}.svc.cluster.local
+  privateKey:
+    algorithm: {{ $algorithm }}
+    {{- if ne $algorithm "Ed25519" }}
+    size: {{ $size }}
+    {{- end }}
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+  issuerRef:
+    {{- if .Values.admissionController.certManager.createSelfSignedIssuer.enabled }}
+    name: {{ include "vertical-pod-autoscaler.admissionController.certManager.caIssuerName" . }}
+    kind: Issuer
+    group: cert-manager.io
+    {{- else }}
+    name: {{ .Values.admissionController.certManager.issuerRef.name }}
+    kind: {{ .Values.admissionController.certManager.issuerRef.kind }}
+    group: {{ .Values.admissionController.certManager.issuerRef.group }}
+    {{- end }}
+  duration: {{ .Values.admissionController.certManager.duration }}
+  renewBefore: {{ .Values.admissionController.certManager.renewBefore }}
+{{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-deployment.yaml
@@ -1,6 +1,3 @@
-{{- if and .Values.admissionController.registerWebhook .Values.admissionController.certGen.enabled }}
-{{- fail "admissionController.registerWebhook and admissionController.certGen.enabled cannot both be true. Choose either application-managed webhook (registerWebhook: true) or Helm-managed webhook with certGen (certGen.enabled: true)." -}}
-{{- end -}}
 {{- if .Values.admissionController.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -85,6 +82,7 @@ spec:
             - --register-webhook=false
           {{- end }}
             - --webhook-service={{ .Values.admissionController.service.name }}
+            - --reload-cert=true
           {{- with .Values.admissionController.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -110,7 +108,13 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
           volumeMounts:
+            {{- if .Values.admissionController.certManager.enabled }}
+            - name: tls-certs
+              mountPath: /etc/tls-certs
+              readOnly: true
+            {{- else }}
             {{- toYaml .Values.admissionController.volumeMounts | nindent 12 }}
+            {{- end }}
           {{- with .Values.admissionController.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -120,5 +124,19 @@ spec:
             {{ toYaml . | nindent 12 | trim }}
           {{- end }}
       volumes:
+        {{- if .Values.admissionController.certManager.enabled }}
+        - name: tls-certs
+          secret:
+            defaultMode: 420
+            secretName: {{ include "vertical-pod-autoscaler.admissionController.tls.secretName" . }}
+            items:
+              - key: ca.crt
+                path: caCert.pem
+              - key: tls.crt
+                path: serverCert.pem
+              - key: tls.key
+                path: serverKey.pem
+        {{- else }}
         {{- toYaml .Values.admissionController.volumes | nindent 8 }}
+        {{- end }}
 {{- end -}}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-validations.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-validations.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.admissionController.enabled }}
+{{- if and .Values.admissionController.registerWebhook .Values.admissionController.certGen.enabled }}
+{{- fail "admissionController.registerWebhook and admissionController.certGen.enabled cannot both be true. Choose either application-managed webhook (registerWebhook: true) or Helm-managed webhook with certGen (certGen.enabled: true)." }}
+{{- end }}
+{{- if and .Values.admissionController.certManager.enabled .Values.admissionController.certGen.enabled }}
+{{- fail "admissionController.certManager.enabled and admissionController.certGen.enabled cannot both be true. Set admissionController.certGen.enabled: false to use cert-manager." }}
+{{- end }}
+{{- if and .Values.admissionController.certManager.enabled .Values.admissionController.registerWebhook }}
+{{- fail "admissionController.certManager.enabled and admissionController.registerWebhook cannot both be true. Set admissionController.registerWebhook: false when using cert-manager." }}
+{{- end }}
+{{- if and .Values.admissionController.certManager.enabled .Values.admissionController.tls.create }}
+{{- fail "admissionController.certManager.enabled and admissionController.tls.create cannot both be true. Set admissionController.tls.create: false when using cert-manager." }}
+{{- end }}
+{{- if .Values.admissionController.certManager.enabled }}
+{{- range .Values.admissionController.extraArgs }}
+{{- if eq . "--reload-cert=false" }}
+{{- fail "admissionController.extraArgs contains --reload-cert=false which conflicts with certManager.enabled. cert-manager requires cert reloading to pick up renewed certificates." }}
+{{- end }}
+{{- end }}
+{{- if and (not .Values.admissionController.certManager.createSelfSignedIssuer.enabled) (empty .Values.admissionController.certManager.issuerRef.name) }}
+{{- fail "admissionController.certManager.issuerRef.name is required when admissionController.certManager.createSelfSignedIssuer.enabled is false. Set issuerRef.name to an existing Issuer/ClusterIssuer or enable createSelfSignedIssuer." }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-webhook.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller-webhook.yaml
@@ -1,19 +1,26 @@
-{{- if and .Values.admissionController.enabled .Values.admissionController.certGen.enabled }}
+{{- if and .Values.admissionController.enabled (or .Values.admissionController.certGen.enabled .Values.admissionController.certManager.enabled) }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.webhook.configName" . }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
+  {{- $annotations := dict }}
+  {{- if .Values.admissionController.certManager.enabled }}
+    {{- $_ := set $annotations "cert-manager.io/inject-ca-from" (printf "%s/%s" .Release.Namespace (include "vertical-pod-autoscaler.admissionController.certManager.certName" .)) }}
+  {{- end }}
   {{- with .Values.admissionController.mutatingWebhookConfiguration.annotations }}
+    {{- $annotations = merge $annotations . }}
+  {{- end }}
+  {{- if $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    # caBundle will be injected by the certgen patch job (post-install/post-upgrade hook)
+    # caBundle is injected by the certgen patch job (certGen mode) or by cert-manager cainjector (certManager mode)
     service:
       name: {{ .Values.admissionController.service.name }}
       namespace: {{ .Release.Namespace }}

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -136,6 +136,43 @@ admissionController:
     tolerations: []
     affinity: {}
 
+  certManager:
+    # admissionController.certManager.enabled -- If true, cert-manager manages the webhook certificate lifecycle.
+    # cert-manager must be installed in the cluster, see https://cert-manager.io/docs/installation.
+    # Mutually exclusive with certGen.enabled, registerWebhook, and tls.create.
+    enabled: false
+    # admissionController.certManager.createSelfSignedIssuer -- Optionally create a SelfSigned Issuer for CA generation.
+    # When enabled, a namespaced SelfSigned Issuer is created in the VPA namespace to issue the intermediate CA certificate,
+    # which in turn signs the webhook TLS certificate.
+    createSelfSignedIssuer:
+      enabled: false
+      # admissionController.certManager.createSelfSignedIssuer.duration -- Lifetime of the intermediate CA certificate.
+      duration: 8760h
+      # admissionController.certManager.createSelfSignedIssuer.renewBefore -- Time before expiry to renew the CA certificate.
+      renewBefore: 720h
+    # admissionController.certManager.issuerRef -- Reference to an existing issuer for signing the webhook TLS certificate.
+    # Required when createSelfSignedIssuer.enabled is false.
+    issuerRef:
+      # admissionController.certManager.issuerRef.name -- Name of the issuer.
+      name: ""
+      # admissionController.certManager.issuerRef.kind -- Kind of the issuer (ClusterIssuer or Issuer).
+      kind: ClusterIssuer
+      # admissionController.certManager.issuerRef.group -- API group of the issuer.
+      group: cert-manager.io
+
+    # admissionController.certManager.duration -- Lifetime of the webhook TLS certificate.
+    duration: 168h
+    # admissionController.certManager.renewBefore -- Time before expiry to renew the TLS certificate.
+    renewBefore: 24h
+
+    privateKey:
+      # admissionController.certManager.privateKey.algorithm -- Key algorithm for certificates (RSA, ECDSA, Ed25519).
+      algorithm: RSA
+      # admissionController.certManager.privateKey.size -- Key size for RSA or ECDSA. Ignored for Ed25519.
+      size: 2048
+    # admissionController.certManager.annotations -- Annotations to add to all cert-manager resources created by Chart.
+    annotations: {}
+
   mutatingWebhookConfiguration:
     # admissionController.mutatingWebhookConfiguration.annotations -- Additional annotations for the MutatingWebhookConfiguration
     annotations: {}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

This PR introduces cert-manager as a first-class option for managing webhook certs in the VPA Helm chart

Two modes are supported:
- **Self-signed**: the chart handles everything, bootstraping issuers & Cert  ([pattern](https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers))
- **normal issuer**: the users provides thier own Issuer.

Hard validations have been added in `/templates/admission-controller-validations.yaml` to prevent conflicting cert management configurations (e.g. `certGen.enabled` and `certManager.enabled` both true).

When cert-manager is enabled, `--reload-cert` is set on the admission controller so new certs and keys are automatically reloaded into the pod. With `registerWebhook=false`, as there is no CA patching, cert-manager's [cainjector](https://cert-manager.io/docs/concepts/ca-injector/)  handles injecting the CA bundle into the MutatingWebhookConfiguration.

#### Which issue(s) this PR fixes:
Fixes #9672

#### Special notes for your reviewer:

For Docs: Once the implementation is approved, I Could work on this.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add cert-manager support to the VPA Helm chart. Supports both a self-signed mode (chart manages the full CA chain) and a custom issuer mode where users provide their own Issuer/ClusterIssuer.
```

```docs

```
