### PR TITLE
cluster-autoscaler: pass context down RunOnce loop

### DIFF
--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package core
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
@@ -28,7 +29,7 @@ type Autoscaler interface {
 	// Start starts components running in background.
 	Start() error
 	// RunOnce represents an iteration in the control-loop of CA
-	RunOnce(currentTime time.Time) errors.AutoscalerError
+	RunOnce(ctx context.Context, currentTime time.Time) errors.AutoscalerError
 	// ExitCleanUp is a clean-up performed just before process termination.
 	ExitCleanUp()
 	// LastScaleUpTime is a time of the last scale up

--- a/cluster-autoscaler/core/bench/benchmark_runonce_test.go
+++ b/cluster-autoscaler/core/bench/benchmark_runonce_test.go
@@ -176,7 +176,7 @@ func (s scenario) runIteration(b *testing.B, i int, fProf, fTrace *os.File) {
 	}
 
 	b.StartTimer()
-	err := autoscaler.RunOnce(time.Now().Add(10 * time.Second))
+	err := autoscaler.RunOnce(b.Context(), time.Now().Add(10*time.Second))
 	b.StopTimer()
 
 	if i == 0 {

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -293,7 +293,7 @@ func (a *StaticAutoscaler) initializeRemainingPdbTracker() caerrors.AutoscalerEr
 }
 
 // RunOnce iterates over node groups and scales them up/down if necessary
-func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerError {
+func (a *StaticAutoscaler) RunOnce(ctx context.Context, currentTime time.Time) caerrors.AutoscalerError {
 	a.cleanUpIfRequired()
 	a.processorCallbacks.reset()
 	a.DebuggingSnapshotter.StartDataCollection()
@@ -568,6 +568,11 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		scaleUpStatus.Result = status.ScaleUpInCooldown
 		klog.V(1).Info("Unschedulable pods are very new, waiting one iteration for more")
 		shouldScaleUp = false
+	}
+
+	if err := ctx.Err(); err != nil {
+		klog.V(0).Infof("Skipping scale-up/scale-down, context cancelled: %v", err)
+		return nil
 	}
 
 	if shouldScaleUp || a.processors.ScaleUpEnforcer.ShouldForceScaleUp(unschedulablePodsToHelp) {

--- a/cluster-autoscaler/core/static_autoscaler_csi_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_csi_test.go
@@ -302,17 +302,17 @@ func TestStaticAutoscalerCSI(t *testing.T) {
 			autoscaler.processors.ScaleDownStatusProcessor = scaleDownProcessor
 
 			if len(tc.expectedScaleDowns) > 0 {
-				err = autoscaler.RunOnce(now)
+				err = autoscaler.RunOnce(t.Context(), now)
 				assert.NoError(t, err)
 			}
 
 			// Run one autoscaler loop.
-			require.NoError(t, autoscaler.RunOnce(now.Add(2*time.Minute)))
+			require.NoError(t, autoscaler.RunOnce(t.Context(), now.Add(2*time.Minute)))
 
 			// Scale-down is a multi-iteration process (mark unneeded -> taint -> delete after delay).
 			// Run one more loop to allow the actuator to call the cloud provider ScaleDown callbacks.
 			if len(tc.expectedScaleDowns) > 0 {
-				require.NoError(t, autoscaler.RunOnce(now.Add(4*time.Minute)))
+				require.NoError(t, autoscaler.RunOnce(t.Context(), now.Add(4*time.Minute)))
 				for range allExpectedScaleDowns {
 					select {
 					case <-setupConfig.nodesDeleted:

--- a/cluster-autoscaler/core/static_autoscaler_dra_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_dra_test.go
@@ -436,11 +436,11 @@ func TestStaticAutoscalerDynamicResources(t *testing.T) {
 			autoscaler.processors.ScaleDownStatusProcessor = scaleDownProcessor
 
 			if len(tc.expectedScaleDowns) > 0 {
-				err = autoscaler.RunOnce(now)
+				err = autoscaler.RunOnce(t.Context(), now)
 				assert.NoError(t, err)
 			}
 
-			err = autoscaler.RunOnce(now.Add(2 * time.Minute))
+			err = autoscaler.RunOnce(t.Context(), now.Add(2*time.Minute))
 			assert.NoError(t, err)
 
 			for range allExpectedScaleDowns {
@@ -453,7 +453,7 @@ func TestStaticAutoscalerDynamicResources(t *testing.T) {
 			}
 
 			if len(tc.expectedNoScaleUps) > 0 || len(tc.expectedNoScaleDowns) > 0 {
-				err = autoscaler.RunOnce(now.Add(4 * time.Minute))
+				err = autoscaler.RunOnce(t.Context(), now.Add(4*time.Minute))
 				assert.NoError(t, err)
 
 				for _, noScaleUp := range tc.expectedNoScaleUps {

--- a/cluster-autoscaler/core/static_autoscaler_salvo_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_salvo_test.go
@@ -118,7 +118,7 @@ func TestStaticAutoscalerSalvoScaleUp(t *testing.T) {
 			return id == "ng1" || id == "ng2"
 		}), 1).Return(nil).Once()
 
-		err := autoscaler.RunOnce(time.Now())
+		err := autoscaler.RunOnce(t.Context(), time.Now())
 		assert.NoError(t, err)
 		mock.AssertExpectationsForObjects(t, onScaleUpMock)
 	})
@@ -130,7 +130,7 @@ func TestStaticAutoscalerSalvoScaleUp(t *testing.T) {
 		onScaleUpMock.On("ScaleUp", "ng1", 1).Return(nil).Once()
 		onScaleUpMock.On("ScaleUp", "ng2", 1).Return(nil).Once()
 
-		err := autoscaler.RunOnce(time.Now())
+		err := autoscaler.RunOnce(t.Context(), time.Now())
 		assert.NoError(t, err)
 		mock.AssertExpectationsForObjects(t, onScaleUpMock)
 
@@ -176,7 +176,7 @@ func TestStaticAutoscalerSalvoScaleUp(t *testing.T) {
 		// Only the first scale up should be triggered before the budget is exhausted
 		onScaleUpMock.On("ScaleUp", mock.Anything, 1).Return(nil).Once()
 
-		err := autoscaler.RunOnce(time.Now())
+		err := autoscaler.RunOnce(t.Context(), time.Now())
 		assert.NoError(t, err)
 		mock.AssertExpectationsForObjects(t, onScaleUpMock)
 	})

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -462,7 +462,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
-	err = autoscaler.RunOnce(time.Now())
+	err = autoscaler.RunOnce(t.Context(), time.Now())
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock, podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
 
@@ -475,7 +475,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	onScaleUpMock.On("ScaleUp", "ng1", 1).Return(nil).Once()
 
 	autoscalingCtx.MaxNodesTotal = 10
-	err = autoscaler.RunOnce(time.Now().Add(time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(time.Hour))
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
@@ -490,7 +490,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	provider.AddNode("ng1", n2)
 	ng1.SetTargetSize(2)
 
-	err = autoscaler.RunOnce(time.Now().Add(2 * time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(2*time.Hour))
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
@@ -503,7 +503,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 	onScaleDownMock.On("ScaleDown", "ng1", "n2").Return(nil).Once()
 
-	err = autoscaler.RunOnce(time.Now().Add(3 * time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(3*time.Hour))
 	waitForDeleteToFinish(t, deleteFinished)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
@@ -519,7 +519,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	provider.AddNodeGroup("ng2", 0, 10, 1)
 	provider.AddNode("ng2", n3)
 
-	err = autoscaler.RunOnce(time.Now().Add(4 * time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(4*time.Hour))
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
@@ -532,7 +532,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	onScaleDownMock.On("ScaleDown", "ng2", "n3").Return(nil).Once()
 	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
-	err = autoscaler.RunOnce(time.Now().Add(5 * time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(5*time.Hour))
 	waitForDeleteToFinish(t, deleteFinished)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
@@ -549,7 +549,7 @@ func TestStaticAutoscalerRunOnce(t *testing.T) {
 	provider.AddNodeGroup("ng3", 3, 10, 1)
 	provider.AddNode("ng3", n4)
 
-	err = autoscaler.RunOnce(time.Now().Add(5 * time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(5*time.Hour))
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, onScaleUpMock)
 }
@@ -744,7 +744,7 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 			daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 			podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
-			err = autoscaler.RunOnce(time.Now())
+			err = autoscaler.RunOnce(t.Context(), time.Now())
 			assert.NoError(t, err)
 			mock.AssertExpectationsForObjects(t, allPodListerMock,
 				podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
@@ -757,7 +757,7 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 			podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil)
 			onScaleDownMock.On("ScaleDown", tc.expectedScaleDownNG, tc.expectedScaleDownNode).Return(nil).Once()
 
-			err = autoscaler.RunOnce(time.Now().Add(config.DefaultScaleDownUnneededTime))
+			err = autoscaler.RunOnce(t.Context(), time.Now().Add(config.DefaultScaleDownUnneededTime))
 			waitForDeleteToFinish(t, deleteFinished)
 			assert.NoError(t, err)
 			mock.AssertExpectationsForObjects(t, allPodListerMock,
@@ -880,7 +880,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	onScaleUpMock.On("ScaleUp", "autoprovisioned-TN2", 1).Return(nil).Once()
 	onNodeGroupDeleteMock.On("Delete", "autoprovisioned-TN1").Return(nil).Once()
 
-	err = autoscaler.RunOnce(time.Now().Add(time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(time.Hour))
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
@@ -899,7 +899,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	provider.AddAutoprovisionedNodeGroup("autoprovisioned-TN2", 0, 10, 1, "TN1")
 	provider.AddNode("autoprovisioned-TN2", n2)
 
-	err = autoscaler.RunOnce(time.Now().Add(1 * time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(1*time.Hour))
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
@@ -913,7 +913,7 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	onNodeGroupDeleteMock.On("Delete", "autoprovisioned-TN1").Return(nil).Once()
 	onScaleDownMock.On("ScaleDown", "autoprovisioned-TN2", "n2").Return(nil).Once()
 
-	err = autoscaler.RunOnce(time.Now().Add(2 * time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(2*time.Hour))
 	waitForDeleteToFinish(t, deleteFinished)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
@@ -1035,7 +1035,7 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 				podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 				onScaleUpMock.On("ScaleUp", "ng1", 1).Return(nil).Once()
 
-				err = autoscaler.RunOnce(later.Add(time.Hour))
+				err = autoscaler.RunOnce(t.Context(), later.Add(time.Hour))
 				assert.NoError(t, err)
 				mock.AssertExpectationsForObjects(t, allPodListerMock,
 					podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
@@ -1053,7 +1053,7 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 			daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 			podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
-			err = autoscaler.RunOnce(later.Add(2 * time.Hour))
+			err = autoscaler.RunOnce(t.Context(), later.Add(2*time.Hour))
 			waitForDeleteToFinish(t, deleteFinished)
 			assert.NoError(t, err)
 			mock.AssertExpectationsForObjects(t, allPodListerMock,
@@ -1188,7 +1188,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 	onScaleUpMock.On("ScaleUp", "ng2", 1).Return(nil).Once()
 
-	err = autoscaler.RunOnce(time.Now())
+	err = autoscaler.RunOnce(t.Context(), time.Now())
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
@@ -1202,7 +1202,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 
 	ng2.SetTargetSize(2)
 
-	err = autoscaler.RunOnce(time.Now().Add(2 * time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(2*time.Hour))
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
@@ -1217,7 +1217,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 
 	p4.Spec.NodeName = "n2"
 
-	err = autoscaler.RunOnce(time.Now().Add(3 * time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(3*time.Hour))
 	waitForDeleteToFinish(t, deleteFinished)
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
@@ -1314,7 +1314,7 @@ func TestStaticAutoscalerRunOnceWithFilteringOnBinPackingEstimator(t *testing.T)
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
-	err = autoscaler.RunOnce(time.Now())
+	err = autoscaler.RunOnce(t.Context(), time.Now())
 	assert.NoError(t, err)
 
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
@@ -1411,7 +1411,7 @@ func TestStaticAutoscalerRunOnceWithFilteringOnUpcomingNodesEnabledNoScaleUp(t *
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
-	err = autoscaler.RunOnce(time.Now())
+	err = autoscaler.RunOnce(t.Context(), time.Now())
 	assert.NoError(t, err)
 
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
@@ -1472,7 +1472,7 @@ func TestStaticAutoscalerRunOnceWithUnselectedNodeGroups(t *testing.T) {
 			autoscaler := buildStaticAutoscaler(t, provider, allNodes, allNodes, fakeClient)
 
 			runningTime := time.Now()
-			err := autoscaler.RunOnce(runningTime)
+			err := autoscaler.RunOnce(t.Context(), runningTime)
 			assert.NoError(t, err)
 
 			newNode, clientErr := fakeClient.CoreV1().Nodes().Get(context.TODO(), test.node.Name, metav1.GetOptions{})
@@ -1576,7 +1576,7 @@ func TestStaticAutoscalerRunOnceWithBypassedSchedulers(t *testing.T) {
 			if tc.expectedScaleUp != nil {
 				tc.setupConfig.mocks.onScaleUp.On("ScaleUp", tc.expectedScaleUp.ng, tc.expectedScaleUp.delta).Return(nil).Once()
 			}
-			err = autoscaler.RunOnce(now.Add(time.Hour))
+			err = autoscaler.RunOnce(t.Context(), now.Add(time.Hour))
 			assert.NoError(t, err)
 			mock.AssertExpectationsForObjects(t, tc.setupConfig.mocks.allPodLister,
 				tc.setupConfig.mocks.podDisruptionBudgetLister, tc.setupConfig.mocks.daemonSetLister, tc.setupConfig.mocks.onScaleUp, tc.setupConfig.mocks.onScaleDown)
@@ -1768,7 +1768,7 @@ func TestStaticAutoscalerRunOnceWithExistingDeletionCandidateNodes(t *testing.T)
 				onScaleDownMock.On("ScaleDown", "ng1", node.Name).Return(nil).Once()
 			}
 
-			err = autoscaler.RunOnce(currentTime)
+			err = autoscaler.RunOnce(t.Context(), currentTime)
 			assert.NoError(t, err)
 			for range tc.expectedDeletionCandidateNodes {
 				waitForDeleteToFinish(t, deleteFinished)
@@ -2525,7 +2525,7 @@ func TestStaticAutoscalerUpcomingScaleDownCandidates(t *testing.T) {
 	// RunOnce run right when the nodes are created. Ready nodes should be passed as scale-down candidates, unready nodes should be classified as
 	// NotStarted and not passed as scale-down candidates (or inserted into the cluster snapshot). The fake upcoming nodes also shouldn't be passed,
 	// but they should be inserted into the snapshot.
-	err = autoscaler.RunOnce(startTime)
+	err = autoscaler.RunOnce(t.Context(), startTime)
 	assert.NoError(t, err)
 	assert.Equal(t, readyNodeNames, planner.lastCandidateNodes)
 	assertNodesInSnapshot(t, autoscaler.ClusterSnapshot, readyNodeNames)
@@ -2533,7 +2533,7 @@ func TestStaticAutoscalerUpcomingScaleDownCandidates(t *testing.T) {
 	assertSnapshotNodeCount(t, autoscaler.ClusterSnapshot, len(allNodeNames)) // Ready nodes + fake upcoming copies for unready nodes.
 
 	// RunOnce run in the last moment when unready nodes are still classified as NotStarted - assertions the same as above.
-	err = autoscaler.RunOnce(startTime.Add(clusterstate.MaxNodeStartupTime).Add(-time.Second))
+	err = autoscaler.RunOnce(t.Context(), startTime.Add(clusterstate.MaxNodeStartupTime).Add(-time.Second))
 	assert.NoError(t, err)
 	assert.Equal(t, readyNodeNames, planner.lastCandidateNodes)
 	assertNodesInSnapshot(t, autoscaler.ClusterSnapshot, readyNodeNames)
@@ -2543,7 +2543,7 @@ func TestStaticAutoscalerUpcomingScaleDownCandidates(t *testing.T) {
 	// RunOnce run in the first moment when unready nodes exceed the startup threshold, stop being classified as NotStarted, and start being classified
 	// Unready instead. The unready nodes should be passed as scale-down candidates at this point, and inserted into the snapshot. Fake upcoming
 	// nodes should no longer be inserted.
-	err = autoscaler.RunOnce(startTime.Add(clusterstate.MaxNodeStartupTime).Add(time.Second))
+	err = autoscaler.RunOnce(t.Context(), startTime.Add(clusterstate.MaxNodeStartupTime).Add(time.Second))
 	assert.Equal(t, allNodeNames, planner.lastCandidateNodes)
 	assertNodesInSnapshot(t, autoscaler.ClusterSnapshot, allNodeNames)
 	assertSnapshotNodeCount(t, autoscaler.ClusterSnapshot, len(allNodeNames)) // Ready nodes + actual unready nodes.
@@ -3071,7 +3071,7 @@ func TestStaticAutoscalerRunOnceInvokesScaleDownStatusProcessor(t *testing.T) {
 			setupConfig.mocks.podDisruptionBudgetLister.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil)
 			setupConfig.mocks.onScaleDown.On("ScaleDown", "ng1", "n2").Return(nil).Maybe()
 
-			err = autoscaler.RunOnce(now.Add(time.Hour))
+			err = autoscaler.RunOnce(t.Context(), now.Add(time.Hour))
 			assert.NoError(t, err)
 
 			assert.Equal(t, statusProcessor.called, 1)
@@ -3264,7 +3264,7 @@ func TestCleaningSoftTaintsInScaleDown(t *testing.T) {
 			autoscaler.processorCallbacks.disableScaleDownForLoop = test.scaleDownInCoolDown
 			assert.Equal(t, autoscaler.isScaleDownInCooldown(time.Now()), test.scaleDownInCoolDown)
 
-			err := autoscaler.RunOnce(time.Now())
+			err := autoscaler.RunOnce(t.Context(), time.Now())
 
 			assert.NoError(t, err)
 			assertNodesSoftTaintsStatus(t, fakeClient, test.expectedNodesWithSoftTaints, true)
@@ -3630,7 +3630,7 @@ func TestStaticAutoscalerWithNodeDeclaredFeatures(t *testing.T) {
 			}
 
 			// Run the autoscaler
-			err = autoscaler.RunOnce(time.Now())
+			err = autoscaler.RunOnce(t.Context(), time.Now())
 			assert.NoError(t, err)
 			mock.AssertExpectationsForObjects(t, allPodListerMock, podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
 		})
@@ -3689,9 +3689,27 @@ func TestStaticAutoscalerRunOnceClearsRegistry(t *testing.T) {
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
-	err := autoscaler.RunOnce(time.Now())
+	err := autoscaler.RunOnce(t.Context(), time.Now())
 	assert.NoError(t, err)
 	assert.Nil(t, registry.GetCapacityBuffer(fakePodUID))
+}
+
+func TestStaticAutoscalerRunOnceWithCancelledContext(t *testing.T) {
+	n1 := BuildTestNode("n1", 1000, 1000)
+	SetNodeReadyState(n1, true, time.Now())
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 1, 10, 1)
+	provider.AddNode("ng1", n1)
+
+	allNodes := []*apiv1.Node{n1}
+	fakeClient := buildFakeClient(t, allNodes...)
+	autoscaler := buildStaticAutoscaler(t, provider, allNodes, allNodes, fakeClient)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := autoscaler.RunOnce(ctx, time.Now())
+	assert.NoError(t, err, "RunOnce should return cleanly, without an error, when the context is already cancelled")
 }
 
 func TestStaticAutoscalerRunOnceWithNominatedNodeName(t *testing.T) {
@@ -3776,7 +3794,7 @@ func TestStaticAutoscalerRunOnceWithNominatedNodeName(t *testing.T) {
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 
-	err = autoscaler.RunOnce(time.Now())
+	err = autoscaler.RunOnce(t.Context(), time.Now())
 	assert.NoError(t, err)
 
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
@@ -3885,11 +3903,11 @@ func TestStaticAutoscalerScaleDownCustomQuota(t *testing.T) {
 	autoscaler.processors.ScaleDownStatusProcessor = statusProcessor
 
 	now := time.Now()
-	err = autoscaler.RunOnce(now)
+	err = autoscaler.RunOnce(t.Context(), now)
 	assert.NoError(t, err)
 
 	now = now.Add(2 * time.Second)
-	err = autoscaler.RunOnce(now)
+	err = autoscaler.RunOnce(t.Context(), now)
 	assert.NoError(t, err)
 
 	onScaleDownMock.AssertNotCalled(t, "ScaleDown", mock.Anything, mock.Anything)

--- a/cluster-autoscaler/loop/run.go
+++ b/cluster-autoscaler/loop/run.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loop
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
@@ -25,15 +26,15 @@ import (
 
 type autoscaler interface {
 	// RunOnce represents an iteration in the control-loop of CA.
-	RunOnce(currentTime time.Time) errors.AutoscalerError
+	RunOnce(ctx context.Context, currentTime time.Time) errors.AutoscalerError
 }
 
 // RunAutoscalerOnce triggers a single autoscaling iteration.
-func RunAutoscalerOnce(autoscaler autoscaler, healthCheck *metrics.HealthCheck, loopStart time.Time) {
+func RunAutoscalerOnce(ctx context.Context, autoscaler autoscaler, healthCheck *metrics.HealthCheck, loopStart time.Time) {
 	metrics.UpdateLastTime(metrics.Main, loopStart)
 	healthCheck.UpdateLastActivity(loopStart)
 
-	err := autoscaler.RunOnce(loopStart)
+	err := autoscaler.RunOnce(ctx, loopStart)
 	if err != nil && err.Type() != errors.TransientError {
 		metrics.RegisterError(err)
 	} else {

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -143,22 +143,24 @@ func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapsho
 			for {
 				select {
 				case <-ctx.Done():
-					// TODO: handle graceful shutdown with context
+					// Context is also passed down to RunOnce, so a long-running
+					// iteration in progress will be interrupted and cleaned up there.
 					return nil
 				default:
 					trigger.Wait(previousRun)
 					previousRun, lastRun = lastRun, time.Now()
-					loop.RunAutoscalerOnce(autoscaler, healthCheck, lastRun)
+					loop.RunAutoscalerOnce(ctx, autoscaler, healthCheck, lastRun)
 				}
 			}
 		} else {
 			for {
 				select {
 				case <-ctx.Done():
-					// TODO: handle graceful shutdown with context
+					// Context is also passed down to RunOnce, so a long-running
+					// iteration in progress will be interrupted and cleaned up there.
 					return nil
 				case <-time.After(autoscalingOpts.ScanInterval):
-					loop.RunAutoscalerOnce(autoscaler, healthCheck, time.Now())
+					loop.RunAutoscalerOnce(ctx, autoscaler, healthCheck, time.Now())
 				}
 			}
 		}

--- a/cluster-autoscaler/test/integration/synctest/utils.go
+++ b/cluster-autoscaler/test/integration/synctest/utils.go
@@ -34,7 +34,7 @@ func RunOnceAfter(t *testing.T, autoscaler core.Autoscaler, d time.Duration) err
 	synctest.Wait()
 
 	time.Sleep(d)
-	err := autoscaler.RunOnce(time.Now())
+	err := autoscaler.RunOnce(t.Context(), time.Now())
 
 	// Let side-effects of the RunOnce finish.
 	synctest.Wait()


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does 


**Autoscaler.RunOnce** did not accept a **context.Context** so a graceful termination signal could not interrupt a long-running autoscaling iteration. In large clusters, a single **RunOnce** call can take longer than the graceful termination period leading to the process being killed without cleaning up properly

This PR threads **context.Context** through **RunOnce** and **loop.RunAutoscalerOnce**  and adds cancellation checks in
**StaticAutoscaler.RunOnce** - one at the start of the iteration and one right before the scale-up/scale-down section ( the most expensive part of the loop ). 
When the context is cancelled **RunOnce** returns early and cleanly without registering an error since this isn't a failure 
it's intentional , graceful stop

See https://github.com/kubernetes/autoscaler/issues/9855

### Special notes for your reviewer :

- Only **StaticAutoscaler** implements the **Autoscaler** interface and **loop/run.go** + **main.go** are the only non-test callers so the blast radius is contained to those plus test call sites
- Added **TestStaticAutoscalerRunOnceWithCancelledContex**t to verify **RunOnce** returns cleanly (no error) when the context is already cancelled
- **main.go** 's **ctx.Done()** branches in the main loop already exist
this change means the context is now also honored during an in-progress iteration not just between iterations. 
Updated the stale **TODO** comments there accordingly

```release-note
Pass context.Context down to Autoscaler.RunOnce to allow graceful shutdown to interrupt long-running autoscaling iterations.
```
