### PR TITLE
docs(metrics): update the metrics documentation

### DIFF
--- a/cluster-autoscaler/proposals/metrics.md
+++ b/cluster-autoscaler/proposals/metrics.md
@@ -155,15 +155,3 @@ scale down reasons are `empty`, `underutilized`, `unready`.
   why the scaling was skipped (eg `CPULimitReached`, `MemoryLimitReached`). This is
   different than failed scaling events in that the autoscaler is choosing not to perform
   a scaling action.
-
-### Node Autoprovisioning operations
-
-This metrics describe operations and state related to Node Autoprovisioning
-feature.
-
-| Metric name | Metric type | Labels | Description |
-| ----------- | ----------- | ------ | ----------- |
-| nap_enabled | Gauge | | Whether or not Node Autoprovisioning is enabled. 1 if it is, 0 otherwise. |
-| created_node_groups_total | Counter | | Number of node groups created by Node Autoprovisioning. |
-| deleted_node_groups_total | Counter | | Number of node groups deleted by Node Autoprovisioning. |
-

--- a/cluster-autoscaler/proposals/metrics.md
+++ b/cluster-autoscaler/proposals/metrics.md
@@ -25,10 +25,10 @@ All the metrics are prefixed with `cluster_autoscaler_`.
 | ----------- | ----------- | ------ | ----------- |
 | cluster_safe_to_autoscale | Gauge | | Whether or not cluster is healthy enough for autoscaling. 1 if it is, 0 otherwise. |
 | nodes_count | Gauge | `state`=&lt;node-state&gt; | Number of nodes in cluster. |
-| unschedulable_pods_count | Gauge | | Number of unschedulable ("Pending") pods in the cluster. |
 | node_groups_count | Gauge | `node_group_type`=&lt;node-group-type&gt; | Number of node groups managed by CA. |
+| unschedulable_pods_count | Gauge | `type`=&lt;`unschedulable` or `scheduler_unprocessed`&gt; | Number of unschedulable ("Pending") pods in the cluster. |
 | max_nodes_count | Gauge | | Maximum number of nodes in all node groups. |
-| cluster_cpu_current_cores | Gauge | | | Current number of cores in the cluster, minus deleting nodes. |
+| cluster_cpu_current_cores | Gauge | | Current number of cores in the cluster, minus deleting nodes. |
 | cpu_limits_cores | Gauge | `direction`=&lt;`minimum` or `maximum`&gt; | Minimum and maximum number of cores in the cluster. |
 | cluster_memory_current_bytes | Gauge | | Current number of bytes of memory in the cluster, minus deleting nodes. |
 | memory_limits_bytes | Gauge | `direction`=&lt;`minimum` or `maximum`&gt; | Minimum and maximum number of bytes of memory in cluster. |
@@ -40,6 +40,19 @@ states are `ready`, `unready`, `notStarted`.
   useful when using dynamic configuration or Node Autoprovisioning. Types of
   node group are `autoscaled` (managed by CA but not created by NAP) and `autoprovisioned` (created by NAP and managed by CA).
 
+#### Per-node-group cluster state
+
+The following per-node-group metrics are emitted only when the
+`--emit-per-nodegroup-metrics` flag is set to `true`.
+
+| Metric name | Metric type | Labels | Description |
+| ----------- | ----------- | ------ | ----------- |
+| node_group_min_count | Gauge | `node_group` | Minimum number of nodes in the node group. |
+| node_group_max_count | Gauge | `node_group` | Maximum number of nodes in the node group. |
+| node_group_target_count | Gauge | `node_group` | Target number of nodes in the node group as set by CA. |
+| node_group_healthiness | Gauge | `node_group` | Whether the node group is healthy enough for autoscaling. 1 if healthy, 0 otherwise. |
+| node_group_backoff_status | Gauge | `node_group`, `reason` | Whether the node group is in backoff (and therefore not autoscaling). 1 if in backoff, 0 otherwise. |
+
 ### Cluster Autoscaler execution
 This metrics are refactored from currently existing metrics and track execution
 of various parts of Cluster Autoscaler loop.
@@ -48,6 +61,8 @@ of various parts of Cluster Autoscaler loop.
 | ----------- | ----------- | ------ | ----------- |
 | last_activity | Gauge | `activity`=&lt;autoscaler-activity&gt; | Last time certain part of CA logic executed |
 | function_duration_seconds | Histogram | `function`=&lt;autoscaler-function&gt; | Time taken by various parts of CA main loop. |
