### PR TITLE
azure: report deleting instances as gone from HasInstance

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -435,8 +435,15 @@ func (as *AgentPool) DeleteInstances(instances []*azureRef) error {
 			return err
 		}
 
+		if !as.manager.config.StrictCacheUpdates {
+			as.manager.azureCache.setInstanceStateByProviderID(instance.Name, cloudprovider.InstanceDeleting)
+		}
+
 		err = as.deleteVirtualMachine(name)
 		if err != nil {
+			// The delete failed, so force a cache refresh on the next loop to
+			// reconcile any stale local cache state.
+			as.manager.invalidateCache()
 			klog.Errorf("Delete virtual machine %q failed: %v", name, err)
 			return err
 		}
@@ -518,7 +525,12 @@ func (as *AgentPool) Nodes() ([]cloudprovider.Instance, error) {
 		if err != nil {
 			return nil, err
 		}
-		nodes = append(nodes, cloudprovider.Instance{Id: resourceID})
+		var provisioningState *string
+		if instance.Properties != nil {
+			provisioningState = instance.Properties.ProvisioningState
+		}
+		status := instanceStatusFromProvisioningStateAndPowerState(resourceID, provisioningState, vmPowerStateRunning, false)
+		nodes = append(nodes, cloudprovider.Instance{Id: resourceID, Status: status})
 	}
 
 	return nodes, nil

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool.go
@@ -529,7 +529,7 @@ func (as *AgentPool) Nodes() ([]cloudprovider.Instance, error) {
 		if instance.Properties != nil {
 			provisioningState = instance.Properties.ProvisioningState
 		}
-		status := instanceStatusFromProvisioningStateAndPowerState(resourceID, provisioningState, vmPowerStateRunning, false)
+		status := instanceStatusFromProvisioningStateAndPowerState(resourceID, provisioningState, vmPowerStateRunning, disableFastDeleteOnFailure)
 		nodes = append(nodes, cloudprovider.Instance{Id: resourceID, Status: status})
 	}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/mock/gomock"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachineclient/mock_virtualmachineclient"
 	providerazureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -500,6 +501,9 @@ func TestAgentPoolNodes(t *testing.T) {
 		{
 			Tags: map[string]*string{"poolName": ptr.To("as")},
 			ID:   &testValidProviderID0,
+			Properties: &armcompute.VirtualMachineProperties{
+				ProvisioningState: ptr.To("Succeeded"),
+			},
 		},
 	}
 
