### PR TITLE
test: mixed consumes/shared counters consumption

### DIFF
--- a/cluster-autoscaler/simulator/dynamicresources/utils/utilization_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/utils/utilization_test.go
@@ -25,6 +25,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
@@ -208,6 +209,91 @@ func TestDynamicResourceUtilization(t *testing.T) {
 				t.Errorf("HighestDynamicResourceUtilization(): unexpected utilization: want %v, got %v", tc.wantHighestUtilization, highestUtil)
 			}
 		})
+	}
+}
+
+func TestDynamicResourceUtilizationMixedAtomicAndPartitionablePool(t *testing.T) {
+	driver := "driver.foo.com"
+	pool := "pool1"
+	nodeName := "node"
+	node := test.BuildTestNode(nodeName, 1000, 1000)
+	counterSet := "gpu-0-counters"
+
+	resourceSlices := []*resourceapi.ResourceSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "devices", UID: types.UID("devices")},
+			Spec: resourceapi.ResourceSliceSpec{
+				Driver:   driver,
+				NodeName: &nodeName,
+				Pool:     resourceapi.ResourcePool{Name: pool, Generation: 0, ResourceSliceCount: 2},
+				Devices: []resourceapi.Device{
+					{Name: "atomic-allocated"},
+					{Name: "atomic-free"},
+					{
+						Name: "gpu-0-partition-0",
+						ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+							{
+								CounterSet: counterSet,
+								Counters: map[string]resourceapi.Counter{
+									"memory": {Value: resource.MustParse("5Gi")},
+								},
+							},
+						},
+					},
+					{
+						Name: "gpu-0-partition-1",
+						ConsumesCounters: []resourceapi.DeviceCounterConsumption{
+							{
+								CounterSet: counterSet,
+								Counters: map[string]resourceapi.Counter{
+									"memory": {Value: resource.MustParse("5Gi")},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "counters", UID: types.UID("counters")},
+			Spec: resourceapi.ResourceSliceSpec{
+				Driver:   driver,
+				NodeName: &nodeName,
+				Pool:     resourceapi.ResourcePool{Name: pool, Generation: 0, ResourceSliceCount: 2},
+				SharedCounters: []resourceapi.CounterSet{
+					{
+						Name: counterSet,
+						Counters: map[string]resourceapi.Counter{
+							"memory": {Value: resource.MustParse("10Gi")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod := test.BuildTestPod("pod", 1, 1, test.WithNodeName(nodeName))
+	claim := &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim", UID: types.UID("claim")},
+		Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{
+					Results: []resourceapi.DeviceRequestAllocationResult{
+						{Request: "request", Driver: driver, Pool: pool, Device: "atomic-allocated"},
+					},
+				},
+			},
+		},
+	}
+
+	utilization, err := CalculateDynamicResourceUtilization(framework.NewNodeInfo(node, resourceSlices, framework.NewPodInfo(pod, []*resourceapi.ResourceClaim{claim})))
+	if err != nil {
+		t.Fatalf("CalculateDynamicResourceUtilization(): unexpected error: %v", err)
+	}
+
+	want := 0.25
+	if got := utilization[driver][pool]; got != want {
+		t.Fatalf("CalculateDynamicResourceUtilization() mixed pool utilization = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds a UT scenario for resourceslice consumption calculation w/ at least nil ConsumesCounters resourceslice. This is to potentially help https://github.com/kubernetes/autoscaler/pull/8559 to validate back-compat.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
