### PR TITLE
Increase the e2e actuation test speed

### DIFF
--- a/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
@@ -141,6 +141,8 @@ for COMPONENT in ${COMPONENTS}; do
       HELM_SET_ARGS+=("--set" "recommender.enabled=true")
       HELM_SET_ARGS+=("--set" "recommender.image.repository=${REGISTRY}/vpa-recommender")
       HELM_SET_ARGS+=("--set" "recommender.image.tag=${TAG}")
+      HELM_SET_ARGS+=("--set" "recommender.extraArgs[0]=--checkpoints-gc-interval=20s")
+      HELM_SET_ARGS+=("--set" "recommender.extraArgs[1]=--recommender-interval=10s")
       ;;
     updater)
       HELM_SET_ARGS+=("--set" "updater.enabled=true")
@@ -156,10 +158,11 @@ for COMPONENT in ${COMPONENTS}; do
   esac
 done
 
-# Add feature gates if specified. The recommender has no preset args, so its
-# extra args start at index 0. RECOM_ARGS_IDX tracks the next free recommender
-# index so feature gates and external-metrics flags don't collide.
-RECOM_ARGS_IDX=0
+# Add feature gates if specified. The recommender has --checkpoints-gc-interval
+# at index 0 and --recommender-interval at index 1, so its extra args start at
+# index 2. RECOM_ARGS_IDX tracks the next free recommender index so feature gates
+# and external-metrics flags don't collide.
+RECOM_ARGS_IDX=2
 if [ -n "${FEATURE_GATES:-}" ]; then
   # Escape commas so Helm --set treats the value as a single assignment
   ESCAPED_FEATURE_GATES="${FEATURE_GATES//,/\\,}"

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
@@ -141,11 +141,13 @@ for COMPONENT in ${COMPONENTS}; do
       HELM_SET_ARGS+=("--set" "recommender.enabled=true")
       HELM_SET_ARGS+=("--set" "recommender.image.repository=${REGISTRY}/vpa-recommender")
       HELM_SET_ARGS+=("--set" "recommender.image.tag=${TAG}")
+      HELM_SET_ARGS+=("--set" "recommender.extraArgs[0]=--recommender-interval=10s")
       ;;
     updater)
       HELM_SET_ARGS+=("--set" "updater.enabled=true")
       HELM_SET_ARGS+=("--set" "updater.image.repository=${REGISTRY}/vpa-updater")
       HELM_SET_ARGS+=("--set" "updater.image.tag=${TAG}")
+      HELM_SET_ARGS+=("--set" "updater.extraArgs[0]=--updater-interval=10s")
       ;;
     admission-controller)
       HELM_SET_ARGS+=("--set" "admissionController.enabled=true")
@@ -155,8 +157,9 @@ for COMPONENT in ${COMPONENTS}; do
   esac
 done
 
-# Add feature gates if specified
-RECOM_ARGS_IDX=0
+# Add feature gates if specified. Index 0 of extraArgs already holds the loop
+# interval set when enabling the component above, so feature gates go after it.
+RECOM_ARGS_IDX=1
 if [ -n "${FEATURE_GATES:-}" ]; then
   # Escape commas so Helm --set treats the value as a single assignment
   ESCAPED_FEATURE_GATES="${FEATURE_GATES//,/\\,}"
@@ -168,7 +171,7 @@ if [ -n "${FEATURE_GATES:-}" ]; then
         RECOM_ARGS_IDX=$((RECOM_ARGS_IDX + 1))
         ;;
       updater)
-        HELM_SET_ARGS+=("--set" "updater.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")
+        HELM_SET_ARGS+=("--set" "updater.extraArgs[1]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         ;;
       admission-controller)
         HELM_SET_ARGS+=("--set" "admissionController.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e-locally.sh
@@ -141,7 +141,6 @@ for COMPONENT in ${COMPONENTS}; do
       HELM_SET_ARGS+=("--set" "recommender.enabled=true")
       HELM_SET_ARGS+=("--set" "recommender.image.repository=${REGISTRY}/vpa-recommender")
       HELM_SET_ARGS+=("--set" "recommender.image.tag=${TAG}")
-      HELM_SET_ARGS+=("--set" "recommender.extraArgs[0]=--recommender-interval=10s")
       ;;
     updater)
       HELM_SET_ARGS+=("--set" "updater.enabled=true")
@@ -157,9 +156,10 @@ for COMPONENT in ${COMPONENTS}; do
   esac
 done
 
