### PR TITLE
 CA: use consistent logic for determining upcoming Nodes in ClusterStateRegistry

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
@@ -22,6 +22,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
@@ -145,14 +146,25 @@ type NodeGroupOption func(*NodeGroup)
 
 // WithNode adds a single initial node to the group and
 // automatically sets the group's template based on that node.
-func WithNode(node *apiv1.Node) NodeGroupOption {
+func WithNode(templateNode *apiv1.Node) NodeGroupOption {
 	return func(n *NodeGroup) {
-		n.provider.nodeToGroup[node.Name] = n.id
-		n.instances[node.Name] = cloudprovider.InstanceRunning
-		n.targetSize = 1
-		n.template = framework.NewTestNodeInfo(node.DeepCopy())
+		n.setTemplateFromNodeAndPods(templateNode)
+		addedNode := n.addNodeFromTemplate(templateNode.Name)
 		if n.provider.k8s != nil {
-			n.provider.k8s.AddNode(node)
+			n.provider.k8s.AddNode(addedNode)
+		}
+	}
+}
+
+// WithNodes configures the provided Node as the template for the NodeGroup, and adds nodeCount copies of the template to the NodeGroup.
+func WithNodes(templateNode *apiv1.Node, nodeCount int) NodeGroupOption {
+	return func(n *NodeGroup) {
+		n.setTemplateFromNodeAndPods(templateNode)
+		for i := range nodeCount {
+			addedNode := n.addNodeFromTemplate(fmt.Sprintf("%s-node-%d", n.id, i))
+			if n.provider.k8s != nil {
+				n.provider.k8s.AddNode(addedNode)
+			}
 		}
 	}
 }
@@ -174,7 +186,7 @@ func WithTemplate(template *framework.NodeInfo) NodeGroupOption {
 }
 
 // AddNodeGroup is a helper for tests to add a group with its template.
-func (c *CloudProvider) AddNodeGroup(id string, opts ...NodeGroupOption) {
+func (c *CloudProvider) AddNodeGroup(id string, opts ...NodeGroupOption) *NodeGroup {
 	c.Lock()
 	defer c.Unlock()
 
@@ -191,6 +203,8 @@ func (c *CloudProvider) AddNodeGroup(id string, opts ...NodeGroupOption) {
 		opt(group)
 	}
 	c.groups[id] = group
+
+	return group
 }
 
 // GetNodeGroup is a helper for tests to get a node group.
@@ -340,41 +354,41 @@ func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*co
 }
 
 // TargetSize returns the current target size of the node group.
-func (n *NodeGroup) TargetSize() (int, error) { return n.targetSize, nil }
+func (n *NodeGroup) TargetSize() (int, error) {
+	n.Lock()
+	defer n.Unlock()
+	return n.targetSize, nil
+}
 
 // IncreaseSize adds nodes to the node group and updates internal instance mapping.
 func (n *NodeGroup) IncreaseSize(delta int) error {
 	n.Lock()
 	defer n.Unlock()
+
 	if n.targetSize+delta > n.maxSize {
 		return fmt.Errorf("size too large")
+	}
+	if n.template == nil || n.template.Node() == nil {
+		return fmt.Errorf("node group %s has no template to create new nodes", n.id)
 	}
 
 	n.provider.Lock()
 	defer n.provider.Unlock()
 
 	for i := 0; i < delta; i++ {
-		instanceNum := n.targetSize + i
-		instanceId := fmt.Sprintf("%s-node-%d", n.id, instanceNum)
-
-		if n.template == nil || n.template.Node() == nil {
-			return fmt.Errorf("node group %s has no template to create new nodes", n.id)
-		}
-		newNode := n.template.Node().DeepCopy()
-		newNode.Name = instanceId
-
-		n.instances[instanceId] = cloudprovider.InstanceRunning
-		n.provider.nodeToGroup[instanceId] = n.id
+		nodeName := fmt.Sprintf("%s-node-%s", n.id, rand.String(4))
+		newNode := n.addNodeFromTemplate(nodeName)
 		if n.provider.k8s != nil {
 			n.provider.k8s.AddNode(newNode)
 		}
 	}
-	n.targetSize += delta
 	return nil
 }
 
 // TemplateNodeInfo returns the template node information for this node group.
 func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+	n.Lock()
+	defer n.Unlock()
 	if n.template == nil {
 		return nil, cloudprovider.ErrNotImplemented
 	}
@@ -382,4 +396,34 @@ func (n *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 }
 
 // GetTargetSize returns the target size as a raw integer (helper method).
-func (n *NodeGroup) GetTargetSize() int { return n.targetSize }
+func (n *NodeGroup) GetTargetSize() int {
+	n.Lock()
+	defer n.Unlock()
+	return n.targetSize
+}
+
+// setTemplateFromNodeAndPods configures the result of TemplateNodeInfo() based on a copy of the provided Node and the provided Pods.
+// Should be called with the NodeGroup mutex already locked, or during NodeGroup object initialization without the lock.
+func (n *NodeGroup) setTemplateFromNodeAndPods(node *apiv1.Node, pods ...*apiv1.Pod) {
+	templateNode := cloneNodeForNodeGroup(node, n.id, fmt.Sprintf("%s-template", n.id))
+	n.template = framework.NewTestNodeInfo(templateNode, pods...)
+}
+
+// addNode adds a deep-copy of the provided Node to this NodeGroup and its CloudProvider. The added Node is returned from the method.
+// Should be called with the NodeGroup mutex already locked, or during NodeGroup object initialization without the lock.
+func (n *NodeGroup) addNodeFromTemplate(nodeName string) *apiv1.Node {
+	node := cloneNodeForNodeGroup(n.template.Node(), n.id, nodeName)
+	n.instances[node.Spec.ProviderID] = cloudprovider.InstanceRunning
+	n.provider.nodeToGroup[node.Name] = n.id
+	n.targetSize += 1
+	return node
+}
+
+// cloneNodeForNodeGroup returns a deep-copy of the provided templateNode, to be tracked by the fake CloudProvider/NodeGroup.
+// Any Node used with the fake CloudProvider should go through this function.
+func cloneNodeForNodeGroup(templateNode *apiv1.Node, ngName, nodeName string) *apiv1.Node {
+	node := templateNode.DeepCopy()
+	node.Name = nodeName
+	node.Spec.ProviderID = fmt.Sprintf("fake-provider/%s/%s", ngName, node.Name)
+	return node
+}

--- a/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
@@ -19,6 +19,7 @@ package test
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	fakek8s "k8s.io/autoscaler/cluster-autoscaler/utils/fake"
+	testutils "k8s.io/autoscaler/cluster-autoscaler/utils/test"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 )
 
