### PR TITLE
Redistribute unclaimed quota to similar node groups on scale-up

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -202,20 +202,6 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	}, nil
 }
 
-func (o *ScaleUpOrchestrator) applyLimits(newNodes int, tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfos map[string]*framework.NodeInfo) (int, errors.AutoscalerError) {
-	nodeInfo, found := nodeInfos[nodeGroup.Id()]
-	if !found {
-		// This should never happen, as we already should have retrieved nodeInfo for any considered nodegroup.
-		klog.Errorf("No node info for: %s", nodeGroup.Id())
-		return 0, errors.NewAutoscalerError(errors.CloudProviderError, "No node info for best expansion option!")
-	}
-	checkResult, err := tracker.CheckDelta(o.autoscalingCtx, nodeGroup, nodeInfo.Node(), newNodes)
-	if err != nil {
-		return 0, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("failed to check resource quotas: ")
-	}
-	return checkResult.AllowedDelta, nil
-}
-
 // ScaleUpToNodeGroupMinSize tries to scale up node groups that have less nodes
 // than the configured min size. The source of truth for the current node group
 // size is the TargetSize queried directly from cloud providers. Returns
@@ -699,11 +685,49 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 		}
 		klog.V(1).Infof("Splitting scale-up between %v similar node groups: {%v}", len(targetNodeGroups), strings.Join(names, ", "))
 	}
-	scaleUpInfos, aErr := o.processors.NodeGroupSetProcessor.BalanceScaleUpBetweenGroups(o.autoscalingCtx, targetNodeGroups, newNodes)
+
+	maxAddByGroup := o.headroomByGroup(targetNodeGroups, nodeInfos, tracker)
+	scaleUpInfos, aErr := o.processors.NodeGroupSetProcessor.BalanceScaleUpBetweenGroups(o.autoscalingCtx, targetNodeGroups, newNodes, maxAddByGroup)
 	if aErr != nil {
 		return nil, aErr
 	}
 	return o.capScaleUpsByQuota(scaleUpInfos, nodeInfos, tracker), nil
+}
+
+// headroomByGroup returns, for each given node group, the maximum number of
+// nodes that may be added to it given its max size and resource quotas. Groups
+// whose headroom cannot be determined are omitted from the result.
+func (o *ScaleUpOrchestrator) headroomByGroup(
+	groups []cloudprovider.NodeGroup,
+	nodeInfos map[string]*framework.NodeInfo,
+	tracker *resourcequotas.Tracker,
+) map[string]int {
+	maxAddByGroup := make(map[string]int, len(groups))
+	for _, ng := range groups {
+		nodeInfo, found := nodeInfos[ng.Id()]
+		if !found {
+			continue
+		}
+		currentSize, err := ng.TargetSize()
+		if err != nil {
+			klog.Warningf("Failed to get target size of node group %s, ignoring its quota when balancing: %v", ng.Id(), err)
+			continue
+		}
+		probe := ng.MaxSize() - currentSize
+		if probe <= 0 {
+			// Group is already at (or above) MaxSize; nothing to add. Leaving it
+			// out of the map yields the same result as a 0 entry, since its
+			// effective max in balancing is then capped at MaxSize <= currentSize.
+			continue
+		}
+		checkResult, err := tracker.CheckQuota(o.autoscalingCtx, ng, nodeInfo.Node(), probe)
+		if err != nil {
+			klog.Warningf("Failed to check quota of node group %s, ignoring its quota when balancing: %v", ng.Id(), err)
+			continue
+		}
+		maxAddByGroup[ng.Id()] = checkResult.AllowedDelta
+	}
+	return maxAddByGroup
 }
 
 // capScaleUpsByQuota caps each group's scale-up delta by its available quota and filters
@@ -1100,26 +1124,6 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 			aErr,
 		)
 		return scaleUpPlan{}, st, err