-# Add feature gates if specified. Index 0 of extraArgs already holds the loop
-# interval set when enabling the component above, so feature gates go after it.
-RECOM_ARGS_IDX=1
+# Add feature gates if specified. The recommender has no preset args, so its
+# extra args start at index 0. RECOM_ARGS_IDX tracks the next free recommender
+# index so feature gates and external-metrics flags don't collide.
+RECOM_ARGS_IDX=0
 if [ -n "${FEATURE_GATES:-}" ]; then
   # Escape commas so Helm --set treats the value as a single assignment
   ESCAPED_FEATURE_GATES="${FEATURE_GATES//,/\\,}"

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -98,7 +98,6 @@ for COMPONENT in ${COMPONENTS}; do
         "--set" "recommender.image.repository=${REGISTRY}/vpa-recommender"
         "--set" "recommender.image.tag=${TAG}"
         "--set" "recommender.image.pullPolicy=Always"
-        "--set" "recommender.extraArgs[0]=--recommender-interval=10s"
       )
       ;;
     updater)
@@ -122,8 +121,9 @@ for COMPONENT in ${COMPONENTS}; do
 done
 
 # Propagate FEATURE_GATES (set on alpha/beta CI lanes) to component args.
-# Helm --set merges by index, so we append --feature-gates after the loop
-# interval already set at index 0 above. For admissionController we also re-add
+# Helm --set merges by index. The updater has --updater-interval at index 0,
+# so its feature-gates go at index 1. The recommender has no preset args, so its
+# feature-gates go at index 0. For admissionController we also re-add
 # --reload-cert (set in values-e2e.yaml for the cert-rotation test) so it isn't
 # dropped. Commas in the value are escaped so Helm --set treats it as one
 # assignment.
@@ -132,7 +132,7 @@ if [[ -n "${FEATURE_GATES:-}" ]]; then
   for COMPONENT in ${COMPONENTS}; do
     case ${COMPONENT} in
       recommender)
-        HELM_SET_ARGS+=("--set" "recommender.extraArgs[1]=--feature-gates=${ESCAPED_FEATURE_GATES}")
+        HELM_SET_ARGS+=("--set" "recommender.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         ;;
       updater)
         HELM_SET_ARGS+=("--set" "updater.extraArgs[1]=--feature-gates=${ESCAPED_FEATURE_GATES}")

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -98,6 +98,8 @@ for COMPONENT in ${COMPONENTS}; do
         "--set" "recommender.image.repository=${REGISTRY}/vpa-recommender"
         "--set" "recommender.image.tag=${TAG}"
         "--set" "recommender.image.pullPolicy=Always"
+        "--set" "recommender.extraArgs[0]=--checkpoints-gc-interval=20s"
+        "--set" "recommender.extraArgs[1]=--recommender-interval=10s"
       )
       ;;
     updater)
@@ -121,18 +123,18 @@ for COMPONENT in ${COMPONENTS}; do
 done
 
 # Propagate FEATURE_GATES (set on alpha/beta CI lanes) to component args.
-# Helm --set merges by index. The updater has --updater-interval at index 0,
-# so its feature-gates go at index 1. The recommender has no preset args, so its
-# feature-gates go at index 0. For admissionController we also re-add
-# --reload-cert (set in values-e2e.yaml for the cert-rotation test) so it isn't
-# dropped. Commas in the value are escaped so Helm --set treats it as one
-# assignment.
+# Helm --set merges by index. The recommender has --checkpoints-gc-interval at
+# index 0 and --recommender-interval at index 1, so its feature-gates go at
+# index 2. The updater has --updater-interval at index 0, so its feature-gates
+# go at index 1. For admissionController we also re-add --reload-cert (set in
+# values-e2e.yaml for the cert-rotation test) so it isn't dropped. Commas in the
+# value are escaped so Helm --set treats it as one assignment.
 if [[ -n "${FEATURE_GATES:-}" ]]; then
   ESCAPED_FEATURE_GATES="${FEATURE_GATES//,/\\,}"
   for COMPONENT in ${COMPONENTS}; do
     case ${COMPONENT} in
       recommender)
-        HELM_SET_ARGS+=("--set" "recommender.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")
+        HELM_SET_ARGS+=("--set" "recommender.extraArgs[2]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         ;;
       updater)
         HELM_SET_ARGS+=("--set" "updater.extraArgs[1]=--feature-gates=${ESCAPED_FEATURE_GATES}")

