### PR TITLE
vpa/admission-controller: escape extended resource names in JSONPatch paths

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/util.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/util.go
@@ -39,7 +39,7 @@ func GetAddEmptyAnnotationsPatch() resource_admission.PatchRecord {
 func GetAddAnnotationPatch(annotationName, annotationValue string) resource_admission.PatchRecord {
 	return resource_admission.PatchRecord{
 		Op:    "add",
-		Path:  fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(annotationName, "/", "~1")),
+		Path:  fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchPath(annotationName)),
 		Value: annotationValue,
 	}
 }
@@ -48,15 +48,22 @@ func GetAddAnnotationPatch(annotationName, annotationValue string) resource_admi
 func GetRemoveAnnotationPatch(annotationName string) resource_admission.PatchRecord {
 	return resource_admission.PatchRecord{
 		Op:   "remove",
-		Path: fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(annotationName, "/", "~1")),
+		Path: fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchPath(annotationName)),
 	}
+}
+
+// escapeJSONPatchPath escapes special JSONPatch path characters (~ and /)
+// inside path segments according to RFC 6901 / RFC 6902.
+func escapeJSONPatchPath(segment string) string {
+	escaped := strings.ReplaceAll(segment, "~", "~0")
+	return strings.ReplaceAll(escaped, "/", "~1")
 }
 
 // GetAddResourceRequirementValuePatch returns a patch record to add resource requirements to a container.
 func GetAddResourceRequirementValuePatch(i int, kind string, resource corev1.ResourceName, quantity resource.Quantity) resource_admission.PatchRecord {
 	return resource_admission.PatchRecord{
 		Op:    "add",
-		Path:  fmt.Sprintf("/spec/containers/%d/resources/%s/%s", i, kind, resource),
+		Path:  fmt.Sprintf("/spec/containers/%d/resources/%s/%s", i, kind, escapeJSONPatchPath(string(resource))),
 		Value: quantity.String()}
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/util_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/util_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetAddResourceRequirementValuePatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		index         int
+		kind          string
+		resource      corev1.ResourceName
+		quantity      resource.Quantity
+		expectedPath  string
+		expectedValue string
+	}{
+		{
+			name:          "Standard resource cpu",
+			index:         0,
+			kind:          "requests",
+			resource:      corev1.ResourceCPU,
+			quantity:      resource.MustParse("500m"),
+			expectedPath:  "/spec/containers/0/resources/requests/cpu",
+			expectedValue: "500m",
+		},
+		{
+			name:          "Standard resource memory",
+			index:         1,
+			kind:          "limits",
+			resource:      corev1.ResourceMemory,
+			quantity:      resource.MustParse("1Gi"),
+			expectedPath:  "/spec/containers/1/resources/limits/memory",
+			expectedValue: "1Gi",
+		},
+		{
+			name:          "Extended resource with slash",
+			index:         2,
+			kind:          "limits",
+			resource:      corev1.ResourceName("nvidia.com/gpu"),
+			quantity:      resource.MustParse("1"),
+			expectedPath:  "/spec/containers/2/resources/limits/nvidia.com~1gpu",
+			expectedValue: "1",
+		},
+		{
+			name:          "Extended resource with tilde and slash",
+			index:         0,
+			kind:          "requests",
+			resource:      corev1.ResourceName("custom~domain.com/resource/name"),
+			quantity:      resource.MustParse("10"),
+			expectedPath:  "/spec/containers/0/resources/requests/custom~0domain.com~1resource~1name",
+			expectedValue: "10",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			patch := GetAddResourceRequirementValuePatch(tc.index, tc.kind, tc.resource, tc.quantity)
+			assert.Equal(t, "add", patch.Op)
+			assert.Equal(t, tc.expectedPath, patch.Path)
+			assert.Equal(t, tc.expectedValue, patch.Value)
+		})
+	}
+}
+
+func TestGetAddAnnotationPatch(t *testing.T) {
+	tests := []struct {
+		name           string
+		annotationName string
+		value          string
+		expectedPath   string
+	}{
+		{
+			name:           "Simple annotation",
+			annotationName: "vpaObservedContainers",
+			value:          "container1",
+			expectedPath:   "/metadata/annotations/vpaObservedContainers",
+		},
+		{
+			name:           "Annotation with slash",
+			annotationName: "example.com/annotation",
+			value:          "value1",
+			expectedPath:   "/metadata/annotations/example.com~1annotation",
+		},
+		{
+			name:           "Annotation with tilde and slash",
+			annotationName: "custom~domain.com/annotation/name",
+			value:          "value2",
+			expectedPath:   "/metadata/annotations/custom~0domain.com~1annotation~1name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			patch := GetAddAnnotationPatch(tc.annotationName, tc.value)
+			assert.Equal(t, "add", patch.Op)
+			assert.Equal(t, tc.expectedPath, patch.Path)
+			assert.Equal(t, tc.value, patch.Value)
+		})
+	}
+}
+
+func TestGetRemoveAnnotationPatch(t *testing.T) {
+	tests := []struct {
+		name           string
+		annotationName string
+		expectedPath   string
+	}{
+		{
+			name:           "Simple annotation",
+			annotationName: "vpaObservedContainers",
+			expectedPath:   "/metadata/annotations/vpaObservedContainers",
+		},
+		{
+			name:           "Annotation with slash",
+			annotationName: "example.com/annotation",
+			expectedPath:   "/metadata/annotations/example.com~1annotation",
+		},
+		{
+			name:           "Annotation with tilde and slash",
+			annotationName: "custom~domain.com/annotation/name",
+			expectedPath:   "/metadata/annotations/custom~0domain.com~1annotation~1name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			patch := GetRemoveAnnotationPatch(tc.annotationName)
+			assert.Equal(t, "remove", patch.Op)
+			assert.Equal(t, tc.expectedPath, patch.Path)
+			assert.Nil(t, patch.Value)
+		})
+	}
+}


