### PR TITLE
Split CapacityQuota usage and validation reconcilers

### DIFF
--- a/cluster-autoscaler/builder/autoscaler.go
+++ b/cluster-autoscaler/builder/autoscaler.go
@@ -233,11 +233,15 @@ func (b *AutoscalerBuilder) Build(ctx context.Context) (core.Autoscaler, *loop.L
 	}
 
 	if autoscalingOptions.CapacityQuotasEnabled {
-		cqReconciler := capacityquota.NewCapacityQuotaReconciler(b.manager.GetClient(), capacityquota.ReconcilerOptions{
-			NodeFilter: utils.VirtualKubeletNodeFilter{},
-		})
+		cqReconciler := capacityquota.NewReconciler(b.manager.GetClient(), capacityquota.ReconcilerOptions{})
 		if err := cqReconciler.SetupWithManager(b.manager); err != nil {
 			return nil, nil, fmt.Errorf("failed to setup CapacityQuota reconciler: %w", err)
+		}
+		cqUsageReconciler := capacityquota.NewUsageReconciler(b.manager.GetClient(), capacityquota.UsageReconcilerOptions{
+			NodeFilter: utils.VirtualKubeletNodeFilter{},
+		})
+		if err := cqUsageReconciler.SetupWithManager(b.manager); err != nil {
+			return nil, nil, fmt.Errorf("failed to setup CapacityQuota usage reconciler: %w", err)
 		}
 	}
 