--- a/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
+++ b/vertical-pod-autoscaler/hack/deploy-for-e2e.sh
@@ -98,6 +98,7 @@ for COMPONENT in ${COMPONENTS}; do
         "--set" "recommender.image.repository=${REGISTRY}/vpa-recommender"
         "--set" "recommender.image.tag=${TAG}"
         "--set" "recommender.image.pullPolicy=Always"
+        "--set" "recommender.extraArgs[0]=--recommender-interval=10s"
       )
       ;;
     updater)
@@ -106,6 +107,7 @@ for COMPONENT in ${COMPONENTS}; do
         "--set" "updater.image.repository=${REGISTRY}/vpa-updater"
         "--set" "updater.image.tag=${TAG}"
         "--set" "updater.image.pullPolicy=Always"
+        "--set" "updater.extraArgs[0]=--updater-interval=10s"
       )
       ;;
     admission-controller)
@@ -120,18 +122,20 @@ for COMPONENT in ${COMPONENTS}; do
 done
 
 # Propagate FEATURE_GATES (set on alpha/beta CI lanes) to component args.
-# Helm --set replaces lists; for admissionController we re-add --reload-cert
-# (set in values-e2e.yaml for the cert-rotation test) so it isn't dropped.
-# Commas in the value are escaped so Helm --set treats it as one assignment.
+# Helm --set merges by index, so we append --feature-gates after the loop
+# interval already set at index 0 above. For admissionController we also re-add
+# --reload-cert (set in values-e2e.yaml for the cert-rotation test) so it isn't
+# dropped. Commas in the value are escaped so Helm --set treats it as one
+# assignment.
 if [[ -n "${FEATURE_GATES:-}" ]]; then
   ESCAPED_FEATURE_GATES="${FEATURE_GATES//,/\\,}"
   for COMPONENT in ${COMPONENTS}; do
     case ${COMPONENT} in
       recommender)
-        HELM_SET_ARGS+=("--set" "recommender.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")
+        HELM_SET_ARGS+=("--set" "recommender.extraArgs[1]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         ;;
       updater)
