### PR TITLE
Fix premature scale-up request removal during concurrent scale-down

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -596,7 +596,14 @@ func (csr *ClusterStateRegistry) getProvisionedAndTargetSizesForNodeGroup(nodeGr
 		}
 		return 0, target, true
 	}
-	provisioned = len(readiness.Registered) - len(readiness.NotStarted)
+	// Nodes that are being deleted are still present in Registered (they
+	// haven't disappeared from the API yet) but they're already excluded
+	// from NodeGroup.TargetSize() once the cloud provider VM deletion call
+	// is made. If we don't exclude them here too , a stale Deleted count
+	// from a finished scale-down can make a new scale-up request look
+	// already-fulfilled (target <= provisioned) causing CA to remove the
+	// scale-up request before any new nodes actually came up. see #9813
+	provisioned = len(readiness.Registered) - len(readiness.NotStarted) - len(readiness.Deleted)
 
 	return provisioned, target, true
 }

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -2272,3 +2272,70 @@ func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
 	// Verify the scale-up request was removed
 	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
 }
+
+func TestScaleUpRequestSurvivesConcurrentScaleDown(t *testing.T) {
+	now := time.Now()
+
+	ng1_1 := BuildTestNode("ng1-1", 1000, 1000)
+	ng1_2 := BuildTestNode("ng1-2", 1000, 1000)
+	ng1_3 := BuildTestNode("ng1-3", 1000, 1000)
+	ng1_4 := BuildTestNode("ng1-4", 1000, 1000)
+	ng1_5 := BuildTestNode("ng1-5", 1000, 1000)
+	allNodes := []*apiv1.Node{ng1_1, ng1_2, ng1_3, ng1_4, ng1_5}
+	for _, n := range allNodes {
+		SetNodeReadyState(n, true, now.Add(-time.Minute))
+	}
+	ng1_1.Spec.ProviderID = "ng1-1"
+	ng1_2.Spec.ProviderID = "ng1-2"
+	ng1_3.Spec.ProviderID = "ng1-3"
+	ng1_4.Spec.ProviderID = "ng1-4"
+	ng1_5.Spec.ProviderID = "ng1-5"
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 1, 10, 5)
+	for _, n := range allNodes {
+		provider.AddNode("ng1", n)
+	}
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system",
+		kube_record.NewFakeRecorder(5), false, "configmap-1")
+
+	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(),
+		nodegroupconfig.NewDefaultNodeGroupConfigProcessor(
+			config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}),
+		&emptyTemplateNodeInfoRegistry{},
+		WithConfig(ClusterStateRegistryConfig{
+			MaxTotalUnreadyPercentage: 10,
+			OkTotalUnreadyCount:       1,
+		}))
+
+	err := clusterstate.UpdateNodes(allNodes, now)
+	assert.NoError(t, err)
+
+	nodeGroup, err := provider.NodeGroupForNode(ng1_4)
+	assert.NoError(t, err)
+	provider.DeleteNode(ng1_4)
+	provider.DeleteNode(ng1_5)
+	nodeGroup.(*testprovider.TestNodeGroup).SetTargetSize(3)
+	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
+
+	err = clusterstate.UpdateNodes(allNodes, now)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(clusterstate.GetClusterReadiness().Deleted))
+
+	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 1, now)
+	nodeGroup.(*testprovider.TestNodeGroup).SetTargetSize(4)
+
+	err = clusterstate.UpdateNodes(allNodes, now)
+	assert.NoError(t, err)
+
+	assert.True(t, clusterstate.HasNodeGroupStartedScaleUp("ng1"),
+		"scale-up request for ng1 should still be tracked; it must not be "+
+			"removed just because stale deleted nodes from a concurrent "+
+			"scale-down are still present (see #9813)")
+
+	upcomingNodes, _ := clusterstate.GetUpcomingNodes()
+	assert.Equal(t, 1, upcomingNodes["ng1"],
+		"the 1 new upcoming node from the scale-up should still be reported")
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it :
**areThereUpcomingNodesInNodeGroup**  determines whether a scale-up request has finished by comparing the NodeGroup's target size against a  **provisioned**  count derived from  **Registered - NotStarted**
Nodes that are being deleted remain in  **Registered**  until they disappear from the K8s API but they're
already excluded from   **NodeGroup.TargetSize( )**  once the cloud provider's VM deletion call is made.

This mismatch lets a *new* scale-up's target-size bump be satisfied by stale `Deleted` nodes left over from an unrelated still finishing scale-down causing the scale-up request to be removed before any new node has actually come up. 
After #9360 this also causes CA to immediately re scale-up for the same pending pods in a tight loop provisioning far
more nodes than needed.

This PR excludes  **Deleted**  nodes from the  **provisioned**  count so they no
longer count toward fulfilling a newer scale-up request.

#### Which issue(s) this PR fixes :
Fixes #9813

#### Special notes for your reviewer:
Added  **TestScaleUpRequestSurvivesConcurrentScaleDown**   which reproduces the exact race from the issue: a scale-down removes nodes from the cloud provider (target size drops) while their K8s Node objects are still present then a smaller scale-up is registered
Without the fix the scale-up request is wrongly removed in the very next loop

#### Does this PR introduce a user-facing change?
```release-note
Fix cluster-autoscaler bug where a scale-up request could be removed before any new node registered 
if it raced with a still-finishing scale-down in the same node group
```

