### PR TITLE
AEP: Add disruption cost scale-down proposal

### DIFF
--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -1,0 +1,163 @@
+# Disruption Cost Based Scale-Down Ordering
+
+Author: YurDuiachenko
+
+## Background
+
+Cluster Autoscaler can scale down non-empty nodes when their pods can be safely moved elsewhere. During scale-down, CA already evaluates whether a node can be removed by considering node utilization, node group limits, drainability rules, PodDisruptionBudgets, scheduling simulation, and other existing blockers.
+
+However, once multiple non-empty nodes are already removable, CA has limited workload-level information to choose which removable node would be least disruptive to remove first.
+
+The existing `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation is useful for expressing whether a pod can be evicted, but it is mostly binary. It can prevent scale-down entirely for a pod, but it does not allow users to express that one removable pod is more expensive to disrupt than another.
+
+This proposal introduces a soft disruption cost signal that can influence the ordering of already-removable scale-down candidates without changing the existing removability checks.
+
+## High level proposal
+
+Introduce a pod-level disruption cost annotation.
+
+The preferred annotation name is:
+
+```text
+node-autoscaling.kubernetes.io/disruption-cost
+```
+
+The original issue suggested:
+
+```text
+cluster-autoscaler.kubernetes.io/disruption-cost
+```
+
+This proposal treats the exact annotation prefix as an open question, because related Karpenter and node-autoscaling work is discussing similar disruption/consolidation ordering semantics.
+
+The annotation value is a unit-less non-negative integer. Higher values mean that disrupting the pod is more expensive. Missing or invalid values are treated as zero.
+
+Cluster Autoscaler will read this annotation from pods that would need to be rescheduled when a node is removed. For each already-removable non-empty node, CA will sum the disruption costs of its reschedulable pods and use this total as a soft ordering signal.
+
+This signal must not make an otherwise non-removable node removable. It only affects ordering among nodes that have already passed existing scale-down safety checks.
+
+### Example
+
+Consider two removable nodes:
+
+```text
+node-a:
+  pod api-0     disruption-cost=100
+  pod worker-0  disruption-cost=20
+  total cost=120
+
+node-b:
+  pod stateless-0 disruption-cost=0
+  pod batch-0     disruption-cost=5
+  total cost=5
+```
+
+If both nodes are removable, CA should prefer removing `node-b` before `node-a`.
+
+## Goals
+
+* Goals
+
+## Non-goals
+
+* Non-goals
+
+## Annotation semantics
+
+### Scope
+
+The annotation is placed on Pods. In practice, users are expected to set it through workload pod templates.
+
+Example:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: expensive-api
+spec:
+  template:
+    metadata:
+      annotations:
+        node-autoscaling.kubernetes.io/disruption-cost: "100"
+    spec:
+      containers:
+      - name: app
+        image: example/app
+```
+
+Cluster Autoscaler only reads the annotation. It does not write or mutate it.
+
+### Value
+
+The value is a unit-less non-negative integer.
+
+Suggested initial behavior:
+
+| table              | table                 |
+|--------------------|-----------------------|
+| missing annotation | 0                     |
+| "0"                | 0                     |
+| "10"               | 10                    |
+| "-1"               | invalid, treated as 0 |
+| "abc"              | invalid, treated as 0 | 
+| "10.5"             | invalid, treated as 0 |
+| overflow           | invalid, treated as 0 |
+
+
+
+Invalid values should not block scale-down. They should be ignored and treated as zero. The implementation may log invalid values and may later expose a metric for observability.
+
+
+## Detailed design
+
+### Existing code integration
+
+
+### Annotation parsing
+
+
+### Node cost aggregation
+
+
+### Candidate ordering
+
+
+## Relationship with Karpenter and related consolidation work
+
+
+## Interaction with existing scale-down blockers
+
+
+## DaemonSet behavior
+
+
+## On-completion pod behavior
+
+
+## Monitoring
+
+The initial implementation may rely on logs for invalid annotation values.
+
+Potential follow-up metric:
+
+```text
+cluster_autoscaler_invalid_disruption_cost_annotations_total
+```
+
+Potential optional debug metric:
+
+```text
+cluster_autoscaler_selected_node_disruption_cost
+```
+
+Metrics are not required for the first implementation unless maintainers request them.
+
+
+## Testing
+
+
+
+## Risks and mitigations
+
+### Risk: 

--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -175,13 +175,13 @@ The updated function should preserve the existing `riskyNodes` and `okNodes` gro
 
 The total disruption cost for a node should be calculated as the sum of annotation values on pods listed in `NodeToBeRemoved.PodsToReschedule`.
 
-
-
 ### Relationship to Karpenter
 
-Karpenter has a related use case for expressing pod disruption cost during consolidation. This proposal captures the same class of user-facing signal as an autoscaler-agnostic annotation under the `node-autoscaling.kubernetes.io` prefix, so workloads do not need separate autoscaler-specific annotations for the same disruption preference.
+Karpenter has a related use case for expressing pod disruption cost during consolidation. This proposal captures the same class of user-facing signal as an autoscaler-agnostic annotation under the `node-autoscaling.kubernetes.io` prefix, 
+so workloads do not need separate autoscaler-specific annotations for the same disruption preference.
 
 Karpenter-specific scoring, normalization, consolidation behavior, feature gates, and migration remain outside the scope of this proposal.