@@ -45,7 +47,9 @@ type CloudProvider struct {
 	maxLimits map[string]int64
 	// nodeToGroup tracks which node name belongs to which group ID.
 	nodeToGroup map[string]string
-	k8s         *fakek8s.Kubernetes
+
+	// k8s is thread-safe, can be safely accessed without the CloudProvider mutex.
+	k8s *fakek8s.Kubernetes
 }
 
 // CloudProviderOption defines a function to configure the CloudProvider.
@@ -185,6 +189,28 @@ func WithTemplate(template *framework.NodeInfo) NodeGroupOption {
 	}
 }
 
+// WithNodeGarbageCollectionDelay can be used to simulate Node objects hanging around in the K8s API for some time after their VMs are deleted.
+func WithNodeGarbageCollectionDelay(delay time.Duration) NodeGroupOption {
+	return func(n *NodeGroup) {
+		n.nodeGarbageCollectionDelay = delay
+	}
+}
+
+// WithNodeRegistrationDelay can be used to simulate Node objects taking some time to appear in the K8s API after their VMs are created.
+func WithNodeRegistrationDelay(delay time.Duration) NodeGroupOption {
+	return func(n *NodeGroup) {
+		n.nodeRegistrationDelay = delay
+	}
+}
+
+// WithNodeReadinessDelay can be used to simulate Node objects taking some time to transition to Ready after they appear in the K8s API. If not used, the Nodes
+// will appear as Ready immediately after registration.
+func WithNodeReadinessDelay(delay time.Duration) NodeGroupOption {
+	return func(n *NodeGroup) {
+		n.nodeReadinessDelay = delay
+	}
+}
+
 // AddNodeGroup is a helper for tests to add a group with its template.
 func (c *CloudProvider) AddNodeGroup(id string, opts ...NodeGroupOption) *NodeGroup {
 	c.Lock()
@@ -240,6 +266,14 @@ type NodeGroup struct {
 	// instances maps instanceID -> state.
 	instances map[string]cloudprovider.InstanceState
 	provider  *CloudProvider
+
+	// nodeGarbageCollectionDelay can be used to simulate Node objects hanging around in the K8s API for some time after their VMs are deleted.
+	nodeGarbageCollectionDelay time.Duration
+	// nodeRegistrationDelay can be used to simulate Node objects taking some time to appear in the K8s API after their VMs are created.
+	nodeRegistrationDelay time.Duration
+	// nodeReadinessDelay can be used to simulate Node objects taking some time to transition to Ready after they appear in the K8s API. If unset,
+	// the Nodes will appear as Ready immediately after registration.
+	nodeReadinessDelay time.Duration
 }
 
 // MaxSize returns the maximum size of the node group.
@@ -269,10 +303,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	for _, node := range nodes {
 		if groupId, exists := n.provider.nodeToGroup[node.Name]; exists && groupId == n.id {
 			delete(n.provider.nodeToGroup, node.Name)
-			delete(n.instances, node.Name)
-			if n.provider.k8s != nil {
-				n.provider.k8s.DeleteNode(node.Name)
-			}
+			delete(n.instances, node.Spec.ProviderID)
 			deletedCount++
 		} else {
 			fmt.Printf("Warning: node %s not found in group %s or already deleted.", node.Name, n.id)
@@ -283,6 +314,21 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 		n.targetSize -= deletedCount
 	} else {
 		n.targetSize = 0
+	}
+
+	// Remove the Nodes from the K8s fake if it's configured.
+	if n.provider.k8s == nil {
+		return nil
+	}
+	if n.nodeGarbageCollectionDelay == 0 {
+		// No delays configured, synchronously delete the Nodes from the K8s fake.
+		for _, node := range nodes {
+			n.provider.k8s.DeleteNode(node.Name)
+		}
+	} else {
+		// Node garbage collection delay is configured, handle deleting the Nodes from the K8s fake asynchronously.
+		// The K8s fake is thread safe, so we don't need the provider lock to access it - should be safe to use in a goroutine.
+		go simulateK8sApiNodeDeletion(n.provider.k8s, nodes, n.nodeGarbageCollectionDelay)
 	}
 
 	return nil
@@ -375,13 +421,29 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 	n.provider.Lock()
 	defer n.provider.Unlock()
 
+	var newNodes []*apiv1.Node
 	for i := 0; i < delta; i++ {
 		nodeName := fmt.Sprintf("%s-node-%s", n.id, rand.String(4))
 		newNode := n.addNodeFromTemplate(nodeName)
-		if n.provider.k8s != nil {
-			n.provider.k8s.AddNode(newNode)
-		}
+		newNodes = append(newNodes, newNode)
 	}
+
+	// Add the new Nodes to the K8s fake if it's configured.
+	if n.provider.k8s == nil {
+		return nil
+	}
+	if n.nodeRegistrationDelay == 0 && n.nodeReadinessDelay == 0 {
+		// No delays configured, synchronously add the Nodes as Ready to the K8s fake.
+		for _, node := range newNodes {
+			testutils.IsReady(true)(node)
+			n.provider.k8s.AddNode(node)
+		}
+	} else {
+		// Node registration/readiness delays are configured, handle adding the Nodes to the K8s fake asynchronously.
+		// The K8s fake is thread safe, so we don't need the provider lock to access it - should be safe to use in a goroutine.
+		go simulateK8sApiNodeRegistration(n.provider.k8s, newNodes, n.nodeRegistrationDelay, n.nodeReadinessDelay)
+	}
+
 	return nil
 }
 
@@ -426,4 +488,41 @@ func cloneNodeForNodeGroup(templateNode *apiv1.Node, ngName, nodeName string) *a
 	node.Name = nodeName
 	node.Spec.ProviderID = fmt.Sprintf("fake-provider/%s/%s", ngName, node.Name)
 	return node
+}
+
+func simulateK8sApiNodeDeletion(k8s *fakek8s.Kubernetes, nodes []*apiv1.Node, garbageCollectionDelay time.Duration) {
+	if garbageCollectionDelay > 0 {
+		// If configured, simulate a delay between the VM deletion call and the Nodes disappearing.
+		time.Sleep(garbageCollectionDelay)
+	}
+
+	for _, node := range nodes {
+		k8s.DeleteNode(node.Name)
+	}
+}
+
+func simulateK8sApiNodeRegistration(k8s *fakek8s.Kubernetes, nodes []*apiv1.Node, registrationDelay, readinessDelay time.Duration) {
+	if registrationDelay > 0 {
+		// If configured, simulate a delay between the VM creation call and the Node registering in the K8s API.
+		time.Sleep(registrationDelay)
+	}
+
+	// If no readinessDelay is configured, the Nodes just start as Ready. Otherwise, they start as not-Ready, and are updated to Ready after readinessDelay.
+	nodesInitiallyReady := readinessDelay == 0
+	for _, node := range nodes {
+		testutils.IsReady(nodesInitiallyReady)(node)
+		k8s.AddNode(node)
+	}
+
+	if readinessDelay == 0 {
+		return
+	}
+	// If configured, simulate a delay between the Node registering in the K8s API and the Node becoming Ready.
+	time.Sleep(readinessDelay)
+	for _, node := range nodes {
+		// We injected the Node object to the API earlier, so something could be reading it asynchronously - we need to deep copy before modifying the readiness.
+		nodeCopy := node.DeepCopy()
+		testutils.IsReady(true)(nodeCopy)
+		k8s.UpdateNode(nodeCopy)
+	}
 }

