### PR TITLE
Register ScaleUpFailures registry as a part of NodeGroupChangeObserverList

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -408,7 +408,6 @@ func (csr *ClusterStateRegistry) backoffNodeGroup(nodeGroup cloudprovider.NodeGr
 // when trying to scale-up node group. It will mark this group as not safe to autoscale
 // for some time.
 func (csr *ClusterStateRegistry) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
-	csr.scaleUpFailures.RegisterFailedScaleUp(nodeGroup, delta, errorInfo, currentTime)
 	csr.backoffNodeGroup(nodeGroup, errorInfo, currentTime)
 }
 

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -100,11 +100,12 @@ func TestOKWithScaleUp(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: time.Minute}),
 		&emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 			MaxTotalUnreadyPercentage: 10,
 			OkTotalUnreadyCount:       1,
-		}))
+		}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 4, time.Now())
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
@@ -139,11 +140,13 @@ func TestEmptyOK(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
+
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: time.Minute}),
 		&emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 			MaxTotalUnreadyPercentage: 10,
 			OkTotalUnreadyCount:       1,
-		}))
+		}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{}, now.Add(-5*time.Second))
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
@@ -294,10 +297,12 @@ func TestOKOneUnreadyNode(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
+
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}))
+	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
@@ -329,10 +334,11 @@ func TestNodeWithoutNodeGroupDontCrash(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}))
+	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{noNgNode}, now)
 	assert.NoError(t, err)
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
@@ -356,10 +362,11 @@ func TestOKOneUnreadyNodeWithScaleDownCandidate(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}))
+	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
 	clusterstate.UpdateScaleDownCandidates([]*scaledown.UnneededNode{{Node: ng1_1}}, now)
 
@@ -410,10 +417,11 @@ func TestMissingNodes(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}))
+	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
@@ -450,10 +458,11 @@ func TestTooManyUnready(t *testing.T) {
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 35 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}))
+	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.False(t, clusterstate.IsClusterHealthy())
@@ -584,8 +593,9 @@ func TestExpiredScaleUp(t *testing.T) {
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 
-	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, withMetrics(mockMetrics, provider))
+	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, withMetrics(mockMetrics, provider), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 
 	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 4, now.Add(-3*time.Minute))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, now)
@@ -615,10 +625,11 @@ func TestRegisterScaleDown(t *testing.T) {
 
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 35 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}))
+	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	now := time.Now()
 	clusterstate.RegisterScaleDown(provider.GetNodeGroup("ng1"), "ng1-1", now.Add(time.Minute), now)
 	assert.Equal(t, 1, len(clusterstate.scaleDownRequests))
@@ -708,10 +719,11 @@ func TestUpcomingNodes(t *testing.T) {
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}))
+	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 6, now)
 	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng2"), 1, now)
 	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng3"), 2, now)
@@ -758,10 +770,11 @@ func TestTaintBasedNodeDeletion(t *testing.T) {
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
 	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
-	}))
+	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2}, now)
 	assert.NoError(t, err)
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
@@ -1200,7 +1213,7 @@ func TestScaleUpFailures(t *testing.T) {
 
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 
-	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, WithScaleUpFailuresRegistry(scaleUpFailuresRegistry), withMetrics(mockMetrics, provider))
+	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, withMetrics(mockMetrics, provider), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 
 	clusterstate.scaleStateNotifier.RegisterFailedScaleUp(provider.GetNodeGroup("ng1"), 3, cloudprovider.InstanceErrorInfo{ErrorCode: string(metrics.Timeout)}, now)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
@@ -2089,6 +2102,15 @@ func TestIsSuspendedNode(t *testing.T) {
 	}
 }
 
+// withNotifiedScaleUpFailuresRegistry sets ScaleUpFailures registry for the ClusterStateRegistry and registers it in the list of observers.
+// The only differtence wrt WithScaleUpFailuresRegistry() is that is autoregisters the scale up failures registry.
+func withNotifiedScaleUpFailuresRegistry(r *scaleupfailures.Registry) Option {
+	return func(o *options) {
+		o.scaleUpFailures = r
+		o.scaleStateNotifier.Register(r)
+	}
+}
+
 // withMetrics sets the metrics for the ClusterStateRegistry.
 func withMetrics(m *mockMetrics, cloudProvider cloudprovider.CloudProvider) Option {
 	return func(o *options) {
@@ -2123,6 +2145,7 @@ func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := newTestClusterStateRegistry(
 		provider,
 		fakeLogRecorder,
@@ -2131,6 +2154,7 @@ func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
 			MaxTotalUnreadyPercentage: 10,
 			OkTotalUnreadyCount:       1,
 		}),
+		withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry),
 	)
 
 	// Register scale up that started 3 minutes ago (exceeded 2 min max provision time)