-	}
-
-	newNodes, aErr = o.applyLimits(newNodes, args.tracker, bestOption.NodeGroup, args.nodeInfos)
-	if aErr != nil {
-		markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ScaleUpExecutionErrorReason)
-		st, err := status.UpdateScaleUpError(
-			&status.ScaleUpStatus{
-				PodsTriggeredScaleUp:    bestOption.Pods,
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
-			},
-			aErr,
-		)
-		return scaleUpPlan{}, st, err
-	}
-
-	if newNodes < bestOption.NodeCount {
-		klog.V(1).Infof("Only %d nodes can be added to %s due to resource quotas", newNodes, bestOption.NodeGroup.Id())
-		if args.allOrNothing {
-			return scaleUpPlan{}, o.abortAllOrNothing(args), nil
-		}
 	}
 
 	// If necessary, create the node group. This is no longer simulation, an empty node group will be created by cloud provider if supported.

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -1486,7 +1486,7 @@ func (p *constNodeGroupSetProcessor) FindSimilarNodeGroups(_ *ca_context.Autosca
 	return p.similarNodeGroups, nil
 }
 
-func (p *constNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(_ *ca_context.AutoscalingContext, _ []cloudprovider.NodeGroup, _ int) ([]nodegroupset.ScaleUpInfo, errors.AutoscalerError) {
+func (p *constNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(_ *ca_context.AutoscalingContext, _ []cloudprovider.NodeGroup, _ int, _ map[string]int) ([]nodegroupset.ScaleUpInfo, errors.AutoscalerError) {
 	return nil, nil
 }
 
@@ -1740,11 +1740,15 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 
 func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 	tests := []struct {
-		name          string
-		initialSizes  map[string]int
-		maxSize       int
-		quotas        []resourcequotas.Quota
-		expectedSizes map[string]int
+		name         string
+		initialSizes map[string]int
+		maxSize      int
+		quotas       []resourcequotas.Quota
+		bestOption   string // node group the expander picks; defaults to ng1
+		// expectedSizes pins deterministic groups; non-deterministic splits use expectedTotalAdded only.
+		expectedSizes       map[string]int
+		expectedTotalAdded  int
+		expectAllGroupsGrew bool // asserts every group grew, i.e. remainder was spread not dumped
 	}{
 		{
 			name:         "per-group quota caps one group",
@@ -1758,11 +1762,15 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 				},
 			},
 			// ng2 has 1 node (1 core), quota allows 2 cores → room for 1 more.
-			// Balance tries 2 each, ng2 capped to 1. ng1: 1→3, ng2: 1→2, ng3: 1→3.
-			expectedSizes: map[string]int{"ng1": 3, "ng2": 2, "ng3": 3},
+			// Balancing knows ng2's quota cap up front (effective max 2), so it
+			// fills ng2 to 2 and redistributes the remainder into ng1/ng3 in a
+			// single loop, placing all 6 nodes.
+			expectedSizes:       map[string]int{"ng2": 2},
+			expectedTotalAdded:  6,
+			expectAllGroupsGrew: true,
 		},
 		{
-			name:         "shared quota including bestOption caps total before balancing",
+			name:         "shared quota including bestOption caps total",
 			initialSizes: map[string]int{"ng1": 1, "ng2": 2, "ng3": 2},
 			maxSize:      10,
 			quotas: []resourcequotas.Quota{
@@ -1772,9 +1780,12 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 					LimitsVal:   map[string]int64{"nodes": 6},
 				},
 			},
-			// 5 existing nodes, shared quota of 6 → room for 1. applyLimits caps total to 1.
-			// ng1 (size 1) is smallest, so balance assigns it the 1 node.
-			expectedSizes: map[string]int{"ng1": 2, "ng2": 2, "ng3": 2},
+			// 5 existing nodes, shared quota of 6 → room for 1 across all three.
+			// Each group's effective max reflects the 1 shared slot, so balancing
+			// adds at most 1 each; capScaleUpsByQuota then commits the single slot
+			// to ng1 (smallest) and caps the rest. ng1: 1→2, ng2/ng3 unchanged.
+			expectedSizes:      map[string]int{"ng1": 2, "ng2": 2, "ng3": 2},
+			expectedTotalAdded: 1,
 		},
 		{
 			name:         "shared quota on similar groups only",
@@ -1788,9 +1799,13 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 				},
 			},
 			// Shared quota on ng2+ng3 (3 existing, limit 4, room for 1). ng1 uncapped.
