### PR TITLE
feat: implement isInfeasibleError for VPA InPlace update mode

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -18,11 +18,14 @@ package logic
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"time"
 
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -402,16 +405,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 				reason := "InPlaceUpdateError"
 				// For InPlace mode, don't evict pods even if we get an error
 				if updateMode == vpa_types.UpdateModeInPlace {
-					// TODO: check for an admission plugin error because of OS and node capacity checks
-					// Check if it's an infeasibility error
-					// infeasible patches are rejected at API server level (soon),
-					// so spec.resources remains unchanged. We must track the attempted
-					// recommendation to prevent infinite retry loops.
-					// This work is still in progress (https://github.com/kubernetes/kubernetes/pull/136043)
-					// Currently isInfeasibleError return false
 					if isInfeasibleError(err) {
-						// TODO: this will be changed when we know how errors shoule be look like
-						// depends on https://github.com/kubernetes/kubernetes/pull/136043
 						reason = "InPlaceUpdateInfeasible"
 						u.recordInfeasibleAttempt(pod, vpa)
 					}
@@ -591,10 +585,25 @@ func newEventRecorder(kubeClient kube_client.Interface) record.EventRecorder {
 	return eventBroadcaster.NewRecorder(vpascheme, corev1.EventSource{Component: "vpa-updater"})
 }
 
-// isInfeasibleError checks if an error indicates the resize is infeasible.
-// Infeasible error detection at the admission controller level is still in progress
-// (https://github.com/kubernetes/kubernetes/pull/136043).
-// This is just a placeholder until that work lands and we know the exact error format.
+// isInfeasibleError checks if an error indicates the resize is infeasible
+// due to insufficient node capacity, as reported by the PodResizeValidator
+// admission plugin (available from Kubernetes 1.36).
+// See https://issues.k8s.io/136043
 func isInfeasibleError(err error) bool {
+	var statusErr *apierrors.StatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	if statusErr.ErrStatus.Reason != metav1.StatusReasonForbidden {
+		return false
+	}
+	if statusErr.ErrStatus.Details == nil {
+		return false
+	}
+	for _, cause := range statusErr.ErrStatus.Details.Causes {
+		if cause.Type == metav1.CauseType(utils.InfeasibleCauseNodeCapacity) {
+			return true
+		}
+	}
 	return false
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/time/rate"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -871,4 +872,56 @@ func TestRunOnce_AutoUnboostThenInPlace(t *testing.T) {
 	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 10)
 	inplace.AssertNumberOfCalls(t, "CanUnboost", 5) // all 5 from previous run only
 	eviction.AssertNumberOfCalls(t, "Evict", 0)
+}
+
+func TestIsInfeasibleError(t *testing.T) {
+	makeStatusErr := func(reason metav1.StatusReason, causeType metav1.CauseType) error {
+		return &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Reason: reason,
+				Details: &metav1.StatusDetails{
+					Causes: []metav1.StatusCause{
+						{Type: causeType},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "NodeCapacity cause returns true",
+			err:  makeStatusErr(metav1.StatusReasonForbidden, "NodeCapacity"),
+			want: true,
+		},
+		{
+			name: "Forbidden with unknown cause returns false",
+			err:  makeStatusErr(metav1.StatusReasonForbidden, "SomethingElse"),
+			want: false,
+		},
+		{
+			name: "Non-Forbidden status error returns false",
+			err:  makeStatusErr(metav1.StatusReasonNotFound, "NodeCapacity"),
+			want: false,
+		},
+		{
+			name: "Plain error returns false",
+			err:  errors.New("plain error"),
+			want: false,
+		},
+		{
+			name: "Nil error returns false",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isInfeasibleError(tc.err))
+		})
+	}
 }

--- a/vertical-pod-autoscaler/pkg/updater/utils/types.go
+++ b/vertical-pod-autoscaler/pkg/updater/utils/types.go
@@ -46,3 +46,8 @@ const (
 	// ResizeStatusNone indicates no resize operation is pending
 	ResizeStatusNone ResizeStatus = "ResizeNone"
 )
+
+// InfeasibleCauseNodeCapacity is the cause type returned by the PodResizeValidator
+// admission plugin when a resize is rejected due to insufficient node capacity.
+// See: https://github.com/kubernetes/kubernetes/blob/35bed76715330c233f0554edbcac761929b9491c/plugin/pkg/admission/podresize/admission.go#L44
+const InfeasibleCauseNodeCapacity = "NodeCapacity"


### PR DESCRIPTION
### What this PR does / why we need it -
Implement the **isInfeasibleError** function in the VPA updater which was previously a placeholder returning false

With **kubernetes/kubernetes#136043** merged (available from Kubernetes 1.36) the **PodResizeValidator** admission plugin now rejects infeasible resize requests at admission time, returning a Forbidden StatusError with cause types **NodeCapacity or UnsupportedPlatform**

This detects those errors so VPA can correctly identify infeasible resize attempts and avoid infinite retry loops in **InPlace mode**

### Kind -
/kind feature

### Which issue this PR fixes -
**Fixes #9646**

### Special notes for your reviewer -
This is a follow-up to **#8888**
The **isInfeasibleError** function was left as a placeholder pending kubernetes/kubernetes#136043 
That PR is now merged so we can implement the actual error detection




