### PR TITLE
feat(hetzner): support per-nodepool Hetzner firewalls

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/README.md
+++ b/cluster-autoscaler/cloudprovider/hetzner/README.md
@@ -40,7 +40,8 @@ The cluster autoscaler for Hetzner Cloud scales worker nodes.
                     "effect": "NoExecute"
                 }
             ],
-            "subnetIPRange": "10.0.0.0/24" // Optional, if not set the defaultSubnetIPRange will be used - make sure this subnet exists within you private network and to use the cidr notation
+            "subnetIPRange": "10.0.0.0/24", // Optional, if not set the defaultSubnetIPRange will be used - make sure this subnet exists within you private network and to use the cidr notation
+            "firewalls": ["my-pool1-firewall"] // Optional, firewall ids or names attached to this pool's servers in addition to HCLOUD_FIREWALL
         }
     }
 }
@@ -70,6 +71,8 @@ The global `defaultSubnetIPRange` can be overridden on a per-nodepool basis by a
 The `labels` field in a `nodeConfig` specifies key-value pairs used to simulate Kubernetes node labels for autoscaler scheduling decisions.
 
 The `serverLabels` field specifies key-value pairs applied directly to the Hetzner Cloud server at creation time (via the Hetzner API). They are merged with the mandatory internal label `cluster.autoscaler.nodeGroupLabel` (which identifies the node group) before being sent to the API. This allows you to tag servers with metadata visible in the Hetzner Cloud Console, usable for filtering via the Hetzner API, or required by cluster bootstrappers that authenticate nodes via Hetzner server labels (e.g. kops).
