### PR TITLE
Mark known CPUStartupBoost flakes as flakes and add a retry

### DIFF
--- a/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
@@ -421,7 +421,8 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
-		f.It("to a subset of containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), func() {
+		// Flake to be fixed with https://github.com/kubernetes/autoscaler/issues/9698
+		f.It("to a subset of containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), framework.WithFlaky(), ginkgo.FlakeAttempts(3), func() {
 			ns := f.Namespace.Name
 
 			ginkgo.By("Setting up a VPA CRD with CPUStartupBoost")
@@ -495,7 +496,8 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
-		f.It("with different durations for different containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), func() {
+		// Flake to be fixed with https://github.com/kubernetes/autoscaler/issues/9698
+		f.It("with different durations for different containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), framework.WithFlaky(), ginkgo.FlakeAttempts(3), func() {
 			ns := f.Namespace.Name
 
 			ginkgo.By("Setting up a VPA CRD with CPUStartupBoost with different durations")


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This marks 2 known flakes as flakes, and adds a retry.
Note: this is not the same as fixing the flakes!
We still want them fixed, but that work is taking place in https://github.com/kubernetes/autoscaler/issues/9698
This is to reduce the noise of the failures in our CI.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #9698

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
