### PR TITLE
chart(vpa): bump chart version to 0.10.0 to publish appVersion 1.7.0

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -4,7 +4,7 @@ WARNING: This chart is currently under development and is not ready for producti
 
 Automatically adjust resources for your workloads
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#9707 ("Update VPA defaults to 1.7.0") bumped the chart `appVersion` from 1.6.0 to 1.7.0 but left the chart `version` at 0.9.0. The chart-release workflow runs `helm/chart-releaser-action` with `skip_existing: true`, and `vertical-pod-autoscaler-chart-0.9.0` was already published (as appVersion 1.6.0), so chart-releaser skips it. As a result no chart carrying appVersion 1.7.0 has ever been published: the latest chart on https://kubernetes.github.io/autoscaler is still 0.9.0 / appVersion 1.6.0, whose bundled CRD predates 1.7.0 (no `InPlace` updateMode, no `observedGeneration` status, no `memoryAggregationInterval*`).

This bumps the chart `version` to 0.10.0 so chart-releaser publishes the chart carrying appVersion 1.7.0 on the next push to master. The README version badge is regenerated to match.

#### Which issue(s) this PR fixes:

(none)

#### Special notes for your reviewer:

Version + README-badge only; `appVersion` is already 1.7.0 on master (from #9707). I chose a minor bump (0.10.0) since the appVersion jump includes a new feature (InPlace updateMode) and CRD schema changes — happy to switch to a patch (0.9.1) if you prefer.

#### Does this PR introduce a user-facing change?

```release-note
The vertical-pod-autoscaler Helm chart is published at 0.10.0, carrying appVersion 1.7.0 (including the InPlace updateMode CRD changes).
```
