### PR TITLE
revert removal of scale-down-enabled flag

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -160,6 +160,8 @@ type AutoscalingOptions struct {
 	NodeGroups []string
 	// EnforceNodeGroupMinSize is used to allow CA to scale up the node group to the configured min size if needed.
 	EnforceNodeGroupMinSize bool
+	// ScaleDownEnabled is used to allow CA to scale down the cluster
+	ScaleDownEnabled bool
 	// ScaleDownUnreadyEnabled is used to allow CA to scale down unready nodes of the cluster
 	ScaleDownUnreadyEnabled bool
 	// ScaleDownDelayAfterAdd sets the duration from the last scale up to the time when CA starts to check scale down options

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -249,6 +249,7 @@ var (
 	// Deprecated flags
 	ignoreTaintsFlag           = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
 	clusterSnapshotParallelism = flag.Int("cluster-snapshot-parallelism", 16, "Maximum parallelism of cluster snapshot creation (Deprecated, use predicate-parallelism instead)")
+	scaleDownEnabled           = flag.Bool("scale-down-enabled", true, "[Deprecated] Should CA scale down the cluster")
 )
 
 var autoscalingOptions *config.AutoscalingOptions
@@ -309,6 +310,10 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		klog.Fatalf("--enable-dynamic-resource-allocation flag must be true: %t", ptr.Deref(enableDynamicResourceAllocation, false))
 	}
 
