### PR TITLE
feat(oci): support node-template tags for OKE node pools

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/README.md
+++ b/cluster-autoscaler/cloudprovider/oci/README.md
@@ -180,6 +180,58 @@ compartmentId:<compartmentId>,instancepoolTags:<tagKey1>=<tagValue1>&<tagKey2>=<
 ```
 Auto discovery can not be used along with static discovery (`node` parameter) to prevent conflicts.
 
+### Node template tags for OKE node pools
+
+For OKE node pools, Cluster Autoscaler can read node template hints from node pool freeform tags. These tags are used
+only when Cluster Autoscaler builds a template node for scale-up simulation. They do not configure kubelet or mutate the
+nodes. Make sure any labels or taints advertised by these tags are also applied by your node bootstrap configuration or
+kubelet arguments, and any resources advertised by these tags are also reported in the node's Kubernetes status after the
+node joins the cluster.
+
+OCI freeform tag keys must follow OCI tag key limits, so arbitrary Kubernetes label, taint, and resource names can be
+placed in the tag value using `<kubernetes-name>=<value>`. This is especially useful for scaling a node pool from 0 to 1
+when pods request an extended resource that is normally reported by a device plugin or other node status updater after a node
+exists. For example, to let Cluster Autoscaler consider a zero-sized node pool for pods requesting
+`example.com/custom-resource: 1`, add this freeform tag to the node pool:
+
+```
+cluster-autoscaler/node-template/resources/custom-resource: "example.com/custom-resource=1"
+```
+
+In this form, `custom-resource` is only an OCI tag-key-safe alias. The actual Kubernetes resource name used in the
+template is `example.com/custom-resource`, taken from the tag value before `=`.
+
+The following freeform tag prefixes are supported for OKE node pools:
+
+```
+cluster-autoscaler/node-template/label/<label-alias>: <label-value>
+cluster-autoscaler/node-template/label/<label-alias>: <label-name>=<label-value>
+cluster-autoscaler/node-template/taint/<taint-alias>: <taint-value>:<taint-effect>
+cluster-autoscaler/node-template/taint/<taint-alias>: <taint-name>=<taint-value>:<taint-effect>
+cluster-autoscaler/node-template/resources/<resource-alias>: <resource-quantity>
+cluster-autoscaler/node-template/resources/<resource-alias>: <resource-name>=<resource-quantity>
+cluster-autoscaler/node-template/autoscaling-options/<option-name>: <option-value>
+```
+
+Examples:
+
+```
+cluster-autoscaler/node-template/label/workload-tier: "batch"
+cluster-autoscaler/node-template/label/workload: "example.com/workload=batch"
+cluster-autoscaler/node-template/taint/dedicated: "batch:NoSchedule"
+cluster-autoscaler/node-template/taint/custom-dedicated: "example.com/dedicated=batch:NoSchedule"
+cluster-autoscaler/node-template/resources/ephemeral-storage: "100Gi"
+cluster-autoscaler/node-template/resources/custom-resource: "example.com/custom-resource=1"
+cluster-autoscaler/node-template/autoscaling-options/scaledownunneededtime: "10m"
+```
+
+Supported autoscaling option names are `scaledownutilizationthreshold`, `scaledowngpuutilizationthreshold`,
+`scaledownunneededtime`, `scaledownunreadytime`, and `ignoredaemonsetsutilization`.
+
+The legacy OCI freeform tag `cluster-autoscaler/node-ephemeral-storage` is still supported. If both that tag and
+`cluster-autoscaler/node-template/resources/ephemeral-storage` are set, the
+`cluster-autoscaler/node-template/resources/ephemeral-storage` tag takes precedence.
+
 ## Deployment
 
 ### Create OCI config secret (only if _not_ using Instance Principals)

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/node_template_tags.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/node_template_tags.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 Oracle and/or its affiliates.
+*/
+
+package nodepools
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	klog "k8s.io/klog/v2"
+)
+
+const (
+	nodeTemplateLabelTagPrefix              = "cluster-autoscaler/node-template/label/"
+	nodeTemplateTaintTagPrefix              = "cluster-autoscaler/node-template/taint/"
+	nodeTemplateResourcesTagPrefix          = "cluster-autoscaler/node-template/resources/"
+	nodeTemplateAutoscalingOptionsTagPrefix = "cluster-autoscaler/node-template/autoscaling-options/"
+)
+
+func extractNodeTemplateLabelsFromTags(tags map[string]string) map[string]string {
+	var labels map[string]string
+	for key, value := range tags {
+		labelName, found := strings.CutPrefix(key, nodeTemplateLabelTagPrefix)
+		if !found || labelName == "" {
+			continue
+		}
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		if tagValueLabelName, labelValue, hasExplicitName := strings.Cut(value, "="); hasExplicitName && tagValueLabelName != "" {
+			labels[tagValueLabelName] = labelValue
+			continue
+		}
+		labels[labelName] = value
+	}
+	return labels
+}
+
+func extractNodeTemplateResourcesFromTags(tags map[string]string) apiv1.ResourceList {
+	var resources apiv1.ResourceList
+	for key, value := range tags {
+		resourceName, found := strings.CutPrefix(key, nodeTemplateResourcesTagPrefix)
+		if !found || resourceName == "" {
+			continue
+		}
+		quantityValue := value
+		if tagValueResourceName, tagValueQuantity, hasExplicitName := strings.Cut(value, "="); hasExplicitName && tagValueResourceName != "" {
+			resourceName = tagValueResourceName
+			quantityValue = tagValueQuantity
+		}
+		quantity, err := resource.ParseQuantity(quantityValue)
+		if err != nil {
+			klog.Warningf("failed to parse node template resource quantity %q for resource %q: %v", quantityValue, resourceName, err)
+			continue
+		}
+		if resources == nil {
+			resources = apiv1.ResourceList{}
+		}
+		resources[apiv1.ResourceName(resourceName)] = quantity
+	}
+	return resources
+}
+
+func extractNodeTemplateTaintsFromTags(tags map[string]string) []apiv1.Taint {
+	var taints []apiv1.Taint
+	for key, value := range tags {
+		taintKey, found := strings.CutPrefix(key, nodeTemplateTaintTagPrefix)
+		if !found || taintKey == "" {
+			continue
+		}
+		taintValue := value
+		if tagValueTaintKey, tagValueTaint, hasExplicitName := strings.Cut(value, "="); hasExplicitName && tagValueTaintKey != "" {
+			taintKey = tagValueTaintKey
+			taintValue = tagValueTaint
+		}
+		parts := strings.SplitN(taintValue, ":", 2)
+		if len(parts) != 2 {
+			klog.Warningf("failed to parse node template taint %q for key %q", taintValue, taintKey)
+			continue
+		}
+		effect := apiv1.TaintEffect(parts[1])
+		if !isSupportedTaintEffect(effect) {
+			klog.Warningf("unsupported node template taint effect %q for key %q", parts[1], taintKey)
+			continue
+		}
+		taints = append(taints, apiv1.Taint{
+			Key:    taintKey,
+			Value:  parts[0],
+			Effect: effect,
+		})
+	}
+	return taints
+}
+
+func isSupportedTaintEffect(effect apiv1.TaintEffect) bool {
+	switch effect {
+	case apiv1.TaintEffectNoSchedule, apiv1.TaintEffectNoExecute, apiv1.TaintEffectPreferNoSchedule:
+		return true
+	default:
+		return false
+	}
+}
+
+func extractNodeTemplateAutoscalingOptionsFromTags(tags map[string]string) map[string]string {
+	var options map[string]string
+	for key, value := range tags {
+		optionName, found := strings.CutPrefix(key, nodeTemplateAutoscalingOptionsTagPrefix)
+		if !found || optionName == "" {
+			continue
+		}
+		if options == nil {
+			options = make(map[string]string)
+		}
+		options[optionName] = value
+	}
+	return options
+}
+
+func buildNodeGroupAutoscalingOptionsFromTags(tags map[string]string, defaults config.NodeGroupAutoscalingOptions, nodePoolID string) *config.NodeGroupAutoscalingOptions {
+	options := extractNodeTemplateAutoscalingOptionsFromTags(tags)
+	if len(options) == 0 {
+		return &defaults
+	}
+
+	defaults.ScaleDownUtilizationThreshold = parseFloatOption(options, config.DefaultScaleDownUtilizationThresholdKey, defaults.ScaleDownUtilizationThreshold, nodePoolID)
+	defaults.ScaleDownGpuUtilizationThreshold = parseFloatOption(options, config.DefaultScaleDownGpuUtilizationThresholdKey, defaults.ScaleDownGpuUtilizationThreshold, nodePoolID)
+	defaults.ScaleDownUnneededTime = parseDurationOption(options, config.DefaultScaleDownUnneededTimeKey, defaults.ScaleDownUnneededTime, nodePoolID)
+	defaults.ScaleDownUnreadyTime = parseDurationOption(options, config.DefaultScaleDownUnreadyTimeKey, defaults.ScaleDownUnreadyTime, nodePoolID)
+	defaults.IgnoreDaemonSetsUtilization = parseBoolOption(options, config.DefaultIgnoreDaemonSetsUtilizationKey, defaults.IgnoreDaemonSetsUtilization, nodePoolID)
+
+	return &defaults
+}
+
+func parseFloatOption(options map[string]string, key string, fallback float64, nodePoolID string) float64 {
+	value, found := options[key]
+	if !found {
+		return fallback
+	}
+	opt, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		klog.Warningf("failed to convert nodepool %s %s tag to float: %v", nodePoolID, key, err)
+		return fallback
+	}
+	return opt
+}
+
+func parseDurationOption(options map[string]string, key string, fallback time.Duration, nodePoolID string) time.Duration {
+	value, found := options[key]
+	if !found {
+		return fallback
+	}
+	opt, err := time.ParseDuration(value)
+	if err != nil {
+		klog.Warningf("failed to convert nodepool %s %s tag to duration: %v", nodePoolID, key, err)
+		return fallback
+	}
+	return opt
+}
+
+func parseBoolOption(options map[string]string, key string, fallback bool, nodePoolID string) bool {
+	value, found := options[key]
+	if !found {
+		return fallback
+	}
+	opt, err := strconv.ParseBool(value)
+	if err != nil {
+		klog.Warningf("failed to convert nodepool %s %s tag to bool: %v", nodePoolID, key, err)
+		return fallback
+	}
+	return opt
+}

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/node_template_tags_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/node_template_tags_test.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2026 Oracle and/or its affiliates.
+*/
+
+package nodepools
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+
+	ocicommon "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/common"
+	npconsts "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/nodepools/consts"
+	ocisdk "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/common"
+	oke "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/containerengine"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/vendor-internal/github.com/oracle/oci-go-sdk/v65/core"
+)
+
+type fakeShapeGetter struct {
+	shape *ocicommon.Shape
+}
+
+func (f fakeShapeGetter) GetNodePoolShape(*oke.NodePool, int64) (*ocicommon.Shape, error) {
+	return f.shape, nil
+}
+
+func (f fakeShapeGetter) GetInstancePoolShape(*core.InstancePool) (*ocicommon.Shape, error) {
+	return f.shape, nil
+}
+
+func (f fakeShapeGetter) Refresh() {}
+
+func TestExtractNodeTemplateLabelsFromTags(t *testing.T) {
+	tags := map[string]string{
+		nodeTemplateLabelTagPrefix + "workload":     "batch",
+		nodeTemplateLabelTagPrefix + "custom-label": "example.com/workload=custom",
+		nodeTemplateLabelTagPrefix:                  "ignored",
+		"unrelated":                                 "ignored",
+	}
+
+	got := extractNodeTemplateLabelsFromTags(tags)
+	want := map[string]string{
+		"workload":             "batch",
+		"example.com/workload": "custom",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got labels %+v, want %+v", got, want)
+	}
+}
+
+func TestExtractNodeTemplateResourcesFromTags(t *testing.T) {
+	tags := map[string]string{
+		nodeTemplateResourcesTagPrefix + "cpu":               "100m",
+		nodeTemplateResourcesTagPrefix + "memory":            "100M",
+		nodeTemplateResourcesTagPrefix + "ephemeral-storage": "20G",
+		nodeTemplateResourcesTagPrefix + "custom-resource":   "example.com/custom-resource=5",
+		nodeTemplateResourcesTagPrefix + "invalid-resource":  "not-a-quantity",
+		nodeTemplateResourcesTagPrefix:                       "1",
+		"unrelated":                                          "ignored",
+	}
+
+	got := extractNodeTemplateResourcesFromTags(tags)
+	if len(got) != 4 {
+		t.Fatalf("got %d resources, want 4: %+v", len(got), got)
+	}
+
+	want := apiv1.ResourceList{
+		apiv1.ResourceCPU:                                 resource.MustParse("100m"),
+		apiv1.ResourceMemory:                              resource.MustParse("100M"),
+		apiv1.ResourceEphemeralStorage:                    resource.MustParse("20G"),
+		apiv1.ResourceName("example.com/custom-resource"): resource.MustParse("5"),
+	}
+	for name, quantity := range want {
+		gotQuantity := got[name]
+		if gotQuantity.Cmp(quantity) != 0 {
+			t.Fatalf("got resource %s=%s, want %s", name, gotQuantity.String(), quantity.String())
+		}
+	}
+}
+
+func TestExtractNodeTemplateTaintsFromTags(t *testing.T) {
+	tags := map[string]string{
+		nodeTemplateTaintTagPrefix + "dedicated": "batch:NoSchedule",
+		nodeTemplateTaintTagPrefix + "group":     "system:NoExecute",
+		nodeTemplateTaintTagPrefix + "app":       "fizz:PreferNoSchedule",
+		nodeTemplateTaintTagPrefix + "custom":    "example.com/dedicated=custom:NoSchedule",
+		nodeTemplateTaintTagPrefix + "bad":       "missing-effect",
+		nodeTemplateTaintTagPrefix + "unknown":   "value:UnknownEffect",
+		nodeTemplateTaintTagPrefix:               "value:NoSchedule",
+		"unrelated":                              "ignored",
+	}
+
+	got := extractNodeTemplateTaintsFromTags(tags)
+	want := []apiv1.Taint{
+		{Key: "dedicated", Value: "batch", Effect: apiv1.TaintEffectNoSchedule},
+		{Key: "group", Value: "system", Effect: apiv1.TaintEffectNoExecute},
+		{Key: "app", Value: "fizz", Effect: apiv1.TaintEffectPreferNoSchedule},
+		{Key: "example.com/dedicated", Value: "custom", Effect: apiv1.TaintEffectNoSchedule},
+	}
+
+	if !reflect.DeepEqual(taintSet(got), taintSet(want)) {
+		t.Fatalf("got taints %+v, want %+v", got, want)
+	}
+}
+
+func TestBuildNodeGroupAutoscalingOptionsFromTags(t *testing.T) {
+	defaults := config.NodeGroupAutoscalingOptions{
+		ScaleDownUtilizationThreshold:    0.1,
+		ScaleDownGpuUtilizationThreshold: 0.2,
+		ScaleDownUnneededTime:            time.Second,
+		ScaleDownUnreadyTime:             time.Minute,
+		IgnoreDaemonSetsUtilization:      false,
+	}
+
+	tests := []struct {
+		name string
+		tags map[string]string
+		want config.NodeGroupAutoscalingOptions
+	}{
+		{
+			name: "use defaults on unspecified tags",
+			tags: map[string]string{},
+			want: defaults,
+		},
+		{
+			name: "keep defaults on invalid tag values",
+			tags: map[string]string{
+				nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultScaleDownUtilizationThresholdKey: "not-a-float",
+				nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultScaleDownUnneededTimeKey:         "not-a-duration",
+				nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultScaleDownUnreadyTimeKey:          "",
+				nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultIgnoreDaemonSetsUtilizationKey:   "not-a-bool",
+			},
+			want: defaults,
+		},
+		{
+			name: "use provided tags and fill missing with defaults",
+			tags: map[string]string{
+				nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultScaleDownUtilizationThresholdKey:    "0.42",
+				nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultScaleDownGpuUtilizationThresholdKey: "0.7",
+				nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultScaleDownUnneededTimeKey:            "1h",
+				nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultScaleDownUnreadyTimeKey:             "25m",
+				nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultIgnoreDaemonSetsUtilizationKey:      "true",
+				nodeTemplateAutoscalingOptionsTagPrefix + "unknown":                                         "ignored",
+			},
+			want: config.NodeGroupAutoscalingOptions{
+				ScaleDownUtilizationThreshold:    0.42,
+				ScaleDownGpuUtilizationThreshold: 0.7,
+				ScaleDownUnneededTime:            time.Hour,
+				ScaleDownUnreadyTime:             25 * time.Minute,
+				IgnoreDaemonSetsUtilization:      true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildNodeGroupAutoscalingOptionsFromTags(tt.tags, defaults, "nodepool-id")
+			if !reflect.DeepEqual(*got, tt.want) {
+				t.Fatalf("got options %+v, want %+v", *got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildNodeFromTemplateWithNodeTemplateTags(t *testing.T) {
+	customResource := apiv1.ResourceName("example.com/custom-resource")
+	manager := &ociManagerImpl{
+		ociShapeGetter: fakeShapeGetter{
+			shape: &ocicommon.Shape{
+				Name:          "VM.Standard.E3.Flex",
+				CPU:           4,
+				MemoryInBytes: 16 * 1024 * 1024 * 1024,
+				GPU:           0,
+			},
+		},
+		ociTagsGetter:          ocicommon.CreateTagsGetter(),
+		registeredTaintsGetter: CreateRegisteredTaintsGetter(),
+	}
+	nodePool := testNodePool(map[string]string{
+		npconsts.EphemeralStorageSize:                          "1Gi",
+		nodeTemplateResourcesTagPrefix + "custom-resource":     string(customResource) + "=1",
+		nodeTemplateResourcesTagPrefix + "ephemeral-storage":   "2Gi",
+		nodeTemplateLabelTagPrefix + "workload":                "example.com/workload=batch",
+		nodeTemplateLabelTagPrefix + "instance-type":           apiv1.LabelInstanceTypeStable + "=tagged-shape",
+		nodeTemplateTaintTagPrefix + "node-template-dedicated": "batch:NoSchedule",
+	})
+	nodePool.NodeMetadata = map[string]string{
+		"kubelet-extra-args": "--register-with-taints=registered=yes:NoSchedule",
+	}
+
+	node, err := manager.buildNodeFromTemplate(nodePool)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	if got := node.Status.Capacity[customResource]; got.Value() != 1 {
+		t.Fatalf("got custom resource capacity %s, want 1", got.String())
+	}
+	if got := node.Status.Allocatable[customResource]; got.Value() != 1 {
+		t.Fatalf("got custom resource allocatable %s, want 1", got.String())
+	}
+	ephemeralStorage := node.Status.Capacity[apiv1.ResourceEphemeralStorage]
+	expectedEphemeralStorage := resource.MustParse("2Gi")
+	if ephemeralStorage.Value() != expectedEphemeralStorage.Value() {
+		t.Fatalf("got ephemeral-storage capacity %s, want 2Gi", ephemeralStorage.String())
+	}
+	if got := node.Labels["example.com/workload"]; got != "batch" {
+		t.Fatalf("got template label %q, want batch", got)
+	}
+	if got := node.Labels[apiv1.LabelInstanceTypeStable]; got != "tagged-shape" {
+		t.Fatalf("got instance type label %q, want tagged-shape", got)
+	}
+	if !hasTaint(node.Spec.Taints, apiv1.Taint{Key: "registered", Value: "yes", Effect: apiv1.TaintEffectNoSchedule}) {
+		t.Fatalf("expected registered taint in %+v", node.Spec.Taints)
+	}
+	if !hasTaint(node.Spec.Taints, apiv1.Taint{Key: "node-template-dedicated", Value: "batch", Effect: apiv1.TaintEffectNoSchedule}) {
+		t.Fatalf("expected node template taint in %+v", node.Spec.Taints)
+	}
+}
+
+func TestBuildNodeFromTemplateWithoutNodeTemplateTags(t *testing.T) {
+	manager := &ociManagerImpl{
+		ociShapeGetter: fakeShapeGetter{
+			shape: &ocicommon.Shape{
+				Name:          "VM.Standard.E3.Flex",
+				CPU:           4,
+				MemoryInBytes: 16 * 1024 * 1024 * 1024,
+				GPU:           0,
+			},
+		},
+		ociTagsGetter:          ocicommon.CreateTagsGetter(),
+		registeredTaintsGetter: CreateRegisteredTaintsGetter(),
+	}
+
+	node, err := manager.buildNodeFromTemplate(testNodePool(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	if _, found := node.Status.Capacity[apiv1.ResourceName("example.com/custom-resource")]; found {
+		t.Fatalf("unexpected custom resource capacity: %+v", node.Status.Capacity)
+	}
+	if _, found := node.Status.Capacity[apiv1.ResourceEphemeralStorage]; found {
+		t.Fatalf("unexpected ephemeral-storage capacity: %+v", node.Status.Capacity)
+	}
+	if _, found := node.Labels["example.com/workload"]; found {
+		t.Fatalf("unexpected template label: %+v", node.Labels)
+	}
+	if len(node.Spec.Taints) != 0 {
+		t.Fatalf("got taints %+v, want none", node.Spec.Taints)
+	}
+}
+
+func TestBuildNodeFromTemplateContinuesOnInvalidRegisteredTaints(t *testing.T) {
+	manager := &ociManagerImpl{
+		ociShapeGetter: fakeShapeGetter{
+			shape: &ocicommon.Shape{
+				Name:          "VM.Standard.E3.Flex",
+				CPU:           4,
+				MemoryInBytes: 16 * 1024 * 1024 * 1024,
+				GPU:           0,
+			},
+		},
+		ociTagsGetter:          ocicommon.CreateTagsGetter(),
+		registeredTaintsGetter: CreateRegisteredTaintsGetter(),
+	}
+	nodePool := testNodePool(map[string]string{
+		nodeTemplateTaintTagPrefix + "template": "batch:NoSchedule",
+	})
+	nodePool.NodeMetadata = map[string]string{
+		"kubelet-extra-args": "--register-with-taints=invalid-taint",
+	}
+
+	node, err := manager.buildNodeFromTemplate(nodePool)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	if !hasTaint(node.Spec.Taints, apiv1.Taint{Key: "template", Value: "batch", Effect: apiv1.TaintEffectNoSchedule}) {
+		t.Fatalf("expected node template taint in %+v", node.Spec.Taints)
+	}
+}
+
+func TestNodePoolGetOptions(t *testing.T) {
+	cache := newNodePoolCache(nil)
+	cache.cache["nodepool-id"] = testNodePool(map[string]string{
+		nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultScaleDownUtilizationThresholdKey: "0.42",
+		nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultScaleDownUnneededTimeKey:         "1h",
+		nodeTemplateAutoscalingOptionsTagPrefix + config.DefaultIgnoreDaemonSetsUtilizationKey:   "true",
+	})
+	manager := &ociManagerImpl{
+		nodePoolCache: cache,
+		ociTagsGetter: ocicommon.CreateTagsGetter(),
+	}
+	np := &nodePool{
+		id:      "nodepool-id",
+		manager: manager,
+	}
+	defaults := config.NodeGroupAutoscalingOptions{
+		ScaleDownUtilizationThreshold:    0.1,
+		ScaleDownGpuUtilizationThreshold: 0.2,
+		ScaleDownUnneededTime:            time.Second,
+		ScaleDownUnreadyTime:             time.Minute,
+		IgnoreDaemonSetsUtilization:      false,
+	}
+
+	got, err := np.GetOptions(defaults)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	want := config.NodeGroupAutoscalingOptions{
+		ScaleDownUtilizationThreshold:    0.42,
+		ScaleDownGpuUtilizationThreshold: 0.2,
+		ScaleDownUnneededTime:            time.Hour,
+		ScaleDownUnreadyTime:             time.Minute,
+		IgnoreDaemonSetsUtilization:      true,
+	}
+	if !reflect.DeepEqual(*got, want) {
+		t.Fatalf("got options %+v, want %+v", *got, want)
+	}
+}
+
+func testNodePool(freeformTags map[string]string) *oke.NodePool {
+	return &oke.NodePool{
+		Id:           ocisdk.String("nodepool-id"),
+		NodeShape:    ocisdk.String("VM.Standard.E3.Flex"),
+		FreeformTags: freeformTags,
+		NodeConfigDetails: &oke.NodePoolNodeConfigDetails{
+			PlacementConfigs: []oke.NodePoolPlacementConfigDetails{
+				{AvailabilityDomain: ocisdk.String("Uocm:PHX-AD-1")},
+			},
+		},
+		InitialNodeLabels: []oke.KeyValue{
+			{Key: ocisdk.String("initial"), Value: ocisdk.String("label")},
+		},
+	}
+}
+
+func taintSet(taints []apiv1.Taint) map[apiv1.Taint]bool {
+	set := map[apiv1.Taint]bool{}
+	for _, taint := range taints {
+		set[taint] = true
+	}
+	return set
+}
+
+func hasTaint(taints []apiv1.Taint, want apiv1.Taint) bool {
+	for _, taint := range taints {
+		if taint == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/client-go/kubernetes"
 	klog "k8s.io/klog/v2"
 
@@ -67,6 +68,8 @@ type NodePoolManager interface {
 	GetNodePoolForInstance(instance ocicommon.OciRef) (NodePool, error)
 	// GetNodePoolTemplateNode returns a template node for NodePool.
 	GetNodePoolTemplateNode(np NodePool) (*apiv1.Node, error)
+	// GetNodePoolOptions returns the node pool-specific autoscaling options.
+	GetNodePoolOptions(np NodePool, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error)
 	// GetNodePoolSize gets NodePool size.
 	GetNodePoolSize(np NodePool) (int, error)
 	// SetNodePoolSize sets NodePool size.
@@ -670,6 +673,23 @@ func (m *ociManagerImpl) GetNodePoolTemplateNode(np NodePool) (*apiv1.Node, erro
 	return node, nil
 }
 
+// GetNodePoolOptions returns the node pool-specific autoscaling options.
+func (m *ociManagerImpl) GetNodePoolOptions(np NodePool, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+	nodePool, err := m.nodePoolCache.get(np.Id())
+	if err != nil {
+		klog.Warningf("could not get node pool %q from cache while reading autoscaling option tags, using defaults: %v", np.Id(), err)
+		return &defaults, nil
+	}
+
+	freeformTags, err := m.ociTagsGetter.GetNodePoolFreeformTags(nodePool)
+	if err != nil {
+		klog.Warningf("could not get freeform tags for node pool %q while reading autoscaling options, using defaults: %v", np.Id(), err)
+		return &defaults, nil
+	}
+
+	return buildNodeGroupAutoscalingOptionsFromTags(freeformTags, defaults, np.Id()), nil
+}
+
 // GetNodePoolSize gets NodePool size.
 func (m *ociManagerImpl) GetNodePoolSize(np NodePool) (int, error) {
 	return m.nodePoolCache.getSize(np.Id())
@@ -743,6 +763,7 @@ func (m *ociManagerImpl) buildNodeFromTemplate(nodePool *oke.NodePool) (*apiv1.N
 	node.Spec = apiv1.NodeSpec{
 		Taints: taints,
 	}
+	node.Spec.Taints = append(node.Spec.Taints, extractNodeTemplateTaintsFromTags(freeformTags)...)
 	if shape.GPU > 0 {
 		node.Spec.Taints = append(node.Spec.Taints, apiv1.Taint{
 			Key:    "nvidia.com/gpu",
@@ -751,15 +772,15 @@ func (m *ociManagerImpl) buildNodeFromTemplate(nodePool *oke.NodePool) (*apiv1.N
 		})
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	node.Status.Capacity[apiv1.ResourcePods] = *resource.NewQuantity(110, resource.DecimalSI)
 	node.Status.Capacity[apiv1.ResourceCPU] = *resource.NewQuantity(int64(shape.CPU), resource.DecimalSI)
 	node.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(int64(shape.MemoryInBytes), resource.DecimalSI)
 	node.Status.Capacity[ipconsts.ResourceGPU] = *resource.NewQuantity(int64(shape.GPU), resource.DecimalSI)
 	if ephemeralStorage != -1 {
 		node.Status.Capacity[apiv1.ResourceEphemeralStorage] = *resource.NewQuantity(ephemeralStorage, resource.DecimalSI)
+	}
+	for name, quantity := range extractNodeTemplateResourcesFromTags(freeformTags) {
+		node.Status.Capacity[name] = quantity
 	}
 
 	node.Status.Allocatable = node.Status.Capacity
@@ -770,6 +791,7 @@ func (m *ociManagerImpl) buildNodeFromTemplate(nodePool *oke.NodePool) (*apiv1.N
 	}
 
 	node.Labels = cloudprovider.JoinStringMaps(node.Labels, ocicommon.BuildGenericLabels(*nodePool.Id, nodeName, shape.Name, availabilityDomain))
+	node.Labels = cloudprovider.JoinStringMaps(node.Labels, extractNodeTemplateLabelsFromTags(freeformTags))
 
 	node.Status.Conditions = cloudprovider.BuildReadyConditions()
 	return &node, nil

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
@@ -355,7 +355,6 @@ func (np *nodePool) Autoprovisioned() bool {
 
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
-// Implementation optional.
 func (np *nodePool) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, cloudprovider.ErrNotImplemented
+	return np.manager.GetNodePoolOptions(np, defaults)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds node-template freeform tag support for OCI OKE node pools.

OKE node pools can now provide Cluster Autoscaler template hints for:

- labels
- taints
- resources
- per-node-group autoscaling options

This addresses scale-from-zero cases where a workload requests an extended
resource that is normally reported only after a node exists, for example by a
device plugin or other node status updater. With this change, a zero-sized OKE
node pool can advertise that resource in the template node used for scale-up
simulation.

Example OKE node pool freeform tag:

```text
cluster-autoscaler/node-template/resources/custom-resource = example.com/custom-resource=1
```

This causes the template node to include:

```text
example.com/custom-resource: 1
```

in both `Capacity` and `Allocatable`.

OCI freeform tag keys have stricter character limits than Kubernetes resource,
label, and taint names, so the tag key suffix can be used as an OCI-safe alias.
When the tag value uses `<kubernetes-name>=<value>`, the Kubernetes name is read
from the tag value.

This is fully backward compatible. Existing OKE initial node labels, kubelet
registered taints, GPU taint behavior, shape-derived resources, discovery
behavior, and the legacy `cluster-autoscaler/node-ephemeral-storage` tag continue
to work. If both the legacy ephemeral storage tag and the generic
`cluster-autoscaler/node-template/resources/ephemeral-storage` tag are present,
the generic resource tag takes precedence.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Scope is limited to OCI OKE node pools. OCI instance pools are unchanged.

The new tags are template hints only. They do not configure kubelet or mutate
real nodes. Any advertised labels, taints, or resources must still be applied or
reported by the node after it joins the cluster.

Tested with:

```sh
go test -count=1 ./cloudprovider/oci/nodepools
go test -vet=off -count=1 ./cloudprovider/oci/...
```

`go test ./cloudprovider/oci/...` currently hits pre-existing vet issues in
vendored OCI SDK/logging code outside this change, so the wider OCI package test
was run with `-vet=off`.

#### Does this PR introduce a user-facing change?

```release-note
OCI OKE node pools can now use freeform tags to provide Cluster Autoscaler
template hints for labels, taints, resources, and per-node-group autoscaling
options.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Usage]: cluster-autoscaler/cloudprovider/oci/README.md
```