+
+The `firewalls` field specifies firewall ids or names attached to that nodepool's servers, in addition to the cluster-wide `HCLOUD_FIREWALL`. The cluster firewall and the per-nodepool firewalls are merged (deduplicated by id), so a pool can carry extra rules without relaxing the firewall on the rest of the cluster. Only available with the `nodeConfigs` format.
 
 `HCLOUD_NETWORK` Default empty , The id or name of the network that is used in the cluster , @see https://docs.hetzner.cloud/#networks
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -345,8 +345,6 @@ func getFirewall(manager *hetznerManager, firewallRef string) (*hcloud.Firewall,
 	defer cancel()
 
 	firewall, _, err := manager.client.Firewall.Get(ctx, firewallRef)
-
-	// Check if an error occurred
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, fmt.Errorf("Timed out checking if firewall `%s` exists.", firewallRef)

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -237,7 +237,7 @@ func BuildHetzner(_ *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDi
 
 		var placementGroup *hcloud.PlacementGroup
 		var subnetIPRange *net.IPNet
-		var firewalls []*hcloud.Firewall
+		var poolFirewalls []*hcloud.Firewall
 		if manager.clusterConfig.IsUsingNewFormat {
 			_, ok := manager.clusterConfig.NodeConfigs[spec.name]
 			if !ok {
@@ -265,7 +265,7 @@ func BuildHetzner(_ *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDi
 				if firewall == nil {
 					klog.Fatalf("The requested firewall `%s` does not appear to exist.", firewallRef)
 				}
-				firewalls = append(firewalls, firewall)
+				poolFirewalls = append(poolFirewalls, firewall)
 			}
 
 			if manager.network != nil {
@@ -295,7 +295,7 @@ func BuildHetzner(_ *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDi
 			clusterUpdateMutex: &clusterUpdateLock,
 			placementGroup:     placementGroup,
 			subnetIPRange:      subnetIPRange,
-			firewalls:          firewalls,
+			firewalls:          buildServerCreateFirewalls(manager.firewall, poolFirewalls),
 		}
 	}
 

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -237,6 +237,7 @@ func BuildHetzner(_ *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDi
 
 		var placementGroup *hcloud.PlacementGroup
 		var subnetIPRange *net.IPNet
+		var firewalls []*hcloud.Firewall
 		if manager.clusterConfig.IsUsingNewFormat {
 			_, ok := manager.clusterConfig.NodeConfigs[spec.name]
 			if !ok {
@@ -255,6 +256,18 @@ func BuildHetzner(_ *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDi
 				}
 				placementGroupTotals[placementGroup.Name] += spec.maxSize
 			}
+
+			for _, firewallRef := range manager.clusterConfig.NodeConfigs[spec.name].Firewalls {
+				firewall, err := getFirewall(manager, firewallRef)
+				if err != nil {
+					klog.Fatalf("Encountered error while fetching firewall: %v", err)
+				}
+				if firewall == nil {
+					klog.Fatalf("The requested firewall `%s` does not appear to exist.", firewallRef)
+				}
+				firewalls = append(firewalls, firewall)
+			}
+
 			if manager.network != nil {
 				if manager.clusterConfig.NodeConfigs[spec.name].SubnetIPRange != "" {
 					_, subnetIPRange, err = net.ParseCIDR(manager.clusterConfig.NodeConfigs[spec.name].SubnetIPRange)
@@ -282,6 +295,7 @@ func BuildHetzner(_ *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDi
 			clusterUpdateMutex: &clusterUpdateLock,
 			placementGroup:     placementGroup,
 			subnetIPRange:      subnetIPRange,
+			firewalls:          firewalls,
 		}
 	}
 
@@ -324,6 +338,23 @@ func getPlacementGroup(manager *hetznerManager, placementGroupRef string) (*hclo
 	}
 
 	return placementGroup, nil
+}
+
+func getFirewall(manager *hetznerManager, firewallRef string) (*hcloud.Firewall, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	firewall, _, err := manager.client.Firewall.Get(ctx, firewallRef)
+
+	// Check if an error occurred
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("Timed out checking if firewall `%s` exists.", firewallRef)
+		}
+		return nil, fmt.Errorf("Failed to verify if firewall `%s` exists. Error: %w", firewallRef, err)
+	}
+
+	return firewall, nil
 }
 
 func createNodePoolSpec(groupSpec string) (*hetznerNodeGroupSpec, error) {

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -81,6 +81,9 @@ type NodeConfig struct {
 	ServerLabels   map[string]string
 	ImagesForArch  *ImageList
 	SubnetIPRange  string
+	// Firewalls are additional firewall ids or names attached to this nodepool's
+	// servers, on top of the cluster-wide HCLOUD_FIREWALL.
+	Firewalls []string
 }
 
 // LegacyConfig holds the configuration in the legacy format

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -51,6 +51,7 @@ type hetznerNodeGroup struct {
 	clusterUpdateMutex *sync.Mutex
 	placementGroup     *hcloud.PlacementGroup
 	subnetIPRange      *net.IPNet
+	firewalls          []*hcloud.Firewall
 }
 
 type hetznerNodeGroupSpec struct {
@@ -454,6 +455,26 @@ func instanceTypeArch(manager *hetznerManager, instanceType string) (string, err
 	}
 }
 
+// buildServerCreateFirewalls returns the firewalls to attach to a new server: the
+// cluster-wide firewall (HCLOUD_FIREWALL, if set) plus the nodepool's own
+// firewalls, deduplicated by id so a pool can harmlessly list the global one.
+func buildServerCreateFirewalls(clusterFirewall *hcloud.Firewall, nodePoolFirewalls []*hcloud.Firewall) []*hcloud.ServerCreateFirewall {
+	var result []*hcloud.ServerCreateFirewall
+	seen := make(map[int64]bool)
+	add := func(firewall *hcloud.Firewall) {
+		if firewall == nil || seen[firewall.ID] {
+			return
+		}
+		seen[firewall.ID] = true
+		result = append(result, &hcloud.ServerCreateFirewall{Firewall: *firewall})
+	}
+	add(clusterFirewall)
+	for _, firewall := range nodePoolFirewalls {
+		add(firewall)
+	}
+	return result
+}
+
 func createServer(n *hetznerNodeGroup) error {
 	ctx, cancel := context.WithTimeout(n.manager.apiCallContext, n.manager.createTimeout)
 	defer cancel()
@@ -503,10 +524,7 @@ func createServer(n *hetznerNodeGroup) error {
 	if n.manager.network != nil && n.subnetIPRange == nil {
 		opts.Networks = []*hcloud.Network{n.manager.network}
 	}
-	if n.manager.firewall != nil {
-		serverCreateFirewall := &hcloud.ServerCreateFirewall{Firewall: *n.manager.firewall}
-		opts.Firewalls = []*hcloud.ServerCreateFirewall{serverCreateFirewall}
-	}
+	opts.Firewalls = buildServerCreateFirewalls(n.manager.firewall, n.firewalls)
 
 	serverCreateResult, _, err := n.manager.client.Server.Create(ctx, opts)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group.go
@@ -51,7 +51,7 @@ type hetznerNodeGroup struct {
 	clusterUpdateMutex *sync.Mutex
 	placementGroup     *hcloud.PlacementGroup
 	subnetIPRange      *net.IPNet
-	firewalls          []*hcloud.Firewall
+	firewalls          []*hcloud.ServerCreateFirewall
 }
 
 type hetznerNodeGroupSpec struct {
@@ -458,6 +458,7 @@ func instanceTypeArch(manager *hetznerManager, instanceType string) (string, err
 // buildServerCreateFirewalls returns the firewalls to attach to a new server: the
 // cluster-wide firewall (HCLOUD_FIREWALL, if set) plus the nodepool's own
 // firewalls, deduplicated by id so a pool can harmlessly list the global one.
+// It is computed once at node-group build time and reused for every server.
 func buildServerCreateFirewalls(clusterFirewall *hcloud.Firewall, nodePoolFirewalls []*hcloud.Firewall) []*hcloud.ServerCreateFirewall {
 	var result []*hcloud.ServerCreateFirewall
 	seen := make(map[int64]bool)
@@ -524,7 +525,7 @@ func createServer(n *hetznerNodeGroup) error {
 	if n.manager.network != nil && n.subnetIPRange == nil {
 		opts.Networks = []*hcloud.Network{n.manager.network}
 	}
-	opts.Firewalls = buildServerCreateFirewalls(n.manager.firewall, n.firewalls)
+	opts.Firewalls = n.firewalls
 
 	serverCreateResult, _, err := n.manager.client.Server.Create(ctx, opts)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_node_group_test.go
@@ -21,7 +21,41 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud"
 )
+
+func TestBuildServerCreateFirewalls(t *testing.T) {
+	global := &hcloud.Firewall{ID: 1}
+	poolA := &hcloud.Firewall{ID: 2}
+	poolB := &hcloud.Firewall{ID: 3}
+
+	idsOf := func(firewalls []*hcloud.ServerCreateFirewall) []int64 {
+		ids := make([]int64, 0, len(firewalls))
+		for _, f := range firewalls {
+			ids = append(ids, f.Firewall.ID)
+		}
+		return ids
+	}
+
+	t.Run("none", func(t *testing.T) {
+		assert.Empty(t, buildServerCreateFirewalls(nil, nil))
+	})
+	t.Run("global only", func(t *testing.T) {
+		assert.Equal(t, []int64{1}, idsOf(buildServerCreateFirewalls(global, nil)))
+	})
+	t.Run("per-pool only", func(t *testing.T) {
+		assert.Equal(t, []int64{2, 3}, idsOf(buildServerCreateFirewalls(nil, []*hcloud.Firewall{poolA, poolB})))
+	})
+	t.Run("global plus per-pool", func(t *testing.T) {
+		assert.Equal(t, []int64{1, 2, 3}, idsOf(buildServerCreateFirewalls(global, []*hcloud.Firewall{poolA, poolB})))
+	})
+	t.Run("dedups the global firewall listed per-pool", func(t *testing.T) {
+		assert.Equal(t, []int64{1, 2}, idsOf(buildServerCreateFirewalls(global, []*hcloud.Firewall{global, poolA})))
+	})
+	t.Run("dedups repeats within per-pool", func(t *testing.T) {
+		assert.Equal(t, []int64{2}, idsOf(buildServerCreateFirewalls(nil, []*hcloud.Firewall{poolA, poolA})))
+	})
+}
 
 func TestFindImageWithPerNodepoolConfig(t *testing.T) {
 	// Test case 1: Nodepool with specific imagesForArch should use those images


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Today the Hetzner cloud provider attaches a single, cluster-wide firewall (`HCLOUD_FIREWALL`) to every server it creates. There is no way to give one nodepool extra firewall rules without applying them to the entire cluster.

This PR adds a `firewalls` field to `NodeConfig` (`nodeConfigs` in `HCLOUD_CLUSTER_CONFIG`) listing additional firewall ids or names to attach to that pool's servers, on top of `HCLOUD_FIREWALL`. The cluster firewall and the per-nodepool firewalls are merged (deduplicated by id) at server creation, so a pool can carry extra rules — e.g. a dedicated ingress/edge pool that needs a public port range — without relaxing the firewall on the rest of the cluster.

Firewalls are resolved once at provider initialization and fail fast if a referenced firewall does not exist, mirroring the existing `placementGroup` handling. `HCLOUD_FIREWALL` is unchanged and remains cluster-wide; the new field is optional and additive, so existing deployments behave identically. Per-nodepool firewalls require the `nodeConfigs` format.

#### Which issue(s) this PR fixes:

Fixes #9809 

#### Special notes for your reviewer:

- Backward compatible: `HCLOUD_FIREWALL` behaviour is untouched and `firewalls` defaults to empty.
- The merge is deduplicated by firewall id, so a pool may list the global firewall harmlessly and Hetzner never sees a duplicate attachment.
- Mirrors the existing per-pool `placementGroup` pattern: resolved in `BuildHetzner`, stored on the node group, applied in `createServer`.
- Firewalls are attached at server *creation*; this does not retroactively change firewalls on already-running nodes.
- Unit test added for the global/per-pool/dedup merge (`TestBuildServerCreateFirewalls`); README updated.

#### Does this PR introduce a user-facing change?

```release-note
The Hetzner cloud provider adds a new `firewalls` field to `nodeConfigs` in `HCLOUD_CLUSTER_CONFIG`. Firewalls specified there (ids or names) are attached to that nodepool's servers at creation time, in addition to the cluster-wide `HCLOUD_FIREWALL`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
