### PR TITLE
Azure: optional ETag concurrency on VMSS capacity updates

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/README.md
+++ b/cluster-autoscaler/cloudprovider/azure/README.md
@@ -197,6 +197,12 @@ The `AZURE_ENABLE_VMSS_FLEX` environment variable enables VMSS Flex support. By 
 |---------------------------|---------|-----------------------------------------|---------------------------|
 | enableVmssFlex            | false   | AZURE_ENABLE_VMSS_FLEX                  | enableVmssFlex            |
 
+The `AZURE_ENABLE_VMSS_ETAG` environment variable controls ETag-based optimistic concurrency on VMSS capacity updates: the cached VMSS ETag is sent as `If-Match` on `BeginCreateOrUpdate`, so a concurrent modification by another writer is rejected with HTTP 412 instead of silently overwritten. On 412 the autoscaler refreshes the ETag with a fresh GET and retries the update once; if the VMSS has meanwhile reached the desired size the scale-up is treated as satisfied, and only a still-failing retry surfaces an error. On a successful update it adopts the new ETag returned by the operation so subsequent updates remain protected. Disabled by default; set to `true` to opt in.
+
+| Config Name      | Default | Environment Variable    | Cloud Config File |
+|------------------|---------|-------------------------|-------------------|
+| enableVMSSEtag   | false   | AZURE_ENABLE_VMSS_ETAG  | enableVMSSEtag    |
+
 When using K8s 1.18 or higher, it is also recommended to configure backoff and retries on the client as described [here](#rate-limit-and-back-off-retries)
 
 ### Standard deployment

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -19,6 +19,7 @@ package azure
 import (
 	"context"
 	"errors"
+	"maps"
 	"reflect"
 	"regexp"
 	"strings"
@@ -165,6 +166,18 @@ func (m *azureCache) getScaleSets() map[string]*armcompute.VirtualMachineScaleSe
 	return m.scaleSets
 }
 
+// setScaleSet replaces the cached entry for a single VMSS, e.g. after a fresh GET.
+// It copies the map before mutating it so readers that obtained the map via
+// getScaleSets() are not exposed to a concurrent map write.
+func (m *azureCache) setScaleSet(name string, vmss *armcompute.VirtualMachineScaleSet) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	scaleSets := maps.Clone(m.scaleSets)
+	scaleSets[name] = vmss
+	m.scaleSets = scaleSets
+}
+
 // Cleanup closes the channel to signal the go routine to stop that is handling the cache
 func (m *azureCache) Cleanup() {
 	close(m.interrupt)
@@ -194,7 +207,7 @@ func (m *azureCache) regenerate() error {
 
 	// Regenerate VMSS to autoscaling options mapping.
 	newAutoscalingOptions := make(map[azureRef]map[string]string)
-	for _, vmss := range m.scaleSets {
+	for _, vmss := range m.getScaleSets() {
 		ref := azureRef{Name: *vmss.Name}
 		options := extractAutoscalingOptionsFromScaleSetTags(vmss.Tags)
 		if !reflect.DeepEqual(m.getAutoscalingOptions(ref), options) {
@@ -512,6 +525,7 @@ func (m *azureCache) FindForInstance(instance *azureRef, vmType string) (cloudpr
 }
 
 // isAllScaleSetsAreUniform determines if all the scale set autoscaler is monitoring are Uniform or not.
+// Should be called with lock, as it reads m.scaleSets directly.
 func (m *azureCache) areAllScaleSetsUniform() bool {
 	for _, scaleSet := range m.scaleSets {
 		if scaleSet.Properties != nil && scaleSet.Properties.OrchestrationMode != nil &&

--- a/cluster-autoscaler/cloudprovider/azure/azure_config.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_config.go
@@ -112,6 +112,11 @@ type Config struct {
 
 	// EnableLabelPredictionsOnTemplate defines whether to enable label predictions on the template when scaling from zero
 	EnableLabelPredictionsOnTemplate bool `json:"enableLabelPredictionsOnTemplate,omitempty" yaml:"enableLabelPredictionsOnTemplate,omitempty"`
+
+	// EnableVMSSEtag sends the cached VMSS ETag as If-Match on capacity-changing
+	// VMSS PUTs so concurrent modifications are rejected with 412 instead of overwritten.
+	// Disabled by default; set to true to opt in.
+	EnableVMSSEtag bool `json:"enableVMSSEtag,omitempty" yaml:"enableVMSSEtag,omitempty"`
 }
 
 // These are only here for backward compabitility. Their equivalent exists in providerazure.Config with a different name.
@@ -143,6 +148,7 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 	cfg.MaxDeploymentsCount = int64(defaultMaxDeploymentsCount)
 	cfg.StrictCacheUpdates = false
 	cfg.EnableLabelPredictionsOnTemplate = true
+	cfg.EnableVMSSEtag = false
 
 	// Config file overrides defaults
 	if configReader != nil {
@@ -281,6 +287,9 @@ func BuildAzureConfig(configReader io.Reader) (*Config, error) {
 		return nil, err
 	}
 	if _, err = assignBoolFromEnvIfExists(&cfg.EnableVMsAgentPool, "AZURE_ENABLE_VMS_AGENT_POOLS"); err != nil {
+		return nil, err
+	}
+	if _, err = assignBoolFromEnvIfExists(&cfg.EnableVMSSEtag, "AZURE_ENABLE_VMSS_ETAG"); err != nil {
 		return nil, err
 	}
 	if _, err = assignBoolFromEnvIfExists(&cfg.EnableDynamicInstanceList, "AZURE_ENABLE_DYNAMIC_INSTANCE_LIST"); err != nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -189,6 +190,9 @@ func (scaleSet *ScaleSet) MaxSize() int {
 	return scaleSet.maxSize
 }
 
+// getVMSSFromCache returns the live cached VMSS object.
+// Callers that read or write mutable fields shared with resize paths,
+// especially SKU.Capacity and Etag, must hold vmssSizeMutex.
 func (scaleSet *ScaleSet) getVMSSFromCache() (*armcompute.VirtualMachineScaleSet, error) {
 	allVMSS := scaleSet.manager.azureCache.getScaleSets()
 
@@ -245,6 +249,9 @@ func (scaleSet *ScaleSet) getCurSize() (int64, *GetVMSSFailedError) {
 			klog.Errorf("failed to get information for VMSS: %s, error: %v", scaleSet.Name, err)
 			return -1, newGetVMSSFailedError(err, azerrors.IsNotFoundErr(err))
 		}
+		// Persist the freshly-fetched VMSS (including its ETag) so subsequent
+		// capacity updates send an up-to-date If-Match.
+		scaleSet.manager.azureCache.setScaleSet(scaleSet.Name, set)
 	}
 
 	vmssSizeMutex.Lock()
@@ -376,15 +383,16 @@ func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
 	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
 	defer cancel()
 
-	poller, err := scaleSet.initCreateOrUpdate(ctx, vmssInfo, newSize)
+	effectiveVMSS, poller, err := scaleSet.initCreateOrUpdate(ctx, vmssInfo, newSize)
 	if err != nil {
 		klog.Errorf("AtomicIncreaseSize: BeginCreateOrUpdate for scale set %q failed: %v", scaleSet.Name, err)
 		return err
 	}
 
+	var resp armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse
 	if poller != nil {
 		klog.V(3).Infof("AtomicIncreaseSize: waiting for VMSS %q capacity update to complete", scaleSet.Name)
-		_, err = poller.PollUntilDone(ctx, nil)
+		resp, err = poller.PollUntilDone(ctx, nil)
 		scaleSet.invalidateInstanceCache()
 		if err != nil {
 			klog.Errorf("AtomicIncreaseSize: VMSS %q capacity update failed during polling: %v", scaleSet.Name, err)
@@ -395,11 +403,25 @@ func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
 	}
 
 	// Only update the size cache after the operation has successfully completed.
+	// initCreateOrUpdate may have refreshed the cache with a different VMSS object (an
+	// ETag retry), so update that object rather than the pre-retry copy.
 	scaleSet.sizeMutex.Lock()
 	vmssSizeMutex.Lock()
-	vmssInfo.SKU.Capacity = &newSize
+	if poller == nil && effectiveVMSS != vmssInfo {
+		// An ETag retry skipped the PUT because the VMSS already met or exceeded the
+		// target; publish its actual capacity rather than a stale (possibly lower) target.
+		scaleSet.curSize = *effectiveVMSS.SKU.Capacity
+	} else {
+		effectiveVMSS.SKU.Capacity = &newSize
+		// A successful PUT changes the server-side ETag. Adopt the new one returned by
+		// the operation so any follow-up PUT before the next cache refresh still carries a
+		// valid If-Match rather than overwriting concurrent changes or hitting a 412.
+		if scaleSet.manager.config.EnableVMSSEtag && resp.Etag != nil {
+			effectiveVMSS.Etag = resp.Etag
+		}
+		scaleSet.curSize = newSize
+	}
 	vmssSizeMutex.Unlock()
-	scaleSet.curSize = newSize
 	scaleSet.lastSizeRefresh = time.Now()
 	scaleSet.sizeMutex.Unlock()
 
@@ -488,9 +510,22 @@ func (scaleSet *ScaleSet) Belongs(node *apiv1.Node) (bool, error) {
 	return true, nil
 }
 
-func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *armcompute.VirtualMachineScaleSet, newSize int64) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+// isPreconditionFailedError reports whether err is an Azure response error with
+// HTTP 412 status, i.e. an ETag If-Match precondition failure.
+func isPreconditionFailedError(err error) bool {
+	r := azerrors.IsResponseError(err)
+	return r != nil && r.StatusCode == http.StatusPreconditionFailed
+}
+
+// initCreateOrUpdate issues the capacity PUT and returns the VMSS object the caller
+// should track going forward. On a normal update that is the same vmssInfo; on an ETag
+// retry it is the freshly-fetched object that now lives in the cache, so the caller's
+// post-completion ETag/capacity updates land on the cached object rather than a stale
+// copy. A nil poller with no error means the update was satisfied without a PUT (the
+// VMSS already met the target); the caller should adopt the returned object's capacity.
+func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *armcompute.VirtualMachineScaleSet, newSize int64) (*armcompute.VirtualMachineScaleSet, *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
 	if vmssInfo == nil {
-		return nil, fmt.Errorf("vmssInfo cannot be nil while increasing scaleSet capacity")
+		return nil, nil, fmt.Errorf("vmssInfo cannot be nil while increasing scaleSet capacity")
 	}
 
 	scaleSet.sizeMutex.Lock()
@@ -519,12 +554,75 @@ func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *armc
 	}
 
 	klog.V(3).Infof("Calling virtualMachineScaleSetsClient.BeginCreateOrUpdate(%s)", scaleSet.Name)
-	poller, err := scaleSet.manager.azClient.vmssClientForDelete.BeginCreateOrUpdate(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, op, nil)
+
+	opts := &armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions{}
+	if scaleSet.manager.config.EnableVMSSEtag {
+		// Read the cached ETag under vmssSizeMutex, the same lock that guards
+		// ETag writes on operation completion, so the read/write pair is
+		// race-free even though initCreateOrUpdate holds only sizeMutex.
+		vmssSizeMutex.Lock()
+		etag := vmssInfo.Etag
+		vmssSizeMutex.Unlock()
+		opts.IfMatch = etag
+	}
+	poller, err := scaleSet.manager.azClient.vmssClientForDelete.BeginCreateOrUpdate(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, op, opts)
 	if err != nil {
 		klog.Errorf("virtualMachineScaleSetsClient.BeginCreateOrUpdate for scale set %q failed: %+v", scaleSet.Name, err)
-		return nil, err
+		if scaleSet.manager.config.EnableVMSSEtag && isPreconditionFailedError(err) {
+			// An ETag precondition failure is an optimistic-concurrency conflict, not a
+			// real scale-up failure. Refresh the ETag from a fresh GET and retry once so
+			// a lost race does not surface as an error that would back off the node group.
+			return scaleSet.retryCreateOrUpdateWithFreshETag(ctx, op, newSize)
+		}
+		return nil, nil, err
 	}
-	return poller, nil
+	return vmssInfo, poller, nil
+}
+
+// retryCreateOrUpdateWithFreshETag handles an ETag precondition failure by fetching
+// the current VMSS, adopting its ETag, and re-issuing the capacity update once. This
+// keeps a lost optimistic-concurrency race from surfacing as a scale-up failure, which
+// would otherwise back off the node group. It returns the freshly-fetched VMSS (now in
+// the cache) so the caller tracks that object instead of the stale pre-retry copy.
+// Callers must hold sizeMutex.
+func (scaleSet *ScaleSet) retryCreateOrUpdateWithFreshETag(ctx context.Context, op armcompute.VirtualMachineScaleSet, newSize int64) (*armcompute.VirtualMachineScaleSet, *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+	klog.V(2).Infof("VMSS %s update hit ETag precondition; refreshing ETag and retrying once", scaleSet.Name)
+
+	fresh, err := scaleSet.manager.azClient.virtualMachineScaleSetsClient.Get(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, nil)
+	if err != nil {
+		klog.Errorf("VMSS %s ETag retry: failed to GET current scale set: %v", scaleSet.Name, err)
+		scaleSet.invalidateForPreconditionFailure()
+		return nil, nil, err
+	}
+
+	// Persist the freshly-fetched VMSS (ETag and capacity) for subsequent operations.
+	scaleSet.manager.azureCache.setScaleSet(scaleSet.Name, fresh)
+
+	// If another writer already grew the VMSS to at least our target, the desired floor
+	// is already met; don't issue a PUT that would shrink it back down. Return the fresh
+	// object (nil poller) so the caller publishes its actual capacity, not a stale target.
+	if fresh.SKU != nil && fresh.SKU.Capacity != nil && *fresh.SKU.Capacity >= newSize {
+		klog.V(2).Infof("VMSS %s already at capacity %d (>= desired %d) after refresh; skipping retry", scaleSet.Name, *fresh.SKU.Capacity, newSize)
+		return fresh, nil, nil
+	}
+
+	opts := &armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions{IfMatch: fresh.Etag}
+	poller, err := scaleSet.manager.azClient.vmssClientForDelete.BeginCreateOrUpdate(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, op, opts)
+	if err != nil {
+		klog.Errorf("VMSS %s ETag retry: BeginCreateOrUpdate failed: %+v", scaleSet.Name, err)
+		scaleSet.invalidateForPreconditionFailure()
+		return nil, nil, err
+	}
+	return fresh, poller, nil
+}
+
+// invalidateForPreconditionFailure invalidates the instance, size, and manager caches
+// so the next loop re-plans from fresh Azure state. Callers must hold sizeMutex.
+func (scaleSet *ScaleSet) invalidateForPreconditionFailure() {
+	scaleSet.invalidateInstanceCache()
+	// Already holding sizeMutex here, so force the size refresh without re-locking.
+	scaleSet.invalidateLastSizeRefresh()
+	scaleSet.manager.invalidateCache()
 }
 
 func (scaleSet *ScaleSet) createOrUpdateInstances(vmssInfo *armcompute.VirtualMachineScaleSet, newSize int64) error {
@@ -534,36 +632,60 @@ func (scaleSet *ScaleSet) createOrUpdateInstances(vmssInfo *armcompute.VirtualMa
 	// to avoid overshooting the max size if multiple scale up requests are made concurrently.
 	// This preserves the existing behavior (before atomic scale up was added).
 	vmssSizeMutex.Lock()
+	previousSize := vmssInfo.SKU.Capacity
 	vmssInfo.SKU.Capacity = &newSize
 	vmssSizeMutex.Unlock()
-	poller, err := scaleSet.initCreateOrUpdate(ctx, vmssInfo, newSize)
+	effectiveVMSS, poller, err := scaleSet.initCreateOrUpdate(ctx, vmssInfo, newSize)
 	if err != nil {
+		// The update was not accepted (e.g. an ETag precondition failure), so roll
+		// back the eager capacity mutation. Otherwise the rejected desired size would
+		// remain on the cached VMSS object and become visible via getCurSize before
+		// the next full cache refresh.
+		vmssSizeMutex.Lock()
+		vmssInfo.SKU.Capacity = previousSize
+		vmssSizeMutex.Unlock()
 		return err
 	}
+
+	// initCreateOrUpdate may have refreshed the cache with a different VMSS object (an
+	// ETag retry). Track that object so the async completion below updates the cached
+	// copy, and decide the size to publish from it.
+	publishedSize := newSize
+	vmssSizeMutex.Lock()
+	if poller != nil {
+		// A PUT is in flight; carry the eager capacity mutation onto whatever object
+		// the async completion will update so the cache stays consistent meanwhile.
+		effectiveVMSS.SKU.Capacity = &newSize
+	} else if effectiveVMSS != vmssInfo {
+		// An ETag retry skipped the PUT because the VMSS already met or exceeded the
+		// target; publish its actual capacity rather than a stale (possibly lower) target.
+		publishedSize = *effectiveVMSS.SKU.Capacity
+	}
+	vmssSizeMutex.Unlock()
 
 	// Proactively set the VMSS size so autoscaler makes better decisions.
 	// initCreateOrUpdate releases sizeMutex before returning, so reacquire it
 	// here to keep curSize / lastSizeRefresh updates serialized with readers
 	// (e.g. getCurSize).
 	scaleSet.sizeMutex.Lock()
-	scaleSet.curSize = newSize
+	scaleSet.curSize = publishedSize
 	scaleSet.lastSizeRefresh = time.Now()
 	scaleSet.sizeMutex.Unlock()
 
 	// Poll for completion asynchronously to avoid blocking the autoscaler
 	if poller != nil {
-		go scaleSet.waitForCreateOrUpdateInstances(poller)
+		go scaleSet.waitForCreateOrUpdateInstances(poller, effectiveVMSS)
 	}
 	return nil
 }
 
 // waitForCreateOrUpdateInstances waits for the outcome of VMSS capacity update initiated via BeginCreateOrUpdate.
-func (scaleSet *ScaleSet) waitForCreateOrUpdateInstances(poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse]) {
+func (scaleSet *ScaleSet) waitForCreateOrUpdateInstances(poller *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], vmssInfo *armcompute.VirtualMachineScaleSet) {
 	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
 	defer cancel()
 
 	klog.V(3).Infof("Calling PollUntilDone for CreateOrUpdate(%s)", scaleSet.Name)
-	_, err := poller.PollUntilDone(ctx, nil)
+	resp, err := poller.PollUntilDone(ctx, nil)
 
 	// Invalidate instanceCache on success and failure. Failure might have created a few instances, but it is very rare.
 	scaleSet.invalidateInstanceCache()
@@ -574,6 +696,24 @@ func (scaleSet *ScaleSet) waitForCreateOrUpdateInstances(poller *runtime.Poller[
 		scaleSet.invalidateLastSizeRefreshWithLock()
 		scaleSet.manager.invalidateCache()
 		return
+	}
+
+	// A successful PUT changes the server-side ETag. Adopt the new one returned by
+	// the operation so any follow-up PUT before the next cache refresh still carries a
+	// valid If-Match rather than overwriting concurrent changes or hitting a 412.
+	if scaleSet.manager.config.EnableVMSSEtag {
+		if resp.Etag != nil {
+			vmssSizeMutex.Lock()
+			vmssInfo.Etag = resp.Etag
+			vmssSizeMutex.Unlock()
+		} else {
+			// The PUT succeeded but the response carried no ETag, so the cached one
+			// is now stale. Mark the cache for refresh so the next operation fetches
+			// a current ETag via GET instead of sending a stale If-Match (which would
+			// otherwise be rejected with a 412 and force an extra re-plan).
+			scaleSet.invalidateLastSizeRefreshWithLock()
+			scaleSet.manager.invalidateCache()
+		}
 	}
 
 	klog.V(3).Infof("PollUntilDone for CreateOrUpdate(%s) success", scaleSet.Name)
@@ -1004,8 +1144,14 @@ func isSpot(vmss *armcompute.VirtualMachineScaleSet) bool {
 
 func (scaleSet *ScaleSet) invalidateLastSizeRefreshWithLock() {
 	scaleSet.sizeMutex.Lock()
-	scaleSet.lastSizeRefresh = time.Now().Add(-1 * scaleSet.sizeRefreshPeriod)
+	scaleSet.invalidateLastSizeRefresh()
 	scaleSet.sizeMutex.Unlock()
+}
+
+// invalidateLastSizeRefresh forces the next getCurSize call to refresh curSize
+// from the VMSS. Callers must already hold sizeMutex.
+func (scaleSet *ScaleSet) invalidateLastSizeRefresh() {
+	scaleSet.lastSizeRefresh = time.Now().Add(-1 * scaleSet.sizeRefreshPeriod)
 }
 
 func (scaleSet *ScaleSet) getOrchestrationMode() (*armcompute.OrchestrationMode, error) {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -517,23 +517,10 @@ func isPreconditionFailedError(err error) bool {
 	return r != nil && r.StatusCode == http.StatusPreconditionFailed
 }
 
-// initCreateOrUpdate issues the capacity PUT and returns the VMSS object the caller
-// should track going forward. On a normal update that is the same vmssInfo; on an ETag
-// retry it is the freshly-fetched object that now lives in the cache, so the caller's
-// post-completion ETag/capacity updates land on the cached object rather than a stale
-// copy. A nil poller with no error means the update was satisfied without a PUT (the
-// VMSS already met the target); the caller should adopt the returned object's capacity.
-func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *armcompute.VirtualMachineScaleSet, newSize int64) (*armcompute.VirtualMachineScaleSet, *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
-	if vmssInfo == nil {
-		return nil, nil, fmt.Errorf("vmssInfo cannot be nil while increasing scaleSet capacity")
-	}
-
-	scaleSet.sizeMutex.Lock()
-	defer scaleSet.sizeMutex.Unlock()
-
-	// Compose a new VMSS for updating.
-	// Copy the SKU rather than sharing the pointer so the cached
-	// vmssInfo.SKU.Capacity is not mutated before the API call completes.
+// buildScaleSetCapacityUpdate composes the sparse VMSS object sent on a capacity PUT.
+// The SKU is copied (not shared) so the cached vmssInfo.SKU.Capacity is not mutated
+// before the API call completes.
+func buildScaleSetCapacityUpdate(vmssInfo *armcompute.VirtualMachineScaleSet, newSize int64) armcompute.VirtualMachineScaleSet {
 	op := armcompute.VirtualMachineScaleSet{
 		Name:     vmssInfo.Name,
 		Location: vmssInfo.Location,
@@ -552,6 +539,25 @@ func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *armc
 
 		klog.V(3).Infof("Passing ExtendedLocation information if it is not nil, with Edge Zone name:(%s)", *op.ExtendedLocation.Name)
 	}
+
+	return op
+}
+
+// initCreateOrUpdate issues the capacity PUT and returns the VMSS object the caller
+// should track going forward. On a normal update that is the same vmssInfo; on an ETag
+// retry it is the freshly-fetched object that now lives in the cache, so the caller's
+// post-completion ETag/capacity updates land on the cached object rather than a stale
+// copy. A nil poller with no error means the update was satisfied without a PUT (the
+// VMSS already met the target); the caller should adopt the returned object's capacity.
+func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *armcompute.VirtualMachineScaleSet, newSize int64) (*armcompute.VirtualMachineScaleSet, *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+	if vmssInfo == nil {
+		return nil, nil, fmt.Errorf("vmssInfo cannot be nil while increasing scaleSet capacity")
+	}
+
+	scaleSet.sizeMutex.Lock()
+	defer scaleSet.sizeMutex.Unlock()
+
+	op := buildScaleSetCapacityUpdate(vmssInfo, newSize)
 
 	klog.V(3).Infof("Calling virtualMachineScaleSetsClient.BeginCreateOrUpdate(%s)", scaleSet.Name)
 
@@ -572,7 +578,7 @@ func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *armc
 			// An ETag precondition failure is an optimistic-concurrency conflict, not a
 			// real scale-up failure. Refresh the ETag from a fresh GET and retry once so
 			// a lost race does not surface as an error that would back off the node group.
-			return scaleSet.retryCreateOrUpdateWithFreshETag(ctx, op, newSize)
+			return scaleSet.retryCreateOrUpdateWithFreshETag(ctx, newSize)
 		}
 		return nil, nil, err
 	}
@@ -585,7 +591,7 @@ func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *armc
 // would otherwise back off the node group. It returns the freshly-fetched VMSS (now in
 // the cache) so the caller tracks that object instead of the stale pre-retry copy.
 // Callers must hold sizeMutex.
-func (scaleSet *ScaleSet) retryCreateOrUpdateWithFreshETag(ctx context.Context, op armcompute.VirtualMachineScaleSet, newSize int64) (*armcompute.VirtualMachineScaleSet, *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+func (scaleSet *ScaleSet) retryCreateOrUpdateWithFreshETag(ctx context.Context, newSize int64) (*armcompute.VirtualMachineScaleSet, *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
 	klog.V(2).Infof("VMSS %s update hit ETag precondition; refreshing ETag and retrying once", scaleSet.Name)
 
 	fresh, err := scaleSet.manager.azClient.virtualMachineScaleSetsClient.Get(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, nil)
@@ -606,6 +612,9 @@ func (scaleSet *ScaleSet) retryCreateOrUpdateWithFreshETag(ctx context.Context, 
 		return fresh, nil, nil
 	}
 
+	// Rebuild the update request from the freshly-fetched VMSS so the retried PUT carries
+	// current SKU/location details rather than the pre-conflict snapshot.
+	op := buildScaleSetCapacityUpdate(fresh, newSize)
 	opts := &armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions{IfMatch: fresh.Etag}
 	poller, err := scaleSet.manager.azClient.vmssClientForDelete.BeginCreateOrUpdate(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, op, opts)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -2162,3 +2162,778 @@ func TestWaitForDeleteInstancesRetryFailure(t *testing.T) {
 	assert.False(t, scaleSet.lastInstanceRefresh.IsZero(),
 		"expected instance cache to be invalidated after retry failure")
 }
+
+func TestScaleSetIncreaseSizeWithETag(t *testing.T) {
+	t.Parallel()
+	const cachedEtag = `W/"abc"`
+	cases := map[string]struct {
+		useEtag         bool
+		cachedEtag      *string
+		expectIfMatch   *string
+		expectFinalSize int64
+	}{
+		"flag off: no IfMatch even with cached ETag": {
+			useEtag:         false,
+			cachedEtag:      ptr.To(cachedEtag),
+			expectIfMatch:   nil,
+			expectFinalSize: 4,
+		},
+		"flag on: IfMatch sent from cached ETag": {
+			useEtag:         true,
+			cachedEtag:      ptr.To(cachedEtag),
+			expectIfMatch:   ptr.To(cachedEtag),
+			expectFinalSize: 4,
+		},
+		"flag on but no cached ETag: no IfMatch": {
+			useEtag:         true,
+			cachedEtag:      nil,
+			expectIfMatch:   nil,
+			expectFinalSize: 4,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			manager := newTestAzureManager(t)
+			manager.config.EnableVMSSEtag = tc.useEtag
+
+			vmssName := "vmss-etag"
+			orchMode := armcompute.OrchestrationModeUniform
+			vmss := &armcompute.VirtualMachineScaleSet{
+				Name: ptr.To(vmssName),
+				SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+				Properties: &armcompute.VirtualMachineScaleSetProperties{
+					OrchestrationMode: &orchMode,
+				},
+				Etag: tc.cachedEtag,
+			}
+
+			mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+				Return([]*armcompute.VirtualMachineScaleSet{vmss}, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+			mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).
+				Return(newTestVMSSVMList(3), nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+			mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+				Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
+
+			var capturedOpts *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions
+			mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+			mockDeleteClient.EXPECT().
+				BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ string, _ string, _ armcompute.VirtualMachineScaleSet,
+					opts *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions,
+				) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+					capturedOpts = opts
+					return nil, nil
+				}).Times(1)
+			mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, nil).AnyTimes()
+			manager.azClient.vmssClientForDelete = mockDeleteClient
+
+			manager.explicitlyConfigured[vmssName] = true
+			ss := newTestScaleSet(manager, vmssName)
+			assert.True(t, manager.RegisterNodeGroup(ss))
+			assert.NoError(t, manager.Refresh())
+
+			provider, err := BuildAzureCloudProvider(manager, nil)
+			assert.NoError(t, err)
+			scaleSet := provider.NodeGroups()[0].(*ScaleSet)
+
+			err = scaleSet.IncreaseSize(1)
+			assert.NoError(t, err)
+
+			if tc.expectIfMatch == nil {
+				assert.True(t, capturedOpts == nil || capturedOpts.IfMatch == nil,
+					"expected no IfMatch but got %v", capturedOpts)
+			} else {
+				if assert.NotNil(t, capturedOpts) && assert.NotNil(t, capturedOpts.IfMatch) {
+					assert.Equal(t, *tc.expectIfMatch, *capturedOpts.IfMatch)
+				}
+			}
+
+			assert.Equal(t, tc.expectFinalSize, scaleSet.curSize)
+		})
+	}
+}
+
+// TestScaleSetETagPreconditionFailureInvalidatesSizeCache verifies that when a
+// 412 ETag precondition failure persists across the in-provider refresh-and-retry,
+// the size cache is invalidated, so a subsequent TargetSize call picks up an
+// out-of-band VMSS capacity change rather than returning the stale cached size.
+func TestScaleSetETagPreconditionFailureInvalidatesSizeCache(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-stale"
+	orchMode := armcompute.OrchestrationModeUniform
+
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name: ptr.To(vmssName),
+		SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{
+			OrchestrationMode: &orchMode,
+		},
+		Etag: ptr.To(`W/"old"`),
+	})
+
+	// The refresh GET returns a fresh ETag but the capacity is still below target,
+	// so the retried PUT is attempted and rejected with another 412.
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name: ptr.To(vmssName),
+			SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+			Etag: ptr.To(`W/"refreshed"`),
+		}, nil).AnyTimes()
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().
+		BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed}).AnyTimes()
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	scaleSet := newTestScaleSet(manager, vmssName)
+	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
+
+	err := scaleSet.IncreaseSize(1)
+	assert.Error(t, err)
+
+	// Simulate an out-of-band capacity change observed on the next cache fetch.
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name: ptr.To(vmssName),
+		SKU:  &armcompute.SKU{Capacity: ptr.To[int64](5)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{
+			OrchestrationMode: &orchMode,
+		},
+		Etag: ptr.To(`W/"new"`),
+	})
+
+	target, err := scaleSet.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 5, target)
+}
+
+// TestScaleSetETagPreconditionFailureRollsBackCapacity verifies that when a capacity
+// update is rejected (412) and the in-provider retry also fails, the eager capacity
+// mutation on the cached VMSS object is rolled back, so TargetSize reports the prior
+// size rather than the rejected desired size.
+func TestScaleSetETagPreconditionFailureRollsBackCapacity(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-rollback"
+	orchMode := armcompute.OrchestrationModeUniform
+
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name: ptr.To(vmssName),
+		SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{
+			OrchestrationMode: &orchMode,
+		},
+		Etag: ptr.To(`W/"old"`),
+	})
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name: ptr.To(vmssName),
+			SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+			Etag: ptr.To(`W/"refreshed"`),
+		}, nil).AnyTimes()
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().
+		BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed}).AnyTimes()
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	scaleSet := newTestScaleSet(manager, vmssName)
+	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
+
+	err := scaleSet.IncreaseSize(1)
+	assert.Error(t, err)
+
+	// Without the rejected mutation, TargetSize must still report the prior size (3),
+	// not the desired size (4) that was never accepted.
+	target, err := scaleSet.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, target)
+}
+
+// TestScaleSetETagRetrySucceedsAfterPreconditionFailure verifies that a single 412
+// is transparently recovered: the provider refreshes the ETag via GET and re-issues
+// the capacity update once with the fresh If-Match, so IncreaseSize succeeds without
+// surfacing an error (which would otherwise back off the node group).
+func TestScaleSetETagRetrySucceedsAfterPreconditionFailure(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-retry"
+	orchMode := armcompute.OrchestrationModeUniform
+	const staleEtag = `W/"stale"`
+	const freshEtag = `W/"fresh"`
+
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name: ptr.To(vmssName),
+		SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{
+			OrchestrationMode: &orchMode,
+		},
+		Etag: ptr.To(staleEtag),
+	})
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name: ptr.To(vmssName),
+			SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+			Etag: ptr.To(freshEtag),
+		}, nil).Times(1)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	var ifMatches []*string
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().
+		BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ string, _ armcompute.VirtualMachineScaleSet,
+			opts *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions,
+		) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+			ifMatches = append(ifMatches, opts.IfMatch)
+			if len(ifMatches) == 1 {
+				return nil, &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed}
+			}
+			return newTestCreateOrUpdatePoller(t, ptr.To(freshEtag)), nil
+		}).Times(2)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	scaleSet := newTestScaleSet(manager, vmssName)
+	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
+
+	err := scaleSet.IncreaseSize(1)
+	assert.NoError(t, err)
+
+	if assert.Len(t, ifMatches, 2) {
+		// First PUT carries the stale cached ETag and is rejected.
+		if assert.NotNil(t, ifMatches[0]) {
+			assert.Equal(t, staleEtag, *ifMatches[0])
+		}
+		// The retried PUT carries the freshly-fetched ETag.
+		if assert.NotNil(t, ifMatches[1]) {
+			assert.Equal(t, freshEtag, *ifMatches[1])
+		}
+	}
+}
+
+// TestScaleSetETagRetrySkippedWhenAlreadyAtTarget verifies that if the refresh GET
+// after a 412 shows the VMSS already at (or above) the desired capacity, the provider
+// treats the scale-up as satisfied and does not issue a second PUT that would shrink it.
+func TestScaleSetETagRetrySkippedWhenAlreadyAtTarget(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-skip"
+	orchMode := armcompute.OrchestrationModeUniform
+
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name: ptr.To(vmssName),
+		SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{
+			OrchestrationMode: &orchMode,
+		},
+		Etag: ptr.To(`W/"stale"`),
+	})
+
+	// A concurrent writer already grew the VMSS to the desired size (4).
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name: ptr.To(vmssName),
+			SKU:  &armcompute.SKU{Capacity: ptr.To[int64](4)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+			Etag: ptr.To(`W/"fresh"`),
+		}, nil).Times(1)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	var putCalls int
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().
+		BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ string, _ armcompute.VirtualMachineScaleSet,
+			_ *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions,
+		) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+			putCalls++
+			return nil, &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed}
+		}).Times(1)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	scaleSet := newTestScaleSet(manager, vmssName)
+	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
+
+	err := scaleSet.IncreaseSize(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, putCalls, "expected no second PUT when VMSS already at target")
+}
+
+// TestScaleSetETagReconcilesConcurrentWriter exercises the core scenario ETag mode is
+// meant to protect: another writer mutates the VMSS between CA's read and its write.
+// Using a mock that enforces optimistic concurrency like the real API, CA's first PUT
+// carries its stale If-Match and is rejected (412) rather than clobbering the concurrent
+// change; CA then refreshes the ETag via GET and re-issues the PUT once with the
+// up-to-date If-Match, so the scale-up still lands on top of the concurrent change.
+func TestScaleSetETagReconcilesConcurrentWriter(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-concurrent"
+	orchMode := armcompute.OrchestrationModeUniform
+
+	// CA's cached view: ETag E1, capacity 3.
+	const caCachedEtag = `W/"E1"`
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name:       ptr.To(vmssName),
+		SKU:        &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+		Etag:       ptr.To(caCachedEtag),
+	})
+
+	// Simulated server state: a concurrent writer already advanced the ETag to E2
+	// (e.g. it retagged the VMSS) while leaving capacity at 3.
+	var (
+		mu             sync.Mutex
+		serverEtag     = `W/"E2"`
+		serverCapacity = int64(3)
+	)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ string, _ *armcompute.ExpandTypesForGetVMScaleSets,
+		) (*armcompute.VirtualMachineScaleSet, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return &armcompute.VirtualMachineScaleSet{
+				Name:       ptr.To(vmssName),
+				SKU:        &armcompute.SKU{Capacity: ptr.To(serverCapacity)},
+				Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+				Etag:       ptr.To(serverEtag),
+			}, nil
+		}).Times(1)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	var ifMatches []*string
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().
+		BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ string, op armcompute.VirtualMachineScaleSet,
+			opts *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions,
+		) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+			mu.Lock()
+			defer mu.Unlock()
+			ifMatches = append(ifMatches, opts.IfMatch)
+			// Enforce optimistic concurrency like the real API: reject a stale If-Match.
+			if opts.IfMatch != nil && *opts.IfMatch != serverEtag {
+				return nil, &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed}
+			}
+			// Accept the write: advance capacity and roll the ETag forward.
+			serverCapacity = *op.SKU.Capacity
+			serverEtag = `W/"E3"`
+			return newTestCreateOrUpdatePoller(t, ptr.To(serverEtag)), nil
+		}).Times(2)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	scaleSet := newTestScaleSet(manager, vmssName)
+	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
+
+	err := scaleSet.IncreaseSize(1)
+	assert.NoError(t, err)
+
+	if assert.Len(t, ifMatches, 2) {
+		// First write used CA's stale ETag and was rejected: the concurrent change is not overwritten.
+		if assert.NotNil(t, ifMatches[0]) {
+			assert.Equal(t, caCachedEtag, *ifMatches[0])
+		}
+		// Second write used the refreshed server ETag and was accepted.
+		if assert.NotNil(t, ifMatches[1]) {
+			assert.Equal(t, `W/"E2"`, *ifMatches[1])
+		}
+	}
+
+	mu.Lock()
+	assert.Equal(t, int64(4), serverCapacity, "scale-up should land after reconciling the concurrent writer")
+	mu.Unlock()
+}
+
+// TestScaleSetETagRetryTracksRefreshedObject verifies that after an ETag retry the
+// object the caller tracks (and that the async completion updates) is the freshly
+// fetched VMSS now living in the cache, not the stale pre-retry copy. Without this the
+// final LRO ETag and capacity would land on a detached object, leaving the cache with a
+// stale ETag (forcing a needless 412 on the next PUT) and a stale TargetSize.
+func TestScaleSetETagRetryTracksRefreshedObject(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-track"
+	orchMode := armcompute.OrchestrationModeUniform
+	const (
+		staleEtag = `W/"E1"` // CA's cached ETag
+		freshEtag = `W/"E2"` // server ETag returned by the refresh GET
+		finalEtag = `W/"E3"` // ETag returned by the successful re-PUT (LRO result)
+	)
+
+	staleObj := &armcompute.VirtualMachineScaleSet{
+		Name:       ptr.To(vmssName),
+		SKU:        &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+		Etag:       ptr.To(staleEtag),
+	}
+	manager.azureCache.setScaleSet(vmssName, staleObj)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name:       ptr.To(vmssName),
+			SKU:        &armcompute.SKU{Capacity: ptr.To[int64](3)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+			Etag:       ptr.To(freshEtag),
+		}, nil).Times(1)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	var puts int
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().
+		BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ string, _ armcompute.VirtualMachineScaleSet,
+			_ *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions,
+		) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+			puts++
+			if puts == 1 {
+				return nil, &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed}
+			}
+			return newTestCreateOrUpdatePoller(t, ptr.To(finalEtag)), nil
+		}).Times(2)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	scaleSet := newTestScaleSet(manager, vmssName)
+	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
+
+	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
+	defer cancel()
+
+	effectiveVMSS, poller, err := scaleSet.initCreateOrUpdate(ctx, staleObj, 4)
+	assert.NoError(t, err)
+	assert.NotNil(t, poller)
+
+	// The tracked object must be the freshly-fetched VMSS now in the cache, not the
+	// stale pre-retry copy.
+	cached := manager.azureCache.getScaleSets()[vmssName]
+	assert.Same(t, cached, effectiveVMSS, "caller should track the refreshed cached object")
+	assert.NotSame(t, staleObj, effectiveVMSS, "caller must not keep tracking the stale object")
+	if assert.NotNil(t, effectiveVMSS.Etag) {
+		assert.Equal(t, freshEtag, *effectiveVMSS.Etag)
+	}
+
+	// Drive completion synchronously so the final ETag deterministically lands on the
+	// cached object.
+	scaleSet.waitForCreateOrUpdateInstances(poller, effectiveVMSS)
+
+	cached = manager.azureCache.getScaleSets()[vmssName]
+	if assert.NotNil(t, cached.Etag) {
+		assert.Equal(t, finalEtag, *cached.Etag, "final LRO ETag should land on the cached object")
+	}
+}
+
+// TestScaleSetETagRetrySkipPublishesFreshCapacity verifies that when the refresh GET
+// after a 412 shows a concurrent writer scaled the VMSS ABOVE our target, the skip
+// publishes the actual (higher) capacity rather than our stale, lower target.
+func TestScaleSetETagRetrySkipPublishesFreshCapacity(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-skip-higher"
+	orchMode := armcompute.OrchestrationModeUniform
+
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name:       ptr.To(vmssName),
+		SKU:        &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+		Etag:       ptr.To(`W/"stale"`),
+	})
+
+	// A concurrent writer grew the VMSS to 5, above our desired target of 4.
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name:       ptr.To(vmssName),
+			SKU:        &armcompute.SKU{Capacity: ptr.To[int64](5)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+			Etag:       ptr.To(`W/"fresh"`),
+		}, nil).Times(1)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	var putCalls int
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().
+		BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ string, _ armcompute.VirtualMachineScaleSet,
+			_ *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions,
+		) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+			putCalls++
+			return nil, &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed}
+		}).Times(1)
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	scaleSet := newTestScaleSet(manager, vmssName)
+	scaleSet.sizeRefreshPeriod = manager.azureCache.refreshInterval
+
+	err := scaleSet.IncreaseSize(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, putCalls, "expected no second PUT when VMSS already above target")
+
+	scaleSet.sizeMutex.Lock()
+	curSize := scaleSet.curSize
+	scaleSet.sizeMutex.Unlock()
+	assert.Equal(t, int64(5), curSize, "skip should publish the concurrent writer's actual capacity")
+}
+
+func TestWaitForCreateOrUpdateInstancesRefreshesETag(t *testing.T) {
+	t.Parallel()
+	const oldEtag = `W/"old"`
+	const newEtag = `W/"new"`
+	cases := map[string]struct {
+		useEtag  bool
+		wantEtag *string
+	}{
+		"flag on: adopts new ETag from completed operation": {useEtag: true, wantEtag: ptr.To(newEtag)},
+		"flag off: leaves cached ETag untouched":            {useEtag: false, wantEtag: ptr.To(oldEtag)},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			manager := newTestAzureManager(t)
+			manager.config.EnableVMSSEtag = tc.useEtag
+			ss := newTestScaleSet(manager, "vmss-etag")
+
+			vmssInfo := &armcompute.VirtualMachineScaleSet{
+				Name: ptr.To("vmss-etag"),
+				SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+				Etag: ptr.To(oldEtag),
+			}
+
+			ss.waitForCreateOrUpdateInstances(newTestCreateOrUpdatePoller(t, ptr.To(newEtag)), vmssInfo)
+
+			if assert.NotNil(t, vmssInfo.Etag) {
+				assert.Equal(t, *tc.wantEtag, *vmssInfo.Etag)
+			}
+		})
+	}
+}
+
+func TestAtomicIncreaseSizeWithETag(t *testing.T) {
+	t.Parallel()
+	const cachedEtag = `W/"abc"`
+	const newEtag = `W/"def"`
+	cases := map[string]struct {
+		useEtag         bool
+		expectIfMatch   *string
+		expectFinalSize int64
+		expectEtag      *string
+	}{
+		"flag off: no IfMatch, ETag untouched": {
+			useEtag:         false,
+			expectIfMatch:   nil,
+			expectFinalSize: 4,
+			expectEtag:      ptr.To(cachedEtag),
+		},
+		"flag on: IfMatch sent and new ETag adopted on success": {
+			useEtag:         true,
+			expectIfMatch:   ptr.To(cachedEtag),
+			expectFinalSize: 4,
+			expectEtag:      ptr.To(newEtag),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			manager := newTestAzureManager(t)
+			manager.config.EnableVMSSEtag = tc.useEtag
+
+			vmssName := "vmss-etag-atomic"
+			orchMode := armcompute.OrchestrationModeUniform
+			vmss := &armcompute.VirtualMachineScaleSet{
+				Name: ptr.To(vmssName),
+				SKU:  &armcompute.SKU{Capacity: ptr.To[int64](3)},
+				Properties: &armcompute.VirtualMachineScaleSetProperties{
+					OrchestrationMode: &orchMode,
+				},
+				Etag: ptr.To(cachedEtag),
+			}
+
+			mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+				Return([]*armcompute.VirtualMachineScaleSet{vmss}, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+			mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).
+				Return(newTestVMSSVMList(3), nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+			mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+			mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+				Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+			manager.azClient.virtualMachinesClient = mockVMClient
+
+			var capturedOpts *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions
+			mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+			mockDeleteClient.EXPECT().
+				BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ string, _ string, _ armcompute.VirtualMachineScaleSet,
+					opts *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions,
+				) (*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+					capturedOpts = opts
+					return newTestCreateOrUpdatePoller(t, ptr.To(newEtag)), nil
+				}).Times(1)
+			manager.azClient.vmssClientForDelete = mockDeleteClient
+
+			manager.explicitlyConfigured[vmssName] = true
+			ss := newTestScaleSet(manager, vmssName)
+			assert.True(t, manager.RegisterNodeGroup(ss))
+			assert.NoError(t, manager.Refresh())
+
+			provider, err := BuildAzureCloudProvider(manager, nil)
+			assert.NoError(t, err)
+			scaleSet := provider.NodeGroups()[0].(*ScaleSet)
+
+			err = scaleSet.AtomicIncreaseSize(1)
+			assert.NoError(t, err)
+
+			if tc.expectIfMatch == nil {
+				assert.True(t, capturedOpts == nil || capturedOpts.IfMatch == nil,
+					"expected no IfMatch but got %v", capturedOpts)
+			} else {
+				if assert.NotNil(t, capturedOpts) && assert.NotNil(t, capturedOpts.IfMatch) {
+					assert.Equal(t, *tc.expectIfMatch, *capturedOpts.IfMatch)
+				}
+			}
+
+			assert.Equal(t, tc.expectFinalSize, scaleSet.curSize)
+
+			cached := manager.azureCache.getScaleSets()[vmssName]
+			if assert.NotNil(t, cached) && assert.NotNil(t, cached.Etag) {
+				assert.Equal(t, *tc.expectEtag, *cached.Etag)
+			}
+		})
+	}
+}
+
+// TestETagConcurrentAccessNoDataRace overlaps the ETag reader (initCreateOrUpdate)
+// with the ETag writer (waitForCreateOrUpdateInstances) on the same shared cached
+// VMSS object. It guards against regressing the ETag read back to sizeMutex (the
+// writer uses vmssSizeMutex); run under -race to detect a cross-lock data race.
+func TestETagConcurrentAccessNoDataRace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+	ss := newTestScaleSet(manager, "vmss-etag-race")
+
+	vmssInfo := &armcompute.VirtualMachineScaleSet{
+		Name:     ptr.To("vmss-etag-race"),
+		Location: ptr.To(testLocation),
+		SKU:      &armcompute.SKU{Name: ptr.To("Standard_D2_v2"), Capacity: ptr.To[int64](3)},
+		Etag:     ptr.To(`W/"r0"`),
+	}
+
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().
+		BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+	manager.azClient.vmssClientForDelete = mockDeleteClient
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := getContextWithTimeout(vmssContextTimeout)
+			defer cancel()
+			_, _, _ = ss.initCreateOrUpdate(ctx, vmssInfo, 4)
+		}()
+		go func(n int) {
+			defer wg.Done()
+			ss.waitForCreateOrUpdateInstances(newTestCreateOrUpdatePoller(t, ptr.To(fmt.Sprintf(`W/"r%d"`, n))), vmssInfo)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/cluster-autoscaler/cloudprovider/azure/fake_poller_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/fake_poller_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeCreateOrUpdatePollingHandler is a runtime.PollingHandler that completes
+// successfully and returns a CreateOrUpdate response carrying the given ETag.
+type fakeCreateOrUpdatePollingHandler struct {
+	etag   *string
+	polled bool
+}
+
+func (f *fakeCreateOrUpdatePollingHandler) Done() bool { return f.polled }
+
+func (f *fakeCreateOrUpdatePollingHandler) Poll(_ context.Context) (*http.Response, error) {
+	f.polled = true
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}, nil
+}
+
+func (f *fakeCreateOrUpdatePollingHandler) Result(_ context.Context, out *armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse) error {
+	out.VirtualMachineScaleSet = armcompute.VirtualMachineScaleSet{Etag: f.etag}
+	return nil
+}
+
+func newTestCreateOrUpdatePoller(t *testing.T, etag *string) *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse] {
+	resp := &http.Response{StatusCode: http.StatusAccepted, Header: http.Header{}, Body: http.NoBody}
+	pl := runtime.NewPipeline("test", "v0.0.0", runtime.PipelineOptions{}, nil)
+	poller, err := runtime.NewPoller(resp, pl, &runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse]{
+		Handler: &fakeCreateOrUpdatePollingHandler{etag: etag},
+	})
+	assert.NoError(t, err)
+	return poller
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area provider/azure

#### What this PR does / why we need it:

Adds optional ETag-based optimistic concurrency to the Azure VMSS capacity update path. When enabled, the cached VMSS ETag is sent as `If-Match` on capacity PUTs, so a concurrent modification is rejected with HTTP 412 instead of silently overwritten. On 412 the autoscaler refreshes its caches and re-plans on the next loop. On by default (`AZURE_ENABLE_VMSS_ETAG` / `enableVMSSEtag`).

#### Which issue(s) this PR fixes:

Fixes #2581

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Azure: optional ETag optimistic concurrency on VMSS capacity updates
```
