### PR TITLE
[cluster-autoscaler-release-1.33] azure: implement AtomicIncreaseSize for VMSS

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -353,13 +353,18 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 	return scaleSet.setScaleSetSize(size+int64(delta), delta)
 }
 
-// AtomicIncreaseSize increases the VMSS capacity atomically by delta.
-// The Azure VMSS BeginCreateOrUpdate API accepts or rejects the entire capacity change
-// as a single request. The method does not wait for VMs to finish provisioning.
+// AtomicIncreaseSize increases the VMSS capacity by delta and blocks until the
+// VMSS update operation completes. This ensures that the capacity change has been
+// fully applied by Azure before returning.
 //
-// Note: while the API request itself is atomic, Azure VMSS does not guarantee that all
-// requested VMs will successfully provision. Partial provisioning failures are possible
-// and are handled by the CA's ProvisioningRequest retry/cleanup logic.
+// On success, the VMSS capacity has been updated and new VM instances have been
+// created (though they may still be booting/joining the cluster). On failure, all
+// caches are invalidated so CA fetches fresh state from Azure.
+//
+// Note: this intentionally deviates from the NodeGroup interface comment that says
+// "doesn't wait until the new instances appear" — the blocking behavior is required
+// for atomic-scale-up ProvisioningRequest support to provide a capacity guarantee
+// before workloads are admitted.
 func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
@@ -378,9 +383,68 @@ func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
 		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, scaleSet.MaxSize())
 	}
 
+	newSize := size + int64(delta)
+
+	vmssInfo, err := scaleSet.getVMSSFromCache()
+	if err != nil {
+		return err
+	}
+
+	// Build the update request from copied values, not the cached object,
+	// to avoid other readers observing the new capacity before it's confirmed.
+	op := armcompute.VirtualMachineScaleSet{
+		Name:     vmssInfo.Name,
+		Location: vmssInfo.Location,
+		SKU: &armcompute.SKU{
+			Name:     vmssInfo.SKU.Name,
+			Tier:     vmssInfo.SKU.Tier,
+			Capacity: &newSize,
+		},
+	}
+
+	if vmssInfo.ExtendedLocation != nil {
+		op.ExtendedLocation = &armcompute.ExtendedLocation{
+			Name: vmssInfo.ExtendedLocation.Name,
+			Type: vmssInfo.ExtendedLocation.Type,
+		}
+	}
+
 	klog.V(3).Infof("AtomicIncreaseSize: requesting atomic scale-up of %d instances for scale set %q (current size: %d, new size: %d)",
-		delta, scaleSet.Name, size, size+int64(delta))
-	return scaleSet.setScaleSetSize(size+int64(delta), delta)
+		delta, scaleSet.Name, size, newSize)
+
+	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
+	defer cancel()
+
+	poller, err := scaleSet.manager.azClient.vmssClientForDelete.BeginCreateOrUpdate(
+		ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, op, nil)
+	if err != nil {
+		klog.Errorf("AtomicIncreaseSize: BeginCreateOrUpdate for scale set %q failed: %v", scaleSet.Name, err)
+		return err
+	}
+
+	if poller != nil {
+		klog.V(3).Infof("AtomicIncreaseSize: waiting for VMSS %q capacity update to complete", scaleSet.Name)
+		_, err = poller.PollUntilDone(ctx, nil)
+		scaleSet.invalidateInstanceCache()
+		if err != nil {
+			klog.Errorf("AtomicIncreaseSize: VMSS %q capacity update failed during polling: %v", scaleSet.Name, err)
+			scaleSet.invalidateLastSizeRefreshWithLock()
+			scaleSet.manager.invalidateCache()
+			return fmt.Errorf("AtomicIncreaseSize: VMSS %q capacity update failed: %w", scaleSet.Name, err)
+		}
+	}
+
+	// Only update the size cache after the operation has successfully completed.
+	scaleSet.sizeMutex.Lock()
+	vmssSizeMutex.Lock()
+	vmssInfo.SKU.Capacity = &newSize
+	vmssSizeMutex.Unlock()
+	scaleSet.curSize = newSize
+	scaleSet.lastSizeRefresh = time.Now()
+	scaleSet.sizeMutex.Unlock()
+
+	klog.V(3).Infof("AtomicIncreaseSize: VMSS %q capacity update completed successfully (new size: %d)", scaleSet.Name, newSize)
+	return nil
 }
 
 // GetScaleSetVms returns list of nodes for the given scale set.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -511,7 +511,7 @@ func (scaleSet *ScaleSet) Belongs(node *apiv1.Node) (bool, error) {
 
 func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *compute.VirtualMachineScaleSet, newSize int64) (*azure.Future, error) {
 	if vmssInfo == nil {
-		return nil, fmt.Errorf("vmssInfo cannot be nil while increating scaleSet capacity")
+		return nil, fmt.Errorf("vmssInfo cannot be nil while increasing scaleSet capacity")
 	}
 
 	scaleSet.sizeMutex.Lock()
@@ -544,7 +544,7 @@ func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *comp
 		klog.Errorf("virtualMachineScaleSetsClient.CreateOrUpdate for scale set %q failed: %+v", scaleSet.Name, rerr)
 		return nil, rerr.Error()
 	}