-			// ng2 (size 1) is smaller than ng3 (size 2), so balance sorts ng2 first.
-			// ng2 gets the 1 quota slot via ApplyDelta; ng3 sees 0 remaining, capped.
-			expectedSizes: map[string]int{"ng1": 4, "ng2": 2, "ng3": 2},
+			// The per-group cap is computed read-only, so ng2 and ng3 each see the
+			// 1 shared slot (over-count); capScaleUpsByQuota then commits quota and
+			// caps ng3 to 0 once ng2 consumes the slot. Because ng2/ng3 contribute
+			// little, ng1 absorbs more of the request than before: ng1: 1→5, ng2:
+			// 1→2, ng3: 2→2 (5 of 6 nodes placed; shared quota respected).
+			expectedSizes:      map[string]int{"ng1": 5, "ng2": 2, "ng3": 2},
+			expectedTotalAdded: 5,
 		},
 		{
 			name:         "pre-filter excludes group already at quota limit",
@@ -1804,8 +1819,30 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 				},
 			},
 			// ng2 has 1 node (1 core), quota allows 1 core → no room.
-			// Pre-filter excludes ng2 from balancing entirely. Only ng1 and ng3 participate.
-			expectedSizes: map[string]int{"ng1": 4, "ng2": 1, "ng3": 4},
+			// Pre-filter excludes ng2 from balancing entirely (stays 1). The 6
+			// nodes are split evenly between ng1 and ng3 (1→4 each).
+			expectedSizes:      map[string]int{"ng1": 4, "ng2": 1, "ng3": 4},
+			expectedTotalAdded: 6,
+		},
+		{
+			name:         "quota-constrained group is the best option",
+			initialSizes: map[string]int{"ng1": 1, "ng2": 1, "ng3": 1},
+			maxSize:      5,
+			bestOption:   "ng2",
+			quotas: []resourcequotas.Quota{
+				&resourcequotas.FakeQuota{
+					Name:        "quota-ng2",
+					AppliesToFn: matchNodeGroups([]string{"ng2"}),
+					LimitsVal:   map[string]int64{"cpu": 2},
+				},
+			},
+			// The expander picks the constrained group (ng2, room for 1) as best.
+			// The scale-up is no longer capped to ng2's quota up front: ng2 fills
+			// to its headroom and the rest is redistributed to ng1/ng3, placing
+			// all 6 nodes.
+			expectedSizes:       map[string]int{"ng2": 2},
+			expectedTotalAdded:  6,
+			expectAllGroupsGrew: true,
 		},
 	}
 
@@ -1828,7 +1865,8 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 
 			now := time.Now()
 
-			for gid, gconf := range testCfg {
+			for _, gid := range []string{"ng1", "ng2", "ng3"} {
+				gconf := testCfg[gid]
 				provider.AddNodeGroup(gid, gconf.min, gconf.max, gconf.size)
 				for i := 0; i < gconf.size; i++ {
 					nodeName := fmt.Sprintf("%v-node-%v", gid, i)
@@ -1872,7 +1910,11 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 				pods = append(pods, BuildTestPod(fmt.Sprintf("test-pod-%v", i), 80, 0))
 			}
 
-			autoscalingCtx.ExpanderStrategy = NewMockReportingStrategy(t, &GroupSizeChange{GroupName: "ng1", SizeChange: 6}, nil)
+			bestOption := tt.bestOption
+			if bestOption == "" {
+				bestOption = "ng1"
+			}
+			autoscalingCtx.ExpanderStrategy = NewMockReportingStrategy(t, &GroupSizeChange{GroupName: bestOption, SizeChange: 6}, nil)
 
 			cloudQuotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
 			fakeQuotasProvider := resourcequotas.NewFakeProvider(tt.quotas)
@@ -1887,11 +1929,19 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 			assert.NoError(t, typedErr)
 			assert.True(t, scaleUpStatus.WasSuccessful())
 
+			totalAdded := 0
 			for _, group := range provider.NodeGroups() {
 				size, err := group.TargetSize()
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expectedSizes[group.Id()], size, "unexpected size for %s", group.Id())
+				if want, ok := tt.expectedSizes[group.Id()]; ok {
+					assert.Equal(t, want, size, "unexpected size for %s", group.Id())
+				}
+				if tt.expectAllGroupsGrew {
+					assert.Greater(t, size, tt.initialSizes[group.Id()], "%s did not grow; nodes were not spread across groups", group.Id())
+				}
+				totalAdded += size - tt.initialSizes[group.Id()]
 			}
+			assert.Equal(t, tt.expectedTotalAdded, totalAdded, "unexpected total nodes added")
 		})
 	}
 }

