### PR TITLE
VPA: Add retry to docker push

### DIFF
--- a/vertical-pod-autoscaler/hack/retry.sh
+++ b/vertical-pod-autoscaler/hack/retry.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the given command, retrying with linear backoff on failure. Useful for
+# wrapping flaky network operations such as `docker push`.
+#
+# Usage:
+#   hack/retry.sh <command> [args...]
+#
+# Configuration via environment variables:
+#   RETRY_ATTEMPTS  Maximum number of attempts (default: 5).
+#   RETRY_BACKOFF   Base backoff in seconds; attempt N waits N*RETRY_BACKOFF
+#                   seconds before retrying (default: 10).
+
+set -o nounset
+set -o pipefail
+
+RETRY_ATTEMPTS="${RETRY_ATTEMPTS:-5}"
+RETRY_BACKOFF="${RETRY_BACKOFF:-10}"
+
+if [ "$#" -eq 0 ]; then
+  echo "ERROR: hack/retry.sh requires a command to run" >&2
+  exit 1
+fi
+
+attempt=1
+while true; do
+  if "$@"; then
+    exit 0
+  fi
+  if [ "${attempt}" -ge "${RETRY_ATTEMPTS}" ]; then
+    echo "Command failed after ${RETRY_ATTEMPTS} attempts: $*" >&2
+    exit 1
+  fi
+  delay=$((attempt * RETRY_BACKOFF))
+  echo "Command failed (attempt ${attempt}/${RETRY_ATTEMPTS}); retrying in ${delay}s: $*" >&2
+  sleep "${delay}"
+  attempt=$((attempt + 1))
+done

--- a/vertical-pod-autoscaler/pkg/admission-controller/Makefile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Makefile
@@ -51,13 +51,13 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker push ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG}
+	../../hack/retry.sh docker push ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG}
 
 .PHONY: push-multi-arch
 push-multi-arch:
 	docker manifest create --amend $(REGISTRY)/${FULL_COMPONENT}:$(TAG) $(shell echo $(ALL_ARCHITECTURES) | sed -e "s~[^ ]*~$(REGISTRY)/${FULL_COMPONENT}\-&:$(TAG)~g")
 	@for arch in $(ALL_ARCHITECTURES); do docker manifest annotate --arch $${arch} $(REGISTRY)/${FULL_COMPONENT}:$(TAG) $(REGISTRY)/${FULL_COMPONENT}-$${arch}:${TAG}; done
-	docker manifest push --purge $(REGISTRY)/${FULL_COMPONENT}:$(TAG)
+	../../hack/retry.sh docker manifest push --purge $(REGISTRY)/${FULL_COMPONENT}:$(TAG)
 
 .PHONY: show-git-info
 show-git-info:

--- a/vertical-pod-autoscaler/pkg/recommender/Makefile
+++ b/vertical-pod-autoscaler/pkg/recommender/Makefile
@@ -53,13 +53,13 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker push ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG}
+	../../hack/retry.sh docker push ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG}
 
 .PHONY: push-multi-arch
 push-multi-arch:
 	docker manifest create --amend $(REGISTRY)/${FULL_COMPONENT}:$(TAG) $(shell echo $(ALL_ARCHITECTURES) | sed -e "s~[^ ]*~$(REGISTRY)/${FULL_COMPONENT}\-&:$(TAG)~g")
 	@for arch in $(ALL_ARCHITECTURES); do docker manifest annotate --arch $${arch} $(REGISTRY)/${FULL_COMPONENT}:$(TAG) $(REGISTRY)/${FULL_COMPONENT}-$${arch}:${TAG}; done
-	docker manifest push --purge $(REGISTRY)/${FULL_COMPONENT}:$(TAG)
+	../../hack/retry.sh docker manifest push --purge $(REGISTRY)/${FULL_COMPONENT}:$(TAG)
 
 .PHONY: show-git-info
 show-git-info:

--- a/vertical-pod-autoscaler/pkg/updater/Makefile
+++ b/vertical-pod-autoscaler/pkg/updater/Makefile
@@ -51,13 +51,13 @@ ifndef TAG
 	ERR = $(error TAG is undefined)
 	$(ERR)
 endif
-	docker push ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG}
+	../../hack/retry.sh docker push ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG}
 
 .PHONY: push-multi-arch
 push-multi-arch:
 	docker manifest create --amend $(REGISTRY)/${FULL_COMPONENT}:$(TAG) $(shell echo $(ALL_ARCHITECTURES) | sed -e "s~[^ ]*~$(REGISTRY)/${FULL_COMPONENT}\-&:$(TAG)~g")
 	@for arch in $(ALL_ARCHITECTURES); do docker manifest annotate --arch $${arch} $(REGISTRY)/${FULL_COMPONENT}:$(TAG) $(REGISTRY)/${FULL_COMPONENT}-$${arch}:${TAG}; done
-	docker manifest push --purge $(REGISTRY)/${FULL_COMPONENT}:$(TAG)
+	../../hack/retry.sh docker manifest push --purge $(REGISTRY)/${FULL_COMPONENT}:$(TAG)
 
 .PHONY: show-git-info
 show-git-info:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In our e2e tests, this seems to flake quite often. I'm unsure if a retry will solve it, but let's try

See:
https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-autoscaling-vpa-recommender/2070088160540364800/build-log.txt
And
https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/autoscaler/9882/pull-autoscaling-e2e-vpa-full/2071163188606406656/build-log.txt

etc.

The failure normally manifests as:
```
  [38;5;9m[FAILED] unexpected error creating VPA
  Unexpected error:
      <*errors.StatusError | 0x3162012c4960>: 
      the server could not find the requested resource (post verticalpodautoscalers.autoscaling.k8s.io)
      {
          ErrStatus: 
              code: 404
              details:
                causes:
                - message: 404 page not found
                  reason: UnexpectedServerResponse
                group: autoscaling.k8s.io
                kind: verticalpodautoscalers
              message: the server could not find the requested resource (post verticalpodautoscalers.autoscaling.k8s.io)
              metadata: {}
              reason: NotFound
              status: Failure,
      }

```

but this seems to start out that the container can't be pushed to GCS.

Sometimes the error is 403 and other times it's a 500.

I figured we can run this change for a bit and see if these infra issues decrease.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