--- a/cluster-autoscaler/resourcequotas/capacityquota/controller.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/controller.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -44,34 +44,30 @@ import (
 
 // Reconciler reconciles a CapacityQuota object
 type Reconciler struct {
-	client     client.Client
-	nodeFilter resourcequotas.NodeFilter
+	client     ctrlclient.Client
 	validators []Validator
 }
 
 // ReconcilerOptions are configuration options for CapacityQuota reconciler.
 type ReconcilerOptions struct {
-	NodeFilter       resourcequotas.NodeFilter
 	CustomValidators []Validator
 }
 
-// NewCapacityQuotaReconciler returns a new CapacityQuotaReconciler
-func NewCapacityQuotaReconciler(client client.Client, opts ReconcilerOptions) *Reconciler {
+// NewReconciler returns a new Reconciler
+func NewReconciler(client ctrlclient.Client, opts ReconcilerOptions) *Reconciler {
 	validators := []Validator{&labelSelectorValidator{}}
 	validators = append(validators, opts.CustomValidators...)
 	return &Reconciler{
 		client:     client,
-		nodeFilter: opts.NodeFilter,
 		validators: validators,
 	}
 }
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
+// Reconcile reconciles CapacityQuota to its desired state.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var cq v1alpha1.CapacityQuota
 	if err := r.client.Get(ctx, req.NamespacedName, &cq); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return ctrl.Result{}, ctrlclient.IgnoreNotFound(err)
 	}
 
 	originalCQ := cq.DeepCopy()
@@ -80,28 +76,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if len(validationErrs) > 0 {
 		errMsg := formatValidationErrors(validationErrs)
 		setCondition(&cq, v1alpha1.ValidCondition, metav1.ConditionFalse, v1alpha1.ValidationFailed, errMsg)
-		setCondition(&cq, v1alpha1.ReconciledCondition, metav1.ConditionFalse, v1alpha1.ReconciliationFailed, "Validation failed")
-
-		if patchErr := r.patchStatus(ctx, originalCQ, &cq); patchErr != nil {
-			return ctrl.Result{}, patchErr
-		}
-		return ctrl.Result{}, nil
-	}
-	setCondition(&cq, v1alpha1.ValidCondition, metav1.ConditionTrue, v1alpha1.ValidationSucceeded, "CapacityQuota is valid")
-
-	result, err := r.reconcileCapacityQuota(ctx, &cq)
-
-	if err != nil {
-		setCondition(&cq, v1alpha1.ReconciledCondition, metav1.ConditionFalse, v1alpha1.ReconciliationFailed, err.Error())
 	} else {
-		setCondition(&cq, v1alpha1.ReconciledCondition, metav1.ConditionTrue, v1alpha1.ReconciliationSucceeded, "CapacityQuota successfully reconciled")
+		setCondition(&cq, v1alpha1.ValidCondition, metav1.ConditionTrue, v1alpha1.ValidationSucceeded, "CapacityQuota is valid")
 	}
 
-	if patchErr := r.patchStatus(ctx, originalCQ, &cq); patchErr != nil {
-		return ctrl.Result{}, patchErr
-	}
-
-	return result, err
+	patchErr := patchStatus(ctx, r.client, originalCQ, &cq)
+	return ctrl.Result{}, patchErr
 }
 
 func formatValidationErrors(errs []error) string {
@@ -110,15 +90,6 @@ func formatValidationErrors(errs []error) string {
 		errStrings[i] = err.Error()
 	}
 	return strings.Join(errStrings, "; ")
-}
-
-func (r *Reconciler) patchStatus(ctx context.Context, originalCQ, currentCQ *v1alpha1.CapacityQuota) error {
-	if !apiequality.Semantic.DeepEqual(originalCQ.Status, currentCQ.Status) {
-		if patchErr := r.client.Status().Patch(ctx, currentCQ, client.MergeFrom(originalCQ)); patchErr != nil {
-			return fmt.Errorf("failed to patch status: %w", patchErr)
-		}
-	}
-	return nil
 }
 
 func (r *Reconciler) validateCapacityQuota(ctx context.Context, cq *v1alpha1.CapacityQuota) []error {
@@ -136,29 +107,75 @@ func (r *Reconciler) validateCapacityQuota(ctx context.Context, cq *v1alpha1.Cap
 	return allErrs
 }
 
-func (r *Reconciler) reconcileCapacityQuota(ctx context.Context, cq *v1alpha1.CapacityQuota) (ctrl.Result, error) {
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.CapacityQuota{}).
+		Complete(r)
+}
+
+// UsageReconciler reconciles CapacityQuota's current usage.
+type UsageReconciler struct {
+	client     ctrlclient.Client
+	nodeFilter resourcequotas.NodeFilter
+}
+
+// UsageReconcilerOptions are configuration options for CapacityQuota usage reconciler.
+type UsageReconcilerOptions struct {
+	NodeFilter resourcequotas.NodeFilter
+}
+
+// NewUsageReconciler returns a new UsageReconciler.
+func NewUsageReconciler(client ctrlclient.Client, opts UsageReconcilerOptions) *UsageReconciler {
+	return &UsageReconciler{
+		client:     client,
+		nodeFilter: opts.NodeFilter,
+	}
+}
+
+// Reconcile reconciles CapacityQuota's current usage..
+func (r *UsageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var cq v1alpha1.CapacityQuota
+	if err := r.client.Get(ctx, req.NamespacedName, &cq); err != nil {
+		return ctrl.Result{}, ctrlclient.IgnoreNotFound(err)
+	}
+
+	originalCQ := cq.DeepCopy()
+	err := r.reconcileUsages(ctx, &cq)
+
+	if err != nil {
+		setCondition(&cq, v1alpha1.ReconciledCondition, metav1.ConditionFalse, v1alpha1.ReconciliationFailed, err.Error())
+	} else {
+		setCondition(&cq, v1alpha1.ReconciledCondition, metav1.ConditionTrue, v1alpha1.ReconciliationSucceeded, "CapacityQuota successfully reconciled")
+	}
+
+	patchErr := patchStatus(ctx, r.client, originalCQ, &cq)
+	return ctrl.Result{}, patchErr
+}
+
+func (r *UsageReconciler) reconcileUsages(ctx context.Context, cq *v1alpha1.CapacityQuota) error {
 	matchingNodes, err := r.getMatchingNodes(ctx, cq)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get matching nodes: %w", err)
+		return fmt.Errorf("failed to get matching nodes: %w", err)
 	}
 
 	cq.Status.Used = &v1alpha1.CapacityQuotaUsage{
 		Resources: calculateResourceUsage(cq, matchingNodes),
 	}
 
-	return ctrl.Result{}, nil
+	return nil
 }
 