--- a/cluster-autoscaler/processors/nodegroupset/balancing_processor.go
+++ b/cluster-autoscaler/processors/nodegroupset/balancing_processor.go
@@ -73,10 +73,15 @@ func (b *BalancingNodeGroupSetProcessor) FindSimilarNodeGroups(autoscalingCtx *c
 //
 // Returns ScaleUpInfos for groups that need to be resized.
 //
-// MaxSize of each group will be respected. If newNodes > total free capacity
-// of all NodeGroups it will be capped to total capacity. In particular if all
-// group already have MaxSize, empty list will be returned.
-func (b *BalancingNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError) {
+// Each group's effective max is respected. If newNodes > total free capacity of
+// all NodeGroups it will be capped to total capacity. In particular if every
+// group is already at its effective max, an empty list will be returned.
+//
+// maxAddByGroup optionally caps, per node group ID, how many nodes may be added
+// beyond a group's current size, lowering its effective max to
+// min(MaxSize, currentSize+maxAdd). A nil map (or absent group) imposes no cap
+// beyond MaxSize, in which case the effective max is just MaxSize.
+func (b *BalancingNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int, maxAddByGroup map[string]int) ([]ScaleUpInfo, errors.AutoscalerError) {
 	if len(groups) == 0 {
 		return []ScaleUpInfo{}, errors.NewAutoscalerError(
 			errors.InternalError, "Can't balance scale up between 0 groups")
@@ -92,20 +97,24 @@ func (b *BalancingNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(autoscaling
 				errors.CloudProviderError,
 				"failed to get node group size: %v", err)
 		}
-		maxSize := ng.MaxSize()
-		if currentSize == maxSize {
-			// group already maxed, ignore it
+		// effMax is the effective maximum size of the group: its MaxSize,
+		// further lowered by any quota headroom passed in maxAddByGroup. The
+		// rest of the algorithm treats effMax exactly as it would MaxSize.
+		effMax := ng.MaxSize()
+		if maxAdd, ok := maxAddByGroup[ng.Id()]; ok {
+			effMax = min(effMax, currentSize+maxAdd)
+		}
+		if currentSize >= effMax {
+			// group already at its effective max (size limit or quota), ignore it
 			continue
 		}
-		if maxSize > currentSize {
-			// we still have capacity to expand
-			totalCapacity += (maxSize - currentSize)
-		}
+		// we still have capacity to expand
+		totalCapacity += (effMax - currentSize)
 		scaleUpInfos = append(scaleUpInfos, ScaleUpInfo{
 			Group:       ng,
 			CurrentSize: currentSize,
 			NewSize:     currentSize,
-			MaxSize:     maxSize,
+			MaxSize:     effMax,
 		})
 	}
 	if totalCapacity < newNodes {

--- a/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
@@ -116,13 +116,13 @@ func TestBalanceSingleGroup(t *testing.T) {
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 
 	// just one node
-	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 1)
+	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 1, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, 2, scaleUpInfo[0].NewSize)
 
 	// multiple nodes
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 4)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 4, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, 5, scaleUpInfo[0].NewSize)
@@ -139,19 +139,19 @@ func TestBalanceUnderMaxSize(t *testing.T) {
 	provider.AddNodeGroup("ng4", 1, 10, 5)
 
 	// add a single node
-	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 1)
+	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 1, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, 2, scaleUpInfo[0].NewSize)
 
 	// add multiple nodes to single group
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 2)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 2, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, 3, scaleUpInfo[0].NewSize)
 
 	// add nodes to groups of different sizes, divisible
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 4)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 4, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(scaleUpInfo))
 	assert.Equal(t, 4, scaleUpInfo[0].NewSize)
