### PR TITLE
[vpa-release-1.7] fix(vpa): honor --history-cpu-metric and --history-memory-metric flags

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
@@ -232,6 +232,8 @@ func initHistoryProvider(ctx context.Context, rec Recommender, config *recommend
 			CtrNameLabel:           config.CtrNameLabel,
 			CadvisorMetricsJobName: config.PrometheusJobName,
 			Namespace:              config.CommonFlags.VpaObjectNamespace,
+			CPUMetricName:          config.HistoryCPUMetric,
+			MemoryMetricName:       config.HistoryMemoryMetric,
 			Authentication: history.PrometheusCredentials{
 				BearerToken: config.PrometheusBearerToken,
 				Username:    config.Username,


### PR DESCRIPTION
Cherry-pick of #9748 onto vpa-release-1.7.

`initHistoryProvider` built the Prometheus history provider config without copying `config.HistoryCPUMetric` and `config.HistoryMemoryMetric` into the provider's `CPUMetricName` / `MemoryMetricName` fields, so the recommender queried Prometheus without a metric name and the `--history-cpu-metric` / `--history-memory-metric` flags had no effect. This branch has the same two-line fix.

/area vertical-pod-autoscaler
/kind bug

```release-note
Fixed the VPA recommender ignoring the --history-cpu-metric and --history-memory-metric flags when using the Prometheus history provider, which caused the historical queries to omit the configured metric name.
```
