### PR TITLE
fix(vpa): do not discard fresh OOMs near aggregation boundary

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -204,8 +204,13 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 
 // RecordOOM adds info regarding OOM event in the model as an artificial memory sample.
 func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory ResourceAmount) error {
-	// Discard old OOM
-	if timestamp.Before(container.WindowEnd.Add(-1 * container.GetMemoryAggregationIntervalDuration())) {
+	// Discard OOMs that are too old to be relevant. The reference point is the
+	// most recently observed memory sample, not WindowEnd: WindowEnd is the end
+	// of the current aggregation interval and can sit up to a full interval ahead
+	// of the latest real sample, so using it here would wrongly drop a fresh OOM
+	// that landed just before an interval boundary (kubernetes/autoscaler#8548).
+	if !container.lastMemorySampleStart.IsZero() &&
+		timestamp.Before(container.lastMemorySampleStart.Add(-1*container.GetMemoryAggregationIntervalDuration())) {
 		return fmt.Errorf("OOM event will be discarded - it is too old (%v)", timestamp)
 	}
 	// Get max of the request and the recent usage-based memory peak.

--- a/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
@@ -210,6 +210,42 @@ func TestRecordOOMInNewWindow(t *testing.T) {
 	assert.NoError(t, test.container.RecordOOM(testTimestamp.Add(2*memoryAggregationInterval), ResourceAmount(1000*mb)))
 }
 
+// TestRecordOOMFreshOOMNearWindowBoundaryIsNotDiscarded reproduces
+// https://github.com/kubernetes/autoscaler/issues/8548.
+//
+// The OOM "too old" check in RecordOOM compares the OOM timestamp against
+// WindowEnd, not against wall-clock now. WindowEnd is driven forward by memory
+// usage samples and can sit up to one full aggregation interval (default 24h)
+// ahead of the most recent sample. When a usage sample crosses an aggregation
+// window boundary, an OOM that happened only seconds earlier - but on the older
+// side of that boundary - is rejected as "too old", even though it is fresh in
+// wall-clock terms.
+func TestRecordOOMFreshOOMNearWindowBoundaryIsNotDiscarded(t *testing.T) {
+	test := newContainerTest()
+	c := test.container
+	interval := GetAggregationsConfig().MemoryAggregationIntervalDuration
+
+	// First usage sample. This shifts WindowEnd to testTimestamp + interval.
+	test.mockMemoryHistogram.On("AddSample", 100.0*mb, 1.0, testTimestamp.Add(interval))
+	assert.True(t, c.AddSample(newUsageSample(testTimestamp, 100*mb, ResourceMemory)))
+
+	// A second usage sample lands exactly on the next aggregation boundary,
+	// shifting WindowEnd a further interval ahead (to testTimestamp + 2*interval).
+	boundary := testTimestamp.Add(interval)
+	windowEnd := testTimestamp.Add(2 * interval)
+	test.mockMemoryHistogram.On("AddSample", 2000.0*mb, 1.0, windowEnd)
+	assert.True(t, c.AddSample(newUsageSample(boundary, 2000*mb, ResourceMemory)))
+
+	// An OOM occurs just 1 second before that last usage sample. In wall-clock
+	// terms it is fresh, well within the aggregation interval, so it must be
+	// recorded rather than discarded as "too old". Recording it bumps the peak
+	// from 2000Mi to 2000Mi*1.2 = 2400Mi.
+	test.mockMemoryHistogram.On("SubtractSample", 2000.0*mb, 1.0, windowEnd)
+	test.mockMemoryHistogram.On("AddSample", 2400.0*mb, 1.0, windowEnd)
+	freshOOM := boundary.Add(-1 * time.Second)
+	assert.NoError(t, c.RecordOOM(freshOOM, ResourceAmount(1000*mb)))
+}
+
 // Tests with custom MemoryAggregationInterval to verify the per-VPA
 // MemoryAggregationIntervalSeconds setting affects container behavior.
 


### PR DESCRIPTION
/area vertical-pod-autoscaler
/kind bug

**What this PR does / why we need it**:

`RecordOOM` discarded an OOM as "too old" by comparing its timestamp against `WindowEnd` minus one aggregation interval:

```go
if timestamp.Before(container.WindowEnd.Add(-1 * container.GetMemoryAggregationIntervalDuration())) {
    return fmt.Errorf("OOM event will be discarded - it is too old (%v)", timestamp)
}
```

`WindowEnd` is the end of the current memory aggregation interval and is advanced by memory usage samples. It is anchored to the container's first sample, so its interval boundaries fall at an arbitrary time of day, and it can sit up to a full interval (24h by default) ahead of the most recent real sample. When a usage sample crosses an interval boundary, `WindowEnd` jumps a full interval forward, and an OOM that happened just before that boundary is then treated as more than one interval old and discarded, even though it is only seconds old in wall-clock terms.

This change anchors the staleness check to `lastMemorySampleStart` (the most recently observed memory sample) instead of `WindowEnd`. The "discard OOMs older than one aggregation interval" intent is preserved; only the reference point changes from the inflated window boundary to the latest real sample time. The zero-value case (no sample seen yet) is handled so the first OOM on a container is not dropped.

A regression test (`TestRecordOOMFreshOOMNearWindowBoundaryIsNotDiscarded`) is included; it fails on master with the reported error and passes with this change.

**Which issue(s) this PR fixes**:

Fixes #8548

**Special notes for your reviewer**:

I opened this off the back of the discussion in #8548. The question I raised there still stands: the existing guard uses a single aggregation interval as the staleness threshold (not the full `interval * count` window). I kept that single-interval semantics deliberately to keep the change minimal, and only corrected the reference point. If you would prefer a different threshold (for example the full aggregation window, or a comparison against wall-clock time), I am happy to adjust.

Full `./pkg/recommender/...` test suite passes with no existing tests modified.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed an issue where a recent OOM event could be incorrectly discarded as "too old" when it occurred just before a memory aggregation interval boundary, preventing the expected memory bump-up.
```