+	if *scaleDownEnabled == false {
+		klog.Warningf("--scale-down-enabled flag is deprecated and will be removed in a future release")
+	}
+
 	maxStartupTime := *maxStartupTimeFlag
 	maxHealthCheckTimeout := max(*maxInactivityTimeFlag, *maxFailingTimeFlag, maxStartupTime)
 	if maxStartupTime < maxHealthCheckTimeout {
@@ -356,6 +361,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ScaleDownDelayTypeLocal:          *scaleDownDelayTypeLocal,
 		ScaleDownDelayAfterDelete:        *scaleDownDelayAfterDelete,
 		ScaleDownDelayAfterFailure:       *scaleDownDelayAfterFailure,
+		ScaleDownEnabled:                 *scaleDownEnabled,
 		ScaleDownUnreadyEnabled:          *scaleDownUnreadyEnabled,
 		ScaleDownNonEmptyCandidatesCount: *scaleDownNonEmptyCandidatesCount,
 		ScaleDownCandidatesPoolRatio:     *scaleDownCandidatesPoolRatio,

--- a/cluster-autoscaler/core/bench/benchmark_runonce_test.go
+++ b/cluster-autoscaler/core/bench/benchmark_runonce_test.go
@@ -516,6 +516,7 @@ func BenchmarkRunOnceScaleDown(b *testing.B) {
 			opts.MaxScaleDownParallelism = 1000
 			opts.MaxDrainParallelism = 1000
 			opts.ScaleDownDelayAfterAdd = 0
+			opts.ScaleDownEnabled = true
 			opts.ScaleDownNonEmptyCandidatesCount = 1000
 			opts.ScaleDownUnreadyEnabled = true
 			opts.ScaleDownSimulationTimeout = 60 * time.Second

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -18,6 +18,7 @@ package planner
 
 import (
 	"fmt"
+
 	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 
 	"testing"
@@ -813,6 +814,7 @@ func TestNewPlannerWithExistingDeletionCandidateNodes(t *testing.T) {
 				},
 				EstimatorName:            estimator.BinpackingEstimatorName,
 				EnforceNodeGroupMinSize:  true,
+				ScaleDownEnabled:         true,
 				MaxNodesTotal:            100,
 				MaxCoresTotal:            100,
 				MaxMemoryTotal:           100000,

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -605,8 +605,10 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		}
 	}
 
-	if typedErr = a.scaleDown(currentTime, allNodes, scaleDownActuationStatus, scaleDownStatus); typedErr != nil {
-		return typedErr
+	if a.ScaleDownEnabled {
+		if typedErr = a.scaleDown(currentTime, allNodes, scaleDownActuationStatus, scaleDownStatus); typedErr != nil {
+			return typedErr
+		}
 	}
 
 	if a.EnforceNodeGroupMinSize {

--- a/cluster-autoscaler/core/static_autoscaler_csi_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_csi_test.go
@@ -258,6 +258,7 @@ func TestStaticAutoscalerCSI(t *testing.T) {
 						ScaleDownUtilizationThreshold: 0.7,
 						MaxNodeProvisionTime:          time.Hour,
 					},
+					ScaleDownEnabled:               true,
 					MaxNodesTotal:                  1000,
 					MaxCoresTotal:                  1000,
 					MaxMemoryTotal:                 100000000,

--- a/cluster-autoscaler/core/static_autoscaler_dra_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_dra_test.go
@@ -409,6 +409,7 @@ func TestStaticAutoscalerDynamicResources(t *testing.T) {
 					ScaleDownSimulationTimeout:       1 * time.Hour,
 					OkTotalUnreadyCount:              9999999,
 					MaxTotalUnreadyPercentage:        1.0,
+					ScaleDownEnabled:                 true,
 					MaxScaleDownParallelism:          10,
 					MaxDrainParallelism:              10,
 					NodeDeletionBatcherInterval:      0 * time.Second,

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -399,9 +399,9 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName:           estimator.BinpackingEstimatorName,
-		EnforceNodeGroupMinSize: true,
-
+		EstimatorName:                  estimator.BinpackingEstimatorName,
+		EnforceNodeGroupMinSize:        true,
+		ScaleDownEnabled:               true,
 		MaxNodesTotal:                  1,
 		MaxCoresTotal:                  10,
 		MaxMemoryTotal:                 100000,
@@ -656,9 +656,9 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 					ScaleDownUtilizationThreshold: 0.5,
 					MaxNodeProvisionTime:          10 * time.Second,
 				},
-				EstimatorName:           estimator.BinpackingEstimatorName,
-				EnforceNodeGroupMinSize: true,
-
+				EstimatorName:                  estimator.BinpackingEstimatorName,
+				EnforceNodeGroupMinSize:        true,
+				ScaleDownEnabled:               true,
 				MaxNodesTotal:                  1,
 				MaxCoresTotal:                  10,
 				MaxMemoryTotal:                 100000,
@@ -811,8 +811,8 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName: estimator.BinpackingEstimatorName,
-
+		EstimatorName:                  estimator.BinpackingEstimatorName,
+		ScaleDownEnabled:               true,
 		MaxNodesTotal:                  100,
 		MaxCoresTotal:                  100,
 		MaxMemoryTotal:                 100000,
@@ -958,8 +958,8 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 					ScaleDownUtilizationThreshold: 0.5,
 					MaxNodeProvisionTime:          10 * time.Second,
 				},
-				EstimatorName: estimator.BinpackingEstimatorName,
-
+				EstimatorName:                    estimator.BinpackingEstimatorName,
+				ScaleDownEnabled:                 true,
 				MaxNodesTotal:                    10,
 				MaxCoresTotal:                    10,
 				MaxMemoryTotal:                   100000,
@@ -1123,8 +1123,8 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 			ScaleDownUnreadyTime:          time.Minute,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName: estimator.BinpackingEstimatorName,
-
+		EstimatorName:                  estimator.BinpackingEstimatorName,
+		ScaleDownEnabled:               true,
 		MaxNodesTotal:                  10,
 		MaxCoresTotal:                  10,
 		MaxMemoryTotal:                 100000,
@@ -1479,10 +1479,11 @@ func TestStaticAutoscalerRunOnceWithBypassedSchedulers(t *testing.T) {
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName:  estimator.BinpackingEstimatorName,
-		MaxNodesTotal:  10,
-		MaxCoresTotal:  10,
-		MaxMemoryTotal: 100000,
+		EstimatorName:    estimator.BinpackingEstimatorName,
+		ScaleDownEnabled: true,
+		MaxNodesTotal:    10,
+		MaxCoresTotal:    10,
+		MaxMemoryTotal:   100000,
 		BypassedSchedulers: scheduler.SchedulersMap([]string{
 			apiv1.DefaultSchedulerName,
 			bypassedScheduler,
@@ -1688,9 +1689,9 @@ func TestStaticAutoscalerRunOnceWithExistingDeletionCandidateNodes(t *testing.T)
 					ScaleDownUtilizationThreshold: 0.5,
 					MaxNodeProvisionTime:          10 * time.Second,
 				},
-				EstimatorName:           estimator.BinpackingEstimatorName,
-				EnforceNodeGroupMinSize: true,
-
+				EstimatorName:                  estimator.BinpackingEstimatorName,
+				EnforceNodeGroupMinSize:        true,
+				ScaleDownEnabled:               true,
 				MaxNodesTotal:                  100,
 				MaxCoresTotal:                  100,
 				MaxMemoryTotal:                 100000,
@@ -1811,8 +1812,8 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 					ScaleDownUtilizationThreshold: 0.5,
 					MaxNodeProvisionTime:          10 * time.Second,
 				},
-				EstimatorName: estimator.BinpackingEstimatorName,
-
+				EstimatorName:                  estimator.BinpackingEstimatorName,
+				ScaleDownEnabled:               true,
 				MaxNodesTotal:                  10,
 				MaxCoresTotal:                  10,
 				MaxMemoryTotal:                 100000,
@@ -2186,8 +2187,8 @@ func setupTestStaticAutoscalerInstanceCreationErrorsForZeroOrMaxScaling(t *testi
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName: estimator.BinpackingEstimatorName,
-
+		EstimatorName:                estimator.BinpackingEstimatorName,
+		ScaleDownEnabled:             true,
 		MaxNodesTotal:                10,
 		MaxCoresTotal:                10,
 		MaxMemoryTotal:               100000,
@@ -2478,7 +2479,7 @@ func TestStaticAutoscalerUpcomingScaleDownCandidates(t *testing.T) {
 
 	// Create context with minimal autoscalingOptions that guarantee we reach the tested logic.
 	// We're only testing the input to UpdateClusterState which should be called whenever scale-down is enabled, other autoscalingOptions shouldn't matter.
-	autoscalingOptions := config.AutoscalingOptions{}
+	autoscalingOptions := config.AutoscalingOptions{ScaleDownEnabled: true}
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOptions)
 	autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOptions, &fake.Clientset{}, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
@@ -2921,10 +2922,11 @@ func TestStaticAutoscalerRunOnceInvokesScaleDownStatusProcessor(t *testing.T) {
 			ScaleDownUtilizationThreshold: 0.5,
 			MaxNodeProvisionTime:          10 * time.Second,
 		},
-		EstimatorName:  estimator.BinpackingEstimatorName,
-		MaxNodesTotal:  10,
-		MaxCoresTotal:  10,
-		MaxMemoryTotal: 100000,
+		EstimatorName:    estimator.BinpackingEstimatorName,
+		ScaleDownEnabled: true,
+		MaxNodesTotal:    10,
+		MaxCoresTotal:    10,
+		MaxMemoryTotal:   100000,
 	}
 	now := time.Now()
 	n1 := BuildTestNode("n1", 1000, 1000)
@@ -3268,6 +3270,7 @@ func buildStaticAutoscaler(t *testing.T, provider cloudprovider.CloudProvider, a
 		},
 		MaxScaleDownParallelism:    10,
 		MaxDrainParallelism:        1,
+		ScaleDownEnabled:           true,
 		MaxBulkSoftTaintCount:      20,
 		MaxBulkSoftTaintTime:       5 * time.Second,
 		NodeDeleteDelayAfterTaint:  5 * time.Minute,
@@ -3451,6 +3454,7 @@ func TestStaticAutoscalerWithNodeDeclaredFeatures(t *testing.T) {
 		},
 		EstimatorName:                  estimator.BinpackingEstimatorName,
 		EnforceNodeGroupMinSize:        true,
+		ScaleDownEnabled:               true,
 		MaxNodesTotal:                  10,
 		MaxCoresTotal:                  10,
 		MaxMemoryTotal:                 1000,

--- a/cluster-autoscaler/test/integration/config.go
+++ b/cluster-autoscaler/test/integration/config.go
@@ -38,6 +38,7 @@ var DefaultAutoscalingOptions = config.AutoscalingOptions{
 	ScaleDownDelayAfterDelete:  0,
 	ScaleDownDelayAfterFailure: 0,
 	ScaleDownDelayTypeLocal:    true,
+	ScaleDownEnabled:           true,
 	MaxNodesTotal:              10,
 	MaxCoresTotal:              10,
 	MaxMemoryTotal:             100000,


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This change is being introduced to revert the removal of the --scale-down-enabled flag which was introduced in pull request #9412. This flag should remain in deprecated state for at least 3 releases before being removed, as per kubernetes deprecation policy.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
