### PR TITLE
Introduce ObservedGeneration to CapacityQuota

### DIFF
--- a/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1/capacityquota_types.go
+++ b/cluster-autoscaler/apis/capacityquota/autoscaling.x-k8s.io/v1alpha1/capacityquota_types.go
@@ -132,6 +132,10 @@ type CapacityQuotaStatus struct {
 	// +patchMergeKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// ObservedGeneration is the last generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // CapacityQuotaUsage shows the current usage of the quota.

--- a/cluster-autoscaler/apis/capacityquota/client/applyconfiguration/autoscaling.x-k8s.io/v1alpha1/capacityquotastatus.go
+++ b/cluster-autoscaler/apis/capacityquota/client/applyconfiguration/autoscaling.x-k8s.io/v1alpha1/capacityquotastatus.go
@@ -32,6 +32,8 @@ type CapacityQuotaStatusApplyConfiguration struct {
 	// Conditions provide a standard mechanism for reporting the quota's state.
 	// CapacityQuota will be enforced only if it has a Valid=True condition.
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	// ObservedGeneration is the last generation observed by the controller.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // CapacityQuotaStatusApplyConfiguration constructs a declarative configuration of the CapacityQuotaStatus type for use with
@@ -58,5 +60,13 @@ func (b *CapacityQuotaStatusApplyConfiguration) WithConditions(values ...*v1.Con
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}
+	return b
+}
+
+// WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObservedGeneration field is set to the value of the last call.
+func (b *CapacityQuotaStatusApplyConfiguration) WithObservedGeneration(value int64) *CapacityQuotaStatusApplyConfiguration {
+	b.ObservedGeneration = &value
 	return b
 }

--- a/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacityquotas.yaml
+++ b/cluster-autoscaler/apis/config/crd/autoscaling.x-k8s.io_capacityquotas.yaml
@@ -203,6 +203,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the last generation observed by
+                  the controller.
+                format: int64
+                type: integer
               used:
                 description: Used shows the current usage of the quota.
                 properties:

--- a/cluster-autoscaler/resourcequotas/capacityquota/controller.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/controller.go
@@ -75,6 +75,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	originalCQ := cq.DeepCopy()
+	cq.Status.ObservedGeneration = cq.Generation
 
 	validationErrs := r.validateCapacityQuota(ctx, &cq)
 	if len(validationErrs) > 0 {

--- a/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
+++ b/cluster-autoscaler/test/integration/controllers/capacityquota_controller_test.go
@@ -298,6 +298,7 @@ var _ = Describe("CapacityQuota Controller", func() {
 			var fetchedCQ cqv1alpha1.CapacityQuota
 			g.Expect(crClient.Get(ctx, cqKey, &fetchedCQ)).To(Succeed())
 
+			g.Expect(fetchedCQ.Status.ObservedGeneration).To(Equal(fetchedCQ.Generation))
 			g.Expect(meta.IsStatusConditionFalse(fetchedCQ.Status.Conditions, cqv1alpha1.ValidCondition)).To(BeTrue())
 			cond := meta.FindStatusCondition(fetchedCQ.Status.Conditions, cqv1alpha1.ValidCondition)
 			g.Expect(cond).NotTo(BeNil())
@@ -313,6 +314,7 @@ func assertQuotaReconciled(ctx context.Context, g Gomega, cqKey types.Namespaced
 	var fetchedCQ cqv1alpha1.CapacityQuota
 	g.Expect(crClient.Get(ctx, cqKey, &fetchedCQ)).To(Succeed())
 
+	g.Expect(fetchedCQ.Status.ObservedGeneration).To(Equal(fetchedCQ.Generation))
 	g.Expect(meta.IsStatusConditionTrue(fetchedCQ.Status.Conditions, cqv1alpha1.ValidCondition)).To(BeTrue())
 	g.Expect(meta.IsStatusConditionTrue(fetchedCQ.Status.Conditions, cqv1alpha1.ReconciledCondition)).To(BeTrue())
 	g.Expect(fetchedCQ.Status.Used).ToNot(BeNil())


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Added ObservedGeneration field. Mainly for observability and operational purposes

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added ObservedGeneration to CapacityQuota status
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
