### PR TITLE
Add a junit file to deadcode-elimination

### DIFF
--- a/vertical-pod-autoscaler/hack/verify-deadcode-elimination.sh
+++ b/vertical-pod-autoscaler/hack/verify-deadcode-elimination.sh
@@ -26,6 +26,12 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${SCRIPT_ROOT}"
 COMPONENTS=("admission-controller" "recommender" "updater")
 FAILED=false
+FAILURE_COUNT=0
+
+# Arrays to collect per-binary results for JUnit output
+declare -a BINARY_SIZES=()
+declare -a BINARY_OUTPUTS=()
+declare -a BINARY_FAILED=()
 
 # Install whydeadcode
 go install github.com/aarzilli/whydeadcode@latest
@@ -43,14 +49,66 @@ for binary in "${COMPONENTS[@]}"; do
     echo "$output"
     FAILED=true
     FAILED_BINARIES+=("${binary}")
+    BINARY_FAILED+=("true")
+    BINARY_OUTPUTS+=("$output")
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  else
+    BINARY_FAILED+=("false")
+    BINARY_OUTPUTS+=("")
   fi
 
   # Find the binary and print its size
   echo "Finding ${binary} binary and checking its size:"
     ls -altrh "${binary}"
+
+  # Capture size in bytes (wc -c is portable across macOS and Linux)
+  size_bytes=$(wc -c < "${binary}" | tr -d ' ')
+  BINARY_SIZES+=("$size_bytes")
+
   echo ""
   popd
 done
+
+# Generate JUnit XML report
+JUNIT_OUTPUT_DIR="${SCRIPT_ROOT}/_output"
+JUNIT_OUTPUT_FILE="${JUNIT_OUTPUT_DIR}/junit_deadcode.xml"
+mkdir -p "${JUNIT_OUTPUT_DIR}"
+
+cat > "${JUNIT_OUTPUT_FILE}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="deadcode-elimination" tests="${#COMPONENTS[@]}" failures="${FAILURE_COUNT}">
+EOF
+
+for i in "${!COMPONENTS[@]}"; do
+  binary="${COMPONENTS[$i]}"
+  size="${BINARY_SIZES[$i]}"
+  failed="${BINARY_FAILED[$i]}"
+
+  cat >> "${JUNIT_OUTPUT_FILE}" <<EOF
+  <testcase name="${binary}" classname="deadcode">
+    <properties>
+      <property name="size_bytes" value="${size}"/>
+    </properties>
+EOF
+
+  if [[ "$failed" == "true" ]]; then
+    # Escape XML special characters in output
+    escaped_output=$(echo "${BINARY_OUTPUTS[$i]}" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g')
+    cat >> "${JUNIT_OUTPUT_FILE}" <<EOF
+    <failure message="dead code detected">${escaped_output}</failure>
+EOF
+  fi
+
+  cat >> "${JUNIT_OUTPUT_FILE}" <<EOF
+  </testcase>
+EOF
+done
+
+cat >> "${JUNIT_OUTPUT_FILE}" <<EOF
+</testsuite>
+EOF
+
+echo "JUnit report written to ${JUNIT_OUTPUT_FILE}"
 
 if [[ "$FAILED" == "true" ]]; then
   echo "Dead code elimination check failed for the following binaries:"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I want to test measuring a metric over time in test-grid (things like: binary size, a benchmark result, number of dependancies, etc). I figured that this script is simple enough to do some testing in.

It seems like test-grid can be configured to look at any junit file, so I figured I'd start here and see how it all works.

I was lazy and vibe-coded this. I plan to come back and tidy this up if it does work.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
