### PR TITLE
Add dynamic watching and pluggable RBAC for scalable objects in capacity buffers

### DIFF
--- a/cluster-autoscaler/capacitybuffer/client/client.go
+++ b/cluster-autoscaler/capacitybuffer/client/client.go
@@ -62,6 +62,7 @@ const ScalableRefIndex = "scalableRef"
 type CapacityBufferClient struct {
 	buffersClient         capacitybuffer.Interface
 	kubernetesClient      kubernetes.Interface
+	dynamicClient         dynamic.Interface
 	scaleGetter           scaleclient.ScalesGetter
 	scaleMapper           meta.RESTMapper
 	buffersLister         bufferslisters.CapacityBufferLister
@@ -85,13 +86,14 @@ type CapacityBufferClient struct {
 }
 
 // NewCapacityBufferClient returns a capacityBufferClient.
-func NewCapacityBufferClient(buffersClient capacitybuffer.Interface, kubernetesClient kubernetes.Interface, buffersLister bufferslisters.CapacityBufferLister,
+func NewCapacityBufferClient(buffersClient capacitybuffer.Interface, kubernetesClient kubernetes.Interface, dynamicClient dynamic.Interface, buffersLister bufferslisters.CapacityBufferLister,
 	podTemplateLister corev1listers.PodTemplateLister, replicaSetsLister appsv1listers.ReplicaSetLister, statefulSetsLister appsv1listers.StatefulSetLister,
 	jobsLister batchv1lister.JobLister, deploymentLister appsv1listers.DeploymentLister, replicationContLister corev1listers.ReplicationControllerLister,
 	scaleGetter scaleclient.ScalesGetter, scaleMapper meta.RESTMapper) (*CapacityBufferClient, error) {
 	return &CapacityBufferClient{
 		buffersClient:         buffersClient,
 		kubernetesClient:      kubernetesClient,
+		dynamicClient:         dynamicClient,
 		scaleGetter:           scaleGetter,
 		buffersLister:         buffersLister,
 		podTemplateLister:     podTemplateLister,
@@ -119,11 +121,15 @@ func NewCapacityBufferClientFromConfig(kubeConfig *rest.Config) (*CapacityBuffer
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create kubernetes client for capacity buffer: %v", err)
 	}
+	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create dynamic client for capacity buffer: %v", err)
+	}
 	scaleGetter, scaleMapper, err := createScaleSubresourceClientGetter(kubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create scale getter for capacity buffer: %v", err)
 	}
-	return NewCapacityBufferClientFromClients(buffersClient, kubernetesClient, scaleGetter, scaleMapper)
+	return NewCapacityBufferClientFromClients(buffersClient, kubernetesClient, dynamicClient, scaleGetter, scaleMapper)
 }
 
 func createScaleSubresourceClientGetter(kubeConfig *rest.Config) (scaleclient.ScalesGetter, meta.RESTMapper, error) {
@@ -141,8 +147,8 @@ func createScaleSubresourceClientGetter(kubeConfig *rest.Config) (scaleclient.Sc
 }
 
 // NewCapacityBufferClientFromClients returns a CapacityBufferClient based on the passed clients
-func NewCapacityBufferClientFromClients(buffersClient capacitybuffer.Interface, kubernetesClient kubernetes.Interface, scaleGetter scaleclient.ScalesGetter, scaleMapper meta.RESTMapper) (*CapacityBufferClient, error) {
-	if buffersClient == nil || kubernetesClient == nil {
+func NewCapacityBufferClientFromClients(buffersClient capacitybuffer.Interface, kubernetesClient kubernetes.Interface, dynamicClient dynamic.Interface, scaleGetter scaleclient.ScalesGetter, scaleMapper meta.RESTMapper) (*CapacityBufferClient, error) {
+	if buffersClient == nil || kubernetesClient == nil || dynamicClient == nil {
 		return nil, fmt.Errorf("Couldn't create capacity buffer client")
 	}
 	defaultResyncPeriod := 5 * time.Minute
@@ -193,6 +199,7 @@ func NewCapacityBufferClientFromClients(buffersClient capacitybuffer.Interface, 
 	bufferClient := &CapacityBufferClient{
 		buffersClient:                 buffersClient,
 		kubernetesClient:              kubernetesClient,
+		dynamicClient:                 dynamicClient,
 		scaleGetter:                   scaleGetter,
 		scaleMapper:                   scaleMapper,
 		buffersLister:                 buffersLister,
@@ -262,6 +269,21 @@ func (c *CapacityBufferClient) GetReplicationControllerInformer() cache.SharedIn
 	return c.replicationControllerInformer
 }
 
+// GetRESTMapper returns the RESTMapper for resolving GVK to GVR.
+func (c *CapacityBufferClient) GetRESTMapper() meta.RESTMapper {
+	return c.scaleMapper
+}
+
+// GetDynamicClient returns the dynamic client for dynamic watching.
+func (c *CapacityBufferClient) GetDynamicClient() dynamic.Interface {
+	return c.dynamicClient
+}
+
+// GetKubernetesClient returns the kubernetes client.
+func (c *CapacityBufferClient) GetKubernetesClient() kubernetes.Interface {
+	return c.kubernetesClient
+}
+
 // ListCapacityBuffers lists all Capacity buffer.
 func (c *CapacityBufferClient) ListCapacityBuffers(namespace string) ([]*v1.CapacityBuffer, error) {
 	if c.buffersLister == nil {
@@ -321,6 +343,18 @@ func (c *CapacityBufferClient) GetPodTemplate(namespace, name string) (*corev1.P
 		return nil, fmt.Errorf("capacity buffer client can't get pod template: %w", err)
 	}
 	return template.DeepCopy(), nil
+}
+
+// GetCapacityBuffer fetches the latest capacity buffer from the API server.
+func (c *CapacityBufferClient) GetCapacityBuffer(namespace, name string) (*v1.CapacityBuffer, error) {
+	if c.buffersClient == nil {
+		return nil, fmt.Errorf("Capacity buffer client is not configured for getting capacity buffer")
+	}
+	buffer, err := c.buffersClient.AutoscalingV1beta1().CapacityBuffers(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		return buffer.DeepCopy(), nil
+	}
+	return nil, err
 }
 
 // UpdateCapacityBuffer fetches the cached object using a lister object in the client

--- a/cluster-autoscaler/capacitybuffer/client/client_test.go
+++ b/cluster-autoscaler/capacitybuffer/client/client_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	buffersfake "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned/fake"
+	"k8s.io/client-go/dynamic/fake"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -69,7 +70,8 @@ func TestClientGetPodTemplate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeKubernetesClient := fakeclient.NewSimpleClientset(test.objectsInKubernetesClient...)
 			fakeBuffersClient := buffersfake.NewSimpleClientset()
-			fakeCapacityBuffersClient, _ := NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, nil, nil)
+			fakeDynamicClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
+			fakeCapacityBuffersClient, _ := NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, fakeDynamicClient, nil, nil)
 			pt, err := fakeCapacityBuffersClient.GetPodTemplate("default", test.objectName)
 			assert.Equal(t, err != nil, test.expectError)
 			assert.Equal(t, pt, test.expectedValue)

--- a/cluster-autoscaler/capacitybuffer/controller/controller.go
+++ b/cluster-autoscaler/capacitybuffer/controller/controller.go
@@ -21,15 +21,21 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
@@ -43,6 +49,13 @@ import (
 	scalableobject "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/translators/scalable_objects"
 	updater "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/updater"
 	"k8s.io/utils/clock"
+)
+
+const (
+	// EventDrivenReconciliationCondition is a condition type that indicates if the buffer is being reconciled via events.
+	EventDrivenReconciliationCondition = "EventDrivenReconciliation"
+	// DynamicWatchFailedReason is a reason for EventDrivenReconciliationCondition when dynamic watch establishment fails.
+	DynamicWatchFailedReason = "DynamicWatchFailed"
 )
 
 // BufferController performs updates on Buffers and convert them to pods to be injected
@@ -60,6 +73,13 @@ type bufferController struct {
 	queue                   workqueue.TypedRateLimitingInterface[string]
 	clock                   clock.Clock
 	reconciliationTimeCache *cbmetrics.ReconciliationCache
+
+	// Dynamic watching and RBAC updates
+	rbacUpdater            CapacityBufferRBACUpdater
+	dynamicClient          dynamic.Interface
+	dynamicInformerFactory dynamicinformer.DynamicSharedInformerFactory
+	watchedGVKs            sync.Map // map[schema.GroupVersionKind]bool
+	stopCh                 <-chan struct{}
 }
 
 // NewBufferController creates new bufferController object
@@ -70,6 +90,8 @@ func NewBufferController(
 	updater updater.StatusUpdater,
 	clock clock.Clock,
 	reconciliationTimeCache *cbmetrics.ReconciliationCache,
+	rbacUpdater CapacityBufferRBACUpdater,
+	dynamicClient dynamic.Interface,
 ) BufferController {
 	bc := &bufferController{
 		client:         client,
@@ -82,6 +104,9 @@ func NewBufferController(
 		),
 		clock:                   clock,
 		reconciliationTimeCache: reconciliationTimeCache,
+		rbacUpdater:             rbacUpdater,
+		dynamicClient:           dynamicClient,
+		dynamicInformerFactory:  dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0),
 	}
 	bc.configureEventHandlers()
 	return bc
@@ -99,7 +124,7 @@ func InitializeAndRunDefaultBufferController(
 	reconciledBuffersCache := cbmetrics.NewReconciliationCache()
 	// Accepting empty string as it represents nil value for ProvisioningStrategy
 	defaultStrategies := []string{capacitybuffer.ActiveProvisioningStrategy, ""}
-	controller := NewDefaultBufferController(client, resolver, defaultStrategies, reconciledBuffersCache, realClock)
+	controller := NewDefaultBufferController(client, resolver, defaultStrategies, reconciledBuffersCache, realClock, NewDefaultRBACUpdater(client.GetKubernetesClient()), client.GetDynamicClient())
 	go controller.Run(ctx.Done())
 
 	cbmetrics.RegisterReconciliationTimestampCollector(client, defaultStrategies, reconciledBuffersCache, realClock)
@@ -112,6 +137,8 @@ func NewDefaultBufferController(
 	strategies []string,
 	reconciliationTimeCache *cbmetrics.ReconciliationCache,
 	clock clock.Clock,
+	rbacUpdater CapacityBufferRBACUpdater,
+	dynamicClient dynamic.Interface,
 ) BufferController {
 	bc := &bufferController{
 		client:         client,
@@ -129,6 +156,9 @@ func NewDefaultBufferController(
 		),
 		clock:                   clock,
 		reconciliationTimeCache: reconciliationTimeCache,
+		rbacUpdater:             rbacUpdater,
+		dynamicClient:           dynamicClient,
+		dynamicInformerFactory:  dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0),
 	}
 	bc.configureEventHandlers()
 	return bc
@@ -332,10 +362,9 @@ func (c *bufferController) Run(stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 	defer c.queue.ShutDown()
 
-	klog.Info("Starting CapacityBuffer controller workers")
+	c.stopCh = stopCh
 
-	// Note: We assume the client passed to us has informers that are running and synced.
-	// CapacityBufferClient.NewCapacityBufferClientFromClients waits for sync before returning.
+	klog.Info("Starting CapacityBuffer controller workers")
 
 	// Launch a single worker (namespace processing is serial per namespace anyway)
 	go wait.Until(c.runWorker, time.Second, stopCh)
@@ -379,6 +408,13 @@ func (c *bufferController) reconcileNamespace(namespace string) error {
 	buffers, err := c.client.ListCapacityBuffers(namespace)
 	if err != nil {
 		return err
+	}
+
+	// Ensure dynamic watches for all scalable objects observed in this namespace
+	for _, buffer := range buffers {
+		if buffer.Spec.ScalableRef != nil {
+			c.ensureWatchFromScalableRef(buffer.Spec.ScalableRef)
+		}
 	}
 
 	// Filter the desired provisioning strategy
@@ -433,4 +469,221 @@ func (c *bufferController) updateReconciliationTimeCache(buffers []*v1.CapacityB
 		return
 	}
 	c.reconciliationTimeCache.Update(buffers, c.clock.Now())
+}
+
+func isBuiltInScalableObject(ref *v1.ScalableRef) bool {
+	if ref == nil {
+		return false
+	}
+	switch ref.Kind {
+	case scalableobject.DeploymentKind, scalableobject.ReplicaSetKind, scalableobject.StatefulSetKind:
+		return ref.APIGroup == scalableobject.ApiGroupApps
+	case scalableobject.JobKind:
+		return ref.APIGroup == scalableobject.ApiGroupBatch
+	case scalableobject.ReplicationControllerKind:
+		return ref.APIGroup == "" || ref.APIGroup == "core" || ref.APIGroup == scalableobject.ApiGroupCore
+	}
+	return false
+}
+
+func (c *bufferController) ensureWatchFromScalableRef(ref *v1.ScalableRef) {
+	if isBuiltInScalableObject(ref) {
+		return
+	}
+
+	gk := schema.GroupKind{
+		Group: ref.APIGroup,
+		Kind:  ref.Kind,
+	}
+
+	// Use RESTMapper to find the preferred version and resource mapping
+	mapping, err := c.client.GetRESTMapper().RESTMapping(gk)
+	if err != nil {
+		klog.V(4).Infof("Failed to resolve GVK for %v: %v", gk, err)
+		c.markBuffersAsNonEventDriven(gk.WithVersion(""), schema.GroupVersionResource{Group: gk.Group, Resource: strings.ToLower(gk.Kind) + "s"})
+		return
+	}
+
+	c.ensureWatch(mapping)
+}
+
+func (c *bufferController) ensureWatch(mapping *meta.RESTMapping) {
+	gvk := mapping.GroupVersionKind
+	if _, loaded := c.watchedGVKs.LoadOrStore(gvk, true); loaded {
+		return
+	}
+
+	klog.V(4).Infof("Establishing dynamic watch for GVK: %v", gvk)
+	// Start watch establishment with RBAC hook and retry mechanism
+	go c.establishWatchWithRetry(mapping)
+}
+
+func (c *bufferController) establishWatchWithRetry(mapping *meta.RESTMapping) {
+	gvk := mapping.GroupVersionKind
+	gvr := mapping.Resource
+
+	// Run RBAC updater hook once for newly discovered resource type
+	if err := c.rbacUpdater.UpdateRBAC(mapping); err != nil {
+		klog.Errorf("Failed to run RBAC updater for GVK %v: %v", gvk, err)
+	}
+
+	informer := c.dynamicInformerFactory.ForResource(gvr).Informer()
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.enqueueBuffersReferencingDynamicObject(obj, gvk)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.enqueueBuffersReferencingDynamicObject(newObj, gvk)
+		},
+		DeleteFunc: func(obj interface{}) {
+			c.enqueueBuffersReferencingDynamicObject(obj, gvk)
+		},
+	})
+
+	// Start any newly registered informers in the factory
+	c.dynamicInformerFactory.Start(c.stopCh)
+
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   1.5,
+		Jitter:   0.1,
+		Steps:    3,
+	}
+
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		klog.V(4).Infof("Waiting for dynamic watch cache sync for GVK: %v", gvk)
+
+		// Tolerate failure by checking cache sync with timeout
+		syncCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if !cache.WaitForCacheSync(syncCtx.Done(), informer.HasSynced) {
+			klog.V(4).Infof("Cache sync for %v not yet ready (might be RBAC or missing CRD). Retrying...", gvk)
+			return false, nil // retry
+		}
+
+		klog.V(2).Infof("Successfully established dynamic watch for GVR: %v", gvr)
+		return true, nil
+	})
+
+	if err != nil {
+		klog.Errorf("Exhausted retries for establishing watch on GVK %v: %v", gvk, err)
+		c.watchedGVKs.Delete(gvk) // Allow retry in next reconciliation cycle
+		c.markBuffersAsNonEventDriven(gvk, gvr)
+	} else {
+		c.markBuffersAsEventDriven(gvk)
+	}
+}
+
+func (c *bufferController) markBuffersAsEventDriven(gvk schema.GroupVersionKind) {
+	buffers, err := c.client.ListCapacityBuffers("")
+	if err != nil {
+		klog.Errorf("Failed to list buffers to mark as event driven: %v", err)
+		return
+	}
+
+	for _, buffer := range buffers {
+		if buffer.Spec.ScalableRef != nil &&
+			buffer.Spec.ScalableRef.Kind == gvk.Kind &&
+			buffer.Spec.ScalableRef.APIGroup == gvk.Group {
+
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latestBuffer, getErr := c.client.GetCapacityBuffer(buffer.Namespace, buffer.Name)
+				if getErr != nil {
+					return getErr
+				}
+
+				newCondition := metav1.Condition{
+					Type:               EventDrivenReconciliationCondition,
+					Status:             metav1.ConditionTrue,
+					Reason:             "DynamicWatchSynced",
+					Message:            fmt.Sprintf("Successfully established dynamic watch for %v. Event-driven reconciliation is active.", gvk),
+					LastTransitionTime: metav1.NewTime(c.clock.Now()),
+				}
+
+				existingCond := meta.FindStatusCondition(latestBuffer.Status.Conditions, EventDrivenReconciliationCondition)
+				if existingCond != nil && existingCond.Status == metav1.ConditionTrue && existingCond.Reason == "DynamicWatchSynced" {
+					return nil // No update needed
+				}
+
+				meta.SetStatusCondition(&latestBuffer.Status.Conditions, newCondition)
+
+				_, updateErr := c.client.UpdateCapacityBuffer(latestBuffer)
+				return updateErr
+			})
+
+			if err != nil {
+				klog.Errorf("Failed to update buffer %s/%s status with event driven condition: %v", buffer.Namespace, buffer.Name, err)
+			}
+		}
+	}
+}
+
+func (c *bufferController) markBuffersAsNonEventDriven(gvk schema.GroupVersionKind, gvr schema.GroupVersionResource) {
+	buffers, err := c.client.ListCapacityBuffers("")
+	if err != nil {
+		klog.Errorf("Failed to list buffers to mark as non-event driven: %v", err)
+		return
+	}
+
+	for _, buffer := range buffers {
+		if buffer.Spec.ScalableRef != nil &&
+			buffer.Spec.ScalableRef.Kind == gvk.Kind &&
+			buffer.Spec.ScalableRef.APIGroup == gvk.Group {
+
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latestBuffer, getErr := c.client.GetCapacityBuffer(buffer.Namespace, buffer.Name)
+				if getErr != nil {
+					return getErr
+				}
+
+				msg := fmt.Sprintf("Failed to establish dynamic watch for %v. Reconciliation will be periodic (up to 5m delay). "+
+					"Please ensure ClusterAutoscaler has 'get/list/watch' permissions for %s and %s/scale.", gvk, gvr.Resource, gvr.Resource)
+
+				newCondition := metav1.Condition{
+					Type:               EventDrivenReconciliationCondition,
+					Status:             metav1.ConditionFalse,
+					Reason:             DynamicWatchFailedReason,
+					Message:            msg,
+					LastTransitionTime: metav1.NewTime(c.clock.Now()),
+				}
+
+				existingCond := meta.FindStatusCondition(latestBuffer.Status.Conditions, EventDrivenReconciliationCondition)
+				if existingCond != nil && existingCond.Status == metav1.ConditionFalse && existingCond.Reason == DynamicWatchFailedReason && existingCond.Message == msg {
+					return nil // No update needed
+				}
+
+				meta.SetStatusCondition(&latestBuffer.Status.Conditions, newCondition)
+
+				_, updateErr := c.client.UpdateCapacityBuffer(latestBuffer)
+				return updateErr
+			})
+
+			if err != nil {
+				klog.Errorf("Failed to update buffer %s/%s status with non-event driven condition: %v", buffer.Namespace, buffer.Name, err)
+			}
+		}
+	}
+}
+
+func (c *bufferController) enqueueBuffersReferencingDynamicObject(obj interface{}, gvk schema.GroupVersionKind) {
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		klog.V(4).Infof("CapacityBuffer controller: failed to get meta accessor for dynamic object: %v", err)
+		return
+	}
+
+	// Use indexer to find buffers referencing this object
+	buffers, err := c.client.GetBufferInformer().GetIndexer().ByIndex(cbclient.ScalableRefIndex, metaObj.GetName())
+	if err != nil {
+		klog.Errorf("CapacityBuffer controller: error looking up buffers for dynamic object %s/%s: %v", gvk.Kind, metaObj.GetName(), err)
+		return
+	}
+
+	for _, b := range buffers {
+		buffer := b.(*v1.CapacityBuffer)
+		if buffer.Namespace == metaObj.GetNamespace() && buffer.Spec.ScalableRef != nil &&
+			buffer.Spec.ScalableRef.Kind == gvk.Kind && buffer.Spec.ScalableRef.APIGroup == gvk.Group {
+			c.enqueueNamespace(buffer)
+		}
+	}
 }

