### PR TITLE
fix: validate balancer priority policy targets

### DIFF
--- a/balancer/pkg/policy/policy.go
+++ b/balancer/pkg/policy/policy.go
@@ -34,6 +34,11 @@ func GetPlacement(balancer *v1alpha1.Balancer, summaries map[string]pods.Summary
 		if balancer.Spec.Policy.Priorities.TargetOrder == nil {
 			return nil, PlacementProblems{}, fmt.Errorf("incomplete policy definition: missing targetOrder")
 		}
+		for _, targetName := range balancer.Spec.Policy.Priorities.TargetOrder {
+			if _, found := targetMap[targetName]; !found {
+				return nil, PlacementProblems{}, fmt.Errorf("priority policy references unknown target: %s", targetName)
+			}
+		}
 		infos := buildTargetInfoMapForPriority(targetMap, summaries)
 		placement, problems := distributeByPriority(balancer.Spec.Replicas, balancer.Spec.Policy.Priorities.TargetOrder, infos)
 		return placement, problems, nil

--- a/balancer/pkg/policy/priority_test.go
+++ b/balancer/pkg/policy/priority_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	balancerapi "k8s.io/autoscaler/balancer/pkg/apis/balancer.x-k8s.io/v1alpha1"
 	"k8s.io/autoscaler/balancer/pkg/pods"
 )
 
@@ -189,4 +192,41 @@ func TestDistributeByPriority(t *testing.T) {
 			assert.Equal(t, tc.problems, problems)
 		})
 	}
+}
+
+func TestGetPlacementRejectsUnknownPriorityTarget(t *testing.T) {
+	balancer := &balancerapi.Balancer{
+		Spec: balancerapi.BalancerSpec{
+			Targets: []balancerapi.BalancerTarget{
+				{
+					Name: "a",
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						Name:       "a",
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+					},
+				},
+				{
+					Name: "b",
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						Name:       "b",
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+					},
+				},
+			},
+			Replicas: 10,
+			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"service": "nginx"}},
+			Policy: balancerapi.BalancerPolicy{
+				PolicyName: balancerapi.PriorityPolicyName,
+				Priorities: &balancerapi.PriorityPolicy{
+					TargetOrder: []string{"a", "c"},
+				},
+			},
+		},
+	}
+
+	_, _, err := GetPlacement(balancer, map[string]pods.Summary{})
+
+	assert.ErrorContains(t, err, "unknown target")
 }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Priority policy could list a target in `targetOrder` that is not in `spec.targets`. The CRD allows that, it is just strings with `minItems`, so a typo can land in the API.

Before this change, `GetPlacement` panicked on nil target info. Now it returns a normal policy error. Small footgun, gone.

Repro:
1. Declare targets `a`, `b`.
2. Set priority `targetOrder` to `["a", "c"]`.
3. Run `go test ./pkg/policy -run TestGetPlacementRejectsUnknownPriorityTarget -count=1 -v`.

Before the fix it panics in `distributeByPriority`; now it passes.

#### Which issue(s) this PR fixes:
None found.

#### Special notes for your reviewer:
Checked related issues and PRs, no direct match.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```