### PR TITLE
Make tainting concurrency configurable and improve context propagation

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -1073,6 +1073,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `max-binpacking-time` | Maximum time spend on binpacking for a single scale-up. If binpacking is limited by this, scale-up will continue with the already calculated scale-up options. | 5m0s |
 | `max-bulk-soft-taint-count` | Maximum number of nodes that can be tainted/untainted PreferNoSchedule at the same time. Set to 0 to turn off such tainting. | 10 |
 | `max-bulk-soft-taint-time` | Maximum duration of tainting/untainting nodes as PreferNoSchedule at the same time. | 3s |
+| `max-concurrent-nodes-tainting` | The maximum number of nodes that can be tainted in parallel. | 5 |
 | `max-drain-parallelism` | Maximum number of nodes needing drain, that can be drained and deleted in parallel. | 1 |
 | `max-failing-time` | Maximum time from last recorded successful autoscaler run before automatic restart | 15m0s |
 | `max-free-difference-ratio` | Maximum difference in free resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's free resource. | 0.05 |

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -378,6 +378,8 @@ type AutoscalingOptions struct {
 	CapacityQuotasEnabled             bool
 	// ScaleUpSimulationForSkippedNodeGroupsEnabled is used to enable/disable the scaleUpSimulation for the skipped node groups
 	ScaleUpSimulationForSkippedNodeGroupsEnabled bool
+	// MaxConcurrentNodesTainting is the maximum number of nodes that can be tainted in parallel.
+	MaxConcurrentNodesTainting int
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -238,6 +238,7 @@ var (
 	predicateParallelism                         = flag.Int("predicate-parallelism", 4, "Maximum parallelism of scheduler predicate checking.")
 	checkCapacityProcessorInstance               = flag.String("check-capacity-processor-instance", "", "Name of the processor instance. Only ProvisioningRequests that define this name in their parameters with the key \"processorInstance\" will be processed by this CA instance. It only refers to check capacity ProvisioningRequests, but if not empty, best-effort atomic ProvisioningRequests processing is disabled in this instance. Not recommended: Until CA 1.35, ProvisioningRequests with this name as prefix in their class will be also processed.")
 	nodeDeletionCandidateTTL                     = flag.Duration("node-deletion-candidate-ttl", time.Duration(0), "Maximum time a node can be marked as removable before the marking becomes stale. This sets the TTL of Cluster-Autoscaler's state if the Cluste-Autoscaler deployment becomes inactive")
+	maxConcurrentNodesTainting                   = flag.Int("max-concurrent-nodes-tainting", 5, "The maximum number of nodes that can be tainted in parallel.")
 	capacitybufferControllerEnabled              = flag.Bool("capacity-buffer-controller-enabled", false, "Whether to enable the default controller for capacity buffers or not")
 	capacitybufferPodInjectionEnabled            = flag.Bool("capacity-buffer-pod-injection-enabled", false, "Whether to enable pod list processor that processes ready capacity buffers and injects fake pods accordingly")
 	capacityBufferPodDryRunEnabled               = flag.Bool("capacity-buffer-pod-dry-run-enabled", true, "Whether to use server dry run to build managed pod templates for capacity buffers. That ensures that the buffers' fake pods will more reliably resemble real pods by going through the pod defaulting, mutating and validating webhooks. No-op if --capacity-buffer-controller-enabled is false. Note: requires \"create\" permission on pods to call server dry run. No real pods will be created.")
@@ -464,6 +465,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MaxNodeSkipEvalTimeTrackerEnabled:            *maxNodeSkipEvalTimeTrackerEnabled,
 		CapacityQuotasEnabled:                        *capacityQuotasEnabled,
 		ScaleUpSimulationForSkippedNodeGroupsEnabled: *scaleUpSimulationForSkippedNodeGroupsEnabled,
+		MaxConcurrentNodesTainting:                   *maxConcurrentNodesTainting,
 	}
 }
 

