### PR TITLE
Validate CapacityQuota resources format

### DIFF
--- a/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1/capacityquota_types.go
+++ b/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1/capacityquota_types.go
@@ -88,9 +88,21 @@ type CapacityQuotaLimits struct {
 	//
 	// Currently supported built-in resources: cpu, memory. Additionally,
 	// nodes key can be used to limit the number of existing nodes.
+	// All resource quantities must be non-negative integers. Binary and decimal units are allowed as long as the quantity
+	// can be converted to an integer.
+	//
+	// Example allowed quantities: "32Gi", "2k", "10"
+	// Example invalid quantities: "3.67Gi", "500m", "0.3"
+	//
+	// **Caveat**: milli quantities are not supported even if they represent an integer, for example: "1000m".
+	//
 	// Node autoscaler implementations and cloud providers can support custom
 	// resources, such as GPU.
 	// +required
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:validation:MaxProperties=20
+	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) <= 63)",message="Resource names must be 63 characters or less."
+	// +kubebuilder:validation:XValidation:rule="self.all(key, type(self[key]) == int ? self[key] >= 0 : (!self[key].startsWith('-') && quantity(self[key]).isInteger()))",message="All resource quantities must be non-negative integers."
 	Resources ResourceList `json:"resources"`
 }
 

--- a/cluster-autoscaler/apis/capacityquota/client/applyconfiguration/autoscaling.x-k8s.io/v1alpha1/capacityquotalimits.go
+++ b/cluster-autoscaler/apis/capacityquota/client/applyconfiguration/autoscaling.x-k8s.io/v1alpha1/capacityquotalimits.go
@@ -31,6 +31,14 @@ type CapacityQuotaLimitsApplyConfiguration struct {
 	//
 	// Currently supported built-in resources: cpu, memory. Additionally,
 	// nodes key can be used to limit the number of existing nodes.
+	// All resource quantities must be non-negative integers. Binary and decimal units are allowed as long as the quantity
+	// can be converted to an integer.
+	//
+	// Example allowed quantities: "32Gi", "2k", "10"
+	// Example invalid quantities: "3.67Gi", "500m", "0.3"
+	//
+	// **Caveat**: milli quantities are not supported even if they represent an integer, for example: "1000m".
+	//
 	// Node autoscaler implementations and cloud providers can support custom
 	// resources, such as GPU.
 	Resources *autoscalingxk8siov1alpha1.ResourceList `json:"resources,omitempty"`

--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacityquotas.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacityquotas.yaml
@@ -66,9 +66,24 @@ spec:
 
                       Currently supported built-in resources: cpu, memory. Additionally,
                       nodes key can be used to limit the number of existing nodes.
+                      All resource quantities must be non-negative integers. Binary and decimal units are allowed as long as the quantity
+                      can be converted to an integer.
+
+                      Example allowed quantities: "32Gi", "2k", "10"
+                      Example invalid quantities: "3.67Gi", "500m", "0.3"
+
+                      **Caveat**: milli quantities are not supported even if they represent an integer, for example: "1000m".
+
                       Node autoscaler implementations and cloud providers can support custom
                       resources, such as GPU.
+                    maxProperties: 20
                     type: object
+                    x-kubernetes-validations:
+                    - message: Resource names must be 63 characters or less.
+                      rule: self.all(key, size(key) <= 63)
+                    - message: All resource quantities must be non-negative integers.
+                      rule: 'self.all(key, type(self[key]) == int ? self[key] >= 0
+                        : (!self[key].startsWith(''-'') && quantity(self[key]).isInteger()))'
                 required:
                 - resources
                 type: object


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Add validation checking that all resource quantities are non-negative integers. Limit the number of resources to 20 (above that CEL expression gets too expensive and realistically we don't need more). Resource name should not exceed 63 characters

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added CEL validation to CapacityQuota. All limits must be non-negative integers, there must be no more than 20 limited resources in a single quota and a resource name must not exceed 63 characters.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