+
 ### Corner cases
 
 * An annotation set on `DaemonSetPods` has no impact on the node disruption cost.

--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -4,7 +4,7 @@ Author: YurDuiachenko
 
 ## Background
 
-When scaling down a cluster, CA is currently not aware of the disruption "cost" action will have, so it can pick node which will be more disruptive than others. Users can prevent Cluster Autoscaler from evicting specific pods by using `safe-to-evict=false` annotation, but it rather complitely blocks scaling-down rather than expressing relative disruption cost.
+When scaling down a cluster, Cluster Autoscaler (CA) is currently not aware of the disruption "cost" the action will have, so it can pick a node that will be more disruptive than others. Users can prevent Cluster Autoscaler from evicting specific pods by using the safe-to-evict=false annotation, but it completely blocks scale-down rather than expressing relative disruption cost.
 
 ## High level proposal
 
@@ -14,7 +14,7 @@ The proposal is to introduce a new pod-level user-facing annotation:
 node-autoscaling.kubernetes.io/disruption-cost
 ```
 
-Cluster Autoscaler will read this annotation from pods that would need to be rescheduled when a node is removed. For each already-removable non-empty node, CA will sum the disruption costs of pods and use this total to pick up which node remove next.
+Cluster Autoscaler will read this annotation from pods that would need to be rescheduled when a node is removed. For each already-removable non-empty node, CA will sum the disruption costs of the pods and use this total to choose which node to remove next.
 
 If there is two removable nodes:
 
@@ -34,14 +34,17 @@ CA should prefer removing `node-b` before `node-a`.
 
 ## Goals
 
-* Add another layer of ordering on scale-down process
-* Protect more long running processes from shutting it down and make them to starting over.
+* Allow users to express the relative disruption cost of evicting a pod.
+* Add another layer of ordering to the scale-down process.
+* Protect long-running processes from being shut down and made to start over.
 
 ## Detailed design
 
 ### Annotation
 
-The annotation is placed on Pods. For deployment it can be to set through workload pod templates:
+The annotation is placed on Pods. In practice, users are expected to set it through workload pod templates.
+
+For example:
 
 ```yaml
 apiVersion: apps/v1
@@ -59,41 +62,52 @@ spec:
         image: example/app
 ```
 
-Cluster Autoscaler only reads the annotation. It does not write or mutate it.
+Cluster Autoscaler only reads the annotation and never changes it.
 
-The annotation value is a unit-less non-negative integer. Higher values mean that disrupting the pod is more expensive. Missing or invalid values are treated as zero.
+The value is a unit-less non-negative integer. A higher value means the pod is more expensive to disrupt. If the annotation is missing or cannot be parsed, CA treats the cost as zero.
 
-The overall behavior:
-
-
-| Value              | is                    |
-| ------------------ | --------------------- |
+| Value              | CA sees it as         |
+| ------------------ |-----------------------|
 | missing annotation | 0                     |
-| "0"                | 0                     |
-| "10"               | 10                    |
-| "-1"               | invalid, treated as 0 |
-| "abc"              | invalid, treated as 0 |
-| "10.5"             | invalid, treated as 0 |
+| `"0"`              | 0                     |
+| `"10"`             | 10                    |
+| `"-1"`             | invalid, treated as 0 |
+| `"abc"`            | invalid, treated as 0 |
+| `"10.5"`           | invalid, treated as 0 |
 | overflow           | invalid, treated as 0 |
-
 
 ### Candidate ordering
 
-## Blocking behavior
 
-safe-to-evict
-Daemonset
-On-complition
+### Blocking behavior
 
-### Existing code integration
+`safe-to-evict`
+
+PodDisruptionBudgets
+
+DaemonSet pods
+
+Completed pods
+
+
+
+
+### Existing code refactoring
+
+### Relationship to Karpenter
+
+`karpenter.sh/disruption-cost`
+
 
 ## Monitoring
+
+
 
 ```text
 cluster_autoscaler_invalid_disruption_cost_annotations_total
 ```
 
-Potential optional debug metric:
+
 
 ```text
 cluster_autoscaler_selected_node_disruption_cost

--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -4,17 +4,26 @@ Author: YurDuiachenko
 
 ## Background
 
-When scaling down a cluster, Cluster Autoscaler (CA) is currently not aware of the disruption "cost" the action will have, so it can pick a node that will be more disruptive than others. Users can prevent Cluster Autoscaler from evicting specific pods by using the `safe-to-evict=false` annotation, but it completely blocks scale-down rather than expressing relative disruption cost.
+Currently, there is no common workload-level API for expressing disruption cost of a pod across different node autoscalers:
+
+- Cluster Autoscaler does not consider pod disruption cost in the scale-down process, so it can pick nodes whose removal will be more disruptive than others. 
+- Karpenter uses `controller.kubernetes.io/pod-deletion-cost` for node disruption scoring, but it overloads a ReplicaSet deletion signal with node disruption semantics.
+
+Users can also prevent specific pods from eviction by using autoscaler-specific annotations such as `cluster-autoscaler.kubernetes.io/safe-to-evict` or `karpenter.sh/do-not-disrupt`, 
+but it delays or completely blocks the scale-down process rather than ordering it.
 
 ## High level proposal
 
