### PR TITLE
fix: AWS HasInstance should ignore unrecognized provider IDs

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -163,7 +163,9 @@ func (aws *awsCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 
 	awsRef, err := AwsRefFromProviderId(node.Spec.ProviderID)
 	if err != nil {
-		return false, err
+		// Dropping this into V as it will be noisy with many Hybrid Nodes
+		klog.V(6).Infof("Node %v has unrecognized providerId: %v", node.Name, node.Spec.ProviderID)
+		return false, nil
 	}
 
 	// we don't care about the status

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -756,6 +756,20 @@ func TestHasInstance(t *testing.T) {
 	present, err = provider.HasInstance(node4)
 	assert.NoError(t, err)
 	assert.False(t, present)
+
+	// Case 5: node with unrecognized provider ID (e.g. EKS Hybrid Nodes,
+	// SageMaker HyperPod) - ignored, no error
+	node5 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hybrid-node-1",
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: "eks-hybrid:///us-west-2/my-cluster/my-node-1",
+		},
+	}
+	present, err = provider.HasInstance(node5)
+	assert.NoError(t, err)
+	assert.False(t, present)
 }
 
 func TestDeleteNodesWithPlaceholderAndStaleCache(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area provider/aws

**What this PR does / why we need it**:

The AWSCloudProvider only supports `aws://zone/name` ProviderIDs. #8047 fixed `NodeGroupForNode` to ignore ProviderIDs it does not recognize (e.g. `eks-hybrid://...` for EKS Hybrid Nodes, or SageMaker HyperPod nodes joined to an EKS cluster), but `HasInstance` still propagates the parse error, which surfaces as errors in the autoscaler loop when such nodes are present in the cluster.

This applies the same handling to `HasInstance`: log at V(6) and report the node as not present, matching the existing pattern in `NodeGroupForNode`.

**Which issue(s) this PR fixes**:

None filed; same class of issue as #8047.

**Special notes for your reviewer**:

Adds a test case to `TestHasInstance` mirroring the one added in #8047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)