### PR TITLE
Add MinQuotasTrackerOptions to support configurable scale-down quotas

### DIFF
--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -83,6 +83,7 @@ func NewAutoscaler(ctx context.Context, opts coreoptions.AutoscalerOptions, info
 		opts.DrainabilityRules,
 		opts.DraProvider,
 		opts.QuotasTrackerOptions,
+		opts.MinQuotasTrackerOptions,
 		opts.CSIProvider,
 		opts.CapacityBufferPodsRegistry,
 	), nil
@@ -167,6 +168,21 @@ func initializeDefaultOptions(ctx context.Context, opts *coreoptions.AutoscalerO
 	if opts.QuotasTrackerOptions.NodeFilter == nil {
 		virtualKubeletNodeFilter := utils.VirtualKubeletNodeFilter{}
 		opts.QuotasTrackerOptions.NodeFilter = resourcequotas.NewCombinedNodeFilter([]resourcequotas.NodeFilter{virtualKubeletNodeFilter})
+	}
+
+	if opts.MinQuotasTrackerOptions.QuotaProvider == nil {
+		opts.MinQuotasTrackerOptions.QuotaProvider = resourcequotas.NewCloudMinProvider(opts.CloudProvider)
+	} else {
+		opts.MinQuotasTrackerOptions.QuotaProvider = resourcequotas.NewCombinedQuotasProvider([]resourcequotas.Provider{
+			resourcequotas.NewCloudMinProvider(opts.CloudProvider),
+			opts.MinQuotasTrackerOptions.QuotaProvider,
+		})
+	}
+	if opts.MinQuotasTrackerOptions.CustomResourcesProcessor == nil {
+		opts.MinQuotasTrackerOptions.CustomResourcesProcessor = opts.Processors.CustomResourcesProcessor
+	}
+	if opts.MinQuotasTrackerOptions.NodeFilter == nil {
+		opts.MinQuotasTrackerOptions.NodeFilter = opts.QuotasTrackerOptions.NodeFilter
 	}
 
 	if opts.CSINodeAwareSchedulingEnabled {

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -172,11 +172,6 @@ func initializeDefaultOptions(ctx context.Context, opts *coreoptions.AutoscalerO
 
 	if opts.MinQuotasTrackerOptions.QuotaProvider == nil {
 		opts.MinQuotasTrackerOptions.QuotaProvider = resourcequotas.NewCloudMinProvider(opts.CloudProvider)
-	} else {
-		opts.MinQuotasTrackerOptions.QuotaProvider = resourcequotas.NewCombinedQuotasProvider([]resourcequotas.Provider{
-			resourcequotas.NewCloudMinProvider(opts.CloudProvider),
-			opts.MinQuotasTrackerOptions.QuotaProvider,
-		})
 	}
 	if opts.MinQuotasTrackerOptions.CustomResourcesProcessor == nil {
 		opts.MinQuotasTrackerOptions.CustomResourcesProcessor = opts.Processors.CustomResourcesProcessor

--- a/cluster-autoscaler/core/options/autoscaler.go
+++ b/cluster-autoscaler/core/options/autoscaler.go
@@ -65,6 +65,7 @@ type AutoscalerOptions struct {
 	DrainabilityRules          rules.Rules
 	DraProvider                *draprovider.Provider
 	QuotasTrackerOptions       resourcequotas.TrackerOptions
+	MinQuotasTrackerOptions    resourcequotas.TrackerOptions
 	CSIProvider                *csinodeprovider.Provider
 	KubeClientNew              client.Client
 	KubeCache                  cache.Cache

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -159,6 +159,7 @@ func NewStaticAutoscaler(
 	drainabilityRules rules.Rules,
 	draProvider *draprovider.Provider,
 	quotasTrackerOptions resourcequotas.TrackerOptions,
+	minQuotasTrackerOptions resourcequotas.TrackerOptions,
 	csiProvider *csinodeprovider.Provider,
 	capacityBufferPodsRegistry *fakepods.Registry) *StaticAutoscaler {
 
@@ -204,11 +205,7 @@ func NewStaticAutoscaler(
 		processors.ScaleDownStatusProcessor = ndlt
 	}
 	quotasTrackerFactory := resourcequotas.NewTrackerFactory(quotasTrackerOptions)
-	minQuotasTrackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
-		CustomResourcesProcessor: processors.CustomResourcesProcessor,
-		QuotaProvider:            resourcequotas.NewCloudMinProvider(cloudProvider),
-		NodeFilter:               quotasTrackerOptions.NodeFilter,
-	})
+	minQuotasTrackerFactory := resourcequotas.NewTrackerFactory(minQuotasTrackerOptions)
 
 	scaleDownPlanner := planner.New(autoscalingCtx, processors, deleteOptions, drainabilityRules, minQuotasTrackerFactory)
 	processorCallbacks.scaleDownPlanner = scaleDownPlanner

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -337,13 +337,15 @@ func setupAutoscaler(config *autoscalerSetupConfig) (*StaticAutoscaler, error) {
 	}
 	autoscalingCtx.ScaleDownActuator = actuation.NewActuator(&autoscalingCtx, clusterState, nodeDeletionTracker, deleteOptions, drainabilityRules, processors.NodeGroupConfigProcessor)
 
-	minQuotasProviders := []resourcequotas.Provider{resourcequotas.NewCloudMinProvider(provider)}
+	var minQuotaProvider resourcequotas.Provider
 	if config.quotaProvider != nil {
-		minQuotasProviders = append(minQuotasProviders, config.quotaProvider)
+		minQuotaProvider = config.quotaProvider
+	} else {
+		minQuotaProvider = resourcequotas.NewCloudMinProvider(provider)
 	}
 	minQuotasTrackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
 		CustomResourcesProcessor: processors.CustomResourcesProcessor,
-		QuotaProvider:            resourcequotas.NewCombinedQuotasProvider(minQuotasProviders),
+		QuotaProvider:            minQuotaProvider,
 	})
 
 	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules, minQuotasTrackerFactory)

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -254,6 +254,7 @@ type autoscalerSetupConfig struct {
 	clusterStateConfig     clusterstate.ClusterStateRegistryConfig
 	mocks                  *commonMocks
 	nodesDeleted           chan bool
+	quotaProvider          resourcequotas.Provider
 }
 
 func setupCloudProvider(config *autoscalerSetupConfig) (*testprovider.TestCloudProvider, error) {
@@ -335,7 +336,17 @@ func setupAutoscaler(config *autoscalerSetupConfig) (*StaticAutoscaler, error) {
 		nodeDeletionTracker = deletiontracker.NewNodeDeletionTracker(0 * time.Second)
 	}
 	autoscalingCtx.ScaleDownActuator = actuation.NewActuator(&autoscalingCtx, clusterState, nodeDeletionTracker, deleteOptions, drainabilityRules, processors.NodeGroupConfigProcessor)
-	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules, quotasTrackerFactory)
+
+	minQuotasProviders := []resourcequotas.Provider{resourcequotas.NewCloudMinProvider(provider)}
+	if config.quotaProvider != nil {
+		minQuotasProviders = append(minQuotasProviders, config.quotaProvider)
+	}
+	minQuotasTrackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
+		CustomResourcesProcessor: processors.CustomResourcesProcessor,
+		QuotaProvider:            resourcequotas.NewCombinedQuotasProvider(minQuotasProviders),
+	})
+
+	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules, minQuotasTrackerFactory)
 
 	processorCallbacks.scaleDownPlanner = sdPlanner
 
