### PR TITLE
Azure: e2e smoke test for VMSS ETag concurrency feature

### DIFF
--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.57.0
+version: 9.58.0

--- a/cluster-autoscaler/charts/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/charts/cluster-autoscaler/README.md
@@ -462,6 +462,7 @@ vpa:
 | azureClientID | string | `""` | Service Principal ClientID with contributor permission to Cluster and Node ResourceGroup. Required if `cloudProvider=azure` |
 | azureClientSecret | string | `""` | Service Principal ClientSecret with contributor permission to Cluster and Node ResourceGroup. Required if `cloudProvider=azure` |
 | azureEnableForceDelete | bool | `false` | Whether to force delete VMs or VMSS instances when scaling down. |
+| azureEnableVMSSEtag | bool | `false` | Whether to send the cached VMSS ETag as an `If-Match` header on capacity updates, so concurrent modifications are rejected (HTTP 412) and retried instead of silently overwritten. |
 | azureResourceGroup | string | `""` | Azure resource group that the cluster is located. Required if `cloudProvider=azure` |
 | azureSubscriptionID | string | `""` | Azure subscription where the resources are located. Required if `cloudProvider=azure` |
 | azureTenantID | string | `""` | Azure tenant where the resources are located. Required if `cloudProvider=azure` |

--- a/cluster-autoscaler/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/templates/deployment.yaml
@@ -187,6 +187,8 @@ spec:
                   name: {{ default (include "cluster-autoscaler.fullname" .) .Values.secretKeyRefNameOverride }}
             - name: AZURE_ENABLE_FORCE_DELETE
               value: "{{ .Values.azureEnableForceDelete }}"
+            - name: AZURE_ENABLE_VMSS_ETAG
+              value: "{{ .Values.azureEnableVMSSEtag }}"
             {{- if .Values.azureUseWorkloadIdentityExtension }}
             - name: ARM_USE_WORKLOAD_IDENTITY_EXTENSION
               value: "true"

--- a/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
@@ -113,6 +113,9 @@ azureVMType: "vmss"
 # azureEnableForceDelete -- Whether to force delete VMs or VMSS instances when scaling down.
 azureEnableForceDelete: false
 
+# azureEnableVMSSEtag -- Whether to send the cached VMSS ETag as an `If-Match` header on capacity updates, so concurrent modifications are rejected (HTTP 412) and retried instead of silently overwritten.
+azureEnableVMSSEtag: false
+
 # civoApiUrl -- URL for the Civo API.
 # Required if `cloudProvider=civo`
 civoApiUrl: "https://api.civo.com"

--- a/cluster-autoscaler/cloudprovider/azure/test/suites/scaleup/suite_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/suites/scaleup/suite_test.go
@@ -71,12 +71,11 @@ func helmValuesForFastScaleDown() map[string]interface{} {
 	}
 }
 
-// withVMSSETag enables the Azure VMSS ETag optimistic-concurrency feature by setting the
-// AZURE_ENABLE_VMSS_ETAG environment variable on the Cluster Autoscaler container.
+// withVMSSETag enables the Azure VMSS ETag optimistic-concurrency feature via the
+// chart's azureEnableVMSSEtag value (which sets AZURE_ENABLE_VMSS_ETAG on the CAS
+// container).
 func withVMSSETag(values map[string]interface{}) map[string]interface{} {
-	values["extraEnv"] = map[string]interface{}{
-		"AZURE_ENABLE_VMSS_ETAG": "true",
-	}
+	values["azureEnableVMSSEtag"] = true
 	return values
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/test/suites/scaleup/suite_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/test/suites/scaleup/suite_test.go
@@ -71,6 +71,98 @@ func helmValuesForFastScaleDown() map[string]interface{} {
 	}
 }
 
