### PR TITLE
Book capacity only for ProvisioningRequest without scheduled pods

### DIFF
--- a/cluster-autoscaler/processors/provreq/processor.go
+++ b/cluster-autoscaler/processors/provreq/processor.go
@@ -142,9 +142,30 @@ func (p *provReqProcessor) bookCapacity(autoscalingCtx *ca_context.AutoscalingCo
 	if err != nil {
 		return fmt.Errorf("couldn't fetch ProvisioningRequests in the cluster: %v", err)
 	}
+	nodeInfos, err := autoscalingCtx.ClusterSnapshot.ListNodeInfos()
+	if err != nil {
+		return fmt.Errorf("couldn't list nodes: %v", err)
+	}
+	// Count pods already scheduled per ProvisioningRequest to exclude consumed PRs from booking.
+	scheduledPods := map[string]int{}
+	for _, nodeInfo := range nodeInfos {
+		for _, podInfo := range nodeInfo.Pods() {
+			if name, ok := provisioningRequestName(podInfo.Pod); ok {
+				scheduledPods[podInfo.Pod.Namespace+"/"+name]++
+			}
+		}
+	}
 	podsToCreate := []*apiv1.Pod{}
 	for _, provReq := range provReqs {
 		if !conditions.ShouldCapacityBeBooked(provReq, p.checkCapacityProcessorInstance) {
+			continue
+		}
+		// All pods already scheduled
+		if scheduledPods[provReq.Namespace+"/"+provReq.Name] >= provReq.PodCount() {
+			conditions.AddOrUpdateCondition(provReq, v1.BookingExpired, metav1.ConditionTrue, conditions.CapacityBookingConsumedReason, conditions.CapacityBookingConsumedMsg, metav1.NewTime(p.now()))
+			if _, err := p.client.UpdateProvisioningRequest(provReq.ProvisioningRequest); err != nil {
+				klog.Errorf("failed to add BookingExpired condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, err)
+			}
 			continue
 		}
 		pods, err := provreq_pods.PodsForProvisioningRequest(provReq)

--- a/cluster-autoscaler/processors/provreq/processor_test.go
+++ b/cluster-autoscaler/processors/provreq/processor_test.go
@@ -18,12 +18,14 @@ package provreq
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
@@ -33,6 +35,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest/provreqwrapper"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
 
 func TestRefresh(t *testing.T) {
@@ -297,6 +300,56 @@ func TestBookCapacity(t *testing.T) {
 			processor.bookCapacity(&autoscalingCtx)
 			if (test.capacityIsBooked && len(injector.pods) == 0) || (!test.capacityIsBooked && len(injector.pods) > 0) {
 				t.Fail()
+			}
+		})
+	}
+}
+
+func TestBookCapacityConsumed(t *testing.T) {
+	const podCount = 2
+	testCases := []struct {
+		name          string
+		scheduledPods int
+		booked        bool
+	}{
+		{name: "none scheduled", scheduledPods: 0, booked: true},
+		{name: "partially scheduled", scheduledPods: 1, booked: true},
+		{name: "fully scheduled", scheduledPods: 2, booked: false},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			provReq := provreqwrapper.BuildTestProvisioningRequest("ns", "pr", "2", "100m", "", podCount, false, time.Now(), v1.ProvisioningClassBestEffortAtomicScaleUp)
+			conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, "", "", metav1.Now())
+
+			node := BuildTestNode("node", 10000, 10000)
+			scheduledPods := make([]*apiv1.Pod, test.scheduledPods)
+			for i := range scheduledPods {
+				pod := BuildTestPod(fmt.Sprintf("pod-%d", i), 1000, 0, func(p *apiv1.Pod) { p.Namespace = "ns"; p.Spec.NodeName = "node" })
+				pod.Annotations[v1.ProvisioningRequestPodAnnotationKey] = "pr"
+				scheduledPods[i] = pod
+			}
+
+			injector := &fakeInjector{pods: []*apiv1.Pod{}}
+			client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, provReq)
+			processor := &provReqProcessor{now: time.Now, client: client, maxUpdated: 20, injector: injector}
+			autoscalingCtx, _ := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, nil, nil, nil, nil, nil, nil)
+			if err := autoscalingCtx.ClusterSnapshot.SetClusterState([]*apiv1.Node{node}, scheduledPods, nil, nil); err != nil {
+				t.Fatalf("failed to set cluster state: %v", err)
+			}
+
+			processor.bookCapacity(&autoscalingCtx)
+
+			if booked := len(injector.pods) > 0; booked != test.booked {
+				t.Errorf("booked: got %v, want %v", booked, test.booked)
+			}
+			updated, err := client.ProvisioningRequest("ns", "pr")
+			if err != nil {
+				t.Fatalf("failed to get ProvisioningRequest: %v", err)
+			}
+			cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1.BookingExpired)
+			consumed := cond != nil && cond.Reason == conditions.CapacityBookingConsumedReason
+			if consumed != !test.booked {
+				t.Errorf("consumed: got %v, want %v", consumed, !test.booked)
 			}
 		})
 	}

