### PR TITLE
Cleanup: remove redundant in-place-skip-disruption-budget V(4) log

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -172,7 +172,6 @@ func (ip *PodsInPlaceRestrictionImpl) CanInPlaceUpdate(pod *corev1.Pod, vpa *vpa
 
 	if ip.inPlaceSkipDisruptionBudget {
 		if utils.IsNonDisruptiveResize(pod) {
-			klog.V(4).InfoS("in-place-skip-disruption-budget enabled, skipping disruption budget check for in-place update")
 			return utils.InPlaceApproved
 		}
 		klog.V(4).InfoS("in-place-skip-disruption-budget enabled, but pod has RestartContainer resize policy", "pod", klog.KObj(pod))

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
@@ -897,6 +897,63 @@ func TestInPlaceSkipDisruptionBudgetWithResizePolicy(t *testing.T) {
 	}
 }
 
+// TestInPlaceSkipDisruptionBudgetNonDisruptiveApproves verifies that when
+// in-place-skip-disruption-budget is enabled and a pod is a non-disruptive
+// resize candidate (all containers NotRequired), the pod is approved without
+// needing to pass the disruption budget check. This is the behavior path
+// previously annotated with a redundant V(4) log line; the log was removed
+// in https://github.com/kubernetes/autoscaler/issues/9870 and this test
+// pins the behavior so the cleanup does not regress.
+func TestInPlaceSkipDisruptionBudgetNonDisruptiveApproves(t *testing.T) {
+	replicas := int32(5)
+	livePods := 5
+	tolerance := 0.1
+
+	rc := corev1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rc",
+			Namespace: "default",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ReplicationController",
+		},
+		Spec: corev1.ReplicationControllerSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	pods := make([]*corev1.Pod, livePods)
+	for i := range pods {
+		pods[i] = test.Pod().
+			WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+			WithName(getTestPodName(i)).
+			AddContainer(test.Container().WithName("c1").
+				WithContainerResizePolicy([]corev1.ContainerResizePolicy{
+					{ResourceName: corev1.ResourceCPU, RestartPolicy: corev1.NotRequired},
+					{ResourceName: corev1.ResourceMemory, RestartPolicy: corev1.NotRequired},
+				}).Get()).
+			Get()
+	}
+
+	clock := baseclocktest.NewFakeClock(time.Time{})
+	lipatm := map[string]time.Time{}
+	basicVpa := getIPORVpa()
+
+	factory, err := getRestrictionFactory(&rc, nil, nil, nil, 2, tolerance, clock, lipatm, GetFakeCalculatorsWithFakeResourceCalc(), true)
+	assert.NoError(t, err)
+
+	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
+	assert.NoError(t, err)
+
+	inplace := factory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+	for _, pod := range pods {
+		decision := inplace.CanInPlaceUpdate(pod, basicVpa, nil)
+		assert.Equalf(t, utils.InPlaceApproved, decision,
+			"non-disruptive pod %s should be approved via in-place-skip-disruption-budget, got %v", pod.Name, decision)
+	}
+}
+
 func TestInPlaceAtLeastOne(t *testing.T) {
 	replicas := int32(5)
 	livePods := 5


### PR DESCRIPTION
## What

Removes a redundant `klog.V(4)` log line from `CanInPlaceUpdate` in `vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go`.

## Why

When `in-place-skip-disruption-budget` is enabled and a pod is a non-disruptive resize candidate, two log lines fire in quick succession:

1. `pods_restriction_factory.go` at V(2): `in-place-skip-disruption-budget enabled, skipping minReplicas check for in-place update` with `kind`, `object`, `livePods`, `requiredPods`, `globalMinReplicas` fields.
2. `pods_inplace_restriction.go` at V(4): `in-place-skip-disruption-budget enabled, skipping disruption budget check for in-place update` with no additional context.

The second log is strictly less informative than the first (no extra fields, no new information) and only adds noise to the log stream. The V(2) log already conveys the full picture and is sufficient for diagnosing disruption-budget skips. Removing the V(4) line keeps the disruption-budget skip activity visible at V(2) without echoing it again at V(4).

Cleanup requested in #9870.

## Changes

- `pods_inplace_restriction.go`: removed the redundant `klog.V(4).InfoS(...)` call. The early `return utils.InPlaceApproved` on the non-disruptive path is unchanged.
- `pods_inplace_restriction_test.go`: added `TestInPlaceSkipDisruptionBudgetNonDisruptiveApproves` — a regression test that exercises the non-disruptive approval path that previously lived behind the removed log. Mirrors the fixture setup already used by `TestInPlaceSkipDisruptionBudgetWithResizePolicy` and asserts every pod is approved.

## Testing

`go test ./vertical-pod-autoscaler/pkg/updater/restriction/...` (new test passes locally alongside existing tests). `gofmt` clean.

/sig autoscaling
/area vertical-pod-autoscaler
/kind cleanup

Fixes #9870