-func (r *Reconciler) getMatchingNodes(ctx context.Context, cq *v1alpha1.CapacityQuota) ([]*corev1.Node, error) {
+func (r *UsageReconciler) getMatchingNodes(ctx context.Context, cq *v1alpha1.CapacityQuota) ([]*corev1.Node, error) {
 	var nodeList corev1.NodeList
-	var listOpts []client.ListOption
+	var listOpts []ctrlclient.ListOption
 
 	if cq.Spec.Selector != nil {
 		selector, err := metav1.LabelSelectorAsSelector(cq.Spec.Selector)
 		if err != nil {
 			return nil, err
 		}
-		listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: selector})
+		listOpts = append(listOpts, ctrlclient.MatchingLabelsSelector{Selector: selector})
 	}
 
 	if err := r.client.List(ctx, &nodeList, listOpts...); err != nil {
@@ -193,21 +210,8 @@ func calculateResourceUsage(cq *v1alpha1.CapacityQuota, matchingNodes []*corev1.
 	return used
 }
 
-func setCondition(cq *v1alpha1.CapacityQuota, condType string, status metav1.ConditionStatus, reason, message string) {
-	newCondition := metav1.Condition{
-		Type:               condType,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-		ObservedGeneration: cq.Generation,
-	}
-
-	meta.SetStatusCondition(&cq.Status.Conditions, newCondition)
-}
-
 // SetupWithManager sets up the controller with the Manager.
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *UsageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	nodePredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldNode, oldOk := e.ObjectOld.(*corev1.Node)
@@ -231,6 +235,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("capacityquota-usage").
 		For(&v1alpha1.CapacityQuota{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&corev1.Node{},
@@ -240,7 +245,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *Reconciler) findCapacityQuotasForNode(ctx context.Context, o client.Object) []reconcile.Request {
+func (r *UsageReconciler) findCapacityQuotasForNode(ctx context.Context, o ctrlclient.Object) []reconcile.Request {
 	node, ok := o.(*corev1.Node)
 	if !ok {
 		return nil
@@ -278,4 +283,26 @@ func (r *Reconciler) findCapacityQuotasForNode(ctx context.Context, o client.Obj
 	}
 
 	return requests
+}
+
+func setCondition(cq *v1alpha1.CapacityQuota, condType string, status metav1.ConditionStatus, reason, message string) {
+	newCondition := metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: cq.Generation,
+	}
+
+	meta.SetStatusCondition(&cq.Status.Conditions, newCondition)
+}
+
+func patchStatus(ctx context.Context, client ctrlclient.Client, originalCQ, currentCQ *v1alpha1.CapacityQuota) error {
+	if !apiequality.Semantic.DeepEqual(originalCQ.Status, currentCQ.Status) {
+		if patchErr := client.Status().Patch(ctx, currentCQ, ctrlclient.MergeFrom(originalCQ)); patchErr != nil {
+			return fmt.Errorf("failed to patch status: %w", patchErr)
+		}
+	}
+	return nil
 }

--- a/cluster-autoscaler/test/integration/controllers/suite_test.go
+++ b/cluster-autoscaler/test/integration/controllers/suite_test.go
@@ -107,7 +107,9 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	err = cqctrl.NewCapacityQuotaReconciler(mgr.GetClient(), cqctrl.ReconcilerOptions{NodeFilter: utils.VirtualKubeletNodeFilter{}}).SetupWithManager(mgr)
+	err = cqctrl.NewReconciler(mgr.GetClient(), cqctrl.ReconcilerOptions{}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred())
+	err = cqctrl.NewUsageReconciler(mgr.GetClient(), cqctrl.UsageReconcilerOptions{NodeFilter: utils.VirtualKubeletNodeFilter{}}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

CapacityQuota controller right now does two steps: validating the quota and calculating usages. Calculating usages is a way more complex task, since it iterates over all nodes in the cluster, while validation only validates the spec of a single CapacityQuota. Those steps also have different triggers - validation should run on every update of CapacityQuota, even a status update in case of manual updating the status by the user. Because of that, the validation reconciler will always run twice in a row, which we definitely want to avoid in case of the usage calculation. Usage reconciler needs to watch Nodes and CapacityQuota spec changes, but it does not need to watch CapacityQuota status changes. Another benefit of splitting the controllers is the fact that they will have separate queues, so the validation can keep running even if the usage reconciler queue is overloaded.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
