### PR TITLE
Fast-track evaluation path for host-scoped affinity/anti-affinity

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -247,6 +247,8 @@ type AutoscalingOptions struct {
 	SchedulerVerbosityOffset int
 	// GCEOptions contain autoscaling options specific to GCE cloud provider.
 	GCEOptions GCEOptions
+	// InterPodAffinityHostnameFastPath enables the fast path for inter-pod affinity calculations in the scheduler.
+	InterPodAffinityHostnameFastPath bool
 	// KubeClientOpts specify options for kube client
 	KubeClientOpts KubeClientOptions
 	// ClusterAPICloudConfigAuthoritative tells the Cluster API provider to treat the CloudConfig option as authoritative and

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -248,6 +248,7 @@ var (
 	scaleUpSimulationForSkippedNodeGroupsEnabled = flag.Bool("scaleup-simulation-for-skipped-node-groups-enabled", false, "Whether to enable the scale up simulation for skipped node groups.")
 	pendingPodsBatchingTimeout                   = flag.Duration("pending-pods-batching-timeout", 4*time.Minute, "The maximum time spends when running scheduling simulations when preparing the batch of pods passed to scale up logic. This timeout is used in core filter-out pod list processor.")
 	enableGracefulDegradation                    = flag.Bool("enable-graceful-degradation", false, "Enables graceful degradation for unschedulable pods. When enabled, scheduling simulations during filter out pod list processor will be stopped after a timeout(specified by scheduling-simulation-timeout) and CA will proceed with a sub set of pods.")
+	interPodAffinityHostnameFastPath             = flag.Bool("InterPodAffinityHostnameFastPath", false, "Enable the InterPodAffinityHostnameFastPath scheduler feature gate.")
 
 	// Deprecated flags
 	ignoreTaintsFlag           = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
@@ -482,6 +483,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ScaleUpSimulationForSkippedNodeGroupsEnabled: *scaleUpSimulationForSkippedNodeGroupsEnabled,
 		PendingPodsBatchingTimeout:                   *pendingPodsBatchingTimeout,
 		GracefulDegradationEnabled:                   *enableGracefulDegradation,
+		InterPodAffinityHostnameFastPath:             *interPodAffinityHostnameFastPath,
 	}
 }
 

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -235,6 +235,12 @@ func main() {
 		}
 	}
 
+	if autoscalingOpts.InterPodAffinityHostnameFastPath != featureGate.Enabled(features.InterPodAffinityHostnameFastPath) {
+		if err := featureGate.SetFromMap(map[string]bool{string(features.InterPodAffinityHostnameFastPath): autoscalingOpts.InterPodAffinityHostnameFastPath}); err != nil {
+			klog.Fatalf("couldn't set the InterPodAffinityHostnameFastPath feature gate to %v: %v", autoscalingOpts.InterPodAffinityHostnameFastPath, err)
+		}
+	}
+
 	logs.InitLogs()
 
 	opts, err := flags.ComputeLoggingOptions(pflag.CommandLine)

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
@@ -27,8 +27,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	scheduler_config_latest "k8s.io/kubernetes/pkg/scheduler/apis/config/latest"
 
@@ -38,6 +40,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/scheduler"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	featuretesting "k8s.io/component-base/featuregate/testing"
 )
 
 func TestRunFiltersOnNode(t *testing.T) {
@@ -522,6 +525,7 @@ func newTestPluginRunnerAndSnapshot(schedConfig *config.KubeSchedulerConfigurati
 }
 
 func BenchmarkRunFiltersUntilPassingNode(b *testing.B) {
+	featuretesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.InterPodAffinityHostnameFastPath, true)
 	pod := BuildTestPod("p", 100, 1000, WithPodHostnameAntiAffinity(map[string]string{"app": "p"}), WithLabels(map[string]string{"app": "p"}))
 	nodes := make([]*apiv1.Node, 0, 5001)
 	podsOnNodes := make(map[string][]*apiv1.Pod)

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -68,6 +68,17 @@ func (data *internalBasicSnapshotData) listNodeInfosThatHavePodsWithRequiredAnti
 	return havePodsWithRequiredAntiAffinityList, nil
 }
 
