### PR TITLE
[cherry-pick 1.35] Add AtomicIncreaseSize method for VMS ap

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -511,7 +511,13 @@ func (vmPool *VMPool) getAgentpoolFromAzure() (armcontainerservice.AgentPool, er
 	return resp.AgentPool, nil
 }
 
-// AtomicIncreaseSize is not implemented.
+// AtomicIncreaseSize increases the VMPool size by delta and blocks until the
+// underlying agent pool PUT operation completes. IncreaseSize already issues a
+// synchronous PUT that waits via PollUntilDone, so it satisfies the atomic
+// contract: on success the capacity change has been fully applied by Azure
+// before returning. This blocking behavior is required for atomic-scale-up
+// ProvisioningRequest support to provide a capacity guarantee before workloads
+// are admitted.
 func (vmPool *VMPool) AtomicIncreaseSize(delta int) error {
-	return cloudprovider.ErrNotImplemented
+	return vmPool.IncreaseSize(delta)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
@@ -248,10 +248,53 @@ func TestTemplateNodeInfo(t *testing.T) {
 }
 
 func TestAtomicIncreaseSize(t *testing.T) {
-	agentPool := &VMPool{}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
 
-	err := agentPool.AtomicIncreaseSize(1)
-	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+	ap := newTestVMsPool(manager)
+	expectedVMs := newTestVMsPoolVMList(3)
+
+	mockVMClient := NewMockInterface(ctrl)
+	ap.manager.azClient.virtualMachinesClient = mockVMClient
+	mockVMClient.EXPECT().List(gomock.Any(), ap.manager.config.ResourceGroup).Return(expectedVMs, nil)
+
+	ap.manager.config.EnableVMsAgentPool = true
+	mockAgentpoolclient := NewMockAgentPoolsClient(ctrl)
+	ap.manager.azClient.agentPoolClient = mockAgentpoolclient
+	agentpool := getTestVMsAgentPool(false)
+	fakeAPListPager := getFakeAgentpoolListPager(&agentpool)
+	mockAgentpoolclient.EXPECT().NewListPager(gomock.Any(), gomock.Any(), nil).
+		Return(fakeAPListPager)
+
+	ac, err := newAzureCache(ap.manager.azClient, refreshInterval, *ap.manager.config)
+	assert.NoError(t, err)
+	ap.manager.azureCache = ac
+
+	// non-positive delta should fail validation (delegates to IncreaseSize).
+	err = ap.AtomicIncreaseSize(-1)
+	assert.Equal(t, fmt.Errorf("size increase must be positive, current delta: -1"), err)
+
+	// success case
+	resp := &http.Response{
+		Header: map[string][]string{
+			"Fake-Poller-Status": {"Done"},
+		},
+	}
+	fakePoller, pollerErr := runtime.NewPoller(resp, runtime.Pipeline{},
+		&runtime.NewPollerOptions[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse]{
+			Handler: &fakehandler[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse]{},
+		})
+	assert.NoError(t, pollerErr)
+
+	mockAgentpoolclient.EXPECT().BeginCreateOrUpdate(
+		gomock.Any(), manager.config.ClusterResourceGroup,
+		manager.config.ClusterName,
+		vmsAgentPoolName,
+		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
+
+	err = ap.AtomicIncreaseSize(1)
+	assert.NoError(t, err)
 }
 
 func TestGetVMsFromCache(t *testing.T) {


### PR DESCRIPTION
(cherry picked from commit 12497a3e9ff33a54da0f78a72310dbeb4922601f)

```release-note
azure: implement AtomicIncreaseSize for VMS
```