### PR TITLE
fix(azure): VMSS size cache handling after delete failures

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -322,6 +322,7 @@ func (scaleSet *ScaleSet) canIncreaseSize(delta int) (int64, error) {
 		return size, err
 	}
 
+	// Defensive: getScaleSetSize already errors on size == -1, so this is unreachable today.
 	if size == -1 {
 		return size, fmt.Errorf("the scale set %s is under initialization, skipping IncreaseSize", scaleSet.Name)
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -712,9 +712,8 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 		klog.Errorf("PollUntilDone for DeleteInstances(%v) for %s retry failed: %v", requiredIds.InstanceIDs, scaleSet.Name, retryErr)
 	}
 
-	if !scaleSet.manager.config.StrictCacheUpdates {
-		scaleSet.invalidateInstanceCache()
-	}
+	scaleSet.invalidateInstanceCache()
+	scaleSet.invalidateLastSizeRefreshWithLock()
 	klog.Errorf("PollUntilDone for DeleteInstances(%v) for %s failed with error: %v", requiredIds.InstanceIDs, scaleSet.Name, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -267,9 +267,14 @@ func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 func (scaleSet *ScaleSet) getScaleSetSize() (int64, error) {
 	// First, get the current size of the ScaleSet
 	size, getVMSSError := scaleSet.getCurSize()
-	if size == -1 || getVMSSError != nil {
-		klog.V(3).Infof("getScaleSetSize: either size is -1 (actual: %d) or error exists (actual err:%v)", size, getVMSSError.error)
+	if getVMSSError != nil {
+		klog.V(3).Infof("getScaleSetSize: error exists (actual err:%v)", getVMSSError.error)
 		return size, getVMSSError.error
+	}
+	if size == -1 {
+		err := fmt.Errorf("failed to get scale set size for %s: cached size is -1 without provider error", scaleSet.Name)
+		klog.V(3).Infof("getScaleSetSize: size is -1 (actual err:%v)", err)
+		return size, err
 	}
 	return size, nil
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -725,6 +725,9 @@ func (scaleSet *ScaleSet) DeleteNodes(nodes []*apiv1.Node) error {
 		return err
 	}
 
+	// This only catches callers already at min size. A future change should also reject
+	// batches that would go below min size; create-error cleanup fallback is the only
+	// currently known path that can reach this check without regular scale-down filtering.
 	if int(size) <= scaleSet.MinSize() {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -643,13 +643,21 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 
 	if !scaleSet.manager.config.StrictCacheUpdates {
 		// Proactively decrement scale set size so that we don't
-		// go below minimum node count if cache data is stale
-		// only do it for non-unregistered nodes
+		// go below minimum node count if cache data is stale.
+		// If the cached size can't represent the delete batch,
+		// mark it stale instead of publishing a negative size.
+		// Only do it for non-unregistered nodes.
 
 		if !hasUnregisteredNodes {
+			deleteCount := int64(len(instanceIDs))
 			scaleSet.sizeMutex.Lock()
-			scaleSet.curSize -= int64(len(instanceIDs))
-			scaleSet.lastSizeRefresh = time.Now()
+			if scaleSet.curSize < deleteCount {
+				klog.Warningf("VMSS: %s, cached size %d is smaller than instances to delete %d, invalidating size cache instead of decrementing", scaleSet.Name, scaleSet.curSize, deleteCount)
+				scaleSet.lastSizeRefresh = time.Time{}
+			} else {
+				scaleSet.curSize -= deleteCount
+				scaleSet.lastSizeRefresh = time.Now()
+			}
 			scaleSet.sizeMutex.Unlock()
 		}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -255,6 +255,22 @@ func TestScaleSetTargetSize(t *testing.T) {
 	}
 }
 
+func TestScaleSetTargetSizeReturnsErrorForCachedNegativeSize(t *testing.T) {
+	provider := newTestProvider(t)
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	scaleSet := newTestScaleSet(provider.azureManager, testASG)
+	scaleSet.curSize = -1
+	scaleSet.lastSizeRefresh = time.Now()
+	scaleSet.sizeRefreshPeriod = time.Hour
+
+	size, err := scaleSet.TargetSize()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cached size is -1 without provider error")
+	assert.Equal(t, -1, size)
+}
+
 func TestScaleSetIncreaseSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -1139,6 +1139,80 @@ func TestScaleSetDeleteNodes(t *testing.T) {
 	}
 }
 
+func TestScaleSetForceDeleteNodesDoesNotPublishNegativeCachedSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	vmssName := testASG
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+	expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", orchMode)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
+
+	manager := newTestAzureManager(t)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, testASG).Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedVMs, nil).AnyTimes()
+	manager.azClient.virtualMachinesClient = mockVMClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	resourceLimiter := cloudprovider.NewResourceLimiter(
+		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
+		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
+	provider, err := BuildAzureCloudProvider(manager, resourceLimiter)
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, testASG))
+	manager.explicitlyConfigured[testASG] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	scaleSet, ok := provider.NodeGroups()[0].(*ScaleSet)
+	assert.True(t, ok)
+
+	targetSize, err := scaleSet.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+
+	scaleSet.curSize = 1
+	scaleSet.lastSizeRefresh = time.Now()
+	scaleSet.sizeRefreshPeriod = time.Hour
+
+	nodesToDelete := []*apiv1.Node{
+		newApiNode(orchMode, 0),
+		newApiNode(orchMode, 2),
+	}
+	err = scaleSet.ForceDeleteNodes(nodesToDelete)
+	assert.NoError(t, err)
+
+	scaleSet.sizeMutex.Lock()
+	curSize := scaleSet.curSize
+	lastSizeRefresh := scaleSet.lastSizeRefresh
+	scaleSet.sizeMutex.Unlock()
+	assert.Equal(t, int64(1), curSize)
+	assert.True(t, lastSizeRefresh.IsZero())
+
+	targetSize, err = scaleSet.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+}
+
 func TestScaleSetDeleteNodeUnregistered(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -2072,15 +2072,28 @@ func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
 		InstanceIDs: []*string{ptr.To("0")},
 	}
 
