### PR TITLE
Enhance scale-down latency tracking to report specific reasons for node un-neediness in metrics.

### DIFF
--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
@@ -47,22 +47,23 @@ type unneededNodeState struct {
 // NodeLatencyTracker keeps track of nodes that are marked as unneeded, when they became unneeded,
 // and removalThresholds to emit node removal latency metrics.
 type NodeLatencyTracker struct {
-	unneededNodes        map[string]unneededNodeState
-	removedUnneededNodes map[string]unneededNodeState
-	wrapped              processor.ScaleDownStatusProcessor
+	unneededNodes         map[string]unneededNodeState
+	unneededNodesToReport map[string]unneededNodeState
+	wrapped               processor.ScaleDownStatusProcessor
 }
 
 // NewNodeLatencyTracker creates a new tracker.
 func NewNodeLatencyTracker(wrapped processor.ScaleDownStatusProcessor) *NodeLatencyTracker {
 	return &NodeLatencyTracker{
-		unneededNodes:        make(map[string]unneededNodeState),
-		removedUnneededNodes: make(map[string]unneededNodeState),
-		wrapped:              wrapped,
+		unneededNodes:         make(map[string]unneededNodeState),
+		unneededNodesToReport: make(map[string]unneededNodeState),
+		wrapped:               wrapped,
 	}
 }
 
 // UpdateScaleDownCandidates updates tracked unneeded nodes and reports those that became needed again.
 func (t *NodeLatencyTracker) UpdateScaleDownCandidates(list []*scaledown.UnneededNode, timestamp time.Time) {
+	t.unneededNodesToReport = make(map[string]unneededNodeState)
 	currentSet := make(map[string]struct{}, len(list))
 	for _, candidate := range list {
 		nodeName := candidate.Node.Name
@@ -83,7 +84,7 @@ func (t *NodeLatencyTracker) UpdateScaleDownCandidates(list []*scaledown.Unneede
 	}
 	for nodeName, info := range t.unneededNodes {
 		if _, exists := currentSet[nodeName]; !exists {
-			t.removedUnneededNodes[nodeName] = info
+			t.unneededNodesToReport[nodeName] = info
 			delete(t.unneededNodes, nodeName)
 		}
 	}
@@ -110,8 +111,8 @@ func (t *NodeLatencyTracker) Process(autoscalingCtx *ca_context.AutoscalingConte
 func (t *NodeLatencyTracker) processScaledDownNodes(scaledDownNodes []*status.ScaleDownNode) {
 	for _, node := range scaledDownNodes {
 		nodeName := node.Node.Name
-		t.recordAndCleanup(nodeName, true, "")
-		delete(t.removedUnneededNodes, nodeName)
+		t.recordAndCleanup(nodeName, true, "deleted")
+		delete(t.unneededNodesToReport, nodeName)
 	}
 }
 
@@ -119,10 +120,10 @@ func (t *NodeLatencyTracker) processScaledDownNodes(scaledDownNodes []*status.Sc
 func (t *NodeLatencyTracker) processRemovedUnneededNodes(scaleDownStatus *status.ScaleDownStatus) {
 	unremovableMap := buildUnremovableMap(scaleDownStatus.UnremovableNodes)
 
-	for nodeName, info := range t.removedUnneededNodes {
+	for nodeName, info := range t.unneededNodesToReport {
 		reason := t.determineReason(nodeName, unremovableMap)
 		t.recordWithState(nodeName, info, false, reason)
-		delete(t.removedUnneededNodes, nodeName)
+		delete(t.unneededNodesToReport, nodeName)
 	}
 }
 
@@ -191,7 +192,7 @@ func (t *NodeLatencyTracker) getTrackedNodes() []string {
 // CleanUp cleans up internal structures.
 func (t *NodeLatencyTracker) CleanUp() {
 	t.unneededNodes = make(map[string]unneededNodeState)
-	t.removedUnneededNodes = make(map[string]unneededNodeState)
+	t.unneededNodesToReport = make(map[string]unneededNodeState)
 	if t.wrapped != nil {
 		t.wrapped.CleanUp()
 	}

--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
@@ -35,6 +35,8 @@ const (
 	// deletion is considered "slow". Deletions that take
 	// longer than this threshold will be logged at a more visible level
 	scaleDownLatencyLogThreshold = 3 * time.Minute
+	// reasonNeededAgain is used when a node became needed again
+	reasonNeededAgain = "needed_again"
 )
 
 type unneededNodeState struct {
@@ -45,15 +47,17 @@ type unneededNodeState struct {
 // NodeLatencyTracker keeps track of nodes that are marked as unneeded, when they became unneeded,
 // and removalThresholds to emit node removal latency metrics.
 type NodeLatencyTracker struct {
-	unneededNodes map[string]unneededNodeState
-	wrapped       processor.ScaleDownStatusProcessor
+	unneededNodes        map[string]unneededNodeState
+	removedUnneededNodes map[string]unneededNodeState
+	wrapped              processor.ScaleDownStatusProcessor
 }
 
 // NewNodeLatencyTracker creates a new tracker.
 func NewNodeLatencyTracker(wrapped processor.ScaleDownStatusProcessor) *NodeLatencyTracker {
 	return &NodeLatencyTracker{
-		unneededNodes: make(map[string]unneededNodeState),
-		wrapped:       wrapped,
+		unneededNodes:        make(map[string]unneededNodeState),
+		removedUnneededNodes: make(map[string]unneededNodeState),
+		wrapped:              wrapped,
 	}
 }
 
@@ -77,22 +81,23 @@ func (t *NodeLatencyTracker) UpdateScaleDownCandidates(list []*scaledown.Unneede
 			}
 		}
 	}
-	for nodeName := range t.unneededNodes {
+	for nodeName, info := range t.unneededNodes {
 		if _, exists := currentSet[nodeName]; !exists {
-			t.recordAndCleanup(nodeName, false)
+			t.removedUnneededNodes[nodeName] = info
+			delete(t.unneededNodes, nodeName)
 		}
 	}
 }
 
 // Process updates unremovableNodes and reports node removal latency based on scale-down status.
-func (t *NodeLatencyTracker) Process(autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus) {
+func (t *NodeLatencyTracker) Process(autoscalingCtx *ca_context.AutoscalingContext, scaleDownStatus *status.ScaleDownStatus) {
 	if t.wrapped != nil {
-		t.wrapped.Process(autoscalingCtx, status)
+		t.wrapped.Process(autoscalingCtx, scaleDownStatus)
 	}
 
-	for _, node := range status.ScaledDownNodes {
-		t.recordAndCleanup(node.Node.Name, true)
-	}
+	t.processScaledDownNodes(scaleDownStatus.ScaledDownNodes)
+
+	t.processRemovedUnneededNodes(scaleDownStatus)
 
 	if klog.V(6).Enabled() {
 		for nodeName := range t.unneededNodes {
@@ -101,29 +106,69 @@ func (t *NodeLatencyTracker) Process(autoscalingCtx *ca_context.AutoscalingConte
 	}
 }
 
+// processScaledDownNodes records metrics and cleans up state for successfully deleted nodes.
+func (t *NodeLatencyTracker) processScaledDownNodes(scaledDownNodes []*status.ScaleDownNode) {
+	for _, node := range scaledDownNodes {
+		nodeName := node.Node.Name
+		t.recordAndCleanup(nodeName, true, "")
+		delete(t.removedUnneededNodes, nodeName)
+	}
+}
+
+// processRemovedUnneededNodes evaluates why nodes are no longer unneeded and emits corresponding metrics.
+func (t *NodeLatencyTracker) processRemovedUnneededNodes(scaleDownStatus *status.ScaleDownStatus) {
+	unremovableMap := buildUnremovableMap(scaleDownStatus.UnremovableNodes)
+
+	for nodeName, info := range t.removedUnneededNodes {
+		reason := t.determineReason(nodeName, unremovableMap)
+		t.recordWithState(nodeName, info, false, reason)
+		delete(t.removedUnneededNodes, nodeName)
+	}
+}
+
+// determineReason figures out exactly why a node was removed from the tracked list.
+func (t *NodeLatencyTracker) determineReason(nodeName string, unremovableMap map[string]string) string {
+	if unremovableReason, exists := unremovableMap[nodeName]; exists {
+		return unremovableReason
+	}
+	return reasonNeededAgain
+}
+
+func buildUnremovableMap(unremovableNodes []*status.UnremovableNode) map[string]string {
+	m := make(map[string]string, len(unremovableNodes))
+	for _, node := range unremovableNodes {
+		m[node.Node.Name] = node.Reason.String()
+	}
+	return m
+}
+
 // recordAndCleanup calculates the time a node spent in the "unneeded" state, updates
 // relevant Prometheus metrics, and removes the node from internal tracking.
-func (t *NodeLatencyTracker) recordAndCleanup(nodeName string, isRemoved bool) {
+func (t *NodeLatencyTracker) recordAndCleanup(nodeName string, isRemoved bool, reason string) {
 	info, exists := t.unneededNodes[nodeName]
 	if !exists {
 		return
 	}
-	defer delete(t.unneededNodes, nodeName)
+	delete(t.unneededNodes, nodeName)
+	t.recordWithState(nodeName, info, isRemoved, reason)
+}
 
+// recordWithState records metrics based on the provided node state and isRemoved flag.
+func (t *NodeLatencyTracker) recordWithState(nodeName string, info unneededNodeState, isRemoved bool, reason string) {
 	duration := time.Since(info.unneededSince)
 	latency := duration - info.removalThreshold
 
 	if latency > 0 {
-		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, latency)
+		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, reason, latency)
 	} else {
-		klog.V(6).Infof("Node %q was unneeded for %s (threshold %s). Latency %s is <= 0, skipping metric. isRemoved: %v",
-			nodeName, duration, info.removalThreshold, latency, isRemoved)
+		klog.V(6).Infof("Node %q was unneeded for %s (threshold %s). Latency %s is <= 0, skipping metric. isRemoved: %v, reason: %v",
+			nodeName, duration, info.removalThreshold, latency, isRemoved, reason)
 	}
 	if isRemoved {
 		t.logDeletion(nodeName, duration, info.removalThreshold, latency)
 	} else {
-		klog.V(4).Infof("Node %q is unremovable, became needed again (unneeded for %s). Latency: %s",
-			nodeName, duration, latency)
+		klog.V(4).Infof("Node %q was not removed (unneeded for %s) because of %q. Latency: %s",
+			nodeName, duration, reason, latency)
 	}
 }
 
@@ -145,6 +190,8 @@ func (t *NodeLatencyTracker) getTrackedNodes() []string {
 
 // CleanUp cleans up internal structures.
 func (t *NodeLatencyTracker) CleanUp() {
+	t.unneededNodes = make(map[string]unneededNodeState)
+	t.removedUnneededNodes = make(map[string]unneededNodeState)
 	if t.wrapped != nil {
 		t.wrapped.CleanUp()
 	}

--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/klog/v2"
 
 	processor "k8s.io/autoscaler/cluster-autoscaler/processors/status"
@@ -35,35 +36,31 @@ const (
 	// deletion is considered "slow". Deletions that take
 	// longer than this threshold will be logged at a more visible level
 	scaleDownLatencyLogThreshold = 3 * time.Minute
-	// reasonNeededAgain is used when a node became needed again
-	reasonNeededAgain = "needed_again"
 )
 
 type unneededNodeState struct {
-	unneededSince    time.Time
-	removalThreshold time.Duration
+	unneededSince     time.Time
+	removalThreshold  time.Duration
+	latestDelayReason string
 }
 
 // NodeLatencyTracker keeps track of nodes that are marked as unneeded, when they became unneeded,
 // and removalThresholds to emit node removal latency metrics.
 type NodeLatencyTracker struct {
-	unneededNodes         map[string]unneededNodeState
-	unneededNodesToReport map[string]unneededNodeState
-	wrapped               processor.ScaleDownStatusProcessor
+	unneededNodes map[string]unneededNodeState
+	wrapped       processor.ScaleDownStatusProcessor
 }
 
 // NewNodeLatencyTracker creates a new tracker.
 func NewNodeLatencyTracker(wrapped processor.ScaleDownStatusProcessor) *NodeLatencyTracker {
 	return &NodeLatencyTracker{
-		unneededNodes:         make(map[string]unneededNodeState),
-		unneededNodesToReport: make(map[string]unneededNodeState),
-		wrapped:               wrapped,
+		unneededNodes: make(map[string]unneededNodeState),
+		wrapped:       wrapped,
 	}
 }
 
 // UpdateScaleDownCandidates updates tracked unneeded nodes and reports those that became needed again.
 func (t *NodeLatencyTracker) UpdateScaleDownCandidates(list []*scaledown.UnneededNode, timestamp time.Time) {
-	t.unneededNodesToReport = make(map[string]unneededNodeState)
 	currentSet := make(map[string]struct{}, len(list))
 	for _, candidate := range list {
 		nodeName := candidate.Node.Name
@@ -82,23 +79,24 @@ func (t *NodeLatencyTracker) UpdateScaleDownCandidates(list []*scaledown.Unneede
 			}
 		}
 	}
-	for nodeName, info := range t.unneededNodes {
+	for nodeName := range t.unneededNodes {
 		if _, exists := currentSet[nodeName]; !exists {
-			t.unneededNodesToReport[nodeName] = info
-			delete(t.unneededNodes, nodeName)
+			t.recordAndCleanup(nodeName, false)
 		}
 	}
 }
 
 // Process updates unremovableNodes and reports node removal latency based on scale-down status.
-func (t *NodeLatencyTracker) Process(autoscalingCtx *ca_context.AutoscalingContext, scaleDownStatus *status.ScaleDownStatus) {
+func (t *NodeLatencyTracker) Process(autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus) {
 	if t.wrapped != nil {
-		t.wrapped.Process(autoscalingCtx, scaleDownStatus)
+		t.wrapped.Process(autoscalingCtx, status)
 	}
 
-	t.processScaledDownNodes(scaleDownStatus.ScaledDownNodes)
+	t.updateLatestDelayReasons(status.UnremovableNodes)
 
-	t.processRemovedUnneededNodes(scaleDownStatus)
+	for _, node := range status.ScaledDownNodes {
+		t.recordAndCleanup(node.Node.Name, true)
+	}
 
 	if klog.V(6).Enabled() {
 		for nodeName := range t.unneededNodes {
@@ -107,69 +105,34 @@ func (t *NodeLatencyTracker) Process(autoscalingCtx *ca_context.AutoscalingConte
 	}
 }
 
-// processScaledDownNodes records metrics and cleans up state for successfully deleted nodes.
-func (t *NodeLatencyTracker) processScaledDownNodes(scaledDownNodes []*status.ScaleDownNode) {
-	for _, node := range scaledDownNodes {
-		nodeName := node.Node.Name
-		t.recordAndCleanup(nodeName, true, "deleted")
-		delete(t.unneededNodesToReport, nodeName)
-	}
-}
-
-// processRemovedUnneededNodes evaluates why nodes are no longer unneeded and emits corresponding metrics.
-func (t *NodeLatencyTracker) processRemovedUnneededNodes(scaleDownStatus *status.ScaleDownStatus) {
-	unremovableMap := buildUnremovableMap(scaleDownStatus.UnremovableNodes)
-
-	for nodeName, info := range t.unneededNodesToReport {
-		reason := t.determineReason(nodeName, unremovableMap)
-		t.recordWithState(nodeName, info, false, reason)
-		delete(t.unneededNodesToReport, nodeName)
-	}
-}
-
-// determineReason figures out exactly why a node was removed from the tracked list.
-func (t *NodeLatencyTracker) determineReason(nodeName string, unremovableMap map[string]string) string {
-	if unremovableReason, exists := unremovableMap[nodeName]; exists {
-		return unremovableReason
-	}
-	return reasonNeededAgain
-}
-
-func buildUnremovableMap(unremovableNodes []*status.UnremovableNode) map[string]string {
-	m := make(map[string]string, len(unremovableNodes))
-	for _, node := range unremovableNodes {
-		m[node.Node.Name] = node.Reason.String()
-	}
-	return m
-}
-
 // recordAndCleanup calculates the time a node spent in the "unneeded" state, updates
 // relevant Prometheus metrics, and removes the node from internal tracking.
-func (t *NodeLatencyTracker) recordAndCleanup(nodeName string, isRemoved bool, reason string) {
+func (t *NodeLatencyTracker) recordAndCleanup(nodeName string, isRemoved bool) {
 	info, exists := t.unneededNodes[nodeName]
 	if !exists {
 		return
 	}
 	delete(t.unneededNodes, nodeName)
-	t.recordWithState(nodeName, info, isRemoved, reason)
-}
 
-// recordWithState records metrics based on the provided node state and isRemoved flag.
-func (t *NodeLatencyTracker) recordWithState(nodeName string, info unneededNodeState, isRemoved bool, reason string) {
 	duration := time.Since(info.unneededSince)
 	latency := duration - info.removalThreshold
 
+	delayReason := info.latestDelayReason
+	if delayReason == "" {
+		delayReason = "none"
+	}
+
 	if latency > 0 {
-		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, reason, latency)
+		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, delayReason, latency)
 	} else {
-		klog.V(6).Infof("Node %q was unneeded for %s (threshold %s). Latency %s is <= 0, skipping metric. isRemoved: %v, reason: %v",
-			nodeName, duration, info.removalThreshold, latency, isRemoved, reason)
+		klog.V(6).Infof("Node %q was unneeded for %s (threshold %s). Latency %s is <= 0, skipping metric. isRemoved: %v, delayReason: %v",
+			nodeName, duration, info.removalThreshold, latency, isRemoved, delayReason)
 	}
 	if isRemoved {
 		t.logDeletion(nodeName, duration, info.removalThreshold, latency)
 	} else {
-		klog.V(4).Infof("Node %q was not removed (unneeded for %s) because of %q. Latency: %s",
-			nodeName, duration, reason, latency)
+		klog.V(4).Infof("Node %q became needed again (unneeded for %s). Blocker: %q. Latency: %s",
+			nodeName, duration, delayReason, latency)
 	}
 }
 
@@ -192,8 +155,24 @@ func (t *NodeLatencyTracker) getTrackedNodes() []string {
 // CleanUp cleans up internal structures.
 func (t *NodeLatencyTracker) CleanUp() {
 	t.unneededNodes = make(map[string]unneededNodeState)
-	t.unneededNodesToReport = make(map[string]unneededNodeState)
 	if t.wrapped != nil {
 		t.wrapped.CleanUp()
 	}
+}
+
+func (t *NodeLatencyTracker) updateLatestDelayReasons(unremovableNodes []*status.UnremovableNode) {
+	for _, val := range unremovableNodes {
+		if info, exists := t.unneededNodes[val.Node.Name]; exists {
+			if isBlocker(val.Reason) {
+				reasonStr := val.Reason.String()
+				info.latestDelayReason = reasonStr
+				t.unneededNodes[val.Node.Name] = info
+				klog.V(6).Infof("Tracking latest delay reason %s for node %s.", reasonStr, val.Node.Name)
+			}
+		}
+	}
+}
+
+func isBlocker(reason simulator.UnremovableReason) bool {
+	return reason != simulator.NoReason && reason != simulator.NotUnneededLongEnough && reason != simulator.NotUnreadyLongEnough
 }

--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
@@ -54,13 +54,17 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 	// 1. Planner calculates unneeded nodes (UpdateScaleDownCandidates)
 	// 2. Actuator attempts deletion and reports status (Process)
 	type step struct {
-		unneededList     []string                 // Nodes found unneeded this loop
-		thresholds       map[string]time.Duration // Specific thresholds for this loop
-		scaledDownList   []string                 // Nodes successfully deleted this loop
-		unremovableList  []string                 // Nodes failed to delete this loop
-		wantTrackedNodes []string                 // Expected internal state after this loop
-		wantThresholds   map[string]time.Duration // Expected threshold values in internal state
+		unneededList          []string                               // Nodes found unneeded this loop
+		thresholds            map[string]time.Duration               // Specific thresholds for this loop
+		scaledDownList        []string                               // Nodes successfully deleted this loop
+		unremovableList       []string                               // Nodes failed to delete this loop
+		unremovableReason     map[string]simulator.UnremovableReason // Nodes failed to delete with specific reasons
+		wantTrackedNodes      []string                               // Expected internal state after this loop
+		wantThresholds        map[string]time.Duration               // Expected threshold values in internal state
+		wantLatestDelayReason map[string]string                      // Expected latestDelayReason values in internal state
 	}
+
+	baseTime := time.Now()
 
 	tests := []struct {
 		name  string
@@ -149,21 +153,70 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Tracks latest blocker reason when node is blocked by expected reasons",
+			steps: []step{
+				{
+					// Step 0: node1 becomes unneeded
+					unneededList:          []string{"node1"},
+					wantTrackedNodes:      []string{"node1"},
+					wantLatestDelayReason: map[string]string{"node1": ""},
+				},
+				{
+					// Step 1: node1 remains unneeded (not blocked)
+					unneededList:          []string{"node1"},
+					wantTrackedNodes:      []string{"node1"},
+					wantLatestDelayReason: map[string]string{"node1": ""},
+				},
+				{
+					// Step 2: node1 is unremovable due to BlockedByPod
+					unneededList:          []string{"node1"},
+					unremovableReason:     map[string]simulator.UnremovableReason{"node1": simulator.BlockedByPod},
+					wantTrackedNodes:      []string{"node1"},
+					wantLatestDelayReason: map[string]string{"node1": "BlockedByPod"},
+				},
+				{
+					// Step 3: node1 is still unremovable due to AtomicScaleDownFailed
+					unneededList:          []string{"node1"},
+					unremovableReason:     map[string]simulator.UnremovableReason{"node1": simulator.AtomicScaleDownFailed},
+					wantTrackedNodes:      []string{"node1"},
+					wantLatestDelayReason: map[string]string{"node1": "AtomicScaleDownFailed"},
+				},
+				{
+					// Step 4: node1 is unremovable due to NotUnneededLongEnough (not a blocker)
+					// The latest blocker reason should NOT be overwritten by a non-blocker!
+					// It should remain "AtomicScaleDownFailed".
+					unneededList:          []string{"node1"},
+					unremovableReason:     map[string]simulator.UnremovableReason{"node1": simulator.NotUnneededLongEnough},
+					wantTrackedNodes:      []string{"node1"},
+					wantLatestDelayReason: map[string]string{"node1": "AtomicScaleDownFailed"},
+				},
+				{
+					// Step 5: node1 is finally deleted
+					unneededList:     []string{"node1"},
+					scaledDownList:   []string{"node1"},
+					wantTrackedNodes: []string{},
+				},
+			},
+		},
 	}
-
-	baseTime := time.Now()
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tracker := NewNodeLatencyTracker(processor.NewDefaultScaleDownStatusProcessor())
 
 			for i, step := range tc.steps {
-				stepTime := baseTime.Add(testStepDuration)
+				stepTime := baseTime.Add(time.Duration(i+1) * testStepDuration)
 
 				candidates := candidatesFromNames(step.unneededList, step.thresholds)
 				tracker.UpdateScaleDownCandidates(candidates, stepTime)
 
-				sd := newScaleDownStatus(step.scaledDownList, step.unremovableList)
+				var sd *status.ScaleDownStatus
+				if step.unremovableReason != nil {
+					sd = newScaleDownStatusWithReasons(step.scaledDownList, step.unremovableReason)
+				} else {
+					sd = newScaleDownStatus(step.scaledDownList, step.unremovableList)
+				}
 				tracker.Process(&ca_context.AutoscalingContext{}, sd)
 
 				gotTracked := tracker.getTrackedNodes()
@@ -183,6 +236,14 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 					if actualInfo, ok := tracker.unneededNodes[nodeName]; ok {
 						if actualInfo.removalThreshold != wantThreshold {
 							t.Errorf("Step %d: node %q incorrect threshold: got %v, want %v", i, nodeName, actualInfo.removalThreshold, wantThreshold)
+						}
+
+						if step.wantLatestDelayReason != nil {
+							if wantReason, ok := step.wantLatestDelayReason[nodeName]; ok {
+								if actualInfo.latestDelayReason != wantReason {
+									t.Errorf("Step %d: node %q incorrect latestDelayReason: got %q, want %q", i, nodeName, actualInfo.latestDelayReason, wantReason)
+								}
+							}
 						}
 					} else {
 						t.Errorf("Step %d: node %q expected to be tracked but was not", i, nodeName)
@@ -238,34 +299,18 @@ func (m *mockStatusProcessor) CleanUp() {
 	m.cleanUpCalled = true
 }
 
-func TestNodeLatencyTracker_ProcessReasons(t *testing.T) {
-	tracker := NewNodeLatencyTracker(processor.NewDefaultScaleDownStatusProcessor())
-	now := time.Now()
-
-	// Start tracking node1, node2 as unneeded
-	tracker.UpdateScaleDownCandidates([]*scaledown.UnneededNode{
-		{Node: &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}, RemovalThreshold: 0},
-		{Node: &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}, RemovalThreshold: 0},
-	}, now)
-
-	// In next iteration:
-	// - node1 became needed again (not in candidates, not in unremovable)
-	// - node2 was unremovable (not in candidates, is in status.UnremovableNodes with BlockedByPod)
-	tracker.UpdateScaleDownCandidates([]*scaledown.UnneededNode{}, now.Add(testStepDuration))
-
-	sd := &status.ScaleDownStatus{
-		UnremovableNodes: []*status.UnremovableNode{
-			{
-				Node:   &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
-				Reason: simulator.BlockedByPod,
-			},
-		},
+func newScaleDownStatusWithReasons(scaledDown []string, unremovable map[string]simulator.UnremovableReason) *status.ScaleDownStatus {
+	sd := &status.ScaleDownStatus{}
+	for _, name := range scaledDown {
+		sd.ScaledDownNodes = append(sd.ScaledDownNodes, &status.ScaleDownNode{Node: &apiv1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}})
 	}
-
-	// We process. This should trigger recordWithState and clear t.unneededNodesToReport.
-	tracker.Process(&ca_context.AutoscalingContext{}, sd)
-
-	if len(tracker.unneededNodesToReport) != 0 {
-		t.Errorf("Expected unneededNodesToReport to be empty, got %v", tracker.unneededNodesToReport)
+	for name, reason := range unremovable {
+		sd.UnremovableNodes = append(sd.UnremovableNodes, &status.UnremovableNode{
+			Node:   &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}},
+			Reason: reason,
+		})
 	}
+	return sd
 }

--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
@@ -262,10 +262,10 @@ func TestNodeLatencyTracker_ProcessReasons(t *testing.T) {
 		},
 	}
 
-	// We process. This should trigger recordWithState and clear t.removedUnneededNodes.
+	// We process. This should trigger recordWithState and clear t.unneededNodesToReport.
 	tracker.Process(&ca_context.AutoscalingContext{}, sd)
 
-	if len(tracker.removedUnneededNodes) != 0 {
-		t.Errorf("Expected removedUnneededNodes to be empty, got %v", tracker.removedUnneededNodes)
+	if len(tracker.unneededNodesToReport) != 0 {
+		t.Errorf("Expected unneededNodesToReport to be empty, got %v", tracker.unneededNodesToReport)
 	}
 }

--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 	processor "k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 )
 
 const testStepDuration = 1 * time.Minute
@@ -235,4 +236,36 @@ func (m *mockStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingCont
 
 func (m *mockStatusProcessor) CleanUp() {
 	m.cleanUpCalled = true
+}
+
+func TestNodeLatencyTracker_ProcessReasons(t *testing.T) {
+	tracker := NewNodeLatencyTracker(processor.NewDefaultScaleDownStatusProcessor())
+	now := time.Now()
+
+	// Start tracking node1, node2 as unneeded
+	tracker.UpdateScaleDownCandidates([]*scaledown.UnneededNode{
+		{Node: &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}, RemovalThreshold: 0},
+		{Node: &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}, RemovalThreshold: 0},
+	}, now)
+
+	// In next iteration:
+	// - node1 became needed again (not in candidates, not in unremovable)
+	// - node2 was unremovable (not in candidates, is in status.UnremovableNodes with BlockedByPod)
+	tracker.UpdateScaleDownCandidates([]*scaledown.UnneededNode{}, now.Add(testStepDuration))
+
+	sd := &status.ScaleDownStatus{
+		UnremovableNodes: []*status.UnremovableNode{
+			{
+				Node:   &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+				Reason: simulator.BlockedByPod,
+			},
+		},
+	}
+
+	// We process. This should trigger recordWithState and clear t.removedUnneededNodes.
+	tracker.Process(&ca_context.AutoscalingContext{}, sd)
+
+	if len(tracker.removedUnneededNodes) != 0 {
+		t.Errorf("Expected removedUnneededNodes to be empty, got %v", tracker.removedUnneededNodes)
+	}
 }

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -372,7 +372,7 @@ func (p *Planner) atomicScaleDownNode(node *simulator.NodeToBeRemoved) bool {
 // especially when they require draining, so incrementing the limit by N every
 // loop may in practice lead the limit to increase too much after a number of
 // loops. To help with that, we can put another, not incremental upper bound on
-// the limit: with max unneded time U and loop interval I, we're going to have
+// the limit: with max unneeded time U and loop interval I, we're going to have
 // up to U/I loops before a node is removed. This means that the total number
 // of unneeded nodes shouldn't really exceed N*U/I - scale down will not be
 // able to keep up with removing them anyway.

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -248,8 +248,8 @@ func ObserveBinpackingHeterogeneity(instanceType, cpuCount, namespaceCount strin
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
 // again after being marked unneeded
-func UpdateScaleDownNodeRemovalLatency(deleted bool, reason string, duration time.Duration) {
-	DefaultMetrics.UpdateScaleDownNodeRemovalLatency(deleted, reason, duration)
+func UpdateScaleDownNodeRemovalLatency(deleted bool, delayReason string, duration time.Duration) {
+	DefaultMetrics.UpdateScaleDownNodeRemovalLatency(deleted, delayReason, duration)
 }
 
 // ObserveMaxNodeSkipEvalDurationSeconds records the longest time during which node was skipped during ScaleDown.

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -247,7 +247,7 @@ func ObserveBinpackingHeterogeneity(instanceType, cpuCount, namespaceCount strin
 }
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
-// again after being marked unneded
+// again after being marked unneeded
 func UpdateScaleDownNodeRemovalLatency(deleted bool, reason string, duration time.Duration) {
 	DefaultMetrics.UpdateScaleDownNodeRemovalLatency(deleted, reason, duration)
 }

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -248,8 +248,8 @@ func ObserveBinpackingHeterogeneity(instanceType, cpuCount, namespaceCount strin
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
 // again after being marked unneded
-func UpdateScaleDownNodeRemovalLatency(deleted bool, duration time.Duration) {
-	DefaultMetrics.UpdateScaleDownNodeRemovalLatency(deleted, duration)
+func UpdateScaleDownNodeRemovalLatency(deleted bool, reason string, duration time.Duration) {
+	DefaultMetrics.UpdateScaleDownNodeRemovalLatency(deleted, reason, duration)
 }
 
 // ObserveMaxNodeSkipEvalDurationSeconds records the longest time during which node was skipped during ScaleDown.

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -500,7 +500,7 @@ func newCaMetrics() *caMetrics {
 			&k8smetrics.HistogramOpts{
 				Namespace: caNamespace,
 				Name:      "node_removal_latency_seconds",
-				Help:      "Latency from when an unneeded node is eligible for scale down until it is removed (deleted=true) or it became needed again (deleted=false).",
+				Help:      "Latency from when an unneeded node is eligible for scale down until it is removed (deleted=true) or it became needed again (deleted=false). The 'reason' label indicates the technical bottleneck that delayed the scale-down ('none' if not delayed).",
 				Buckets:   k8smetrics.ExponentialBuckets(1, 1.5, 19), // ~1s → ~24min
 			}, []string{"deleted", "reason"},
 		),

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -502,7 +502,7 @@ func newCaMetrics() *caMetrics {
 				Name:      "node_removal_latency_seconds",
 				Help:      "Latency from when an unneeded node is eligible for scale down until it is removed (deleted=true) or it became needed again (deleted=false).",
 				Buckets:   k8smetrics.ExponentialBuckets(1, 1.5, 19), // ~1s → ~24min
-			}, []string{"deleted"},
+			}, []string{"deleted", "reason"},
 		),
 	}
 }
@@ -848,8 +848,8 @@ func (m *caMetrics) ObserveBinpackingHeterogeneity(instanceType, cpuCount, names
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
 // again after being marked unneded
-func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, duration time.Duration) {
-	m.scaleDownNodeRemovalLatency.WithLabelValues(strconv.FormatBool(deleted)).Observe(duration.Seconds())
+func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, reason string, duration time.Duration) {
+	m.scaleDownNodeRemovalLatency.WithLabelValues(strconv.FormatBool(deleted), reason).Observe(duration.Seconds())
 }
 
 // ObserveMaxNodeSkipEvalDurationSeconds records the longest time during which node was skipped during ScaleDown.

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -500,9 +500,9 @@ func newCaMetrics() *caMetrics {
 			&k8smetrics.HistogramOpts{
 				Namespace: caNamespace,
 				Name:      "node_removal_latency_seconds",
-				Help:      "Latency from when an unneeded node is eligible for scale down until it is removed (deleted=true) or it became needed again (deleted=false). The 'reason' label indicates the technical bottleneck that delayed the scale-down ('none' if not delayed).",
+				Help:      "Latency from when an unneeded node is eligible for scale down until it is removed (deleted=true) or it became needed again (deleted=false). The 'delay_reason' label indicates the technical bottleneck that delayed the scale-down ('none' if not delayed).",
 				Buckets:   k8smetrics.ExponentialBuckets(1, 1.5, 19), // ~1s → ~24min
-			}, []string{"deleted", "reason"},
+			}, []string{"deleted", "delay_reason"},
 		),
 	}
 }
@@ -848,8 +848,8 @@ func (m *caMetrics) ObserveBinpackingHeterogeneity(instanceType, cpuCount, names
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
 // again after being marked unneeded
-func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, reason string, duration time.Duration) {
-	m.scaleDownNodeRemovalLatency.WithLabelValues(strconv.FormatBool(deleted), reason).Observe(duration.Seconds())
+func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, delayReason string, duration time.Duration) {
+	m.scaleDownNodeRemovalLatency.WithLabelValues(strconv.FormatBool(deleted), delayReason).Observe(duration.Seconds())
 }
 
 // ObserveMaxNodeSkipEvalDurationSeconds records the longest time during which node was skipped during ScaleDown.

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -847,7 +847,7 @@ func (m *caMetrics) ObserveBinpackingHeterogeneity(instanceType, cpuCount, names
 }
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
-// again after being marked unneded
+// again after being marked unneeded
 func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, reason string, duration time.Duration) {
 	m.scaleDownNodeRemovalLatency.WithLabelValues(strconv.FormatBool(deleted), reason).Observe(duration.Seconds())
 }

--- a/cluster-autoscaler/metrics/metrics_test.go
+++ b/cluster-autoscaler/metrics/metrics_test.go
@@ -18,8 +18,11 @@ package metrics
 
 import (
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/component-base/metrics"
 )
@@ -68,4 +71,25 @@ func TestUpdateNodesCount(t *testing.T) {
 	assert.Equal(t, 4, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(suspendedLabel))))
 	assert.Equal(t, 5, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(longUnregisteredLabel))))
 	assert.Equal(t, 6, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(unregisteredLabel))))
+}
+
+func TestUpdateScaleDownNodeRemovalLatency(t *testing.T) {
+	reg := metrics.NewKubeRegistry()
+	m := newCaMetricsWithRegistry(reg)
+	m.RegisterAll(false)
+
+	m.UpdateScaleDownNodeRemovalLatency(true, "deleted", 10*time.Second)
+	m.UpdateScaleDownNodeRemovalLatency(false, "BlockedByPod", 20*time.Second)
+
+	var metric1 dto.Metric
+	err := m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("true", "deleted").(prometheus.Histogram).Write(&metric1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), metric1.Histogram.GetSampleCount())
+	assert.Equal(t, 10.0, metric1.Histogram.GetSampleSum())
+
+	var metric2 dto.Metric
+	err = m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("false", "BlockedByPod").(prometheus.Histogram).Write(&metric2)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), metric2.Histogram.GetSampleCount())
+	assert.Equal(t, 20.0, metric2.Histogram.GetSampleSum())
 }