+| function_duration_quantile_seconds | Summary | `function`=&lt;autoscaler-function&gt; | Quantiles of time taken by various parts of CA main loop, computed over a sliding 1h window. Complementary to `function_duration_seconds` for cases where Histogram quantiles are insufficient. |
+| pending_node_deletions | Gauge | | Number of nodes that haven't been removed or aborted after the scale-down phase finished. |
 
 * `last_activity` records last time certain part of cluster autoscaler logic
 executed. Represented with unix timestamp. autoscaler-activity values are:
@@ -77,15 +92,28 @@ This metrics describe internal state and actions taken by Cluster Autoscaler.
 | Metric name | Metric type | Labels | Description |
 | ----------- | ----------- | ------ | ----------- |
 | errors_total | Counter | `type`=&lt;error-type&gt; | The number of CA loops failed due to an error. |
-| scaled_up_nodes_total | Counter | | Number of nodes added by CA. |
-| scaled_down_nodes_total | Counter | `reason`=&lt;scale-down-reason&gt; | Number of nodes removed by CA. |
-| scaled_up_gpu_nodes_total | Counter | `gpu_name`=&lt;gpu-name&gt; | Number of GPU-enabled nodes added by CA. |
-| scaled_down_gpu_nodes_total | Counter | `reason`=&lt;scale-down-reason&gt;, `gpu_name`=&lt;gpu-name&gt; | Number of GPU-enabled nodes removed by CA. |
-| failed_scale_ups_total | Counter | `reason`=&lt;failure-reason&gt; | Number of times scale-up operation has failed. |
-| evicted_pods_total | Counter | | Number of pods evicted by CA. |
+| scaled_up_nodes_total | Counter | `gpu_resource_name`=&lt;gpu-resource-name&gt;, `gpu_name`=&lt;gpu-name&gt;, `dra_drivers`=&lt;dra-driver-names&gt; | Number of nodes added by CA. |
+| scaled_up_gpu_nodes_total | Counter | `gpu_resource_name`=&lt;gpu-resource-name&gt;, `gpu_name`=&lt;gpu-name&gt; | **Deprecated since 1.36.0**. Number of GPU nodes added by CA, by GPU name. |
+| failed_scale_ups_total | Counter | `reason`=&lt;failure-reason&gt;, `gpu_resource_name`=&lt;gpu-resource-name&gt;, `gpu_name`=&lt;gpu-name&gt;, `dra_drivers`=&lt;dra-driver-names&gt; | Number of times scale-up operation has failed. |
+| failed_node_creations_total | Counter | `reason`=&lt;failure-reason&gt; | Number of nodes that CA failed to add. Per-node granularity, contrasted with `failed_scale_ups_total` which is per-operation: a single failed scale-up that requested 5 nodes increments this metric by 5 and `failed_scale_ups_total` by 1. |
+| failed_gpu_scale_ups_total | Counter | `reason`=&lt;failure-reason&gt;, `gpu_resource_name`=&lt;gpu-resource-name&gt;, `gpu_name`=&lt;gpu-name&gt; | **Deprecated since 1.36.0**. Number of times scale-up operation has failed for GPU node groups. |
+| scaled_down_nodes_total | Counter | `reason`=&lt;scale-down-reason&gt;, `gpu_resource_name`=&lt;gpu-resource-name&gt;, `gpu_name`=&lt;gpu-name&gt;, `dra_drivers`=&lt;dra-driver-names&gt; | Number of nodes removed by CA. |
+| scaled_down_gpu_nodes_total | Counter | `reason`=&lt;scale-down-reason&gt;, `gpu_resource_name`=&lt;gpu-resource-name&gt;, `gpu_name`=&lt;gpu-name&gt; | **Deprecated since 1.36.0**. Number of GPU nodes removed by CA, by reason and GPU name. |
+| evicted_pods_total | Counter | `eviction_result`=&lt;`succeeded` or `failed`&gt; | Number of pods evicted by CA. |
 | unneeded_nodes_count | Gauge | | Number of nodes currently considered unneeded by CA. |
