### PR TITLE
Adding support for optional ClusterNameLabel and ClusterName while querying Prometheus for metrics

### DIFF
--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -113,6 +113,8 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `password` | string |  | The password used in the prometheus server basic auth. Can also be set via the PROMETHEUS_PASSWORD environment variable |
 | `pod-label-prefix` | string |  "pod_label_" | Which prefix to look for pod labels in metrics  |
 | `pod-name-label` | string |  "kubernetes_pod_name" | Label name to look for pod names  |
+| `cluster-name-label` | string |  "" | Label name to look for cluster name  |
+| `cluster-name` | string |  "" | Name of cluster  |
 | `pod-namespace-label` | string |  "kubernetes_namespace" | Label name to look for pod namespaces  |
 | `pod-recommendation-min-cpu-millicores` | float |  25 | Minimum CPU recommendation for a pod  |
 | `pod-recommendation-min-memory-mb` | float |  250 | Minimum memory recommendation for a pod  |

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -67,6 +67,8 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `alsologtostderrthreshold` | severity |  | logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true) |
 | `checkpoints-gc-interval` |  |  10m0s | duration                       How often orphaned checkpoints should be garbage collected  |
 | `checkpoints-timeout` |  |  1m0s | duration                           Timeout for writing checkpoints since the start of the recommender's main loop  |
+| `cluster-name` | string |  | Name of cluster |
+| `cluster-name-label` | string |  | Label name to look for cluster name |
 | `confidence-interval-cpu` |  |  24h0m0s | duration                       The time interval used for computing the confidence multiplier for the CPU lower and upper bound. Default: 24h  |
 | `confidence-interval-memory` |  |  24h0m0s | duration                    The time interval used for computing the confidence multiplier for the memory lower and upper bound. Default: 24h  |
 | `container-name-label` | string |  "name" | Label name to look for container names  |
@@ -113,8 +115,6 @@ This document is auto-generated from the flag definitions in the VPA recommender
 | `password` | string |  | The password used in the prometheus server basic auth. Can also be set via the PROMETHEUS_PASSWORD environment variable |
 | `pod-label-prefix` | string |  "pod_label_" | Which prefix to look for pod labels in metrics  |
 | `pod-name-label` | string |  "kubernetes_pod_name" | Label name to look for pod names  |
-| `cluster-name-label` | string |  "" | Label name to look for cluster name  |
-| `cluster-name` | string |  "" | Name of cluster  |
 | `pod-namespace-label` | string |  "kubernetes_namespace" | Label name to look for pod namespaces  |
 | `pod-recommendation-min-cpu-millicores` | float |  25 | Minimum CPU recommendation for a pod  |
 | `pod-recommendation-min-memory-mb` | float |  250 | Minimum memory recommendation for a pod  |

--- a/vertical-pod-autoscaler/go.mod
+++ b/vertical-pod-autoscaler/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/google/go-cmp v0.7.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.68.0

