### PR TITLE
cleanup: remove redundant in-place resize log

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -172,7 +172,6 @@ func (ip *PodsInPlaceRestrictionImpl) CanInPlaceUpdate(pod *corev1.Pod, vpa *vpa
 
 	if ip.inPlaceSkipDisruptionBudget {
 		if utils.IsNonDisruptiveResize(pod) {
-			klog.V(4).InfoS("in-place-skip-disruption-budget enabled, skipping disruption budget check for in-place update")
 			return utils.InPlaceApproved
 		}
 		klog.V(4).InfoS("in-place-skip-disruption-budget enabled, but pod has RestartContainer resize policy", "pod", klog.KObj(pod))


### PR DESCRIPTION
Summary
- Remove the lower-level in-place skip disruption budget log line while keeping the higher-level log that includes controller context.

Testing
- `go test ./pkg/updater/restriction` from `vertical-pod-autoscaler`

```release-note
NONE
```

Fixes #9870