--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -47,6 +47,7 @@ import (
 // AutoscalingContext contains user-configurable constant and configuration-related objects passed to
 // scale up/scale down functions.
 type AutoscalingContext struct {
+	context.Context
 	// Options to customize how autoscaling works
 	config.AutoscalingOptions
 	// Kubernetes API clients.
@@ -130,6 +131,7 @@ func NewResourceLimiterFromAutoscalingOptions(options config.AutoscalingOptions)
 
 // NewAutoscalingContext returns an autoscaling context from all the necessary parameters passed via arguments
 func NewAutoscalingContext(
+	ctx context.Context,
 	options config.AutoscalingOptions,
 	fwHandle *framework.Handle,
 	clusterSnapshot clustersnapshot.ClusterSnapshot,
@@ -145,6 +147,7 @@ func NewAutoscalingContext(
 	csiProvider *csinodeprovider.Provider,
 ) *AutoscalingContext {
 	return &AutoscalingContext{
+		Context:                  ctx,
 		AutoscalingOptions:       options,
 		CloudProvider:            cloudProvider,
 		AutoscalingKubeClients:   *autoscalingKubeClients,

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -64,6 +64,7 @@ func NewAutoscaler(ctx context.Context, opts coreoptions.AutoscalerOptions, info
 		return nil, errors.ToAutoscalerError(errors.InternalError, err)
 	}
 	return NewStaticAutoscaler(
+		ctx,
 		opts.AutoscalingOptions,
 		opts.FrameworkHandle,
 		opts.ClusterSnapshot,

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -51,8 +51,7 @@ import (
 )
 
 const (
-	pastLatencyExpireDuration  = time.Hour
-	maxConcurrentNodesTainting = 5
+	pastLatencyExpireDuration = time.Hour
 )
 
 // Actuator is responsible for draining and deleting nodes.
@@ -217,7 +216,11 @@ func (a *Actuator) taintNodesSync(NodeGroupViews []*budgets.NodeGroupView) (time
 		err  error
 	}, len(nodesToTaint))
 	taintedNodes := make(chan *apiv1.Node, len(nodesToTaint))
-	workqueue.ParallelizeUntil(context.Background(), maxConcurrentNodesTainting, len(nodesToTaint), func(piece int) {
+	concurrency := a.autoscalingCtx.AutoscalingOptions.MaxConcurrentNodesTainting
+	if concurrency <= 0 {
+		concurrency = 5
+	}
+	workqueue.ParallelizeUntil(context.Background(), concurrency, len(nodesToTaint), func(piece int) {
 		node := nodesToTaint[piece]
 		err := a.taintNode(node)
 		if err != nil {

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -17,7 +17,6 @@ limitations under the License.
 package actuation
 
 import (
-	"context"
 	"strings"
 	"time"
 
@@ -220,7 +219,7 @@ func (a *Actuator) taintNodesSync(NodeGroupViews []*budgets.NodeGroupView) (time
 	if concurrency <= 0 {
 		concurrency = 5
 	}
-	workqueue.ParallelizeUntil(context.Background(), concurrency, len(nodesToTaint), func(piece int) {
+	workqueue.ParallelizeUntil(a.autoscalingCtx, concurrency, len(nodesToTaint), func(piece int) {
 		node := nodesToTaint[piece]
 		err := a.taintNode(node)
 		if err != nil {

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -1228,7 +1229,7 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 	}
 
 	registry := kube_util.NewListerRegistry(nil, nil, podLister, pdbLister, dsLister, nil, nil, nil, nil)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(opts, fakeClient, registry, provider, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), opts, fakeClient, registry, provider, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Couldn't set up autoscaling context: %v", err)
 	}
@@ -1539,7 +1540,7 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 			podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
 			pdbLister := kube_util.NewTestPodDisruptionBudgetLister([]*policyv1.PodDisruptionBudget{})
 			registry := kube_util.NewListerRegistry(nil, nil, podLister, pdbLister, nil, nil, nil, nil, nil)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(opts, fakeClient, registry, provider, nil, nil, nil)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), opts, fakeClient, registry, provider, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("Couldn't set up autoscaling context: %v", err)
 			}

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -35,7 +36,7 @@ import (
 
 func TestAddNodeToBucket(t *testing.T) {
 	provider := testprovider.NewTestCloudProviderBuilder().Build()
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, nil, nil, provider, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), config.AutoscalingOptions{}, nil, nil, provider, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Couldn't set up autoscaling context: %v", err)
 	}
@@ -158,7 +159,7 @@ func TestRemove(t *testing.T) {
 					return true, obj, nil
 				})
 
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, fakeClient, nil, provider, nil, nil, nil)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), config.AutoscalingOptions{}, fakeClient, nil, provider, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("Couldn't set up autoscaling context: %v", err)
 			}

--- a/cluster-autoscaler/core/scaledown/actuation/drain_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -142,7 +143,7 @@ func TestDaemonSetEvictionForEmptyNodes(t *testing.T) {
 			provider.AddNode("ng1", n1)
 			registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, registry, provider, nil, nil, nil)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, registry, provider, nil, nil, nil)
 			assert.NoError(t, err)
 
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1}, dsPods)
@@ -209,7 +210,7 @@ func TestDrainNodeWithPods(t *testing.T) {
 		MaxPodEvictionTime:                5 * time.Second,
 		DaemonSetEvictionForOccupiedNodes: true,
 	}
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, nil, nil, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	legacyFlagDrainConfig := SingleRuleDrainConfig(autoscalingCtx.MaxGracefulTerminationSec)
@@ -273,7 +274,7 @@ func TestDrainNodeWithPodsWithRescheduled(t *testing.T) {
 		MaxGracefulTerminationSec: 20,
 		MaxPodEvictionTime:        5 * time.Second,
 	}
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, nil, nil, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	legacyFlagDrainConfig := SingleRuleDrainConfig(autoscalingCtx.MaxGracefulTerminationSec)
@@ -342,7 +343,7 @@ func TestDrainNodeWithPodsWithRetries(t *testing.T) {
 		MaxPodEvictionTime:                5 * time.Second,
 		DaemonSetEvictionForOccupiedNodes: true,
 	}
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, nil, nil, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	legacyFlagDrainConfig := SingleRuleDrainConfig(autoscalingCtx.MaxGracefulTerminationSec)
@@ -417,7 +418,7 @@ func TestDrainNodeWithPodsDaemonSetEvictionFailure(t *testing.T) {
 		MaxGracefulTerminationSec: 20,
 		MaxPodEvictionTime:        0 * time.Second,
 	}
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, nil, nil, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	legacyFlagDrainConfig := SingleRuleDrainConfig(autoscalingCtx.MaxGracefulTerminationSec)
@@ -479,7 +480,7 @@ func TestDrainNodeWithPodsEvictionFailure(t *testing.T) {
 		MaxGracefulTerminationSec: 20,
 		MaxPodEvictionTime:        0 * time.Second,
 	}
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, nil, nil, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 	r := evRegister{}
 	legacyFlagDrainConfig := SingleRuleDrainConfig(autoscalingCtx.MaxGracefulTerminationSec)
@@ -560,7 +561,7 @@ func TestDrainForceNodeWithPodsEvictionFailure(t *testing.T) {
 		MaxGracefulTerminationSec: 20,
 		MaxPodEvictionTime:        0 * time.Second,
 	}
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, nil, nil, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 	r := evRegister{}
 	legacyFlagDrainConfig := SingleRuleDrainConfig(autoscalingCtx.MaxGracefulTerminationSec)
@@ -622,7 +623,7 @@ func TestDrainWithPodsNodeDisappearanceFailure(t *testing.T) {
 		MaxGracefulTerminationSec: 0,
 		MaxPodEvictionTime:        0 * time.Second,
 	}
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, nil, nil, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	legacyFlagDrainConfig := SingleRuleDrainConfig(autoscalingCtx.MaxGracefulTerminationSec)

--- a/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -147,7 +148,7 @@ func TestScheduleDeletion(t *testing.T) {
 				t.Fatalf("Couldn't create daemonset lister")
 			}
 			registry := kube_util.NewListerRegistry(nil, nil, podLister, pdbLister, dsLister, nil, nil, nil, nil)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(opts, fakeClient, registry, provider, nil, nil, nil)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), opts, fakeClient, registry, provider, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("Couldn't set up autoscaling context: %v", err)
 			}

--- a/cluster-autoscaler/core/scaledown/actuation/priority_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/priority_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func TestPriorityEvictor(t *testing.T) {
 		MaxGracefulTerminationSec: 20,
 		MaxPodEvictionTime:        5 * time.Second,
 	}
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, nil, nil, nil, nil, nil)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	evictor := Evictor{

--- a/cluster-autoscaler/core/scaledown/actuation/softtaint_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/softtaint_test.go
@@ -69,7 +69,7 @@ func TestSoftTaintUpdate(t *testing.T) {
 	}
 	registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
-	actx, err := test.NewScaleTestAutoscalingContext(options, fakeClient, registry, provider, nil, nil, nil)
+	actx, err := test.NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, registry, provider, nil, nil, nil)
 	assert.NoError(t, err)
 
 	// Test no superfluous nodes
@@ -153,7 +153,7 @@ func TestSoftTaintTimeLimit(t *testing.T) {
 	}
 	registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
-	actx, err := test.NewScaleTestAutoscalingContext(options, fakeClient, registry, provider, nil, nil, nil)
+	actx, err := test.NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, registry, provider, nil, nil, nil)
 	assert.NoError(t, err)
 
 	// Test bulk taint

--- a/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package budgets
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -451,7 +452,7 @@ func TestCropNodesToBudgets(t *testing.T) {
 				NodeDeleteDelayAfterTaint:   1 * time.Second,
 			}
 
-			autoscalingCtx, err := test.NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, nil, nil, nil)
+			autoscalingCtx, err := test.NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, nil, nil, nil)
 			assert.NoError(t, err)
 			ndt := deletiontracker.NewNodeDeletionTracker(1 * time.Hour)
 			for i := 0; i < tc.emptyDeletionsInProgress; i++ {

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eligibility
 
 import (
+	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -310,7 +311,7 @@ func TestFilterOutUnremovable(t *testing.T) {
 			for _, n := range tc.nodes {
 				provider.AddNode("ng1", n)
 			}
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(*options, &fake.Clientset{}, nil, provider, nil, nil, nil)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), *options, &fake.Clientset{}, nil, provider, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("Could not create autoscaling context: %v", err)
 			}

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package planner
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
@@ -504,7 +505,7 @@ func TestUpdateClusterState(t *testing.T) {
 				MaxScaleDownParallelism:    10,
 			}
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(opts)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(opts, &fake.Clientset{}, registry, provider, nil, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), opts, &fake.Clientset{}, registry, provider, nil, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, tc.nodes, tc.pods)
 			deleteOptions := options.NodeDeleteOptions{}
