### PR TITLE
vpa: remove redundant in-place-skip-disruption-budget log

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -172,7 +172,6 @@ func (ip *PodsInPlaceRestrictionImpl) CanInPlaceUpdate(pod *corev1.Pod, vpa *vpa
 
 	if ip.inPlaceSkipDisruptionBudget {
 		if utils.IsNonDisruptiveResize(pod) {
-			klog.V(4).InfoS("in-place-skip-disruption-budget enabled, skipping disruption budget check for in-place update")
 			return utils.InPlaceApproved
 		}
 		klog.V(4).InfoS("in-place-skip-disruption-budget enabled, but pod has RestartContainer resize policy", "pod", klog.KObj(pod))


### PR DESCRIPTION
/kind cleanup

### What this PR does :
Removes a redundant log line in **pods_inplace_restriction.go** that duplicated the more informative log already emitted in
**pods_restriction_factory.go** for the same in-place-skip-disruption-budget flow , adding noise without extra context

### Which issue this PR fixes :
Fixes https://github.com/kubernetes/autoscaler/issues/9870

### Special notes for reviewers :
This only removes one log line ( verified the surrounding **if** block still reads cleanly ) and does not change any behavior
Build and existing unittests in **pkg/updater/restriction** pass