-The proposal is to introduce a new pod-level user-facing annotation:
+The proposal is to introduce a new user-facing autoscaler-agnostic annotation:
 
 ```text
 node-autoscaling.kubernetes.io/disruption-cost
 ```
 
-Cluster Autoscaler will read this annotation from pods that would need to be rescheduled when a node is removed. For each already-removable non-empty node, CA will sum the disruption costs of the pods and use this total to choose which node to remove next.
+Node autoscalers will read this annotation from pods, with higher values indicating a higher relative disruption cost. 
+Each autoscaler can use its own algorithms for aggregation and candidate selection.
+
+Cluster Autoscaler, for example, will sum the disruption costs of the pods that need to be rescheduled and use this total to choose which node to remove next.
 
 If there are two removable nodes:
 
@@ -30,11 +39,12 @@ node-b:
   total cost=15
 ```
 
-CA should prefer removing `node-b` before `node-a`.
+`node-b` should be removed before `node-a`.
 
 ## Goals
 
 * Allow users to express the relative disruption cost of evicting a pod.
+* Define a common API that can be consumed by different node autoscalers.
 * Add another layer of ordering to the scale-down process.
 * Protect long-running processes from being shut down and made to start over.
 
@@ -62,16 +72,18 @@ spec:
         image: example/app
 ```
 
-CA handles the annotation as follows:
+The common annotation semantics are:
 
-* Cluster Autoscaler only reads the annotation and does not change it.
-* The value is a unitless non-negative integer.
-* A higher value means the pod is more expensive to disrupt.
-* If the annotation is missing or cannot be parsed, CA treats the cost as zero.
+* The annotation is set by user.
+* Node autoscalers only read the annotation and never change it.
+* A higher value represents that disrupting the pod is relatively more expensive.
+* The annotation is a best-effort preference rather than a hard disruption constraint. 
+
+The annotation value is a unitless non-negative integer in the range `[0, MaxInt32]`, so missing, unparsable, negative or out-of-range value should be treated as zero.
 
 Examples:
 
-| Value              | CA sees it as         |
+| Value              | seen as               |
 | ------------------ |-----------------------|
 | missing annotation | 0                     |
 | `"0"`              | 0                     |
@@ -81,9 +93,46 @@ Examples:
 | `"10.5"`           | invalid, treated as 0 |
 | overflow           | invalid, treated as 0 |
 
-### Existing code integration
+### Difference with Pod Deletion Cost
 
-The main logic will be implemented in `Planner.NodesToDelete()`.
+Kubernetes already defines the `controller.kubernetes.io/pod-deletion-cost` annotation, so why is it preferred to introduce a new annotation over reusing the existing one?
+
+While both annotations are placed on pods and have similar naming, during the scale-down process `controller.kubernetes.io/pod-deletion-cost` is used to hint at the deletion cost of a pod compared to other pods within the same **_ReplicaSet_**,
+whereas `node-autoscaling.kubernetes.io/disruption-cost` is used to hint at the disruption cost of a pod compared across different **_nodes_**.
+
+Therefore, reusing the existing annotation would overload it with two independent meanings and consumers.
+The ReplicaSet controller needs a signal for which pods should be deleted first, and node autoscalers need a signal for which pods are more expensive to disrupt during node removal or consolidation. 
+These values are not necessarily the same and may even point in opposite directions.
+
+### Implementation in Cluster Autoscaler
+
+Disruption cost should influence two stages of the Cluster Autoscaler scale-down process:
+
+1. the order in which scale-down candidates are evaluated before node-removal simulation;
+2. the final ordering of already-removable non-empty nodes.
+
+Applying disruption cost only during final node deletion ordering is not sufficient, 
+because candidate evaluation order affects which nodes are marked as unneeded.
+
+For example, consider that either node A or node B can be removed, but not both:
+
+```text
+node-a:
+  total disruption cost=10
+
+node-b:
+  total disruption cost=100
+```
+
+If node B is evaluated first, the scale-down planner may determine that its pods can be moved to node A and mark node B as unneeded. Node A may then never be marked as unneeded. By the time final removable-node ordering is performed, node B may be the only available candidate, leaving no alternative for disruption-cost ordering to prefer.
+
+#### Candidate evaluation ordering
+
+TODO
+
+#### Final removable-node ordering
+
+The final logic will be implemented in `Planner.NodesToDelete()`.
 
 After CA has already calculated removable nodes:
 
@@ -98,7 +147,7 @@ emptyRemovableNodes, needDrainRemovableNodes, unremovableNodes :=
 needDrainRemovableNodes = sortByRisk(needDrainRemovableNodes)
 ```
 
-The proposal extends that ordering with disruption cost:
+That ordering should be extended with disruption cost:
 
 ```go
 needDrainRemovableNodes = sortByRiskAndDisruptionCost(needDrainRemovableNodes)