@@ -703,7 +704,7 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 				MaxScaleDownParallelism:    tc.maxParallelism,
 			}
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOpts)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOpts, &fake.Clientset{}, nil, provider, nil, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), autoscalingOpts, &fake.Clientset{}, nil, provider, nil, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, nodes, nil)
 			deleteOptions := options.NodeDeleteOptions{}
@@ -827,7 +828,7 @@ func TestNewPlannerWithExistingDeletionCandidateNodes(t *testing.T) {
 			}
 
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOptions)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(),
 				autoscalingOptions,
 				&fake.Clientset{},
 				kube_util.NewListerRegistry(
@@ -1106,7 +1107,7 @@ func TestNodesToDelete(t *testing.T) {
 				ScaleDownSimulationTimeout: 5 * time.Minute,
 			}
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOpts)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOpts, &fake.Clientset{}, nil, provider, nil, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), autoscalingOpts, &fake.Clientset{}, nil, provider, nil, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, allNodes, nil)
 			deleteOptions := options.NodeDeleteOptions{}
@@ -1286,7 +1287,7 @@ func TestAtomicScaleDownNodeNilGroup(t *testing.T) {
 
 	autoscalingOptions := config.AutoscalingOptions{}
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOptions)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOptions, &fake.Clientset{}, nil, provider, nil, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), autoscalingOptions, &fake.Clientset{}, nil, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	deleteOptions := options.NodeDeleteOptions{}

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package unneeded
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -260,7 +261,7 @@ func TestRemovableAt(t *testing.T) {
 			rsLister, err := kube_util.NewTestReplicaSetLister(nil)
 			assert.NoError(t, err)
 			registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, rsLister, nil)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(config.AutoscalingOptions{ScaleDownSimulationTimeout: 5 * time.Minute}, &fake.Clientset{}, registry, provider, nil, nil, nil)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), config.AutoscalingOptions{ScaleDownSimulationTimeout: 5 * time.Minute}, &fake.Clientset{}, registry, provider, nil, nil, nil)
 			assert.NoError(t, err)
 			expectedThreshold := 5 * time.Minute
 			fakeTimeGetter := &fakeScaleDownTimeGetter{

--- a/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -96,7 +97,7 @@ func TestNodePoolAsyncInitialization(t *testing.T) {
 	upcomingNodeGroup := provider.BuildNodeGroup("upcoming-ng", 0, 100, 0, false, true, "T1", nil)
 	options := config.AutoscalingOptions{AsyncNodeGroupsEnabled: true}
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	context, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 	option := expander.Option{NodeGroup: upcomingNodeGroup, Pods: []*apiv1.Pod{pod}}
 	processors.AsyncNodeGroupStateChecker = &asyncnodegroups.MockAsyncNodeGroupStateChecker{IsUpcomingNodeGroup: map[string]bool{upcomingNodeGroup.Id(): true}}
@@ -185,7 +186,7 @@ func TestPrepareScaleUps(t *testing.T) {
 	listers := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	options := config.AutoscalingOptions{AsyncNodeGroupsEnabled: true}
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	context, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	context, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 	processors.AsyncNodeGroupStateChecker = &asyncnodegroups.MockAsyncNodeGroupStateChecker{IsUpcomingNodeGroup: map[string]bool{upcomingNodeGroup.Id(): true}}
 	executor := newScaleUpExecutor(&context, processors.ScaleStateNotifier, processors.AsyncNodeGroupStateChecker)

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -1212,7 +1213,7 @@ func runSimpleScaleUpTest(t *testing.T, testConfig *ScaleUpTestConfig) *ScaleUpT
 	}
 	// build orchestrator
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 	err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, kube_util.ScheduledPods(pods), nil, nil)
 	assert.NoError(t, err)
@@ -1333,7 +1334,7 @@ func TestScaleUpUnhealthy(t *testing.T) {
 		MaxNodeGroupBinpackingDuration: 1 * time.Second,
 	}
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 	err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, pods, nil, nil)
 	assert.NoError(t, err)
