### PR TITLE
GCE: remove ResourceLimiter dead code

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -47,7 +47,7 @@ type InstanceTemplateName struct {
 // - keep track of instances in the cluster,
 // - keep track of MIGs to instances mapping,
 // - keep track of MIGs configuration such as target size and basename,
-// - keep track of resource limiters and machine types,
+// - keep track of machine types,
 // - limit repetitive GCE API calls.
 //
 // Cache keeps these values and gives access to getters, setters and
@@ -68,7 +68,6 @@ type GceCache struct {
 	instancesUpdateTime              map[GceRef]time.Time
 	instancesToMig                   map[GceRef]GceRef
 	instancesFromUnknownMig          map[GceRef]bool
-	resourceLimiter                  *cloudprovider.ResourceLimiter
 	autoscalingOptionsCache          map[GceRef]map[string]string
 	machinesCache                    map[MachineTypeKey]MachineType
 	migTargetSizeCache               map[GceRef]int64
@@ -305,22 +304,6 @@ func (gc *GceCache) GetAutoscalingOptions(ref GceRef) map[string]string {
 	gc.cacheMutex.Lock()
 	defer gc.cacheMutex.Unlock()
 	return gc.autoscalingOptionsCache[ref]
-}
-
-// SetResourceLimiter sets resource limiter.
-func (gc *GceCache) SetResourceLimiter(resourceLimiter *cloudprovider.ResourceLimiter) {
-	gc.cacheMutex.Lock()
-	defer gc.cacheMutex.Unlock()
-
-	gc.resourceLimiter = resourceLimiter
-}
-
-// GetResourceLimiter returns resource limiter.
-func (gc *GceCache) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
-	gc.cacheMutex.Lock()
-	defer gc.cacheMutex.Unlock()
-
-	return gc.resourceLimiter, nil
 }
 
 // GetMigTargetSize returns the cached targetSize for a GceRef

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -59,8 +59,7 @@ var (
 
 // GceCloudProvider implements CloudProvider interface.
 type GceCloudProvider struct {
-	gceManager GceManager
-	// This resource limiter is used if resource limits are not defined through cloud API.
+	gceManager               GceManager
 	resourceLimiterFromFlags *cloudprovider.ResourceLimiter
 	pricingModel             cloudprovider.PricingModel
 }
@@ -159,13 +158,6 @@ func (gce *GceCloudProvider) NewNodeGroup(machineType string, labels map[string]
 
 // GetResourceLimiter returns struct containing limits (max, min) for resources (cores, memory etc.).
 func (gce *GceCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
-	resourceLimiter, err := gce.gceManager.GetResourceLimiter()
-	if err != nil {
-		return nil, err
-	}
-	if resourceLimiter != nil {
-		return resourceLimiter, nil
-	}
 	return gce.resourceLimiterFromFlags, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gce
 
 import (
-	"fmt"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -81,11 +80,6 @@ func (m *gceManagerMock) Cleanup() error {
 func (m *gceManagerMock) GetMigs() []Mig {
 	args := m.Called()
 	return args.Get(0).([]Mig)
-}
-
-func (m *gceManagerMock) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
-	args := m.Called()
-	return args.Get(0).(*cloudprovider.ResourceLimiter), args.Error(1)
 }
 
 func (m *gceManagerMock) findMigsNamed(name *regexp.Regexp) ([]string, error) {
@@ -154,34 +148,18 @@ func TestNodeGroupForNode(t *testing.T) {
 }
 
 func TestGetResourceLimiter(t *testing.T) {
-	gceManagerMock := &gceManagerMock{}
 	resourceLimiter := cloudprovider.NewResourceLimiter(
 		map[string]int64{cloudprovider.ResourceNameCores: 1, cloudprovider.ResourceNameMemory: 10000000},
 		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
 	gce := &GceCloudProvider{
-		gceManager:               gceManagerMock,
+		gceManager:               nil,
 		resourceLimiterFromFlags: resourceLimiter,
 	}
 
 	// Return default.
-	gceManagerMock.On("GetResourceLimiter").Return((*cloudprovider.ResourceLimiter)(nil), nil).Once()
 	returnedResourceLimiter, err := gce.GetResourceLimiter()
 	assert.NoError(t, err)
 	assert.Equal(t, resourceLimiter, returnedResourceLimiter)
-
-	// Return for GKE.
-	resourceLimiterGKE := cloudprovider.NewResourceLimiter(
-		map[string]int64{cloudprovider.ResourceNameCores: 2, cloudprovider.ResourceNameMemory: 20000000},
-		map[string]int64{cloudprovider.ResourceNameCores: 5, cloudprovider.ResourceNameMemory: 200000000})
-	gceManagerMock.On("GetResourceLimiter").Return(resourceLimiterGKE, nil).Once()
-	returnedResourceLimiterGKE, err := gce.GetResourceLimiter()
-	assert.NoError(t, err)
-	assert.Equal(t, returnedResourceLimiterGKE, resourceLimiterGKE)
-
-	// Error in GceManager.
-	gceManagerMock.On("GetResourceLimiter").Return((*cloudprovider.ResourceLimiter)(nil), fmt.Errorf("some error")).Once()
-	_, err = gce.GetResourceLimiter()
-	assert.Error(t, err)
 }
 
 const getInstanceGroupManagerResponse = `{

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -89,8 +89,6 @@ type GceManager interface {
 	GetMigForInstance(instance GceRef) (Mig, error)
 	// GetMigTemplateNode returns a template node for MIG.
 	GetMigTemplateNode(mig Mig) (*apiv1.Node, error)
-	// GetResourceLimiter returns resource limiter.
-	GetResourceLimiter() (*cloudprovider.ResourceLimiter, error)
 	// GetMigSize gets MIG size.
 	GetMigSize(mig Mig) (int64, error)
 	// GetMigOptions returns MIG's NodeGroupAutoscalingOptions
@@ -512,11 +510,6 @@ func (m *gceManagerImpl) fetchAutoMigs() error {
 	}
 
 	return nil
-}
-
-// GetResourceLimiter returns resource limiter from cache.
-func (m *gceManagerImpl) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
-	return m.cache.GetResourceLimiter()
 }
 
 func (m *gceManagerImpl) clearMachinesCache() {


### PR DESCRIPTION
GCE cloudprovider had fetchResourceLimiter() function at the time when it was the one with the GKE cloudprovider. Since then, GKE was separated in its own cloudprovider and then removed. So GCE can have only the ResourceLimiter set by the core.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Cleanup needed for the multicloud provider implementation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Reviving this https://github.com/kubernetes/autoscaler/pull/8000 PR

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
