### PR TITLE
Add inplace mode to quick start

### DIFF
--- a/vertical-pod-autoscaler/docs/quickstart.md
+++ b/vertical-pod-autoscaler/docs/quickstart.md
@@ -13,7 +13,7 @@ resource requests for your pods.
 In order to use it, you need to insert a *Vertical Pod Autoscaler* resource for
 each controller that you want to have automatically computed resource requirements.
 This will be most commonly a **Deployment**.
-There are six modes in which *VPAs* operate:
+There are several modes in which *VPAs* operate:
 
 - `"Auto"` [__deprecated__]: VPA assigns resource requests on pod creation as well as updates
   them on existing pods using the preferred update mechanism. Currently, this is

--- a/vertical-pod-autoscaler/docs/quickstart.md
+++ b/vertical-pod-autoscaler/docs/quickstart.md
@@ -13,7 +13,7 @@ resource requests for your pods.
 In order to use it, you need to insert a *Vertical Pod Autoscaler* resource for
 each controller that you want to have automatically computed resource requirements.
 This will be most commonly a **Deployment**.
-There are five modes in which *VPAs* operate:
+There are six modes in which *VPAs* operate:
 
 - `"Auto"` [__deprecated__]: VPA assigns resource requests on pod creation as well as updates
   them on existing pods using the preferred update mechanism. Currently, this is
@@ -28,6 +28,11 @@ There are five modes in which *VPAs* operate:
   them on existing pods by leveraging [Kubernetes `in-place` update](https://kubernetes.io/blog/2025/05/16/kubernetes-v1-33-in-place-pod-resize-beta/) capability.
   If `in-place` update fails, it falls back to evicting the pods, performing a _recreation_.
   For more details, see the [In-Place Updates documentation](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/features.md#in-place-updates-inplaceorrecreate).
+- `"InPlace"`: VPA assigns resource requests on pod creation as well as updates
+  them on existing pods using only Kubernetes `in-place` pod resize capability.
+  Unlike `"InPlaceOrRecreate"`, this mode never evicts pods. If an `in-place`
+  resize cannot be performed, VPA retries the update later when cluster conditions
+  change. This mode is recommended for workloads where any disruption is unacceptable.
 - `"Initial"`: VPA only assigns resource requests on pod creation and never changes them
   later.
 - `"Off"`: VPA does not automatically change the resource requirements of the pods.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