@@ -1382,7 +1383,7 @@ func TestBinpackingLimiter(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 	err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, nil, nil, nil)
 	assert.NoError(t, err)
@@ -1447,7 +1448,7 @@ func TestScaleUpNoHelp(t *testing.T) {
 		MaxNodeGroupBinpackingDuration: 1 * time.Second,
 	}
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 	err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, pods, nil, nil)
 	assert.NoError(t, err)
@@ -1608,7 +1609,7 @@ func TestComputeSimilarNodeGroups(t *testing.T) {
 
 			listers := kube_util.NewListerRegistry(nil, nil, kube_util.NewTestPodLister(nil), nil, nil, nil, nil, nil, nil)
 			templateNodeInfoRegistry := nodeinfosprovider.NewTemplateNodeInfoRegistry(nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false))
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(config.AutoscalingOptions{BalanceSimilarNodeGroups: tc.balancingEnabled, MaxNodeGroupBinpackingDuration: 1 * time.Second}, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), config.AutoscalingOptions{BalanceSimilarNodeGroups: tc.balancingEnabled, MaxNodeGroupBinpackingDuration: 1 * time.Second}, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 			err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, nil, nil, nil)
 			assert.NoError(t, err)
@@ -1695,7 +1696,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 				MaxNodeGroupBinpackingDuration: 1 * time.Second,
 			}
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 			err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, podList, nil, nil)
 			assert.NoError(t, err)