-	return &future, nil
+	return future, nil
 }
 
 func (scaleSet *ScaleSet) createOrUpdateInstances(vmssInfo *compute.VirtualMachineScaleSet, newSize int64) error {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -332,9 +332,9 @@ func (scaleSet *ScaleSet) TargetSize() (int, error) {
 	return int(size), err
 }
 
-// CanIncreaseSize checks if the size increase is possible.
+// canIncreaseSize checks if the size increase is possible.
 // It returns the current size of the scale set if the increase is possible, otherwise returns an error.
-func (scaleSet *ScaleSet) CanIncreaseSize(delta int) (int64, error) {
+func (scaleSet *ScaleSet) canIncreaseSize(delta int) (int64, error) {
 	if delta <= 0 {
 		return -1, fmt.Errorf("size increase must be positive")
 	}
@@ -357,7 +357,7 @@ func (scaleSet *ScaleSet) CanIncreaseSize(delta int) (int64, error) {
 
 // IncreaseSize increases Scale Set size
 func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
-	size, err := scaleSet.CanIncreaseSize(delta)
+	size, err := scaleSet.canIncreaseSize(delta)
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 // for atomic-scale-up ProvisioningRequest support to provide a capacity guarantee
 // before workloads are admitted.
 func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
-	size, err := scaleSet.CanIncreaseSize(delta)
+	size, err := scaleSet.canIncreaseSize(delta)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -353,9 +353,34 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 	return scaleSet.setScaleSetSize(size+int64(delta), delta)
 }
 
-// AtomicIncreaseSize is not implemented.
+// AtomicIncreaseSize increases the VMSS capacity atomically by delta.
+// The Azure VMSS BeginCreateOrUpdate API accepts or rejects the entire capacity change
+// as a single request. The method does not wait for VMs to finish provisioning.
+//
+// Note: while the API request itself is atomic, Azure VMSS does not guarantee that all
+// requested VMs will successfully provision. Partial provisioning failures are possible
+// and are handled by the CA's ProvisioningRequest retry/cleanup logic.
 func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
-	return cloudprovider.ErrNotImplemented
+	if delta <= 0 {
+		return fmt.Errorf("size increase must be positive")
+	}
+
+	size, err := scaleSet.getScaleSetSize()
+	if err != nil {
+		return err
+	}
+
+	if size == -1 {
+		return fmt.Errorf("the scale set %s is under initialization, skipping AtomicIncreaseSize", scaleSet.Name)
+	}
+
+	if int(size)+delta > scaleSet.MaxSize() {
+		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, scaleSet.MaxSize())
+	}
+
+	klog.V(3).Infof("AtomicIncreaseSize: requesting atomic scale-up of %d instances for scale set %q (current size: %d, new size: %d)",
+		delta, scaleSet.Name, size, size+int64(delta))
+	return scaleSet.setScaleSetSize(size+int64(delta), delta)
 }
 
 // GetScaleSetVms returns list of nodes for the given scale set.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -331,23 +332,34 @@ func (scaleSet *ScaleSet) TargetSize() (int, error) {
 	return int(size), err
 }
 
-// IncreaseSize increases Scale Set size
-func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
+// CanIncreaseSize checks if the size increase is possible.
+// It returns the current size of the scale set if the increase is possible, otherwise returns an error.
+func (scaleSet *ScaleSet) CanIncreaseSize(delta int) (int64, error) {
 	if delta <= 0 {
-		return fmt.Errorf("size increase must be positive")
+		return -1, fmt.Errorf("size increase must be positive")
 	}
 
 	size, err := scaleSet.getScaleSetSize()
 	if err != nil {
-		return err
+		return size, err
 	}
 
 	if size == -1 {
-		return fmt.Errorf("the scale set %s is under initialization, skipping IncreaseSize", scaleSet.Name)
+		return size, fmt.Errorf("the scale set %s is under initialization, skipping IncreaseSize", scaleSet.Name)
 	}
 
 	if int(size)+delta > scaleSet.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, scaleSet.MaxSize())
