### PR TITLE
fix(vpa): honor --history-cpu-metric and --history-memory-metric flags

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
@@ -232,6 +232,8 @@ func initHistoryProvider(ctx context.Context, rec Recommender, config *recommend
 			CtrNameLabel:           config.CtrNameLabel,
 			CadvisorMetricsJobName: config.PrometheusJobName,
 			Namespace:              config.CommonFlags.VpaObjectNamespace,
+			CPUMetricName:          config.HistoryCPUMetric,
+			MemoryMetricName:       config.HistoryMemoryMetric,
 			Authentication: history.PrometheusCredentials{
 				BearerToken: config.PrometheusBearerToken,
 				Username:    config.Username,


### PR DESCRIPTION
/area vertical-pod-autoscaler
/kind bug

**What this PR does / why we need it**:

`initHistoryProvider` built the `history.PrometheusHistoryProviderConfig` without copying `config.HistoryCPUMetric` and `config.HistoryMemoryMetric` into the provider's `CPUMetricName` and `MemoryMetricName` fields, so they stayed empty. `GetClusterHistory` then built its queries without a metric name:

```go
historicalCpuQuery := fmt.Sprintf("rate(%s{%s}[%s])", p.config.CPUMetricName, podSelector, p.config.HistoryResolution)
historicalMemoryQuery := fmt.Sprintf("%s{%s}", p.config.MemoryMetricName, podSelector)
```

producing `rate({<selector>}[<res>])` and `{<selector>}`, which do not target the intended cadvisor metrics. As a result the `--history-cpu-metric` and `--history-memory-metric` flags had no effect.

This PR extracts the provider config construction into a testable helper `newPrometheusHistoryProviderConfig` and copies the two metric names into it. A regression test asserts the names are propagated.

**Which issue(s) this PR fixes**:

Fixes #9747

**Special notes for your reviewer**:

Found while documenting the Prometheus history provider (#9724). The existing provider unit tests pass because they set `CPUMetricName` / `MemoryMetricName` directly in the test config; this was purely a wiring gap in the controller. Full `./pkg/recommender/...` suite passes.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed the VPA recommender ignoring the --history-cpu-metric and --history-memory-metric flags when using the Prometheus history provider, which caused the historical queries to omit the configured metric name.
```