--- a/cluster-autoscaler/metrics/metrics_test.go
+++ b/cluster-autoscaler/metrics/metrics_test.go
@@ -78,11 +78,11 @@ func TestUpdateScaleDownNodeRemovalLatency(t *testing.T) {
 	m := newCaMetricsWithRegistry(reg)
 	m.RegisterAll(false)
 
-	m.UpdateScaleDownNodeRemovalLatency(true, "deleted", 10*time.Second)
+	m.UpdateScaleDownNodeRemovalLatency(true, "none", 10*time.Second)
 	m.UpdateScaleDownNodeRemovalLatency(false, "BlockedByPod", 20*time.Second)
 
 	var metric1 dto.Metric
-	err := m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("true", "deleted").(prometheus.Histogram).Write(&metric1)
+	err := m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("true", "none").(prometheus.Histogram).Write(&metric1)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), metric1.Histogram.GetSampleCount())
 	assert.Equal(t, 10.0, metric1.Histogram.GetSampleSum())

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -59,6 +59,52 @@ type UnremovableNode struct {
 // UnremovableReason represents a reason why a node can't be removed by CA.
 type UnremovableReason int
 
+// String returns the string representation of UnremovableReason.
+func (r UnremovableReason) String() string {
+	switch r {
+	case NoReason:
+		return "NoReason"
+	case ScaleDownDisabledAnnotation:
+		return "ScaleDownDisabledAnnotation"
+	case ScaleDownUnreadyDisabled:
+		return "ScaleDownUnreadyDisabled"
+	case NotAutoscaled:
+		return "NotAutoscaled"
+	case NotUnneededLongEnough:
+		return "NotUnneededLongEnough"
+	case NotUnreadyLongEnough:
+		return "NotUnreadyLongEnough"
+	case NodeGroupMinSizeReached:
+		return "NodeGroupMinSizeReached"
+	case NodeGroupMaxDeletionCountReached:
+		return "NodeGroupMaxDeletionCountReached"
+	case AtomicScaleDownFailed:
+		return "AtomicScaleDownFailed"
+	case MinimalResourceLimitExceeded:
+		return "MinimalResourceLimitExceeded"
+	case CurrentlyBeingDeleted:
+		return "CurrentlyBeingDeleted"
+	case NotUnderutilized:
+		return "NotUnderutilized"
+	case NotUnneededOtherReason:
+		return "NotUnneededOtherReason"
+	case RecentlyUnremovable:
+		return "RecentlyUnremovable"
+	case NoPlaceToMovePods:
+		return "NoPlaceToMovePods"
+	case BlockedByPod:
+		return "BlockedByPod"
+	case UnexpectedError:
+		return "UnexpectedError"
+	case NoNodeInfo:
+		return "NoNodeInfo"
+	case BlockedByOnCompletionPod:
+		return "BlockedByOnCompletionPod"
+	default:
+		return "Unknown"
+	}
+}
+
 const (
 	// NoReason - sanity check, this should never be set explicitly. If this is found in the wild, it means that it was
 	// implicitly initialized and might indicate a bug.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR enhances scale-down latency tracking by introducing a `delay_reason` label to the `node_removal_latency_seconds` Prometheus metric to capture the technical bottleneck that delayed node removal.
Previously, `node_removal_latency_seconds` only recorded a boolean `deleted` label. When nodes were delayed by expected technical blockers (such as `AtomicScaleDownFailed` or `BlockedByPod`), their latency accumulated and eventually emitted as a large spike upon deletion or resolution, making it difficult to set clean SLO alerts.
This PR strictly decouples **Exit Outcomes** from **Technical Bottlenecks**:
* **Outcome (`deleted` label):** A boolean indicating whether the node was successfully removed (`true`) or stopped being tracked because it became needed again (`false`).
* **Bottleneck (`delay_reason` label):** Indicates the technical constraint that delayed the scale-down (e.g., `BlockedByPod`, `AtomicScaleDownFailed`, `NodeGroupMinSizeReached`). If the node scaled down without experiencing any technical delay, `delay_reason` defaults to `"none"`.

Key changes:
* **Decoupled Metric Labels:** Added `delay_reason` label to `node_removal_latency_seconds` representing the technical delay reason (defaulting to `"none"`).
* **Blocker Tracking:** Updated `NodeLatencyTracker` to track `latestDelayReason` for unneeded nodes across simulation loops. Normal waiting states (`NotUnneededLongEnough`, `NotUnreadyLongEnough`, `NoReason`) are ignored so historical technical blockers are preserved.
* **Simplified Architecture:** Streamlined `NodeLatencyTracker` by consolidating state updates and cleanup in `recordAndCleanup`, removing intermediate tracking maps.
* **Metric Documentation:** Updated the metric Help string in `metrics.go` to clearly document the `deleted` and `delay_reason` labels.
* **Unit Tests:** Updated unit tests in `node_latency_tracker_test.go` and `metrics_test.go` to verify blocker tracking across multi-step simulation loops.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
#### Special notes for your reviewer:
* The `node_removal_latency_seconds` metric signature is updated to accept `deleted` and `delay_reason` labels.
* The `delay_reason` label strictly carries the technical delay bottleneck (defaulting to `"none"`), while the outcome (deleted vs needed again) is carried by the `deleted` boolean label.
* The existing `UnremovableReason` type now implements `fmt.Stringer` to provide readable labels for metrics.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Enhance `node_removal_latency_seconds` scale-down metric with a new `delay_reason` label detailing the technical blocker that delayed scale-down (e.g. `none`, `BlockedByPod`, `AtomicScaleDownFailed`).

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