+		return size, fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, scaleSet.MaxSize())
+	}
+
+	return size, nil
+}
+
+// IncreaseSize increases Scale Set size
+func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
+	size, err := scaleSet.CanIncreaseSize(delta)
+	if err != nil {
+		return err
 	}
 
 	return scaleSet.setScaleSetSize(size+int64(delta), delta)
@@ -366,47 +378,17 @@ func (scaleSet *ScaleSet) IncreaseSize(delta int) error {
 // for atomic-scale-up ProvisioningRequest support to provide a capacity guarantee
 // before workloads are admitted.
 func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
-	if delta <= 0 {
-		return fmt.Errorf("size increase must be positive")
-	}
-
-	size, err := scaleSet.getScaleSetSize()
+	size, err := scaleSet.CanIncreaseSize(delta)
 	if err != nil {
 		return err
-	}
-
-	if size == -1 {
-		return fmt.Errorf("the scale set %s is under initialization, skipping AtomicIncreaseSize", scaleSet.Name)
-	}
-
-	if int(size)+delta > scaleSet.MaxSize() {
-		return fmt.Errorf("size increase too large - desired:%d max:%d", int(size)+delta, scaleSet.MaxSize())
 	}
 
 	newSize := size + int64(delta)
 
 	vmssInfo, err := scaleSet.getVMSSFromCache()
 	if err != nil {
+		klog.Errorf("Failed to get information for VMSS (%q): %v", scaleSet.Name, err)
 		return err
-	}
-
-	// Build the update request from copied values, not the cached object,
-	// to avoid other readers observing the new capacity before it's confirmed.
-	op := armcompute.VirtualMachineScaleSet{
-		Name:     vmssInfo.Name,
-		Location: vmssInfo.Location,
-		SKU: &armcompute.SKU{
-			Name:     vmssInfo.SKU.Name,
-			Tier:     vmssInfo.SKU.Tier,
-			Capacity: &newSize,
-		},
-	}
-
-	if vmssInfo.ExtendedLocation != nil {
-		op.ExtendedLocation = &armcompute.ExtendedLocation{
-			Name: vmssInfo.ExtendedLocation.Name,
-			Type: vmssInfo.ExtendedLocation.Type,
-		}
 	}
 
 	klog.V(3).Infof("AtomicIncreaseSize: requesting atomic scale-up of %d instances for scale set %q (current size: %d, new size: %d)",
@@ -415,18 +397,18 @@ func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
 	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
 	defer cancel()
 
-	poller, err := scaleSet.manager.azClient.vmssClientForDelete.BeginCreateOrUpdate(
-		ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, op, nil)
+	future, err := scaleSet.initCreateOrUpdate(ctx, &vmssInfo, newSize)
 	if err != nil {
-		klog.Errorf("AtomicIncreaseSize: BeginCreateOrUpdate for scale set %q failed: %v", scaleSet.Name, err)
+		klog.Errorf("AtomicIncreaseSize: CreateOrUpdate for scale set %q failed: %v", scaleSet.Name, err)
 		return err
 	}
 
-	if poller != nil {
+	if future != nil {
 		klog.V(3).Infof("AtomicIncreaseSize: waiting for VMSS %q capacity update to complete", scaleSet.Name)
-		_, err = poller.PollUntilDone(ctx, nil)
+		httpResponse, err := scaleSet.manager.azClient.virtualMachineScaleSetsClient.WaitForCreateOrUpdateResult(ctx, future, scaleSet.manager.config.ResourceGroup)
+		isSuccess, err := isSuccessHTTPResponse(httpResponse, err)
 		scaleSet.invalidateInstanceCache()
-		if err != nil {
+		if !isSuccess {
 			klog.Errorf("AtomicIncreaseSize: VMSS %q capacity update failed during polling: %v", scaleSet.Name, err)
 			scaleSet.invalidateLastSizeRefreshWithLock()
 			scaleSet.manager.invalidateCache()
@@ -437,7 +419,7 @@ func (scaleSet *ScaleSet) AtomicIncreaseSize(delta int) error {
 	// Only update the size cache after the operation has successfully completed.
 	scaleSet.sizeMutex.Lock()
 	vmssSizeMutex.Lock()
-	vmssInfo.SKU.Capacity = &newSize
+	vmssInfo.Sku.Capacity = &newSize
 	vmssSizeMutex.Unlock()
 	scaleSet.curSize = newSize
 	scaleSet.lastSizeRefresh = time.Now()
@@ -527,23 +509,24 @@ func (scaleSet *ScaleSet) Belongs(node *apiv1.Node) (bool, error) {
 	return true, nil
 }
 
-func (scaleSet *ScaleSet) createOrUpdateInstances(vmssInfo *compute.VirtualMachineScaleSet, newSize int64) error {
+func (scaleSet *ScaleSet) initCreateOrUpdate(ctx context.Context, vmssInfo *compute.VirtualMachineScaleSet, newSize int64) (*azure.Future, error) {
 	if vmssInfo == nil {
-		return fmt.Errorf("vmssInfo cannot be nil while increating scaleSet capacity")
+		return nil, fmt.Errorf("vmssInfo cannot be nil while increating scaleSet capacity")
 	}
 
 	scaleSet.sizeMutex.Lock()
 	defer scaleSet.sizeMutex.Unlock()
 
-	// Update the new capacity to cache.
-	vmssSizeMutex.Lock()
-	vmssInfo.Sku.Capacity = &newSize
-	vmssSizeMutex.Unlock()
-
 	// Compose a new VMSS for updating.
+	// Copy the SKU rather than sharing the pointer so the cached
+	// vmssInfo.Sku.Capacity is not mutated before the API call completes.
 	op := compute.VirtualMachineScaleSet{
-		Name:     vmssInfo.Name,
-		Sku:      vmssInfo.Sku,
+		Name: vmssInfo.Name,
+		Sku: &compute.Sku{
+			Name:     vmssInfo.Sku.Name,
+			Tier:     vmssInfo.Sku.Tier,
+			Capacity: ptr.To[int64](newSize),
+		},
 		Location: vmssInfo.Location,
 	}
 
@@ -555,21 +538,42 @@ func (scaleSet *ScaleSet) createOrUpdateInstances(vmssInfo *compute.VirtualMachi
 
 		klog.V(3).Infof("Passing ExtendedLocation information if it is not nil, with Edge Zone name:(%s)", *op.ExtendedLocation.Name)
 	}
-
-	ctx, cancel := getContextWithTimeout(vmssContextTimeout)
-	defer cancel()
-	klog.V(3).Infof("Waiting for virtualMachineScaleSetsClient.CreateOrUpdateAsync(%s)", scaleSet.Name)
+	klog.V(3).Infof("Calling virtualMachineScaleSetsClient.CreateOrUpdateAsync(%s)", scaleSet.Name)
 	future, rerr := scaleSet.manager.azClient.virtualMachineScaleSetsClient.CreateOrUpdateAsync(ctx, scaleSet.manager.config.ResourceGroup, scaleSet.Name, op)
 	if rerr != nil {
 		klog.Errorf("virtualMachineScaleSetsClient.CreateOrUpdate for scale set %q failed: %+v", scaleSet.Name, rerr)
-		return rerr.Error()
+		return nil, rerr.Error()
+	}
+	return &future, nil
+}
+
+func (scaleSet *ScaleSet) createOrUpdateInstances(vmssInfo *compute.VirtualMachineScaleSet, newSize int64) error {
+	ctx, cancel := getContextWithTimeout(vmssContextTimeout)
+	defer cancel()
+	// For non-atomic scale up, we eagerly update the VMSS size in the cache
+	// to avoid overshooting the max size if multiple scale up requests are made concurrently.
+	// This preserves the existing behavior (before atomic scale up was added).
+	vmssSizeMutex.Lock()
+	vmssInfo.Sku.Capacity = &newSize
+	vmssSizeMutex.Unlock()
+	future, err := scaleSet.initCreateOrUpdate(ctx, vmssInfo, newSize)
+	if err != nil {
+		return err
 	}
 
 	// Proactively set the VMSS size so autoscaler makes better decisions.
+	// initCreateOrUpdate releases sizeMutex before returning, so reacquire it
+	// here to keep curSize / lastSizeRefresh updates serialized with readers
+	// (e.g. getCurSize).
+	scaleSet.sizeMutex.Lock()
 	scaleSet.curSize = newSize
 	scaleSet.lastSizeRefresh = time.Now()
+	scaleSet.sizeMutex.Unlock()
 
-	go scaleSet.waitForCreateOrUpdateInstances(future)
+	// Poll for completion asynchronously to avoid blocking the autoscaler
+	if future != nil {
+		go scaleSet.waitForCreateOrUpdateInstances(future)
+	}
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
+	autorestazure "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	apiv1 "k8s.io/api/core/v1"
@@ -32,6 +35,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 const (
@@ -363,36 +367,129 @@ func TestScaleSetIncreaseSize(t *testing.T) {
 	}
 }
 
-func TestScaleSetAtomicIncreaseSize(t *testing.T) {
+// TestScaleSetIncreaseSizeRaceCondition reproduces a data race between the
+// non-atomic createOrUpdateInstances code path and concurrent readers.
+//
+// This test must be run with `-race` to detect the race. Without -race it is
+// a no-op smoke test. `make test-unit` runs the suite with -race.
+func TestScaleSetIncreaseSizeRaceCondition(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", armcompute.OrchestrationModeUniform)
+	expectedScaleSets := newTestVMSSList(3, testASG, testLocation, compute.Uniform)
 	expectedVMSSVMs := newTestVMSSVMList(3)
 
 	provider := newTestProvider(t)
 
-	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
 	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	// BeginCreateOrUpdate returns nil poller — simulates immediate success.
-	// Verify the request payload contains the expected new capacity (3 + 2 = 5).
-	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
-	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(),
-		gomock.Cond(func(x any) bool {
-			vmss, ok := x.(armcompute.VirtualMachineScaleSet)
-			return ok && vmss.SKU != nil && vmss.SKU.Capacity != nil && *vmss.SKU.Capacity == 5
-		}),
-		gomock.Any()).Return(nil, nil)
-	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
+	// BeginCreateOrUpdate signals that the writer is parked inside the call
+	// (sizeMutex still held by initCreateOrUpdate's deferred Unlock), then
+	// blocks until the test releases it. This lets us start reader goroutines
+	// while the lock is held so they will be racing against the unprotected
+	// writes that follow once initCreateOrUpdate returns.
+	started := make(chan struct{})
+	release := make(chan struct{})
+	mockVMSSClient.EXPECT().CreateOrUpdateAsync(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).DoAndReturn(func(_ context.Context, _, _ string, _ compute.VirtualMachineScaleSet) (*autorestazure.Future, *retry.Error) {
+		close(started)
+		<-release
+		return nil, nil
+	})
 
-	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
-	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]compute.VirtualMachine{}, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
 
-	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(expectedVMSSVMs, nil).AnyTimes()
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG, string(compute.InstanceViewTypesInstanceView)).Return(expectedVMSSVMs, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := provider.azureManager.RegisterNodeGroup(
+		newTestScaleSet(provider.azureManager, testASG))
+	assert.True(t, registered)
+
+	ng := provider.NodeGroups()[0]
+
+	// Kick off the writer (non-atomic IncreaseSize -> createOrUpdateInstances).
+	increaseDone := make(chan error, 1)
+	go func() {
+		increaseDone <- ng.IncreaseSize(2)
+	}()
+
+	// Wait until createOrUpdateInstances is parked inside BeginCreateOrUpdate
+	// with sizeMutex held.
+	<-started
+
+	// Spin concurrent readers that touch curSize / lastSizeRefresh under
+	// sizeMutex. Once we release the writer, it will exit BeginCreateOrUpdate,
+	// drop sizeMutex, and perform the (unprotected) writes to curSize /
+	// lastSizeRefresh. The race detector will flag the unsynchronized access.
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_, _ = ng.TargetSize()
+				}
+			}
+		}()
+	}
+
+	// Give readers a moment to start contending for sizeMutex, then release
+	// the writer so the unprotected writes execute concurrently with reads.
+	time.Sleep(10 * time.Millisecond)
+	close(release)
+
+	err = <-increaseDone
+	assert.NoError(t, err)
+
+	// Let the readers run a bit longer past the unprotected writes to widen
+	// the race window, then stop them.
+	time.Sleep(10 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+func TestScaleSetAtomicIncreaseSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", compute.Uniform)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	provider := newTestProvider(t)
+
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	// CreateOrUpdateAsync returns nil future — simulates immediate success.
+	// Verify the request payload contains the expected new capacity (3 + 2 = 5).
+	mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Cond(func(x any) bool {
+			vmss, ok := x.(compute.VirtualMachineScaleSet)
+			return ok && vmss.Sku != nil && vmss.Sku.Capacity != nil && *vmss.Sku.Capacity == 5
+		})).Return(nil, nil)
+
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]compute.VirtualMachine{}, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG, string(compute.InstanceViewTypesInstanceView)).Return(expectedVMSSVMs, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
 
 	err := provider.azureManager.forceRefresh()
@@ -442,33 +539,30 @@ func TestScaleSetAtomicIncreaseSizeFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", armcompute.OrchestrationModeUniform)
+	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", compute.Uniform)
 	expectedVMSSVMs := newTestVMSSVMList(3)
 
 	provider := newTestProvider(t)
 
-	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
 	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	// BeginCreateOrUpdate returns an error — simulates Azure rejecting the request.
+	// CreateOrUpdateAsync returns an error — simulates Azure rejecting the request.
 	// Verify the request payload contains the expected new capacity (3 + 2 = 5).
-	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
-	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(),
+	mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Cond(func(x any) bool {
-			vmss, ok := x.(armcompute.VirtualMachineScaleSet)
-			return ok && vmss.SKU != nil && vmss.SKU.Capacity != nil && *vmss.SKU.Capacity == 5
-		}),
-		gomock.Any()).
-		Return(nil, fmt.Errorf("azure capacity unavailable"))
-	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
+			vmss, ok := x.(compute.VirtualMachineScaleSet)
+			return ok && vmss.Sku != nil && vmss.Sku.Capacity != nil && *vmss.Sku.Capacity == 5
+		})).
+		Return(nil, &retry.Error{RawError: fmt.Errorf("azure capacity unavailable")})
 
