### PR TITLE
VPA: Increase e2e test concurrency

### DIFF
--- a/vertical-pod-autoscaler/hack/run-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-locally.sh
@@ -121,6 +121,8 @@ case ${SUITE} in
     "${SCRIPT_ROOT}"/hack/deploy-for-e2e-locally.sh "${SUITE}"
 
     echo " ** Running E2E tests..."
+    # Use a lower concurrency for local runs (the default in run-e2e-tests.sh is 8).
+    export NUMPROC=${NUMPROC:-4}
     if [ "${SUITE}" == recommender-externalmetrics ]; then
        ARTIFACTS="${ARTIFACTS}" "${SCRIPT_ROOT}"/hack/run-e2e-tests.sh recommender
     else 

--- a/vertical-pod-autoscaler/hack/run-e2e-tests.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-tests.sh
@@ -55,7 +55,7 @@ if [ "${TEST_WITH_FEATURE_GATES_ENABLED:-}" == "true" ]; then
   SKIP=""
 fi
 
-NUMPROC=${NUMPROC:-4}
+NUMPROC=${NUMPROC:-8}
 
 case ${SUITE} in
   recommender|updater|admission-controller|actuation|full-vpa)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I want to test if we can increase the concurrency in prow to 8 jobs.
For now this is a test, I think local tests should be set to 4 (that seems sane)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