+// withVMSSETag enables the Azure VMSS ETag optimistic-concurrency feature by setting the
+// AZURE_ENABLE_VMSS_ETAG environment variable on the Cluster Autoscaler container.
+func withVMSSETag(values map[string]interface{}) map[string]interface{} {
+	values["extraEnv"] = map[string]interface{}{
+		"AZURE_ENABLE_VMSS_ETAG": "true",
+	}
+	return values
+}
+
+// newScaleUpDeployment returns a CPU-hungry Deployment whose pending Pods force the
+// Cluster Autoscaler to scale up node pools.
+func newScaleUpDeployment(namespace string, replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "php-apache",
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"run": "php-apache"},
+			},
+			Replicas: ptr.To[int32](replicas),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"run": "php-apache"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "php-apache",
+							Image: "registry.k8s.io/hpa-example",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("500m"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("200m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// runScaleUpDownFlow deploys CAS with scaleUpValues, drives a scale-up by creating
+// pending Pods, then redeploys with scaleDownValues and removes the Pods to drive a
+// scale-down back to the original node count. It is shared by the default and
+// ETag-enabled specs so both exercise the same scaling behavior.
+func runScaleUpDownFlow(namespace string, scaleUpValues, scaleDownValues map[string]interface{}) {
+	By("Deploying Cluster Autoscaler for scale up")
+	env.EnsureHelmRelease(scaleUpValues)
+
+	nodes := &corev1.NodeList{}
+	Expect(env.K8s.List(env.Ctx, nodes)).To(Succeed())
+	nodeCountBefore := len(nodes.Items)
+
+	By("Creating 100 Pods")
+	deploy := newScaleUpDeployment(namespace, 100)
+	Expect(env.K8s.Create(env.Ctx, deploy)).To(Succeed())
+
+	By("Waiting for more Ready Nodes to exist")
+	Eventually(env.ReadyNodeCount, "10m", "10s").Should(BeNumerically(">", nodeCountBefore))
+
+	Eventually(env.AllVMSSStable, "20m", "30s").Should(Succeed())
+
+	By("Reconfiguring Cluster Autoscaler for fast scale down")
+	env.EnsureHelmRelease(scaleDownValues)
+
+	By("Deleting 100 Pods")
+	Expect(env.K8s.Delete(env.Ctx, deploy)).To(Succeed())
+
+	By("Waiting for the original number of Nodes to be Ready")
+	Eventually(func(g Gomega) {
+		nodes := &corev1.NodeList{}
+		g.Expect(env.K8s.List(env.Ctx, nodes)).To(Succeed())
+		g.Expect(nodes.Items).To(SatisfyAll(
+			HaveLen(nodeCountBefore),
+			ContainElements(Satisfy(func(node corev1.Node) bool {
+				for _, cond := range node.Status.Conditions {
+					if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			})),
+		))
+	}, "20m", "10s").Should(Succeed())
+}
+
 func init() {
 	flag.StringVar(&resourceGroup, "resource-group", "", "resource group containing cluster-autoscaler-managed resources (the MC_ node resource group)")
 	flag.StringVar(&clusterName, "cluster-name", "", "Cluster API Cluster name (CI only)")
@@ -124,91 +216,10 @@ var _ = Describe("Azure Provider", func() {
 	})
 
 	It("scales up AKS node pools when pending Pods exist", func() {
-		nodes := &corev1.NodeList{}
-		Expect(env.K8s.List(env.Ctx, nodes)).To(Succeed())
-		nodeCountBefore := len(nodes.Items)
+		runScaleUpDownFlow(namespace.Name, helmValuesForScaleUp(), helmValuesForFastScaleDown())
+	})
 
-		By("Creating 100 Pods")
-		deploy := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "php-apache",
-				Namespace: namespace.Name,
-			},
-			Spec: appsv1.DeploymentSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"run": "php-apache",
-					},
-				},
-				Replicas: ptr.To[int32](100),
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							"run": "php-apache",
-						},
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "php-apache",
-								Image: "registry.k8s.io/hpa-example",
-								Resources: corev1.ResourceRequirements{
-									Limits: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("500m"),
-									},
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("200m"),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		Expect(env.K8s.Create(env.Ctx, deploy)).To(Succeed())
-
-		By("Waiting for more Ready Nodes to exist")
-		Eventually(func() (int, error) {
-			readyCount := 0
-			nodes := &corev1.NodeList{}
-			if err := env.K8s.List(env.Ctx, nodes); err != nil {
-				return 0, err
-			}
-			for _, node := range nodes.Items {
-				for _, cond := range node.Status.Conditions {
-					if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-						readyCount++
-						break
-					}
-				}
-			}
-			return readyCount, nil
-		}, "10m", "10s").Should(BeNumerically(">", nodeCountBefore))
-
-		Eventually(env.AllVMSSStable, "20m", "30s").Should(Succeed())
-
-		By("Reconfiguring Cluster Autoscaler for fast scale down")
-		env.EnsureHelmRelease(helmValuesForFastScaleDown())
-
-		By("Deleting 100 Pods")
-		Expect(env.K8s.Delete(env.Ctx, deploy)).To(Succeed())
-
-		By("Waiting for the original number of Nodes to be Ready")
-		Eventually(func(g Gomega) {
-			nodes := &corev1.NodeList{}
-			g.Expect(env.K8s.List(env.Ctx, nodes)).To(Succeed())
-			g.Expect(nodes.Items).To(SatisfyAll(
-				HaveLen(nodeCountBefore),
-				ContainElements(Satisfy(func(node corev1.Node) bool {
-					for _, cond := range node.Status.Conditions {
-						if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-							return true
-						}
-					}
-					return false
-				})),
-			))
-		}, "20m", "10s").Should(Succeed())
+	It("scales up and down AKS node pools with VMSS ETag concurrency enabled", func() {
+		runScaleUpDownFlow(namespace.Name, withVMSSETag(helmValuesForScaleUp()), withVMSSETag(helmValuesForFastScaleDown()))
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Follow-up to #9783. Adds an e2e smoke test that exercises the Azure VMSS ETag concurrency feature (#2581) with the flag enabled, so we have a regression guard that turning it on doesn't break normal scale up/down. It reuses the existing scale-up flow, so the net diff is small.

I deliberately didn't try to e2e the genuine 412 retry/skip path. That only fires when an external writer changes the VMSS between CA's read and write, which we can't control from outside, so it'd be inherently flaky for little gain. That path is already covered deterministically by `TestScaleSetETagReconcilesConcurrentWriter` using a stateful optimistic-concurrency mock.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
