### PR TITLE
[cluster-autoscaler-release-1.34] Add AtomicIncreaseSize method for VMS ap

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -510,7 +510,13 @@ func (vmPool *VMPool) getAgentpoolFromAzure() (armcontainerservice.AgentPool, er
 	return resp.AgentPool, nil
 }
 
-// AtomicIncreaseSize is not implemented.
+// AtomicIncreaseSize increases the VMPool size by delta and blocks until the
+// underlying agent pool PUT operation completes. IncreaseSize already issues a
+// synchronous PUT that waits via PollUntilDone, so it satisfies the atomic
+// contract: on success the capacity change has been fully applied by Azure
+// before returning. This blocking behavior is required for atomic-scale-up
+// ProvisioningRequest support to provide a capacity guarantee before workloads
+// are admitted.
 func (vmPool *VMPool) AtomicIncreaseSize(delta int) error {
-	return cloudprovider.ErrNotImplemented
+	return vmPool.IncreaseSize(delta)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
@@ -272,11 +272,6 @@ func TestAtomicIncreaseSize(t *testing.T) {
 	assert.NoError(t, err)
 	ap.manager.azureCache = ac
 
-	// non-positive delta should fail validation (delegates to IncreaseSize).
-	err = ap.AtomicIncreaseSize(-1)
-	assert.Equal(t, fmt.Errorf("size increase must be positive, current delta: -1"), err)
-
-	// success case
 	resp := &http.Response{
 		Header: map[string][]string{
 			"Fake-Poller-Status": {"Done"},
@@ -294,8 +289,71 @@ func TestAtomicIncreaseSize(t *testing.T) {
 		vmsAgentPoolName,
 		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
 
+	// Before scale-up, target size matches the initial VM count.
+	targetSize, err := ap.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, targetSize)
+
 	err = ap.AtomicIncreaseSize(1)
 	assert.NoError(t, err)
+
+	// Simulate Azure having created the new VM by seeding the cache with the
+	// post-scale VM list, then assert the pool reports the new target size.
+	ap.manager.azureCache.virtualMachines[vmsAgentPoolName] = newTestVMsPoolVMList(4)
+	targetSize, err = ap.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 4, targetSize)
+}
+
+func TestAtomicIncreaseSizeNegativeDelta(t *testing.T) {
+	ap := newTestVMsPool(newTestAzureManager(t))
+
+	err := ap.AtomicIncreaseSize(-1)
+	assert.Equal(t, fmt.Errorf("size increase must be positive, current delta: -1"), err)
+}
+
+func TestAtomicIncreaseSizePollerFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
+
+	ap := newTestVMsPool(manager)
+	expectedVMs := newTestVMsPoolVMList(3)
+
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	ap.manager.azClient.virtualMachinesClient = mockVMClient
+	mockVMClient.EXPECT().List(gomock.Any(), ap.manager.config.ResourceGroup).Return(expectedVMs, nil)
+
+	ap.manager.config.EnableVMsAgentPool = true
+	mockAgentpoolclient := NewMockAgentPoolsClient(ctrl)
+	ap.manager.azClient.agentPoolClient = mockAgentpoolclient
+	agentpool := getTestVMsAgentPool(false)
+	fakeAPListPager := getFakeAgentpoolListPager(&agentpool)
+	mockAgentpoolclient.EXPECT().NewListPager(gomock.Any(), gomock.Any(), nil).
+		Return(fakeAPListPager)
+
+	ac, err := newAzureCache(ap.manager.azClient, refreshInterval, *ap.manager.config)
+	assert.NoError(t, err)
+	ap.manager.azureCache = ac
+
+	// Poller that returns an error from PollUntilDone.
+	failingPoller, pollerErr := runtime.NewPoller(&http.Response{Header: http.Header{}}, runtime.Pipeline{},
+		&runtime.NewPollerOptions[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse]{
+			Handler: &fakeErrorPollerHandler[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse]{
+				pollErr: fmt.Errorf("long running operation failed"),
+			},
+		})
+	assert.NoError(t, pollerErr)
+
+	mockAgentpoolclient.EXPECT().BeginCreateOrUpdate(
+		gomock.Any(), manager.config.ClusterResourceGroup,
+		manager.config.ClusterName,
+		vmsAgentPoolName,
+		gomock.Any(), gomock.Any()).Return(failingPoller, nil)
+
+	err = ap.AtomicIncreaseSize(1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "long running operation failed")
 }
 
 func TestGetVMsFromCache(t *testing.T) {
@@ -589,6 +647,23 @@ func (f *fakehandler[T]) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 func (f *fakehandler[T]) Result(ctx context.Context, out *T) error {
+	return nil
+}
+
+// fakeErrorPollerHandler simulates a poller that fails during Poll.
+type fakeErrorPollerHandler[T any] struct {
+	pollErr error
+}
+
+func (f *fakeErrorPollerHandler[T]) Done() bool {
+	return false
+}
+
+func (f *fakeErrorPollerHandler[T]) Poll(ctx context.Context) (*http.Response, error) {
+	return nil, f.pollErr
+}
+
+func (f *fakeErrorPollerHandler[T]) Result(ctx context.Context, out *T) error {
 	return nil
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
@@ -249,10 +249,53 @@ func TestTemplateNodeInfo(t *testing.T) {
 }
 
 func TestAtomicIncreaseSize(t *testing.T) {
-	agentPool := &VMPool{}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	manager := newTestAzureManager(t)
 
-	err := agentPool.AtomicIncreaseSize(1)
-	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+	ap := newTestVMsPool(manager)
+	expectedVMs := newTestVMsPoolVMList(3)
+
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	ap.manager.azClient.virtualMachinesClient = mockVMClient
+	mockVMClient.EXPECT().List(gomock.Any(), ap.manager.config.ResourceGroup).Return(expectedVMs, nil)
+
+	ap.manager.config.EnableVMsAgentPool = true
+	mockAgentpoolclient := NewMockAgentPoolsClient(ctrl)
+	ap.manager.azClient.agentPoolClient = mockAgentpoolclient
+	agentpool := getTestVMsAgentPool(false)
+	fakeAPListPager := getFakeAgentpoolListPager(&agentpool)
+	mockAgentpoolclient.EXPECT().NewListPager(gomock.Any(), gomock.Any(), nil).
+		Return(fakeAPListPager)
+
+	ac, err := newAzureCache(ap.manager.azClient, refreshInterval, *ap.manager.config)
+	assert.NoError(t, err)
+	ap.manager.azureCache = ac
+
+	// non-positive delta should fail validation (delegates to IncreaseSize).
+	err = ap.AtomicIncreaseSize(-1)
+	assert.Equal(t, fmt.Errorf("size increase must be positive, current delta: -1"), err)
+
+	// success case
+	resp := &http.Response{
+		Header: map[string][]string{
+			"Fake-Poller-Status": {"Done"},
+		},
+	}
+	fakePoller, pollerErr := runtime.NewPoller(resp, runtime.Pipeline{},
+		&runtime.NewPollerOptions[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse]{
+			Handler: &fakehandler[armcontainerservice.AgentPoolsClientCreateOrUpdateResponse]{},
+		})
+	assert.NoError(t, pollerErr)
+
+	mockAgentpoolclient.EXPECT().BeginCreateOrUpdate(
+		gomock.Any(), manager.config.ClusterResourceGroup,
+		manager.config.ClusterName,
+		vmsAgentPoolName,
+		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
+
+	err = ap.AtomicIncreaseSize(1)
+	assert.NoError(t, err)
 }
 
 func TestGetVMsFromCache(t *testing.T) {


### PR DESCRIPTION
(cherry picked from commit 12497a3e9ff33a54da0f78a72310dbeb4922601f)

```release-note
azure: implement AtomicIncreaseSize for VMS
```