@@ -107,6 +156,11 @@ needDrainRemovableNodes = sortByRiskAndDisruptionCost(needDrainRemovableNodes)
 The updated function should preserve the existing `riskyNodes` and `okNodes` grouping and use disruption cost as an additional ordering signal within each group.
 
 The total disruption cost for a node should be calculated as the sum of annotation values on pods listed in `NodeToBeRemoved.PodsToReschedule`.
+
+
+### Relationship to Karpenter
+
+TODO
 
 ### Corner cases
 

--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -4,7 +4,7 @@ Author: YurDuiachenko
 
 ## Background
 
-Currently, there is no common workload-level API for expressing disruption cost of a pod across different node autoscalers:
+Currently, there is no shared workload-level API for expressing disruption cost of a pod across different node autoscalers:
 
 - Cluster Autoscaler does not consider pod disruption cost in the scale-down process, so it can pick nodes whose removal will be more disruptive than others. 
 - Karpenter uses `controller.kubernetes.io/pod-deletion-cost` for node disruption scoring, but it overloads a ReplicaSet deletion signal with node disruption semantics.
@@ -39,7 +39,7 @@ node-b:
   total cost=15
 ```
 
-`node-b` should be removed before `node-a`.
+`node-b` will be removed before `node-a`.
 
 ## Goals
 
@@ -47,6 +47,7 @@ node-b:
 * Define a common API that can be consumed by different node autoscalers.
 * Add another layer of ordering to the scale-down process.
 * Protect long-running processes from being shut down and made to start over.
+* Reduce avoidable disruption to workloads that are expensive to restart.
 
 ## Detailed design
 
@@ -74,10 +75,9 @@ spec:
 
 The common annotation semantics are:
 
-* The annotation is set by user.
 * Node autoscalers only read the annotation and never change it.
 * A higher value represents that disrupting the pod is relatively more expensive.
-* The annotation is a best-effort preference rather than a hard disruption constraint. 
+* The annotation is a best-effort preference rather than a hard disruption constraint.
 
 The annotation value is a unitless non-negative integer in the range `[0, MaxInt32]`, so missing, unparsable, negative or out-of-range value should be treated as zero.
 
@@ -93,7 +93,7 @@ Examples:
 | `"10.5"`           | invalid, treated as 0 |
 | overflow           | invalid, treated as 0 |
 
-### Difference with Pod Deletion Cost
+### Difference from Pod Deletion Cost
 
 Kubernetes already defines the `controller.kubernetes.io/pod-deletion-cost` annotation, so why is it preferred to introduce a new annotation over reusing the existing one?
 
@@ -108,12 +108,10 @@ These values are not necessarily the same and may even point in opposite directi
 
 Disruption cost should influence two stages of the Cluster Autoscaler scale-down process:
 
-1. the order in which scale-down candidates are evaluated before node-removal simulation;
-2. the final ordering of already-removable non-empty nodes.
+1. the order in which scale-down candidates are evaluated before removal simulation;
+2. the final ordering of removable nodes.
 
-Applying disruption cost only during final node deletion ordering is not sufficient, 
-because candidate evaluation order affects which nodes are marked as unneeded.
-
+Otherwise, CA will behave incorrectly. 
 For example, consider that either node A or node B can be removed, but not both:
 
 ```text
@@ -124,11 +122,32 @@ node-b:
   total disruption cost=100
 ```
 
-If node B is evaluated first, the scale-down planner may determine that its pods can be moved to node A and mark node B as unneeded. Node A may then never be marked as unneeded. By the time final removable-node ordering is performed, node B may be the only available candidate, leaving no alternative for disruption-cost ordering to prefer.
+If node B is evaluated first, the scale-down planner may determine that its pods can be moved to node A and mark node B as unneeded. 
+Node A may then never be marked as unneeded. By the time final removable-node ordering is performed, node B may be the only available candidate,
+leaving no alternative to prefer.
 
 #### Candidate evaluation ordering
 
-TODO
+Candidate ordering should be applied after the existing eligibility filtering and before node-removal simulation.
+
+In `Planner.categorizeNodes()`, Cluster Autoscaler first filters out candidates that cannot be removed:
+
+```go
+currentlyUnneededNodeNames, utilizationMap, ineligible := p.eligibilityChecker.FilterOutUnremovable(...)
+```
+
+The remaining candidates are then evaluated one by one by `SimulateNodeRemoval()`. 
+The proposal adds a stable disruption cost ordering between these two steps:
+
+```go
+currentlyUnneededNodeNames = sortByPreliminaryDisruptionCost(currentlyUnneededNodeNames)
+
+for _, node := range currentlyUnneededNodeNames {
+    removable, unremovable := p.rs.SimulateNodeRemoval(...)
+}
+```
+
+Candidate nodes with lower preliminary disruption cost should be evaluated first, and candidates with equal preliminary disruption cost should preserve their existing relative order.
 
 #### Final removable-node ordering
 
@@ -137,8 +156,7 @@ The final logic will be implemented in `Planner.NodesToDelete()`.
 After CA has already calculated removable nodes:
 
 ```go