@@ -2146,6 +2170,21 @@ func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
 
 	// Verify the scale-up request was removed from the registry
 	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
+
+	failures := clusterstate.GetScaleUpFailures()
+	assert.Equal(t, map[string][]scaleupfailures.Record{
+		"ng1": {
+			{
+				ErrorInfo: cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OtherErrorClass,
+					ErrorCode:    string(metrics.Timeout),
+					ErrorMessage: "Scale-up timed out for node group ng1 after 3m0s",
+				},
+				Delta: 4,
+				Time:  now,
+			},
+		},
+	}, failures)
 }
 
 func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
@@ -2173,6 +2212,7 @@ func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := newTestClusterStateRegistry(
 		provider,
 		fakeLogRecorder,
@@ -2181,6 +2221,7 @@ func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
 			MaxTotalUnreadyPercentage: 10,
 			OkTotalUnreadyCount:       1,
 		}),
+		withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry),
 	)
 
 	// Register scale up that started 3 minutes ago (exceeded 2 min max provision time)
@@ -2215,6 +2256,21 @@ func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
 
 	// The scale-up request should still be removed even when DecreaseTargetSize fails
 	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
+
+	failures := clusterstate.GetScaleUpFailures()
+	assert.Equal(t, map[string][]scaleupfailures.Record{
+		"ng1": {
+			{
+				ErrorInfo: cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OtherErrorClass,
+					ErrorCode:    string(metrics.Timeout),
+					ErrorMessage: "Scale-up timed out for node group ng1 after 3m0s",
+				},
+				Delta: 4,
+				Time:  now,
+			},
+		},
+	}, failures)
 }
 
 func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
@@ -2247,6 +2303,7 @@ func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
+	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := newTestClusterStateRegistry(
 		provider,
 		fakeLogRecorder,
@@ -2255,6 +2312,7 @@ func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
 			MaxTotalUnreadyPercentage: 10,
 			OkTotalUnreadyCount:       1,
 		}),
+		withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry),
 	)
 
 	// Register scale up requesting 4 nodes that started 3 minutes ago
@@ -2271,4 +2329,19 @@ func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
 
 	// Verify the scale-up request was removed
 	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
+
+	failures := clusterstate.GetScaleUpFailures()
+	assert.Equal(t, map[string][]scaleupfailures.Record{
+		"ng1": {
+			{
+				ErrorInfo: cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OtherErrorClass,
+					ErrorCode:    string(metrics.Timeout),
+					ErrorMessage: "Scale-up timed out for node group ng1 after 3m0s",
+				},
+				Delta: 4,
+				Time:  now,
+			},
+		},
+	}, failures)
 }

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -2102,29 +2102,6 @@ func TestIsSuspendedNode(t *testing.T) {
 	}
 }
 
-// withNotifiedScaleUpFailuresRegistry sets ScaleUpFailures registry for the ClusterStateRegistry and registers it in the list of observers.
-// The only differtence wrt WithScaleUpFailuresRegistry() is that is autoregisters the scale up failures registry.
-func withNotifiedScaleUpFailuresRegistry(r *scaleupfailures.Registry) Option {
-	return func(o *options) {
-		o.scaleUpFailures = r
-		o.scaleStateNotifier.Register(r)
-	}
-}
-
-// withMetrics sets the metrics for the ClusterStateRegistry.
-func withMetrics(m *mockMetrics, cloudProvider cloudprovider.CloudProvider) Option {
-	return func(o *options) {
-		metricProducer := nodegroupchange.NewNodeGroupChangeMetricsProducer(cloudProvider, m)
-		o.scaleStateNotifier.Register(metricProducer)
-	}
-}
-
-// newTestClusterStateRegistry creates new ClusterStateRegistry object and registers mock metrics observers.
-func newTestClusterStateRegistry(cloudProvider cloudprovider.CloudProvider, logRecorder *utils.LogEventRecorder, opts ...Option) *ClusterStateRegistry {
-	nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute})
-	return NewNotifiedClusterStateRegistry(cloudProvider, logRecorder, newBackoff(), nodeGroupConfigProcessor, &emptyTemplateNodeInfoRegistry{}, opts...)
-}
-
 func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
 	now := time.Now()
 