@@ -1858,7 +1859,7 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
 			// Override NodeGroupSetProcessor to ignore nodeGroupLabel so ng1/ng2/ng3 are recognized as similar.
 			processors.NodeGroupSetProcessor = nodegroupset.NewDefaultNodeGroupSetProcessor([]string{nodeGroupLabel}, config.NodeGroupDifferenceRatios{})
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 			err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, podList, nil, nil)
 			assert.NoError(t, err)
@@ -1926,7 +1927,7 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
 	listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, listers, provider, nil, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
@@ -1996,7 +1997,7 @@ func TestScaleUpBalanceAutoprovisionedNodeGroups(t *testing.T) {
 	podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
 	listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, listers, provider, nil, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
@@ -2072,7 +2073,7 @@ func TestScaleUpToMeetNodeGroupMinSize(t *testing.T) {
 		MaxNodeGroupBinpackingDuration: 1 * time.Second,
 	}
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	nodes := []*apiv1.Node{n1, n2}
@@ -2169,7 +2170,7 @@ func TestScaleupAsyncNodeGroupsEnabled(t *testing.T) {
 		podLister := kube_util.NewTestPodLister([]*apiv1.Pod{})
 		listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
 		processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-		autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, listers, provider, nil, nil, templateNodeInfoRegistry)
+		autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, listers, provider, nil, nil, templateNodeInfoRegistry)
 		assert.NoError(t, err)
 
 		clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