-emptyRemovableNodes, needDrainRemovableNodes, unremovableNodes :=
-    p.unneededNodes.RemovableAt(...)
+emptyRemovableNodes, needDrainRemovableNodes, unremovableNodes := p.unneededNodes.RemovableAt(...)
 ```
 
 `needDrainRemovableNodes` are ordered with `sortByRisk`:
@@ -158,15 +176,18 @@ The updated function should preserve the existing `riskyNodes` and `okNodes` gro
 The total disruption cost for a node should be calculated as the sum of annotation values on pods listed in `NodeToBeRemoved.PodsToReschedule`.
 
 
+
 ### Relationship to Karpenter
 
-TODO
+Karpenter has a related use case for expressing pod disruption cost during consolidation. This proposal captures the same class of user-facing signal as an autoscaler-agnostic annotation under the `node-autoscaling.kubernetes.io` prefix, so workloads do not need separate autoscaler-specific annotations for the same disruption preference.
 
+Karpenter-specific scoring, normalization, consolidation behavior, feature gates, and migration remain outside the scope of this proposal.
 ### Corner cases
 
 * An annotation set on `DaemonSetPods` has no impact on the node disruption cost.
 * `PodDisruptionBudget`s keep their current behavior.
-* Pods with `safe-to-evict=false` should keep blocking scale-down.
+* Pods with `cluster-autoscaler.kubernetes.io/safe-to-evict=false` keep blocking scale-down.
+* Pods with `cluster-autoscaler.kubernetes.io/safe-to-evict=on-completion` keep delaying scale-down until completion.
 
 ## Testing
 
@@ -176,3 +197,8 @@ The following unit test scenarios should be added:
 * [TC2] Valid annotation values are parsed and summed for pods in `NodeToBeRemoved.PodsToReschedule`.
 * [TC3] Nodes with lower total disruption cost are preferred within the same existing ordering group.
 * [TC4] Existing `riskyNodes` and `okNodes` ordering is preserved.
+* [TC5] Candidates with lower preliminary disruption cost are evaluated before higher-cost candidates before node-removal simulation.
+* [TC6] Existing candidate order is preserved when preliminary disruption costs are equal.
+* [TC7] Pods that do not require rescheduling, such as DaemonSet pods, are not included in disruption cost calculation.
+* [TC8] Existing behavior is unchanged when the annotation is absent.
+* [TC9] Increasing a pod's disruption cost does not make an otherwise equivalent node more preferred for removal.

--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -110,7 +110,7 @@ The total disruption cost for a node should be calculated as the sum of annotati
 
 ### Corner cases
 
-* An annotation set on `DaemonSetPods` or `OnCompletionPods` has no impact on the node disruption cost.
+* An annotation set on `DaemonSetPods` has no impact on the node disruption cost.
 * `PodDisruptionBudget`s keep their current behavior.
 * Pods with `safe-to-evict=false` should keep blocking scale-down.
 
@@ -122,4 +122,3 @@ The following unit test scenarios should be added:
 * [TC2] Valid annotation values are parsed and summed for pods in `NodeToBeRemoved.PodsToReschedule`.
 * [TC3] Nodes with lower total disruption cost are preferred within the same existing ordering group.
 * [TC4] Existing `riskyNodes` and `okNodes` ordering is preserved.
-* [TC5] `DaemonSetPods` and `OnCompletionPods` do not affect the initial disruption cost calculation.

--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -4,13 +4,7 @@ Author: YurDuiachenko
 
 ## Background
 
-Cluster Autoscaler can scale down non-empty nodes when their pods can be safely moved elsewhere. During scale-down, CA already evaluates whether a node can be removed by considering node utilization, node group limits, drainability rules, PodDisruptionBudgets, scheduling simulation, and other existing blockers.
-
-However, once multiple non-empty nodes are already removable, CA has limited workload-level information to choose which removable node would be least disruptive to remove first.
-
-The existing `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation is useful for expressing whether a pod can be evicted, but it is mostly binary. It can prevent scale-down entirely for a pod, but it does not allow users to express that one removable pod is more expensive to disrupt than another.
-
-This proposal introduces a soft disruption cost signal that can influence the ordering of already-removable scale-down candidates without changing the existing removability checks.
+When scaling down the cluster it is currently not aware of the disruption "cost" action will have. Therefore it can pick node which will be more disruptive than others.
 
 ## High level proposal
 
@@ -117,19 +111,10 @@ Invalid values should not block scale-down. They should be ignored and treated a
 ### Annotation parsing
 
 
-### Node cost aggregation
-
-
 ### Candidate ordering
 
 
-## Relationship with Karpenter and related consolidation work
-
-
-## Interaction with existing scale-down blockers
-
-
-## DaemonSet behavior
+### DaemonSet behavior
 
 
 ## On-completion pod behavior
@@ -137,9 +122,7 @@ Invalid values should not block scale-down. They should be ignored and treated a
 
 ## Monitoring
 
-The initial implementation may rely on logs for invalid annotation values.
 
-Potential follow-up metric:
 
 ```text
 cluster_autoscaler_invalid_disruption_cost_annotations_total
@@ -151,13 +134,4 @@ Potential optional debug metric:
 cluster_autoscaler_selected_node_disruption_cost
 ```
 