@@ -514,6 +518,13 @@ func TestAgentPoolNodes(t *testing.T) {
 	nodes, err := as.Nodes()
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(nodes))
+	assert.Equal(t, cloudprovider.InstanceRunning, nodes[0].Status.State)
+
+	expectedVMs[1].Properties = &armcompute.VirtualMachineProperties{ProvisioningState: ptr.To(VMProvisioningStateDeleting)}
+	as.manager.azureCache.virtualMachines["as"] = expectedVMs
+	nodes, err = as.Nodes()
+	assert.NoError(t, err)
+	assert.Equal(t, cloudprovider.InstanceDeleting, nodes[0].Status.State)
 
 	expectedVMs = []*armcompute.VirtualMachine{
 		{
@@ -528,4 +539,77 @@ func TestAgentPoolNodes(t *testing.T) {
 	expectedErr := fmt.Errorf("\"azure://foo\" isn't in Azure resource ID format")
 	assert.Equal(t, expectedErr, err)
 	assert.Nil(t, nodes)
+}
+
+func TestAgentPoolDeleteInstancesProactivelyMarksDeletion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as
+
+	mockVMClient := NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+
+	vmName, err := resourceName(testValidProviderID0)
+	assert.NoError(t, err)
+	mockVMClient.EXPECT().Get(gomock.Any(), as.manager.config.ResourceGroup, vmName, nil).DoAndReturn(
+		func(ctx context.Context, resourceGroupName, vmName string, expand *string) (*armcompute.VirtualMachine, error) {
+			hasInstance, hasInstanceErr := as.manager.azureCache.HasInstance(testValidProviderID0)
+			assert.False(t, hasInstance)
+			assert.Equal(t, cloudprovider.ErrNotImplemented, hasInstanceErr)
+			return &armcompute.VirtualMachine{
+				Properties: &armcompute.VirtualMachineProperties{
+					StorageProfile: &armcompute.StorageProfile{OSDisk: &armcompute.OSDisk{ManagedDisk: &armcompute.ManagedDiskParameters{}}},
+				},
+			}, nil
+		})
+	mockVMClient.EXPECT().Delete(gomock.Any(), as.manager.config.ResourceGroup, vmName).Return(nil)
+
+	hasInstance, err := as.manager.azureCache.HasInstance(testValidProviderID0)
+	assert.True(t, hasInstance)
+	assert.NoError(t, err)
+
+	err = as.DeleteInstances([]*azureRef{{Name: testValidProviderID0}})
+	assert.NoError(t, err)
+}
+
+func TestAgentPoolDeleteInstancesStrictCacheDoesNotProactivelyMarkDeletion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	as := newTestAgentPool(newTestAzureManager(t), "as")
+	as.manager.config.StrictCacheUpdates = true
+	as.manager.azureCache.instanceToNodeGroup[azureRef{Name: testValidProviderID0}] = as
+
+	mockVMClient := NewMockInterface(ctrl)
+	as.manager.azClient.virtualMachinesClient = mockVMClient
+
+	vmName, err := resourceName(testValidProviderID0)
+	assert.NoError(t, err)
+	mockVMClient.EXPECT().Get(gomock.Any(), as.manager.config.ResourceGroup, vmName, nil).DoAndReturn(
+		func(ctx context.Context, resourceGroupName, vmName string, expand *string) (*armcompute.VirtualMachine, error) {
+			hasInstance, hasInstanceErr := as.manager.azureCache.HasInstance(testValidProviderID0)
+			assert.True(t, hasInstance)
+			assert.NoError(t, hasInstanceErr)
+			return &armcompute.VirtualMachine{
+				Properties: &armcompute.VirtualMachineProperties{
+					StorageProfile: &armcompute.StorageProfile{OSDisk: &armcompute.OSDisk{ManagedDisk: &armcompute.ManagedDiskParameters{}}},
+				},
+			}, nil
+		})
+	mockVMClient.EXPECT().Delete(gomock.Any(), as.manager.config.ResourceGroup, vmName).Return(nil)
+
+	hasInstance, err := as.manager.azureCache.HasInstance(testValidProviderID0)
+	assert.True(t, hasInstance)
+	assert.NoError(t, err)
+
+	err = as.DeleteInstances([]*azureRef{{Name: testValidProviderID0}})
+	assert.NoError(t, err)
+
+	// Strict cache mode should not mutate instance state proactively; the instance
+	// remains present until the next refresh reflects Azure state.
+	hasInstance, err = as.manager.azureCache.HasInstance(testValidProviderID0)
+	assert.True(t, hasInstance)
+	assert.NoError(t, err)
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_agent_pool_test.go
@@ -502,7 +502,7 @@ func TestAgentPoolNodes(t *testing.T) {
 			Tags: map[string]*string{"poolName": ptr.To("as")},
 			ID:   &testValidProviderID0,
 			Properties: &armcompute.VirtualMachineProperties{
-				ProvisioningState: ptr.To("Succeeded"),
+				ProvisioningState: new("Succeeded"),
 			},
 		},
 	}