--- a/cluster-autoscaler/provisioningrequest/conditions/conditions.go
+++ b/cluster-autoscaler/provisioningrequest/conditions/conditions.go
@@ -52,6 +52,10 @@ const (
 	CapacityReservationTimeExpiredReason = "CapacityReservationTimeExpired"
 	// CapacityReservationTimeExpiredMsg is added if capacity reservation time is expired.
 	CapacityReservationTimeExpiredMsg = "Capacity reservation time is expired"
+	// CapacityBookingConsumedReason is added when all of a ProvisioningRequest's pods are scheduled.
+	CapacityBookingConsumedReason = "CapacityBookingConsumed"
+	// CapacityBookingConsumedMsg is added when all of a ProvisioningRequest's pods are scheduled.
+	CapacityBookingConsumedMsg = "Capacity booking consumed: all pods scheduled"
 	// ExpiredReason is added if ProvisioningRequest is expired.
 	ExpiredReason = "Expired"
 	// ExpiredMsg is added if ProvisioningRequest is expired.

--- a/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
+++ b/cluster-autoscaler/provisioningrequest/provreqwrapper/wrapper.go
@@ -67,6 +67,15 @@ func (pr *ProvisioningRequest) PodSets() ([]PodSet, error) {
 	return podSets, nil
 }
 
+// PodCount returns the total number of pods the Provisioning Request provisions for.
+func (pr *ProvisioningRequest) PodCount() int {
+	count := 0
+	for _, podSet := range pr.Spec.PodSets {
+		count += int(podSet.Count)
+	}
+	return count
+}
+
 // errMissingPodTemplates creates error that is passed when there are missing pod templates.
 func errMissingPodTemplates(podSets []v1.PodSet, podTemplates []*apiv1.PodTemplate) error {
 	foundPodTemplates := map[string]struct{}{}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Expires booking once it founds that the all pods for the ProvisioningRequest are scheduled.

This solves a bug when bookCapacity reserves capacity for every pod of a Provisioned ProvisioningRequest, including pods already running in the cluster, for the full reservation window. This leads to duplicate capacity calculation so some other ProvisioningRequests remain with CapacityIsNotFound.

* Sets BookingExpired for PRs with all pods already scheduled
* Adds a new reason for BookingExpired - CapacityBookingConsumed
* Adds a test for the bug


#### Which issue(s) this PR fixes:

Fixes #9805

#### Special notes for your reviewer:

I tried to make the minial change, so I used BookingExpired. But maybe it makes sense to add a new condition. Or vice versa, to skip consumed PRs silently without booking - in this case it will be just a fix for a duplicated resource count without any externally visible changes.

#### Does this PR introduce a user-facing change?

* Adds a new reason for BookingExpired - CapacityBookingConsumed

```release-note
Once all pods for the ProvisioningRequest are scheduled the ProvisioningRequest adds condition BookingExpired with the reason CapacityBookingConsumed
```
