### PR TITLE
Make dependabot manage the VPA 1.7 release branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+### VPA master branch
 - package-ecosystem: gomod
   directories:
     - "/vertical-pod-autoscaler"
@@ -41,6 +42,45 @@ updates:
       update-types:
         - "minor"
         - "patch"
+### VPA release 1.7 branch
+- package-ecosystem: gomod
+  target-branch: vpa-release-1.7
+  directories:
+    - "/vertical-pod-autoscaler"
+    - "/vertical-pod-autoscaler/test/"
+  schedule:
+    interval: weekly
+  labels:
+    - "area/vertical-pod-autoscaler"
+    - "release-note-none"
+    - "ok-to-test"
+    - "triage/accepted"
+  allow:
+    - dependency-type: "all"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+- package-ecosystem: docker
+  target-branch: vpa-release-1.7
+  directories:
+    - "/vertical-pod-autoscaler/pkg/admission-controller"
+    - "/vertical-pod-autoscaler/pkg/recommender"
+    - "/vertical-pod-autoscaler/pkg/updater"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 3
+  labels:
+    - "area/vertical-pod-autoscaler"
+    - "release-note-none"
+    - "ok-to-test"
+  groups:
+    actions:
+      update-types:
+        - "minor"
+        - "patch"
+### Addon-resizer
 - package-ecosystem: gomod
   directory: "/addon-resizer"
   schedule:

--- a/vertical-pod-autoscaler/RELEASE.md
+++ b/vertical-pod-autoscaler/RELEASE.md
@@ -211,6 +211,10 @@ sure nothing we care about will break if we do.
 
     IMPORTANT: Make sure the tags created above exist before merging into the main branch!
 
+## Update dependabot
+
+Update dependabot to include the latest 3 minor releases
+
 ## Permissions
 
 * Permissions to access `gcr.io/k8s-staging-autoscaling` are governed by list


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I'd like to start paying attention to VPA patch releases from now on.
The idea here is to get dependabot to patch godeps and the Go version for us in release branches.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