-	scaleSet := newTestScaleSet(manager, "test-asg")
+	for _, strictCacheUpdates := range []bool{false, true} {
+		t.Run(fmt.Sprintf("strict cache updates %t", strictCacheUpdates), func(t *testing.T) {
+			manager.config.StrictCacheUpdates = strictCacheUpdates
+			scaleSet := newTestScaleSet(manager, "test-asg")
+			scaleSet.curSize = 1
+			scaleSet.lastSizeRefresh = time.Now()
+			scaleSet.sizeRefreshPeriod = time.Hour
 
-	// Create a poller that returns a non-preempted error
-	otherErrorPoller := newTestPollerWithError(errors.New("InternalServerError: something went wrong"))
+			// Create a poller that returns a non-preempted error
+			otherErrorPoller := newTestPollerWithError(errors.New("InternalServerError: something went wrong"))
 
-	// Act: PollUntilDone fails with a non-preempted error — should NOT trigger retry
-	scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds)
+			// Act: PollUntilDone fails with a non-preempted error — should NOT trigger retry
+			scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds)
 
-	// Assert: BeginDeleteInstances was never called. gomock.Times(0) enforces this.
+			// Assert: BeginDeleteInstances was never called. gomock.Times(0) enforces this.
+			// Assert: caches were invalidated so TargetSize refreshes from VMSS capacity.
+			assert.False(t, scaleSet.lastInstanceRefresh.IsZero())
+			targetSize, err := scaleSet.TargetSize()
+			assert.NoError(t, err)
+			assert.Equal(t, 3, targetSize)
+		})
+	}
 }
 
 func TestWaitForDeleteInstancesRetryFailure(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR hardens Azure VMSS target-size bookkeeping around failed or uncertain delete operations.

It fixes a VMSS crash path where `getScaleSetSize()` could dereference a nil provider error when the cached size was `-1`, returning an explicit error instead. https://github.com/kubernetes/autoscaler/pull/9779/commits/227d6525cc918fe2f7e73cb98efb619b14bf4562

It also prevents Azure VMSS delete bookkeeping from publishing a negative cached size. When a speculative delete decrement cannot be represented by the current cached size, the size cache is marked stale instead of being decremented below zero. https://github.com/kubernetes/autoscaler/pull/9779/commits/be542d81b2aa019637eeec7c524e1be7a3683887

Finally, async delete polling failures now invalidate both instance and size cache state, including when `StrictCacheUpdates` is enabled. This ensures the next target-size read refreshes from Azure instead of trusting a speculative local decrement after an uncertain delete outcome. https://github.com/kubernetes/autoscaler/pull/9779/commits/03029540bc81c117f29765a464e67d38db43fd4f

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Added regression coverage for:

- `TargetSize()` returning an error instead of panicking when cached VMSS size is `-1`
- `ForceDeleteNodes()` avoiding negative cached VMSS size after delete bookkeeping
- async delete polling failures invalidating size cache in both strict and non-strict cache modes

This PR does not implement the broader Azure `DeleteNodes()` batch min-size guard. A comment documents that future follow-up: the current guard only rejects callers already at min size, while a separate PR should reject non-force delete batches that would go below min size. The currently known path that can reach this check without regular scale-down filtering is create-error cleanup fallback. https://github.com/kubernetes/autoscaler/pull/9779/commits/1cd1bdb841736f19cb3a013f9d2c85b6d667c999

`getScaleSetSize()` now returns an error whenever size == -1, so the subsequent size == -1 check in `canIncreaseSize` is unreachable. It is kept as a safety net with a comment. https://github.com/kubernetes/autoscaler/pull/9779/commits/f5e54e1507b4f475e78ae7ee58b0952951473e7a

#### Does this PR introduce a user-facing change?

```release-note
Azure Cluster Autoscaler now handles VMSS target-size cache failures during delete operations more defensively, preventing negative cached sizes and target-size panics after failed or uncertain VMSS deletes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
