### PR TITLE
Increase bucket count for function_duration_seconds metric

### DIFF
--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -323,7 +323,7 @@ func newCaMetrics() *caMetrics {
 				Namespace: caNamespace,
 				Name:      "function_duration_seconds",
 				Help:      "Time taken by various parts of CA main loop.",
-				Buckets:   k8smetrics.ExponentialBuckets(0.01, 1.5, 30), // 0.01, 0.015, 0.0225, ..., 852.2269299239293, 1278.3403948858938
+				Buckets:   k8smetrics.ExponentialBucketsRange(0.1, 1800.0, 150),
 			}, []string{"function"},
 		),
 


### PR DESCRIPTION
Enhance the precision of the existing function_duration_seconds histogram-based metric by expanding its bucket count. This improvement aims to provide more accurate performance measurements for Cluster Autoscaler functions by increasing the number of observation points within critical duration ranges.

```release-note
NONE
```