-Metrics are not required for the first implementation unless maintainers request them.
-
-
 ## Testing
-
-
-
-## Risks and mitigations
-
-### Risk: 

--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -1,38 +1,22 @@
-# Disruption Cost Based Scale-Down Ordering
+# Disruption Cost in Scale-Down Ordering
 
 Author: YurDuiachenko
 
 ## Background
 
-When scaling down the cluster it is currently not aware of the disruption "cost" action will have. Therefore it can pick node which will be more disruptive than others.
+When scaling down a cluster, CA is currently not aware of the disruption "cost" action will have, so it can pick node which will be more disruptive than others. Users can prevent Cluster Autoscaler from evicting specific pods by using `safe-to-evict=false` annotation, but it rather complitely blocks scaling-down rather than expressing relative disruption cost.
 
 ## High level proposal
 
-Introduce a pod-level disruption cost annotation.
-
-The preferred annotation name is:
+The proposal is to introduce a new pod-level user-facing annotation:
 
 ```text
 node-autoscaling.kubernetes.io/disruption-cost
 ```
 
-The original issue suggested:
+Cluster Autoscaler will read this annotation from pods that would need to be rescheduled when a node is removed. For each already-removable non-empty node, CA will sum the disruption costs of pods and use this total to pick up which node remove next.
 
-```text
-cluster-autoscaler.kubernetes.io/disruption-cost
-```
-
-This proposal treats the exact annotation prefix as an open question, because related Karpenter and node-autoscaling work is discussing similar disruption/consolidation ordering semantics.
-
-The annotation value is a unit-less non-negative integer. Higher values mean that disrupting the pod is more expensive. Missing or invalid values are treated as zero.
-
-Cluster Autoscaler will read this annotation from pods that would need to be rescheduled when a node is removed. For each already-removable non-empty node, CA will sum the disruption costs of its reschedulable pods and use this total as a soft ordering signal.
-
-This signal must not make an otherwise non-removable node removable. It only affects ordering among nodes that have already passed existing scale-down safety checks.
-
-### Example
-
-Consider two removable nodes:
+If there is two removable nodes:
 
 ```text
 node-a:
@@ -41,34 +25,29 @@ node-a:
   total cost=120
 
 node-b:
-  pod stateless-0 disruption-cost=0
-  pod batch-0     disruption-cost=5
-  total cost=5
+  pod api-1     disruption-cost=5
+  pod worker-1  disruption-cost=10
+  total cost=15
 ```
 
-If both nodes are removable, CA should prefer removing `node-b` before `node-a`.
+CA should prefer removing `node-b` before `node-a`.
 
 ## Goals
 
-* Goals
+* Add another layer of ordering on scale-down process
+* Protect more long running processes from shutting it down and make them to starting over.
 
-## Non-goals
+## Detailed design
 
-* Non-goals
+### Annotation
 
-## Annotation semantics
-
-### Scope
-
-The annotation is placed on Pods. In practice, users are expected to set it through workload pod templates.
-
-Example:
+The annotation is placed on Pods. For deployment it can be to set through workload pod templates:
 
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: expensive-api
+  name: app
 spec:
   template:
     metadata:
@@ -82,47 +61,33 @@ spec:
 
 Cluster Autoscaler only reads the annotation. It does not write or mutate it.
 
-### Value
+The annotation value is a unit-less non-negative integer. Higher values mean that disrupting the pod is more expensive. Missing or invalid values are treated as zero.
 
-The value is a unit-less non-negative integer.
+The overall behavior:
 
-Suggested initial behavior:
 
-| table              | table                 |
-|--------------------|-----------------------|
+| Value              | is                    |
+| ------------------ | --------------------- |
 | missing annotation | 0                     |
 | "0"                | 0                     |
 | "10"               | 10                    |
 | "-1"               | invalid, treated as 0 |
-| "abc"              | invalid, treated as 0 | 
+| "abc"              | invalid, treated as 0 |
 | "10.5"             | invalid, treated as 0 |
 | overflow           | invalid, treated as 0 |
 
 
+### Candidate ordering
 
-Invalid values should not block scale-down. They should be ignored and treated as zero. The implementation may log invalid values and may later expose a metric for observability.
+## Blocking behavior
 
-
-## Detailed design
+safe-to-evict
+Daemonset
+On-complition
 
 ### Existing code integration
 
-
-### Annotation parsing
-
-
-### Candidate ordering
-
-
-### DaemonSet behavior
-
-
-## On-completion pod behavior
-
-
 ## Monitoring
