### PR TITLE
feat(cluster-autoscaler): integrate scheduler extender filtering into pod scheduling simulation

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -1,4 +1,4 @@
-ALL_ARCH = amd64 arm64 s390x
+ALL_ARCH = amd64 # arm64 s390x
 all: $(addprefix build-arch-,$(ALL_ARCH))
 
 # TODO: #8127 - Use default analyzers set by `go test` to include `printf` analyzer.

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -41,6 +41,9 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+	apiv1 "k8s.io/api/core/v1"
+	scheduler_config "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/client-go/informers"
 )
 
@@ -89,6 +92,18 @@ func NewAutoscaler(ctx context.Context, opts coreoptions.AutoscalerOptions, info
 }
 
 // Initialize default options if not provided.
+func registerExtenderManagedResources(schedConfig *scheduler_config.KubeSchedulerConfiguration) {
+	if schedConfig == nil {
+		return
+	}
+	for _, extender := range schedConfig.Extenders {
+		for _, mr := range extender.ManagedResources {
+			gpu.RegisterGPUResourceNames(apiv1.ResourceName(mr.Name))
+		}
+	}
+}
+
+// Initialize default options if not provided.
 func initializeDefaultOptions(ctx context.Context, opts *coreoptions.AutoscalerOptions, informerFactory informers.SharedInformerFactory) error {
 	if opts.Processors == nil {
 		opts.Processors = ca_processors.DefaultProcessors(opts.AutoscalingOptions)
@@ -100,6 +115,7 @@ func initializeDefaultOptions(ctx context.Context, opts *coreoptions.AutoscalerO
 		opts.AutoscalingKubeClients = ca_context.NewAutoscalingKubeClients(ctx, opts.AutoscalingOptions, opts.KubeClient, opts.InformerFactory)
 	}
 	if opts.FrameworkHandle == nil {
+		registerExtenderManagedResources(opts.SchedulerConfig)
 		fwHandle, err := framework.NewHandle(ctx, opts.InformerFactory, opts.SchedulerConfig, opts.DynamicResourceAllocationEnabled, opts.CSINodeAwareSchedulingEnabled)
 		if err != nil {
 			return err

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	apiv1 "k8s.io/api/core/v1"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
 	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -37,16 +38,25 @@ type SchedulerPluginRunner struct {
 	snapshot            clustersnapshot.ClusterSnapshot
 	defaultNodeOrdering clustersnapshot.NodeOrderMapping
 	parallelism         int
+	extenders           []schedulerinterface.Extender
 }
 
 // NewSchedulerPluginRunner builds a SchedulerPluginRunner.
-func NewSchedulerPluginRunner(fwHandle *framework.Handle, snapshot clustersnapshot.ClusterSnapshot, parallelism int) *SchedulerPluginRunner {
+func NewSchedulerPluginRunner(fwHandle *framework.Handle, snapshot clustersnapshot.ClusterSnapshot, parallelism int, extenders []schedulerinterface.Extender) *SchedulerPluginRunner {
 	return &SchedulerPluginRunner{
 		fwHandle:            fwHandle,
 		snapshot:            snapshot,
 		defaultNodeOrdering: clustersnapshot.NewLastIndexOrderMapping(1),
 		parallelism:         parallelism,
+		extenders:           extenders,
 	}
+}
+
+// nodeFilterResult holds the result of running framework Filter plugins on a node.
+type nodeFilterResult struct {
+	orderIndex int
+	nodeIndex  int
+	nodeInfo   *framework.NodeInfo
 }
 
 // RunFiltersUntilPassingNode runs the scheduler framework PreFilter phase once, and then keeps running the Filter phase for all nodes in the cluster that match the
@@ -71,12 +81,6 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 		return nil, nil, clustersnapshot.NewFailingPredicateError(pod, preFilterStatus.Plugin(), preFilterStatus.Reasons(), "PreFilter failed", "")
 	}
 
-	var (
-		foundNode  *apiv1.Node
-		foundIndex int
-		mu         sync.Mutex
-	)
-
 	nodeOrdering := opts.NodeOrdering
 	if nodeOrdering == nil {
 		nodeOrdering = p.defaultNodeOrdering
@@ -84,14 +88,14 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 
 	nodeOrdering.Reset(nodeInfosList)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	earliestMatch := len(nodeInfosList)
+	var (
+		mu           sync.Mutex
+		passingNodes []nodeFilterResult
+	)
 
 	checkNode := func(i int) {
 		nodeIndex := nodeOrdering.At(i)
 		if nodeIndex < 0 {
-			cancel()
 			return
 		}
 
@@ -121,25 +125,40 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 		if filterStatus.IsSuccess() {
 			// Filter passed for all plugins, so this pod can be scheduled on this Node.
 			mu.Lock()
-			defer mu.Unlock()
-			if i < earliestMatch {
-				earliestMatch = i
-				foundNode = nodeInfo.Node()
-				foundIndex = nodeIndex
-				cancel()
-			}
+			passingNodes = append(passingNodes, nodeFilterResult{orderIndex: i, nodeIndex: nodeIndex, nodeInfo: nodeInfo})
+			mu.Unlock()
 		}
 		// Filter didn't pass for some plugin, so this Node won't work - move on to the next one.
 	}
 
-	workqueue.ParallelizeUntil(ctx, p.parallelism, len(nodeInfosList), checkNode, workqueue.WithChunkSize(chunkSizeFor(len(nodeInfosList), p.parallelism)))
+	workqueue.ParallelizeUntil(context.Background(), p.parallelism, len(nodeInfosList), checkNode, workqueue.WithChunkSize(chunkSizeFor(len(nodeInfosList), p.parallelism)))
 
-	if foundNode != nil {
-		nodeOrdering.MarkMatch(foundIndex)
-		return foundNode, state, nil
+	if len(passingNodes) == 0 {
+		return nil, nil, clustersnapshot.NewNoNodesPassingPredicatesFoundError(pod)
 	}
 
-	return nil, nil, clustersnapshot.NewNoNodesPassingPredicatesFoundError(pod)
+	if len(p.extenders) > 0 {
+		extenderFiltered, err := p.runExtenderFilters(pod, passingNodes)
+		if err != nil {
+			return nil, nil, err
+		}
+		passingNodes = extenderFiltered
+		if len(passingNodes) == 0 {
+			return nil, nil, clustersnapshot.NewNoNodesPassingPredicatesFoundError(pod)
+		}
+	}
+
+	earliest := passingNodes[0]
+	for _, r := range passingNodes[1:] {
+		if r.orderIndex < earliest.orderIndex {
+			earliest = r
+		}
+	}
+
+	nodeOrdering.MarkMatch(earliest.nodeIndex)
+	foundNode := earliest.nodeInfo.Node()
+
+	return foundNode, state, nil
 }
 
 // RunFiltersOnNode runs the scheduler framework PreFilter and Filter phases to check if the given pod can be scheduled on the given node.
@@ -176,6 +195,16 @@ func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string
 		return nil, nil, clustersnapshot.NewFailingPredicateError(pod, filterName, filterReasons, unexpectedErrMsg, p.failingFilterDebugInfo(filterName, nodeInfo))
 	}
 
+	if len(p.extenders) > 0 {
+		passingNodes, schedErr := p.runExtenderFilters(pod, []nodeFilterResult{{nodeInfo: nodeInfo}})
+		if schedErr != nil {
+			return nil, nil, schedErr
+		}
+		if len(passingNodes) == 0 {
+			return nil, nil, clustersnapshot.NewFailingPredicateError(pod, "ExtenderFilter", nil, "extender(s) filtered out the node", "")
+		}
+	}
+
 	// PreFilter and Filter phases checked, this Pod can be scheduled on this Node.
 	return nodeInfo.Node(), state, nil
 }
@@ -190,6 +219,56 @@ func (p *SchedulerPluginRunner) RunReserveOnNode(pod *apiv1.Pod, nodeName string
 		return fmt.Errorf("couldn't reserve node %s for pod %s/%s: %v", nodeName, pod.Namespace, pod.Name, status.Message())
 	}
 	return nil
+}
+
+// runExtenderFilters calls each configured extender's Filter endpoint for the given pod and candidate nodes.
+// It returns the subset of nodes that pass all extender filters.
+func (p *SchedulerPluginRunner) runExtenderFilters(pod *apiv1.Pod, candidates []nodeFilterResult) ([]nodeFilterResult, clustersnapshot.SchedulingError) {
+	candidateNodes := make([]schedulerinterface.NodeInfo, len(candidates))
+	for i, c := range candidates {
+		candidateNodes[i] = c.nodeInfo
+	}
+
+	for _, extender := range p.extenders {
+		if !extender.IsFilter() {
+			continue
+		}
+		if !extender.IsInterested(pod) {
+			continue
+		}
+
+		filteredNodes, failedNodes, _, err := extender.Filter(pod, candidateNodes)
+		if err != nil {
+			if extender.IsIgnorable() {
+				continue
+			}
+			return nil, clustersnapshot.NewFailingPredicateError(pod, "ExtenderFilter", nil,
+				fmt.Sprintf("extender %q filter failed: %v", extender.Name(), err), "")
+		}
+
+		nodeNames := make(map[string]bool, len(filteredNodes))
+		for _, n := range filteredNodes {
+			nodeNames[n.Node().Name] = true
+		}
+
+		var newCandidates []nodeFilterResult
+		for _, c := range candidates {
+			if nodeNames[c.nodeInfo.Node().Name] {
+				newCandidates = append(newCandidates, c)
+			}
+		}
+		candidates = newCandidates
+		candidateNodes = filteredNodes
+
+		if len(candidates) == 0 {
+			if !extender.IsIgnorable() {
+				_ = failedNodes
+			}
+			break
+		}
+	}
+
+	return candidates, nil
 }
 
 func (p *SchedulerPluginRunner) failingFilterDebugInfo(filterName string, nodeInfo *framework.NodeInfo) string {

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
@@ -18,17 +18,23 @@ package predicate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	scheduler_config_latest "k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 
@@ -518,7 +524,7 @@ func newTestPluginRunnerAndSnapshot(schedConfig *config.KubeSchedulerConfigurati
 		return nil, nil, err
 	}
 	snapshot := NewPredicateSnapshot(store.NewBasicSnapshotStore(), fwHandle, true, 1, false)
-	return NewSchedulerPluginRunner(fwHandle, snapshot, 1), snapshot, nil
+	return NewSchedulerPluginRunner(fwHandle, snapshot, 1, nil), snapshot, nil
 }
 
 func BenchmarkRunFiltersUntilPassingNode(b *testing.B) {

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
@@ -61,7 +61,7 @@ func NewPredicateSnapshot(snapshotStore clustersnapshot.ClusterSnapshotStore, fw
 	// which operate on *framework.NodeInfo. The only object that allows obtaining *framework.NodeInfos is PredicateSnapshot, so we have an ugly circular
 	// dependency between PluginRunner and PredicateSnapshot.
 	// TODO: Refactor PluginRunner so that it doesn't depend on PredicateSnapshot (e.g. move retrieving NodeInfos out of PluginRunner, to PredicateSnapshot).
-	snapshot.pluginRunner = NewSchedulerPluginRunner(fwHandle, snapshot, parallelism)
+	snapshot.pluginRunner = NewSchedulerPluginRunner(fwHandle, snapshot, parallelism, fwHandle.Extenders)
 	return snapshot
 }
 

--- a/cluster-autoscaler/simulator/framework/handle.go
+++ b/cluster-autoscaler/simulator/framework/handle.go
@@ -23,6 +23,8 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources"
 	"k8s.io/client-go/informers"
+	schedulerinterface "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	schedulerconfiglatest "k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 	schedulerimpl "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -40,6 +42,7 @@ var (
 type Handle struct {
 	Framework        schedulerimpl.Framework
 	DelegatingLister *DelegatingSchedulerSharedLister
+	Extenders        []schedulerinterface.Extender
 }
 
 // NewHandle builds a framework Handle based on the provided informers and scheduler config.
@@ -92,8 +95,18 @@ func NewHandle(ctx context.Context, informerFactory informers.SharedInformerFact
 		return nil, fmt.Errorf("couldn't create scheduler framework; %v", err)
 	}
 
+	var extenders []schedulerinterface.Extender
+	for i := range schedConfig.Extenders {
+		extender, err := scheduler.NewHTTPExtender(&schedConfig.Extenders[i])
+		if err != nil {
+			return nil, fmt.Errorf("couldn't create HTTP extender for %q: %v", schedConfig.Extenders[i].URLPrefix, err)
+		}
+		extenders = append(extenders, extender)
+	}
+
 	return &Handle{
 		Framework:        framework,
 		DelegatingLister: sharedLister,
+		Extenders:        extenders,
 	}, nil
 }

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -51,6 +51,12 @@ var GPUVendorResourceNames = []apiv1.ResourceName{
 	ResourceDirectX,
 }
 
+// RegisterGPUResourceNames appends additional GPU vendor resource names at runtime.
+// Must be called before any scheduling simulation begins. Thread-safe to call once at startup.
+func RegisterGPUResourceNames(names ...apiv1.ResourceName) {
+	GPUVendorResourceNames = append(GPUVendorResourceNames, names...)
+}
+
 const (
 	// MetricsGenericGPU - for when there is no information about GPU type
 	MetricsGenericGPU = "generic"

--- a/cluster-autoscaler/utils/gpu/gpu_test.go
+++ b/cluster-autoscaler/utils/gpu/gpu_test.go
@@ -303,3 +303,53 @@ func TestDetectNodeGPUResourceName(t *testing.T) {
 		})
 	}
 }
