### PR TITLE
Fix Kamatera retry request bodies

### DIFF
--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_request.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_request.go
@@ -42,9 +42,11 @@ type ProviderConfig struct {
 }
 
 func request(ctx context.Context, provider ProviderConfig, method string, path string, body interface{}, numRetries int, secondsBetweenRetries int) (interface{}, error) {
-	buf := new(bytes.Buffer)
+	var bodyBytes []byte
 	if body != nil {
-		if err := json.NewEncoder(buf).Encode(body); err != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -53,12 +55,12 @@ func request(ctx context.Context, provider ProviderConfig, method string, path s
 	var result interface{}
 	var err error
 	for attempt := 0; attempt < numRetries; attempt++ {
-		klog.V(2).Infof("kamatera request: %s %s %s", method, url, buf.String())
+		klog.V(2).Infof("kamatera request: %s %s %s", method, url, string(bodyBytes))
 		if attempt > 0 {
 			klog.V(2).Infof("kamatera request retry %d", attempt)
 			time.Sleep(time.Duration(secondsBetweenRetries<<attempt) * time.Second)
 		}
-		req, e := http.NewRequestWithContext(ctx, method, fmt.Sprintf("%s/%s", provider.ApiUrl, path), buf)
+		req, e := http.NewRequestWithContext(ctx, method, fmt.Sprintf("%s/%s", provider.ApiUrl, path), bytes.NewReader(bodyBytes))
 		if e != nil {
 			err = e
 			continue
@@ -72,18 +74,23 @@ func request(ctx context.Context, provider ProviderConfig, method string, path s
 			err = e
 			continue
 		}
-		defer res.Body.Close()
-		e = json.NewDecoder(res.Body).Decode(&result)
-		if e != nil {
-			if res.StatusCode != 200 {
-				err = fmt.Errorf("bad status code from Kamatera API: %d", res.StatusCode)
-			} else {
-				err = fmt.Errorf("invalid response from Kamatera API: %+v", result)
+
+		err = func() error {
+			defer res.Body.Close()
+
+			e = json.NewDecoder(res.Body).Decode(&result)
+			if e != nil {
+				if res.StatusCode != 200 {
+					return fmt.Errorf("bad status code from Kamatera API: %d", res.StatusCode)
+				}
+				return fmt.Errorf("invalid response from Kamatera API: %+v", result)
 			}
-			continue
-		}
-		if res.StatusCode != 200 {
-			err = fmt.Errorf("error response from Kamatera API (%d): %+v", res.StatusCode, result)
+			if res.StatusCode != 200 {
+				return fmt.Errorf("error response from Kamatera API (%d): %+v", res.StatusCode, result)
+			}
+			return nil
+		}()
+		if err != nil {
 			continue
 		}
 		break

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_request_test.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_request_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kamatera
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequest_ShouldReuseBodyIfRetryingPost(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu            sync.Mutex
+		requestBodies []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			return
+		}
+
+		mu.Lock()
+		requestBodies = append(requestBodies, string(body))
+		attempt := len(requestBodies)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if attempt == 1 {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			_, _ = w.Write([]byte(`{"message":"retry"}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	_, err := request(
+		context.Background(),
+		ProviderConfig{ApiUrl: server.URL, ApiClientID: mockKamateraClientId, ApiSecret: mockKamateraSecret},
+		"POST",
+		"/service/server/terminate",
+		KamateraServerTerminatePostRequest{ServerName: "test-server", Force: true},
+		2,
+		0,
+	)
+
+	require.NoError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, requestBodies, 2)
+	assert.NotEmpty(t, requestBodies[0])
+	assert.Equal(t, requestBodies[0], requestBodies[1])
+}


### PR DESCRIPTION
## Summary
- recreate the Kamatera request body reader on every retry instead of reusing a consumed buffer
- close each response body within the retry loop
- add a regression test covering retried POST requests

## Why
The retry path added in `3c187264c` reuses the same request body reader across attempts. After the first `Do`, later retries can send an empty body. The same loop also defers `res.Body.Close()`, which keeps response bodies open until the helper returns.

## Impact
Kamatera POST retries now resend the original JSON payload for calls like poweroff, terminate, and server tags.

Fixes #9688

## Testing
- `go test ./cloudprovider/kamatera`