--- a/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
@@ -22,11 +22,13 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	fakek8s "k8s.io/autoscaler/cluster-autoscaler/utils/fake"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 )
 
 const (
@@ -59,8 +61,9 @@ func NewCloudProvider(k8s *fakek8s.Kubernetes) *CloudProvider {
 		},
 		maxLimits: map[string]int64{
 			// Set to a effectively infinite number for tests.
+			// TODO: The fake cloud provider shouldn't have its own limits configuration for CPU and memory, it should honor AutoscalingOptions.MaxCoresTotal/MaxMemoryTotal.
 			cloudprovider.ResourceNameCores:  1000000,
-			cloudprovider.ResourceNameMemory: 1000000,
+			cloudprovider.ResourceNameMemory: 1000000 * units.GiB,
 		},
 		k8s: k8s,
 	}

--- a/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -47,6 +48,14 @@ type CloudProvider struct {
 	maxLimits map[string]int64
 	// nodeToGroup tracks which node name belongs to which group ID.
 	nodeToGroup map[string]string
+	// nodeGroupForNodeWorksForDeletedNodes controls the behavior of CloudProvider.NodeGroupForNode(), so that different behaviors can be tested:
+	// - [default] If false, NodeGroupForNode() returns the NodeGroup based on the CloudProvider.nodeToGroup map, which means it doesn't work for deleted Nodes.
+	// - If true, NodeGroupForNode() returns the NodeGroup based on Node.ProviderID, which means it works for deleted Nodes.
+	nodeGroupForNodeWorksForDeletedNodes bool
+	// hasInstanceImplemented controls the behavior of CloudProvider.HasInstance(), so that different behaviors can be tested:
+	// - [default] If false, HasInstance() is implemented and responds true for Nodes tracked by the fake CloudProvider until they're deleted via DeleteNodes().
+	// - If true, HasInstance() always returns the ErrNotImplemented error. This is supported by CA, HasInstance() is an optional method.
+	hasInstanceNotImplemented bool // The field is negated so that the default behavior with the field being false is "HasInstance() is implemented".
 
 	// k8s is thread-safe, can be safely accessed without the CloudProvider mutex.
 	k8s *fakek8s.Kubernetes
@@ -86,9 +95,20 @@ func (c *CloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 // NodeGroupForNode returns the node group that a given node belongs to.
+// The method behaves differently based on the CloudProvider.nodeGroupForNodeWorksForDeletedNodes field,
+// so that different behaviors can be tested (see the comment on the field for more details).
 func (c *CloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
 	c.Lock()
 	defer c.Unlock()
+
+	if c.nodeGroupForNodeWorksForDeletedNodes {
+		groupId, err := groupIdFromNodeProviderId(node.Spec.ProviderID)
+		if err != nil {
+			return nil, err
+		}
+		return c.groups[groupId], nil
+	}
+
 	groupId, ok := c.nodeToGroup[node.Name]
 	if !ok {
 		return nil, nil
@@ -96,10 +116,17 @@ func (c *CloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGr
 	return c.groups[groupId], nil
 }
 
-// HasInstance returns true if the given node is managed by this cloud provider.
+// HasInstance returns true if the given node is managed by this cloud provider, until the Node is deleted via DeleteNodes().
+// The method behaves differently based on the CloudProvider.nodeGroupForNodeWorksForDeletedNodes field,
+// so that different behaviors can be tested (see the comment on the field for more details).
 func (c *CloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	c.Lock()
 	defer c.Unlock()
+
+	if c.hasInstanceNotImplemented {
+		return false, cloudprovider.ErrNotImplemented
+	}
+
 	_, found := c.nodeToGroup[node.Name]
 	return found, nil
 }
@@ -253,6 +280,22 @@ func (c *CloudProvider) SetResourceLimit(resource string, min, max int64) {
 	defer c.Unlock()
 	c.minLimits[resource] = min
 	c.maxLimits[resource] = max
+}
+
+// ConfigureNodeGroupForNodeBehavior configures the behavior of CloudProvider.NodeGroupForNode(). See the comment on CloudProvider.nodeGroupForNodeWorksForDeletedNodes for more details.
+func (c *CloudProvider) ConfigureNodeGroupForNodeBehavior(worksForDeletedNodes bool) {
+	c.Lock()
+	defer c.Unlock()
+	c.nodeGroupForNodeWorksForDeletedNodes = worksForDeletedNodes
+}
+
+// ConfigureHasInstanceBehavior configures the behavior of CloudProvider.HasInstance(). See the comment on CloudProvider.hasInstanceNotImplemented for more details.
+func (c *CloudProvider) ConfigureHasInstanceBehavior(notImplemented bool) {
+	c.Lock()
+	defer c.Unlock()
+	// The field is negated so that the default behavior with the field being false is "HasInstance() is implemented". The argument to this method is also negated so that
+	// they match 1-1 and the comment on the field works for this method as well.
+	c.hasInstanceNotImplemented = notImplemented
 }
 
 // NodeGroup is a fake implementation of the cloudprovider.NodeGroup interface for testing.
@@ -488,6 +531,15 @@ func cloneNodeForNodeGroup(templateNode *apiv1.Node, ngName, nodeName string) *a
 	node.Name = nodeName
 	node.Spec.ProviderID = fmt.Sprintf("fake-provider/%s/%s", ngName, node.Name)
 	return node
+}
+
+// groupIdFromNodeProviderId parses the Spec.ProviderID set by cloneNodeForNodeGroup() and extracts the NodeGroup id from it.
+func groupIdFromNodeProviderId(nodeProviderId string) (string, error) {
+	parts := strings.Split(nodeProviderId, "/")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("ngIdFromNodeProviderId(): nodeProviderId should be in the format <provider_name>/<ng_id>/<node_name>, got %s", nodeProviderId)
+	}
+	return parts[1], nil
 }
 
 func simulateK8sApiNodeDeletion(k8s *fakek8s.Kubernetes, nodes []*apiv1.Node, garbageCollectionDelay time.Duration) {

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -575,38 +575,36 @@ func (csr *ClusterStateRegistry) NodeGroupScaleUpSafety(nodeGroup cloudprovider.
 	return NodeGroupScalingSafety{SafeToScale: isHealthy && !backoffStatus.IsBackedOff, Healthy: isHealthy, BackoffStatus: backoffStatus}
 }
 
-func (csr *ClusterStateRegistry) getProvisionedAndTargetSizesForNodeGroup(nodeGroupName string) (provisioned, target int, ok bool) {
+func (csr *ClusterStateRegistry) getUpcomingNodesInNodeGroup(nodeGroupName string) (upcoming int, ok bool) {
 	if len(csr.acceptableRanges) == 0 {
 		klog.Warningf("AcceptableRanges have not been populated yet. Skip checking")
-		return 0, 0, false
+		return 0, false
 	}
 
 	acceptable, found := csr.acceptableRanges[nodeGroupName]
 	if !found {
 		klog.Warningf("Failed to find acceptable ranges for %v", nodeGroupName)
-		return 0, 0, false
+		return 0, false
 	}
-	target = acceptable.CurrentTarget
 
 	readiness, found := csr.perNodeGroupReadiness[nodeGroupName]
 	if !found {
-		// No need to warn if node group has size 0 (was scaled to 0 before).
 		if acceptable.MinNodes != 0 {
+			// No need to warn if node group has size 0 (was scaled to 0 before).
 			klog.Warningf("Failed to find readiness information for %v", nodeGroupName)
 		}
-		return 0, target, true
+		return acceptable.CurrentTarget, true
 	}
-	provisioned = len(readiness.Registered) - len(readiness.NotStarted)
-
-	return provisioned, target, true
+	// TODO: Unify the logic determining the input to calculateUpcomingNodesInNodeGroup() with GetUpcomingNodes().
+	return calculateUpcomingNodesInNodeGroup(readiness, acceptable), true
 }
 
 func (csr *ClusterStateRegistry) areThereUpcomingNodesInNodeGroup(nodeGroupName string) bool {
-	provisioned, target, ok := csr.getProvisionedAndTargetSizesForNodeGroup(nodeGroupName)
+	upcoming, ok := csr.getUpcomingNodesInNodeGroup(nodeGroupName)
 	if !ok {
 		return false
 	}
-	return target > provisioned
+	return upcoming > 0
 }
 
 // IsNodeGroupRegistered returns true if the node group is registered in cluster state.
@@ -617,11 +615,11 @@ func (csr *ClusterStateRegistry) IsNodeGroupRegistered(nodeGroupName string) boo
 
 // IsNodeGroupAtTargetSize returns true if the number of nodes provisioned in the group is equal to the target number of nodes.
 func (csr *ClusterStateRegistry) IsNodeGroupAtTargetSize(nodeGroupName string) bool {
-	provisioned, target, ok := csr.getProvisionedAndTargetSizesForNodeGroup(nodeGroupName)
+	upcoming, ok := csr.getUpcomingNodesInNodeGroup(nodeGroupName)
 	if !ok {
 		return false
 	}
-	return target == provisioned
+	return upcoming == 0
 }
 
 // IsNodeGroupScalingUp returns true if the node group is currently scaling up.
@@ -1120,8 +1118,8 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() (upcomingCounts map[string]i
 		}
 		readiness := csr.perNodeGroupReadiness[id]
 		ar := csr.acceptableRanges[id]
-		// newNodes is the number of nodes that
-		newNodes := ar.CurrentTarget - (len(readiness.Ready) + len(readiness.Unready) + len(readiness.Suspended) + len(readiness.LongUnregistered))
+		// TODO: Unify the logic determining the input to calculateUpcomingNodesInNodeGroup() with getUpcomingNodesInNodeGroup().
+		newNodes := calculateUpcomingNodesInNodeGroup(readiness, ar)
 		if newNodes <= 0 {
 			// Negative value is unlikely but theoretically possible.
 			continue
@@ -1148,6 +1146,12 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() (upcomingCounts map[string]i
 		registeredNodeNames[id] = readiness.NotStarted
 	}
 	return upcomingCounts, registeredNodeNames
+}
+
+// calculateUpcomingNodesInNodeGroup calculates how many upcoming Nodes there are in a given NodeGroup, based on the provided CSR tracking
+// objects for the NodeGroup.
+func calculateUpcomingNodesInNodeGroup(ngReadiness Readiness, ngAcceptableRange AcceptableRange) int {
+	return ngAcceptableRange.CurrentTarget - (len(ngReadiness.Ready) + len(ngReadiness.Unready) + len(ngReadiness.Suspended) + len(ngReadiness.LongUnregistered))
 }
 
 // getRunningNodeGroups returns running node groups, filters out upcoming ones.

--- a/cluster-autoscaler/core/bench/benchmark_runonce_test.go
+++ b/cluster-autoscaler/core/bench/benchmark_runonce_test.go
@@ -33,6 +33,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8s_testing "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"k8s.io/autoscaler/cluster-autoscaler/builder"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
@@ -46,10 +51,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/test/integration"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
-	"k8s.io/client-go/kubernetes/fake"
-	k8s_testing "k8s.io/client-go/testing"
-	"k8s.io/klog/v2"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // Benchmark evaluates the performance of the Cluster Autoscaler's primary control loop (RunOnce).
@@ -425,22 +426,16 @@ func setupScaleDown60Percent(nodesCount int) func(*integration.FakeSet) error {
 		nTemplate := BuildTestNode("n-template", nodeCPU, nodeMem)
 		SetNodeReadyState(nTemplate, true, time.Now())
 
-		clusterFakes.CloudProvider.AddNodeGroup(ngName,
-			testprovider.WithTemplate(framework.NewNodeInfo(nTemplate, nil)),
+		ng := clusterFakes.CloudProvider.AddNodeGroup(ngName,
+			testprovider.WithNodes(nTemplate, nodesCount),
 			testprovider.WithNGSize(0, maxNGSize),
 		)
 
-		ng := clusterFakes.CloudProvider.GetNodeGroup(ngName)
-		if err := ng.IncreaseSize(nodesCount); err != nil {
-			return err
-		}
-
-		ngID := ng.Id()
 		// Create 40 pods per node.
 		// Each pod uses 1% of a node's resources, leading to 40% utilization.
 		for i := range nodesCount * 40 {
 			podName := fmt.Sprintf("pod-%d", i)
-			nodeName := fmt.Sprintf("%s-node-%d", ngID, i%nodesCount)
+			nodeName := fmt.Sprintf("%s-node-%d", ng.Id(), i%nodesCount) // testprovider.WithNodes() names Nodes in this format.
 			cpu := int64(nodeCPU / 100)
 			mem := int64(nodeMem / 100)
 			pod := BuildTestPod(podName, cpu, mem)

--- a/cluster-autoscaler/test/integration/config.go
+++ b/cluster-autoscaler/test/integration/config.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 )
 
 // DefaultAutoscalingOptions provides the baseline configuration for all tests.
@@ -31,17 +32,21 @@ var DefaultAutoscalingOptions = config.AutoscalingOptions{
 		ScaleDownUtilizationThreshold: 0.5,
 		MaxNodeProvisionTime:          10 * time.Second,
 	},
+	MaxTotalUnreadyPercentage:  1,
+	OkTotalUnreadyCount:        100000,
 	EstimatorName:              estimator.BinpackingEstimatorName,
 	EnforceNodeGroupMinSize:    true,
 	ScaleDownSimulationTimeout: 24 * time.Hour,
 	ScaleDownDelayAfterAdd:     0,
 	ScaleDownDelayAfterDelete:  0,
 	ScaleDownDelayAfterFailure: 0,
+	MaxScaleDownParallelism:    10,
+	MaxDrainParallelism:        1,
 	ScaleDownDelayTypeLocal:    true,
 	ScaleDownEnabled:           true,
-	MaxNodesTotal:              10,
-	MaxCoresTotal:              10,
-	MaxMemoryTotal:             100000,
+	MaxNodesTotal:              10000,
+	MaxCoresTotal:              100000,             // WARN: This setting isn't actually used by the fake CloudProvider.GetResourceLimiter(), there's a separate config there.
+	MaxMemoryTotal:             100000 * units.GiB, // WARN: This setting isn't actually used by the fake CloudProvider.GetResourceLimiter(), there's a separate config there.
 	ExpanderNames:              "least-waste",
 	ScaleUpFromZero:            true,
 	FrequentLoopsEnabled:       true,

--- a/cluster-autoscaler/test/integration/inmemory/clusterstateregistry_test.go
+++ b/cluster-autoscaler/test/integration/inmemory/clusterstateregistry_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	fakecloudprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/test/integration"
+	synctestutils "k8s.io/autoscaler/cluster-autoscaler/test/integration/synctest"
+	fakek8s "k8s.io/autoscaler/cluster-autoscaler/utils/fake"
+	testutils "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
+)
+
+// TestClusterStateRegistryScaleUpWithDeletedNodes is an integration test validating that ClusterStateRegistry correctly handles scaling up while deleted Nodes
+// from a previous scale-down are still hanging around in the K8s API.
+func TestClusterStateRegistryScaleUpWithDeletedNodes(t *testing.T) {
+	// This is a regression test for a complex race-condition bug in ClusterStateRegistry.
+	// Full details about the bug can be found in https://github.com/kubernetes/autoscaler/issues/9813
+	for _, tc := range []struct {
+		testName string
+		// nodeGroupForNodeWorksForDeletedNodes is used to test different supported behaviors of the CloudProvider.NodeGroupForNode() method.
+		nodeGroupForNodeWorksForDeletedNodes bool
+		// hasInstanceNotImplemented is used to test different supported behaviors of the CloudProvider.HasInstance() method.
+		// Note that the behavior of HasInstance() returning still returning true for Nodes deleted via NodeGroup.DeleteNodes() is not supported
+		// and this test would not pass with it.
+		hasInstanceNotImplemented bool // The field is negated to match the parameter to ConfigureHasInstanceBehavior().
+	}{
+		{
+			testName:                             "NodeGroupForNode_works_for_deleted_HasInstance_implemented",
+			nodeGroupForNodeWorksForDeletedNodes: true,
+			hasInstanceNotImplemented:            false,
+		},
+		{
+			testName:                             "NodeGroupForNode_works_for_deleted_HasInstance_not_implemented",
+			nodeGroupForNodeWorksForDeletedNodes: true,
+			hasInstanceNotImplemented:            true,
+		},
+		{
+			testName:                             "NodeGroupForNode_returns_nil_for_deleted_HasInstance_implemented",
+			nodeGroupForNodeWorksForDeletedNodes: false,
+			hasInstanceNotImplemented:            false,
+		},
+		{
+			testName:                             "NodeGroupForNode_returns_nil_for_deleted_HasInstance_not_implemented",
+			nodeGroupForNodeWorksForDeletedNodes: false,
+			hasInstanceNotImplemented:            true,
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			sdUnneededTime := 1 * time.Minute // arbitrary
+			stepDuration := 10 * time.Second  // arbitrary
+			stepsBetweenScaleDownAndGarbageCollection := 3
+			stepsBetweenScaleUpAndNodeRegistration := 3
+			nodeGarbageCollectionDelay := time.Duration(stepsBetweenScaleDownAndGarbageCollection) * stepDuration
+			nodeRegistrationDelay := time.Duration(stepsBetweenScaleUpAndNodeRegistration) * stepDuration
+			// maxNodeProvisionTime is intentionally higher than nodeRegistrationDelay so that CSR never hits a timeout when waiting for the upcoming Nodes.
+			maxNodeProvisionTime := nodeRegistrationDelay + stepDuration
+
+			options := integration.NewTestConfig().WithOverrides(func(opts *config.AutoscalingOptions) {
+				opts.NodeGroupDefaults.ScaleDownUnneededTime = sdUnneededTime
+				opts.NodeGroupDefaults.MaxNodeProvisionTime = maxNodeProvisionTime
+			}).ResolveOptions()
+
+			infra := integration.SetupInfrastructure(t)
+			// Configure the behavior of the fake CloudProvider methods according to the test case.
+			infra.Fakes.CloudProvider.ConfigureNodeGroupForNodeBehavior(tc.nodeGroupForNodeWorksForDeletedNodes)
+			infra.Fakes.CloudProvider.ConfigureHasInstanceBehavior(tc.hasInstanceNotImplemented)
+
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer synctestutils.TearDown(cancel)
+
+				autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+				if err != nil {
+					t.Fatalf("DefaultAutoscalingBuilder() unexpected error: %v", err)
+				}
+
+				// ======== STEP 0: Prepare the initial state of the test NodeGroup ========
+				initialNodeCount := 10
+				ngName := "ng"
+				templateNode := testutils.BuildTestNode("ng-template", 1000, 2*units.GiB, testutils.IsReady(true))
+				// The test NodeGroup is configured with artificial delays simulating real-world conditions that have impact on ClusterStateRegistry logic:
+				// - Node objects are only deleted from the K8s API fake after nodeGarbageCollectionDelay elapses since the DeleteNodes() call. This is to simulate Node objects
+				//   hanging around for some time after the VM deletion call, and being processed by subsequent CA loops.
+				// - Node objects are only added to the K8s API fake after nodeRegistrationDelay elapses since the IncreaseSize() call. This is to simulate a delay between VM creation
+				//   call and the VM registering as Node in K8s. During this delay, CA needs to model upcoming Nodes correctly in order not to scale-up again unnecessarily.
+				fakeNodeGroup := infra.Fakes.CloudProvider.AddNodeGroup(ngName,
+					fakecloudprovider.WithNodes(templateNode, initialNodeCount),
+					fakecloudprovider.WithNodeGarbageCollectionDelay(nodeGarbageCollectionDelay),
+					fakecloudprovider.WithNodeRegistrationDelay(nodeRegistrationDelay),
+				)
+				// Create scheduled Pods to block a portion of the initial Nodes from being scaled down. Each Pod requires a dedicated Node, and blocks CA from scaling it down.
+				fullNodesCount := 6
+				for i := range fullNodesCount {
+					podName := fmt.Sprintf("scheduled-pods-%d", i)
+					nodeName := fmt.Sprintf("%s-node-%d", ngName, i) // fakecloudprovider.WithNodes() names Nodes in this format.
+					pod := testutils.BuildTestPod(podName, 800, 1*units.GiB, testutils.WithNodeName(nodeName))
+					infra.Fakes.K8s.AddPod(pod)
+				}
+
+				// ======== STEP 1: Force CA to scale down some empty Nodes ========
+				// The remaining Nodes from the NodeGroup that don't have a Pod scheduled are empty. Run CA loop once to start tracking them as unneeded.
+				if err := synctestutils.RunOnceAfter(t, autoscaler, 0); err != nil {
+					t.Fatalf("RunOnce() unexpected error: %v", err)
+				}
+				// Run CA loop again after the unneeded threshold has passed, CA should start scaling down the empty Nodes.
+				if err := synctestutils.RunOnceAfter(t, autoscaler, sdUnneededTime+time.Microsecond); err != nil {
+					t.Fatalf("RunOnce() unexpected error: %v", err)
+				}
+				// RunOnceAfter() above only returns after all goroutines in the bubble are blocked, so we're guaranteed that DeleteNodes() already decreased the
+				// target size of the NodeGroup. We're also guaranteed that CA loops will still process the deleted Nodes for the next nodeGarbageCollectionDelay.
+				assertNodeGroupSize(t, fakeNodeGroup, infra.Fakes.K8s, fullNodesCount, initialNodeCount)
+
+				// ======== STEP 2: Force CA to scale up some Nodes in the same NodeGroup ========
+				// Create some pending Pods so that CA needs to scale the same NodeGroup up still immediately after a previous scale-down.
+				pendingPodsCount := 2
+				for i := range pendingPodsCount {
+					podName := fmt.Sprintf("pending-pods-%d", i)
+					pod := testutils.BuildTestPod(podName, 800, 1*units.GiB, testutils.MarkUnschedulable())
+					infra.Fakes.K8s.AddPod(pod)
+				}
+				// Run CA loop with the new pending Pods, CA should scale up a dedicated Node for each pending Pod.
+				if err := synctestutils.RunOnceAfter(t, autoscaler, stepDuration); err != nil {
+					t.Fatalf("RunOnce() unexpected error: %v", err)
+				}
+				// RunOnceAfter() above only returns after all goroutines in the bubble are blocked, so we're guaranteed that IncreaseSize() already increased the
+				// target size of the NodeGroup back to the initial count. We're also guaranteed that CA loops will not see the new Nodes for the next nodeGarbageCollectionDelay,
+				// so upcoming Nodes will have to be modeled.
+				assertNodeGroupSize(t, fakeNodeGroup, infra.Fakes.K8s, fullNodesCount+pendingPodsCount, initialNodeCount)
+
+				// ======== STEP 3: Assert that CA doesn't scale up again for the same Pods ========
+				// Run CA loop after a short delay. The deleted Nodes should still be present, and the new Nodes still shouldn't.
+				if err := synctestutils.RunOnceAfter(t, autoscaler, stepDuration); err != nil {
+					t.Fatalf("RunOnce() unexpected error: %v", err)
+				}
+				// CA shouldn't scale up, because the pending Pods should be packed on upcoming Nodes from the previous scale-up. The sizes should be identical to the previous step.
+				assertNodeGroupSize(t, fakeNodeGroup, infra.Fakes.K8s, fullNodesCount+pendingPodsCount, initialNodeCount)
+
+				// ======== STEP 4: Assert that deleted Nodes disappear from the API at the expected time ========
+				// Run CA loop after nodeGarbageCollectionDelay (3 times stepDuration) elapses since the scale-down.
+				if err := synctestutils.RunOnceAfter(t, autoscaler, stepDuration); err != nil {
+					t.Fatalf("RunOnce() unexpected error: %v", err)
+				}
+				// The Nodes should be gone from the API, so we should only see the original Nodes that had Pods scheduled. No changes to the targetSize are expected.
+				assertNodeGroupSize(t, fakeNodeGroup, infra.Fakes.K8s, fullNodesCount+pendingPodsCount, fullNodesCount)
+
+				// ======== STEP 5: Assert that scaled-up Nodes appear in the API at the expected time ========
+				// Run CA loop after nodeRegistrationDelay elapses since the scale-up.
+				if err := synctestutils.RunOnceAfter(t, autoscaler, stepDuration+time.Microsecond); err != nil {
+					t.Fatalf("RunOnce() unexpected error: %v", err)
+				}
+				// The new Nodes should finally be visible in the API. No changes to the targetSize are expected.
+				assertNodeGroupSize(t, fakeNodeGroup, infra.Fakes.K8s, fullNodesCount+pendingPodsCount, fullNodesCount+pendingPodsCount)
+
+				// ======== STEP 6: Assert that the final state is stable  ========
+				// Run CA loop after a long delay to verify that the final state is stable.
+				if err := synctestutils.RunOnceAfter(t, autoscaler, 100*stepDuration); err != nil {
+					t.Fatalf("RunOnce() unexpected error: %v", err)
+				}
+				// Sizes should be identical to the previous step.
+				assertNodeGroupSize(t, fakeNodeGroup, infra.Fakes.K8s, fullNodesCount+pendingPodsCount, fullNodesCount+pendingPodsCount)
+			})
+		})
+	}
+}
+
+func assertNodeGroupSize(t *testing.T, ng *fakecloudprovider.NodeGroup, k8s *fakek8s.Kubernetes, wantTargetSize, wantNodeCount int) {
+	t.Helper()
+	if gotSize, err := ng.TargetSize(); err != nil || wantTargetSize != gotSize {
+		t.Fatalf("fakeNodeGroup.TargetSize(): want <%d, <nil>>, got <%d, %v>", wantTargetSize, gotSize, err)
+	}
+	if gotNodeCount := len(k8s.Nodes().Items); wantNodeCount != gotNodeCount {
+		t.Fatalf("Fakes.K8s.Nodes(): want len=%d, got len=%d", wantNodeCount, gotNodeCount)
+	}
+}

--- a/cluster-autoscaler/test/integration/inmemory/staticautoscaler_test.go
+++ b/cluster-autoscaler/test/integration/inmemory/staticautoscaler_test.go
@@ -35,6 +35,7 @@ const (
 )
 
 func TestStaticAutoscaler_FullLifecycle(t *testing.T) {
+	stepDuration := 10 * time.Second
 	config := integration.NewTestConfig().
 		WithOverrides(
 			integration.WithCloudProviderName("gce"),
@@ -52,25 +53,28 @@ func TestStaticAutoscaler_FullLifecycle(t *testing.T) {
 		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
 		assert.NoError(t, err)
 
+		// Configure a test NodeGroup with a single Node.
 		n := test.BuildTestNode("ng1-node-0", 1000, 1000, test.IsReady(true))
 		fakes.CloudProvider.AddNodeGroup("ng1", fakecloudprovider.WithNode(n))
 		fakes.K8s.AddPod(test.BuildScheduledTestPod("p1", 600, 100, n.Name))
 
+		// Create a pending Pod that doesn't fit on the single existing Node.
 		p := test.BuildTestPod("p2", 600, 100, test.MarkUnschedulable())
 		fakes.K8s.AddPod(p)
 
-		synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime)
-
+		// Run a loop, CA should scale up a single Node for the pending Pod.
+		synctestutils.MustRunOnceAfter(t, autoscaler, stepDuration)
 		tg1, _ := fakes.CloudProvider.GetNodeGroup("ng1").TargetSize()
 		assert.Equal(t, 2, tg1)
-
 		assert.Equal(t, 2, len(fakes.K8s.Nodes().Items))
 
+		// Delete the Pod that was pending, the second Node should be empty now.
 		fakes.K8s.DeletePod(p.Namespace, p.Name)
 
-		// Detection and deletion steps.
-		synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime)
-		synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime)
+		// Run CA loop once to mark the Node as unneeded.
+		synctestutils.MustRunOnceAfter(t, autoscaler, stepDuration)
+		// Run another CA loop after the unneeded time elapses, CA should delete the Node.
+		synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime+time.Nanosecond)
 
 		finalSize, _ := fakes.CloudProvider.GetNodeGroup("ng1").TargetSize()
 		assert.Equal(t, 1, finalSize)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

tl;dr:
CSR had 2 different places calculating upcoming Nodes with slightly different logic. One of them didn’t handle Nodes going through scale-down correctly, which could lead to not predicting any upcoming Nodes, and doing unnecessary extra scale-ups. This PR changes CSR to use the calculation that handles scale-down Nodes correctly everywhere - which fixes the extra scale-up bug.

Full reasoning:

CSR has two distinct places that calculate how many upcoming Nodes there are in a given NodeGroup:

* GetUpcomingNodes() iterates over all tracked NodeGroups and calculates how many upcoming Nodes there are in each one.
* getProvisionedAndTargetSizesForNodeGroup() doesn't directly calculate how many upcoming Nodes there are, but it returns the final parts of the calculation - the target size, and the number of "provisioned" Nodes. Subtracting provisioned from target is extremely close to the upcoming Node calculation in GetUpcomingNodes() - with subtle differences. The way the return values are used, it's basically finishing the upcoming calculation anyway:
   * areThereUpcomingNodesInNodeGroup() returns true if `target > provisioned`, which is the same as `upcoming = (target-provisioned) > 0`.
   * IsNodeGroupAtTargetSize() returns true if `target == provisioned`, which is the same as `upcoming = (target-provisioned) == 0`

GetUpcomingNodes() is used to determine how many upcoming Nodes CSR injects into the cluster simulation. getProvisionedAndTargetSizesForNodeGroup() is used to determine when to drop the scale-up request tracked by CSR for a given NodeGroup. Historically the scale-up request was mostly used for observability (metrics, logging, status config map), but after #9360 if a scale-up request is dropped CSR no longer predicts any upcoming Nodes.

The 2 calculations are almost identical, but have important subtle differences:
* GetUpcomingNodes() subtracts `readiness.LongUnregistered` from the target size, getProvisionedAndTargetSizesForNodeGroup() doesn't.
* getProvisionedAndTargetSizesForNodeGroup() subtracts `readiness.Deleted` from the target size, GetUpcomingNodes() doesn't.

In both cases, the GetUpcomingNodes() logic seems better:
* LongUnregistered Nodes should always be included in the target size, not subtracting them from the target size would overcount them as upcoming.
* Deleted Nodes shouldn’t be included in the target size _if_ CloudProvider.HasInstance() is correctly implemented and starts responding with false immediately after NodeGroup.DeleteNodes(). Subtracting them from the target size would undercount the upcoming Nodes and lead to CA doing extra, unnecessary scale-ups.

Note that the following considerations for CloudProvider methods apply:
* If a CloudProvider doesn’t implement HasInstance(), Deleted Nodes are included in the target size between the time they are cordoned with the CA scale-down taint and the VM deletion call. Not subtracting them from the target size during that time will lead to overcounting upcoming Nodes, but the important part determining how many upcoming Nodes to inject would already behave like this. This commit only changes the other part that determines if the scale-up request should be dropped altogether - so the only impact would be terminating a scale-up request too late which shouldn’t be a problem.
* If a CloudProvider implements HasInstance() in a way that still returns true after the VMs are deleted by NodeGroup.DeleteNodes() (e.g. not invalidating cache during DeleteNodes()), the scaled-down Nodes are not counted as Deleted, but as Ready/Unready instead. After the target size is decreased in DeleteNodes(), CSR will still subtract the scaled-down Nodes from the target size. This leads to undercounting the upcoming Nodes and the exact same bug - extra, unnecessary scale-ups. There’s no way to fix this from the CSR side, HasInstance() implementations should be fixed to start responding with false immediately after DeleteNodes().
* If a CloudProvider implements NodeGroupForNode() so that it immediately starts returning nil for Nodes scaled-down via NodeGroup.DeleteNodes(), the extra scale-up bug would be masked and never trigger (because the Nodes are not matched to the NodeGroup at all, so the deleted ones are not subtracted from the target size and no undercounting happens). After this fix, NodeGroupForNode() can keep returning non-nil for Nodes that went through DeletedNodes().

#### Which issue(s) this PR fixes:

Fixes #9813

#### Special notes for your reviewer:

The PR is split into meaningful commits, to be reviewed one-by-one. Only the top commit contains the fix, which is pretty minimal. The remaining prefix of commits makes a series of changes to the fake CloudProvider, and implements a comprehensive regression test for this behavior.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
TODO
```