+| unremovable_nodes_count | Gauge | `reason`=&lt;unremovable-reason&gt; | Number of nodes currently considered unremovable by CA, broken down by reason. |
+| scale_down_in_cooldown | Gauge | | Whether scale-down is currently in cooldown. 1 if it is, 0 otherwise. |
 | old_unregistered_nodes_removed_count | Counter | | Number of unregistered nodes removed by CA. |
+| overflowing_controllers_count | Gauge | | Number of controllers that own a large set of heterogenous pods, preventing CA from treating these pods as equivalent during binpacking. |
 | skipped_scale_events_count | Counter | `direction`=&lt;scaling-direction&gt;, `reason`=&lt;skipped-scale-reason&gt; | Number of times scaling has been skipped due to a resource limit being reached, or similar event. |
+| created_node_groups_total | Counter | `group_type`=&lt;node-group-type&gt; | Number of node groups created by Node Autoprovisioning. |
+| deleted_node_groups_total | Counter | `group_type`=&lt;node-group-type&gt; | Number of node groups deleted by Node Autoprovisioning. |
+| node_taints_count | Gauge | `type`=&lt;taint-type&gt; | Number of node taints currently present in the cluster, grouped by taint type. |
+| inconsistent_instances_migs_count | Gauge | | Number of migs where instance count according to `InstanceGroupManagers.List()` differs from the results of `Instances.List()`. This can happen when some instances are abandoned or a user edits instance `created-by` metadata. |
+| binpacking_heterogeneity | Histogram | `instance_type`, `cpu_count`, `namespace_count` | Number of groups of equivalent pods being processed as a part of the same binpacking simulation. |
+| max_node_skip_eval_duration_seconds | Gauge | | Maximum evaluation time of a node being skipped during ScaleDown. |
+| node_removal_latency_seconds | Histogram | `deleted`=&lt;`true` or `false`&gt; | Latency from when an unneeded node becomes eligible for scale-down until it is actually removed (`deleted=true`) or becomes needed again (`deleted=false`). |
+| dra_node_template_resources_mismatch | Gauge | `driver`=&lt;dra-driver-name&gt;, `mismatch_type`=&lt;`missing` or `extra` or `mismatch` or `unknown`&gt; | Count of resource pool mismatches between ready nodes and the node template that CA used to predict the node, useful for diagnosing scale-up correctness with Dynamic Resource Allocation (DRA). |
 
 * `errors_total` counter increases every time main CA loop encounters an error.
   * Growing `errors_total` count signifies an internal error in CA or a problem


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area cluster-autoscaler

#### What this PR does / why we need it:

This PR expands the metrics documentation by adding the metrics that are not yet documented, and re-syncs `proposals/metrics.md` with `metrics.go` so the doc reflects the actual implementation.

`cluster-autoscaler/proposals/metrics.md` is one of the entry points users rely on to discover what metrics Cluster Autoscaler exposes, but a number of metrics defined in `cluster-autoscaler/metrics/metrics.go` have never been listed there. This makes it hard for operators to learn which metrics are available and what their labels are without reading the source code.

**Newly documented metrics:**

- Per-node-group metrics gated behind `--emit-per-nodegroup-metrics`
- `failed_node_creations_total`
- `failed_gpu_scale_ups_total`
- `unneeded_nodes_count`
- `unremovable_nodes_count`
- `scale_down_in_cooldown`
- `overflowing_controllers_count`
- `created_node_groups_total`
- `deleted_node_groups_total`
- `node_taints_count`
- `inconsistent_instances_migs_count`
- `binpacking_heterogeneity`
- `max_node_skip_eval_duration_seconds`
- `node_removal_latency_seconds`
- `dra_node_template_resources_mismatch`

**Other changes:**

- Reorder the "Cluster state" and "Cluster Autoscaler operations" tables to match the declaration order in `metrics.go`, so future drift is easier to spot.
- Fix labels on existing rows so they match what is actually emitted (e.g. add `gpu_resource_name` / `dra_drivers` to the scale-up/down rows, `type` to `unschedulable_pods_count`, `eviction_result` to `evicted_pods_total`).
- Mark `scaled_up_gpu_nodes_total`, `scaled_down_gpu_nodes_total`, and `failed_gpu_scale_ups_total` as deprecated since 1.36.0, in line with their `DeprecatedVersion` in code.

The doc is intentionally only re-synced; no metrics are added, removed or renamed in this PR.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