@@ -161,7 +161,7 @@ func TestBalanceUnderMaxSize(t *testing.T) {
 
 	// add nodes to groups of different sizes, non-divisible
 	// we expect new sizes to be 4 and 5, doesn't matter which group gets how many
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 5)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 5, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(scaleUpInfo))
 	assert.Equal(t, 9, scaleUpInfo[0].NewSize+scaleUpInfo[1].NewSize)
@@ -170,7 +170,7 @@ func TestBalanceUnderMaxSize(t *testing.T) {
 	assert.True(t, scaleUpInfo[0].Group.Id() == "ng2" || scaleUpInfo[1].Group.Id() == "ng2")
 
 	// add nodes to all groups, divisible
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 10)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 10, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(scaleUpInfo))
 	for _, info := range scaleUpInfo {
@@ -210,33 +210,33 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	}
 
 	// Just one maxed out group
-	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng1"), 1)
+	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng1"), 1, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(scaleUpInfo))
 
 	// Smallest group already maxed out, add one node
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng1", "ng2"), 1)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng1", "ng2"), 1, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, "ng2", scaleUpInfo[0].Group.Id())
 	assert.Equal(t, 2, scaleUpInfo[0].NewSize)
 
 	// Smallest group already maxed out, too many nodes (should cap to max capacity)
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng1", "ng2"), 5)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng1", "ng2"), 5, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, "ng2", scaleUpInfo[0].Group.Id())
 	assert.Equal(t, 3, scaleUpInfo[0].NewSize)
 
 	// First group maxes out before proceeding to next one
-	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng3"), 4)
+	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng3"), 4, nil)
 	assert.Equal(t, 2, len(scaleUpInfo))
 	scaleUpMap := toMap(scaleUpInfo)
 	assert.Equal(t, 3, scaleUpMap["ng2"].NewSize)
 	assert.Equal(t, 5, scaleUpMap["ng3"].NewSize)
 
 	// Last group maxes out before previous one
-	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng3", "ng4"), 9)
+	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng3", "ng4"), 9, nil)
 	assert.Equal(t, 3, len(scaleUpInfo))
 	scaleUpMap = toMap(scaleUpInfo)
 	assert.Equal(t, 3, scaleUpMap["ng2"].NewSize)
@@ -244,7 +244,7 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	assert.Equal(t, 7, scaleUpMap["ng4"].NewSize)
 
 	// Use all capacity, cap to max
-	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng3", "ng4"), 900)
+	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng3", "ng4"), 900, nil)
 	assert.Equal(t, 3, len(scaleUpInfo))
 	scaleUpMap = toMap(scaleUpInfo)
 	assert.Equal(t, 3, scaleUpMap["ng2"].NewSize)
@@ -252,8 +252,115 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	assert.Equal(t, 7, scaleUpMap["ng4"].NewSize)
 
 	// One node group exceeds max.
-	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng5"), 1)
+	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng5"), 1, nil)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	scaleUpMap = toMap(scaleUpInfo)
 	assert.Equal(t, 2, scaleUpMap["ng2"].NewSize)