--- a/cluster-autoscaler/capacitybuffer/controller/controller_test.go
+++ b/cluster-autoscaler/capacitybuffer/controller/controller_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakeK8s "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/clock"
+	buffersfake "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned/fake"
+	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/updater"
+)
+
+func TestEnsureWatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := scheme.Scheme
+	gvk := schema.GroupVersionKind{Group: "custom.io", Version: "v1", Kind: "CustomType"}
+	gvr := schema.GroupVersionResource{Group: "custom.io", Version: "v1", Resource: "customtypes"}
+
+	fakeDynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(s, map[schema.GroupVersionResource]string{
+		gvr: "CustomTypeList",
+	})
+
+	// Create a mock RESTMapper
+	mockMapper := &mockRESTMapper{
+		mappings: map[schema.GroupKind]*schema.GroupVersionResource{
+			{Group: "custom.io", Kind: "CustomType"}: &gvr,
+		},
+	}
+
+	fakeBuffersClient := buffersfake.NewSimpleClientset()
+	fakeK8sClient := fakeK8s.NewSimpleClientset()
+	fakeCBClient, err := cbclient.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeK8sClient, fakeDynamicClient, nil, mockMapper)
+	assert.NoError(t, err)
+
+	rbacUpdater := &mockRBACUpdater{}
+
+	bc := &bufferController{
+		client:                 fakeCBClient,
+		rbacUpdater:            rbacUpdater,
+		dynamicClient:          fakeDynamicClient,
+		dynamicInformerFactory: dynamicinformer.NewDynamicSharedInformerFactory(fakeDynamicClient, 0),
+		stopCh:                 ctx.Done(),
+		clock:                  clock.RealClock{},
+	}
+
+	gvk = schema.GroupVersionKind{Group: "custom.io", Version: "v1", Kind: "CustomType"}
+	mapping := &meta.RESTMapping{
+		Resource:         schema.GroupVersionResource{Group: "custom.io", Version: "v1", Resource: "customtypes"},
+		GroupVersionKind: gvk,
+	}
+
+	// First call should establish watch
+	bc.ensureWatch(mapping)
+
+	// Since establishWatchWithRetry runs in a goroutine, we need to wait
+	assert.Eventually(t, func() bool {
+		return len(rbacUpdater.updatedMappings) == 1
+	}, 5*time.Second, 100*time.Millisecond)
+
+	assert.Equal(t, gvk, rbacUpdater.updatedMappings[0].GroupVersionKind)
+
+	// Second call should be a no-op (cached)
+	bc.ensureWatch(mapping)
+	// Give it a bit of time to make sure no extra call was made
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 1, len(rbacUpdater.updatedMappings))
+	_, loaded := bc.watchedGVKs.Load(gvk)
+	assert.True(t, loaded)
+}
+
+func TestMarkBuffersAsNonEventDriven(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "custom.io", Version: "v1", Kind: "CustomType"}
+	gvr := schema.GroupVersionResource{Group: "custom.io", Version: "v1", Resource: "customtypes"}
+
+	buffer := &v1.CapacityBuffer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-buffer",
+			Namespace: "default",
+		},
+		Spec: v1.CapacityBufferSpec{
+			ScalableRef: &v1.ScalableRef{
+				APIGroup: gvk.Group,
+				Kind:     gvk.Kind,
+				Name:     "target",
+			},
+		},
+	}
+
+	fakeBuffersClient := buffersfake.NewSimpleClientset(buffer)
+	fakeK8sClient := fakeK8s.NewSimpleClientset()
+	fakeDynamicClient := fake.NewSimpleDynamicClient(scheme.Scheme)
+	fakeCBClient, err := cbclient.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeK8sClient, fakeDynamicClient, nil, nil)
+	assert.NoError(t, err)
+	
+	statusUpdater := updater.NewStatusUpdater(fakeCBClient)
+	
+	bc := &bufferController{
+		client:  fakeCBClient,
+		updater: *statusUpdater,
+		clock:   clock.RealClock{},
+	}
+
+	bc.markBuffersAsNonEventDriven(gvk, gvr)
+
+	// Verify status via client
+	updated, err := fakeBuffersClient.AutoscalingV1beta1().CapacityBuffers("default").Get(context.TODO(), "test-buffer", metav1.GetOptions{})
+	assert.NoError(t, err)
+	
+	found := false
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == EventDrivenReconciliationCondition {
+			assert.Equal(t, metav1.ConditionFalse, cond.Status)
+			assert.Equal(t, DynamicWatchFailedReason, cond.Reason)
+			assert.Contains(t, cond.Message, "Failed to establish dynamic watch")
+			found = true
+			break
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestIsBuiltInScalableObject(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      *v1.ScalableRef
+		expected bool
+	}{
+		{
+			name:     "nil ref",
+			ref:      nil,
+			expected: false,
+		},
+		{
+			name:     "Deployment apps",
+			ref:      &v1.ScalableRef{APIGroup: "apps", Kind: "Deployment"},
+			expected: true,
+		},
+		{
+			name:     "Deployment wrong group",
+			ref:      &v1.ScalableRef{APIGroup: "custom.io", Kind: "Deployment"},
+			expected: false,
+		},
+		{
+			name:     "Job batch",
+			ref:      &v1.ScalableRef{APIGroup: "batch", Kind: "Job"},
+			expected: true,
+		},
+		{
+			name:     "ReplicationController core empty group",
+			ref:      &v1.ScalableRef{APIGroup: "", Kind: "ReplicationController"},
+			expected: true,
+		},
+		{
+			name:     "ReplicationController core core group",
+			ref:      &v1.ScalableRef{APIGroup: "core", Kind: "ReplicationController"},
+			expected: true,
+		},
+		{
+			name:     "Custom type",
+			ref:      &v1.ScalableRef{APIGroup: "custom.io", Kind: "CustomType"},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isBuiltInScalableObject(test.ref))
+		})
+	}
+}
+
+type mockRESTMapper struct {
+	mappings map[schema.GroupKind]*schema.GroupVersionResource
+}
+
+func (m *mockRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+
+func (m *mockRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, nil
+}
+
+func (m *mockRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, nil
+}
+
+func (m *mockRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, nil
+}
+
+func (m *mockRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	gvr, ok := m.mappings[gk]
+	if !ok {
+		return nil, nil
+	}
+	return &meta.RESTMapping{
+		Resource:         *gvr,
+		GroupVersionKind: gk.WithVersion(gvr.Version),
+	}, nil
+}
+
+func (m *mockRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return nil, nil
+}
+
+func (m *mockRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	return "", nil
+}

--- a/cluster-autoscaler/capacitybuffer/controller/rbac.go
+++ b/cluster-autoscaler/capacitybuffer/controller/rbac.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// CapacityBufferRBACUpdater defines an interface for updating RBAC permissions
+// or logging warnings/guidelines for target GVKs. This allows cloud providers to provide
+// their own implementation for ensuring the controller has necessary permissions.
+type CapacityBufferRBACUpdater interface {
+	// UpdateRBAC ensures or logs that the controller has permissions to get, list, and watch
+	// the specified resource.
+	UpdateRBAC(mapping *meta.RESTMapping) error
+}
+
+// DefaultRBACUpdater is a default implementation of CapacityBufferRBACUpdater.
+type DefaultRBACUpdater struct {
+	kubeClient kubernetes.Interface
+}
+
+// NewDefaultRBACUpdater returns a new DefaultRBACUpdater.
+func NewDefaultRBACUpdater(kubeClient kubernetes.Interface) *DefaultRBACUpdater {
+	return &DefaultRBACUpdater{
+		kubeClient: kubeClient,
+	}
+}
+
+// UpdateRBAC logs a message that a dynamic watch is being established for the resource.
+func (d *DefaultRBACUpdater) UpdateRBAC(mapping *meta.RESTMapping) error {
+	gvk := mapping.GroupVersionKind
+	gvr := mapping.Resource
+	klog.Infof("Establishing dynamic watch for GVK: %v (GVR: %v). Please ensure ClusterAutoscaler has 'get/list/watch' permissions for this resource.", gvk, gvr)
+	return nil
+}

--- a/cluster-autoscaler/capacitybuffer/controller/rbac_test.go
+++ b/cluster-autoscaler/capacitybuffer/controller/rbac_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDefaultRBACUpdater(t *testing.T) {
+	fakeK8s := fake.NewSimpleClientset()
+	updater := NewDefaultRBACUpdater(fakeK8s)
+	gvk := schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	}
+	mapping := &meta.RESTMapping{
+		GroupVersionKind: gvk,
+		Resource:         schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+	}
+
+	err := updater.UpdateRBAC(mapping)
+	assert.NoError(t, err)
+}
+
+type mockRBACUpdater struct {
+	updatedMappings []*meta.RESTMapping
+}
+
+func (m *mockRBACUpdater) UpdateRBAC(mapping *meta.RESTMapping) error {
+	m.updatedMappings = append(m.updatedMappings, mapping)
+	return nil
+}