@@ -3764,4 +3775,120 @@ func TestStaticAutoscalerRunOnceWithNominatedNodeName(t *testing.T) {
 
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
+}
+
+type customQuota struct {
+	id     string
+	label  string
+	minCpu int64
+}
+
+func (q *customQuota) ID() string { return q.id }
+func (q *customQuota) AppliesTo(node *apiv1.Node) bool {
+	if node.Labels == nil {
+		return false
+	}
+	_, hasLabel := node.Labels[q.label]
+	return hasLabel
+}
+func (q *customQuota) Limits() map[string]int64 {
+	return map[string]int64{
+		apiv1.ResourceCPU.String(): q.minCpu,
+	}
+}
+
+type customQuotaProvider struct {
+	quotas []resourcequotas.Quota
+}
+
+func (p *customQuotaProvider) Quotas() ([]resourcequotas.Quota, error) {
+	return p.quotas, nil
+}
+
+func TestStaticAutoscalerScaleDownCustomQuota(t *testing.T) {
+	label := "custom-quota-label"
+	quotaId := "custom-quota"
+	minCpu := int64(3) // Minimum 3 CPUs required for nodes with this label
+
+	cq := &customQuota{
+		id:     quotaId,
+		label:  label,
+		minCpu: minCpu,
+	}
+	qp := &customQuotaProvider{
+		quotas: []resourcequotas.Quota{cq},
+	}
+
+	n1 := BuildTestNode("n1", 2000, 1000) // 2 CPUs
+	n1.Labels = map[string]string{label: "true"}
+	SetNodeReadyState(n1, true, time.Now())
+
+	n2 := BuildTestNode("n2", 2000, 1000) // 2 CPUs
+	n2.Labels = map[string]string{label: "true"}
+	SetNodeReadyState(n2, true, time.Now())
+
+	allNodes := []*apiv1.Node{n1, n2}
+
+	readyNodeLister := kubernetes.NewTestNodeLister(allNodes)
+	allNodeLister := kubernetes.NewTestNodeLister(allNodes)
+	allPodListerMock := &podListerMock{}
+	allPodListerMock.On("List").Return([]*apiv1.Pod{}, nil)
+
+	podDisruptionBudgetListerMock := &podDisruptionBudgetListerMock{}
+	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil)
+	daemonSetListerMock := &daemonSetListerMock{}
+	daemonSetListerMock.On("List", mock.Anything).Return([]*appsv1.DaemonSet{}, nil)
+	daemonSetListerMock.On("GetPodDaemonSets", mock.Anything).Return([]*appsv1.DaemonSet{}, nil)
+
+	onScaleDownMock := &onScaleDownMock{}
+
+	setupConfig := &autoscalerSetupConfig{
+		nodeGroups: []*nodeGroup{
+			{
+				name:  "ng1",
+				nodes: allNodes,
+				min:   1,
+				max:   10,
+			},
+		},
+		mocks: &commonMocks{
+			allNodeLister:             allNodeLister,
+			readyNodeLister:           readyNodeLister,
+			allPodLister:              allPodListerMock,
+			podDisruptionBudgetLister: podDisruptionBudgetListerMock,
+			daemonSetLister:           daemonSetListerMock,
+			onScaleDown:               onScaleDownMock,
+		},
+		quotaProvider: qp,
+		autoscalingOptions: config.AutoscalingOptions{
+			NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+				ScaleDownUnneededTime:         0 * time.Second,
+				ScaleDownUnreadyTime:          0 * time.Second,
+				ScaleDownUtilizationThreshold: 0.5,
+			},
+			ScaleDownSimulationTimeout: 10 * time.Second,
+			MaxScaleDownParallelism:    10,
+		},
+	}
+
+	autoscaler, err := setupAutoscaler(setupConfig)
+	assert.NoError(t, err)
+
+	statusProcessor := &scaleDownStatusProcessorMock{}
+	autoscaler.processors.ScaleDownStatusProcessor = statusProcessor
+
+	now := time.Now()
+	err = autoscaler.RunOnce(now)
+	assert.NoError(t, err)
+
+	now = now.Add(2 * time.Second)
+	err = autoscaler.RunOnce(now)
+	assert.NoError(t, err)
+
+	onScaleDownMock.AssertNotCalled(t, "ScaleDown", mock.Anything, mock.Anything)
+
+	assert.Equal(t, 2, len(statusProcessor.scaleDownStatus.UnremovableNodes))
+	for _, unremovableNode := range statusProcessor.scaleDownStatus.UnremovableNodes {
+		assert.Equal(t, simulator.MinimalResourceLimitExceeded, unremovableNode.Reason)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR introduces  MinQuotasTrackerOptions  to cleanly separate scale-up (maximum limits) and scale-down (minimum limits) quota configurations.
Previously, scale-down quotas were hardcoded to GCE minimum limits, making it impossible to safely configure custom scale-down quotas without interfering with scale-up or accidentally blocking scale-down due to GCE maximum limits leakage.

#Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/autoscaler/issues/8703

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
-[Proposal]: https://github.com/kubernetes/autoscaler/blob/9db3d2536ebd1484a5ae24a601f2d147cb3217a3/cluster-autoscaler/proposals/granular-resource-limits.md
```