### PR TITLE
Add template-node label to mitigate scale up issue (#9700)

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -42,6 +42,7 @@ this document:
   * [How can I enable/disable eviction for a specific DaemonSet](#how-can-i-enabledisable-eviction-for-a-specific-daemonset)
   * [How can I enable Cluster Autoscaler to scale up when Node's max volume count is exceeded (CSI migration enabled)?](#how-can-i-enable-cluster-autoscaler-to-scale-up-when-nodes-max-volume-count-is-exceeded-csi-migration-enabled)
   * [How can I use ProvisioningRequest to run batch workloads?](#how-can-i-use-provisioningrequest-to-run-batch-workloads)
+  * [How can I enable scale-up when a CSI driver uses node-specific CSIStorageCapacity objects?](#how-can-i-enable-scale-up-when-a-csi-driver-uses-node-specific-csistoragecapacity-objects)
 * [Internals](#internals)
   * [Are all of the mentioned heuristics and timings final?](#are-all-of-the-mentioned-heuristics-and-timings-final)
   * [How does scale-up work?](#how-does-scale-up-work)
@@ -754,6 +755,18 @@ Autoscaler configuration:
 spend processing CheckCapacity ProvisioningRequests in a single iteration by
 setting the following flag in your Cluster Autoscaler configuration:
 `--check-capacity-provisioning-request-batch-timebox=<timebox>`. The default value is 10s.
+
+### How can I enable scale-up when a CSI driver uses node-specific CSIStorageCapacity objects?
+
+Some CSI drivers publish `CSIStorageCapacity` objects with node-specific topology keys (e.g.
+`kubernetes.io/hostname=<node-name>`). During scale-up simulation, Cluster Autoscaler creates a
+template node based on an existing node. Because no `CSIStorageCapacity` object exists for this
+template node, the scheduler's storage capacity check fails during simulation and scale-up is
+blocked (see [#9700](https://github.com/kubernetes/autoscaler/issues/9700)).
+
+To mitigate this, Cluster Autoscaler adds the label `cluster-autoscaler.kubernetes.io/template-node=true`
+to template nodes. CSI storage vendors can use this label to create a dedicated `CSIStorageCapacity`
+object that matches template nodes, allowing the scale-up simulation to succeed.
 
 ****************
 

--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -764,7 +764,7 @@ template node based on an existing node. Because no `CSIStorageCapacity` object 
 template node, the scheduler's storage capacity check fails during simulation and scale-up is
 blocked (see [#9700](https://github.com/kubernetes/autoscaler/issues/9700)).
 
-To mitigate this, Cluster Autoscaler adds the label `cluster-autoscaler.kubernetes.io/template-node=true`
+For mitigating issues like this, Cluster Autoscaler adds the label `cluster-autoscaler.kubernetes.io/template-node=true`
 to template nodes. CSI storage vendors can use this label to create a dedicated `CSIStorageCapacity`
 object that matches template nodes, allowing the scale-up simulation to succeed.
 

--- a/cluster-autoscaler/simulator/node_info_utils.go
+++ b/cluster-autoscaler/simulator/node_info_utils.go
@@ -80,6 +80,9 @@ func SanitizedTemplateNodeInfoFromNodeInfo(example *framework.NodeInfo, nodeGrou
 	// TODO: refactor this code to use update `NewNodeInfo` signature, so as this is no longer necessary.
 	templateNodeInfo.CSINode = sanitizedExample.CSINode
 
+	// Allow this node to be recognized as a template node, so scale up issues like https://github.com/kubernetes/autoscaler/issues/9700 can be mitigated.
+	templateNodeInfo.Node().Labels["cluster-autoscaler.kubernetes.io/template-node"] = "true"
+
 	// No need to sanitize the expected pods again - they either come from sanitizedExample and were sanitized above,
 	// or were added by podsExpectedOnFreshNode and sanitized there.
 	return templateNodeInfo, nil

--- a/cluster-autoscaler/simulator/node_info_utils_test.go
+++ b/cluster-autoscaler/simulator/node_info_utils_test.go
@@ -668,6 +668,9 @@ func verifySanitizedNode(initialNode, sanitizedNode *apiv1.Node, wantNodeName st
 		wantLabels[k] = v
 	}
 	wantLabels[apiv1.LabelHostname] = wantNodeName
+	if strings.HasPrefix(wantNodeName, "template-node-for-") {
+		wantLabels["cluster-autoscaler.kubernetes.io/template-node"] = "true"
+	}
 	if wantDeprecatedLabels {
 		labels.UpdateDeprecatedLabels(wantLabels)
 	}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Adds the label `cluster-autoscaler.kubernetes.io/template-node=true` to template nodes created during scale-up simulation.

CSI drivers that use node-local topology keys (e.g., `kubernetes.io/hostname`) for capacity tracking publish `CSIStorageCapacity` objects that don't match template node names. This causes the scheduler to reject simulated pod placements during scale-up, blocking valid scale-ups.

With this label, CSI storage vendors can create a dedicated `CSIStorageCapacity` object with a topology selector matching `cluster-autoscaler.kubernetes.io/template-node=true`, enabling capacity tracking for template nodes and unblocking scale-ups.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9700

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add template-node label to mitigate scale up issue
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