-        HELM_SET_ARGS+=("--set" "updater.extraArgs[0]=--feature-gates=${ESCAPED_FEATURE_GATES}")
+        HELM_SET_ARGS+=("--set" "updater.extraArgs[1]=--feature-gates=${ESCAPED_FEATURE_GATES}")
         ;;
       admission-controller)
         HELM_SET_ARGS+=(

--- a/vertical-pod-autoscaler/test/e2e/utils/common.go
+++ b/vertical-pod-autoscaler/test/e2e/utils/common.go
@@ -46,7 +46,7 @@ const (
 	// RecommenderDeploymentName is VPA recommender deployment name
 	RecommenderDeploymentName = "vpa-recommender"
 	// PollInterval is interval for polling
-	PollInterval = 10 * time.Second
+	PollInterval = 5 * time.Second
 	// PollTimeout is timeout for polling
 	PollTimeout = 15 * time.Minute
 

--- a/vertical-pod-autoscaler/test/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/actuation.go
@@ -925,7 +925,7 @@ func setupHamsterController(f *framework.Framework, controllerKind, cpu, memory 
 	case "Job":
 		setupHamsterJob(f, cpu, memory, replicas)
 	case "CronJob":
-		SetupHamsterCronJob(f, "*/2 * * * *", cpu, memory, replicas)
+		SetupHamsterCronJob(f, "*/1 * * * *", cpu, memory, replicas)
 	case "ReplicaSet":
 		setupHamsterRS(f, cpu, memory, replicas)
 	case "StatefulSet":

--- a/vertical-pod-autoscaler/test/e2e/v1/common.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/common.go
@@ -49,11 +49,13 @@ const (
 	actuationSuite               = "actuation"
 	cronJobsWaitTimeout          = 15 * time.Minute
 	// VpaEvictionTimeout is a timeout for VPA to restart a pod if there are no
-	// mechanisms blocking it (for example PDB).
-	VpaEvictionTimeout = 3 * time.Minute
+	// mechanisms blocking it (for example PDB). The e2e deployment runs the
+	// updater with a 10s loop interval, so this window covers several loops.
+	VpaEvictionTimeout = 45 * time.Second
 	// VpaInPlaceTimeout is a timeout for the VPA to finish in-place resizing a
-	// pod, if there are no mechanisms blocking it.
-	VpaInPlaceTimeout = 2 * time.Minute
+	// pod, if there are no mechanisms blocking it. The e2e deployment runs the
+	// updater with a 10s loop interval, so this window covers several loops.
+	VpaInPlaceTimeout = 45 * time.Second
 )
 
 // UpdaterE2eDescribe describes a VPA updater e2e test.

--- a/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
@@ -48,6 +48,11 @@ const (
 	initialCPU     = int64(10) // mCPU
 	initialMemory  = int64(10) // MB
 	oomTestTimeout = 8 * time.Minute
+	// noActuationTimeout is how long we wait to confirm that a non-recognized
+	// recommender does NOT scale the pods. The default recommender never emits a
+	// recommendation for such a VPA, so the pod requests stay put; this window
+	// only needs to cover a few updater loops and at least one recommender loop.
+	noActuationTimeout = 90 * time.Second
 )
 
 func init() {
@@ -351,7 +356,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with non-recognized recommender expli
 		// consume more CPU to get a higher recommendation
 		rc.ConsumeCPU(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
-			f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
+			f, noActuationTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
 			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1000m"))
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})

--- a/vertical-pod-autoscaler/test/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/recommender.go
@@ -242,7 +242,7 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	// FIXME todo(adrianmoisey): This test seems to be flaky after running in parallel, unsure why, see if it's possible to fix
+	// This test deletes the recommender, which requires it to be run in serial
 	f.It("doesn't drop lower/upper after recommender's restart", framework.WithSerial(), framework.WithSlow(), func() {
 
 		o := getVpaObserver(vpaClientSet, f.Namespace.Name)
@@ -262,8 +262,28 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 		}
 		ginkgo.By("Deleting recommender")
 		gomega.Expect(deleteRecommender(f.ClientSet)).To(gomega.BeNil())
-		ginkgo.By("Accumulating diffs after restart, sleeping for 5 minutes...")
-		time.Sleep(5 * time.Minute)
+
+		ginkgo.By("Waiting for the recommender to restart and reload its checkpoint")
+		gomega.Expect(waitForRecommenderReady(f.ClientSet)).To(gomega.BeNil())
+		// Give the restarted recommender a couple of loops to produce
+		// recommendations from the restored checkpoint. This skips the brief
+		// cold-start window (before the checkpoint is loaded) which can emit a
+		// transient low-confidence recommendation with a wider upper bound.
+		time.Sleep(recommenderRestartSettle)
+
+		ginkgo.By("Draining cold-start diffs")
+	drain:
+		for {
+			select {
+			case recommendationDiff := <-o.channel:
+				fmt.Println("Dropping post-restart settle diff", recommendationDiff)
+			default:
+				break drain
+			}
+		}
+
+		ginkgo.By("Accumulating steady-state diffs after restart...")
+		time.Sleep(recommenderRestartCollect)
 		changeDetected := false
 	finish:
 		for {
@@ -479,6 +499,43 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 				oomBumpUpRatio))
 	})
 })
+
+const (
+	// recommenderRestartSettle is how long to wait after the recommender pod is
+	// ready again so it can load its checkpoint and emit at least one steady-state
+	// recommendation before we start checking diffs.
+	recommenderRestartSettle = 30 * time.Second
+	// recommenderRestartCollect is the window over which we accumulate diffs to
+	// verify the recommender does not regress its lower/upper bounds after restart.
+	recommenderRestartCollect = 30 * time.Second
+)
+
+// waitForRecommenderReady waits until a recommender pod is running and ready in
+// the VPA namespace. Used after deleting the recommender to ensure it has
+// restarted (and loaded its checkpoint) before assertions continue.
+func waitForRecommenderReady(c clientset.Interface) error {
+	namespace := utils.VpaNamespace
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=recommender",
+	}
+	return wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		podList, err := c.CoreV1().Pods(namespace).List(ctx, listOptions)
+		if err != nil {
+			return false, err
+		}
+		for _, pod := range podList.Items {
+			if pod.Status.Phase != apiv1.PodRunning {
+				continue
+			}
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == apiv1.PodReady && cond.Status == apiv1.ConditionTrue {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+}
 
 func deleteRecommender(c clientset.Interface) error {
 	namespace := utils.VpaNamespace


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Our e2e tests are slow and annoying to wait for. I gave an AI the junit files, and it came up with these suggestions.
On my local, the tests went from 26 minutes to 12 minutes. That's a massive win!
I'm not to sure on changing the recommender and updater intervals, but, I also don't see why we wouldn't. I'm very on the fence here.
/hold
Holding to get more opinions.

Note: 100% of this is AI written.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
