### PR TITLE
Fix "Skipping scale down on node group" log spam in ScaleDownCandidatesDelayProcessor

### DIFF
--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
@@ -46,6 +46,7 @@ func (p *ScaleDownCandidatesDelayProcessor) GetPodDestinationCandidates(autoscal
 func (p *ScaleDownCandidatesDelayProcessor) GetScaleDownCandidates(autoscalingCtx *ca_context.AutoscalingContext,
 	nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
 	result := []*apiv1.Node{}
+	alreadyLoggedGroups := make(map[string]bool)
 
 	for _, node := range nodes {
 		nodeGroup, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)
@@ -62,8 +63,11 @@ func (p *ScaleDownCandidatesDelayProcessor) GetScaleDownCandidates(autoscalingCt
 
 		recent := func(m map[string]time.Time, d time.Duration, msg string) bool {
 			if !m[nodeGroup.Id()].IsZero() && m[nodeGroup.Id()].Add(d).After(currentTime) {
-				klog.V(4).Infof("Skipping scale down on node group %s because it %s recently at %v",
-					nodeGroup.Id(), msg, m[nodeGroup.Id()])
+				if !alreadyLoggedGroups[nodeGroup.Id()] {
+					klog.V(4).Infof("Skipping scale down on node group %s because it %s recently at %v",
+						nodeGroup.Id(), msg, m[nodeGroup.Id()])
+					alreadyLoggedGroups[nodeGroup.Id()] = true
+				}
 				return true
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Currently `GetScaleDownCandidates` iterates over all nodes and logs "Skipping scale down on node group X because it scaled up recently" once per node rather than once per node group. This causes a burst of duplicate messages within the same millisecond whenever a large node group is in scale-down cooldown.

With large clusters this generates significant log volume, all with identical content and the same timestamp.

This fix adds an alreadyLoggedGroups map to deduplicate the log to once per node group per call to GetScaleDownCandidates. I tested this change on a cluster and confirm it only emits one log per node group per loop now instead of many

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix "Skipping scale down on node group" log spam in ScaleDownCandidatesDelayProcessor
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
