### PR TITLE
Apply Provisioned condition with SSA

### DIFF
--- a/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
+++ b/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	v1ac "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/client/applyconfiguration/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaleup"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaleup/orchestrator"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
 )
@@ -98,8 +100,15 @@ func (o *bestEffortAtomicProvClass) Provision(
 	// For provisioning requests, unschedulablePods are actually all injected pods. Some may even be schedulable!
 	actuallyUnschedulablePods, err := o.filterOutSchedulable(unschedulablePods)
 	if err != nil {
-		conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.FailedToCheckCapacityReason, conditions.FailedToCheckCapacityMsg, metav1.Now())
-		if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+		prAC := v1ac.ProvisioningRequest(pr.Name, pr.Namespace)
+		condition := metav1ac.Condition().
+			WithType(v1.Provisioned).
+			WithStatus(metav1.ConditionFalse).
+			WithReason(conditions.FailedToCheckCapacityReason).
+			WithMessage(conditions.FailedToCheckCapacityMsg).
+			WithLastTransitionTime(metav1.Now())
+		prAC.WithStatus(v1ac.ProvisioningRequestStatus().WithConditions(condition))
+		if _, updateErr := o.client.ApplyProvisioningRequest(prAC, "cluster-autoscaler"); updateErr != nil {
 			klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
 		}
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "error during ScaleUp: %s", err.Error()))
@@ -107,8 +116,15 @@ func (o *bestEffortAtomicProvClass) Provision(
 
 	if len(actuallyUnschedulablePods) == 0 {
 		// Nothing to do here - everything fits without scale-up.
-		conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
-		if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+		prAC := v1ac.ProvisioningRequest(pr.Name, pr.Namespace)
+		condition := metav1ac.Condition().
+			WithType(v1.Provisioned).
+			WithStatus(metav1.ConditionTrue).
+			WithReason(conditions.CapacityIsFoundReason).
+			WithMessage(conditions.CapacityIsFoundMsg).
+			WithLastTransitionTime(metav1.Now())
+		prAC.WithStatus(v1ac.ProvisioningRequestStatus().WithConditions(condition))
+		if _, updateErr := o.client.ApplyProvisioningRequest(prAC, "cluster-autoscaler"); updateErr != nil {
 			klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
 			return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "capacity available, but failed to admit workload: %s", updateErr.Error()))
 		}
@@ -118,8 +134,15 @@ func (o *bestEffortAtomicProvClass) Provision(
 	st, err := o.scaleUpOrchestrator.ScaleUp(actuallyUnschedulablePods, nodes, daemonSets, nodeInfos, true)
 	if err == nil && st.Result == status.ScaleUpSuccessful {
 		// Happy path - all is well.
-		conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsProvisionedReason, conditions.CapacityIsProvisionedMsg, metav1.Now())
-		if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+		prAC := v1ac.ProvisioningRequest(pr.Name, pr.Namespace)
+		condition := metav1ac.Condition().
+			WithType(v1.Provisioned).
+			WithStatus(metav1.ConditionTrue).
+			WithReason(conditions.CapacityIsProvisionedReason).
+			WithMessage(conditions.CapacityIsProvisionedMsg).
+			WithLastTransitionTime(metav1.Now())
+		prAC.WithStatus(v1ac.ProvisioningRequestStatus().WithConditions(condition))
+		if _, updateErr := o.client.ApplyProvisioningRequest(prAC, "cluster-autoscaler"); updateErr != nil {
 			klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
 			return st, errors.NewAutoscalerErrorf(errors.InternalError, "scale up requested, but failed to admit workload: %s", updateErr.Error())
 		}
@@ -127,8 +150,15 @@ func (o *bestEffortAtomicProvClass) Provision(
 	}
 
 	// We are not happy with the results.
-	conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
-	if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+	prAC := v1ac.ProvisioningRequest(pr.Name, pr.Namespace)
+	condition := metav1ac.Condition().
+		WithType(v1.Provisioned).
+		WithStatus(metav1.ConditionFalse).
+		WithReason(conditions.CapacityIsNotFoundReason).
+		WithMessage("Capacity is not found, CA will try to find it later.").
+		WithLastTransitionTime(metav1.Now())
+	prAC.WithStatus(v1ac.ProvisioningRequestStatus().WithConditions(condition))
+	if _, updateErr := o.client.ApplyProvisioningRequest(prAC, "cluster-autoscaler"); updateErr != nil {
 		klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
 	}
 	if err != nil {

--- a/cluster-autoscaler/provisioningrequest/provreqclient/client.go
+++ b/cluster-autoscaler/provisioningrequest/provreqclient/client.go
@@ -24,9 +24,9 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/labels"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	v1ac "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/client/applyconfiguration/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/client/clientset/versioned"
 	listers "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/client/listers/autoscaling.x-k8s.io/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/provisioningrequest"
@@ -116,8 +116,22 @@ func (c *ProvisioningRequestClient) UpdateProvisioningRequest(pr *v1.Provisionin
 	if err != nil {
 		return pr, err
 	}
-	klog.V(4).Infof("Updated ProvisioningRequest %s/%s,  status: %q,", updatedPr.Namespace, updatedPr.Name, updatedPr.Status)
+	klog.V(4).Infof("Updated ProvisioningRequest %s/%s, status: %+v,", updatedPr.Namespace, updatedPr.Name, updatedPr.Status)
 	return updatedPr, nil
+}
+
+// ApplyProvisioningRequest applies the given ProvisioningRequest with Server-Side Apply.
+func (c *ProvisioningRequestClient) ApplyProvisioningRequest(prAC *v1ac.ProvisioningRequestApplyConfiguration, fieldOwner string) (*v1.ProvisioningRequest, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), provisioningRequestClientCallTimeout)
+	defer cancel()
+	if prAC.Name == nil || prAC.Namespace == nil {
+		return nil, fmt.Errorf("failed to apply ProvisioningRequest: name and namespace are required")
+	}
+	pr, err := c.client.AutoscalingV1().ProvisioningRequests(*prAC.Namespace).ApplyStatus(ctx, prAC, metav1.ApplyOptions{FieldManager: fieldOwner, Force: true})
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
 }
 
 // ProvisioningRequestsForPods check that all pods belong to one ProvisioningRequest and return it.


### PR DESCRIPTION


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

We noticed a very frequent conflict when adding a Provisioned condition to the ProvisioningRequest. That usually happens in best-effort-atomic PRs, where CA adds Accepted and then Provisioned conditions in a very quick succession. The informer cache does not catch up with the first update, and therefore a conflict is detected during the second update. SSA fixes that, as it allows to update a single condition without a risk of conflict. This solution is preferred over a retry loop, since the API calls run synchronously in the CA main loop. Strategic merge patch could not be used, since it's not supported with CRDs. JSON merge patch replaces the entire conditions list. That leaves SSA an only viable solution.

**Note:** that fixes only the most frequently detected race condition. Other race conditions are still possible, for example Provisioned condition not synced with the informer cache in the next autoscaler loop. However, other races have not been observed in a real cluster. Eventually, all PR condition updates should be migrated to SSA.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
