### PR TITLE
[cluster-autoscaler-release-1.33] fix: OperationPreempted does not retry when failed delete operation

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -83,4 +84,20 @@ func shouldForceDelete(skuName string, scaleSet *ScaleSet) bool {
 
 func isOperationNotAllowed(rerr *retry.Error) bool {
 	return rerr != nil && rerr.ServiceErrorCode() == retry.OperationNotAllowed
+}
+
+// isOperationPreempted reports whether err represents an Azure "OperationPreempted"
+// failure — i.e. a concurrent VMSS mutation (scale-up, update, another delete)
+// superseded our operation. The track1 long-running-operation result surfaces this
+// as consts.OperationPreemptedErrorMessage (rather than a structured service error
+// code), so we match on that message, mirroring cloud-provider-azure's own
+// vmssvmclient.updateVMSSVMs() preemption handling.
+func isOperationPreempted(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(
+		strings.ToLower(err.Error()),
+		strings.ToLower(consts.OperationPreemptedErrorMessage),
+	)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_force_delete_scale_set_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package azure
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -76,4 +78,32 @@ func TestIsOperationNotAllowed(t *testing.T) {
 	// It is difficult to condition the case where return error matched expected error string for forceDelete and the
 	// function should return true.
 
+}
+
+func TestIsOperationPreempted(t *testing.T) {
+	t.Run("should return false because error is nil", func(t *testing.T) {
+		assert.Equal(t, isOperationPreempted(nil), false)
+	})
+
+	t.Run("should return false for unrelated error", func(t *testing.T) {
+		err := errors.New("BadRequest: something went wrong")
+		assert.Equal(t, isOperationPreempted(err), false)
+	})
+
+	t.Run("should return true for plain error containing the preempted message", func(t *testing.T) {
+		err := errors.New(consts.OperationPreemptedErrorMessage)
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
+
+	t.Run("should return true for a retry.Error wrapping the preempted message", func(t *testing.T) {
+		// This mirrors how the error surfaces in production: WaitForDeleteInstancesResult
+		// returns retry.Error.Error(), which wraps the raw error message.
+		err := retry.NewError(false, errors.New(consts.OperationPreemptedErrorMessage)).Error()
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
+
+	t.Run("should be case-insensitive", func(t *testing.T) {
+		err := errors.New("operation execution has been PREEMPTED by a more recent operation")
+		assert.Equal(t, isOperationPreempted(err), true)
+	})
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -673,6 +673,31 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(future *azure.Future, requiredI
 		}
 		return
 	}
+
+	// Retry once on OperationPreempted: this CRP error means a concurrent VMSS
+	// mutation (e.g., scale-up, update, another delete) superseded our delete.
+	// A single retry is statistically sufficient — two consecutive preemptions
+	// would require three operations racing on the same VMSS, which is unlikely
+	// in CAS's scale-down flow. This mirrors cloud-provider-azure's track1
+	// vmssvmclient.updateVMSSVMs() preemption handling.
+	if isOperationPreempted(err) {
+		klog.V(2).Infof("WaitForDeleteInstancesResult(%v) for %s was preempted, retrying once", requiredIds.InstanceIds, scaleSet.Name)
+		retryCtx, retryCancel := getContextWithTimeout(vmssContextTimeout)
+		retryFuture, retryRerr := scaleSet.deleteInstances(retryCtx, requiredIds, scaleSet.Name)
+		retryCancel()
+		if retryRerr == nil && retryFuture != nil {
+			waitCtx, waitCancel := getContextWithTimeout(asyncContextTimeout)
+			retryResp, retryErr := scaleSet.manager.azClient.virtualMachineScaleSetsClient.WaitForDeleteInstancesResult(waitCtx, retryFuture, scaleSet.manager.config.ResourceGroup)
+			waitCancel()
+			if retrySuccess, _ := isSuccessHTTPResponse(retryResp, retryErr); retrySuccess {
+				klog.V(3).Infof("WaitForDeleteInstancesResult(%v) for %s retry success", requiredIds.InstanceIds, scaleSet.Name)
+				scaleSet.invalidateInstanceCache()
+				return
+			}
+		}
+		klog.Errorf("WaitForDeleteInstancesResult(%v) for %s retry failed", requiredIds.InstanceIds, scaleSet.Name)
+	}
+
 	if !scaleSet.manager.config.StrictCacheUpdates {
 		// On failure, invalidate the instanceCache - cannot have instances in deletingState
 		scaleSet.invalidateInstanceCache()

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -1750,4 +1752,111 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 			assert.NotNil(t, status.ErrorInfo)
 		})
 	})
+}
+
+// setupScaleSetForDeleteTest registers a uniform test scale set and returns a
+// fresh *ScaleSet plus its manager with the VMSS/instance caches populated, ready
+// for exercising waitForDeleteInstances directly.
+func setupScaleSetForDeleteTest(t *testing.T, ctrl *gomock.Controller) (*AzureManager, *mockvmssclient.MockInterface) {
+	manager := newTestAzureManager(t)
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	expectedScaleSets := newTestVMSSList(vmssCapacity, vmssName, "eastus", compute.Uniform)
+	expectedVMSSVMs := newTestVMSSVMList(3)
+	expectedVMs := newTestVMList(3)
+
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup, "test-asg", gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	mockVMClient := mockvmclient.NewMockInterface(ctrl)
+	mockVMClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedVMs, nil).AnyTimes()
+	manager.azClient.virtualMachinesClient = mockVMClient
+
+	err := manager.forceRefresh()
+	assert.NoError(t, err)
+
+	registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
+	manager.explicitlyConfigured["test-asg"] = true
+	assert.True(t, registered)
+	err = manager.forceRefresh()
+	assert.NoError(t, err)
+
+	return manager, mockVMSSClient
+}
+
+func TestWaitForDeleteInstancesWithOperationPreemptedRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient := setupScaleSetForDeleteTest(t, ctrl)
+
+	// The initial WaitForDeleteInstancesResult reports OperationPreempted (surfaced
+	// as retry.Error.Error(), mirroring production); the retry then succeeds.
+	gomock.InOrder(
+		mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).
+			Return(&http.Response{StatusCode: http.StatusOK}, retry.NewError(false, errors.New(consts.OperationPreemptedErrorMessage)).Error()).Times(1),
+		mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).
+			Return(&http.Response{StatusCode: http.StatusOK}, nil).Times(1),
+	)
+	// The retry re-issues exactly one delete.
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&autorestazure.Future{}, nil).Times(1)
+
+	requiredIds := &compute.VirtualMachineScaleSetVMInstanceRequiredIDs{InstanceIds: &[]string{"0"}}
+	scaleSet := newTestScaleSet(manager, "test-asg")
+	assert.True(t, scaleSet.lastInstanceRefresh.IsZero())
+
+	scaleSet.waitForDeleteInstances(&autorestazure.Future{}, requiredIds)
+
+	// Cache invalidated on retry success (lastInstanceRefresh moves off its zero value).
+	assert.False(t, scaleSet.lastInstanceRefresh.IsZero(),
+		"expected instance cache to be invalidated after preempted retry success")
+}
+
+func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient := setupScaleSetForDeleteTest(t, ctrl)
+
+	// A non-preempted failure must NOT trigger a retry.
+	mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).
+		Return(&http.Response{StatusCode: http.StatusInternalServerError}, errors.New("InternalServerError: something went wrong")).Times(1)
+	// If the retry path is accidentally taken, gomock.Times(0) fails the test.
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	requiredIds := &compute.VirtualMachineScaleSetVMInstanceRequiredIDs{InstanceIds: &[]string{"0"}}
+	scaleSet := newTestScaleSet(manager, "test-asg")
+
+	scaleSet.waitForDeleteInstances(&autorestazure.Future{}, requiredIds)
+}
+
+func TestWaitForDeleteInstancesRetryFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager, mockVMSSClient := setupScaleSetForDeleteTest(t, ctrl)
+
+	// Initial poll is preempted; the retry's delete call itself fails.
+	mockVMSSClient.EXPECT().WaitForDeleteInstancesResult(gomock.Any(), gomock.Any(), manager.config.ResourceGroup).
+		Return(&http.Response{StatusCode: http.StatusOK}, retry.NewError(false, errors.New(consts.OperationPreemptedErrorMessage)).Error()).Times(1)
+	mockVMSSClient.EXPECT().DeleteInstancesAsync(gomock.Any(), manager.config.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, retry.NewError(false, errors.New("ResourceGroupNotFound"))).Times(1)
+
+	requiredIds := &compute.VirtualMachineScaleSetVMInstanceRequiredIDs{InstanceIds: &[]string{"0"}}
+	scaleSet := newTestScaleSet(manager, "test-asg")
+	assert.True(t, scaleSet.lastInstanceRefresh.IsZero())
+
+	scaleSet.waitForDeleteInstances(&autorestazure.Future{}, requiredIds)
+
+	// Even though the retry failed, the cache is still invalidated via the
+	// non-strict failure path.
+	assert.False(t, scaleSet.lastInstanceRefresh.IsZero(),
+		"expected instance cache to be invalidated after retry failure")
 }