@@ -2344,4 +2321,27 @@ func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
 			},
 		},
 	}, failures)
+}
+
+// withNotifiedScaleUpFailuresRegistry sets ScaleUpFailures registry for the ClusterStateRegistry and registers it in the list of observers.
+// The only differtence wrt WithScaleUpFailuresRegistry() is that is autoregisters the scale up failures registry.
+func withNotifiedScaleUpFailuresRegistry(r *scaleupfailures.Registry) Option {
+	return func(o *options) {
+		o.scaleUpFailures = r
+		o.scaleStateNotifier.Register(r)
+	}
+}
+
+// withMetrics sets the metrics for the ClusterStateRegistry.
+func withMetrics(m *mockMetrics, cloudProvider cloudprovider.CloudProvider) Option {
+	return func(o *options) {
+		metricProducer := nodegroupchange.NewNodeGroupChangeMetricsProducer(cloudProvider, m)
+		o.scaleStateNotifier.Register(metricProducer)
+	}
+}
+
+// newTestClusterStateRegistry creates new ClusterStateRegistry object and registers mock metrics observers.
+func newTestClusterStateRegistry(cloudProvider cloudprovider.CloudProvider, logRecorder *utils.LogEventRecorder, opts ...Option) *ClusterStateRegistry {
+	nodeGroupConfigProcessor := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 2 * time.Minute})
+	return NewNotifiedClusterStateRegistry(cloudProvider, logRecorder, newBackoff(), nodeGroupConfigProcessor, &emptyTemplateNodeInfoRegistry{}, opts...)
 }

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -170,6 +170,8 @@ func NewStaticAutoscaler(
 		MaxTotalUnreadyPercentage: opts.MaxTotalUnreadyPercentage,
 		OkTotalUnreadyCount:       opts.OkTotalUnreadyCount,
 	}
+	// Register the scale up failures registry before CSR so that it is updated before the node group is sent to the backoff.
+	processors.ScaleStateNotifier.Register(scaleUpFailuresRegistry)
 	clusterStateRegistry := clusterstate.NewNotifiedClusterStateRegistry(cloudProvider, autoscalingKubeClients.LogRecorder, backoff, processors.NodeGroupConfigProcessor, templateNodeInfoRegistry, clusterstate.WithScaleUpFailuresRegistry(scaleUpFailuresRegistry), clusterstate.WithConfig(clusterStateConfig), clusterstate.WithAsyncNodeGroupStateChecker(processors.AsyncNodeGroupStateChecker), clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
@@ -190,8 +192,6 @@ func NewStaticAutoscaler(
 
 	taintConfig := taints.NewTaintConfig(opts)
 
-	// TODO(autoscaler/issues/9642): Register ScaleUpFailuresRegistry to processors.ScaleStateNotifier before ClusterStateRegistry
-	// and remove manual updates from ClusterStateRegistry.RegisterFailedScaleUp method.
 	processors.ScaleDownCandidatesNotifier.Register(clusterStateRegistry)
 	processors.ScaleStateNotifier.Register(nodegroupchange.NewNodeGroupChangeMetricsProducer(cloudProvider, metrics.DefaultMetrics))
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is a follow up for retrieving scale up registry outside of CSR (more on this: https://github.com/kubernetes/autoscaler/pull/9308). 
Here we finalizing it by registering `scaleupfailures.Registry` in `NodeGroupChangeObserversList` and calling its methods only through the chain processor. Effectively we called directly only `RegisterFailedScaleUp` from the CSR and now it is no longer needed.
Also, I modified the unit tests to properly register `scaleupfailures.Registry` in the majority of them (which is not strictly needed I guess, but nice-to-have)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9642

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
