### PR TITLE
Use Hash Array Mapped Trie in Patchset to improve the DRA and Affinity performance

### DIFF
--- a/cluster-autoscaler/simulator/common/patchset.go
+++ b/cluster-autoscaler/simulator/common/patchset.go
@@ -165,6 +165,42 @@ func (p *PatchSet[K, V]) AsMap() map[K]V {
 	return p.top.ToNativeMap()
 }
 
+// ListValues returns a slice of all effective values in the PatchSet.
+// This is much more performant than calling AsMap() and then iterating,
+// as it avoids allocating an intermediate Go map.
+func (p *PatchSet[K, V]) ListValues() []V {
+	if len(p.stack) == 0 {
+		return nil
+	}
+	values := make([]V, 0, p.top.Len())
+	p.top.Range(func(k K, v V) bool {
+		values = append(values, v)
+		return true
+	})
+	return values
+}
+
+// WalkValues iterates over all effective values in the PatchSet.
+// It calls the provided function `f` for each value.
+// If `f` returns false, the iteration stops.
+func (p *PatchSet[K, V]) WalkValues(f func(V) bool) {
+	if len(p.stack) == 0 {
+		return
+	}
+	p.top.Range(func(k K, v V) bool {
+		return f(v)
+	})
+}
+
+// Len returns the number of keys in the active patch layer.
+func (p *PatchSet[K, V]) Len() int {
+	if len(p.stack) == 0 {
+		return 0
+	}
+	return p.top.Len()
+}
+
+
 // SetCurrent adds or updates a key-value pair in the topmost patch layer.
 func (p *PatchSet[K, V]) SetCurrent(key K, value V) {
 	if len(p.stack) == 0 {

--- a/cluster-autoscaler/simulator/common/patchset.go
+++ b/cluster-autoscaler/simulator/common/patchset.go
@@ -16,103 +16,130 @@ limitations under the License.
 
 package common
 
+import "unsafe"
+
 // PatchSet manages a stack of patches, allowing for fork/revert/commit operations.
 // It provides a view of the data as if all patches were applied sequentially.
 //
 // Time Complexities:
 //   - Fork(): O(1).
-//   - Commit(): O(P), where P is the number of modified/deleted entries
-//     in the current patch or no-op for PatchSet with a single patch.
-//   - Revert(): O(P), where P is the number of modified/deleted entries
-//     in the topmost patch or no-op for PatchSet with a single patch.
-//   - FindValue(key): O(1) for cached keys, O(N * P) - otherwise.
-//   - AsMap(): O(N * P) as it needs to iterate through all the layers
-//     modifications and deletions to get the latest state. Best case -
-//     if the cache is currently in sync with the PatchSet data complexity becomes
-//     O(C), where C is the actual number key/value pairs in flattened PatchSet.
-//   - SetCurrent(key, value): O(1).
-//   - DeleteCurrent(key): O(1).
-//   - InCurrentPatch(key): O(1).
-//
-// Variables used in complexity analysis:
-//   - N: The number of patch layers in the PatchSet.
-//   - P: The number of modified/deleted entries in a single patch layer
-//
-// Caching:
-//
-// The PatchSet employs a lazy caching mechanism to speed up access to data. When a specific item is requested,
-// the cache is checked first. If the item isn't cached, its effective value is computed by traversing the layers
-// of patches from the most recent to the oldest, and the result is then stored in the cache. For operations that
-// require the entire dataset like AsMap, if a cache is fully up-to-date, the data is served directly from the cache.
-// Otherwise, the entire dataset is rebuilt by applying all patches, and this process fully populates the cache.
-// Direct modifications to the current patch update the specific item in the cache immediately. Reverting the latest
-// patch will clear affected items from the cache and mark the cache as potentially out-of-sync, as underlying values may
-// no longer represent the PatchSet as a whole. Committing and forking does not invalidate the cache, as the effective
-// values remain consistent from the perspective of read operations.
+//   - Commit(): O(1).
+//   - Revert(): O(1).
+//   - FindValue(key): O(log M) where M is the number of keys in the map (effectively O(1) lookup).
+//   - AsMap(): O(M) where M is the number of keys in the map.
+//   - SetCurrent(key, value): O(log M) (in-place mutable speed for transient top layer!).
+//   - DeleteCurrent(key): O(log M) (in-place mutable speed for transient top layer!).
+//   - InCurrentPatch(key): O(log M).
 type PatchSet[K comparable, V any] struct {
-	// patches is a stack of individual modification layers. The base data is
-	// at index 0, and subsequent modifications are layered on top.
-	// PatchSet should always contain at least a single patch.
-	patches []*Patch[K, V]
+	stack []*persistentMap[K, V] // Frozen immutable lower layers
+	top   *transientMap[K, V]    // Active mutable transient topmost layer
+}
 
-	// cache stores the computed effective value for keys that have been accessed.
-	// A nil pointer indicates the key is effectively deleted or not present.
-	cache map[K]*V
-
-	// cacheInSync indicates whether the cache map accurately reflects the
-	// current state derived from applying all patches in the 'patches' slice.
-	// When false, the cache may be stale and needs to be rebuilt or validated
-	// before being fully trusted for all keys.
-	cacheInSync bool
+// NewPatchSetFromMap creates a new PatchSet initialized with the provided map.
+// This is more performant than creating a Patch and passing it to NewPatchSet
+// as it populates the persistent map in a single pass without allocation of Patch structures.
+func NewPatchSetFromMap[K comparable, V any](m map[K]V) *PatchSet[K, V] {
+	base := NewpersistentMapFromNativeMap(m)
+	return &PatchSet[K, V]{
+		stack: []*persistentMap[K, V]{base},
+		top:   base.AsTransient(),
+	}
 }
 
 // NewPatchSet creates a new PatchSet, initializing it with the provided base patches.
 func NewPatchSet[K comparable, V any](patches ...*Patch[K, V]) *PatchSet[K, V] {
-	return &PatchSet[K, V]{
-		patches:     patches,
-		cache:       make(map[K]*V),
-		cacheInSync: false,
+	if len(patches) == 0 {
+		base := NewpersistentMap[K, V]()
+		return &PatchSet[K, V]{
+			stack: []*persistentMap[K, V]{base},
+			top:   base.AsTransient(),
+		}
 	}
+
+	stack := make([]*persistentMap[K, V], len(patches))
+	state := NewpersistentMap[K, V]()
+	for i, patch := range patches {
+		state = patch.applyTo(state)
+		stack[i] = state
+	}
+
+	return &PatchSet[K, V]{
+		stack: stack,
+		top:   stack[len(stack)-1].AsTransient(),
+	}
+}
+
+func (p *Patch[K, V]) applyTo(m *persistentMap[K, V]) *persistentMap[K, V] {
+	session := &editSession{}
+	transient := &transientMap[K, V]{session: session, root: m.root, size: m.size}
+
+	for k, v := range p.modified {
+		transient.Store(k, v)
+	}
+
+	for k := range p.deleted {
+		transient.Delete(k)
+	}
+
+	return transient.Persistent()
 }
 
 // Fork adds a new, empty patch layer to the top of the stack.
 // Subsequent modifications will be recorded in this new layer.
 func (p *PatchSet[K, V]) Fork() {
-	p.patches = append(p.patches, NewPatch[K, V]())
+	if len(p.stack) == 0 {
+		base := NewpersistentMap[K, V]()
+		p.stack = []*persistentMap[K, V]{base}
+		p.top = base.AsTransient()
+		return
+	}
+
+	// Freeze the active transient layer and store it back to the stack
+	frozen := p.top.Persistent()
+	p.stack[len(p.stack)-1] = frozen
+
+	// Append it as the new layer
+	p.stack = append(p.stack, frozen)
+
+	// Create the new active transient layer forked from it
+	p.top = frozen.AsTransient()
 }
 
 // Commit merges the topmost patch layer into the one below it.
 // If there's only one layer (or none), it's a no-op.
 func (p *PatchSet[K, V]) Commit() {
-	if len(p.patches) < 2 {
+	if len(p.stack) < 2 {
 		return
 	}
 
-	currentPatch := p.patches[len(p.patches)-1]
-	previousPatch := p.patches[len(p.patches)-2]
-	mergePatchesInPlace(previousPatch, currentPatch)
-	p.patches = p.patches[:len(p.patches)-1]
+	// Freeze the active transient layer
+	frozen := p.top.Persistent()
+
+	topIndex := len(p.stack) - 1
+	prevIndex := len(p.stack) - 2
+
+	// Overwrite the parent layer with the frozen state
+	p.stack[prevIndex] = frozen
+
+	// Drop the top layer from the stack
+	p.stack = p.stack[:topIndex]
+
+	// Recreate the active transient from the new topmost layer
+	p.top = p.stack[len(p.stack)-1].AsTransient()
 }
 
 // Revert removes the topmost patch layer.
 // Any modifications or deletions recorded in that layer are discarded.
 func (p *PatchSet[K, V]) Revert() {
-	if len(p.patches) <= 1 {
+	if len(p.stack) <= 1 {
 		return
 	}
 
-	currentPatch := p.patches[len(p.patches)-1]
-	p.patches = p.patches[:len(p.patches)-1]
+	// Discard the active transient layer (Persistent is NOT called, so it is just abandoned)
+	p.stack = p.stack[:len(p.stack)-1]
 
-	for key := range currentPatch.modified {
-		delete(p.cache, key)
-	}
-
-	for key := range currentPatch.deleted {
-		delete(p.cache, key)
-	}
-
-	p.cacheInSync = false
+	// Recreate the active transient from the restored parent layer
+	p.top = p.stack[len(p.stack)-1].AsTransient()
 }
 
 // FindValue searches for the effective value of a key by looking through the patches
@@ -121,118 +148,99 @@ func (p *PatchSet[K, V]) Revert() {
 func (p *PatchSet[K, V]) FindValue(key K) (value V, found bool) {
 	var zero V
 
-	if cachedValue, cacheHit := p.cache[key]; cacheHit {
-		if cachedValue == nil {
-			return zero, false
-		}
-
-		return *cachedValue, true
+	if len(p.stack) == 0 {
+		return zero, false
 	}
 
-	value = zero
-	found = false
-	for i := len(p.patches) - 1; i >= 0; i-- {
-		patch := p.patches[i]
-		if patch.IsDeleted(key) {
-			break
-		}
-
-		foundValue, ok := patch.Get(key)
-		if ok {
-			value = foundValue
-			found = true
-			break
-		}
-	}
-
-	if found {
-		p.cache[key] = &value
-	} else {
-		p.cache[key] = nil
-	}
-
-	return value, found
+	return p.top.Load(key)
 }
 
 // AsMap merges all patches into a single map representing the current effective state.
 // It iterates through all patches from bottom to top, applying modifications and deletions.
-// The cache is populated with the results during this process.
 func (p *PatchSet[K, V]) AsMap() map[K]V {
-	if p.cacheInSync {
-		patchSetMap := make(map[K]V, len(p.cache))
-		for key, value := range p.cache {
-			if value != nil {
-				patchSetMap[key] = *value
-			}
-		}
-		return patchSetMap
+	if len(p.stack) == 0 {
+		return make(map[K]V)
 	}
 
-	keysCount := p.totalKeyCount()
-	patchSetMap := make(map[K]V, keysCount)
-
-	for _, patch := range p.patches {
-		for key, value := range patch.modified {
-			patchSetMap[key] = value
-		}
-
-		for key := range patch.deleted {
-			delete(patchSetMap, key)
-		}
-	}
-
-	for key, value := range patchSetMap {
-		p.cache[key] = &value
-	}
-	p.cacheInSync = true
-
-	return patchSetMap
+	return p.top.ToNativeMap()
 }
 
 // SetCurrent adds or updates a key-value pair in the topmost patch layer.
 func (p *PatchSet[K, V]) SetCurrent(key K, value V) {
-	if len(p.patches) == 0 {
+	if len(p.stack) == 0 {
 		p.Fork()
 	}
 
-	currentPatch := p.patches[len(p.patches)-1]
-	currentPatch.Set(key, value)
-	p.cache[key] = &value
+	p.top.Store(key, value)
 }
 
 // DeleteCurrent marks a key as deleted in the topmost patch layer.
 func (p *PatchSet[K, V]) DeleteCurrent(key K) {
-	if len(p.patches) == 0 {
+	if len(p.stack) == 0 {
 		p.Fork()
 	}
 
-	currentPatch := p.patches[len(p.patches)-1]
-	currentPatch.Delete(key)
-	p.cache[key] = nil
+	p.top.Delete(key)
 }
 
 // InCurrentPatch checks if the key is available in the topmost patch layer.
 func (p *PatchSet[K, V]) InCurrentPatch(key K) bool {
-	if len(p.patches) == 0 {
+	if len(p.stack) == 0 {
+		return false
+	}
+	topVal, active := p.FindValue(key)
+	if !active {
 		return false
 	}
 
-	currentPatch := p.patches[len(p.patches)-1]
-	_, found := currentPatch.Get(key)
-	return found
-}
-
-// totalKeyCount calculates an approximate total number of key-value
-// pairs across all patches taking the highest number of records possible
-// this calculation does not consider deleted records - thus it is likely
-// to be not accurate
-func (p *PatchSet[K, V]) totalKeyCount() int {
-	count := 0
-	for _, patch := range p.patches {
-		count += len(patch.modified)
+	if len(p.stack) == 1 {
+		return true
 	}
 
-	return count
+	prevMap := p.stack[len(p.stack)-2]
+	prevVal, prevFound := prevMap.Load(key)
+	if !prevFound {
+		return true
+	}
+
+	return !safeEqual(topVal, prevVal)
+}
+
+// interfaceHeader represents the internal memory layout of a Go empty interface (any).
+type interfaceHeader struct {
+	typ  unsafe.Pointer
+	data unsafe.Pointer
+}
+
+// safeEqual checks if two values are equal or represent the same instance,
+// safely handling non-comparable types like slices without panicking,
+// using high-performance pointer comparisons.
+func safeEqual(a, b any) bool {
+	ha := *(*interfaceHeader)(unsafe.Pointer(&a))
+	hb := *(*interfaceHeader)(unsafe.Pointer(&b))
+
+	// If types are different, they are not equal.
+	if ha.typ != hb.typ {
+		return false
+	}
+
+	// Fast path: if the data pointers are identical, they are the same instance/value.
+	if ha.data == hb.data {
+		return true
+	}
+
+	// Slow path: different data pointers.
+	return standardEqual(a, b)
+}
+
+// standardEqual performs standard Go comparison with panic recovery for non-comparable types.
+func standardEqual(a, b any) (res bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			res = false
+		}
+	}()
+	return a == b
 }
 
 // ClonePatchSet creates a deep copy of a PatchSet object with the same patch layers
@@ -245,21 +253,34 @@ func ClonePatchSet[K comparable, V any](ps *PatchSet[K, V], cloneKey func(K) K, 
 		return nil
 	}
 
-	cloned := NewPatchSet[K, V]()
-	for _, patch := range ps.patches {
-		clonedPatch := NewPatch[K, V]()
-		for key, value := range patch.modified {
-			clonedKey, clonedValue := cloneKey(key), cloneValue(value)
-			clonedPatch.Set(clonedKey, clonedValue)
-		}
-
-		for key := range patch.deleted {
-			clonedKey := cloneKey(key)
-			clonedPatch.Delete(clonedKey)
-		}
-
-		cloned.patches = append(cloned.patches, clonedPatch)
+	cloned := &PatchSet[K, V]{
+		stack: make([]*persistentMap[K, V], len(ps.stack)),
 	}
 
+	cloneMap := func(m *persistentMap[K, V]) *persistentMap[K, V] {
+		session := &editSession{}
+		transient := &transientMap[K, V]{session: session}
+		m.Range(func(k K, v V) bool {
+			transient.Store(cloneKey(k), cloneValue(v))
+			return true
+		})
+		return transient.Persistent()
+	}
+
+	for i, m := range ps.stack {
+		if i == len(ps.stack)-1 {
+			session := &editSession{}
+			transient := &transientMap[K, V]{session: session}
+			ps.top.Range(func(k K, v V) bool {
+				transient.Store(cloneKey(k), cloneValue(v))
+				return true
+			})
+			cloned.stack[i] = transient.Persistent()
+		} else {
+			cloned.stack[i] = cloneMap(m)
+		}
+	}
+
+	cloned.top = cloned.stack[len(cloned.stack)-1].AsTransient()
 	return cloned
 }

--- a/cluster-autoscaler/simulator/common/patchset_test.go
+++ b/cluster-autoscaler/simulator/common/patchset_test.go
@@ -150,27 +150,27 @@ func TestPatchSetCommit(t *testing.T) {
 	for testName, tc := range tests {
 		t.Run(testName, func(t *testing.T) {
 			ps := buildTestPatchSet(t, tc.patchLayers)
-			initialNumPatches := len(ps.patches)
+			initialNumPatches := len(ps.stack)
 
 			if currentMap := ps.AsMap(); !maps.Equal(currentMap, tc.wantMap) {
 				t.Errorf("AsMap() before any commits mismatch: got %v, want %v", currentMap, tc.wantMap)
 			}
 
 			for i := 0; i < initialNumPatches-1; i++ {
-				expectedPatchesAfterCommit := len(ps.patches) - 1
+				expectedPatchesAfterCommit := len(ps.stack) - 1
 				ps.Commit()
-				if len(ps.patches) != expectedPatchesAfterCommit {
-					t.Errorf("After commit #%d, expected %d patches, got %d", i+1, expectedPatchesAfterCommit, len(ps.patches))
+				if len(ps.stack) != expectedPatchesAfterCommit {
+					t.Errorf("After commit #%d, expected %d patches, got %d", i+1, expectedPatchesAfterCommit, len(ps.stack))
 				}
 				if currentMap := ps.AsMap(); !maps.Equal(currentMap, tc.wantMap) {
 					t.Errorf("AsMap() after commit #%d mismatch: got %v, want %v", i+1, currentMap, tc.wantMap)
 				}
 			}
 
-			if initialNumPatches > 0 && len(ps.patches) != 1 {
-				t.Errorf("Expected 1 patch after all commits, got %d", len(ps.patches))
-			} else if initialNumPatches == 0 && len(ps.patches) != 0 {
-				t.Errorf("Expected 0 patches after all commits, got %d", len(ps.patches))
+			if initialNumPatches > 0 && len(ps.stack) != 1 {
+				t.Errorf("Expected 1 patch after all commits, got %d", len(ps.stack))
+			} else if initialNumPatches == 0 && len(ps.stack) != 0 {
+				t.Errorf("Expected 0 patches after all commits, got %d", len(ps.stack))
 			}
 		})
 	}
@@ -235,17 +235,17 @@ func TestPatchSetRevert(t *testing.T) {
 	for testName, tc := range tests {
 		t.Run(testName, func(t *testing.T) {
 			ps := buildTestPatchSet(t, tc.patchLayers)
-			patchesNumber := len(ps.patches)
+			patchesNumber := len(ps.stack)
 
 			if currentMap := ps.AsMap(); !maps.Equal(currentMap, tc.wantInitialMap) {
 				t.Errorf("AsMap() before any reverts mismatch: got %v, want %v", currentMap, tc.wantInitialMap)
 			}
 
 			for i := 0; i <= patchesNumber; i++ {
-				wantPatchesAfterRevert := len(ps.patches) - 1
+				wantPatchesAfterRevert := len(ps.stack) - 1
 				ps.Revert()
-				if len(ps.patches) != wantPatchesAfterRevert && len(ps.patches) > 1 {
-					t.Errorf("After revert #%d, expected %d patches, got %d", i+1, wantPatchesAfterRevert, len(ps.patches))
+				if len(ps.stack) != wantPatchesAfterRevert && len(ps.stack) > 1 {
+					t.Errorf("After revert #%d, expected %d patches, got %d", i+1, wantPatchesAfterRevert, len(ps.stack))
 				}
 
 				currentMap := ps.AsMap()
@@ -259,10 +259,10 @@ func TestPatchSetRevert(t *testing.T) {
 				}
 			}
 
-			if patchesNumber >= 1 && len(ps.patches) != 1 {
-				t.Errorf("Expected 1 patch after all reverts, got %d", len(ps.patches))
-			} else if patchesNumber == 0 && len(ps.patches) != 0 {
-				t.Errorf("Expected 0 patches after all reverts, got %d", len(ps.patches))
+			if patchesNumber >= 1 && len(ps.stack) != 1 {
+				t.Errorf("Expected 1 patch after all reverts, got %d", len(ps.stack))
+			} else if patchesNumber == 0 && len(ps.stack) != 0 {
+				t.Errorf("Expected 0 patches after all reverts, got %d", len(ps.stack))
 			}
 		})
 	}
@@ -277,8 +277,8 @@ func TestPatchSetForkRevert(t *testing.T) {
 
 	// 2. Call Fork
 	ps.Fork()
-	if len(ps.patches) != 2 {
-		t.Fatalf("Expected 2 patches after Fork(), got %d", len(ps.patches))
+	if len(ps.stack) != 2 {
+		t.Fatalf("Expected 2 patches after Fork(), got %d", len(ps.stack))
 	}
 
 	// 3. Perform some mutation operations on the new layer
@@ -288,8 +288,8 @@ func TestPatchSetForkRevert(t *testing.T) {
 
 	// 4. Call Revert
 	ps.Revert()
-	if len(ps.patches) != 1 {
-		t.Fatalf("Expected 1 patch after Revert(), got %d", len(ps.patches))
+	if len(ps.stack) != 1 {
+		t.Fatalf("Expected 1 patch after Revert(), got %d", len(ps.stack))
 	}
 
 	// 5. Compare state to the empty map
@@ -308,8 +308,8 @@ func TestPatchSetForkCommit(t *testing.T) {
 	// 2. Call Fork two times
 	ps.Fork()
 	ps.Fork()
-	if len(ps.patches) != 3 {
-		t.Fatalf("Expected 3 patches after 2xFork(), got %d", len(ps.patches))
+	if len(ps.stack) != 3 {
+		t.Fatalf("Expected 3 patches after 2xFork(), got %d", len(ps.stack))
 	}
 
 	// 3. Perform some mutation operations on the current layer
@@ -319,14 +319,14 @@ func TestPatchSetForkCommit(t *testing.T) {
 
 	// 4. Call Commit to persist changes
 	ps.Commit()
-	if len(ps.patches) != 2 {
-		t.Fatalf("Expected 1 patch after Commit(), got %d", len(ps.patches))
+	if len(ps.stack) != 2 {
+		t.Fatalf("Expected 1 patch after Commit(), got %d", len(ps.stack))
 	}
 
 	// 5. Call Revert on the empty layer
 	ps.Revert()
-	if len(ps.patches) != 1 {
-		t.Fatalf("Expected 1 patch after Revert(), got %d", len(ps.patches))
+	if len(ps.stack) != 1 {
+		t.Fatalf("Expected 1 patch after Revert(), got %d", len(ps.stack))
 	}
 
 	// 6. Compare state to the empty map
@@ -535,154 +535,38 @@ func TestPatchSetOperations(t *testing.T) {
 	}
 }
 
-func TestPatchSetCache(t *testing.T) {
-	tests := map[string]struct {
-		patchLayers     []map[string]*int
-		mutatePatchSet  func(ps *PatchSet[string, int])
-		wantCache       map[string]*int
-		wantCacheInSync bool
-	}{
-		"Initial_EmptyPatchSet": {
-			patchLayers:     []map[string]*int{},
-			mutatePatchSet:  func(ps *PatchSet[string, int]) {},
-			wantCache:       map[string]*int{},
-			wantCacheInSync: false,
-		},
-		"Initial_WithData_NoCacheAccess": {
-			patchLayers:     []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet:  func(ps *PatchSet[string, int]) {},
-			wantCache:       map[string]*int{},
-			wantCacheInSync: false,
-		},
-		"FindValue_PopulatesCacheForKey": {
-			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": ptr.To(2)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.FindValue("a")
-			},
-			wantCache:       map[string]*int{"a": ptr.To(1)},
-			wantCacheInSync: false,
-		},
-		"FindValue_DeletedKey_PopulatesCacheWithNil": {
-			patchLayers: []map[string]*int{{"a": nil, "b": ptr.To(2)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.FindValue("a")
-			},
-			wantCache:       map[string]*int{"a": nil},
-			wantCacheInSync: false,
-		},
-		"AsMap_PopulatesAndSyncsCache": {
-			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": nil, "c": ptr.To(3)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.AsMap()
-			},
-			wantCache:       map[string]*int{"a": ptr.To(1), "c": ptr.To(3)}, // Cache does not necessarily track deletions like 'b' key
-			wantCacheInSync: true,
-		},
-		"SetCurrent_UpdatesCache_NewKey": {
-			patchLayers: []map[string]*int{{}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.SetCurrent("x", 10)
-			},
-			wantCache:       map[string]*int{"x": ptr.To(10)},
-			wantCacheInSync: false,
-		},
-		"SetCurrent_UpdatesCache_OverwriteKey": {
-			patchLayers: []map[string]*int{{"x": ptr.To(5)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.FindValue("x")
-				ps.SetCurrent("x", 10)
-			},
-			wantCache:       map[string]*int{"x": ptr.To(10)},
-			wantCacheInSync: false,
-		},
-		"DeleteCurrent_UpdatesCache": {
-			patchLayers: []map[string]*int{{"x": ptr.To(5)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.FindValue("x")
-				ps.DeleteCurrent("x")
-			},
-			wantCache:       map[string]*int{"x": nil},
-			wantCacheInSync: false,
-		},
-		"Revert_ClearsAffectedCacheEntries_And_SetsCacheNotInSync": {
-			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2), "a": ptr.To(11)}}, // Layer 0: a=1; Layer 1: b=2, a=11
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.FindValue("a")
-				ps.FindValue("b")
-				ps.Revert()
-			},
-			wantCache:       map[string]*int{},
-			wantCacheInSync: false,
-		},
-		"Revert_OnSyncedCache_SetsCacheNotInSync": {
-			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.AsMap()
-				ps.Revert()
-			},
-			wantCache:       map[string]*int{"a": ptr.To(1)},
-			wantCacheInSync: false,
-		},
-		"Commit_DoesNotInvalidateCache_IfValuesConsistent": {
-			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.FindValue("a")
-				ps.FindValue("b")
-				ps.Commit()
-			},
-			wantCache:       map[string]*int{"a": ptr.To(1), "b": ptr.To(2)},
-			wantCacheInSync: false,
-		},
-		"Commit_OnSyncedCache_KeepsCacheInSync": {
-			patchLayers: []map[string]*int{{"a": ptr.To(1)}, {"b": ptr.To(2)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.AsMap()
-				ps.Commit()
-			},
-			wantCache:       map[string]*int{"a": ptr.To(1), "b": ptr.To(2)},
-			wantCacheInSync: true,
-		},
-		"Fork_DoesNotInvalidateCache": {
-			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.FindValue("a")
-				ps.Fork()
-			},
-			wantCache:       map[string]*int{"a": ptr.To(1)},
-			wantCacheInSync: false,
-		},
-		"Fork_OnSyncedCache_KeepsCacheInSync": {
-			patchLayers: []map[string]*int{{"a": ptr.To(1)}},
-			mutatePatchSet: func(ps *PatchSet[string, int]) {
-				ps.AsMap()
-				ps.Fork()
-			},
-			wantCache:       map[string]*int{"a": ptr.To(1)},
-			wantCacheInSync: true,
-		},
+
+
+func TestNewPatchSetFromMap(t *testing.T) {
+	nativeMap := map[string]int{
+		"a": 1,
+		"b": 2,
+		"c": 3,
 	}
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			ps := buildTestPatchSet(t, tc.patchLayers)
-			tc.mutatePatchSet(ps)
+	ps := NewPatchSetFromMap(nativeMap)
 
-			if !maps.EqualFunc(ps.cache, tc.wantCache, func(a, b *int) bool {
-				if a == nil && b == nil {
-					return true
-				}
-				if a == nil || b == nil {
-					return false
-				}
-				return *a == *b
-			}) {
-				t.Errorf("Cache content mismatch: got %v, want %v", ps.cache, tc.wantCache)
-			}
+	if len(ps.stack) != 1 {
+		t.Fatalf("Expected 1 stack item, got %d", len(ps.stack))
+	}
 
-			if ps.cacheInSync != tc.wantCacheInSync {
-				t.Errorf("cacheInSync status mismatch: got %v, want %v", ps.cacheInSync, tc.wantCacheInSync)
-			}
-		})
+	for k, expectedVal := range nativeMap {
+		val, found := ps.FindValue(k)
+		if !found {
+			t.Errorf("Expected key %q to be found", k)
+		}
+		if val != expectedVal {
+			t.Errorf("Key %q: got value %d, want %d", k, val, expectedVal)
+		}
+	}
+
+	// Empty map case
+	psEmpty := NewPatchSetFromMap(map[string]int{})
+	if len(psEmpty.stack) != 1 {
+		t.Fatalf("Expected 1 stack item for empty map, got %d", len(psEmpty.stack))
+	}
+	if psEmpty.stack[0].Len() != 0 {
+		t.Errorf("Expected empty map state, got length %d", psEmpty.stack[0].Len())
 	}
 }
 
@@ -705,4 +589,18 @@ func buildTestPatchSet[K comparable, V any](t *testing.T, patchLayers []map[K]*V
 	}
 
 	return NewPatchSet(patches...)
+}
+
+func TestInterfaceHashStability(t *testing.T) {
+	type DummyId struct {
+		Name      string
+		Namespace string
+	}
+	id1 := DummyId{Name: "claim-1", Namespace: "default"}
+	id2 := DummyId{Name: "claim-1", Namespace: "default"}
+	h1 := hashKey(id1)
+	h2 := hashKey(id2)
+	if h1 != h2 {
+		t.Errorf("hashKey is unstable for struct keys: h1=%d, h2=%d", h1, h2)
+	}
 }

--- a/cluster-autoscaler/simulator/common/persistent_map_gen.go
+++ b/cluster-autoscaler/simulator/common/persistent_map_gen.go
@@ -1,0 +1,756 @@
+package common
+
+import (
+	"math/bits"
+	"unsafe"
+)
+
+//go:noescape
+//go:linkname nilinterhash runtime.nilinterhash
+func nilinterhash(p unsafe.Pointer, h uintptr) uintptr
+
+//go:noescape
+//go:linkname strhash runtime.strhash
+func strhash(p unsafe.Pointer, h uintptr) uintptr
+
+//go:noescape
+//go:linkname memhash runtime.memhash
+func memhash(p unsafe.Pointer, h, size uintptr) uintptr
+
+func interfaceHash(x interface{}) uint32 {
+	return uint32(nilinterhash(unsafe.Pointer(&x), 0))
+}
+
+func stringHash(x string) uint32 {
+	return uint32(strhash(unsafe.Pointer(&x), 0))
+}
+
+func uint8Hash(x uint8) uint32 {
+	return uint32(memhash(unsafe.Pointer(&x), 0, 1))
+}
+
+func int8Hash(x int8) uint32 {
+	return uint8Hash(uint8(x))
+}
+
+func uint16Hash(x uint16) uint32 {
+	return uint32(memhash(unsafe.Pointer(&x), 0, 2))
+}
+
+func int16Hash(x int16) uint32 {
+	return uint16Hash(uint16(x))
+}
+
+func uint32Hash(x uint32) uint32 {
+	return uint32(memhash(unsafe.Pointer(&x), 0, 4))
+}
+
+func int32Hash(x int32) uint32 {
+	return uint32Hash(uint32(x))
+}
+
+func uint64Hash(x uint64) uint32 {
+	return uint32(memhash(unsafe.Pointer(&x), 0, 8))
+}
+
+func int64Hash(x int64) uint32 {
+	return uint64Hash(uint64(x))
+}
+
+func intHash(x int) uint32 {
+	return uint32(memhash(unsafe.Pointer(&x), 0, uintptr(unsafe.Sizeof(x))))
+}
+
+func uintHash(x uint) uint32 {
+	return uint32(memhash(unsafe.Pointer(&x), 0, uintptr(unsafe.Sizeof(x))))
+}
+
+func boolHash(x bool) uint32 {
+	return uint32(memhash(unsafe.Pointer(&x), 0, 1))
+}
+
+func runeHash(x rune) uint32 {
+	return int32Hash(int32(x))
+}
+
+func float64Hash(x float64) uint32 {
+	return uint32(memhash(unsafe.Pointer(&x), 0, 8))
+}
+
+func float32Hash(x float32) uint32 {
+	return uint32(memhash(unsafe.Pointer(&x), 0, 4))
+}
+
+func hashKey[K comparable](key K) uint32 {
+	switch k := any(key).(type) {
+	case string:
+		return stringHash(k)
+	case int:
+		return intHash(k)
+	case int64:
+		return int64Hash(k)
+	case int32:
+		return int32Hash(k)
+	case uint64:
+		return uint64Hash(k)
+	case float64:
+		return float64Hash(k)
+	default:
+		return interfaceHash(key)
+	}
+}
+
+// editSession represents a unique transaction session for transient map mutations.
+type editSession struct {
+	dummy bool
+}
+
+// box is a helper used to return state from recursive calls
+type box struct {
+	val any
+}
+
+// node represents a generic node in the Hash Array Mapped Trie
+type node[K comparable, V any] interface {
+	assoc(session *editSession, shift uint, hash uint32, key K, val V, addedLeaf *box) node[K, V]
+	without(session *editSession, shift uint, hash uint32, key K, removedLeaf *box) node[K, V]
+	find(shift uint, hash uint32, key K) (V, bool)
+	rangeElements(f func(K, V) bool) bool
+}
+
+// bitmapNodeEntry represents a single slot in a BitmapIndexedNode dense array.
+type bitmapNodeEntry[K comparable, V any] struct {
+	isNode bool
+	hash   uint32
+	key    K
+	value  V
+	child  node[K, V]
+}
+
+// bitmapIndexedNode is a compact node using a 32-bit bitmap to track occupied slots.
+type bitmapIndexedNode[K comparable, V any] struct {
+	session *editSession
+	bitmap  uint32
+	array   []bitmapNodeEntry[K, V]
+}
+
+func (n *bitmapIndexedNode[K, V]) index(bit uint32) int {
+	return bits.OnesCount32(n.bitmap & (bit - 1))
+}
+
+func (n *bitmapIndexedNode[K, V]) ensureEditable(session *editSession) *bitmapIndexedNode[K, V] {
+	if session != nil && n.session == session {
+		return n
+	}
+	newArray := make([]bitmapNodeEntry[K, V], len(n.array))
+	copy(newArray, n.array)
+	return &bitmapIndexedNode[K, V]{session: session, bitmap: n.bitmap, array: newArray}
+}
+
+func (n *bitmapIndexedNode[K, V]) find(shift uint, hash uint32, key K) (V, bool) {
+	bit := uint32(1) << ((hash >> shift) & 0x1f)
+	if (n.bitmap & bit) == 0 {
+		var zero V
+		return zero, false
+	}
+	idx := n.index(bit)
+	entry := n.array[idx]
+	if entry.isNode {
+		return entry.child.find(shift+5, hash, key)
+	}
+	if entry.key == key {
+		return entry.value, true
+	}
+	var zero V
+	return zero, false
+}
+
+func (n *bitmapIndexedNode[K, V]) assoc(session *editSession, shift uint, hash uint32, key K, val V, addedLeaf *box) node[K, V] {
+	bit := uint32(1) << ((hash >> shift) & 0x1f)
+	idx := n.index(bit)
+
+	if (n.bitmap & bit) != 0 {
+		entry := n.array[idx]
+		if entry.isNode {
+			child := entry.child.assoc(session, shift+5, hash, key, val, addedLeaf)
+			if child == entry.child {
+				return n
+			}
+			editable := n.ensureEditable(session)
+			editable.array[idx].child = child
+			return editable
+		}
+		if entry.key == key {
+			if safeEqual(entry.value, val) {
+				return n
+			}
+			editable := n.ensureEditable(session)
+			editable.array[idx].value = val
+			return editable
+		}
+		addedLeaf.val = addedLeaf
+		subNode := createNode(session, shift+5, entry.key, entry.value, entry.hash, key, val, hash)
+		editable := n.ensureEditable(session)
+		editable.array[idx] = bitmapNodeEntry[K, V]{
+			isNode: true,
+			hash:   entry.hash,
+			child:  subNode,
+		}
+		return editable
+	}
+
+	addedLeaf.val = addedLeaf
+	card := bits.OnesCount32(n.bitmap)
+	if card >= 16 {
+		var nodes [32]node[K, V]
+		j := 0
+		for i := uint(0); i < 32; i++ {
+			if (n.bitmap & (1 << i)) != 0 {
+				entry := n.array[j]
+				if entry.isNode {
+					nodes[i] = entry.child
+				} else {
+					nodes[i] = &bitmapIndexedNode[K, V]{
+						session: session,
+						bitmap:  1 << ((entry.hash >> (shift + 5)) & 0x1f),
+						array:   []bitmapNodeEntry[K, V]{entry},
+					}
+				}
+				j++
+			}
+		}
+		idx := (hash >> shift) & 0x1f
+		nodes[idx] = &bitmapIndexedNode[K, V]{
+			session: session,
+			bitmap:  1 << ((hash >> (shift + 5)) & 0x1f),
+			array: []bitmapNodeEntry[K, V]{{
+				isNode: false,
+				hash:   hash,
+				key:    key,
+				value:  val,
+			}},
+		}
+		return &arrayNode[K, V]{session: session, count: card + 1, array: nodes}
+	}
+
+	newArray := make([]bitmapNodeEntry[K, V], card+1)
+	copy(newArray[:idx], n.array[:idx])
+	newArray[idx] = bitmapNodeEntry[K, V]{
+		isNode: false,
+		hash:   hash,
+		key:    key,
+		value:  val,
+	}
+	copy(newArray[idx+1:], n.array[idx:])
+	if session != nil && n.session == session {
+		n.bitmap |= bit
+		n.array = newArray
+		return n
+	}
+	return &bitmapIndexedNode[K, V]{session: session, bitmap: n.bitmap | bit, array: newArray}
+}
+
+func (n *bitmapIndexedNode[K, V]) without(session *editSession, shift uint, hash uint32, key K, removedLeaf *box) node[K, V] {
+	bit := uint32(1) << ((hash >> shift) & 0x1f)
+	if (n.bitmap & bit) == 0 {
+		return n
+	}
+	idx := n.index(bit)
+	entry := n.array[idx]
+	if entry.isNode {
+		child := entry.child.without(session, shift+5, hash, key, removedLeaf)
+		if child == entry.child {
+			return n
+		}
+		if child == nil {
+			if n.bitmap == bit {
+				return nil
+			}
+			newArray := make([]bitmapNodeEntry[K, V], len(n.array)-1)
+			copy(newArray[:idx], n.array[:idx])
+			copy(newArray[idx:], n.array[idx+1:])
+			if session != nil && n.session == session {
+				n.bitmap ^= bit
+				n.array = newArray
+				return n
+			}
+			return &bitmapIndexedNode[K, V]{session: session, bitmap: n.bitmap ^ bit, array: newArray}
+		}
+		editable := n.ensureEditable(session)
+		editable.array[idx].child = child
+		return editable
+	}
+
+	if entry.key == key {
+		removedLeaf.val = removedLeaf
+		if n.bitmap == bit {
+			return nil
+		}
+		newArray := make([]bitmapNodeEntry[K, V], len(n.array)-1)
+		copy(newArray[:idx], n.array[:idx])
+		copy(newArray[idx:], n.array[idx+1:])
+		if session != nil && n.session == session {
+			n.bitmap ^= bit
+			n.array = newArray
+			return n
+		}
+		return &bitmapIndexedNode[K, V]{session: session, bitmap: n.bitmap ^ bit, array: newArray}
+	}
+	return n
+}
+
+func (n *bitmapIndexedNode[K, V]) rangeElements(f func(K, V) bool) bool {
+	for _, entry := range n.array {
+		if entry.isNode {
+			if !entry.child.rangeElements(f) {
+				return false
+			}
+		} else {
+			if !f(entry.key, entry.value) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// arrayNode represents a flat, 32-way branched node for fast lookups in highly populated nodes.
+type arrayNode[K comparable, V any] struct {
+	session *editSession
+	count   int
+	array   [32]node[K, V]
+}
+
+func (n *arrayNode[K, V]) ensureEditable(session *editSession) *arrayNode[K, V] {
+	if session != nil && n.session == session {
+		return n
+	}
+	return &arrayNode[K, V]{session: session, count: n.count, array: n.array}
+}
+
+func (n *arrayNode[K, V]) find(shift uint, hash uint32, key K) (V, bool) {
+	idx := (hash >> shift) & 0x1f
+	child := n.array[idx]
+	if child == nil {
+		var zero V
+		return zero, false
+	}
+	return child.find(shift+5, hash, key)
+}
+
+func (n *arrayNode[K, V]) assoc(session *editSession, shift uint, hash uint32, key K, val V, addedLeaf *box) node[K, V] {
+	idx := (hash >> shift) & 0x1f
+	child := n.array[idx]
+	if child == nil {
+		newChild := &bitmapIndexedNode[K, V]{
+			session: session,
+			bitmap:  1 << ((hash >> (shift + 5)) & 0x1f),
+			array: []bitmapNodeEntry[K, V]{{
+				isNode: false,
+				hash:   hash,
+				key:    key,
+				value:  val,
+			}},
+		}
+		addedLeaf.val = addedLeaf
+		editable := n.ensureEditable(session)
+		editable.array[idx] = newChild
+		editable.count++
+		return editable
+	}
+
+	newChild := child.assoc(session, shift+5, hash, key, val, addedLeaf)
+	if newChild == child {
+		return n
+	}
+	editable := n.ensureEditable(session)
+	editable.array[idx] = newChild
+	return editable
+}
+
+func (n *arrayNode[K, V]) without(session *editSession, shift uint, hash uint32, key K, removedLeaf *box) node[K, V] {
+	idx := (hash >> shift) & 0x1f
+	child := n.array[idx]
+	if child == nil {
+		return n
+	}
+	newChild := child.without(session, shift+5, hash, key, removedLeaf)
+	if newChild == child {
+		return n
+	}
+	if newChild == nil {
+		if n.count <= 8 {
+			var newArray []bitmapNodeEntry[K, V]
+			var bitmap uint32
+			for i := uint(0); i < 32; i++ {
+				if uint32(i) != idx && n.array[i] != nil {
+					bitmap |= 1 << i
+					c := n.array[i]
+					if bNode, ok := c.(*bitmapIndexedNode[K, V]); ok && bits.OnesCount32(bNode.bitmap) == 1 && !bNode.array[0].isNode {
+						newArray = append(newArray, bNode.array[0])
+					} else {
+						newArray = append(newArray, bitmapNodeEntry[K, V]{
+							isNode: true,
+							child:  c,
+						})
+					}
+				}
+			}
+			return &bitmapIndexedNode[K, V]{session: session, bitmap: bitmap, array: newArray}
+		}
+		editable := n.ensureEditable(session)
+		editable.array[idx] = nil
+		editable.count--
+		return editable
+	}
+	editable := n.ensureEditable(session)
+	editable.array[idx] = newChild
+	return editable
+}
+
+func (n *arrayNode[K, V]) rangeElements(f func(K, V) bool) bool {
+	for _, child := range n.array {
+		if child != nil {
+			if !child.rangeElements(f) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+type collisionEntry[K comparable, V any] struct {
+	key   K
+	value V
+}
+
+// hashCollisionNode handles keys that have different values but produce the exact same 32-bit hash.
+type hashCollisionNode[K comparable, V any] struct {
+	session *editSession
+	hash    uint32
+	array   []collisionEntry[K, V]
+}
+
+func (n *hashCollisionNode[K, V]) ensureEditable(session *editSession) *hashCollisionNode[K, V] {
+	if session != nil && n.session == session {
+		return n
+	}
+	newArray := make([]collisionEntry[K, V], len(n.array))
+	copy(newArray, n.array)
+	return &hashCollisionNode[K, V]{session: session, hash: n.hash, array: newArray}
+}
+
+func (n *hashCollisionNode[K, V]) find(shift uint, hash uint32, key K) (V, bool) {
+	for _, entry := range n.array {
+		if entry.key == key {
+			return entry.value, true
+		}
+	}
+	var zero V
+	return zero, false
+}
+
+func (n *hashCollisionNode[K, V]) assoc(session *editSession, shift uint, hash uint32, key K, val V, addedLeaf *box) node[K, V] {
+	if hash == n.hash {
+		for idx, entry := range n.array {
+			if entry.key == key {
+				if safeEqual(entry.value, val) {
+					return n
+				}
+				editable := n.ensureEditable(session)
+				editable.array[idx].value = val
+				return editable
+			}
+		}
+
+		addedLeaf.val = addedLeaf
+		newArray := make([]collisionEntry[K, V], len(n.array)+1)
+		copy(newArray, n.array)
+		newArray[len(n.array)] = collisionEntry[K, V]{key: key, value: val}
+		if session != nil && n.session == session {
+			n.array = newArray
+			return n
+		}
+		return &hashCollisionNode[K, V]{session: session, hash: n.hash, array: newArray}
+	}
+
+	return (&bitmapIndexedNode[K, V]{
+		session: session,
+		bitmap:  1 << ((n.hash >> shift) & 0x1f),
+		array: []bitmapNodeEntry[K, V]{{
+			isNode: true,
+			hash:   n.hash,
+			child:  n,
+		}},
+	}).assoc(session, shift, hash, key, val, addedLeaf)
+}
+
+func (n *hashCollisionNode[K, V]) without(session *editSession, shift uint, hash uint32, key K, removedLeaf *box) node[K, V] {
+	if hash != n.hash {
+		return n
+	}
+	for idx, entry := range n.array {
+		if entry.key == key {
+			removedLeaf.val = removedLeaf
+			if len(n.array) == 1 {
+				return nil
+			}
+			if len(n.array) == 2 {
+				otherIdx := 1 - idx
+				other := n.array[otherIdx]
+				return &bitmapIndexedNode[K, V]{
+					session: session,
+					bitmap:  1 << ((n.hash >> shift) & 0x1f),
+					array: []bitmapNodeEntry[K, V]{{
+						isNode: false,
+						hash:   n.hash,
+						key:    other.key,
+						value:  other.value,
+					}},
+				}
+			}
+			newArray := make([]collisionEntry[K, V], len(n.array)-1)
+			copy(newArray[:idx], n.array[:idx])
+			copy(newArray[idx:], n.array[idx+1:])
+			if session != nil && n.session == session {
+				n.array = newArray
+				return n
+			}
+			return &hashCollisionNode[K, V]{session: session, hash: n.hash, array: newArray}
+		}
+	}
+	return n
+}
+
+func (n *hashCollisionNode[K, V]) rangeElements(f func(K, V) bool) bool {
+	for _, entry := range n.array {
+		if !f(entry.key, entry.value) {
+			return false
+		}
+	}
+	return true
+}
+
+func createNode[K comparable, V any](session *editSession, shift uint, key1 K, val1 V, hash1 uint32, key2 K, val2 V, hash2 uint32) node[K, V] {
+	if hash1 == hash2 {
+		return &hashCollisionNode[K, V]{
+			session: session,
+			hash:    hash1,
+			array: []collisionEntry[K, V]{
+				{key: key1, value: val1},
+				{key: key2, value: val2},
+			},
+		}
+	}
+
+	box := &box{}
+	return (&bitmapIndexedNode[K, V]{session: session, bitmap: 0, array: nil}).
+		assoc(session, shift, hash1, key1, val1, box).
+		assoc(session, shift, hash2, key2, val2, box)
+}
+
+// persistentMap is a true Hash Array Mapped Trie (HAMT) persistent key-value map.
+type persistentMap[K comparable, V any] struct {
+	root node[K, V]
+	size int
+}
+
+func (m *persistentMap[K, V]) Len() int {
+	return m.size
+}
+
+func (m *persistentMap[K, V]) Load(key K) (value V, ok bool) {
+	if m.root == nil {
+		var zero V
+		return zero, false
+	}
+	return m.root.find(0, hashKey(key), key)
+}
+
+func (m *persistentMap[K, V]) Store(key K, value V) *persistentMap[K, V] {
+	hash := hashKey(key)
+	addedLeaf := &box{}
+	var newRoot node[K, V]
+	if m.root == nil {
+		newRoot = &bitmapIndexedNode[K, V]{
+			bitmap: 1 << ((hash >> 0) & 0x1f),
+			array: []bitmapNodeEntry[K, V]{{
+				isNode: false,
+				hash:   hash,
+				key:    key,
+				value:  value,
+			}},
+		}
+		addedLeaf.val = addedLeaf
+	} else {
+		newRoot = m.root.assoc(nil, 0, hash, key, value, addedLeaf)
+	}
+
+	if newRoot == m.root {
+		return m
+	}
+
+	newSize := m.size
+	if addedLeaf.val != nil {
+		newSize++
+	}
+
+	return &persistentMap[K, V]{root: newRoot, size: newSize}
+}
+
+func (m *persistentMap[K, V]) Delete(key K) *persistentMap[K, V] {
+	if m.root == nil {
+		return m
+	}
+	hash := hashKey(key)
+	removedLeaf := &box{}
+	newRoot := m.root.without(nil, 0, hash, key, removedLeaf)
+	if newRoot == m.root {
+		return m
+	}
+	newSize := m.size
+	if removedLeaf.val != nil {
+		newSize--
+	}
+	return &persistentMap[K, V]{root: newRoot, size: newSize}
+}
+
+func (m *persistentMap[K, V]) Range(f func(K, V) bool) {
+	if m.root != nil {
+		m.root.rangeElements(f)
+	}
+}
+
+func (m *persistentMap[K, V]) ToNativeMap() map[K]V {
+	result := make(map[K]V)
+	m.Range(func(key K, value V) bool {
+		result[key] = value
+		return true
+	})
+	return result
+}
+
+func (m *persistentMap[K, V]) AsTransient() *transientMap[K, V] {
+	return &transientMap[K, V]{
+		session: &editSession{},
+		root:    m.root,
+		size:    m.size,
+	}
+}
+
+type persistentMapItem[K comparable, V any] struct {
+	Key   K
+	Value V
+}
+
+// NewpersistentMap returns a new persistentMap containing all items.
+func NewpersistentMap[K comparable, V any](items ...persistentMapItem[K, V]) *persistentMap[K, V] {
+	if len(items) == 0 {
+		return &persistentMap[K, V]{}
+	}
+	session := &editSession{}
+	transient := &transientMap[K, V]{session: session}
+	for _, item := range items {
+		transient.Store(item.Key, item.Value)
+	}
+	return transient.Persistent()
+}
+
+// NewpersistentMapFromNativeMap returns a new persistentMap containing all items in m.
+func NewpersistentMapFromNativeMap[K comparable, V any](m map[K]V) *persistentMap[K, V] {
+	if len(m) == 0 {
+		return &persistentMap[K, V]{}
+	}
+	session := &editSession{}
+	transient := &transientMap[K, V]{session: session}
+	for key, value := range m {
+		transient.Store(key, value)
+	}
+	return transient.Persistent()
+}
+
+// transientMap is a mutable, single-threaded view of a HAMT that optimizes batch modifications.
+type transientMap[K comparable, V any] struct {
+	session *editSession
+	root    node[K, V]
+	size    int
+}
+
+func (t *transientMap[K, V]) Len() int {
+	return t.size
+}
+
+func (t *transientMap[K, V]) Load(key K) (V, bool) {
+	if t.root == nil {
+		var zero V
+		return zero, false
+	}
+	return t.root.find(0, hashKey(key), key)
+}
+
+func (t *transientMap[K, V]) Store(key K, value V) {
+	if t.session == nil {
+		panic("Transient Store called after Persistent transition!")
+	}
+	hash := hashKey(key)
+	addedLeaf := &box{}
+	if t.root == nil {
+		t.root = &bitmapIndexedNode[K, V]{
+			session: t.session,
+			bitmap:  1 << ((hash >> 0) & 0x1f),
+			array: []bitmapNodeEntry[K, V]{{
+				isNode: false,
+				hash:   hash,
+				key:    key,
+				value:  value,
+			}},
+		}
+		addedLeaf.val = addedLeaf
+	} else {
+		t.root = t.root.assoc(t.session, 0, hash, key, value, addedLeaf)
+	}
+
+	if addedLeaf.val != nil {
+		t.size++
+	}
+}
+
+func (t *transientMap[K, V]) Delete(key K) {
+	if t.session == nil {
+		panic("Transient Delete called after Persistent transition!")
+	}
+	if t.root == nil {
+		return
+	}
+	hash := hashKey(key)
+	removedLeaf := &box{}
+	t.root = t.root.without(t.session, 0, hash, key, removedLeaf)
+	if removedLeaf.val != nil {
+		t.size--
+	}
+}
+
+func (t *transientMap[K, V]) Range(f func(K, V) bool) {
+	if t.root != nil {
+		t.root.rangeElements(f)
+	}
+}
+
+func (t *transientMap[K, V]) ToNativeMap() map[K]V {
+	result := make(map[K]V)
+	t.Range(func(key K, value V) bool {
+		result[key] = value
+		return true
+	})
+	return result
+}
+
+func (t *transientMap[K, V]) Persistent() *persistentMap[K, V] {
+	if t.session == nil {
+		panic("Transient Persistent called multiple times!")
+	}
+	p := &persistentMap[K, V]{root: t.root, size: t.size}
+	t.root = nil
+	t.session = nil // Permanently freeze all nodes owned by this session
+	return p
+}

--- a/cluster-autoscaler/simulator/common/persistent_map_test.go
+++ b/cluster-autoscaler/simulator/common/persistent_map_test.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPersistentMapBasic(t *testing.T) {
+	m := NewpersistentMap[string, int]()
+	if m.Len() != 0 {
+		t.Errorf("Expected empty map, got len %d", m.Len())
+	}
+
+	// Store
+	m1 := m.Store("a", 1)
+	if m1.Len() != 1 {
+		t.Errorf("Expected len 1, got %d", m1.Len())
+	}
+	if m.Len() != 0 {
+		t.Errorf("Original map mutated: expected len 0, got %d", m.Len())
+	}
+
+	// Load
+	val, ok := m1.Load("a")
+	if !ok || val != 1 {
+		t.Errorf("Expected to load 1 for key 'a', got %v, %t", val, ok)
+	}
+
+	// Overwrite
+	m2 := m1.Store("a", 2)
+	if m2.Len() != 1 {
+		t.Errorf("Expected len 1 after overwrite, got %d", m2.Len())
+	}
+	val, ok = m2.Load("a")
+	if !ok || val != 2 {
+		t.Errorf("Expected to load 2 for key 'a', got %v, %t", val, ok)
+	}
+	val, ok = m1.Load("a")
+	if !ok || val != 1 {
+		t.Errorf("Original map affected by overwrite: expected 1, got %v, %t", val, ok)
+	}
+
+	// Delete
+	m3 := m2.Delete("a")
+	if m3.Len() != 0 {
+		t.Errorf("Expected len 0 after delete, got %d", m3.Len())
+	}
+	_, ok = m3.Load("a")
+	if ok {
+		t.Error("Expected key 'a' to be deleted")
+	}
+}
+
+func TestPersistentMapMultipleKeys(t *testing.T) {
+	m := NewpersistentMap[string, int]()
+	keys := []string{"foo", "bar", "baz", "qux"}
+	for i, k := range keys {
+		m = m.Store(k, i+10)
+	}
+
+	if m.Len() != len(keys) {
+		t.Errorf("Expected len %d, got %d", len(keys), m.Len())
+	}
+
+	for i, k := range keys {
+		val, ok := m.Load(k)
+		if !ok || val != i+10 {
+			t.Errorf("Expected %d for key %q, got %v, %t", i+10, k, val, ok)
+		}
+	}
+}
+
+func TestTransientMapMutations(t *testing.T) {
+	m := NewpersistentMap[string, int]()
+	transient := m.AsTransient()
+
+	if transient.Len() != 0 {
+		t.Errorf("Expected empty transient, got len %d", transient.Len())
+	}
+
+	// Store in transient
+	transient.Store("a", 1)
+	transient.Store("b", 2)
+	transient.Store("c", 3)
+
+	if transient.Len() != 3 {
+		t.Errorf("Expected transient len 3, got %d", transient.Len())
+	}
+
+	// Verify original is still empty
+	if m.Len() != 0 {
+		t.Errorf("Original map mutated during transient work: got len %d", m.Len())
+	}
+
+	// Convert to persistent
+	p := transient.Persistent()
+	if p.Len() != 3 {
+		t.Errorf("Expected persistent len 3, got %d", p.Len())
+	}
+
+	for k, expected := range map[string]int{"a": 1, "b": 2, "c": 3} {
+		val, ok := p.Load(k)
+		if !ok || val != expected {
+			t.Errorf("Expected %d for key %q, got %v, %t", expected, k, val, ok)
+		}
+	}
+
+	// Verify transient methods panic after transition
+	verifyPanic(t, "Store", func() {
+		transient.Store("d", 4)
+	})
+	verifyPanic(t, "Delete", func() {
+		transient.Delete("a")
+	})
+	verifyPanic(t, "Persistent", func() {
+		transient.Persistent()
+	})
+}
+
+func verifyPanic(t *testing.T, name string, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected %s to panic, but it did not", name)
+		}
+	}()
+	f()
+}
+
+func TestPersistentMapRange(t *testing.T) {
+	input := map[string]int{
+		"k1": 100,
+		"k2": 200,
+		"k3": 300,
+	}
+
+	m := NewpersistentMapFromNativeMap(input)
+	visited := make(map[string]int)
+
+	m.Range(func(k string, v int) bool {
+		visited[k] = v
+		return true
+	})
+
+	if len(visited) != len(input) {
+		t.Errorf("Range visited %d elements, expected %d", len(visited), len(input))
+	}
+
+	for k, v := range input {
+		if visited[k] != v {
+			t.Errorf("Range value mismatch for key %q: got %d, expected %d", k, visited[k], v)
+		}
+	}
+}
+
+func TestPersistentMapScale(t *testing.T) {
+	const count = 5000
+	m := NewpersistentMap[int, int]()
+
+	// 1. Bulk insertion
+	session := &editSession{}
+	transient := &transientMap[int, int]{session: session}
+	for i := 0; i < count; i++ {
+		transient.Store(i, i*10)
+	}
+
+	m = transient.Persistent()
+	if m.Len() != count {
+		t.Errorf("Expected scale map len %d, got %d", count, m.Len())
+	}
+
+	// 2. Bulk validation
+	for i := 0; i < count; i++ {
+		val, ok := m.Load(i)
+		if !ok || val != i*10 {
+			t.Fatalf("Load failed for key %d: got %v, %t, expected %d", i, val, ok, i*10)
+		}
+	}
+
+	// 3. Bulk deletions of even keys
+	transient = m.AsTransient()
+	for i := 0; i < count; i += 2 {
+		transient.Delete(i)
+	}
+	m = transient.Persistent()
+
+	if m.Len() != count/2 {
+		t.Errorf("Expected len %d after deleting half, got %d", count/2, m.Len())
+	}
+
+	// 4. Validate remaining keys
+	for i := 0; i < count; i++ {
+		val, ok := m.Load(i)
+		if i%2 == 0 {
+			if ok {
+				t.Fatalf("Key %d should have been deleted, but was found with value %d", i, val)
+			}
+		} else {
+			if !ok || val != i*10 {
+				t.Fatalf("Load failed for key %d: got %v, %t, expected %d", i, val, ok, i*10)
+			}
+		}
+	}
+}
+
+func TestPersistentMapComplexStructKeys(t *testing.T) {
+	type complexKey struct {
+		ID   int
+		Name string
+	}
+
+	m := NewpersistentMap[complexKey, string]()
+	k1 := complexKey{ID: 1, Name: "one"}
+	k2 := complexKey{ID: 2, Name: "two"}
+
+	m = m.Store(k1, "value-one")
+	m = m.Store(k2, "value-two")
+
+	val, ok := m.Load(k1)
+	if !ok || val != "value-one" {
+		t.Errorf("Expected 'value-one', got %q, %t", val, ok)
+	}
+
+	val, ok = m.Load(k2)
+	if !ok || val != "value-two" {
+		t.Errorf("Expected 'value-two', got %q, %t", val, ok)
+	}
+}
+
+func TestSafeEqual(t *testing.T) {
+	// Simple comparable values
+	if !safeEqual(10, 10) {
+		t.Error("Expected 10 == 10")
+	}
+	if safeEqual(10, 20) {
+		t.Error("Expected 10 != 20")
+	}
+
+	// Strings
+	if !safeEqual("hello", "hello") {
+		t.Error("Expected strings to be equal")
+	}
+
+	// Slices (normally non-comparable, should return false instead of panicking)
+	slice1 := []int{1, 2}
+	slice2 := []int{1, 2}
+	if safeEqual(slice1, slice2) {
+		t.Error("Expected slices to not be equal under safeEqual")
+	}
+
+	// Same slice variable (since boxing copies the slice header, interface data pointers are different, so it should safely return false without panicking)
+	if safeEqual(slice1, slice1) {
+		t.Error("Expected slice compared to itself to be false under safeEqual (due to boxing pointer difference)")
+	}
+}
+
+func TestNewpersistentMapVarargs(t *testing.T) {
+	m := NewpersistentMap[string, int](
+		persistentMapItem[string, int]{Key: "a", Value: 1},
+		persistentMapItem[string, int]{Key: "b", Value: 2},
+	)
+
+	if m.Len() != 2 {
+		t.Errorf("Expected len 2, got %d", m.Len())
+	}
+	if val, ok := m.Load("a"); !ok || val != 1 {
+		t.Errorf("Expected 'a' to be 1, got %d, %t", val, ok)
+	}
+	if val, ok := m.Load("b"); !ok || val != 2 {
+		t.Errorf("Expected 'b' to be 2, got %d, %t", val, ok)
+	}
+}
+
+func TestArrayNodeTransitions(t *testing.T) {
+	// Array node has 32 slots. If a bitmap node grows past 16 occupied slots,
+	// it transitions to an arrayNode. If it shrinks below 8, it transitions back.
+	// Let's create keys that end up in the same node but different slots at a specific level.
+	// Actually, just inserting 30 keys with slightly different values will naturally disperse them,
+	// but to make sure they share a prefix, we can just insert many keys.
+	m := NewpersistentMap[string, int]()
+	const numKeys = 50
+	for i := 0; i < numKeys; i++ {
+		m = m.Store(fmt.Sprintf("key-%d", i), i)
+	}
+
+	// Verify all keys are present
+	for i := 0; i < numKeys; i++ {
+		val, ok := m.Load(fmt.Sprintf("key-%d", i))
+		if !ok || val != i {
+			t.Errorf("Expected %d for key-%d, got %v, %t", i, i, val, ok)
+		}
+	}
+
+	// Delete them one by one
+	for i := 0; i < numKeys; i++ {
+		m = m.Delete(fmt.Sprintf("key-%d", i))
+		val, ok := m.Load(fmt.Sprintf("key-%d", i))
+		if ok {
+			t.Errorf("key-%d should be deleted, but loaded value %v", i, val)
+		}
+	}
+
+	if m.Len() != 0 {
+		t.Errorf("Expected empty map after all deletes, got len %d", m.Len())
+	}
+}

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
@@ -60,13 +60,10 @@ func NewSnapshot(claims map[ResourceClaimId]*resourceapi.ResourceClaim, nodeLoca
 	maps.Copy(slices, nodeLocalSlices)
 	slices[nonNodeLocalResourceSlicesIdentifier] = nonNodeLocalSlices
 
-	claimsPatch := common.NewPatchFromMap(claims)
-	slicesPatch := common.NewPatchFromMap(slices)
-	devicesPatch := common.NewPatchFromMap(deviceClasses)
 	return &Snapshot{
-		resourceClaims: common.NewPatchSet(claimsPatch),
-		resourceSlices: common.NewPatchSet(slicesPatch),
-		deviceClasses:  common.NewPatchSet(devicesPatch),
+		resourceClaims: common.NewPatchSetFromMap(claims),
+		resourceSlices: common.NewPatchSetFromMap(slices),
+		deviceClasses:  common.NewPatchSetFromMap(deviceClasses),
 	}
 }
 
@@ -256,26 +253,19 @@ func (s *Snapshot) Fork() {
 	s.resourceSlices.Fork()
 }
 
-// listDeviceClasses retrieves all effective DeviceClasses from the snapshot.
-func (s *Snapshot) listDeviceClasses() []*resourceapi.DeviceClass {
-	deviceClasses := s.deviceClasses.AsMap()
-	deviceClassesList := make([]*resourceapi.DeviceClass, 0, len(deviceClasses))
-	for _, class := range deviceClasses {
-		deviceClassesList = append(deviceClassesList, class)
-	}
-
-	return deviceClassesList
+// WalkDeviceClasses iterates over all DeviceClasses in the snapshot.
+func (s *Snapshot) WalkDeviceClasses(f func(*resourceapi.DeviceClass) bool) {
+	s.deviceClasses.WalkValues(f)
 }
 
-// listResourceClaims retrieves all effective ResourceClaims from the snapshot.
-func (s *Snapshot) listResourceClaims() []*resourceapi.ResourceClaim {
-	claims := s.resourceClaims.AsMap()
-	claimsList := make([]*resourceapi.ResourceClaim, 0, len(claims))
-	for _, claim := range claims {
-		claimsList = append(claimsList, claim)
-	}
+// WalkResourceClaims iterates over all ResourceClaims in the snapshot.
+func (s *Snapshot) WalkResourceClaims(f func(*resourceapi.ResourceClaim) bool) {
+	s.resourceClaims.WalkValues(f)
+}
 
-	return claimsList
+// WalkResourceSlices iterates over all ResourceSlices in the snapshot.
+func (s *Snapshot) WalkResourceSlices(f func([]*resourceapi.ResourceSlice) bool) {
+	s.resourceSlices.WalkValues(f)
 }
 
 // configureResourceClaim updates or adds a ResourceClaim in the current patch layer.
@@ -288,17 +278,6 @@ func (s *Snapshot) configureResourceClaim(claim *resourceapi.ResourceClaim) {
 // getResourceClaim retrieves a specific ResourceClaim by its ID from the snapshot.
 func (s *Snapshot) getResourceClaim(claimId ResourceClaimId) (*resourceapi.ResourceClaim, bool) {
 	return s.resourceClaims.FindValue(claimId)
-}
-
-// listResourceSlices retrieves all effective ResourceSlices from the snapshot.
-func (s *Snapshot) listResourceSlices() []*resourceapi.ResourceSlice {
-	resourceSlices := s.resourceSlices.AsMap()
-	resourceSlicesList := make([]*resourceapi.ResourceSlice, 0, len(resourceSlices))
-	for _, nodeSlices := range resourceSlices {
-		resourceSlicesList = append(resourceSlicesList, nodeSlices...)
-	}
-
-	return resourceSlicesList
 }
 
 // getDeviceClass retrieves a specific DeviceClass by its name from the snapshot.

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_claim_tracker.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_claim_tracker.go
@@ -32,7 +32,13 @@ type snapshotClaimTracker struct {
 }
 
 func (ct snapshotClaimTracker) List() ([]*resourceapi.ResourceClaim, error) {
-	return ct.snapshot.listResourceClaims(), nil
+	capacity := ct.snapshot.resourceClaims.Len()
+	result := make([]*resourceapi.ResourceClaim, 0, capacity)
+	ct.snapshot.WalkResourceClaims(func(claim *resourceapi.ResourceClaim) bool {
+		result = append(result, claim)
+		return true
+	})
+	return result, nil
 }
 
 func (ct snapshotClaimTracker) Get(namespace, claimName string) (*resourceapi.ResourceClaim, error) {
@@ -46,12 +52,13 @@ func (ct snapshotClaimTracker) Get(namespace, claimName string) (*resourceapi.Re
 
 func (ct snapshotClaimTracker) ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error) {
 	result := sets.New[structured.DeviceID]()
-	for _, claim := range ct.snapshot.listResourceClaims() {
+	ct.snapshot.WalkResourceClaims(func(claim *resourceapi.ResourceClaim) bool {
 		foreachAllocatedDevice(claim,
 			func(deviceID structured.DeviceID) {
 				result.Insert(deviceID)
 			}, false, func(structured.SharedDeviceID) {}, func(capacity structured.DeviceConsumedCapacity) {})
-	}
+		return true
+	})
 	return result, nil
 }
 
@@ -62,7 +69,7 @@ func (ct snapshotClaimTracker) GatherAllocatedState() (*structured.AllocatedStat
 
 	enabledConsumableCapacity := utilfeature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity)
 
-	for _, claim := range ct.snapshot.listResourceClaims() {
+	ct.snapshot.WalkResourceClaims(func(claim *resourceapi.ResourceClaim) bool {
 		foreachAllocatedDevice(claim,
 			func(deviceID structured.DeviceID) {
 				allocatedDevices.Insert(deviceID)
@@ -75,7 +82,8 @@ func (ct snapshotClaimTracker) GatherAllocatedState() (*structured.AllocatedStat
 				aggregatedCapacity.Insert(capacity)
 			},
 		)
-	}
+		return true
+	})
 
 	return &structured.AllocatedState{
 		AllocatedDevices:         allocatedDevices,

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_lister.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_lister.go
@@ -27,7 +27,13 @@ type snapshotClassLister struct {
 }
 
 func (s snapshotClassLister) List() ([]*resourceapi.DeviceClass, error) {
-	return s.snapshot.listDeviceClasses(), nil
+	capacity := s.snapshot.deviceClasses.Len()
+	result := make([]*resourceapi.DeviceClass, 0, capacity)
+	s.snapshot.WalkDeviceClasses(func(class *resourceapi.DeviceClass) bool {
+		result = append(result, class)
+		return true
+	})
+	return result, nil
 }
 
 func (s snapshotClassLister) Get(className string) (*resourceapi.DeviceClass, error) {

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_resolver.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_class_resolver.go
@@ -32,7 +32,7 @@ var _ schedulerinterface.DeviceClassResolver = &snapshotDeviceClassResolver{}
 // newSnapshotDeviceClassResolver implements DeviceClassResolver for a snapshot
 func newSnapshotDeviceClassResolver(snapshot *Snapshot) schedulerinterface.DeviceClassResolver {
 	deviceClassMap := make(map[v1.ResourceName]*resourceapi.DeviceClass)
-	for _, class := range snapshot.listDeviceClasses() {
+	snapshot.WalkDeviceClasses(func(class *resourceapi.DeviceClass) bool {
 		if class != nil {
 			deviceClassMap[v1.ResourceName(resourceapi.ResourceDeviceClassPrefix+class.Name)] = class
 			extendedResourceName := class.Spec.ExtendedResourceName
@@ -40,7 +40,8 @@ func newSnapshotDeviceClassResolver(snapshot *Snapshot) schedulerinterface.Devic
 				deviceClassMap[v1.ResourceName(*extendedResourceName)] = class
 			}
 		}
-	}
+		return true
+	})
 	return snapshotDeviceClassResolver{deviceClassMap: deviceClassMap}
 }
 

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_slice_lister.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_slice_lister.go
@@ -26,5 +26,11 @@ type snapshotSliceLister struct {
 
 // TODO(DRA): Actually handle the taint rules.
 func (sl snapshotSliceLister) ListWithDeviceTaintRules() ([]*resourceapi.ResourceSlice, error) {
-	return sl.snapshot.listResourceSlices(), nil
+	capacity := sl.snapshot.resourceSlices.Len()
+	result := make([]*resourceapi.ResourceSlice, 0, capacity)
+	sl.snapshot.WalkResourceSlices(func(slices []*resourceapi.ResourceSlice) bool {
+		result = append(result, slices...)
+		return true
+	})
+	return result, nil
 }

--- a/cluster-autoscaler/simulator/dynamicresources/utils/utilization.go
+++ b/cluster-autoscaler/simulator/dynamicresources/utils/utilization.go
@@ -31,8 +31,7 @@ import (
 // an error if the NodeInfo doesn't have all ResourceSlices from a pool.
 func CalculateDynamicResourceUtilization(nodeInfo *framework.NodeInfo) (map[string]map[string]float64, error) {
 	result := map[string]map[string]float64{}
-	claims := nodeInfo.ResourceClaims()
-	allocatedDevices, err := groupAllocatedReservedDevices(claims)
+	allocatedDevices, err := groupAllocatedReservedDevices(nodeInfo.WalkResourceClaims)
 	if err != nil {
 		return nil, err
 	}
@@ -222,12 +221,14 @@ func getAllDevices(slices []*resourceapi.ResourceSlice) []resourceapi.Device {
 // groupAllocatedReservedDevices groups reserved devices from claim allocations by their driver and pool.
 // If a deviced will not exclusively reserved (i.e. AdminAccess), it will not be included in the result.
 // Returns an error if any of the claims isn't allocated.
-func groupAllocatedReservedDevices(claims []*resourceapi.ResourceClaim) (map[string]map[string][]string, error) {
+func groupAllocatedReservedDevices(walkClaims func(func(*resourceapi.ResourceClaim) bool)) (map[string]map[string][]string, error) {
 	result := map[string]map[string][]string{}
-	for _, claim := range claims {
+	var walkErr error
+	walkClaims(func(claim *resourceapi.ResourceClaim) bool {
 		alloc := claim.Status.Allocation
 		if alloc == nil {
-			return nil, fmt.Errorf("claim %s/%s not allocated", claim.Namespace, claim.Name)
+			walkErr = fmt.Errorf("claim %s/%s not allocated", claim.Namespace, claim.Name)
+			return false
 		}
 
 		for _, deviceAlloc := range alloc.Devices.Results {
@@ -241,6 +242,10 @@ func groupAllocatedReservedDevices(claims []*resourceapi.ResourceClaim) (map[str
 			}
 			result[deviceAlloc.Driver][deviceAlloc.Pool] = append(result[deviceAlloc.Driver][deviceAlloc.Pool], deviceAlloc.Device)
 		}
+		return true
+	})
+	if walkErr != nil {
+		return nil, walkErr
 	}
 	return result, nil
 }

--- a/cluster-autoscaler/simulator/framework/infos.go
+++ b/cluster-autoscaler/simulator/framework/infos.go
@@ -142,19 +142,40 @@ func (n *NodeInfo) Snapshot() schedulerinterface.NodeInfo {
 //
 // TODO(DRA): Beware that it may return stale ResourceClaim data.
 // See PodInfo.NeededResourceClaims comment.
-func (n *NodeInfo) ResourceClaims() []*resourceapi.ResourceClaim {
+// WalkResourceClaims iterates over all ResourceClaims contained in the PodInfos in this NodeInfo.
+// Shared claims are taken into account, each claim should only be visited once.
+func (n *NodeInfo) WalkResourceClaims(f func(*resourceapi.ResourceClaim) bool) {
+	if n == nil {
+		return
+	}
 	processedClaims := map[types.UID]bool{}
-	var result []*resourceapi.ResourceClaim
 	for _, pod := range n.Pods() {
 		for _, claim := range pod.NeededResourceClaims {
 			if processedClaims[claim.UID] {
 				// Shared claim, already grouped.
 				continue
 			}
-			result = append(result, claim)
 			processedClaims[claim.UID] = true
+			if !f(claim) {
+				return
+			}
 		}
 	}
+}
+
+// ResourceClaims returns all ResourceClaims contained in the PodInfos in this NodeInfo. Shared claims
+// are taken into account, each claim should only be returned once.
+//
+// Deprecated: Use WalkResourceClaims to avoid slice allocation.
+//
+// TODO(DRA): Beware that it may return stale ResourceClaim data.
+// See PodInfo.NeededResourceClaims comment.
+func (n *NodeInfo) ResourceClaims() []*resourceapi.ResourceClaim {
+	var result []*resourceapi.ResourceClaim
+	n.WalkResourceClaims(func(claim *resourceapi.ResourceClaim) bool {
+		result = append(result, claim)
+		return true
+	})
 	return result
 }
 


### PR DESCRIPTION
Use Hash Array Mapped Trie in Patchset to improve the DRA and Affinity performance

#### What type of PR is this?
/kind feature

(actually a performance improvement)

#### What this PR does / why we need it:

This is an optimization of PatchSet data type to improve the time complexities of operations, improving the performance of Affinity, DRA and CSI simulation by up to 20% in synthetic benchmarks - executed on node pools between 1000 and 2000 nodes.

   - Fork(): O(1).
   - Commit(): O(1).
   - Revert(): O(1).
   - FindValue(key): O(log32 M) where M is the number of keys in the map (effectively O(1) lookup).
   - AsMap(): O(M) where M is the number of keys in the map.
   - SetCurrent(key, value): O(log32 M) - effectively O(1).
   - DeleteCurrent(key): O(log32 M) - effectively O(1).
   - InCurrentPatch(key): O(log32 M) - effectively O(1).

This is achieved by the introduction of implementation of persistent HashMap based on [Hash Array Mapped Trie](https://en.wikipedia.org/wiki/Hash_array_mapped_trie) and inspired by Clojure's `hash-map` implementation.

The [existing golang persistent hashmap implementation](https://pkg.go.dev/golang.org/x/tools/internal/persistent) turned out to be far inferior in performance and memory usage, therefore another path to consider (once the performance is confirmed in real life scenario) is to propose more optimal persistent data structure implementations as a separate library.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
