### PR TITLE
VPA: Test and document recommender metrics

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -7,6 +7,7 @@
 - [Getting Started](#getting-started)
 - [Components and Architecture](#components-and-architecture)
 - [Features and Known limitations](#features-and-known-limitations)
+- [Metrics](#metrics)
 - [Development and testing](#development-and-testing)
 - [Related links](#related-links)
 <!-- /toc -->
@@ -52,6 +53,10 @@ You can also read about the [features](./docs/features.md) and [known limitation
 > At the moment, VPA is not compatible with workloads that define pod-level `resources` stanzas. Work has started to add pod-level resources support for VPA, for more details see [AEP-7571](https://github.com/kubernetes/autoscaler/pull/8586). Users of VPA may encounter the following issues if they enable VPA for a workload with a pod-level resources stanza defined:
 > * When the admission-controller tries to set a container-level limit higher than the pod-level limit, the operation is prohibited, and the pod will not be created.
 > * When the admission-controller tries to set the newly recommended container-level requests, their total value cannot exceed the pod-level request or limit. For example, if the pod-level memory request is 100Mi, but the newly recommended total of container-level requests is 250Mi, the pod will fail to be created.
+
+## Metrics
+
+See [Recommender metrics](./docs/recommender-metrics.md) for the Prometheus metrics exported by the VPA Recommender.
 
 ## Development and testing
 

--- a/vertical-pod-autoscaler/docs/recommender-metrics.md
+++ b/vertical-pod-autoscaler/docs/recommender-metrics.md
@@ -1,0 +1,18 @@
+# Recommender metrics
+
+## Contents
+
+<!-- toc -->
+<!-- /toc -->
+
+The VPA Recommender exposes Prometheus metrics on the address configured by its `--address` flag. All Recommender metric names are prefixed with `vpa_recommender_`.
+
+| Metric name | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `vpa_recommender_vpa_objects_count` | Gauge | `update_mode`, `has_recommendation`, `api`, `matches_pods`, `unsupported_config` | Number of VPA objects present in the cluster. |
+| `vpa_recommender_recommendation_latency_seconds` | Histogram | None | Time elapsed from creating a valid VPA configuration to the first recommendation. |
+| `vpa_recommender_execution_latency_seconds` | Histogram | `step` | Time spent in parts of the VPA Recommender main loop. |
+| `vpa_recommender_aggregate_container_states_count` | Gauge | None | Number of aggregate container states tracked by the Recommender. |
+| `vpa_recommender_metric_server_responses` | Counter | `is_error`, `client_name` | Number of responses to Metrics Server queries. |
+| `vpa_recommender_prometheus_client_api_requests_count` | Counter | `code`, `method` | Number of requests to the Prometheus API. |
+| `vpa_recommender_prometheus_client_api_requests_duration_seconds` | Histogram | `code`, `method` | Duration of requests to the Prometheus API. |

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
@@ -23,12 +23,70 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 )
+
+func TestObserveRecommendationLatency(t *testing.T) {
+	before := readHistogram(t, recommendationLatency)
+
+	ObserveRecommendationLatency(time.Now().Add(-time.Second))
+
+	after := readHistogram(t, recommendationLatency)
+	if got, want := after.GetSampleCount(), before.GetSampleCount()+1; got != want {
+		t.Errorf("unexpected sample count: got %d, want %d", got, want)
+	}
+	if elapsed := after.GetSampleSum() - before.GetSampleSum(); elapsed < 1 || elapsed > 30 {
+		t.Errorf("unexpected observed recommendation latency: got %f seconds, want between 1 and 30 seconds", elapsed)
+	}
+}
+
+func TestRecordAggregateContainerStatesCount(t *testing.T) {
+	t.Cleanup(func() {
+		aggregateContainerStatesCount.Set(0)
+	})
+
+	RecordAggregateContainerStatesCount(5)
+
+	if got, want := testutil.ToFloat64(aggregateContainerStatesCount), float64(5); got != want {
+		t.Errorf("unexpected aggregate container states count: got %f, want %f", got, want)
+	}
+}
+
+func TestRecordMetricsServerResponse(t *testing.T) {
+	metricServerResponses.Reset()
+	t.Cleanup(metricServerResponses.Reset)
+
+	RecordMetricsServerResponse(nil, "default-client")
+	RecordMetricsServerResponse(nil, "default-client")
+	RecordMetricsServerResponse(fmt.Errorf("metrics server unavailable"), "default-client")
+	RecordMetricsServerResponse(fmt.Errorf("metrics server unavailable"), "fallback-client")
+
+	cases := []struct {
+		name       string
+		isError    string
+		clientName string
+		want       float64
+	}{
+		{name: "successful default client responses", isError: "false", clientName: "default-client", want: 2},
+		{name: "failed default client responses", isError: "true", clientName: "default-client", want: 1},
+		{name: "failed fallback client responses", isError: "true", clientName: "fallback-client", want: 1},
+		{name: "missing successful fallback client responses", isError: "false", clientName: "fallback-client", want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := testutil.ToFloat64(metricServerResponses.WithLabelValues(tc.isError, tc.clientName))
+			if got != tc.want {
+				t.Errorf("unexpected response count: got %f, want %f", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestObjectCounter(t *testing.T) {
 	// We verify that other update modes are handled correctly as validation
@@ -300,6 +358,16 @@ func labelsToKey(labels []*dto.LabelPair) string {
 		key.WriteRune(',')
 	}
 	return key.String()
+}
+
+func readHistogram(t *testing.T, histogram prometheus.Histogram) *dto.Histogram {
+	t.Helper()
+
+	metric := &dto.Metric{}
+	if err := histogram.Write(metric); err != nil {
+		t.Fatalf("failed to read histogram: %v", err)
+	}
+	return metric.GetHistogram()
 }
 
 func TestObjectCounterResetsAllUpdateModes(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package recommender
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -63,8 +64,8 @@ func TestRecordMetricsServerResponse(t *testing.T) {
 
 	RecordMetricsServerResponse(nil, "default-client")
 	RecordMetricsServerResponse(nil, "default-client")
-	RecordMetricsServerResponse(fmt.Errorf("metrics server unavailable"), "default-client")
-	RecordMetricsServerResponse(fmt.Errorf("metrics server unavailable"), "fallback-client")
+	RecordMetricsServerResponse(errors.New("metrics server unavailable"), "default-client")
+	RecordMetricsServerResponse(errors.New("metrics server unavailable"), "fallback-client")
 
 	cases := []struct {
 		name       string


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds unit coverage for behavior owned by the VPA Recommender metrics utilities:

- recording recommendation latency in seconds
- reporting the current aggregate container state count
- classifying Metrics Server responses by error status and client name

It also documents all Prometheus metrics emitted by the Recommender and links the reference from the VPA README.

The tests intentionally do not exercise the thin Prometheus RoundTripper wrappers, following the review feedback on the previous revision. This updates the earlier work explored in #8143 for the current codebase and keeps the coverage focused on Autoscaler-owned behavior.

#### Which issue(s) this PR fixes:

Fixes #8128

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Validation:

```text
go test -race ./pkg/utils/metrics/recommender ./pkg/recommender/routines ./pkg/recommender/input/metrics ./pkg/recommender/input/history
go vet ./pkg/utils/metrics/recommender ./pkg/recommender/routines ./pkg/recommender/input/metrics ./pkg/recommender/input/history
bash hack/verify-toc.sh
```