### PR TITLE
update contributing doc with deprecation policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,13 @@ Autoscaler collaborators may add "LGTM" (Looks Good To Me) or an equivalent comm
 that a PR is acceptable. Any change requires at least one LGTM. No pull requests can be merged 
 until at least one Autoscaler collaborator signs off with an LGTM.
 
+### Deprecation Policy
+
+This repository follows the [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecating-a-flag-or-cli).
+When planning to deprecate a Kubernetes resource API, command line flag or CLI behavior, or
+a feature, please review the deprecation policy to ensure that functionality has not been removed before the
+appropriate signals have been broadcast and the proper amount of deprecation time has been observed.
+
 ### Support Channels
 
 Whether you are a user or contributor, official support channels include:


### PR DESCRIPTION


#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This change adds a link to the kubernetes deprecation policy and some language about when to observe it. This change is being added to help broadcast how deprecations should occur within this repository.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
