### PR TITLE
Update VPA defaults to 1.7.0

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.9.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.6.0"
+appVersion: "1.7.0"
 
 icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
 

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -6,7 +6,7 @@ Automatically adjust resources for your workloads
 
 ![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 ## Introduction
 The Vertical Pod Autoscaler (VPA) automatically adjusts the CPU and memory resource requests of pods to match their actual resource utilization.
@@ -61,8 +61,8 @@ If you need to update the CRDs to a newer version, please use `kubectl` to upgra
 ```bash
 kubectl apply --server-side -f "https://raw.githubusercontent.com/kubernetes/autoscaler/vertical-pod-autoscaler-<appVersion>/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml"
 
-# Eg. version v1.6.0
-kubectl apply --server-side -f "https://raw.githubusercontent.com/kubernetes/autoscaler/vertical-pod-autoscaler-1.6.0/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml"
+# Eg. version v1.7.0
+kubectl apply --server-side -f "https://raw.githubusercontent.com/kubernetes/autoscaler/vertical-pod-autoscaler-1.7.0/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml"
 ```
 
 ## Migration Guides

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md.gotmpl
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md.gotmpl
@@ -58,8 +58,8 @@ If you need to update the CRDs to a newer version, please use `kubectl` to upgra
 ```bash
 kubectl apply --server-side -f "https://raw.githubusercontent.com/kubernetes/autoscaler/vertical-pod-autoscaler-<appVersion>/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml"
 
-# Eg. version v1.6.0
-kubectl apply --server-side -f "https://raw.githubusercontent.com/kubernetes/autoscaler/vertical-pod-autoscaler-1.6.0/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml"
+# Eg. version v1.7.0
+kubectl apply --server-side -f "https://raw.githubusercontent.com/kubernetes/autoscaler/vertical-pod-autoscaler-1.7.0/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml"
 ```
 
 ## Migration Guides

--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
-          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.6.0
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.7.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.6.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.7.0
         imagePullPolicy: Always
         args:
           - --recommender-name=performance

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.6.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.7.0
         imagePullPolicy: Always
         args:
           - --recommender-name=frugal

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.6.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: updater
-          image: registry.k8s.io/autoscaling/vpa-updater:1.6.0
+          image: registry.k8s.io/autoscaling/vpa-updater:1.7.0
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -1,7 +1,7 @@
 # Vertical Pod Autoscaler Flags
 This document contains the flags for all VPA components.
 
-To view the most recent _release_ of flags for all VPA components, consult the release tag [flags(1.6.0)](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-1.6.0/vertical-pod-autoscaler/docs/flags.md) documentation.
+To view the most recent _release_ of flags for all VPA components, consult the release tag [flags(1.7.0)](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-1.7.0/vertical-pod-autoscaler/docs/flags.md) documentation.
 
 > **Note:** This document is auto-generated from the default branch (master) of the VPA repository.
 

--- a/vertical-pod-autoscaler/docs/installation.md
+++ b/vertical-pod-autoscaler/docs/installation.md
@@ -13,28 +13,30 @@
 - [Tear down](#tear-down)
 <!-- /toc -->
 
-The current default version is Vertical Pod Autoscaler 1.3.1
+The current default version is Vertical Pod Autoscaler 1.7.0
 
 ## Compatibility
 
-| VPA version     | Kubernetes version                                              |
-|-----------------|-----------------------------------------------------------------|
-| 1.6.x           | 1.28+ (1.33+ when using `InPlaceOrRecreate` )                   |
-| 1.5.x           | 1.28+ (1.33+ when using `InPlaceOrRecreate` )                   |
-| 1.4.x           | 1.28+ (1.33+ when using `InPlaceOrRecreate` Alpha Feature Gate) |
-| 1.3.x           | 1.28+                                                           |
-| 1.2.x           | 1.27+                                                           |
-| 1.1.x           | 1.25+                                                           |
-| 1.0             | 1.25+                                                           |
-| 0.14            | 1.25+                                                           |
-| 0.13            | 1.25+                                                           |
-| 0.12            | 1.25+                                                           |
-| 0.11            | 1.22 - 1.24                                                     |
-| 0.10            | 1.22+                                                           |
-| 0.9             | 1.16+                                                           |
-| 0.8             | 1.13+                                                           |
-| 0.4 to 0.7      | 1.11+                                                           |
-| 0.3.X and lower | 1.7+                                                            |
+| VPA version     | Kubernetes version                                                          |
+| --------------- | --------------------------------------------------------------------------- |
+| 1.7.x           | 1.28+ (`InPlace`, `InPlaceOrRecreate`, and `CPUStartupBoost` require 1.33+) |
+| 1.6.x           | 1.28+ (`InPlaceOrRecreate` requires 1.33+)                                  |
+| 1.5.x           | 1.28+ (`InPlaceOrRecreate` requires 1.33+)                                  |
+| 1.4.x           | 1.28+ (`InPlaceOrRecreate` alpha feature gate requires 1.33+)               |
+| 1.3.x           | 1.28+                                                                       |
+| 1.2.x           | 1.27+                                                                       |
+| 1.1.x           | 1.25+                                                                       |
+| 1.0             | 1.25+                                                                       |
+| 0.14            | 1.25+                                                                       |
+| 0.13            | 1.25+                                                                       |
+| 0.12            | 1.25+                                                                       |
+| 0.11            | 1.22–1.24                                                                   |
+| 0.10            | 1.22+                                                                       |
+| 0.9             | 1.16+                                                                       |
+| 0.8             | 1.13+                                                                       |
+| 0.4–0.7         | 1.11+                                                                       |
+| 0.3.x and lower | 1.7+                                                                        |
+
 
 ## Notice on CRD update (>=1.0.0)
 

--- a/vertical-pod-autoscaler/hack/generate-flags.sh
+++ b/vertical-pod-autoscaler/hack/generate-flags.sh
@@ -21,7 +21,7 @@ set -o pipefail
 SCRIPT_ROOT=$(realpath $(dirname "${BASH_SOURCE[0]}"))/..
 TARGET_FILE="${SCRIPT_ROOT}/docs/flags.md"
 COMPONENTS=("admission-controller" "recommender" "updater")
-DEFAULT_TAG="1.6.0"
+DEFAULT_TAG="1.7.0"
 
 # Function to extract flags from a binary
 extract_flags() {

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -54,7 +54,7 @@ if [ $# -eq 0 ]; then
 fi
 
 DEFAULT_REGISTRY="registry.k8s.io/autoscaling"
-DEFAULT_TAG="1.6.0"
+DEFAULT_TAG="1.7.0"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}

--- a/vertical-pod-autoscaler/hack/vpa-up.sh
+++ b/vertical-pod-autoscaler/hack/vpa-up.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
-DEFAULT_TAG="1.6.0"
+DEFAULT_TAG="1.7.0"
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}
 
 if [ "${TAG_TO_APPLY}" == "${DEFAULT_TAG}" ]; then


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
VPA 1.7.0 release, see #9705.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
