### PR TITLE
Enable dependabot updates for the Azure provider

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,10 +125,6 @@ updates:
     - dependency-name: "k8s.io/cloud-provider-gcp/*"
     - dependency-name: "cloud.google.com/go/compute"
     - dependency-name: "cloud.google.com/go/compute/*"
-    - dependency-name: "sigs.k8s.io/cloud-provider-azure"
-    - dependency-name: "sigs.k8s.io/cloud-provider-azure/*"
-    - dependency-name: "github.com/Azure/*"
-    - dependency-name: "github.com/Azure/go-autorest/autorest/*"
     - dependency-name: "github.com/digitalocean/*"
     # Update dependencies exclusively used by providers manually
     - dependency-name: "github.com/gofrs/uuid"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We (AKS) are keen on keeping dependencies up to date with dependabot. 

This PR removes four specific exclusions from dependabot.yml that were blocking updates of dependencies only used by the Azure Cloud Provider.

#### Which issue(s) this PR fixes:

-

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