-	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
-	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]compute.VirtualMachine{}, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
 
-	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(expectedVMSSVMs, nil).AnyTimes()
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG, string(compute.InstanceViewTypesInstanceView)).Return(expectedVMSSVMs, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
 
 	err := provider.azureManager.forceRefresh()
@@ -489,66 +583,37 @@ func TestScaleSetAtomicIncreaseSizeFailure(t *testing.T) {
 	assert.Equal(t, 3, targetSize)
 }
 
-// fakeErrorPollerHandler simulates a poller that fails during Poll.
-type fakeErrorPollerHandler[T any] struct {
-	pollErr error
-}
-
-func (f *fakeErrorPollerHandler[T]) Done() bool {
-	return false
-}
-
-func (f *fakeErrorPollerHandler[T]) Poll(ctx context.Context) (*http.Response, error) {
-	return nil, f.pollErr
-}
-
-func (f *fakeErrorPollerHandler[T]) Result(ctx context.Context, out *T) error {
-	return nil
-}
-
 func TestScaleSetAtomicIncreaseSizePollerFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", armcompute.OrchestrationModeUniform)
+	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", compute.Uniform)
 	expectedVMSSVMs := newTestVMSSVMList(3)
 
 	provider := newTestProvider(t)
 
-	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
 	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	// Create a poller that will fail during PollUntilDone
-	pollerResp := &http.Response{
-		Header: http.Header{},
-	}
-	failingPoller, pollerErr := runtime.NewPoller(pollerResp, runtime.Pipeline{},
-		&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse]{
-			Handler: &fakeErrorPollerHandler[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse]{
-				pollErr: fmt.Errorf("long running operation failed"),
-			},
-		})
-	assert.NoError(t, pollerErr)
-
-	// BeginCreateOrUpdate succeeds (returns a poller), but PollUntilDone will fail.
+	// CreateOrUpdateAsync succeeds (returns a future), but WaitForCreateOrUpdateResult will fail.
 	// Verify the request payload contains the expected new capacity (3 + 2 = 5).