+}
+
+func TestBalanceRespectsMaxAddByGroup(t *testing.T) {
+	// Three groups starting at size 1 with a large MaxSize that does not bind:
+	// zone A (ng1) has quota for 5 more nodes, zones B and C (ng2, ng3) have
+	// quota for 1 each.
+	const initialSize = 1
+	const maxSize = 100
+
+	tests := []struct {
+		name     string
+		maxAdd   map[string]int
+		newNodes int
+		// expectedSizes pins deterministic groups; non-deterministic splits use expectedTotalAdded only.
+		expectedSizes      map[string]int
+		expectedTotalAdded int
+	}{
+		{
+			// Per-group headroom A=5, B=1, C=1; 9 requested → optimal (5,1,1)=7.
+			name:               "redistributes into the high-quota group in one loop",
+			maxAdd:             map[string]int{"ng1": 5, "ng2": 1, "ng3": 1},
+			newNodes:           9,
+			expectedSizes:      map[string]int{"ng1": 6, "ng2": 2, "ng3": 2},
+			expectedTotalAdded: 7,
+		},
+		{
+			// Quota tighter than MaxSize: each group capped to +2.
+			name:               "quota cap below MaxSize is respected",
+			maxAdd:             map[string]int{"ng1": 2, "ng2": 2, "ng3": 2},
+			newNodes:           100,
+			expectedSizes:      map[string]int{"ng1": 3, "ng2": 3, "ng3": 3},
+			expectedTotalAdded: 6,
+		},
+		{
+			// maxAdd far exceeds MaxSize headroom; the effective max must stay
+			// clamped at MaxSize. A request larger than the total MaxSize headroom
+			// fills every group exactly to MaxSize and no further.
+			name:               "quota cap above MaxSize does not raise it",
+			maxAdd:             map[string]int{"ng1": 1000, "ng2": 1000, "ng3": 1000},
+			newNodes:           400,
+			expectedSizes:      map[string]int{"ng1": maxSize, "ng2": maxSize, "ng3": maxSize},
+			expectedTotalAdded: 3 * (maxSize - initialSize),
+		},
+		{
+			// ng2 capped to 0 is excluded entirely; ng1/ng3 absorb the request.
+			name:               "group capped to zero is excluded",
+			maxAdd:             map[string]int{"ng1": 5, "ng2": 0, "ng3": 5},
+			newNodes:           4,
+			expectedSizes:      map[string]int{"ng2": initialSize},
+			expectedTotalAdded: 4,
+		},
+		{
+			// Only ng2 is constrained (capped to +1); ng1 and ng3 fall back to
+			// MaxSize (no cap) and absorb the rest, so all 9 nodes are placed.
+			name:               "group absent from map falls back to MaxSize",
+			maxAdd:             map[string]int{"ng2": 1},
+			newNodes:           9,
+			expectedSizes:      map[string]int{"ng2": 2},
+			expectedTotalAdded: 9,
+		},
+		{
+			// Headroom sums to 3; a request of 10 is capped to 3.
+			name:               "total capped to available quota capacity",
+			maxAdd:             map[string]int{"ng1": 1, "ng2": 1, "ng3": 1},
+			newNodes:           10,
+			expectedSizes:      map[string]int{"ng1": 2, "ng2": 2, "ng3": 2},
+			expectedTotalAdded: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor := NewDefaultNodeGroupSetProcessor([]string{}, config.NodeGroupDifferenceRatios{})
+			autoscalingCtx := &ca_context.AutoscalingContext{}
+
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
+			provider.AddNodeGroup("ng1", 1, maxSize, initialSize)
+			provider.AddNodeGroup("ng2", 1, maxSize, initialSize)
+			provider.AddNodeGroup("ng3", 1, maxSize, initialSize)
+			groupsMap := make(map[string]cloudprovider.NodeGroup)
+			for _, group := range provider.NodeGroups() {
+				groupsMap[group.Id()] = group
+			}
+			groups := []cloudprovider.NodeGroup{groupsMap["ng1"], groupsMap["ng2"], groupsMap["ng3"]}
+
+			scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, groups, tt.newNodes, tt.maxAdd)
+			assert.NoError(t, err)
+
+			// A group missing from the result was not scaled, i.e. stays at its
+			// initial size.
+			finalSizes := map[string]int{"ng1": initialSize, "ng2": initialSize, "ng3": initialSize}
+			totalAdded := 0
+			for _, sui := range scaleUpInfo {
+				added := sui.NewSize - sui.CurrentSize
+				// No group may be scaled past its quota cap (when one was given).
+				if maxAdd, ok := tt.maxAdd[sui.Group.Id()]; ok {
+					assert.LessOrEqualf(t, added, maxAdd, "%s added %d nodes, exceeds maxAdd %d", sui.Group.Id(), added, maxAdd)
+				}
+				finalSizes[sui.Group.Id()] = sui.NewSize
+				totalAdded += added
+			}
+			for id, want := range tt.expectedSizes {
+				assert.Equal(t, want, finalSizes[id], "unexpected size for %s", id)
+			}
+			assert.Equal(t, tt.expectedTotalAdded, totalAdded, "unexpected total nodes added")
+		})
+	}
 }