### PR DESCRIPTION
Escape special characters ( ~ to ~0, / to ~1) inside extended resource names when generating JSONPatch paths in .

This complies with JSONPointer (RFC 6901) and JSONPatch (RFC 6902) specifications, preventing patch-application failures in the API server (which otherwise lead to VPA policy bypasses on workloads requesting extended resources such as GPUs).

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR resolves a JSONPatch format non-compliance bug in the Vertical Pod Autoscaler (VPA) admission controller.

According to the JSONPointer (RFC 6901) and JSONPatch (RFC 6902) specifications, slash (/) and tilde (~) characters inside path keys must be escaped (/ becomes ~1, and ~ becomes ~0). The VPA admission controller constructs mutation patches by generating paths like /spec/containers/<index>/resources/<kind>/<resource_name>. However, custom and extended resources (e.g. nvidia.com/gpu) naturally contain slashes in their names.

Previously, the controller formatted resource names directly without escaping, generating paths like /spec/containers/0/resources/requests/nvidia.com/gpu. The Kubernetes API Server's JSONPatch parser failed to process these unescaped paths, throwing errors. When the webhook runs with its default FailurePolicy: Ignore, these patch failures fail silently, allowing pods requesting extended resources to be admitted completely bypassing intended VPA resource policies (such as maxAllowed caps).

This PR adds an escapeJSONPatchPath helper that correctly escapes ~ and / in resource names before formatting the JSONPatch Path inside GetAddResourceRequirementValuePatch.


#### Special notes for your reviewer:
- Standard resources (cpu, memory) do not contain special characters and remain fully unaffected.
- New unit tests have been added to util_test.go covering both standard resource formatting and custom/extended resources containing / and ~ to ensure perfect escaping.
- Boilerplate and import group structures are fully compliant with the modern Kubernetes lint rules.

#### Does this PR introduce a user-facing change?
NONE