-	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
-	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(),
+	failingFuture := &autorestazure.Future{}
+	mockVMSSClient.EXPECT().CreateOrUpdateAsync(gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Cond(func(x any) bool {
-			vmss, ok := x.(armcompute.VirtualMachineScaleSet)
-			return ok && vmss.SKU != nil && vmss.SKU.Capacity != nil && *vmss.SKU.Capacity == 5
-		}),
-		gomock.Any()).
-		Return(failingPoller, nil)
-	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
+			vmss, ok := x.(compute.VirtualMachineScaleSet)
+			return ok && vmss.Sku != nil && vmss.Sku.Capacity != nil && *vmss.Sku.Capacity == 5
+		})).
+		Return(failingFuture, nil)
+	mockVMSSClient.EXPECT().WaitForCreateOrUpdateResult(gomock.Any(), failingFuture, provider.azureManager.config.ResourceGroup).
+		Return(nil, fmt.Errorf("long running operation failed"))
 
-	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
-	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]compute.VirtualMachine{}, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
 
-	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
-	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(expectedVMSSVMs, nil).AnyTimes()
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG, string(compute.InstanceViewTypesInstanceView)).Return(expectedVMSSVMs, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
 
 	err := provider.azureManager.forceRefresh()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -477,6 +477,85 @@ func TestScaleSetAtomicIncreaseSizeFailure(t *testing.T) {
 	assert.Equal(t, 3, targetSize)
 }
 
+// fakeErrorPollerHandler simulates a poller that fails during Poll.
+type fakeErrorPollerHandler[T any] struct {
+	pollErr error
+}
+
+func (f *fakeErrorPollerHandler[T]) Done() bool {
+	return false
+}
+
+func (f *fakeErrorPollerHandler[T]) Poll(ctx context.Context) (*http.Response, error) {
+	return nil, f.pollErr
+}
+
+func (f *fakeErrorPollerHandler[T]) Result(ctx context.Context, out *T) error {
+	return nil
+}
+
+func TestScaleSetAtomicIncreaseSizePollerFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", armcompute.OrchestrationModeUniform)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	provider := newTestProvider(t)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	// Create a poller that will fail during PollUntilDone
+	pollerResp := &http.Response{
+		Header: http.Header{},
+	}
+	failingPoller, pollerErr := runtime.NewPoller(pollerResp, runtime.Pipeline{},
+		&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse]{
+			Handler: &fakeErrorPollerHandler[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse]{
+				pollErr: fmt.Errorf("long running operation failed"),
+			},
+		})
+	assert.NoError(t, pollerErr)
+
+	// BeginCreateOrUpdate succeeds (returns a poller), but PollUntilDone will fail
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(failingPoller, nil).AnyTimes()
+	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
+
+	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(expectedVMSSVMs, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := provider.azureManager.RegisterNodeGroup(
+		newTestScaleSet(provider.azureManager, testASG))
+	assert.True(t, registered)
+
+	// Current target size is 3.
+	targetSize, err := provider.NodeGroups()[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+
+	// PollUntilDone fails — size should NOT be updated.
+	err = provider.NodeGroups()[0].AtomicIncreaseSize(2)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "long running operation failed")
+
+	// Target size should remain 3 (not updated on poller failure).
+	targetSize, err = provider.NodeGroups()[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+}
+
 // TestIncreaseSizeOnVMProvisioningFailed has been tweeked only for Uniform Orchestration mode.
 // If ProvisioningState == failed and power state is not running, Status.State == InstanceCreating with errorInfo populated.
 func TestScaleSetIncreaseSizeOnVMProvisioningFailed(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -376,9 +376,15 @@ func TestScaleSetAtomicIncreaseSize(t *testing.T) {
 	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	// BeginCreateOrUpdate returns nil poller — simulates immediate success
+	// BeginCreateOrUpdate returns nil poller — simulates immediate success.
+	// Verify the request payload contains the expected new capacity (3 + 2 = 5).
 	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
-	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Cond(func(x any) bool {
+			vmss, ok := x.(armcompute.VirtualMachineScaleSet)
+			return ok && vmss.SKU != nil && vmss.SKU.Capacity != nil && *vmss.SKU.Capacity == 5
+		}),
+		gomock.Any()).Return(nil, nil)
 	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
 
 	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
@@ -445,10 +451,16 @@ func TestScaleSetAtomicIncreaseSizeFailure(t *testing.T) {
 	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
-	// BeginCreateOrUpdate returns an error — simulates Azure rejecting the request
+	// BeginCreateOrUpdate returns an error — simulates Azure rejecting the request.
+	// Verify the request payload contains the expected new capacity (3 + 2 = 5).
 	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
-	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, fmt.Errorf("azure capacity unavailable")).AnyTimes()
+	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Cond(func(x any) bool {
+			vmss, ok := x.(armcompute.VirtualMachineScaleSet)
+			return ok && vmss.SKU != nil && vmss.SKU.Capacity != nil && *vmss.SKU.Capacity == 5
+		}),
+		gomock.Any()).
+		Return(nil, fmt.Errorf("azure capacity unavailable"))
 	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
 
 	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
@@ -519,10 +531,16 @@ func TestScaleSetAtomicIncreaseSizePollerFailure(t *testing.T) {
 		})
 	assert.NoError(t, pollerErr)
 