--- a/cluster-autoscaler/processors/nodegroupset/nodegroup_set_processor.go
+++ b/cluster-autoscaler/processors/nodegroupset/nodegroup_set_processor.go
@@ -48,7 +48,7 @@ type NodeGroupSetProcessor interface {
 	FindSimilarNodeGroups(autoscalingCtx *ca_context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup,
 		nodeInfosForGroups map[string]*framework.NodeInfo) ([]cloudprovider.NodeGroup, errors.AutoscalerError)
 
-	BalanceScaleUpBetweenGroups(autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError)
+	BalanceScaleUpBetweenGroups(autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int, maxAddByGroup map[string]int) ([]ScaleUpInfo, errors.AutoscalerError)
 	CleanUp()
 }
 
@@ -63,7 +63,7 @@ func (n *NoOpNodeGroupSetProcessor) FindSimilarNodeGroups(autoscalingCtx *ca_con
 }
 
 // BalanceScaleUpBetweenGroups splits a scale-up between provided NodeGroups.
-func (n *NoOpNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError) {
+func (n *NoOpNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int, maxAddByGroup map[string]int) ([]ScaleUpInfo, errors.AutoscalerError) {
 	return []ScaleUpInfo{}, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?


/kind feature



#### What this PR does / why we need it:
Followup to #9494, which made similar-node-group balancing respect resource quotas but enforced them after balancing, capping the total scale-up to the best-option group's quota up front and dropping any unclaimed capacity. That left scale-ups suboptimal and order-dependent: with CapacityQuotas of 5/1/1 across three zones and a need for 9 nodes, the result was roughly (2,1,1) or (1,0,0) depending on which group the expander picked, instead of the optimal (5,1,1) achievable in one loop.

This PR makes BalanceSimilarNodeGroups quota-aware so a scale-up claims the full collective quota across similar node groups in a single loop, instead of being capped to the best option's quota up front.

Previously prepareScaleUp called applyLimits, which capped the total scale-up to the single best-option group's quota before balancing. With per-zone CapacityQuotas this produced suboptimal results (e.g. zones with quota 5/1/1 yielded ~(2,1,1) instead of the optimal (5,1,1)), and the outcome depended on which group the expander happened to pick.

Now balanceScaleUps computes each target group's quota headroom (in nodes) via a read-only Tracker.CheckQuota and passes it to BalanceScaleUpBetweenGroups as a maxAddByGroup map. Each group's effective max is lowered to min(MaxSize, currentSize+headroom), so balancing fills groups up to their quota and redistributes the remainder, all in one loop. The balancing algorithm itself is unchanged. capScaleUpsByQuota is kept as the safety net that commits quota and caps the residual for shared quotas (where the read-only per-group headroom over-counts).

A nil maxAddByGroup map preserves the original MaxSize-only behavior, so configurations without quotas are unaffected.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/9567

#### Special notes for your reviewer:
For testing, I deployed this change to an AWS cluster. I had 3 similar node groups with 1 node each. One nodegroup had a quota of 5, and the other nodegroups had a quota of 2.

I created 9 new pods that each needed their own node and got the following scale-up plan: `Final scale-up plan: [{asg-A 1->2 (max: 2)} {asg-B 1->2 (max: 2)} {asg-C 1->5 (max: 5)}]` (real AutoScalingGroup names have been redacted)

We can see that all quotas were fully consumed and a total of 6 nodes were scaled up. Before this PR, we would have only gotten up to 4 (asg-C's remaining quota) new nodes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Cluster Autoscaler now distributes a scale-up optimally across similar node groups when resource quotas are configured
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
