### PR TITLE
Rename CapacityQuota Valid condition

### DIFF
--- a/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1/capacityquota_types.go
+++ b/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1/capacityquota_types.go
@@ -34,12 +34,6 @@ const (
 	ResourceMemory ResourceName = "memory"
 	// ResourceNodes - number of nodes, in units.
 	ResourceNodes ResourceName = "nodes"
-	// ValidCondition is the condition specifying whether the CapacityQuota is valid
-	ValidCondition = "Valid"
-	// ValidationSucceeded specifies that the CapacityQuota is valid
-	ValidationSucceeded = "ValidationSucceeded"
-	// ValidationFailed specifies that the CapacityQuota is invalid
-	ValidationFailed = "ValidationFailed"
 	// ReconciledCondition is the condition specifying whether the CapacityQuota status has been reconciled.
 	ReconciledCondition = "Reconciled"
 	// ReconciliationSucceeded specifies that the CapacityQuota status has been reconciled successfully.
@@ -125,7 +119,11 @@ type CapacityQuotaStatus struct {
 	Used *CapacityQuotaUsage `json:"used,omitempty"`
 
 	// Conditions provide a standard mechanism for reporting the quota's state.
-	// CapacityQuota will be enforced only if it has a Valid=True condition.
+	//
+	// Cluster Autoscaler manages cluster-autoscaler.kubernetes.io/valid condition, and will enforce
+	// the quota only if the status of the condition is True. Note that this condition is not considered a part
+	// of the public API.
+	//
 	// +listType=map
 	// +listMapKey=type
 	// +patchStrategy=merge

--- a/cluster-autoscaler/apis/capacityquota/client/applyconfiguration/autoscaling.x-k8s.io/v1alpha1/capacityquotastatus.go
+++ b/cluster-autoscaler/apis/capacityquota/client/applyconfiguration/autoscaling.x-k8s.io/v1alpha1/capacityquotastatus.go
@@ -30,7 +30,10 @@ type CapacityQuotaStatusApplyConfiguration struct {
 	// Used shows the current usage of the quota.
 	Used *CapacityQuotaUsageApplyConfiguration `json:"used,omitempty"`
 	// Conditions provide a standard mechanism for reporting the quota's state.
-	// CapacityQuota will be enforced only if it has a Valid=True condition.
+	//
+	// Cluster Autoscaler manages cluster-autoscaler.kubernetes.io/valid condition, and will enforce
+	// the quota only if the status of the condition is True. Note that this condition is not considered a part
+	// of the public API.
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 	// ObservedGeneration is the last generation observed by the controller.
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`

--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacityquotas.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacityquotas.yaml
@@ -144,7 +144,10 @@ spec:
               conditions:
                 description: |-
                   Conditions provide a standard mechanism for reporting the quota's state.
-                  CapacityQuota will be enforced only if it has a Valid=True condition.
+
+                  Cluster Autoscaler manages cluster-autoscaler.kubernetes.io/valid condition, and will enforce
+                  the quota only if the status of the condition is True. Note that this condition is not considered a part
+                  of the public API.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/cluster-autoscaler/resourcequotas/capacityquota/controller.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/controller.go
@@ -42,6 +42,15 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1"
 )
 
+const (
+	// ValidCondition is the condition specifying whether the CapacityQuota is valid
+	ValidCondition = "cluster-autoscaler.kubernetes.io/valid"
+	// ValidationSucceeded specifies that the CapacityQuota is valid
+	ValidationSucceeded = "ValidationSucceeded"
+	// ValidationFailed specifies that the CapacityQuota is invalid
+	ValidationFailed = "ValidationFailed"
+)
+
 // Reconciler reconciles a CapacityQuota object
 type Reconciler struct {
 	client     client.Client
@@ -80,7 +89,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	validationErrs := r.validateCapacityQuota(ctx, &cq)
 	if len(validationErrs) > 0 {
 		errMsg := formatValidationErrors(validationErrs)
-		setCondition(&cq, v1alpha1.ValidCondition, metav1.ConditionFalse, v1alpha1.ValidationFailed, errMsg)
+		setCondition(&cq, ValidCondition, metav1.ConditionFalse, ValidationFailed, errMsg)
 		setCondition(&cq, v1alpha1.ReconciledCondition, metav1.ConditionFalse, v1alpha1.ReconciliationFailed, "Validation failed")
 
 		if patchErr := r.patchStatus(ctx, originalCQ, &cq); patchErr != nil {
@@ -88,7 +97,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		return ctrl.Result{}, nil
 	}
-	setCondition(&cq, v1alpha1.ValidCondition, metav1.ConditionTrue, v1alpha1.ValidationSucceeded, "CapacityQuota is valid")
+	setCondition(&cq, ValidCondition, metav1.ConditionTrue, ValidationSucceeded, "CapacityQuota is valid")
 
 	result, err := r.reconcileCapacityQuota(ctx, &cq)
 

--- a/cluster-autoscaler/resourcequotas/capacityquota/provider.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/provider.go
@@ -49,7 +49,7 @@ func (p *Provider) Quotas() ([]resourcequotas.Quota, error) {
 	}
 	var quotas []resourcequotas.Quota
 	for _, cq := range capacityQuotas.Items {
-		if !meta.IsStatusConditionTrue(cq.Status.Conditions, cqv1alpha1.ValidCondition) {
+		if !meta.IsStatusConditionTrue(cq.Status.Conditions, ValidCondition) {
 			klog.V(5).Infof("CapacityQuota %q is not valid, skipping", cq.Name)
 			continue
 		}

--- a/cluster-autoscaler/resourcequotas/capacityquota/testutil/testutil.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/testutil/testutil.go
@@ -22,6 +22,12 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1"
 )
 
+const (
+	validCondition      = "cluster-autoscaler.kubernetes.io/valid"
+	validationSucceeded = "ValidationSucceeded"
+	validationFailed    = "ValidationFailed"
+)
+
 // QuotaOption is a functional option for configuring a CapacityQuota.
 type QuotaOption func(*v1alpha1.CapacityQuota)
 
@@ -60,9 +66,9 @@ func WithLimits(limits v1alpha1.ResourceList) QuotaOption {
 func WithValidCondition() QuotaOption {
 	return func(cq *v1alpha1.CapacityQuota) {
 		c := metav1.Condition{
-			Type:   v1alpha1.ValidCondition,
+			Type:   validCondition,
 			Status: metav1.ConditionTrue,
-			Reason: v1alpha1.ValidationSucceeded,
+			Reason: validationSucceeded,
 		}
 		meta.SetStatusCondition(&cq.Status.Conditions, c)
 	}
@@ -72,9 +78,9 @@ func WithValidCondition() QuotaOption {
 func WithInvalidCondition() QuotaOption {
 	return func(cq *v1alpha1.CapacityQuota) {
 		c := metav1.Condition{
-			Type:   v1alpha1.ValidCondition,
+			Type:   validCondition,
 			Status: metav1.ConditionFalse,
-			Reason: v1alpha1.ValidationFailed,
+			Reason: validationFailed,
 		}
 		meta.SetStatusCondition(&cq.Status.Conditions, c)
 	}

--- a/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
+++ b/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas/capacityquota"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cqv1alpha1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1"
@@ -299,8 +300,8 @@ var _ = Describe("CapacityQuota Controller", func() {
 			g.Expect(crClient.Get(ctx, cqKey, &fetchedCQ)).To(Succeed())
 
 			g.Expect(fetchedCQ.Status.ObservedGeneration).To(Equal(fetchedCQ.Generation))
-			g.Expect(meta.IsStatusConditionFalse(fetchedCQ.Status.Conditions, cqv1alpha1.ValidCondition)).To(BeTrue())
-			cond := meta.FindStatusCondition(fetchedCQ.Status.Conditions, cqv1alpha1.ValidCondition)
+			g.Expect(meta.IsStatusConditionFalse(fetchedCQ.Status.Conditions, capacityquota.ValidCondition)).To(BeTrue())
+			cond := meta.FindStatusCondition(fetchedCQ.Status.Conditions, capacityquota.ValidCondition)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Reason).To(Equal("ValidationFailed"))
 			g.Expect(cond.Message).To(ContainSubstring("is not a valid label selector operator"))
@@ -315,8 +316,7 @@ func assertQuotaReconciled(ctx context.Context, g Gomega, cqKey types.Namespaced
 	g.Expect(crClient.Get(ctx, cqKey, &fetchedCQ)).To(Succeed())
 
 	g.Expect(fetchedCQ.Status.ObservedGeneration).To(Equal(fetchedCQ.Generation))
-	g.Expect(meta.IsStatusConditionTrue(fetchedCQ.Status.Conditions, cqv1alpha1.ValidCondition)).To(BeTrue())
-	g.Expect(meta.IsStatusConditionTrue(fetchedCQ.Status.Conditions, cqv1alpha1.ReconciledCondition)).To(BeTrue())
+	g.Expect(meta.IsStatusConditionTrue(fetchedCQ.Status.Conditions, capacityquota.ValidCondition)).To(BeTrue())
 	g.Expect(fetchedCQ.Status.Used).ToNot(BeNil())
 	g.Expect(apiequality.Semantic.DeepEqual(fetchedCQ.Status.Used.Resources, wantResources)).To(BeTrue())
 }


### PR DESCRIPTION


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
As discussed, we decided to not add Valid condition as a part of CapacityQuota public API for now. To make it cluster-autoscaler specific, renamed the condition type to label name format, which is a common convention for custom conditions

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Renamed CapacityQuota Valid condition to cluster-autoscaler.kubernetes.io/valid to clarify that it is not a part of CapacityQuota public API
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