-	// BeginCreateOrUpdate succeeds (returns a poller), but PollUntilDone will fail
+	// BeginCreateOrUpdate succeeds (returns a poller), but PollUntilDone will fail.
+	// Verify the request payload contains the expected new capacity (3 + 2 = 5).
 	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
-	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(failingPoller, nil).AnyTimes()
+	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Cond(func(x any) bool {
+			vmss, ok := x.(armcompute.VirtualMachineScaleSet)
+			return ok && vmss.SKU != nil && vmss.SKU.Capacity != nil && *vmss.SKU.Capacity == 5
+		}),
+		gomock.Any()).
+		Return(failingPoller, nil)
 	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
 
 	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -363,6 +363,74 @@ func TestScaleSetIncreaseSize(t *testing.T) {
 	}
 }
 
+func TestScaleSetAtomicIncreaseSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", armcompute.OrchestrationModeUniform)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	provider := newTestProvider(t)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
+
+	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(expectedVMSSVMs, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	// Error: non-existent scale set
+	ss := newTestScaleSet(provider.azureManager, "test-asg-doesnt-exist")
+	err = ss.AtomicIncreaseSize(1)
+	expectedErr := fmt.Errorf("could not find vmss: test-asg-doesnt-exist")
+	assert.Equal(t, expectedErr, err)
+
+	registered := provider.azureManager.RegisterNodeGroup(
+		newTestScaleSet(provider.azureManager, testASG))
+	assert.True(t, registered)
+
+	// Error: negative delta
+	err = provider.NodeGroups()[0].AtomicIncreaseSize(-1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "size increase must be positive")
+
+	// Error: zero delta
+	err = provider.NodeGroups()[0].AtomicIncreaseSize(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "size increase must be positive")
+
+	// Error: exceeds max size (max is 5, current is 3, delta 3 = 6 > 5)
+	err = provider.NodeGroups()[0].AtomicIncreaseSize(3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "size increase too large")
+
+	// Current target size is 3.
+	targetSize, err := provider.NodeGroups()[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+
+	// Success: atomic increase by 2.
+	err = provider.NodeGroups()[0].AtomicIncreaseSize(2)
+	assert.NoError(t, err)
+
+	// New target size should be 5.
+	targetSize, err = provider.NodeGroups()[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 5, targetSize)
+}
+
 // TestIncreaseSizeOnVMProvisioningFailed has been tweeked only for Uniform Orchestration mode.
 // If ProvisioningState == failed and power state is not running, Status.State == InstanceCreating with errorInfo populated.
 func TestScaleSetIncreaseSizeOnVMProvisioningFailed(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -376,6 +376,7 @@ func TestScaleSetAtomicIncreaseSize(t *testing.T) {
 	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
 	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
 
+	// BeginCreateOrUpdate returns nil poller — simulates immediate success
 	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
 	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
@@ -421,7 +422,7 @@ func TestScaleSetAtomicIncreaseSize(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, targetSize)
 
-	// Success: atomic increase by 2.
+	// Success: atomic increase by 2 (blocks until complete, nil poller = immediate).
 	err = provider.NodeGroups()[0].AtomicIncreaseSize(2)
 	assert.NoError(t, err)
 
@@ -429,6 +430,51 @@ func TestScaleSetAtomicIncreaseSize(t *testing.T) {
 	targetSize, err = provider.NodeGroups()[0].TargetSize()
 	assert.NoError(t, err)
 	assert.Equal(t, 5, targetSize)
+}
+
+func TestScaleSetAtomicIncreaseSizeFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedScaleSets := newTestVMSSList(3, testASG, "eastus", armcompute.OrchestrationModeUniform)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	provider := newTestProvider(t)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	// BeginCreateOrUpdate returns an error — simulates Azure rejecting the request
+	mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+	mockDeleteClient.EXPECT().BeginCreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("azure capacity unavailable")).AnyTimes()
+	provider.azureManager.azClient.vmssClientForDelete = mockDeleteClient
+
+	mockVMClient := mock_virtualmachineclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), provider.azureManager.config.ResourceGroup).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachinesClient = mockVMClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), provider.azureManager.config.ResourceGroup, testASG).Return(expectedVMSSVMs, nil).AnyTimes()
+	provider.azureManager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	err := provider.azureManager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := provider.azureManager.RegisterNodeGroup(
+		newTestScaleSet(provider.azureManager, testASG))
+	assert.True(t, registered)
+
+	// BeginCreateOrUpdate fails — size should NOT be updated.
+	err = provider.NodeGroups()[0].AtomicIncreaseSize(2)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "azure capacity unavailable")
+
+	// Target size should remain 3 (not updated on failure).
+	targetSize, err := provider.NodeGroups()[0].TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
 }
 
 // TestIncreaseSizeOnVMProvisioningFailed has been tweeked only for Uniform Orchestration mode.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR is a manual cherry-pick of https://github.com/kubernetes/autoscaler/pull/9514, implementing the AtomicIncreaseSize method for Azure VMSS.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
azure: implement AtomicIncreaseSize for VMSS
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
