### PR TITLE
Add CapacityQuota test case for nil selector

### DIFF
--- a/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
+++ b/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
@@ -73,6 +73,24 @@ var _ = Describe("CapacityQuota Controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should correctly sum capacities of all nodes with nil selector", func() {
+		By("creating a CapacityQuota without label selector")
+		cq := cqtest.NewCapacityQuota("test-quota-all",
+			cqtest.WithLimits(cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("20"),
+			}),
+		)
+		Expect(crClient.Create(ctx, cq)).To(Succeed())
+
+		By("waiting for the CapacityQuota to be reconciled with correct usage")
+		cqKey := types.NamespacedName{Name: "test-quota-all"}
+		Eventually(func(g Gomega) {
+			assertQuotaReconciled(ctx, g, cqKey, cqv1alpha1.ResourceList{
+				cqv1alpha1.ResourceCPU: resource.MustParse("14"),
+			})
+		}).Should(Succeed())
+	})
+
 	It("should correctly sum capacities of matching nodes", func() {
 		By("creating a CapacityQuota")
 		cq := cqtest.NewCapacityQuota("test-quota-pool",


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
CQ controller tests were missing a test case with a nil node selector. This test case is needed, since CQ selector behaves differently from the default k8s label selector. By default, nil label selector matches no node, in CQ, nil selector matches all nodes. This behavior works correctly, though it should be covered by a test case

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