--- a/cluster-autoscaler/capacitybuffer/controller/resourcequotas_test.go
+++ b/cluster-autoscaler/capacitybuffer/controller/resourcequotas_test.go
@@ -495,7 +495,7 @@ func TestResourceQuotaAllocator(t *testing.T) {
 			}
 
 			fakeK8s := fakeClient.NewSimpleClientset(objs...)
-			client, _ := cbclient.NewCapacityBufferClient(nil, fakeK8s, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			client, _ := cbclient.NewCapacityBufferClient(nil, fakeK8s, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			allocator := newResourceQuotaAllocator(client)
 
 			// Assign namespace and names to buffers

--- a/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter_test.go
@@ -44,7 +44,7 @@ func TestPodTemplateGenerationFilter(t *testing.T) {
 		},
 	}
 	fakeClient := fakeclient.NewSimpleClientset(podTempGen3, podTempGen4)
-	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClient(nil, fakeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClient(nil, fakeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	tests := []struct {
 		name                       string

--- a/cluster-autoscaler/capacitybuffer/translators/pod_template_translator_test.go
+++ b/cluster-autoscaler/capacitybuffer/translators/pod_template_translator_test.go
@@ -67,7 +67,7 @@ func TestPodTemplateBufferTranslator(t *testing.T) {
 	})
 	zero := int64(0)
 	fakeClient := fakeClient.NewSimpleClientset(registeredPodTemplate, anotherRegisteredPodTemplate, podTemp4mem100cpu, podTemp8mem200cpu, podTemp4gpu)
-	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClient(nil, fakeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClient(nil, fakeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	noReplicasMsg := "Buffer not ready for provisioning: couldn't get number of replicas for buffer: replicas, percentage and limits are not defined"
 	podTemplateNotFoundMsg := "Buffer not ready for provisioning: capacity buffer client can't get pod template: podtemplates %q not found"
 	resourcesNotFoundMsg := "Buffer not ready for provisioning: couldn't get number of replicas for buffer: resources in configured limits not found in the pod template"
@@ -284,7 +284,7 @@ func TestPodTemplateBufferTranslator_ManagedPodTemplate(t *testing.T) {
 	)
 
 	fakeClient := fakeClient.NewSimpleClientset(bufferPodTemplate)
-	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClient(nil, fakeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClient(nil, fakeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	resolver := fakepods.NewDefaultingResolver()
 	podTemplateBufferTranslator := NewPodTemplateBufferTranslator(fakeCapacityBuffersClient, resolver)
 	buffers := []*v1.CapacityBuffer{buffer}

--- a/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator_test.go
+++ b/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator_test.go
@@ -26,11 +26,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	buffersfake "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned/fake"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/fakepods"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
+	"k8s.io/client-go/dynamic/fake"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 )
@@ -86,7 +88,8 @@ func TestScalableObjectsTranslator(t *testing.T) {
 	}
 	fakeKubernetesClient := fakeclient.NewSimpleClientset(podTemplate1, podTemplate2, replicaSet1, replicaSetWithResources)
 	fakeBuffersClient := buffersfake.NewSimpleClientset()
-	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, nil, nil)
+	fakeDynamicClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
+	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, fakeDynamicClient, nil, nil)
 	notReadyMsg := "Buffer not ready for provisioning: couldn't get number of replicas for buffer: replicas, percentage and limits are not defined"
 	tests := []struct {
 		name                   string

--- a/cluster-autoscaler/capacitybuffer/updater/status_updater_test.go
+++ b/cluster-autoscaler/capacitybuffer/updater/status_updater_test.go
@@ -48,7 +48,7 @@ func TestStatusUpdater(t *testing.T) {
 		Spec: v1.CapacityBufferSpec{},
 	}
 	fakeClient := fakeclientset.NewSimpleClientset(exitingBuffer)
-	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClient(fakeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	fakeCapacityBuffersClient, _ := cbclient.NewCapacityBufferClient(fakeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	tests := []struct {
 		name               string

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
@@ -36,6 +36,7 @@ import (
 
 	buffersfake "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/client/clientset/versioned/fake"
 	testutil "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
+	"k8s.io/client-go/dynamic/fake"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -190,7 +191,8 @@ func TestPodListProcessor(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeKubernetesClient := fakeclient.NewSimpleClientset(test.objectsInKubernetesClient...)
 			fakeBuffersClient := buffersfake.NewSimpleClientset(test.objectsInBuffersClient...)
-			fakeCapacityBuffersClient, _ := client.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, nil, nil)
+			fakeDynamicClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
+			fakeCapacityBuffersClient, _ := client.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, fakeDynamicClient, nil, nil)
 			capacityBuffersRegistry := fakepods.NewRegistry(nil)
 
 			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, capacityBuffersRegistry, test.forceSafeToEvict)
@@ -277,7 +279,8 @@ func TestCapacityBufferFakePodsRegistry(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeKubernetesClient := fakeclient.NewSimpleClientset(test.objectsInKubernetesClient...)
 			fakeBuffersClient := buffersfake.NewSimpleClientset(test.objectsInBuffersClient...)
-			fakeCapacityBuffersClient, _ := client.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, nil, nil)
+			fakeDynamicClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
+			fakeCapacityBuffersClient, _ := client.NewCapacityBufferClientFromClients(fakeBuffersClient, fakeKubernetesClient, fakeDynamicClient, nil, nil)
 
 			registry := fakepods.NewRegistry(nil)
 			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, registry, false)

--- a/cluster-autoscaler/test/integration/controllers/capacitybuffer_controller_test.go
+++ b/cluster-autoscaler/test/integration/controllers/capacitybuffer_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbapi "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer"
 	"k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/testutil"
@@ -282,6 +283,119 @@ var _ = Describe("CapacityBuffer Controller", func() {
 				snapshot := reconciliationCache.Snapshot()
 				g.Expect(snapshot[bSupported.UID]).To(BeTemporally("~", clock.Now(), toleranceRange))
 				g.Expect(snapshot[bUnsupported.UID]).To(BeTemporally("~", clock.Now(), toleranceRange))
+			}).Should(Succeed())
+		})
+	})
+
+	Context("Dynamic Watching and Custom CRD", func() {
+		SetDefaultEventuallyTimeout(10 * time.Second)
+		SetDefaultEventuallyPollingInterval(500 * time.Millisecond)
+
+		BeforeEach(func() {
+			By("creating a pod template")
+			podTemp := testutil.NewPodTemplate(
+				testutil.WithPodTemplateName("pod-temp"),
+				testutil.WithNamespace[*corev1.PodTemplate](namespace),
+				testutil.WithPodTemplateResources(corev1.ResourceList{"cpu": resource.MustParse("1")}, nil),
+			)
+			_, err := k8sClient.CoreV1().PodTemplates(namespace).Create(ctx, podTemp, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			By("cleaning up test resources")
+			_ = buffersClient.AutoscalingV1beta1().CapacityBuffers(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
+			_ = k8sClient.CoreV1().PodTemplates(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
+		})
+
+		It("should fail to establish a watch on an unregistered custom CRD", func() {
+			By("defining an unregistered custom CRD name and GVK")
+			gvk := schema.GroupVersionKind{
+				Group:   "example.com",
+				Version: "v1",
+				Kind:    "CustomScalable",
+			}
+
+			By("creating a buffer referencing an unregistered custom CRD")
+			b1 := testutil.NewBuffer(
+				testutil.WithName("custom-buffer"),
+				testutil.WithNamespace[*v1beta1.CapacityBuffer](namespace),
+				testutil.WithScalableRef(gvk.Group, gvk.Kind, "my-custom-obj"),
+				testutil.WithPercentage(50),
+				testutil.WithActiveProvisioningStrategy(),
+			)
+			_, err := buffersClient.AutoscalingV1beta1().CapacityBuffers(namespace).Create(ctx, b1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the controller remains responsive for other buffers")
+			b2 := testutil.NewBuffer(
+				testutil.WithName("healthy-buffer"),
+				testutil.WithNamespace[*v1beta1.CapacityBuffer](namespace),
+				testutil.WithPodTemplateRef("pod-temp"),
+				testutil.WithReplicas(1),
+				testutil.WithActiveProvisioningStrategy(),
+			)
+			_, err = buffersClient.AutoscalingV1beta1().CapacityBuffers(namespace).Create(ctx, b2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				b, err := buffersClient.AutoscalingV1beta1().CapacityBuffers(namespace).Get(ctx, "healthy-buffer", metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(b.Status.Replicas).To(Equal(new(int32(1))))
+			}).Should(Succeed())
+
+			By("verifying the custom-buffer has EventDrivenReconciliation=False condition")
+			Eventually(func(g Gomega) {
+				b, err := buffersClient.AutoscalingV1beta1().CapacityBuffers(namespace).Get(ctx, "custom-buffer", metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				found := false
+				for _, cond := range b.Status.Conditions {
+					if cond.Type == "EventDrivenReconciliation" {
+						g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+						g.Expect(cond.Reason).To(Equal("DynamicWatchFailed"))
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "EventDrivenReconciliation condition not found")
+			}).Should(Succeed())
+		})
+
+		It("should successfully establish a watch on a registered custom CRD", func() {
+			By("defining a registered custom CRD GVK")
+			gvk := schema.GroupVersionKind{
+				Group:   "autoscaling.x-k8s.io",
+				Version: "v1beta1",
+				Kind:    "CapacityQuota",
+			}
+
+			By("creating a buffer referencing the registered custom CRD")
+			b := testutil.NewBuffer(
+				testutil.WithName("success-buffer"),
+				testutil.WithNamespace[*v1beta1.CapacityBuffer](namespace),
+				testutil.WithScalableRef(gvk.Group, gvk.Kind, "my-quota-obj"),
+				testutil.WithPercentage(50),
+				testutil.WithActiveProvisioningStrategy(),
+			)
+			_, err := buffersClient.AutoscalingV1beta1().CapacityBuffers(namespace).Create(ctx, b, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the success-buffer has EventDrivenReconciliation=True condition")
+			Eventually(func(g Gomega) {
+				b, err := buffersClient.AutoscalingV1beta1().CapacityBuffers(namespace).Get(ctx, "success-buffer", metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				found := false
+				for _, cond := range b.Status.Conditions {
+					if cond.Type == "EventDrivenReconciliation" {
+						g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+						g.Expect(cond.Reason).To(Equal("DynamicWatchSynced"))
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "EventDrivenReconciliation condition not found or not True")
 			}).Should(Succeed())
 		})
 	})

--- a/cluster-autoscaler/test/integration/controllers/suite_test.go
+++ b/cluster-autoscaler/test/integration/controllers/suite_test.go
@@ -127,6 +127,8 @@ var _ = BeforeSuite(func() {
 		[]string{cbapi.ActiveProvisioningStrategy, ""},
 		reconciliationCache,
 		clock,
+		cbctrl.NewDefaultRBACUpdater(client.GetKubernetesClient()),
+		client.GetDynamicClient(),
 	)
 
 	go controller.Run(ctx.Done())


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
The CapacityBuffer controller faces challenges in defining and provisioning capacity when referencing scalable resources that are not part of the core Kubernetes objects, such as various Custom Resource Definitions (CRDs). Since the controller cannot know every potential GroupVersionKind (GVK) in advance, it struggles with hard-coded support and static RBAC permissions. Furthermore, polling approaches introduce latency and API server load, while watching every possible resource type is not scalable, creating a need for a solution that can reactively and efficiently observe target object states for accurate buffer calculation.

As a result of this, Capacity buffers controller latency for processing buffers when a scale sub resource changes can go up to 5 mins which is the informer sync time. 

The implemented fix utilizes a Dynamic Watching approach that enables the controller to resolve unknown GVKs at runtime through a RESTMapper and initialize Dynamic Informers on-the-fly. This system is supported by a dynamic RBAC updater suggests logged for the user to create to ensure the controller has the necessary permissions to watch specific resources only when they are actively referenced in the cluster. This reactive architecture eliminates the dependency on slow polling intervals by triggering near-instantaneous re-reconciliation for buffers namespace whenever a state change is detected in a target workload.

In case the user has not applied the cluster role to give CA permissions to watch the referenced CRD, buffers controller will log the needed role and will set a condition EventDrivenReconciliation to  false with descriptive message clarifying that for this buffer the reconciliation will be periodic and not event driven and suggests creating the role we logged before.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
- Cluster autoscaler RBAC needs to be updated to include the aggregator
- The changes were tested on a GKE cluster after giving the correct RBAC permissions to CA component
- On testing note that capacity buffers controller doesn't support scale from 0 for scale sub resource as the template can't be defined so we there should be at least one running pod


#### Does this PR introduce a user-facing change?

```release-note
Improve Capacity Buffers controller reaction time for scalableRef 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
