### PR TITLE
digitalocean: fix broken autoscaler repository link

### DIFF
--- a/cluster-autoscaler/cloudprovider/digitalocean/README.md
+++ b/cluster-autoscaler/cloudprovider/digitalocean/README.md
@@ -28,7 +28,7 @@ picks up the configuration from the API and adjusts the behavior accordingly.
 # Development
 
 Make sure you're inside the root path of the [autoscaler
-repository](https://github.com/kubernetes/autoscaler/cluster-autoscaler)
+repository](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler)
 
 1.) Build the `cluster-autoscaler` binary:
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The `[autoscaler repository]` link in the DigitalOcean cloud provider README pointed to `https://github.com/kubernetes/autoscaler/cluster-autoscaler`, which returns a 404. GitHub needs a `/tree/<branch>/` segment to browse into a directory, and the old URL was missing it. This inserts `/tree/master` so the link resolves to the `cluster-autoscaler` directory on the `master` branch.

#### Which issue(s) this PR fixes:

N/A — no associated issue (found while reading the docs).

#### Special notes for your reviewer:

Trivial one-line documentation fix. I verified that the old URL returns a 404 and that the corrected URL resolves to the `cluster-autoscaler` directory listing on `master`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```