### PR TITLE
Add in-place infeasible cached metric

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -516,7 +516,7 @@ func filterPods(pods []*corev1.Pod, predicate func(*corev1.Pod) bool) []*corev1.
 	return result
 }
 
-func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restriction.PodsInPlaceRestriction, vpa *vpa_types.VerticalPodAutoscaler, vpaSize int, infeasibleAttempts map[types.UID]*vpa_types.RecommendedPodResources, eventRecorder record.EventRecorder) []*corev1.Pod {
+func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restriction.PodsInPlaceRestriction, vpa *vpa_types.VerticalPodAutoscaler, vpaCount int, infeasibleAttempts map[types.UID]*vpa_types.RecommendedPodResources, eventRecorder record.EventRecorder) []*corev1.Pod {
 	return filterPods(pods, func(pod *corev1.Pod) bool {
 		updateMode := *vpa.Spec.UpdatePolicy.UpdateMode
 		decision := inplaceRestriction.CanInPlaceUpdate(pod, vpa, infeasibleAttempts)

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -334,7 +334,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 		withEvictable := false
 
 		if (updateMode == vpa_types.UpdateModeInPlaceOrRecreate) || (updateMode == vpa_types.UpdateModeInPlace && inPlaceFeatureEnabled) {
-			podsForInPlace = u.getPodsUpdateOrder(filterNonInPlaceUpdatablePods(podsAvailableForUpdate, inPlaceLimiter, vpa, u.infeasibleAttempts), vpa)
+			podsForInPlace = u.getPodsUpdateOrder(filterNonInPlaceUpdatablePods(podsAvailableForUpdate, inPlaceLimiter, vpa, len(livePods), u.infeasibleAttempts, u.eventRecorder), vpa)
 			inPlaceUpdatablePodsCounter.Add(vpaSize, len(podsForInPlace))
 			if len(podsForInPlace) > 0 {
 				withInPlaceUpdatable = true
@@ -374,10 +374,9 @@ func (u *updater) RunOnce(ctx context.Context) {
 				continue
 
 			case utils.InPlaceInfeasibleCached:
-				// this can only be happening for InPlace mode
+				// This should be unreachable — filterNonInPlaceUpdatablePods already handles InPlaceInfeasibleCached and filters those pods out.
 				klog.V(2).InfoS("In-place update infeasible, no resource is lower in new recommendation, skipping pod", "pod", klog.KObj(pod))
 				continue
-
 			case utils.InPlaceInfeasible:
 				// This should only happen for InPlace mode
 				// Status is Infeasible, but recommendation has changed
@@ -517,7 +516,7 @@ func filterPods(pods []*corev1.Pod, predicate func(*corev1.Pod) bool) []*corev1.
 	return result
 }
 
-func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restriction.PodsInPlaceRestriction, vpa *vpa_types.VerticalPodAutoscaler, infeasibleAttempts map[types.UID]*vpa_types.RecommendedPodResources) []*corev1.Pod {
+func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restriction.PodsInPlaceRestriction, vpa *vpa_types.VerticalPodAutoscaler, vpaSize int, infeasibleAttempts map[types.UID]*vpa_types.RecommendedPodResources, eventRecorder record.EventRecorder) []*corev1.Pod {
 	return filterPods(pods, func(pod *corev1.Pod) bool {
 		updateMode := *vpa.Spec.UpdatePolicy.UpdateMode
 		decision := inplaceRestriction.CanInPlaceUpdate(pod, vpa, infeasibleAttempts)
@@ -537,6 +536,8 @@ func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restri
 		case utils.InPlaceInfeasibleCached:
 			// Cached infeasibility means we've already determined this pod cannot be
 			// updated in-place and cached the result to avoid redundant checks
+			eventRecorder.Event(pod, corev1.EventTypeNormal, "InPlaceResizeSkipped", "Previously recorded in-place update was infeasible, current recommendation is not lower than previous, skipping pod")
+			metrics_updater.RecordInPlaceInfeasibleCached(vpaSize, vpa.Name, vpa.Namespace)
 			return false
 		default:
 			return false

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -537,7 +537,7 @@ func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restri
 			// Cached infeasibility means we've already determined this pod cannot be
 			// updated in-place and cached the result to avoid redundant checks
 			eventRecorder.Event(pod, corev1.EventTypeNormal, "InPlaceResizeSkipped", "Previously recorded in-place update was infeasible, current recommendation is not lower than previous, skipping pod")
-			metrics_updater.RecordInPlaceInfeasibleCached(vpaSize, vpa.Name, vpa.Namespace)
+			metrics_updater.RecordInPlaceInfeasibleCached(vpaCount, vpa.Name, vpa.Namespace)
 			return false
 		default:
 			return false

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -536,7 +536,7 @@ func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restri
 		case utils.InPlaceInfeasibleCached:
 			// Cached infeasibility means we've already determined this pod cannot be
 			// updated in-place and cached the result to avoid redundant checks
-			eventRecorder.Event(pod, corev1.EventTypeNormal, "InPlaceResizeSkipped", "Previously recorded in-place update was infeasible, current recommendation is not lower than previous, skipping pod")
+			eventRecorder.Event(pod, corev1.EventTypeNormal, "InPlaceResizeSkipped", "Previously recorded in-place update was infeasible, current recommendation is not lower than previous, skipping resize")
 			metrics_updater.RecordInPlaceInfeasibleCached(vpaCount, vpa.Name, vpa.Namespace)
 			return false
 		default:

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go
@@ -132,6 +132,14 @@ var (
 		}, []string{"vpa_size_log2", "reason", "vpa_name", "vpa_namespace"},
 	)
 
+	inPlaceInfeasibleCachedCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "in_place_infeasible_skip_pods_total",
+			Help:      "Number of pods that were skipped for in-place update due to cached infeasibility",
+		}, []string{"vpa_size_log2", "vpa_name", "vpa_namespace"},
+	)
+
 	functionLatency = metrics.CreateExecutionTimeMetric(metricsNamespace,
 		"Time spent in various parts of VPA Updater main loop.")
 )
@@ -147,6 +155,7 @@ func Register() {
 		failedEvictionAttempts,
 		inPlaceUpdatableCount,
 		inPlaceUpdatedCount,
+		inPlaceInfeasibleCachedCount,
 		vpasWithInPlaceUpdatablePodsCount,
 		vpasWithInPlaceUpdatedPodsCount,
 		failedInPlaceUpdateAttempts,
@@ -250,6 +259,12 @@ func AddInPlaceUpdatedPod(vpaSize int, vpaName string, vpaNamespace string) {
 func RecordFailedInPlaceUpdate(vpaSize int, vpaName string, vpaNamespace string, reason string) {
 	log2 := metrics.GetVpaSizeLog2(vpaSize)
 	failedInPlaceUpdateAttempts.WithLabelValues(strconv.Itoa(log2), reason, vpaName, vpaNamespace).Inc()
+}
+
+// RecordInPlaceInfeasibleCached increases the counter of pods skipped from in-place updates due to cache by given VPA size, name, namespace
+func RecordInPlaceInfeasibleCached(vpaSize int, vpaName string, vpaNamespace string) {
+	log2 := metrics.GetVpaSizeLog2(vpaSize)
+	inPlaceInfeasibleCachedCount.WithLabelValues(strconv.Itoa(log2), vpaName, vpaNamespace).Inc()
 }
 
 // Add increases the counter for the given VPA size

--- a/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater_test.go
@@ -150,6 +150,42 @@ func TestRecordFailedEviction(t *testing.T) {
 	}
 }
 
+func TestRecordInPlaceInfeasibleCached(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		vpaSize      int
+		log2         string
+		vpaName      string
+		vpaNamespace string
+	}{
+		{
+			desc:         "VPA size 2",
+			vpaSize:      2,
+			log2:         "1",
+			vpaName:      "vpa-2",
+			vpaNamespace: "vpa-2-ns",
+		},
+		{
+			desc:         "VPA size 20",
+			vpaSize:      20,
+			log2:         "4",
+			vpaName:      "vpa-20",
+			vpaNamespace: "vpa-20-ns",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Cleanup(inPlaceInfeasibleCachedCount.Reset)
+			RecordInPlaceInfeasibleCached(tc.vpaSize, tc.vpaName, tc.vpaNamespace)
+			val := testutil.ToFloat64(inPlaceInfeasibleCachedCount.WithLabelValues(tc.log2, tc.vpaName, tc.vpaNamespace))
+			if val != 1 {
+				t.Errorf("Unexpected value for inPlaceInfeasibleCachedCount metric with labels (%s, %s): got %v, want 1", tc.log2, tc.vpaName, val)
+			}
+		})
+	}
+}
+
 func TestAddInPlaceUpdatedPod(t *testing.T) {
 	testCases := []struct {
 		desc         string


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a Prometheus counter metric (`inplace_cache_pods_total`) to track pods that were skipped from in-place updates because the infeasible result was already cached. This provides observability into how often the cache prevents redundant in-place update attempts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds a Prometheus counter metric (inplace_cache_pods_total) to track pods that were skipped from in-place updates because the infeasible result was already cached.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
