### PR TITLE
Fix the equivalence.PodGroup's mutation during scale up simulations for skipped node groups

### DIFF
--- a/cluster-autoscaler/core/scaleup/equivalence/groups.go
+++ b/cluster-autoscaler/core/scaleup/equivalence/groups.go
@@ -17,6 +17,7 @@ limitations under the License.
 package equivalence
 
 import (
+	"maps"
 	"reflect"
 
 	"k8s.io/autoscaler/cluster-autoscaler/utils"
@@ -101,4 +102,29 @@ func match(egs []equivalenceGroup, pod *apiv1.Pod) *equivalenceGroupId {
 		}
 	}
 	return nil
+}
+
+// Clone returns a copy of the PodGroup. It deep copies the mutable scheduling state
+// (SchedulingErrors, SchedulableGroups) but shares the Pods slice reference.
+// Note: We do not copy the Pods slice because it is read-only and never mutated
+// after the PodGroup is constructed in BuildPodGroups. Sharing the reference
+// avoids unnecessary allocations and pointer copying.
+func (eg *PodGroup) Clone() *PodGroup {
+	if eg == nil {
+		return nil
+	}
+	clonedErrors := make(map[string]status.Reasons, len(eg.SchedulingErrors))
+	maps.Copy(clonedErrors, eg.SchedulingErrors)
+	var clonedGroups []string
+	if eg.SchedulableGroups != nil {
+		clonedGroups = make([]string, len(eg.SchedulableGroups))
+		copy(clonedGroups, eg.SchedulableGroups)
+	}
+
+	return &PodGroup{
+		Pods:              eg.Pods,
+		SchedulingErrors:  clonedErrors,
+		SchedulableGroups: clonedGroups,
+		Schedulable:       eg.Schedulable,
+	}
 }

--- a/cluster-autoscaler/core/scaleup/equivalence/groups_test.go
+++ b/cluster-autoscaler/core/scaleup/equivalence/groups_test.go
@@ -25,7 +25,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -183,4 +185,82 @@ func TestEquivalenceGroupIgnoresDaemonSets(t *testing.T) {
 	pods[1].OwnerReferences = GenerateOwnerReferences(ds.Name, "DaemonSet", "apps/v1", ds.UID)
 	podGroups := groupPodsBySchedulingProperties(pods)
 	assert.Equal(t, 2, len(podGroups))
+}
+
+type testReason struct {
+	ReasonsList []string
+}
+
+func (tr *testReason) Reasons() []string {
+	return tr.ReasonsList
+}
+
+func TestPodGroupClone(t *testing.T) {
+	p1 := BuildTestPod("p1", 100, 200)
+	p2 := BuildTestPod("p2", 200, 300)
+	testCases := []struct {
+		name       string
+		mutate     func(pg *PodGroup)
+		expectDiff bool
+	}{
+		{
+			name: "modify schedulable",
+			mutate: func(pg *PodGroup) {
+				pg.Schedulable = !pg.Schedulable
+			},
+			expectDiff: true,
+		},
+		{
+			name: "modify schedulable groups",
+			mutate: func(pg *PodGroup) {
+				pg.SchedulableGroups[0] = "mutated-group"
+			},
+			expectDiff: true,
+		},
+		{
+			name: "modify scheduling errors",
+			mutate: func(pg *PodGroup) {
+				pg.SchedulingErrors["ng1"] = &testReason{ReasonsList: []string{"mutated-error"}}
+			},
+			expectDiff: true,
+		},
+		{
+			// If Pods are modified then both original and cloned are modified
+			name: "modify pods (shallow copy)",
+			mutate: func(pg *PodGroup) {
+				pg.Pods[0].Namespace = "mutated-namespace"
+			},
+			expectDiff: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pg := &PodGroup{
+				Pods: []*apiv1.Pod{p1.DeepCopy(), p2.DeepCopy()},
+				SchedulingErrors: map[string]status.Reasons{
+					"ng1": &testReason{ReasonsList: []string{"error1"}},
+				},
+				SchedulableGroups: []string{"ng1", "ng2"},
+				Schedulable:       true,
+			}
+			cloned := pg.Clone()
+			assert.NotNil(t, cloned)
+			// Verify that there are different pointers.
+			assert.True(t, pg != cloned, "Clone should return a new pointer")
+
+			// Verify that clone's content is initially identical to original's
+			assert.Empty(t, cmp.Diff(pg, cloned))
+
+			// Mutate original
+			tc.mutate(pg)
+
+			// Verify that clone is now differentiate from original (except for pod's modifications)
+			diff := cmp.Diff(pg, cloned)
+			if tc.expectDiff {
+				assert.NotEmpty(t, diff)
+			} else {
+				assert.Empty(t, diff)
+			}
+		})
+	}
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -823,7 +823,7 @@ func (o *ScaleUpOrchestrator) GetRemainingPods(egs []*equivalence.PodGroup, node
 	for _, eg := range egs {
 		// there is no need to run the simulation for the schedulable pod groups, because for them we still do not return anything.
 		if !eg.Schedulable {
-			nonSchedulableEgs = append(nonSchedulableEgs, eg)
+			nonSchedulableEgs = append(nonSchedulableEgs, eg.Clone())
 		}
 	}
 	return o.getRemainingPodsConsideringSkippedNodeGroups(nonSchedulableEgs, nodeGroups, skipped, nodeInfos)

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -2415,6 +2415,9 @@ func TestScaleUpSimulationForSkippedNodeGroups(t *testing.T) {
 					assert.Contains(t, actualInfo.RejectedNodeGroups, ng)
 				}
 			}
+			// This assertion ensures that the skipped node group simulation did not mutate the Schedulable status of the original equivalence groups.
+			// Without cloning the "partial scale-up successful" case would fail as p1 would be marked as schedulable on ng1 and would be added to podsAwaitEvaluation.
+			assert.Empty(t, scaleUpStatus.PodsAwaitEvaluation)
 		})
 	}
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In #9346 there is a bug which allows the mutation of equivalence pod group (`eg`) state to become Schedulable if there is a skipped node group which satisfies the pod predicates. Later down the line this `eg` is considered schedulable which is not true.

The fix is to do the extra `SchedulablePodGroups()` simulations on the cloned `eg`(s).
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