+
+func TestRegisterGPUResourceNames(t *testing.T) {
+	customResource := apiv1.ResourceName("nvidia.com/gpumem")
+	gpu.RegisterGPUResourceNames(customResource, "nvidia.com/gpucores")
+
+	t.Run("PodRequestsGpu detects custom resources", func(t *testing.T) {
+		pod := test.BuildTestPod("test-pod", 0, 0)
+		pod.Spec.Containers[0].Resources.Requests = apiv1.ResourceList{
+			customResource: resource.MustParse("3000"),
+		}
+		assert.True(t, gpu.PodRequestsGpu(pod))
+	})
+
+	t.Run("NodeHasGpuAllocatable detects custom resources", func(t *testing.T) {
+		node := &apiv1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "gpu-node"},
+			Status: apiv1.NodeStatus{
+				Allocatable: apiv1.ResourceList{
+					customResource: *resource.NewQuantity(16000, resource.DecimalSI),
+				},
+			},
+		}
+		val, hasGPU := gpu.NodeHasGpuAllocatable(node)
+		assert.True(t, hasGPU)
+		assert.Equal(t, int64(16000), val)
+	})
+
+	t.Run("DetectNodeGPUResourceName detects custom resources", func(t *testing.T) {
+		node := &apiv1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "gpu-node"},
+			Status: apiv1.NodeStatus{
+				Capacity: apiv1.ResourceList{
+					customResource: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+				Allocatable: apiv1.ResourceList{
+					customResource: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+		}
+		assert.Equal(t, customResource, gpu.DetectNodeGPUResourceName(node))
+	})
+
+	t.Run("PodRequestsGpu ignores unknown resources", func(t *testing.T) {
+		pod := test.BuildTestPod("test-pod", 0, 0)
+		pod.Spec.Containers[0].Resources.Requests = apiv1.ResourceList{
+			apiv1.ResourceName("example.com/not-a-gpu"): resource.MustParse("1"),
+		}
+		assert.False(t, gpu.PodRequestsGpu(pod))
+	})
+}


### PR DESCRIPTION
- Add `Extenders` field to `framework.Handle` and create HTTP extenders from scheduler config
- Pass extenders to `SchedulerPluginRunner` and filter nodes via `runExtenderFilters`
- Register extender-managed resources as custom GPU vendor resource names at startup
- Refactor `RunFiltersUntilPassingNode` to collect all passing nodes for extender post-filtering
feat(cluster-autoscaler): integrate scheduler extender filtering into pod scheduling simulation
