### PR TITLE
Initialize counters with zero in vpa-updater

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -276,6 +276,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 			klog.ErrorS(err, "Failed to get creator maps")
 			continue
 		}
+		metrics_updater.InitCounters(vpaSize, vpa.Name, vpa.Namespace, updateMode)
 
 		inPlaceLimiter := u.restrictionFactory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 		podsAvailableForUpdate := make([]*corev1.Pod, 0)
@@ -322,7 +323,6 @@ func (u *updater) RunOnce(ctx context.Context) {
 		if updateMode == vpa_types.UpdateModeOff || updateMode == vpa_types.UpdateModeInitial {
 			continue
 		}
-		metrics_updater.InitCounters(vpaSize, vpa.Name, vpa.Namespace, updateMode)
 
 		evictionLimiter := u.restrictionFactory.NewPodsEvictionRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 		podsForEviction := make([]*corev1.Pod, 0)

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -272,7 +272,6 @@ func (u *updater) RunOnce(ctx context.Context) {
 		updateMode := vpa_api_util.GetUpdateMode(vpa)
 		controlledPodsCounter.Add(vpaSize, updateMode, vpaSize)
 		creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := u.restrictionFactory.GetCreatorMaps(livePods, vpa)
-		metrics_updater.InitCounters(vpaSize, vpa.Name, vpa.Namespace, updateMode)
 		if err != nil {
 			klog.ErrorS(err, "Failed to get creator maps")
 			continue
@@ -323,6 +322,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 		if updateMode == vpa_types.UpdateModeOff || updateMode == vpa_types.UpdateModeInitial {
 			continue
 		}
+		metrics_updater.InitCounters(vpaSize, vpa.Name, vpa.Namespace, updateMode)
 
 		evictionLimiter := u.restrictionFactory.NewPodsEvictionRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 		podsForEviction := make([]*corev1.Pod, 0)

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -272,6 +272,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 		updateMode := vpa_api_util.GetUpdateMode(vpa)
 		controlledPodsCounter.Add(vpaSize, updateMode, vpaSize)
 		creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := u.restrictionFactory.GetCreatorMaps(livePods, vpa)
+		metrics_updater.InitCounters(vpaSize, vpa.Name, vpa.Namespace, updateMode)
 		if err != nil {
 			klog.ErrorS(err, "Failed to get creator maps")
 			continue

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
@@ -209,6 +209,13 @@ func AddEvictedPod(vpaSize int, vpaName string, vpaNamespace string, mode vpa_ty
 	evictedCount.WithLabelValues(strconv.Itoa(log2), string(mode), vpaName, vpaNamespace).Inc()
 }
 
+// InitCounters initializes counters to 0 for a given VPA so they are visible before any events occur
+func InitCounters(vpaSize int, vpaName string, vpaNamespace string, mode vpa_types.UpdateMode) {
+	log2 := strconv.Itoa(metrics.GetVpaSizeLog2(vpaSize))
+	evictedCount.WithLabelValues(log2, string(mode), vpaName, vpaNamespace).Add(0)
+	inPlaceUpdatedCount.WithLabelValues(log2, vpaName, vpaNamespace).Add(0)
+}
+
 // RecordFailedEviction increases the counter of failed eviction attempts by given VPA size, name, namespace, update mode and reason
 func RecordFailedEviction(vpaSize int, vpaName string, vpaNamespace string, mode vpa_types.UpdateMode, reason string) {
 	log2 := metrics.GetVpaSizeLog2(vpaSize)

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -74,7 +74,7 @@ func TestInitCountersAreZero(t *testing.T) {
 		vpaNamespace string
 	}{
 		{
-			desc:         "VPA size 5, mode Auto",
+			desc:         "VPA size 5, mode Recreate",
 			vpaSize:      5,
 			mode:         vpa_types.UpdateModeRecreate,
 			log2:         "2",
@@ -94,7 +94,7 @@ func TestInitCountersAreZero(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Cleanup(evictedCount.Reset)
-			t.Cleanup(inPlaceUpdatableCount.Reset)
+			t.Cleanup(inPlaceUpdatedCount.Reset)
 			InitCounters(tc.vpaSize, tc.vpaName, tc.vpaNamespace, tc.mode)
 
 			evictedVal := testutil.ToFloat64(evictedCount.WithLabelValues(tc.log2, string(tc.mode), tc.vpaName, tc.vpaNamespace))

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -104,7 +104,7 @@ func TestInitCountersAreZero(t *testing.T) {
 
 			inPlaceVal := testutil.ToFloat64(inPlaceUpdatedCount.WithLabelValues(tc.log2, tc.vpaName, tc.vpaNamespace))
 			if inPlaceVal != 0 {
-				t.Errorf("Expected inPlaceUpdatedCount to be 0 after init got %v", evictedVal)
+				t.Errorf("Expected inPlaceUpdatedCount to be 0 after init got %v", inPlaceVal)
 			}
 		})
 	}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -76,7 +76,7 @@ func TestInitCountersAreZero(t *testing.T) {
 		{
 			desc:         "VPA size 5, mode Auto",
 			vpaSize:      5,
-			mode:         vpa_types.UpdateModeAuto, //nolint:staticcheck
+			mode:         vpa_types.UpdateModeRecreate,
 			log2:         "2",
 			vpaName:      "vpa-5",
 			vpaNamespace: "vpa-ns-5",

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -64,6 +64,52 @@ func TestAddEvictedPod(t *testing.T) {
 	}
 }
 
+func TestInitCountersAreZero(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		vpaSize      int
+		mode         vpa_types.UpdateMode
+		log2         string
+		vpaName      string
+		vpaNamespace string
+	}{
+		{
+			desc:         "VPA size 5, mode Auto",
+			vpaSize:      5,
+			mode:         vpa_types.UpdateModeAuto, //nolint:staticcheck
+			log2:         "2",
+			vpaName:      "vpa-5",
+			vpaNamespace: "vpa-ns-5",
+		},
+		{
+			desc:         "VPA size 10, mode Off",
+			vpaSize:      10,
+			mode:         vpa_types.UpdateModeOff,
+			log2:         "3",
+			vpaName:      "vpa-10",
+			vpaNamespace: "vpa-ns-10",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Cleanup(evictedCount.Reset)
+			t.Cleanup(inPlaceUpdatableCount.Reset)
+			InitCounters(tc.vpaSize, tc.vpaName, tc.vpaNamespace, tc.mode)
+
+			evictedVal := testutil.ToFloat64(evictedCount.WithLabelValues(tc.log2, string(tc.mode), tc.vpaName, tc.vpaNamespace))
+			if evictedVal != 0 {
+				t.Errorf("Expected evictedCount to be 0 after init got %v", evictedVal)
+			}
+
+			inPlaceVal := testutil.ToFloat64(inPlaceUpdatedCount.WithLabelValues(tc.log2, tc.vpaName, tc.vpaNamespace))
+			if inPlaceVal != 0 {
+				t.Errorf("Expected inPlaceUpdatedCount to be 0 after init got %v", evictedVal)
+			}
+		})
+	}
+}
+
 func TestRecordFailedEviction(t *testing.T) {
 	testCases := []struct {
 		desc         string


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR will Initialize `evicted_pods_total` and `in_place_updated_pods_total` counters to zero so that when querying for metrics before VPA has been updated or evicted, we see the number 0.

This feels needed because showing metrics as not existing is different than if a metric was 0.

#### Which issue(s) this PR fixes:
Fixes #9058 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
VPA Updater: Initialized counter metrics to 0 on pod creation. This fixed metric queries returning no data instead of 0 for VPAs with no updates or evictions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