-
-
 
 ```text
 cluster_autoscaler_invalid_disruption_cost_annotations_total

--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -4,7 +4,7 @@ Author: YurDuiachenko
 
 ## Background
 
-When scaling down a cluster, Cluster Autoscaler (CA) is currently not aware of the disruption "cost" the action will have, so it can pick a node that will be more disruptive than others. Users can prevent Cluster Autoscaler from evicting specific pods by using the safe-to-evict=false annotation, but it completely blocks scale-down rather than expressing relative disruption cost.
+When scaling down a cluster, Cluster Autoscaler (CA) is currently not aware of the disruption "cost" the action will have, so it can pick a node that will be more disruptive than others. Users can prevent Cluster Autoscaler from evicting specific pods by using the `safe-to-evict=false` annotation, but it completely blocks scale-down rather than expressing relative disruption cost.
 
 ## High level proposal
 
@@ -16,7 +16,7 @@ node-autoscaling.kubernetes.io/disruption-cost
 
 Cluster Autoscaler will read this annotation from pods that would need to be rescheduled when a node is removed. For each already-removable non-empty node, CA will sum the disruption costs of the pods and use this total to choose which node to remove next.
 
-If there is two removable nodes:
+If there are two removable nodes:
 
 ```text
 node-a:
@@ -62,9 +62,14 @@ spec:
         image: example/app
 ```
 
-Cluster Autoscaler only reads the annotation and never changes it.
+CA handles the annotation as follows:
 
-The value is a unit-less non-negative integer. A higher value means the pod is more expensive to disrupt. If the annotation is missing or cannot be parsed, CA treats the cost as zero.
+* Cluster Autoscaler only reads the annotation and does not change it.
+* The value is a unitless non-negative integer.
+* A higher value means the pod is more expensive to disrupt.
+* If the annotation is missing or cannot be parsed, CA treats the cost as zero.
+
+Examples:
 
 | Value              | CA sees it as         |
 | ------------------ |-----------------------|
@@ -76,41 +81,45 @@ The value is a unit-less non-negative integer. A higher value means the pod is m
 | `"10.5"`           | invalid, treated as 0 |
 | overflow           | invalid, treated as 0 |
 
-### Candidate ordering
+### Existing code integration
 
+The main logic will be implemented in `Planner.NodesToDelete()`.
 
-### Blocking behavior
+After CA has already calculated removable nodes:
 
-`safe-to-evict`
-
-PodDisruptionBudgets
-
-DaemonSet pods
-
-Completed pods
-
-
-
-
-### Existing code refactoring
-
-### Relationship to Karpenter
-
-`karpenter.sh/disruption-cost`
-
-
-## Monitoring
-
-
-
-```text
-cluster_autoscaler_invalid_disruption_cost_annotations_total
+```go
+emptyRemovableNodes, needDrainRemovableNodes, unremovableNodes :=
+    p.unneededNodes.RemovableAt(...)
 ```
 
+`needDrainRemovableNodes` are ordered with `sortByRisk`:
 
-
-```text
-cluster_autoscaler_selected_node_disruption_cost
+```go
+needDrainRemovableNodes = sortByRisk(needDrainRemovableNodes)
 ```
+
+The proposal extends that ordering with disruption cost:
+
+```go
+needDrainRemovableNodes = sortByRiskAndDisruptionCost(needDrainRemovableNodes)
+```
+
+The updated function should preserve the existing `riskyNodes` and `okNodes` grouping and use disruption cost as an additional ordering signal within each group.
+
+The total disruption cost for a node should be calculated as the sum of annotation values on pods listed in `NodeToBeRemoved.PodsToReschedule`.
+
+### Corner cases
+
+* An annotation set on `DaemonSetPods` or `OnCompletionPods` has no impact on the node disruption cost.
+* `PodDisruptionBudget`s keep their current behavior.
+* Pods with `safe-to-evict=false` should keep blocking scale-down.
 
 ## Testing
+
+The following unit test scenarios should be added:
+
+* [TC1] Missing, invalid, negative, non-integer, and overflowing annotation values are treated as zero.
+* [TC2] Valid annotation values are parsed and summed for pods in `NodeToBeRemoved.PodsToReschedule`.
+* [TC3] Nodes with lower total disruption cost are preferred within the same existing ordering group.
+* [TC4] Existing `riskyNodes` and `okNodes` ordering is preserved.
+* [TC5] `DaemonSetPods` and `OnCompletionPods` do not affect the initial disruption cost calculation.

--- a/cluster-autoscaler/proposals/disruption_cost.md
+++ b/cluster-autoscaler/proposals/disruption_cost.md
@@ -39,7 +39,7 @@ node-b:
   total cost=15
 ```
 
-`node-b` will be removed before `node-a`.
+`node-b` should be removed before `node-a`.
 
 ## Goals
 
@@ -48,6 +48,12 @@ node-b:
 * Add another layer of ordering to the scale-down process.
 * Protect long-running processes from being shut down and made to start over.
 * Reduce avoidable disruption to workloads that are expensive to restart.
+
+## Non-Goals
+
+* Define Karpenter-specific scoring, normalization, consolidation behavior, feature gates, or migration.
+* Unify autoscaler-specific hard eviction controls such as `cluster-autoscaler.kubernetes.io/safe-to-evict` and `karpenter.sh/do-not-disrupt`.
+* Guarantee a strict pod or node disruption order.
 
 ## Detailed design
 
@@ -79,30 +85,34 @@ The common annotation semantics are:
 * A higher value represents that disrupting the pod is relatively more expensive.
 * The annotation is a best-effort preference rather than a hard disruption constraint.
 
