### PR TITLE
Fix cronjob flake

### DIFF
--- a/vertical-pod-autoscaler/test/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/common.go
@@ -196,6 +196,23 @@ func waitForActiveJobs(c clientset.Interface, ns, cronJobName string, active int
 	})
 }
 
+func waitForCronJobPodsRunning(f *framework.Framework, replicas int32) error {
+	return wait.PollUntilContextTimeout(context.Background(), utils.PollInterval, utils.PollTimeout, true, func(ctx context.Context) (done bool, err error) {
+		podList, err := GetHamsterPods(f)
+		if err != nil {
+			framework.Logf("Error listing pods, retrying: %v", err)
+			return false, nil
+		}
+		podsRunning := int32(0)
+		for _, pod := range podList.Items {
+			if pod.Status.Phase == apiv1.PodRunning {
+				podsRunning++
+			}
+		}
+		return podsRunning >= replicas, nil
+	})
+}
+
 func createCronJob(c clientset.Interface, ns string, cronJob *batchv1.CronJob) (*batchv1.CronJob, error) {
 	return c.BatchV1().CronJobs(ns).Create(context.TODO(), cronJob, metav1.CreateOptions{})
 }
@@ -214,6 +231,8 @@ func SetupHamsterCronJob(f *framework.Framework, schedule, cpu, memory string, r
 	cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = waitForActiveJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = waitForCronJobPodsRunning(f, replicas)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This add a step to wait for running pods, much like the other tests that get run from this codepath


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9647

#### Special notes for your reviewer:

I didn't put much effort into this, I asked AI to fix it. 
I also couldn't reproduce the error flake.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