+func (data *internalBasicSnapshotData) listNodeInfosThatHavePodsWithRequiredNonHostScopedAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
+	havePodsWithRequiredNonHostScopedAntiAffinityList := make([]schedulerinterface.NodeInfo, 0, len(data.nodeInfoMap))
+	for _, v := range data.nodeInfoMap {
+		if len(v.GetPodsWithRequiredNonHostScopedAntiAffinity()) > 0 {
+			havePodsWithRequiredNonHostScopedAntiAffinityList = append(havePodsWithRequiredNonHostScopedAntiAffinityList, v)
+		}
+	}
+
+	return havePodsWithRequiredNonHostScopedAntiAffinityList, nil
+}
+
 func (data *internalBasicSnapshotData) getNodeInfo(nodeName string) (schedulerinterface.NodeInfo, error) {
 	if v, ok := data.nodeInfoMap[nodeName]; ok {
 		return v, nil
@@ -297,6 +308,11 @@ func (snapshot *basicSnapshotStoreNodeLister) HavePodsWithAffinityList() ([]sche
 // HavePodsWithRequiredAntiAffinityList returns the list of NodeInfos of nodes with pods with required anti-affinity terms.
 func (snapshot *basicSnapshotStoreNodeLister) HavePodsWithRequiredAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
 	return (*BasicSnapshotStore)(snapshot).getInternalData().listNodeInfosThatHavePodsWithRequiredAntiAffinityList()
+}
+
+// HavePodsWithRequiredNonHostScopedAntiAffinityList returns nodes containing pods that require a wider topology scan (topologyKey other than hostname).
+func (snapshot *basicSnapshotStoreNodeLister) HavePodsWithRequiredNonHostScopedAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
+	return (*BasicSnapshotStore)(snapshot).getInternalData().listNodeInfosThatHavePodsWithRequiredNonHostScopedAntiAffinityList()
 }
 
 // Returns the NodeInfo of the given node name.

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
@@ -279,6 +281,9 @@ func (snapshot *BasicSnapshotStore) Clear() {
 type basicSnapshotStoreNodeLister BasicSnapshotStore
 type basicSnapshotStoreStorageLister BasicSnapshotStore
 type basicSnapshotStorePodGroupStateLister BasicSnapshotStore
+type basicSnapshotStorePodGroupLister BasicSnapshotStore
+type basicSnapshotStoreCompositePodGroupStateLister BasicSnapshotStore
+type basicSnapshotStoreCompositePodGroupLister BasicSnapshotStore
 
 // NodeInfos exposes snapshot as NodeInfoLister.
 func (snapshot *BasicSnapshotStore) NodeInfos() schedulerinterface.NodeInfoLister {
@@ -293,6 +298,21 @@ func (snapshot *BasicSnapshotStore) StorageInfos() schedulerinterface.StorageInf
 // PodGroupStates exposes snapshot as PodGroupStateLister.
 func (snapshot *BasicSnapshotStore) PodGroupStates() schedulerinterface.PodGroupStateLister {
 	return (*basicSnapshotStorePodGroupStateLister)(snapshot)
+}
+
+// PodGroups exposes snapshot as PodGroupLister.
+func (snapshot *BasicSnapshotStore) PodGroups() schedulerinterface.PodGroupLister {
+	return (*basicSnapshotStorePodGroupLister)(snapshot)
+}
+
+// CompositePodGroupStates exposes snapshot as CompositePodGroupStateLister.
+func (snapshot *BasicSnapshotStore) CompositePodGroupStates() schedulerinterface.CompositePodGroupStateLister {
+	return (*basicSnapshotStoreCompositePodGroupStateLister)(snapshot)
+}
+
+// CompositePodGroups exposes snapshot as CompositePodGroupLister.
+func (snapshot *BasicSnapshotStore) CompositePodGroups() schedulerinterface.CompositePodGroupLister {
+	return (*basicSnapshotStoreCompositePodGroupLister)(snapshot)
 }
 
 // List returns the list of nodes in the snapshot.
@@ -330,5 +350,17 @@ func (snapshot *basicSnapshotStoreStorageLister) IsPVCUsedByPods(key string) boo
 // This method is never supposed to be called in the cluster autoscaler simulations
 // as pod group states are not integrated with cluster autoscaler.
 func (snapshot *basicSnapshotStorePodGroupStateLister) Get(namespace string, podGroupName string) (schedulerinterface.PodGroupState, error) {
+	return nil, errorGettingPodGroupState
+}
+
+func (snapshot *basicSnapshotStorePodGroupLister) Get(namespace string, name string) (*schedulingapi.PodGroup, error) {
+	return nil, errorGettingPodGroupState
+}
+
+func (snapshot *basicSnapshotStoreCompositePodGroupStateLister) Get(namespace string, name string) (schedulerinterface.CompositePodGroupState, error) {
+	return nil, errorGettingPodGroupState
+}
+
+func (snapshot *basicSnapshotStoreCompositePodGroupLister) Get(namespace string, name string) (*schedulingv1alpha3.CompositePodGroup, error) {
 	return nil, errorGettingPodGroupState
 }

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -67,10 +67,11 @@ type internalDeltaSnapshotData struct {
 	modifiedNodeInfoMap map[string]schedulerinterface.NodeInfo
 	deletedNodeInfos    map[string]bool
 
-	nodeInfoList                     []schedulerinterface.NodeInfo
-	havePodsWithAffinity             []schedulerinterface.NodeInfo
-	havePodsWithRequiredAntiAffinity []schedulerinterface.NodeInfo
-	pvcNamespaceMap                  map[string]int
+	nodeInfoList                                  []schedulerinterface.NodeInfo
+	havePodsWithAffinity                          []schedulerinterface.NodeInfo
+	havePodsWithRequiredAntiAffinity              []schedulerinterface.NodeInfo
+	havePodsWithRequiredNonHostScopedAntiAffinity []schedulerinterface.NodeInfo
+	pvcNamespaceMap                               map[string]int
 }
 
 func newInternalDeltaSnapshotData() *internalDeltaSnapshotData {
@@ -178,6 +179,7 @@ func (data *internalDeltaSnapshotData) clearCaches() {
 func (data *internalDeltaSnapshotData) clearPodCaches() {
 	data.havePodsWithAffinity = nil
 	data.havePodsWithRequiredAntiAffinity = nil
+	data.havePodsWithRequiredNonHostScopedAntiAffinity = nil
 	// TODO: update the cache when adding/removing pods instead of invalidating the whole cache
 	data.pvcNamespaceMap = nil
 }
@@ -361,6 +363,24 @@ func (snapshot *deltaSnapshotStoreNodeLister) HavePodsWithRequiredAntiAffinityLi
 	}
 	data.havePodsWithRequiredAntiAffinity = havePodsWithRequiredAntiAffinityList
 	return data.havePodsWithRequiredAntiAffinity, nil
+}
+
+// HavePodsWithRequiredNonHostScopedAntiAffinityList returns nodes containing pods that require a wider topology scan (topologyKey other than hostname).
+func (snapshot *deltaSnapshotStoreNodeLister) HavePodsWithRequiredNonHostScopedAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
+	data := snapshot.data
+	if data.havePodsWithRequiredNonHostScopedAntiAffinity != nil {
+		return data.havePodsWithRequiredNonHostScopedAntiAffinity, nil
+	}
+
+	nodeInfoList := snapshot.data.getNodeInfoList()
+	havePodsWithRequiredNonHostScopedAntiAffinityList := make([]schedulerinterface.NodeInfo, 0, len(nodeInfoList))
+	for _, node := range nodeInfoList {
+		if len(node.GetPodsWithRequiredNonHostScopedAntiAffinity()) > 0 {
+			havePodsWithRequiredNonHostScopedAntiAffinityList = append(havePodsWithRequiredNonHostScopedAntiAffinityList, node)
+		}
+	}
+	data.havePodsWithRequiredNonHostScopedAntiAffinity = havePodsWithRequiredNonHostScopedAntiAffinityList
+	return data.havePodsWithRequiredNonHostScopedAntiAffinity, nil
 }
 
 // Get returns node info by node name.

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -20,6 +20,9 @@ import (
 	"errors"
 	"fmt"
 
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	schedulingapi "k8s.io/api/scheduling/v1beta1"
+
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/klog/v2"
@@ -59,6 +62,9 @@ type DeltaSnapshotStore struct {
 type deltaSnapshotStoreNodeLister DeltaSnapshotStore
 type deltaSnapshotStoreStorageLister DeltaSnapshotStore
 type deltaSnapshotPodGroupStateLister DeltaSnapshotStore
+type deltaSnapshotPodGroupLister DeltaSnapshotStore
+type deltaSnapshotCompositePodGroupStateLister DeltaSnapshotStore
+type deltaSnapshotCompositePodGroupLister DeltaSnapshotStore
 
 type internalDeltaSnapshotData struct {
 	baseData *internalDeltaSnapshotData
@@ -401,6 +407,18 @@ func (snapshot *deltaSnapshotPodGroupStateLister) Get(namespace string, podGroup
 	return nil, errorGettingPodGroupState
 }
 
+func (snapshot *deltaSnapshotPodGroupLister) Get(namespace string, name string) (*schedulingapi.PodGroup, error) {
+	return nil, errorGettingPodGroupState
+}
+
+func (snapshot *deltaSnapshotCompositePodGroupStateLister) Get(namespace string, name string) (schedulerinterface.CompositePodGroupState, error) {
+	return nil, errorGettingPodGroupState
+}
+
+func (snapshot *deltaSnapshotCompositePodGroupLister) Get(namespace string, name string) (*schedulingv1alpha3.CompositePodGroup, error) {
+	return nil, errorGettingPodGroupState
+}
+
 func (snapshot *DeltaSnapshotStore) getNodeInfo(nodeName string) (schedulerinterface.NodeInfo, error) {
 	data := snapshot.data
 	node, found := data.getNodeInfo(nodeName)
@@ -423,6 +441,21 @@ func (snapshot *DeltaSnapshotStore) StorageInfos() schedulerinterface.StorageInf
 // PodGroupStates returns pod group state lister.
 func (snapshot *DeltaSnapshotStore) PodGroupStates() schedulerinterface.PodGroupStateLister {
 	return (*deltaSnapshotPodGroupStateLister)(snapshot)
+}
+
+// PodGroups returns pod group lister.
+func (snapshot *DeltaSnapshotStore) PodGroups() schedulerinterface.PodGroupLister {
+	return (*deltaSnapshotPodGroupLister)(snapshot)
+}
+
+// CompositePodGroupStates returns composite pod group state lister.
+func (snapshot *DeltaSnapshotStore) CompositePodGroupStates() schedulerinterface.CompositePodGroupStateLister {
+	return (*deltaSnapshotCompositePodGroupStateLister)(snapshot)
+}
+
+// CompositePodGroups returns composite pod group lister.
+func (snapshot *DeltaSnapshotStore) CompositePodGroups() schedulerinterface.CompositePodGroupLister {
+	return (*deltaSnapshotCompositePodGroupLister)(snapshot)
 }
 
 // NewDeltaSnapshotStore creates instances of DeltaSnapshotStore.

--- a/cluster-autoscaler/simulator/dynamicresources/noop_manager.go
+++ b/cluster-autoscaler/simulator/dynamicresources/noop_manager.go
@@ -21,7 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	schedulingapi "k8s.io/api/scheduling/v1alpha2"
+	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/dynamic-resource-allocation/structured"

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_pod_group_lister.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_pod_group_lister.go
@@ -19,7 +19,7 @@ package snapshot
 import (
 	"errors"
 
-	schedulingapi "k8s.io/api/scheduling/v1alpha2"
+	schedulingapi "k8s.io/api/scheduling/v1beta1"
 )
 
 var (

--- a/cluster-autoscaler/simulator/framework/delegating_shared_lister.go
+++ b/cluster-autoscaler/simulator/framework/delegating_shared_lister.go
@@ -21,7 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	schedulingapi "k8s.io/api/scheduling/v1alpha2"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -129,6 +129,11 @@ func (lister *unsetNodeInfoLister) HavePodsWithAffinityList() ([]schedulerinterf
 
 // HavePodsWithRequiredAntiAffinityList always returns an error.
 func (lister *unsetNodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
+	return nil, fmt.Errorf("lister not set in delegate")
+}
+
+// HavePodsWithRequiredNonHostScopedAntiAffinityList always returns an error.
+func (lister *unsetNodeInfoLister) HavePodsWithRequiredNonHostScopedAntiAffinityList() ([]schedulerinterface.NodeInfo, error) {
 	return nil, fmt.Errorf("lister not set in delegate")
 }
 

--- a/cluster-autoscaler/simulator/framework/delegating_shared_lister.go
+++ b/cluster-autoscaler/simulator/framework/delegating_shared_lister.go
@@ -21,7 +21,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	schedulingapi "k8s.io/api/scheduling/v1alpha3"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -101,6 +102,16 @@ func (lister *DelegatingSchedulerSharedLister) PodGroups() schedulerinterface.Po
 	return lister.delegate.PodGroups()
 }
 
+// CompositePodGroupStates returns a CompositePodGroupStateLister
+func (lister *DelegatingSchedulerSharedLister) CompositePodGroupStates() schedulerinterface.CompositePodGroupStateLister {
+	return lister.delegate.CompositePodGroupStates()
+}
+
+// CompositePodGroups returns a CompositePodGroupLister
+func (lister *DelegatingSchedulerSharedLister) CompositePodGroups() schedulerinterface.CompositePodGroupLister {
+	return lister.delegate.CompositePodGroups()
+}
+
 // ResetDelegate resets delegate to the unsetSharedListerSingleton.
 func (lister *DelegatingSchedulerSharedLister) ResetDelegate() {
 	lister.delegate = unsetSharedListerSingleton
@@ -115,6 +126,8 @@ type unsetResourceSliceLister unsetSharedLister
 type unsetDeviceClassLister unsetSharedLister
 type unsetDeviceClassResolver unsetSharedLister
 type unsetPodGroupLister unsetSharedLister
+type unsetCompositePodGroupStateLister unsetSharedLister
+type unsetCompositePodGroupLister unsetSharedLister
 type unsetCSINodeLister unsetSharedLister
 
 // List always returns an error
@@ -209,6 +222,14 @@ func (l *unsetPodGroupLister) Get(namespace, podGroupName string) (*schedulingap
 	return nil, fmt.Errorf("lister not set in delegate")
 }
 
+func (l *unsetCompositePodGroupStateLister) Get(namespace, compositePodGroupName string) (schedulerinterface.CompositePodGroupState, error) {
+	return nil, fmt.Errorf("lister not set in delegate")
+}
+
+func (l *unsetCompositePodGroupLister) Get(namespace, name string) (*schedulingv1alpha3.CompositePodGroup, error) {
+	return nil, fmt.Errorf("lister not set in delegate")
+}
+
 func (u *unsetCSINodeLister) List() ([]*storagev1.CSINode, error) {
 	return nil, fmt.Errorf("lister not set in delegate")
 }
@@ -249,6 +270,14 @@ func (lister *unsetSharedLister) DeviceClassResolver() schedulerinterface.Device
 
 func (lister *unsetSharedLister) PodGroups() schedulerinterface.PodGroupLister {
 	return (*unsetPodGroupLister)(lister)
+}
+
+func (lister *unsetSharedLister) CompositePodGroupStates() schedulerinterface.CompositePodGroupStateLister {
+	return (*unsetCompositePodGroupStateLister)(lister)
+}
+
+func (lister *unsetSharedLister) CompositePodGroups() schedulerinterface.CompositePodGroupLister {
+	return (*unsetCompositePodGroupLister)(lister)
 }
 
 func (lister *unsetSharedLister) CSINodes() schedulerinterface.CSINodeLister {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR updates the simulator snapshot store interfaces to support the corresponding fast-track scheduler optimizations in `k8s.io/kube-scheduler` and `k8s.io/kubernetes` in [PR#138198 ](https://github.com/kubernetes/kubernetes/pull/138198)
which optimizes the evaluation of inter-pod affinity and anti-affinity in the Cluster Autoscaler simulator by introducing a fast-track evaluation path for hostname-scoped rules (`topologyKey == kubernetes.io/hostname`):
- Enables the scheduler simulator's `PreFilter` and `Filter` phases to skip expensive cluster-wide `O(N*M)` node topology lookups when only hostname-scoped rules are present.
- Performs efficient local node checks for hostname anti-affinity while preserving Kubernetes scheduling semantics.

Key changes:
- Extended `NodeInfoLister` and snapshot stores (`basicStore`, `deltaStore`, and `delegating_shared_lister`) to support `HavePodsWithRequiredNonHostScopedAntiAffinityList`.

Results of the `BenchmarkRunFiltersUntilPassingNode` benchmark in simulator/clustersnapshot/predicate/plugin_runner_test.go:

```
                                             │ bench_before.txt │      bench_after_fg_enabled.txt      │
                                             │     sec/op      │    sec/op     vs base                │
RunFiltersUntilPassingNode/parallelism-1-12       6.634m ± 13%   2.998m ±  7%  -54.80% (p=0.000 n=10)
RunFiltersUntilPassingNode/parallelism-2-12       5.309m ± 15%   2.248m ±  7%  -57.65% (p=0.000 n=10)
RunFiltersUntilPassingNode/parallelism-4-12       4.567m ±  9%   1.445m ±  6%  -68.37% (p=0.000 n=10)
RunFiltersUntilPassingNode/parallelism-8-12       4.198m ± 12%   1.082m ± 16%  -74.23% (p=0.000 n=10)
RunFiltersUntilPassingNode/parallelism-16-12      4.368m ± 13%   1.003m ± 10%  -77.03% (p=0.000 n=10)
geomean                                           4.942m         1.603m        -67.58%
```

#### Which issue(s) this PR fixes:
N/A
#### Special notes for your reviewer:
This PR updates the simulator snapshot store interfaces to support the corresponding fast-track scheduler optimizations in `k8s.io/kube-scheduler` and `k8s.io/kubernetes`.
It also adds to the SharedLister implementations no-op methods related to pod groups (which aren't used in CA).

#### Does this PR introduce a user-facing change?
```release-note
Improved performance for interpod affinity and anti-affinity with topologyKey "kubernetes.io/hostname"
```
