### PR TITLE
clusterapi: fall back to replica decrement for MachinePool nodes without matching Machine

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -110,7 +110,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 		return err
 	}
 
-	// if we are at minSize already we wail early.
+	// if we are at minSize already we fail early.
 	if replicas <= ng.MinSize() {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
@@ -119,7 +119,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	for _, node := range nodes {
 		actualNodeGroup, err := ng.machineController.nodeGroupForNode(node)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		if actualNodeGroup == nil {
@@ -135,18 +135,62 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	// < minSize, then the request to delete that many nodes is bogus
 	// and we fail fast.
 	if replicas-len(nodes) < ng.MinSize() {
+<<<<<<< HEAD
 		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are %d, minSize is %d ", len(nodes), ng.Id(), replicas, ng.MinSize())
+=======
+		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are %d, minSize is %d", len(nodes), ng.Id(), replicas, ng.MinSize())
+>>>>>>> 6ae1e394c (clusterapi: fall back to replica decrement for MachinePool nodes without matching Machine)
 	}
 
-	// Step 3: annotate the corresponding machine that it is a
-	// suitable candidate for deletion and drop the replica count
-	// by 1. Fail fast on any error.
+	// Step 3: when a backing Machine exists, mark it as a deletion candidate
+	// and decrease the replica count by 1. For MachinePool-backed node groups,
+	// if no per-node Machine can be resolved, fall back to replica decrement
+	// after verifying the node belongs to the MachinePool providerID list.
 	for _, node := range nodes {
+		nodeGroup, err := ng.machineController.nodeGroupForNode(node)
+		if err != nil {
+			return err
+		}
+
 		machine, err := ng.machineController.findMachineByProviderID(normalizedProviderString(node.Spec.ProviderID))
 		if err != nil {
 			return err
 		}
+
 		if machine == nil {
+			// Fallback for MachinePool-based providers where no per-node Machine
+			// objects exist. In that case, allow scale-down by decreasing replicas,
+			// but only if the node providerID is explicitly present in the
+			// MachinePool providerIDList.
+			if nodeGroup.scalableResource.Kind() == machinePoolKind {
+				providerIDs, err := nodeGroup.scalableResource.ProviderIDs()
+				if err != nil {
+					return err
+				}
+
+				nodeProviderID := normalizedProviderString(node.Spec.ProviderID)
+				found := false
+				for _, id := range providerIDs {
+					if normalizedProviderString(id) == nodeProviderID {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					return fmt.Errorf("node %q is not present in MachinePool providerIDList for nodegroup %q", node.Spec.ProviderID, nodeGroup.Id())
+				}
+
+				klog.Warningf("No Machine found for node %q in MachinePool %q, falling back to replica decrement only", node.Spec.ProviderID, nodeGroup.Id())
+
+				if err := nodeGroup.scalableResource.SetSize(replicas - 1); err != nil {
+					return err
+				}
+
+				replicas--
+				continue
+			}
+
 			return fmt.Errorf("unknown machine for node %q", node.Spec.ProviderID)
 		}
 
@@ -157,16 +201,11 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 			continue
 		}
 
-		nodeGroup, err := ng.machineController.nodeGroupForNode(node)
-		if err != nil {
-			return err
-		}
-
 		if err := nodeGroup.scalableResource.MarkMachineForDeletion(machine); err != nil {
 			return err
 		}
 
-		if err := ng.scalableResource.SetSize(replicas - 1); err != nil {
+		if err := nodeGroup.scalableResource.SetSize(replicas - 1); err != nil {
 			_ = nodeGroup.scalableResource.UnmarkMachineForDeletion(machine)
 			return err
 		}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -136,11 +136,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	// < minSize, then the request to delete that many nodes is bogus
 	// and we fail fast.
 	if replicas-len(nodes) < ng.MinSize() {
-<<<<<<< HEAD
 		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are %d, minSize is %d ", len(nodes), ng.Id(), replicas, ng.MinSize())
-=======
-		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are %d, minSize is %d", len(nodes), ng.Id(), replicas, ng.MinSize())
->>>>>>> 6ae1e394c (clusterapi: fall back to replica decrement for MachinePool nodes without matching Machine)
 	}
 
 	// Step 3: when a backing Machine exists, mark it as a deletion candidate

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -157,7 +157,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 		}
 
 		machine, err := ng.machineController.findMachineByProviderID(normalizedProviderString(node.Spec.ProviderID))
-		if err != nil {
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return err
 		}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -136,7 +136,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	// < minSize, then the request to delete that many nodes is bogus
 	// and we fail fast.
 	if replicas-len(nodes) < ng.MinSize() {
-		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are %d, minSize is %d ", len(nodes), ng.Id(), replicas, ng.MinSize())
+		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are %d, minSize is %d", len(nodes), ng.Id(), replicas, ng.MinSize())
 	}
 
 	// Step 3: when a backing Machine exists, mark it as a deletion candidate

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
@@ -119,10 +120,12 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	for _, node := range nodes {
 		actualNodeGroup, err := ng.machineController.nodeGroupForNode(node)
 		if err != nil {
-			klog.Warningf("Failed to find node group for node %q, skipping verification: %v", node.Spec.ProviderID, err)
-			continue
+			if k8serrors.IsNotFound(err) {
+				klog.Warningf("Node group not found for node %q, skipping verification: %v", node.Spec.ProviderID, err)
+				continue
+			}
+			return err
 		}
-
 		if actualNodeGroup == nil {
 			return fmt.Errorf("no node group found for node %q", node.Spec.ProviderID)
 		}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -149,8 +149,11 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	for _, node := range nodes {
 		nodeGroup, err := ng.machineController.nodeGroupForNode(node)
 		if err != nil {
-			klog.Warningf("Failed to find node group for node %q, skipping deletion: %v", node.Spec.ProviderID, err)
-			continue
+			if k8serrors.IsNotFound(err) {
+				klog.Warningf("Node group not found for node %q, skipping deletion: %v", node.Spec.ProviderID, err)
+				continue
+			}
+			return err
 		}
 
 		machine, err := ng.machineController.findMachineByProviderID(normalizedProviderString(node.Spec.ProviderID))

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -119,7 +119,8 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	for _, node := range nodes {
 		actualNodeGroup, err := ng.machineController.nodeGroupForNode(node)
 		if err != nil {
-			return err
+			klog.Warningf("Failed to find node group for node %q, skipping verification: %v", node.Spec.ProviderID, err)
+			continue
 		}
 
 		if actualNodeGroup == nil {
@@ -149,7 +150,8 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	for _, node := range nodes {
 		nodeGroup, err := ng.machineController.nodeGroupForNode(node)
 		if err != nil {
-			return err
+			klog.Warningf("Failed to find node group for node %q, skipping deletion: %v", node.Spec.ProviderID, err)
+			continue
 		}
 
 		machine, err := ng.machineController.findMachineByProviderID(normalizedProviderString(node.Spec.ProviderID))

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -2210,6 +2210,250 @@ func TestNodeGroupNodesInstancesStatus(t *testing.T) {
 	})
 }
 
+func TestNodeGroupMachinePoolDeleteNodes(t *testing.T) {
+	type testCase struct {
+		description         string
+		nodeCount           int
+		nodesToDelete       int
+		expectedError       bool
+		errorMsg            string
+		useUnknownNode      bool
+		emptyProviderIDList bool
+	}
+
+	testCases := []testCase{
+		{
+			// Happy path: node providerID is found in MachinePool providerIDList
+			description:   "happy path: node providerID found in MachinePool providerIDList, scale-down allowed",
+			nodeCount:     3,
+			nodesToDelete: 1,
+			expectedError: false,
+		},
+		{
+			// Error case: node providerID NOT found in MachinePool providerIDList
+			description:    "error: node providerID not found in MachinePool providerIDList, scale-down rejected",
+			nodeCount:      3,
+			nodesToDelete:  1,
+			expectedError:  true,
+			errorMsg:       "no node group found for node",
+			useUnknownNode: true,
+		},
+		{
+			// Edge case: empty providerIDList
+			description:   "edge case: MachinePool has empty providerIDList, scale-down rejected",
+			nodeCount:     0,
+			nodesToDelete: 1,
+			expectedError: true,
+			errorMsg:      "min size reached",
+		},
+		{
+			description:         "error: node providerID known to controller but not in MachinePool providerIDList",
+			nodeCount:           3,
+			nodesToDelete:       1,
+			expectedError:       true,
+			errorMsg:            "no node group found for node",
+			emptyProviderIDList: true,
+		},
+	}
+
+	annotations := map[string]string{
+		nodeGroupMinSizeAnnotationKey: "1",
+		nodeGroupMaxSizeAnnotationKey: "10",
+	}
+	capacity := map[string]string{
+		"cpu":    "2",
+		"memory": "4Gi",
+	}
+	t.Run("MachinePool", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.description, func(t *testing.T) {
+				testConfig := NewTestConfigBuilder().
+					ForMachinePool().
+					WithNodeCount(tc.nodeCount).
+					WithAnnotations(annotations).
+					WithCapacity(capacity).
+					Build()
+
+				controller := NewTestMachineController(t)
+				defer controller.Stop()
+				controller.AddTestConfigs(testConfig)
+
+				if tc.emptyProviderIDList {
+					updatedPool := testConfig.machinePool.DeepCopy()
+					unstructured.RemoveNestedField(updatedPool.Object, "spec", "providerIDList")
+					if err := controller.machinePoolInformer.Informer().GetStore().Update(updatedPool); err != nil {
+						t.Fatalf("failed to update machinePool in store: %v", err)
+					}
+					for i := range testConfig.machines {
+						if err := controller.DeleteResource(
+							controller.machineInformer,
+							controller.machineResource,
+							testConfig.machines[i],
+						); err != nil {
+							t.Fatalf("failed to delete machine from store: %v", err)
+						}
+					}
+				}
+
+				nodegroups, err := controller.nodeGroups()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if l := len(nodegroups); l != 1 {
+					t.Fatalf("expected 1 nodegroup, got %d", l)
+				}
+
+				ng := nodegroups[0].(*nodegroup)
+
+				var nodesToDelete []*corev1.Node
+				if !tc.useUnknownNode && !tc.emptyProviderIDList && tc.nodesToDelete > 0 && len(testConfig.nodes) > 0 {
+					nodesToDelete = testConfig.nodes[:tc.nodesToDelete]
+				} else {
+					// Node not belonging to this MachinePool
+					nodesToDelete = []*corev1.Node{
+						{
+							Spec: corev1.NodeSpec{
+								ProviderID: "azure:///subscriptions/unknown/virtualMachineScaleSets/unknown/virtualMachines/0",
+							},
+						},
+					}
+				}
+
+				err = ng.DeleteNodes(nodesToDelete)
+				if tc.expectedError {
+					if err == nil {
+						t.Fatal("expected an error but got none")
+					}
+					if tc.errorMsg != "" && !strings.Contains(err.Error(), tc.errorMsg) {
+						t.Errorf("expected error to contain %q, got %q", tc.errorMsg, err.Error())
+					}
+				} else {
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+				}
+			})
+		}
+	})
+}
+
+func TestNodeGroupMachinePoolProviderIDList(t *testing.T) {
+	type testCase struct {
+		description     string
+		nodeProviderID  string
+		poolProviderIDs []string
+		expectAllowed   bool
+	}
+
+	testCases := []testCase{
+		{
+			description:    "happy path: providerID found in list",
+			nodeProviderID: "azure:///subscriptions/sub1/virtualMachineScaleSets/vmss1/virtualMachines/0",
+			poolProviderIDs: []string{
+				"azure:///subscriptions/sub1/virtualMachineScaleSets/vmss1/virtualMachines/0",
+				"azure:///subscriptions/sub1/virtualMachineScaleSets/vmss1/virtualMachines/1",
+				"azure:///subscriptions/sub1/virtualMachineScaleSets/vmss1/virtualMachines/2",
+			},
+			expectAllowed: true,
+		},
+		{
+			description:    "error: providerID not found in list",
+			nodeProviderID: "azure:///subscriptions/sub1/virtualMachineScaleSets/vmss1/virtualMachines/99",
+			poolProviderIDs: []string{
+				"azure:///subscriptions/sub1/virtualMachineScaleSets/vmss1/virtualMachines/0",
+				"azure:///subscriptions/sub1/virtualMachineScaleSets/vmss1/virtualMachines/1",
+			},
+			expectAllowed: false,
+		},
+		{
+			description:     "edge case: empty providerIDList",
+			nodeProviderID:  "azure:///subscriptions/sub1/virtualMachineScaleSets/vmss1/virtualMachines/0",
+			poolProviderIDs: []string{},
+			expectAllowed:   false,
+		},
+		{
+			description:    "edge case: multiple MachinePools, only one matching",
+			nodeProviderID: "azure:///subscriptions/sub1/virtualMachineScaleSets/vmss2/virtualMachines/0",
+			poolProviderIDs: []string{
+				"azure:///subscriptions/sub1/virtualMachineScaleSets/vmss1/virtualMachines/0",
+				"azure:///subscriptions/sub1/virtualMachineScaleSets/vmss2/virtualMachines/0",
+			},
+			expectAllowed: true,
+		},
+	}
+
+	annotations := map[string]string{
+		nodeGroupMinSizeAnnotationKey: "1",
+		nodeGroupMaxSizeAnnotationKey: "10",
+	}
+	capacity := map[string]string{
+		"cpu":    "2",
+		"memory": "4Gi",
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			testConfig := NewTestConfigBuilder().
+				ForMachinePool().
+				WithNodeCount(len(tc.poolProviderIDs)).
+				WithAnnotations(annotations).
+				WithCapacity(capacity).
+				Build()
+
+			controller := NewTestMachineController(t)
+			defer controller.Stop()
+			controller.AddTestConfigs(testConfig)
+
+			if len(tc.poolProviderIDs) > 0 {
+				rawIDs := make([]interface{}, len(tc.poolProviderIDs))
+				for i, id := range tc.poolProviderIDs {
+					rawIDs[i] = id
+				}
+				if err := unstructured.SetNestedSlice(
+					testConfig.machinePool.Object,
+					rawIDs,
+					"spec", "providerIDList",
+				); err != nil {
+					t.Fatalf("failed to set providerIDList: %v", err)
+				}
+				controller.UpdateResource(
+					controller.machinePoolInformer,
+					controller.machinePoolResource,
+					testConfig.machinePool,
+				)
+			}
+
+			nodegroups, err := controller.nodeGroups()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if l := len(nodegroups); l != 1 {
+				t.Fatalf("expected 1 nodegroup, got %d", l)
+			}
+
+			ng := nodegroups[0].(*nodegroup)
+
+			node := &corev1.Node{
+				Spec: corev1.NodeSpec{
+					ProviderID: tc.nodeProviderID,
+				},
+			}
+
+			err = ng.DeleteNodes([]*corev1.Node{node})
+			if tc.expectAllowed {
+				if err != nil {
+					t.Fatalf("expected scale-down to be allowed, got error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("expected scale-down to be rejected, but got no error")
+				}
+			}
+		})
+	}
+}
+
 func validateCSIDrivers(t *testing.T, expectedDrivers []storagev1.CSINodeDriver, gotDrivers []storagev1.CSINodeDriver) {
 	t.Helper()
 	for _, gotDriver := range gotDrivers {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_test_framework.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_test_framework.go
@@ -50,6 +50,7 @@ type scalableTestType string
 const (
 	machineSetType        scalableTestType = "MachineSet"
 	machineDeploymentType scalableTestType = "MachineDeployment"
+	machinePoolType       scalableTestType = "MachinePool"
 )
 
 type testConfigBuilder struct {
@@ -83,6 +84,7 @@ func (b *testConfigBuilder) Build() *TestConfig {
 		panic("scalable API type must be specified")
 	}
 	isMachineDeployment := b.scalableType == machineDeploymentType
+	isMachinePool := b.scalableType == machinePoolType
 	configCount := 1
 
 	return createTestConfigs(
@@ -93,6 +95,7 @@ func (b *testConfigBuilder) Build() *TestConfig {
 			configCount,
 			b.nodeCount,
 			isMachineDeployment,
+			isMachinePool,
 			b.annotations,
 			b.capacity,
 			b.nodeInfo,
@@ -107,6 +110,7 @@ func (b *testConfigBuilder) BuildMultiple(configCount int) []*TestConfig {
 		panic("scalable API type must be specified")
 	}
 	isMachineDeployment := b.scalableType == machineDeploymentType
+	isMachinePool := b.scalableType == machinePoolType
 
 	return createTestConfigs(
 		createTestSpecs(
@@ -116,6 +120,7 @@ func (b *testConfigBuilder) BuildMultiple(configCount int) []*TestConfig {
 			configCount,
 			b.nodeCount,
 			isMachineDeployment,
+			isMachinePool,
 			b.annotations,
 			b.capacity,
 			b.nodeInfo,
@@ -132,6 +137,11 @@ func (b *testConfigBuilder) ForMachineSet() *testConfigBuilder {
 
 func (b *testConfigBuilder) ForMachineDeployment() *testConfigBuilder {
 	b.scalableType = machineDeploymentType
+	return b
+}
+
+func (b *testConfigBuilder) ForMachinePool() *testConfigBuilder {
+	b.scalableType = machinePoolType
 	return b
 }
 
@@ -288,9 +298,9 @@ func createTestConfigs(specs ...TestSpec) []*TestConfig {
 			}
 		}
 
-		if !spec.rootIsMachineDeployment {
+		if !spec.rootIsMachineDeployment && !spec.rootIsMachinePool {
 			config.machineSet.SetAnnotations(spec.annotations)
-		} else {
+		} else if spec.rootIsMachineDeployment {
 			machineSetLabels["machineDeploymentName"] = spec.machineDeploymentName
 
 			machineDeploymentLabels := map[string]string{
@@ -356,16 +366,89 @@ func createTestConfigs(specs ...TestSpec) []*TestConfig {
 					panic(err)
 				}
 			}
-		}
-		config.machineSet.SetLabels(machineSetLabels)
-		if err := unstructured.SetNestedStringMap(config.machineSet.Object, machineSetLabels, "spec", "selector", "matchLabels"); err != nil {
-			panic(err)
+		} else if spec.rootIsMachinePool {
+			config.machinePool = &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       machinePoolKind,
+					"apiVersion": "cluster.x-k8s.io/v1beta1",
+					"metadata": map[string]interface{}{
+						"name":      spec.machinePoolName,
+						"namespace": spec.namespace,
+						"uid":       spec.machinePoolName,
+					},
+					"spec": map[string]interface{}{
+						"clusterName": spec.clusterName,
+						"replicas":    int64(spec.nodeCount),
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"infrastructureRef": map[string]interface{}{
+									"apiGroup": "infrastructure.cluster.x-k8s.io",
+									"kind":     machineTemplateKind,
+									"name":     "TestMachineTemplate",
+								},
+								"metadata": map[string]interface{}{
+									"labels": map[string]interface{}{},
+								},
+							},
+						},
+					},
+					"status": map[string]interface{}{},
+				},
+			}
+			config.machinePool.SetAnnotations(spec.annotations)
+
+			if spec.nodeCount > 0 {
+				providerIDs := make([]interface{}, spec.nodeCount)
+				for j := 0; j < spec.nodeCount; j++ {
+					providerIDs[j] = fmt.Sprintf("test:////%s-%s-nodeid-%d",
+						spec.namespace, spec.machinePoolName, j)
+				}
+				if err := unstructured.SetNestedSlice(
+					config.machinePool.Object,
+					providerIDs,
+					"spec", "providerIDList",
+				); err != nil {
+					panic(err)
+				}
+			}
+
+			if spec.managedLabels != nil {
+				if err := unstructured.SetNestedStringMap(config.machinePool.Object, spec.managedLabels, "spec", "template", "spec", "metadata", "labels"); err != nil {
+					panic(err)
+				}
+			}
+
+			if spec.specTaints != nil {
+				rawTaints := make([]interface{}, len(spec.specTaints))
+				for i, t := range spec.specTaints {
+					rawTaints[i] = t
+				}
+				if err := unstructured.SetNestedSlice(config.machinePool.Object, rawTaints, "spec", "template", "spec", "taints"); err != nil {
+					panic(err)
+				}
+			}
 		}
 
-		machineOwner := metav1.OwnerReference{
-			Name: config.machineSet.GetName(),
-			Kind: config.machineSet.GetKind(),
-			UID:  config.machineSet.GetUID(),
+		if !spec.rootIsMachinePool {
+			config.machineSet.SetLabels(machineSetLabels)
+			if err := unstructured.SetNestedStringMap(config.machineSet.Object, machineSetLabels, "spec", "selector", "matchLabels"); err != nil {
+				panic(err)
+			}
+		}
+
+		var machineOwner metav1.OwnerReference
+		if spec.rootIsMachinePool {
+			machineOwner = metav1.OwnerReference{
+				Name: config.machinePool.GetName(),
+				Kind: config.machinePool.GetKind(),
+				UID:  config.machinePool.GetUID(),
+			}
+		} else {
+			machineOwner = metav1.OwnerReference{
+				Name: config.machineSet.GetName(),
+				Kind: config.machineSet.GetKind(),
+				UID:  config.machineSet.GetUID(),
+			}
 		}
 
 		if spec.capacity != nil || spec.nodeInfo != nil {
@@ -424,6 +507,7 @@ type TestSpec struct {
 	namespace               string
 	nodeCount               int
 	rootIsMachineDeployment bool
+	rootIsMachinePool       bool
 }
 
 func createTestSpecs(
@@ -433,6 +517,7 @@ func createTestSpecs(
 	scalableResourceCount int,
 	nodeCount int,
 	isMachineDeployment bool,
+	isMachinePool bool,
 	annotations map[string]string,
 	capacity map[string]string,
 	nodeInfo map[string]string,
@@ -442,7 +527,7 @@ func createTestSpecs(
 	var specs []TestSpec
 
 	for i := 0; i < scalableResourceCount; i++ {
-		specs = append(specs, createTestSpec(namespace, clusterName, fmt.Sprintf("%s-%d", namePrefix, i), nodeCount, isMachineDeployment, annotations, capacity, nodeInfo, managedLabels, specTaints))
+		specs = append(specs, createTestSpec(namespace, clusterName, fmt.Sprintf("%s-%d", namePrefix, i), nodeCount, isMachineDeployment, isMachinePool, annotations, capacity, nodeInfo, managedLabels, specTaints))
 	}
 
 	return specs
@@ -454,6 +539,7 @@ func createTestSpec(
 	name string,
 	nodeCount int,
 	isMachineDeployment bool,
+	isMachinePool bool,
 	annotations map[string]string,
 	capacity map[string]string,
 	nodeInfo map[string]string,
@@ -467,10 +553,12 @@ func createTestSpec(
 		specTaints:              specTaints,
 		machineDeploymentName:   name,
 		machineSetName:          name,
+		machinePoolName:         name,
 		clusterName:             clusterName,
 		namespace:               namespace,
 		nodeCount:               nodeCount,
 		rootIsMachineDeployment: isMachineDeployment,
+		rootIsMachinePool:       isMachinePool,
 		nodeInfo:                nodeInfo,
 	}
 }


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes the scale-down behavior for Cluster API MachinePool-backed node groups.

The current deletion flow attempts to find a matching Machine object for the node being removed. However, for MachinePool-backed nodes, relying on the presence of an individual Machine is not always appropriate. In this case, scale-down should still proceed by decreasing the MachinePool replica count.

This change makes the MachinePool deletion path fall back to replica decrement when no matching Machine is found, instead of failing the scale-down operation.

This PR adds that fallback so MachinePool scale-down does not fail when no matching Machine is found.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9681

#### Special notes for your reviewer:
This change is limited to the MachinePool scale-down path.
If a matching Machine is found, the existing behavior is preserved.
If no matching Machine is found, the implementation falls back to decrementing the MachinePool replicas count.

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