### PR DESCRIPTION
Manual cherry-pick of #9505 onto `cluster-autoscaler-release-1.33`.

This is a **manual** back-port rather than an automated one. #9505 targets the track2 azure-sdk-for-go (`azcore` / `armcompute` / `runtime.Poller`), but this release branch still uses the track1 autorest SDK, so the fix is re-implemented against `*azure.Future` / `*retry.Error`:

- `isOperationPreempted` detects the preemption from the long-running-operation result message (`consts.OperationPreemptedErrorMessage`), mirroring cloud-provider-azure's own `vmssvmclient.updateVMSSVMs()` handling.
- `waitForDeleteInstances` retries the delete once when the poll result is an `OperationPreempted` error (a concurrent VMSS mutation superseded the delete).

Unit tests cover the helper plus the retry-success, no-retry-on-other-errors, and retry-failure paths.

/assign comtalyst

```release-note
azure: OperationPreempted does not retry if delete fails
```

### Note for reviewers

This branch surfaces an `OperationPreempted` from the long-running delete operation as a **message** rather than a parseable service error code, so detection is intentionally message-based (`consts.OperationPreemptedErrorMessage`) instead of a `ServiceErrorCode`-based check. A code-based check would silently miss the preemption on this SDK path. Detection lives in a single helper (`isOperationPreempted` in `azure_force_delete_scale_set.go`) if a different approach is preferred.