-The annotation value is a unitless non-negative integer in the range `[0, MaxInt32]`, so missing, unparsable, negative or out-of-range value should be treated as zero.
+The annotation value is a unitless non-negative integer in the range `[0, MaxInt32]`, so missing, unparsable, negative or out-of-range value should be treated as the default for the autoscaler.
 
 Examples:
 
-| Value              | seen as               |
-| ------------------ |-----------------------|
-| missing annotation | 0                     |
-| `"0"`              | 0                     |
-| `"10"`             | 10                    |
-| `"-1"`             | invalid, treated as 0 |
-| `"abc"`            | invalid, treated as 0 |
-| `"10.5"`           | invalid, treated as 0 |
-| overflow           | invalid, treated as 0 |
+| Value              | seen as                     |
+| ------------------ |-----------------------------|
+| missing annotation | autoscaler default          |
+| `"0"`              | 0                           |
+| `"10"`             | 10                          |
+| `"-1"`             | invalid, treated as default |
+| `"abc"`            | invalid, treated as default |
+| `"10.5"`           | invalid, treated as default |
+| overflow           | invalid, treated as default |
 
 ### Difference from Pod Deletion Cost
 
 Kubernetes already defines the `controller.kubernetes.io/pod-deletion-cost` annotation, so why is it preferred to introduce a new annotation over reusing the existing one?
 
-While both annotations are placed on pods and have similar naming, during the scale-down process `controller.kubernetes.io/pod-deletion-cost` is used to hint at the deletion cost of a pod compared to other pods within the same **_ReplicaSet_**,
-whereas `node-autoscaling.kubernetes.io/disruption-cost` is used to hint at the disruption cost of a pod compared across different **_nodes_**.
+While both annotations are placed on pods and have similar naming, they have different shapes and consumers:
 
-Therefore, reusing the existing annotation would overload it with two independent meanings and consumers.
-The ReplicaSet controller needs a signal for which pods should be deleted first, and node autoscalers need a signal for which pods are more expensive to disrupt during node removal or consolidation. 
-These values are not necessarily the same and may even point in opposite directions.
+- `controller.kubernetes.io/pod-deletion-cost` is a relative ordering signal between pods that belong to the same ***ReplicaSet***. 
+It is consumed by the _ReplicaSet controller_ when deciding which replica should be deleted first during scale down.
+
+- `node-autoscaling.kubernetes.io/disruption-cost` is a relative disruption preference between potentially unrelated pods or workloads. 
+It is consumed by _node autoscalers_ when comparing node removal or consolidation candidates.
+
+Reusing `controller.kubernetes.io/pod-deletion-cost` would overload it with two independent meanings, 
+while separation allows autoscalers to write or derive it for ReplicaSet coordination without overwriting the user-facing disruption preference.
 
 ### Implementation in Cluster Autoscaler
 
@@ -184,7 +194,7 @@ Karpenter-specific scoring, normalization, consolidation behavior, feature gates
 
 ### Corner cases
 
-* An annotation set on `DaemonSetPods` has no impact on the node disruption cost.
+* DaemonSet pods do not contribute to node disruption cost.
 * `PodDisruptionBudget`s keep their current behavior.
 * Pods with `cluster-autoscaler.kubernetes.io/safe-to-evict=false` keep blocking scale-down.
 * Pods with `cluster-autoscaler.kubernetes.io/safe-to-evict=on-completion` keep delaying scale-down until completion.
@@ -193,7 +203,7 @@ Karpenter-specific scoring, normalization, consolidation behavior, feature gates
 
 The following unit test scenarios should be added:
 
-* [TC1] Missing, invalid, negative, non-integer, and overflowing annotation values are treated as zero.
+* [TC1] Missing, invalid, negative, non-integer, and out-of-range annotation values are treated as absent and resolved to the autoscaler default.
 * [TC2] Valid annotation values are parsed and summed for pods in `NodeToBeRemoved.PodsToReschedule`.
 * [TC3] Nodes with lower total disruption cost are preferred within the same existing ordering group.
 * [TC4] Existing `riskyNodes` and `okNodes` ordering is preserved.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds an AEP for a new user-facing `node-autoscaling.kubernetes.io/disruption-cost` annotation for expressing the relative cost of disrupting a pod that would work as a shared API  for different node autoscalers.

#### Which issue(s) this PR fixes:

Proposal for #9399

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Key design decisions

- Introducing `node-autoscaling.kubernetes.io/disruption-cost` as a shared user-facing Pod annotation for node autoscalers.
- Node autoscalers only read the annotation and never change it.
- A higher value represents that disrupting the pod is relatively more expensive.
- The annotation is a best-effort preference rather than a hard disruption constraint.
- The annotation value is a unitless non-negative integer in the range `[0, MaxInt32]`, so missing, unparsable, negative or out-of-range value should be treated as zero.

#### Changes since last review

- The proposal is rephrased as more autoscaler-agnostic.
- Added sections for the relationship to Karpenter and the difference from `controller.kubernetes.io/pod-deletion-cost`.
- Updated the CA implementation design so disruption cost affects both candidate evaluation and final removable-node ordering.
- Added `safe-to-evict=on-completion` and additional unit test scenarios.

#### Related

- CA Implementation: still in progress


