### PR TITLE
Improve file size output for VPA verify

### DIFF
--- a/vertical-pod-autoscaler/hack/verify-deadcode-elimination.sh
+++ b/vertical-pod-autoscaler/hack/verify-deadcode-elimination.sh
@@ -57,13 +57,17 @@ for binary in "${COMPONENTS[@]}"; do
     BINARY_OUTPUTS+=("")
   fi
 
-  # Find the binary and print its size
-  echo "Finding ${binary} binary and checking its size:"
-    ls -altrh "${binary}"
+  # Build a stripped binary (-s) to measure the size we actually ship.
+  # The dead code build above uses -dumpdep which produces a non-stripped
+  # binary, so we rebuild here with -s to report a representative size.
+  echo "Building stripped ${binary} binary and checking its size:"
+  go build -ldflags=-s -o "${binary}"
 
   # Capture size in bytes (wc -c is portable across macOS and Linux)
   size_bytes=$(wc -c < "${binary}" | tr -d ' ')
   BINARY_SIZES+=("$size_bytes")
+
+  echo "$size_bytes $binary"
 
   echo ""
   popd


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Now that prow is measuring the size of the VPA binaries, I figured it should be reporting the size that users would see. 
This tweaks the script to detect dead code and report the size correctly.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