--- a/vertical-pod-autoscaler/pkg/recommender/config/config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -81,6 +82,8 @@ type RecommenderConfig struct {
 	CtrNamespaceLabel         string
 	CtrPodNameLabel           string
 	CtrNameLabel              string
+	ClusterNameLabel          string
+	ClusterName               string
 	Username                  string
 	Password                  string
 	PrometheusBearerToken     string
@@ -153,6 +156,8 @@ func DefaultRecommenderConfig() *RecommenderConfig {
 		CtrNamespaceLabel:         "namespace",
 		CtrPodNameLabel:           "pod_name",
 		CtrNameLabel:              "name",
+		ClusterNameLabel:          "",
+		ClusterName:               "",
 		Username:                  "",
 		Password:                  "",
 		PrometheusBearerToken:     "",
@@ -226,6 +231,8 @@ func InitRecommenderFlags() *RecommenderConfig {
 	flag.StringVar(&config.CtrNamespaceLabel, "container-namespace-label", config.CtrNamespaceLabel, `Label name to look for container namespaces`)
 	flag.StringVar(&config.CtrPodNameLabel, "container-pod-name-label", config.CtrPodNameLabel, `Label name to look for container pod names`)
 	flag.StringVar(&config.CtrNameLabel, "container-name-label", config.CtrNameLabel, `Label name to look for container names`)
+	flag.StringVar(&config.ClusterNameLabel, "cluster-name-label", config.ClusterNameLabel, `Label name to look for cluster name`)
+	flag.StringVar(&config.ClusterName, "cluster-name", config.ClusterName, `Name of cluster`)
 	flag.StringVar(&config.Username, "username", config.Username, "The username used in the prometheus server basic auth. Can also be set via the PROMETHEUS_USERNAME environment variable")
 	flag.StringVar(&config.Password, "password", config.Password, "The password used in the prometheus server basic auth. Can also be set via the PROMETHEUS_PASSWORD environment variable")
 	flag.StringVar(&config.PrometheusBearerToken, "prometheus-bearer-token", config.PrometheusBearerToken, "The bearer token used in the Prometheus server bearer token auth")
@@ -258,30 +265,41 @@ func InitRecommenderFlags() *RecommenderConfig {
 	features.MutableFeatureGate.AddFlag(pflag.CommandLine)
 	kube_flag.InitFlags()
 
-	ValidateRecommenderConfig(config)
+	if err := ValidateRecommenderConfig(config); err != nil {
+		klog.ErrorS(err, "Configuration validation failed")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
 
 	return config
 }
 
 // ValidateRecommenderConfig performs validation of the recommender flags
-func ValidateRecommenderConfig(config *RecommenderConfig) {
+func ValidateRecommenderConfig(config *RecommenderConfig) error {
 	common.ValidateCommonConfig(config.CommonFlags)
 
 	if config.MinCheckpointsPerRun != 10 { // Default value is 10
 		klog.InfoS("DEPRECATION WARNING: The 'min-checkpoints' flag is deprecated and has no effect. It will be removed in a future release.")
 	}
 
+	// Cluster Name Label or Cluster Name, if one of those is not set
+	clusterNameLabelButNotClusterName := config.ClusterNameLabel != "" && config.ClusterName == ""
+	clusterNameButNotClusterNameLabel := config.ClusterNameLabel == "" && config.ClusterName != ""
+
+	if clusterNameButNotClusterNameLabel || clusterNameLabelButNotClusterName {
+		return fmt.Errorf("either one of --cluster-name-label or --cluster-name is not set")
+	}
+
 	if config.PrometheusBearerToken != "" && config.PrometheusBearerTokenFile != "" && config.Username != "" {
-		klog.ErrorS(nil, "--bearer-token, --bearer-token-file and --username are mutually exclusive and can't be set together.")
-		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		return fmt.Errorf("--bearer-token, --bearer-token-file and --username are mutually exclusive")
 	}
 
 	if config.PrometheusBearerTokenFile != "" {
 		fileContent, err := os.ReadFile(config.PrometheusBearerTokenFile)
 		if err != nil {
-			klog.ErrorS(err, "Unable to read bearer token file", "filename", config.PrometheusBearerTokenFile)
-			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+			return fmt.Errorf("unable to read bearer token file: %w", err)
 		}
 		config.PrometheusBearerToken = strings.TrimSpace(string(fileContent))
 	}
+
+	return nil
 }

--- a/vertical-pod-autoscaler/pkg/recommender/config/config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -286,17 +287,18 @@ func ValidateRecommenderConfig(config *RecommenderConfig) error {
 	clusterNameButNotClusterNameLabel := config.ClusterNameLabel == "" && config.ClusterName != ""
 
 	if clusterNameButNotClusterNameLabel || clusterNameLabelButNotClusterName {
-		return fmt.Errorf("either one of --cluster-name-label or --cluster-name is not set")
+		return errors.New("either one of --cluster-name-label or --cluster-name is not set")
 	}
 
 	if config.PrometheusBearerToken != "" && config.PrometheusBearerTokenFile != "" && config.Username != "" {
-		return fmt.Errorf("--bearer-token, --bearer-token-file and --username are mutually exclusive")
+		return errors.New("--bearer-token, --bearer-token-file and --username are mutually exclusive")
 	}
 
 	if config.PrometheusBearerTokenFile != "" {
 		fileContent, err := os.ReadFile(config.PrometheusBearerTokenFile)
 		if err != nil {
-			return fmt.Errorf("unable to read bearer token file: %w", err)
+			errMsg := fmt.Sprintf("unable to read bearer token file: %v", err)
+			return errors.New(errMsg)
 		}
 		config.PrometheusBearerToken = strings.TrimSpace(string(fileContent))
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/config/config_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
+
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 )
 
@@ -133,7 +134,6 @@ func TestValidateRecommenderConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			inputConfig := DefaultRecommenderConfig()
 			inputConfig.CommonFlags = common.DefaultCommonConfig()
 
@@ -162,7 +162,7 @@ func TestValidateRecommenderConfigLoadsBearerTokenFromFile(t *testing.T) {
 	}
 	config.PrometheusBearerTokenFile = tokenFilePath
 
-	ValidateRecommenderConfig(config)
+	_ = ValidateRecommenderConfig(config)
 
 	if got, want := config.PrometheusBearerToken, "my-secret-token"; got != want {
 		t.Fatalf("PrometheusBearerToken = %q, want %q", got, want)

--- a/vertical-pod-autoscaler/pkg/recommender/config/config_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config_test.go
@@ -17,11 +17,10 @@ limitations under the License.
 package config
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
-
-	"flag"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
@@ -132,7 +131,6 @@ func TestValidateRecommenderConfig(t *testing.T) {
 			expectError: true,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 

--- a/vertical-pod-autoscaler/pkg/recommender/config/config_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/config/config_test.go
@@ -20,7 +20,139 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"flag"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/pflag"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 )
+
+// resetFlags clears the global flag registries between t.Run test blocks.
+func resetFlags() {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+}
+
+func Test_InitRecommenderFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		setupExpected func(*RecommenderConfig) // Directly uses the struct without config. prefix
+	}{
+		{
+			name: "base defaults",
+			args: []string{},
+			setupExpected: func(c *RecommenderConfig) {
+				// Base case expects exactly what DefaultRecommenderConfig() produces
+			},
+		},
+		{
+			name: "custom recommender name and address",
+			args: []string{
+				"--recommender-name=custom-vpa-engine",
+				"--address=:9090",
+			},
+			setupExpected: func(c *RecommenderConfig) {
+				c.RecommenderName = "custom-vpa-engine"
+				c.Address = ":9090"
+			},
+		},
+		{
+			name: "custom cluster flags configuration",
+			args: []string{
+				"--cluster-name=production-main",
+				"--cluster-name-label=k8s_cluster_id",
+			},
+			setupExpected: func(c *RecommenderConfig) {
+				c.ClusterName = "production-main"
+				c.ClusterNameLabel = "k8s_cluster_id"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFlags()
+
+			os.Args = append([]string{"vpa-recommender-binary"}, tt.args...)
+
+			expectedConfig := DefaultRecommenderConfig()
+			expectedConfig.CommonFlags = common.DefaultCommonConfig()
+
+			if tt.setupExpected != nil {
+				tt.setupExpected(expectedConfig)
+			}
+
+			actualConfig := InitRecommenderFlags()
+
+			if diff := cmp.Diff(expectedConfig, actualConfig); diff != "" {
+				t.Errorf("InitRecommenderFlags mismatch (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateRecommenderConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupInput  func(*RecommenderConfig)
+		expectError bool
+	}{
+		{
+			name: "Cluster Name Label and Cluster Name, both not set",
+			setupInput: func(c *RecommenderConfig) {
+				c.ClusterName = ""
+				c.ClusterNameLabel = ""
+			},
+			expectError: false,
+		},
+		{
+			name: "Cluster Name Label and Cluster Name, both are set",
+			setupInput: func(c *RecommenderConfig) {
+				c.ClusterName = "prod-cluster"
+				c.ClusterNameLabel = "cluster_id"
+			},
+			expectError: false,
+		},
+		{
+			name: "Cluster Name Label missing but Cluster Name is set",
+			setupInput: func(c *RecommenderConfig) {
+				c.ClusterName = "prod-cluster"
+				c.ClusterNameLabel = ""
+			},
+			expectError: true,
+		},
+		{
+			name: "Cluster Name Label is set but Cluster Name is missing",
+			setupInput: func(c *RecommenderConfig) {
+				c.ClusterName = ""
+				c.ClusterNameLabel = "cluster_id"
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			inputConfig := DefaultRecommenderConfig()
+			inputConfig.CommonFlags = common.DefaultCommonConfig()
+
+			if tt.setupInput != nil {
+				tt.setupInput(inputConfig)
+			}
+
+			err := ValidateRecommenderConfig(inputConfig)
+
+			hasError := (err != nil)
+			if hasError != tt.expectError {
+				t.Errorf("Validation mismatch for %s: expected error status %v, got error: %v",
+					tt.name, tt.expectError, err)
+			}
+		})
+	}
+}
 
 func TestValidateRecommenderConfigLoadsBearerTokenFromFile(t *testing.T) {
 	t.Parallel()

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -89,6 +89,8 @@ type PrometheusHistoryProviderConfig struct {
 	PodLabelPrefix, PodLabelsMetricName              string
 	PodNamespaceLabel, PodNameLabel                  string
 	CtrNamespaceLabel, CtrPodNameLabel, CtrNameLabel string
+	ClusterNameLabel                                 string
+	ClusterName                                      string
 	CadvisorMetricsJobName                           string
 	Namespace                                        string
 	CPUMetricName, MemoryMetricName                  string
@@ -356,8 +358,7 @@ func (p *prometheusHistoryProvider) readLastLabels(res map[model.PodID]*PodHisto
 	return nil
 }
 
-func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHistory, error) {
-	res := make(map[model.PodID]*PodHistory)
+func GetBasePodSelectorQuery(p *prometheusHistoryProvider) string {
 	var podSelector string
 	if p.config.CadvisorMetricsJobName != "" {
 		podSelector = fmt.Sprintf("job=\"%s\", ", p.config.CadvisorMetricsJobName)
@@ -368,6 +369,18 @@ func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHis
 	if p.config.Namespace != "" {
 		podSelector = fmt.Sprintf("%s, %s=\"%s\"", podSelector, p.config.CtrNamespaceLabel, p.config.Namespace)
 	}
+
+	if p.config.ClusterNameLabel != "" && p.config.ClusterName != "" {
+		podSelector = fmt.Sprintf("%s, %s=\"%s\"", podSelector, p.config.ClusterNameLabel, p.config.ClusterName)
+	}
+	return podSelector
+}
+
+func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHistory, error) {
+	res := make(map[model.PodID]*PodHistory)
+
+	podSelector := GetBasePodSelectorQuery(p)
+
 	historicalCpuQuery := fmt.Sprintf("rate(%s{%s}[%s])", p.config.CPUMetricName, podSelector, p.config.HistoryResolution)
 	klog.V(4).InfoS("Historical CPU usage query", "query", historicalCpuQuery)
 	err := p.readResourceHistory(res, historicalCpuQuery, model.ResourceCPU)

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -358,7 +358,7 @@ func (p *prometheusHistoryProvider) readLastLabels(res map[model.PodID]*PodHisto
 	return nil
 }
 
-func GetBasePodSelectorQuery(p *prometheusHistoryProvider) string {
+func getBasePodSelectorQuery(p *prometheusHistoryProvider) string {
 	var podSelector string
 	if p.config.CadvisorMetricsJobName != "" {
 		podSelector = fmt.Sprintf("job=\"%s\", ", p.config.CadvisorMetricsJobName)
@@ -379,7 +379,7 @@ func GetBasePodSelectorQuery(p *prometheusHistoryProvider) string {
 func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHistory, error) {
 	res := make(map[model.PodID]*PodHistory)
 
-	podSelector := GetBasePodSelectorQuery(p)
+	podSelector := getBasePodSelectorQuery(p)
 
 	historicalCpuQuery := fmt.Sprintf("rate(%s{%s}[%s])", p.config.CPUMetricName, podSelector, p.config.HistoryResolution)
 	klog.V(4).InfoS("Historical CPU usage query", "query", historicalCpuQuery)

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -414,3 +414,63 @@ func TestPrometheusAuth(t *testing.T) {
 		assert.Equal(t, capturedRequest.Header.Get("Authorization"), "Basic cHJvbV91c2VyOnByb21fcGFzc3dvcmQ=") // "prom_user:prom_password"
 	})
 }
+
+func TestGetBasePodSelectorQuery(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupInput    func(*PrometheusHistoryProviderConfig)
+		expectedQuery string
+	}{
+		{
+			name: "base scenario without cluster details",
+			setupInput: func(c *PrometheusHistoryProviderConfig) {
+				c.ClusterName = ""
+				c.ClusterNameLabel = ""
+			},
+			expectedQuery: "job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"",
+		},
+		{
+			name: "cluster details are fully injected into selector query",
+			setupInput: func(c *PrometheusHistoryProviderConfig) {
+				c.ClusterName = "production-us-east"
+				c.ClusterNameLabel = "k8s_cluster_id"
+			},
+			expectedQuery: "job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\", k8s_cluster_id=\"production-us-east\"",
+		},
+		{
+			name: "partially missing configuration: label empty ignored",
+			setupInput: func(c *PrometheusHistoryProviderConfig) {
+				c.ClusterName = "production-us-east"
+				c.ClusterNameLabel = ""
+			},
+			expectedQuery: "job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"",
+		},
+		{
+			name: "partially missing configuration: name empty ignored",
+			setupInput: func(c *PrometheusHistoryProviderConfig) {
+				c.ClusterName = ""
+				c.ClusterNameLabel = "k8s_cluster_id"
+			},
+			expectedQuery: "job=\"kubernetes-cadvisor\", pod_name=~\".+\", name!=\"POD\", name!=\"\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			config := getDefaultPrometheusHistoryProviderConfigForTest()
+
+			if tt.setupInput != nil {
+				tt.setupInput(&config)
+			}
+
+			provider := &prometheusHistoryProvider{
+				config: config,
+			}
+
+			actualQuery := GetBasePodSelectorQuery(provider)
+
+			assert.Equal(t, tt.expectedQuery, actualQuery)
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -457,7 +457,6 @@ func TestGetBasePodSelectorQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			config := getDefaultPrometheusHistoryProviderConfigForTest()
 
 			if tt.setupInput != nil {

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider_test.go
@@ -468,7 +468,7 @@ func TestGetBasePodSelectorQuery(t *testing.T) {
 				config: config,
 			}
 
-			actualQuery := GetBasePodSelectorQuery(provider)
+			actualQuery := getBasePodSelectorQuery(provider)
 
 			assert.Equal(t, tt.expectedQuery, actualQuery)
 		})

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
@@ -230,6 +230,8 @@ func initHistoryProvider(ctx context.Context, rec Recommender, config *recommend
 			CtrNamespaceLabel:      config.CtrNamespaceLabel,
 			CtrPodNameLabel:        config.CtrPodNameLabel,
 			CtrNameLabel:           config.CtrNameLabel,
+			ClusterNameLabel:       config.ClusterNameLabel,
+			ClusterName:            config.ClusterName,
 			CadvisorMetricsJobName: config.PrometheusJobName,
 			Namespace:              config.CommonFlags.VpaObjectNamespace,
 			Authentication: history.PrometheusCredentials{


### PR DESCRIPTION
#### PR Changes
1.
Introducing 2 optional recommender flags:
- ClusterNameLabel
- ClusterName

2. 
- If either of these two values are not set, then the query would NOT include this filter
- Only when both values are set, the query would include this filter

3.
I've also improved use of this function
https://github.com/kubernetes/autoscaler/blob/1c15fc68567ff66b06240bc67973edad26e5fa75/vertical-pod-autoscaler/pkg/recommender/config/config.go#L267
It now returns an error message in case of validation failure.
It helps to write better test cases

4.
Improved this function by splitting these lines to create a new function
https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go#L361-L370
Again it helps in testing

5.
Updated documentation in `flags.md`

6. 
Added unit test cases

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Prometheus can hold metrics for multiple clusters.
So a support is needed to provide "optional" arguments to Recommender to take that into consideration while querying Prometheus for metrics.
This would prevent fetching unnecessary metrics in case the namespace and pod name is same across multiple clusters.

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/autoscaler/issues/9491

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for optional ClusterNameLabel and ClusterName arguments for Recommender to be used while querying prometheus

```