### PR TITLE
docs(vpa): document Prometheus history provider behavior

### DIFF
--- a/vertical-pod-autoscaler/docs/faq.md
+++ b/vertical-pod-autoscaler/docs/faq.md
@@ -6,6 +6,8 @@
 - [VPA restarts my pods but does not modify CPU or memory settings](#vpa-restarts-my-pods-but-does-not-modify-cpu-or-memory-settings)
 - [How can I apply VPA to my Custom Resource?](#how-can-i-apply-vpa-to-my-custom-resource)
 - [How can I use Prometheus as a history provider for the VPA recommender](#how-can-i-use-prometheus-as-a-history-provider-for-the-vpa-recommender)
+  - [Loading historical metrics for Pods that no longer exist](#loading-historical-metrics-for-pods-that-no-longer-exist)
+  - [Checkpoints are disabled when using Prometheus](#checkpoints-are-disabled-when-using-prometheus)
 - [I get recommendations for my single pod replicaset but they are not applied](#i-get-recommendations-for-my-single-pod-replicaset-but-they-are-not-applied)
 - [Can I run the VPA in an HA configuration?](#can-i-run-the-vpa-in-an-ha-configuration)
 - [What are the parameters to VPA recommender?](#what-are-the-parameters-to-vpa-recommender)
@@ -205,6 +207,59 @@ spec:
     - --prometheus-address=http://prometheus.default.svc.cluster.local:9090
     - --prometheus-bearer-token=<example-token>
 ```
+
+#### Loading historical metrics for Pods that no longer exist
+
+To attribute a historical metric series to a VPA object, the recommender needs the
+labels of the Pod that produced it (a VPA selects the Pods it manages by label
+selector). Because a metric series may belong to a Pod that has already been deleted,
+the recommender reads the labels from a dedicated Prometheus metric rather than from the
+cluster. Two flags control this:
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--metric-for-pod-labels` | `up{job="kubernetes-pods"}` | The Prometheus query used to look up Pod labels. |
+| `--pod-label-prefix` | `pod_label_` | The prefix the recommender strips from each label of that metric to reconstruct the Pod's labels (e.g. `pod_label_app="foo"` becomes `app="foo"`). |
+
+The defaults assume your Pods expose their own labels (for example, via a `/metrics`
+endpoint scraped under `job=kubernetes-pods`). A common alternative is to source the
+labels from [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics),
+which publishes Pod labels through the `kube_pod_labels` metric and prefixes each label
+with `label_`. To use it, override both flags. Note that the value of
+`--metric-for-pod-labels` must be a [range query](https://prometheus.io/docs/prometheus/latest/querying/basics/#range-vector-selectors)
+(it ends in a range selector such as `[8d]`); the recommender expects this query to
+return a matrix:
+
+```yaml
+spec:
+  containers:
+  - args:
+    - --v=4
+    - --storage=prometheus
+    - --prometheus-address=http://prometheus.default.svc.cluster.local:9090
+    - --metric-for-pod-labels=kube_pod_labels{job="kube-state-metrics"}[8d]
+    - --pod-label-prefix=label_
+```
+
+> [!IMPORTANT]
+> If the prefix or the metric is wrong, the recommender cannot reconstruct the Pod
+> labels, so the historical samples are loaded but never matched to a VPA object, and
+> recommendations will silently look as if there were no history at all.
+
+#### Checkpoints are disabled when using Prometheus
+
+When `--storage=prometheus` is set, the recommender does **not** write or garbage-collect
+`VerticalPodAutoscalerCheckpoint` objects. Prometheus itself is the source of history in
+this mode, so checkpoints are not needed. (Checkpoints are only used by the default
+`--storage=checkpoint` mode.)
+
+> [!NOTE]
+> History is loaded **once, at recommender startup**. If Prometheus cannot be reached at
+> that time, the error is logged (`Cannot get cluster history`) and the recommender
+> continues **without** any historical data — it does not retry, crash, or fall back to
+> checkpoints. It will only have the live samples it gathers from the metrics server from
+> that point on. If you expect history to be loaded, confirm the recommender can reach
+> `--prometheus-address` at startup.
 
 ### I get recommendations for my single pod replicaset but they are not applied
 


### PR DESCRIPTION
/area vertical-pod-autoscaler
/kind documentation

**What this PR does / why we need it**:

Documents two behaviors of the VPA recommender's Prometheus history provider that were previously undocumented (raised in #9228):

- **Pod label loading** — how `--metric-for-pod-labels` and `--pod-label-prefix` are used to reconstruct Pod labels (including a kube-state-metrics setup), so that historical metrics belonging to already-deleted Pods can be matched to a VPA object. Also notes that the label metric must be a range query.
- **Checkpoints + reachability** — that `--storage=prometheus` disables VPACheckpoint writing entirely, and that history is loaded only once at startup and is silently skipped (logged, not retried) if Prometheus is unreachable.

No code changes; documentation only.

**Which issue(s) this PR fixes**:

Fixes #9228

**Special notes for your reviewer**:

Findings originally reported by @plkokanov and @vitanovs in the issue. I verified each against the recommender source (`history_provider.go`, `recommender_controller.go`, `cluster_feeder.go`) before writing.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