@@ -2376,7 +2377,7 @@ func TestScaleUpSimulationForSkippedNodeGroups(t *testing.T) {
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
 			fakeClient := &fake.Clientset{}
 
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, fakeClient, listers, provider, nil, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, fakeClient, listers, provider, nil, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 
 			nodes := []*apiv1.Node{node1, node2, node3}

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -140,6 +140,7 @@ func (callbacks *staticAutoscalerProcessorCallbacks) reset() {
 
 // NewStaticAutoscaler creates an instance of Autoscaler filled with provided parameters
 func NewStaticAutoscaler(
+	ctx context.Context,
 	opts config.AutoscalingOptions,
 	fwHandle *framework.Handle,
 	clusterSnapshot clustersnapshot.ClusterSnapshot,
@@ -174,6 +175,7 @@ func NewStaticAutoscaler(
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 	autoscalingCtx := ca_context.NewAutoscalingContext(
+		ctx,
 		opts,
 		fwHandle,
 		clusterSnapshot,

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -316,7 +316,7 @@ func setupAutoscaler(config *autoscalerSetupConfig) (*StaticAutoscaler, error) {
 	}
 
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(config.autoscalingOptions)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(config.autoscalingOptions, &fake.Clientset{}, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), config.autoscalingOptions, &fake.Clientset{}, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +423,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 	processors, TemplateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, TemplateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, TemplateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	setUpScaleDownActuator(&autoscalingCtx, options)
@@ -684,7 +684,7 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 			processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 
 			setUpScaleDownActuator(&autoscalingCtx, options)
@@ -834,7 +834,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	setUpScaleDownActuator(&autoscalingCtx, options)
@@ -982,7 +982,7 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 			processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 
 			setUpScaleDownActuator(&autoscalingCtx, options)
@@ -1148,7 +1148,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	setUpScaleDownActuator(&autoscalingCtx, options)
@@ -1279,7 +1279,7 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	setUpScaleDownActuator(&autoscalingCtx, options)
@@ -1376,7 +1376,7 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	setUpScaleDownActuator(&autoscalingCtx, options)
@@ -1720,7 +1720,7 @@ func TestStaticAutoscalerRunOnceWithExistingDeletionCandidateNodes(t *testing.T)
 			allNodeLister := kubernetes.NewDynamicTestNodeLister(clientset)
 
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(),
 				options,
 				clientset,
 				nil,
@@ -1843,7 +1843,7 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 			}
 
 			_, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 
 			clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
@@ -2210,7 +2210,7 @@ func setupTestStaticAutoscalerInstanceCreationErrorsForZeroOrMaxScaling(t *testi
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 	_, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
@@ -2495,7 +2495,7 @@ func TestStaticAutoscalerUpcomingScaleDownCandidates(t *testing.T) {
 	autoscalingOptions := config.AutoscalingOptions{ScaleDownEnabled: true}
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOptions)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOptions, &fake.Clientset{}, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), autoscalingOptions, &fake.Clientset{}, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	// Create CSR with unhealthy cluster protection effectively disabled, to guarantee we reach the tested logic.
@@ -3302,7 +3302,7 @@ func buildStaticAutoscaler(t *testing.T, provider cloudprovider.CloudProvider, a
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOptions)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOptions, fakeClient, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), autoscalingOptions, fakeClient, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	cp := scaledowncandidates.NewCombinedScaleDownCandidatesProcessor()
@@ -3584,7 +3584,7 @@ func TestStaticAutoscalerWithNodeDeclaredFeatures(t *testing.T) {
 			processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 			listerRegistry := kube_util.NewListerRegistry(allNodeLister, readyNodeLister, allPodListerMock, podDisruptionBudgetListerMock, daemonSetListerMock, nil, nil, nil, nil)
 			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-			autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listerRegistry, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 			assert.NoError(t, err)
 
 			for _, node := range tc.initialNodes {
@@ -3654,7 +3654,7 @@ func TestStaticAutoscalerRunOnceClearsRegistry(t *testing.T) {
 	options := config.AutoscalingOptions{}
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, _ := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, _ := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	listerRegistry := kube_util.NewListerRegistry(allNodeLister, readyNodeLister, allPodListerMock, podDisruptionBudgetListerMock, daemonSetListerMock, nil, nil, nil, nil)
 	autoscalingCtx.ListerRegistry = listerRegistry
 
@@ -3737,7 +3737,7 @@ func TestStaticAutoscalerRunOnceWithNominatedNodeName(t *testing.T) {
 	processorCallbacks := newStaticAutoscalerProcessorCallbacks()
 
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, nil, provider, processorCallbacks, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	setUpScaleDownActuator(&autoscalingCtx, options)

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"slices"
@@ -168,6 +169,7 @@ func ExtractPodNames(pods []*apiv1.Pod) []string {
 
 // NewScaleTestAutoscalingContext creates a new test autoscaling context for scaling tests.
 func NewScaleTestAutoscalingContext(
+	ctx context.Context,
 	options config.AutoscalingOptions, fakeClient kube_client.Interface,
 	listers kube_util.ListerRegistry, provider cloudprovider.CloudProvider,
 	processorCallbacks processor_callbacks.ProcessorCallbacks, debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter,
@@ -189,6 +191,7 @@ func NewScaleTestAutoscalingContext(
 		return ca_context.AutoscalingContext{}, err
 	}
 	return ca_context.AutoscalingContext{
+		Context:            ctx,
 		AutoscalingOptions: options,
 		AutoscalingKubeClients: ca_context.AutoscalingKubeClients{
 			ClientSet:      fakeClient,

--- a/cluster-autoscaler/processors/nodes/scale_down_set_processor_test.go
+++ b/cluster-autoscaler/processors/nodes/scale_down_set_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodes
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -360,7 +361,7 @@ func TestAtomicResizeFilterUnremovableNodes(t *testing.T) {
 				provider.AddNode(node.nodeGroup, node.node)
 				nodes = append(nodes, node.node)
 			}
-			context, _ := NewScaleTestAutoscalingContext(config.AutoscalingOptions{
+			context, _ := NewScaleTestAutoscalingContext(context.Background(), config.AutoscalingOptions{
 				NodeGroupDefaults: config.NodeGroupAutoscalingOptions{},
 			}, &fake.Clientset{}, nil, provider, nil, nil, nil)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, nil)

--- a/cluster-autoscaler/processors/provreq/processor_test.go
+++ b/cluster-autoscaler/processors/provreq/processor_test.go
@@ -293,7 +293,7 @@ func TestBookCapacity(t *testing.T) {
 				maxUpdated: 20,
 				injector:   injector,
 			}
-			autoscalingCtx, _ := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, nil, nil, nil, nil, nil, nil)
+			autoscalingCtx, _ := NewScaleTestAutoscalingContext(context.Background(), config.AutoscalingOptions{}, nil, nil, nil, nil, nil, nil)
 			processor.bookCapacity(&autoscalingCtx)
 			if (test.capacityIsBooked && len(injector.pods) == 0) || (!test.capacityIsBooked && len(injector.pods) > 0) {
 				t.Fail()

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -492,7 +492,7 @@ func setupTest(t *testing.T, client *provreqclient.ProvisioningRequestClient, no
 	}
 
 	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
-	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(context.Background(), options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
 	assert.NoError(t, err)
 
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, nodes, nil)

--- a/cluster-autoscaler/test/integration/config.go
+++ b/cluster-autoscaler/test/integration/config.go
@@ -53,6 +53,7 @@ var DefaultAutoscalingOptions = config.AutoscalingOptions{
 	ClusterName:                "cluster-test",
 	MaxBinpackingTime:          10 * time.Second,
 	PredicateParallelism:       1,
+	MaxConcurrentNodesTainting: 5,
 }
 
 // TestConfig is the "blueprint" for a test. It defines the entire
@@ -114,5 +115,12 @@ func WithScaleDownUnneededTime(d time.Duration) AutoscalingOptionOverride {
 func WithProvisioningRequestEnabled() AutoscalingOptionOverride {
 	return func(o *config.AutoscalingOptions) {
 		o.ProvisioningRequestEnabled = true
+	}
+}
+
+// WithMaxConcurrentNodesTainting sets the max concurrent nodes tainting option.
+func WithMaxConcurrentNodesTainting(n int) AutoscalingOptionOverride {
+	return func(o *config.AutoscalingOptions) {
+		o.MaxConcurrentNodesTainting = n
 	}
 }

--- a/cluster-autoscaler/test/integration/inmemory/tainting_test.go
+++ b/cluster-autoscaler/test/integration/inmemory/tainting_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	fakecloudprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/test/integration"
+	synctestutils "k8s.io/autoscaler/cluster-autoscaler/test/integration/synctest"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+// TestTaintingConcurrency verifies that the ScaleDown process correctly taints and deletes nodes
+// across different concurrency levels.
+//
+// Concurrency levels tested:
+// - 5 (Default): Ensures standard behavior remains stable.
+// - 10 (Medium): Validates throughput improvements without overwhelming the API server.
+// - 100 (High): Tests the system's resilience under high parallel pressure, confirming that
+//   the workqueue and context management handle extreme concurrency gracefully.
+func TestTaintingConcurrency(t *testing.T) {
+	for _, concurrency := range []int{5, 10, 100} {
+		t.Run(fmt.Sprintf("concurrency-%d", concurrency), func(t *testing.T) {
+			stepDuration := 10 * time.Second
+			config := integration.NewTestConfig().
+				WithOverrides(
+					integration.WithCloudProviderName("gce"),
+					integration.WithScaleDownUnneededTime(unneededTime),
+					integration.WithMaxConcurrentNodesTainting(concurrency),
+				)
+
+			options := config.ResolveOptions()
+			infra := integration.SetupInfrastructure(t)
+			fakes := infra.Fakes
+
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer synctestutils.TearDown(cancel)
+
+				autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+				assert.NoError(t, err)
+
+				// Create 10 empty nodes that should be deleted.
+				templateNode := test.BuildTestNode("template", 1000, 1000, test.IsReady(true))
+				fakes.CloudProvider.AddNodeGroup("ng1", fakecloudprovider.WithNGSize(0, 20), fakecloudprovider.WithNodes(templateNode, 10))
+
+				// Run CA loop to mark nodes as unneeded.
+				synctestutils.MustRunOnceAfter(t, autoscaler, stepDuration)
+				
+				// Run another CA loop after unneededTime, nodes should be deleted.
+				synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime+time.Nanosecond)
+
+				// Check if nodes are gone.
+				assert.Eventually(t, func() bool {
+					return len(fakes.K8s.Nodes().Items) == 0
+				}, 5*time.Second, 100*time.Millisecond, "All nodes should be deleted")
+			})
+		})
+	}
+}

--- a/cluster-autoscaler/test/integration/inmemory/tainting_test.go
+++ b/cluster-autoscaler/test/integration/inmemory/tainting_test.go
@@ -34,10 +34,10 @@ import (
 // across different concurrency levels.
 //
 // Concurrency levels tested:
-// - 5 (Default): Ensures standard behavior remains stable.
-// - 10 (Medium): Validates throughput improvements without overwhelming the API server.
-// - 100 (High): Tests the system's resilience under high parallel pressure, confirming that
-//   the workqueue and context management handle extreme concurrency gracefully.
+//   - 5 (Default): Ensures standard behavior remains stable.
+//   - 10 (Medium): Validates throughput improvements without overwhelming the API server.
+//   - 100 (High): Tests the system's resilience under high parallel pressure, confirming that
+//     the workqueue and context management handle extreme concurrency gracefully.
 func TestTaintingConcurrency(t *testing.T) {
 	for _, concurrency := range []int{5, 10, 100} {
 		t.Run(fmt.Sprintf("concurrency-%d", concurrency), func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestTaintingConcurrency(t *testing.T) {
 
 				// Run CA loop to mark nodes as unneeded.
 				synctestutils.MustRunOnceAfter(t, autoscaler, stepDuration)
-				
+
 				// Run another CA loop after unneededTime, nodes should be deleted.
 				synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime+time.Nanosecond)
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/kind feature

#### What this PR does / why we need it:
This PR introduces two main improvements to the Cluster Autoscaler:

   1. Configurable Tainting Concurrency:
      - Adds the --max-concurrent-nodes-tainting flag (defaulting to 5).
      - This allows operators to tune scale-down performance at scale. Increasing this value can significantly
        reduce the time spent tainting nodes during large scale-down events, provided the API server and client-side
        QPS/Burst settings can handle the increased load.
   2. Context Propagation Refactor:
      - Embeds context.Context within the AutoscalingContext struct.
      - Refactors the Actuator to use this embedded context for parallel tasks (e.g., workqueue.ParallelizeUntil for
        node tainting) instead of context.Background(). 
      - This ensures proper lifecycle management and cancellation propagation throughout the autoscaling loop.

  A new in-memory integration test was added to verify the correctness of the tainting process under different
  concurrency levels (5, 10, and 100).
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
The refactor for context propagation required updating the signatures of NewAutoscalingContext,
  NewStaticAutoscaler, and several test helpers (NewScaleTestAutoscalingContext). This ensures that the entire
  codebase benefits from proper context handling.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduced --max-concurrent-nodes-tainting flag to control the maximum number of nodes tainted in parallel during scale-down. Defaults to 5.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[Usage]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca
```