@@ -557,7 +557,7 @@ func TestAgentPoolDeleteInstancesProactivelyMarksDeletion(t *testing.T) {
 		func(ctx context.Context, resourceGroupName, vmName string, expand *string) (*armcompute.VirtualMachine, error) {
 			hasInstance, hasInstanceErr := as.manager.azureCache.HasInstance(testValidProviderID0)
 			assert.False(t, hasInstance)
-			assert.Equal(t, cloudprovider.ErrNotImplemented, hasInstanceErr)
+			assert.NoError(t, hasInstanceErr)
 			return &armcompute.VirtualMachine{
 				Properties: &armcompute.VirtualMachineProperties{
 					StorageProfile: &armcompute.StorageProfile{OSDisk: &armcompute.OSDisk{ManagedDisk: &armcompute.ManagedDiskParameters{}}},

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -488,7 +488,7 @@ func (m *azureCache) HasInstance(providerID string) (bool, error) {
 		// An instance that is actively being deleted is reported as gone so that
 		// ClusterStateRegistry stops counting it as an upcoming node.
 		if state, found := m.instanceStates[instanceID]; found && state == cloudprovider.InstanceDeleting {
-			return false, cloudprovider.ErrNotImplemented
+			return false, nil
 		}
 		return true, nil
 	}

--- a/cluster-autoscaler/cloudprovider/azure/azure_cache.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cache.go
@@ -97,6 +97,12 @@ type azureCache struct {
 	// for a given instance id (see FindForInstance).
 	instanceToNodeGroup map[azureRef]cloudprovider.NodeGroup
 
+	// instanceStates maintains a mapping from instance Ids to their last known
+	// cloudprovider.InstanceState. It is populated alongside instanceToNodeGroup
+	// from the results of calling Nodes() on each nodegroup. It is used by
+	// HasInstance to not include instances in an active state of deletion.
+	instanceStates map[azureRef]cloudprovider.InstanceState
+
 	// unownedInstance maintains a set of instance ids not belonging to any nodegroup.
 	// It is used (together with instanceToNodeGroup) when looking up the nodegroup for a given instance id.
 	// It is reset by invalidateUnownedInstanceCache().
@@ -127,6 +133,7 @@ func newAzureCache(client *azClient, cacheTTL time.Duration, config Config) (*az
 		virtualMachines:      make(map[string][]*armcompute.VirtualMachine),
 		registeredNodeGroups: make([]cloudprovider.NodeGroup, 0),
 		instanceToNodeGroup:  make(map[azureRef]cloudprovider.NodeGroup),
+		instanceStates:       make(map[azureRef]cloudprovider.InstanceState),
 		unownedInstances:     make(map[azureRef]bool),
 		autoscalingOptions:   make(map[azureRef]map[string]string),
 		skus:                 &skewer.Cache{}, // populated iff config.EnableDynamicInstanceList
@@ -191,6 +198,7 @@ func (m *azureCache) regenerate() error {
 
 	// Regenerate instance to node groups mapping.
 	newInstanceToNodeGroupCache := make(map[azureRef]cloudprovider.NodeGroup)
+	newInstanceStates := make(map[azureRef]cloudprovider.InstanceState)
 	for _, ng := range m.registeredNodeGroups {
 		klog.V(4).Infof("regenerate: finding nodes for node group %s", ng.Id())
 		instances, err := ng.Nodes()
@@ -202,6 +210,9 @@ func (m *azureCache) regenerate() error {
 		for _, instance := range instances {
 			ref := azureRef{Name: instance.Id}
 			newInstanceToNodeGroupCache[ref] = ng
+			if instance.Status != nil {
+				newInstanceStates[ref] = instance.Status.State
+			}
 		}
 	}
 
@@ -220,6 +231,7 @@ func (m *azureCache) regenerate() error {
 	defer m.mutex.Unlock()
 
 	m.instanceToNodeGroup = newInstanceToNodeGroupCache
+	m.instanceStates = newInstanceStates
 	m.autoscalingOptions = newAutoscalingOptions
 
 	// Reset unowned instances cache.
@@ -466,9 +478,21 @@ func (m *azureCache) HasInstance(providerID string) (bool, error) {
 		return false, err
 	}
 
-	if m.getInstanceFromCache(resourceID) != nil {
+	// A single pass over instanceToNodeGroup locates the instance. The matched key
+	// also indexes instanceStates, which setInstanceStateByProviderID keeps aligned
+	// with instanceToNodeGroup, so the state can be retrieved with a direct lookup.
+	for instanceID := range m.instanceToNodeGroup {
+		if !strings.EqualFold(instanceID.GetKey(), resourceID) {
+			continue
+		}
+		// An instance that is actively being deleted is reported as gone so that
+		// ClusterStateRegistry stops counting it as an upcoming node.
+		if state, found := m.instanceStates[instanceID]; found && state == cloudprovider.InstanceDeleting {
+			return false, cloudprovider.ErrNotImplemented
+		}
 		return true, nil
 	}
+
 	// couldn't find instance in the cache, assume it's deleted
 	return false, cloudprovider.ErrNotImplemented
 }
@@ -546,4 +570,24 @@ func (m *azureCache) getInstanceFromCache(providerID string) cloudprovider.NodeG
 	}
 
 	return nil
+}
+
+// setInstanceStateByProviderID records the last known InstanceState for the given
+// providerID.
+func (m *azureCache) setInstanceStateByProviderID(providerID string, state cloudprovider.InstanceState) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	resourceID, err := convertResourceGroupNameToLower(providerID)
+	if err != nil {
+		klog.Errorf("setInstanceStateByProviderID: error converting providerID %s: %v", providerID, err)
+		return
+	}
+
+	for instanceID := range m.instanceToNodeGroup {
+		if strings.EqualFold(instanceID.GetKey(), resourceID) {
+			m.instanceStates[instanceID] = state
+			return
+		}
+	}
 }

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -140,17 +140,6 @@ func (azure *AzureCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovid
 }
 
 // HasInstance returns whether a given node has a corresponding instance in this cloud provider.
-//
-// Used to prevent undercount of existing VMs (taint-based overcount of deleted VMs),
-// and so should not return false, nil (no instance) if uncertain; return error instead.
-// (Think "has instance for sure, else error".) Returning an error causes fallback to taint-based
-// determination; use ErrNotImplemented for silent fallback, any other error will be logged.
-//
-// Expected behavior (should work for VMSS Uniform/Flex, and VMs):
-// -  exists            : return true, nil
-// - !exists            : return *,    ErrNotImplemented (could use custom error for autoscaled nodes)
-// - unimplemented case : return *,    ErrNotImplemented
-// - any other error    : return *,    error
 func (azure *AzureCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 	if node.Spec.ProviderID == "" {
 		return false, fmt.Errorf("ProviderID for node: %s is empty, skipped", node.Name)

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -220,6 +220,96 @@ func TestHasInstance(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestHasInstanceReportsDeletingNodesAsGone(t *testing.T) {
+	testCases := []struct {
+		name                        string
+		strictCacheUpdates          bool
+		expectDeletingBeforeRefresh bool
+	}{
+		{
+			name:                        "non-strict cache updates",
+			strictCacheUpdates:          false,
+			expectDeletingBeforeRefresh: true,
+		},
+		{
+			name:                        "strict cache updates",
+			strictCacheUpdates:          true,
+			expectDeletingBeforeRefresh: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			manager := newTestAzureManager(t)
+			manager.config.StrictCacheUpdates = tc.strictCacheUpdates
+
+			expectedScaleSets := newTestVMSSList(3, "test-asg", "eastus", armcompute.OrchestrationModeUniform)
+			expectedVMSSVMs := newTestVMSSVMList(3)
+
+			mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+			mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+			mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, "test-asg").Return(expectedVMSSVMs, nil).AnyTimes()
+			manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+			mockDeleteClient := NewMockVMSSDeleteClient(ctrl)
+			mockDeleteClient.EXPECT().BeginDeleteInstances(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			manager.azClient.vmssClientForDelete = mockDeleteClient
+
+			registered := manager.RegisterNodeGroup(newTestScaleSet(manager, "test-asg"))
+			manager.explicitlyConfigured["test-asg"] = true
+			assert.True(t, registered)
+			assert.NoError(t, manager.forceRefresh())
+
+			deletedNode := newApiNode(armcompute.OrchestrationModeUniform, 0)
+			survivingNode := newApiNode(armcompute.OrchestrationModeUniform, 1)
+
+			// Before the scale-down both instances are reported as present.
+			hasInstance, err := manager.azureCache.HasInstance(deletedNode.Spec.ProviderID)
+			assert.True(t, hasInstance)
+			assert.NoError(t, err)
+
+			scaleSet, ok := manager.azureCache.registeredNodeGroups[0].(*ScaleSet)
+			assert.True(t, ok)
+			assert.NoError(t, scaleSet.DeleteNodes([]*apiv1.Node{deletedNode}))
+
+			// In non-strict mode, deleting state is proactive. In strict mode, it is
+			// only reflected after refresh from Azure.
+			hasInstance, err = manager.azureCache.HasInstance(deletedNode.Spec.ProviderID)
+			if tc.expectDeletingBeforeRefresh {
+				assert.False(t, hasInstance)
+				assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+			} else {
+				assert.True(t, hasInstance)
+				assert.NoError(t, err)
+			}
+
+			// Simulate Azure still listing the VM in the Deleting provisioning state
+			// during the deletion window, then refresh the cache.
+			expectedVMSSVMs[0].Properties.ProvisioningState = ptr.To(VMProvisioningStateDeleting)
+			assert.NoError(t, manager.forceRefresh())
+
+			// The node being deleted must now be reported as gone (with the
+			// ErrNotImplemented taint-based fallback), even though it is still tracked
+			// by the node group.
+			hasInstance, err = manager.azureCache.HasInstance(deletedNode.Spec.ProviderID)
+			assert.False(t, hasInstance)
+			assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+			assert.NotNil(t, manager.azureCache.getInstanceFromCache(deletedNode.Spec.ProviderID))
+
+			// Nodes that are not being deleted continue to be reported as present.
+			hasInstance, err = manager.azureCache.HasInstance(survivingNode.Spec.ProviderID)
+			assert.True(t, hasInstance)
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestUnownedInstancesFallbackToDeletionTaint(t *testing.T) {
 	// VMSS Instances that belong to a VMSS on the cluster but do not belong to a registered ASG
 	// should return err unimplemented for HasInstance

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider_test.go
@@ -283,7 +283,7 @@ func TestHasInstanceReportsDeletingNodesAsGone(t *testing.T) {
 			hasInstance, err = manager.azureCache.HasInstance(deletedNode.Spec.ProviderID)
 			if tc.expectDeletingBeforeRefresh {
 				assert.False(t, hasInstance)
-				assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+				assert.NoError(t, err)
 			} else {
 				assert.True(t, hasInstance)
 				assert.NoError(t, err)
@@ -294,12 +294,11 @@ func TestHasInstanceReportsDeletingNodesAsGone(t *testing.T) {
 			expectedVMSSVMs[0].Properties.ProvisioningState = ptr.To(VMProvisioningStateDeleting)
 			assert.NoError(t, manager.forceRefresh())
 
-			// The node being deleted must now be reported as gone (with the
-			// ErrNotImplemented taint-based fallback), even though it is still tracked
-			// by the node group.
+			// The node being deleted must now be reported as gone (false, nil),
+			// even though it is still tracked by the node group.
 			hasInstance, err = manager.azureCache.HasInstance(deletedNode.Spec.ProviderID)
 			assert.False(t, hasInstance)
-			assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, manager.azureCache.getInstanceFromCache(deletedNode.Spec.ProviderID))
 
 			// Nodes that are not being deleted continue to be reported as present.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -55,6 +55,8 @@ const (
 	provisioningStateMigrating string = "Migrating"
 	provisioningStateSucceeded string = "Succeeded"
 	provisioningStateUpdating  string = "Updating"
+	enableFastDeleteOnFailure  bool   = true
+	disableFastDeleteOnFailure bool   = false
 )
 
 // ScaleSet implements NodeGroup interface.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -814,6 +814,7 @@ func (scaleSet *ScaleSet) DeleteInstances(instances []*azureRef, hasUnregistered
 		// Proactively set the status of the instances to be deleted in cache
 		for _, instance := range instancesToDelete {
 			scaleSet.setInstanceStatusByProviderID(instance.Name, cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting})
+			scaleSet.manager.azureCache.setInstanceStateByProviderID(instance.Name, cloudprovider.InstanceDeleting)
 		}
 	}
 
@@ -832,8 +833,9 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 	if err == nil {
 		klog.V(3).Infof("PollUntilDone for DeleteInstances(%v) for %s success", requiredIds.InstanceIDs, scaleSet.Name)
 		if scaleSet.manager.config.StrictCacheUpdates {
-			if err := scaleSet.manager.forceRefresh(); err != nil {
-				klog.Errorf("forceRefresh failed with error: %v", err)
+			if refreshErr := scaleSet.manager.forceRefresh(); refreshErr != nil {
+				klog.Errorf("forceRefresh failed after successful DeleteInstances(%v) for %s: %v", requiredIds.InstanceIDs, scaleSet.Name, refreshErr)
+				scaleSet.manager.invalidateCache()
 			}
 			scaleSet.invalidateInstanceCache()
 		}
@@ -864,6 +866,10 @@ func (scaleSet *ScaleSet) waitForDeleteInstances(poller *runtime.Poller[armcompu
 
 	scaleSet.invalidateInstanceCache()
 	scaleSet.invalidateLastSizeRefreshWithLock()
+	if refreshErr := scaleSet.manager.forceRefresh(); refreshErr != nil {
+		klog.Errorf("forceRefresh failed after DeleteInstances(%v) for %s returned error: %v", requiredIds.InstanceIDs, scaleSet.Name, refreshErr)
+		scaleSet.manager.invalidateCache()
+	}
 	klog.Errorf("PollUntilDone for DeleteInstances(%v) for %s failed with error: %v", requiredIds.InstanceIDs, scaleSet.Name, err)
 }
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -1827,21 +1827,21 @@ func newVMObjectWithState(provisioningState string, powerState string) *armcompu
 func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 	t.Run("fast delete enablement = false", func(t *testing.T) {
 		t.Run("provisioning state = failed, power state = starting", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStarting, false)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStarting, disableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateRunning, false)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateRunning, disableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStopping, false)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStopping, disableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
@@ -1849,21 +1849,21 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 
 		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
 
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStopped, false)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStopped, disableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateDeallocated, false)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateDeallocated, disableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateUnknown, false)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateUnknown, disableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
@@ -1872,21 +1872,21 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 
 	t.Run("fast delete enablement = true", func(t *testing.T) {
 		t.Run("provisioning state = failed, power state = starting", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStarting, true)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStarting, enableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = running", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateRunning, true)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateRunning, enableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceRunning, status.State)
 		})
 
 		t.Run("provisioning state = failed, power state = stopping", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStopping, true)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStopping, enableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
@@ -1894,7 +1894,7 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 		})
 
 		t.Run("provisioning state = failed, power state = stopped", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStopped, true)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateStopped, enableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
@@ -1902,7 +1902,7 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 		})
 
 		t.Run("provisioning state = failed, power state = deallocated", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateDeallocated, true)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateDeallocated, enableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
@@ -1910,7 +1910,7 @@ func TestInstanceStatusFromProvisioningStateAndPowerState(t *testing.T) {
 		})
 
 		t.Run("provisioning state = failed, power state = unknown", func(t *testing.T) {
-			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateUnknown, true)
+			status := instanceStatusFromProvisioningStateAndPowerState("1", ptr.To(string(armcompute.GalleryProvisioningStateFailed)), vmPowerStateUnknown, enableFastDeleteOnFailure)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, cloudprovider.InstanceCreating, status.State)
@@ -2140,7 +2140,7 @@ func TestWaitForDeleteInstancesFailureRefreshesAzureCacheInstanceState(t *testin
 	// Simulate stale proactive deleting state before the delete operation result is known.
 	hasInstance, err := manager.azureCache.HasInstance(deletedNode.Spec.ProviderID)
 	assert.False(t, hasInstance)
-	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+	assert.NoError(t, err)
 
 	requiredIds := &armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
 		InstanceIDs: []*string{ptr.To("0")},

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -2096,6 +2096,65 @@ func TestWaitForDeleteInstancesNoRetryOnOtherErrors(t *testing.T) {
 	}
 }
 
+func TestWaitForDeleteInstancesFailureRefreshesAzureCacheInstanceState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.StrictCacheUpdates = false
+
+	vmssName := "test-asg"
+	var vmssCapacity int64 = 3
+	orchMode := armcompute.OrchestrationModeUniform
+
+	expectedScaleSets := []*armcompute.VirtualMachineScaleSet{
+		{
+			Name: &vmssName,
+			SKU: &armcompute.SKU{
+				Capacity: &vmssCapacity,
+			},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{
+				OrchestrationMode: &orchMode,
+			},
+		},
+	}
+	expectedVMSSVMs := newTestVMSSVMList(3)
+
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).Return(expectedScaleSets, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	mockVMSSVMClient := mock_virtualmachinescalesetvmclient.NewMockInterface(ctrl)
+	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), manager.config.ResourceGroup, vmssName).Return(expectedVMSSVMs, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	scaleSet := newTestScaleSet(manager, vmssName)
+	registered := manager.RegisterNodeGroup(scaleSet)
+	manager.explicitlyConfigured[vmssName] = true
+	assert.True(t, registered)
+	assert.NoError(t, manager.forceRefresh())
+
+	deletedNode := newApiNode(armcompute.OrchestrationModeUniform, 0)
+	manager.azureCache.setInstanceStateByProviderID(deletedNode.Spec.ProviderID, cloudprovider.InstanceDeleting)
+
+	// Simulate stale proactive deleting state before the delete operation result is known.
+	hasInstance, err := manager.azureCache.HasInstance(deletedNode.Spec.ProviderID)
+	assert.False(t, hasInstance)
+	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+
+	requiredIds := &armcompute.VirtualMachineScaleSetVMInstanceRequiredIDs{
+		InstanceIDs: []*string{ptr.To("0")},
+	}
+	otherErrorPoller := newTestPollerWithError(errors.New("InternalServerError: something went wrong"))
+
+	// A failed waiter should trigger a refresh and reconcile stale deleting state.
+	scaleSet.waitForDeleteInstances(otherErrorPoller, requiredIds)
+
+	hasInstance, err = manager.azureCache.HasInstance(deletedNode.Spec.ProviderID)
+	assert.True(t, hasInstance)
+	assert.NoError(t, err)
+}
+
 func TestWaitForDeleteInstancesRetryFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -247,6 +247,16 @@ func (vmPool *VMPool) DeleteNodes(nodes []*apiv1.Node) error {
 
 	klog.V(3).Infof("Deleting nodes from vmPool %s: %v", vmPool.Name, providerIDs)
 
+	// In non-strict mode, proactively mark instances as deleting in the cache so
+	// HasInstance reports them as gone before the next cache refresh. A failed
+	// delete is reconciled by the deferred invalidateCache() below, which forces a
+	// refresh on the next loop.
+	if !vmPool.manager.config.StrictCacheUpdates {
+		for _, providerID := range providerIDs {
+			vmPool.manager.azureCache.setInstanceStateByProviderID(providerID, cloudprovider.InstanceDeleting)
+		}
+	}
+
 	machineNames := make([]*string, len(providerIDs))
 	for i, providerID := range providerIDs {
 		// extract the machine name from the providerID by splitting the providerID by '/' and get the last element
@@ -459,7 +469,12 @@ func (vmPool *VMPool) Nodes() ([]cloudprovider.Instance, error) {
 		if err != nil {
 			return nil, err
 		}
-		nodes = append(nodes, cloudprovider.Instance{Id: resourceID})
+		// Surface the VM provisioning state so the cache (and HasInstance /
+		// ClusterStateRegistry through it) can observe VMs that are being deleted.
+		// VMs pools do not support fast-delete-on-failed-provisioning, so the power
+		// state is irrelevant here.
+		status := instanceStatusFromProvisioningStateAndPowerState(resourceID, vm.Properties.ProvisioningState, vmPowerStateRunning, false)
+		nodes = append(nodes, cloudprovider.Instance{Id: resourceID, Status: status})
 	}
 
 	return nodes, nil

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool.go
@@ -473,7 +473,11 @@ func (vmPool *VMPool) Nodes() ([]cloudprovider.Instance, error) {
 		// ClusterStateRegistry through it) can observe VMs that are being deleted.
 		// VMs pools do not support fast-delete-on-failed-provisioning, so the power
 		// state is irrelevant here.
-		status := instanceStatusFromProvisioningStateAndPowerState(resourceID, vm.Properties.ProvisioningState, vmPowerStateRunning, false)
+		var provisioningState *string
+		if vm.Properties != nil {
+			provisioningState = vm.Properties.ProvisioningState
+		}
+		status := instanceStatusFromProvisioningStateAndPowerState(resourceID, provisioningState, vmPowerStateRunning, disableFastDeleteOnFailure)
 		nodes = append(nodes, cloudprovider.Instance{Id: resourceID, Status: status})
 	}
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
@@ -676,6 +676,148 @@ func TestDeleteVMsPoolNodes_Success(t *testing.T) {
 	assert.NoError(t, derr)
 }
 
+func TestVMsPoolNodesReportsProvisioningState(t *testing.T) {
+	manager := newTestAzureManager(t)
+	ap := newTestVMsPool(manager)
+
+	vms := newTestVMsPoolVMList(3)
+	vms[0].Properties.ProvisioningState = ptr.To(VMProvisioningStateDeleting)
+	manager.azureCache.virtualMachines[vmsAgentPoolName] = vms
+
+	instances, err := ap.Nodes()
+	assert.NoError(t, err)
+	assert.Len(t, instances, 3)
+
+	statesByID := make(map[string]cloudprovider.InstanceState)
+	for _, instance := range instances {
+		if instance.Status != nil {
+			statesByID[instance.Id] = instance.Status.State
+		}
+	}
+
+	deletingID, err := convertResourceGroupNameToLower("azure://" + fmt.Sprintf(fakeVMsPoolVMID, 0))
+	assert.NoError(t, err)
+	runningID, err := convertResourceGroupNameToLower("azure://" + fmt.Sprintf(fakeVMsPoolVMID, 1))
+	assert.NoError(t, err)
+
+	// The VM in the Deleting provisioning state is surfaced as InstanceDeleting,
+	// while healthy VMs are surfaced as InstanceRunning.
+	assert.Equal(t, cloudprovider.InstanceDeleting, statesByID[deletingID])
+	assert.Equal(t, cloudprovider.InstanceRunning, statesByID[runningID])
+}
+
+func TestDeleteVMsPoolNodesProactivelyMarksDeletion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ap := newTestVMsPool(newTestAzureManager(t))
+
+	expectedVMs := newTestVMsPoolVMList(5)
+	mockVMClient := NewMockInterface(ctrl)
+	ap.manager.azClient.virtualMachinesClient = mockVMClient
+	ap.manager.config.EnableVMsAgentPool = true
+	mockAgentpoolclient := NewMockAgentPoolsClient(ctrl)
+	agentpool := getTestVMsAgentPool(false)
+	ap.manager.azClient.agentPoolClient = mockAgentpoolclient
+	fakeAPListPager := getFakeAgentpoolListPager(&agentpool)
+	mockAgentpoolclient.EXPECT().NewListPager(gomock.Any(), gomock.Any(), nil).Return(fakeAPListPager)
+	mockVMClient.EXPECT().List(gomock.Any(), ap.manager.config.ResourceGroup).Return(expectedVMs, nil)
+
+	ap.manager.azureCache.enableVMsAgentPool = true
+	registered := ap.manager.RegisterNodeGroup(ap)
+	assert.True(t, registered)
+	ap.manager.explicitlyConfigured[vmsNodeGroupName] = true
+	assert.NoError(t, ap.manager.forceRefresh())
+
+	deletingNode := newVMsNode(0)
+	survivingNode := newVMsNode(1)
+
+	// Before the delete, both nodes are reported as present.
+	hasInstance, err := ap.manager.azureCache.HasInstance(deletingNode.Spec.ProviderID)
+	assert.True(t, hasInstance)
+	assert.NoError(t, err)
+
+	resp := &http.Response{
+		Header: map[string][]string{
+			"Fake-Poller-Status": {"Done"},
+		},
+	}
+	fakePoller, pollerErr := runtime.NewPoller(resp, runtime.Pipeline{},
+		&runtime.NewPollerOptions[armcontainerservice.AgentPoolsClientDeleteMachinesResponse]{
+			Handler: &fakehandler[armcontainerservice.AgentPoolsClientDeleteMachinesResponse]{},
+		})
+	assert.NoError(t, pollerErr)
+	mockAgentpoolclient.EXPECT().BeginDeleteMachines(
+		gomock.Any(), ap.manager.config.ClusterResourceGroup,
+		ap.manager.config.ClusterName,
+		vmsAgentPoolName,
+		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
+
+	assert.NoError(t, ap.DeleteNodes([]*apiv1.Node{deletingNode}))
+
+	// The deleted node is proactively reported as gone (with the ErrNotImplemented
+	// taint-based fallback), while other nodes remain reported as present.
+	hasInstance, err = ap.manager.azureCache.HasInstance(deletingNode.Spec.ProviderID)
+	assert.False(t, hasInstance)
+	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+
+	hasInstance, err = ap.manager.azureCache.HasInstance(survivingNode.Spec.ProviderID)
+	assert.True(t, hasInstance)
+	assert.NoError(t, err)
+}
+
+func TestDeleteVMsPoolNodesStrictCacheDoesNotProactivelyMarkDeletion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ap := newTestVMsPool(newTestAzureManager(t))
+	ap.manager.config.StrictCacheUpdates = true
+
+	expectedVMs := newTestVMsPoolVMList(5)
+	mockVMClient := NewMockInterface(ctrl)
+	ap.manager.azClient.virtualMachinesClient = mockVMClient
+	ap.manager.config.EnableVMsAgentPool = true
+	mockAgentpoolclient := NewMockAgentPoolsClient(ctrl)
+	agentpool := getTestVMsAgentPool(false)
+	ap.manager.azClient.agentPoolClient = mockAgentpoolclient
+	fakeAPListPager := getFakeAgentpoolListPager(&agentpool)
+	mockAgentpoolclient.EXPECT().NewListPager(gomock.Any(), gomock.Any(), nil).Return(fakeAPListPager)
+	mockVMClient.EXPECT().List(gomock.Any(), ap.manager.config.ResourceGroup).Return(expectedVMs, nil)
+
+	ap.manager.azureCache.enableVMsAgentPool = true
+	registered := ap.manager.RegisterNodeGroup(ap)
+	assert.True(t, registered)
+	ap.manager.explicitlyConfigured[vmsNodeGroupName] = true
+	assert.NoError(t, ap.manager.forceRefresh())
+
+	deletingNode := newVMsNode(0)
+
+	hasInstance, err := ap.manager.azureCache.HasInstance(deletingNode.Spec.ProviderID)
+	assert.True(t, hasInstance)
+	assert.NoError(t, err)
+
+	resp := &http.Response{
+		Header: map[string][]string{
+			"Fake-Poller-Status": {"Done"},
+		},
+	}
+	fakePoller, pollerErr := runtime.NewPoller(resp, runtime.Pipeline{},
+		&runtime.NewPollerOptions[armcontainerservice.AgentPoolsClientDeleteMachinesResponse]{
+			Handler: &fakehandler[armcontainerservice.AgentPoolsClientDeleteMachinesResponse]{},
+		})
+	assert.NoError(t, pollerErr)
+	mockAgentpoolclient.EXPECT().BeginDeleteMachines(
+		gomock.Any(), ap.manager.config.ClusterResourceGroup,
+		ap.manager.config.ClusterName,
+		vmsAgentPoolName,
+		gomock.Any(), gomock.Any()).Return(fakePoller, nil)
+
+	assert.NoError(t, ap.DeleteNodes([]*apiv1.Node{deletingNode}))
+
+	// Strict cache mode should not mark deleting nodes as gone before a refresh.
+	hasInstance, err = ap.manager.azureCache.HasInstance(deletingNode.Spec.ProviderID)
+	assert.True(t, hasInstance)
+	assert.NoError(t, err)
+}
+
 type fakehandler[T any] struct{}
 
 func (f *fakehandler[T]) Done() bool {

--- a/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_vms_pool_test.go
@@ -754,11 +754,11 @@ func TestDeleteVMsPoolNodesProactivelyMarksDeletion(t *testing.T) {
 
 	assert.NoError(t, ap.DeleteNodes([]*apiv1.Node{deletingNode}))
 
-	// The deleted node is proactively reported as gone (with the ErrNotImplemented
-	// taint-based fallback), while other nodes remain reported as present.
+	// The deleted node is proactively reported as gone (false, nil), while other
+	// nodes remain reported as present.
 	hasInstance, err = ap.manager.azureCache.HasInstance(deletingNode.Spec.ProviderID)
 	assert.False(t, hasInstance)
-	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+	assert.NoError(t, err)
 
 	hasInstance, err = ap.manager.azureCache.HasInstance(survivingNode.Spec.ProviderID)
 	assert.True(t, hasInstance)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR builds upon https://github.com/kubernetes/autoscaler/pull/9860 for the Azure cloudprovider. The problem:

When a scale-down and scale-up race in the same node group, the ClusterStateRegistry can drop the scale-up request prematurely and trigger unnecessary extra scale-ups (kubernetes/autoscaler#9813). This happens when HasInstance() keeps returning true for VMs that have already been deleted.

This PRs ensures that each instance's last known InstanceState is tracked in the azureCache, and makes sure that HasInstance() reports instances in the Deleting state as gone, so the ClusterStateRegistry stops counting them as upcoming nodes. Failed deletes are handled w/ a cache invalidation so that the next loop gets the right source of truth.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
azure: report deleting instances as gone from HasInstance
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
