### PR TITLE
vpa/admission-controller: limit request payload size to 5MB

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
@@ -19,6 +19,7 @@ package logic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,6 +46,11 @@ const (
 	autoDeprecationWarning = `UpdateMode "Auto" is deprecated and will be removed in a future API version. ` +
 		`Use explicit update modes like "Recreate", "Initial", or "InPlaceOrRecreate" instead. ` +
 		`See https://github.com/kubernetes/autoscaler/issues/8424 for more details.`
+	// maxAdmissionPayloadSize limits the size of the incoming admission request payload
+	// to prevent OOM (Denial of Service) attacks. A typical AdmissionReview is well under 100KB,
+	// and etcd limits objects to 1.5MB. With updates including both the new and old object,
+	// 5MB is an extremely safe upper bound that leaves a comfortable margin.
+	maxAdmissionPayloadSize = 1024 * 1024 * 5 // 5MB
 )
 
 // AdmissionServer is an admission webhook server that modifies pod resources request based on VPA recommendation
@@ -190,18 +196,28 @@ func (s *AdmissionServer) Serve(w http.ResponseWriter, r *http.Request) {
 	defer executionTimer.ObserveTotal()
 	admissionLatency := metrics_admission.NewAdmissionLatency()
 
-	var body []byte
-	if r.Body != nil {
-		if data, err := io.ReadAll(r.Body); err == nil {
-			body = data
-		}
-	}
 	// verify the content type is accurate
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
 		klog.Errorf("contentType=%s, expect application/json", contentType)
 		admissionLatency.Observe(metrics_admission.Error, metrics_admission.Unknown)
 		return
+	}
+
+	var body []byte
+	if r.Body != nil {
+		if data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxAdmissionPayloadSize)); err == nil {
+			body = data
+		} else {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				klog.ErrorS(err, "Admission request body exceeds size limit", "limit", maxAdmissionPayloadSize)
+				http.Error(w, "request payload too large", http.StatusRequestEntityTooLarge)
+				admissionLatency.Observe(metrics_admission.Error, metrics_admission.Unknown)
+				return
+			}
+			klog.ErrorS(err, "Failed to read admission request body")
+		}
 	}
 	executionTimer.ObserveStep("read_request")
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource"
+)
+
+// InfiniteReader simulates an endless stream of bytes to trigger an oversized request error.
+type InfiniteReader struct{}
+
+func (r *InfiniteReader) Read(p []byte) (n int, err error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+func (r *InfiniteReader) Close() error {
+	return nil
+}
+
+// FailureReader simulates a read failure that is not an oversized error.
+type FailureReader struct{}
+
+func (r *FailureReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("simulated read error")
+}
+
+func (r *FailureReader) Close() error {
+	return nil
+}
+
+func TestServePayloadLimit(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestBody    *bytes.Buffer
+		isEndless      bool
+		isFailure      bool
+		expectedStatus int
+	}{
+		{
+			name:           "Small valid JSON payload",
+			requestBody:    bytes.NewBufferString(`{"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","request":{"uid":"123","resource":{"group":"autoscaling.k8s.io","version":"v1","resource":"verticalpodautoscalers"},"requestKind":{"group":"autoscaling.k8s.io","version":"v1","kind":"VerticalPodAutoscaler"}}}`),
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "Oversized payload exceeding limit",
+			isEndless:      true,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+		},
+		{
+			name:           "General read error",
+			isFailure:      true,
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &AdmissionServer{
+				resourceHandlers: make(map[metav1.GroupResource]resource.Handler), // Unused in basic HTTP parse step
+			}
+
+			var req *http.Request
+			if tc.isEndless {
+				req = httptest.NewRequest(http.MethodPost, "/admit", &InfiniteReader{})
+			} else if tc.isFailure {
+				req = httptest.NewRequest(http.MethodPost, "/admit", &FailureReader{})
+			} else {
+				req = httptest.NewRequest(http.MethodPost, "/admit", tc.requestBody)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			server.Serve(w, req)
+
+			assert.Equal(t, tc.expectedStatus, w.Code)
+
+			if tc.expectedStatus == http.StatusOK {
+				var ar admissionv1.AdmissionReview
+				if err := json.Unmarshal(w.Body.Bytes(), &ar); assert.NoError(t, err) {
+					if assert.NotNil(t, ar.Response) {
+						assert.True(t, ar.Response.Allowed)
+						if tc.isFailure {
+							assert.Empty(t, ar.Response.UID)
+						} else {
+							assert.Equal(t, "123", string(ar.Response.UID))
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a 5MB payload size cap using  on the HTTP request body in the VPA Admission Controller webhook. Return 413 when request exceeds the limit.

This prevents arbitrary/maliciously large payload requests from exhausting memory resources and triggering OOM crashes. The webhook continues to fail open on other reading or unmarshaling errors.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR adds a 5MB payload size limit to the Vertical Pod Autoscaler (VPA) admission controller webhook server.

Prior to this change, the webhook handler used io.ReadAll(r.Body) to read the incoming HTTP request body into memory without bounds checking. A maliciously large payload (e.g. an endless stream of data) sent to the webhook endpoint could consume all memory resources and trigger an OOM crash. Since the admission controller is a critical component for scheduling, its crash could lead to a DoS blocking all new pod creation in the cluster if configured to fail closed.

By wrapping r.Body with `http.MaxBytesReader`, we cap the maximum memory allocation during the read step. If the payload size exceeds the limit, we will return 413 code.

#### Special notes for your reviewer:
The 5MB limit was selected to comfortably accommodate valid massive Kubernetes update requests (which contain both the object and oldObject payloads, each up to etcd's default 1.5MB limit plus metadata overhead) while remaining well below standard container memory limits to eliminate OOM risk.

Unit tests have been added to server_test.go to cover both normal and oversized payload scenarios.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
VPA Admission Controller now limits incoming request payload sizes to 5MB and returns HTTP 413 (Payload Too Large) when exceeded, preventing potential OOM crashes.
```


