### PR TITLE
fix OOM feedback loop

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -91,6 +91,9 @@ type ContainerStateAggregator interface {
 	GetOOMMinBumpUp() float64
 	// GetMemoryAggregationIntervalDuration returns the memory aggregation interval for this container.
 	GetMemoryAggregationIntervalDuration() time.Duration
+	// GetMaxAllowedMemory returns the maximum allowed memory from the VPA policy.
+	// Returns 0 if no maximum is configured.
+	GetMaxAllowedMemory() ResourceAmount
 }
 
 // AggregateContainerState holds input signals aggregated from a set of containers.
@@ -124,6 +127,7 @@ type AggregateContainerState struct {
 	MemoryAggregationIntervalDuration time.Duration
 	MemoryAggregationIntervalCount    int64
 	ControlledResources               *[]ResourceName
+	MaxAllowedMemory                  ResourceAmount
 
 	mutex sync.RWMutex
 }
@@ -181,6 +185,12 @@ func (a *AggregateContainerState) GetOOMMinBumpUp() float64 {
 // GetMemoryAggregationIntervalDuration returns the memory aggregation interval for this container state.
 func (a *AggregateContainerState) GetMemoryAggregationIntervalDuration() time.Duration {
 	return a.MemoryAggregationIntervalDuration
+}
+
+// GetMaxAllowedMemory returns the maximum allowed memory from the VPA policy.
+// Returns 0 if no maximum is configured.
+func (a *AggregateContainerState) GetMaxAllowedMemory() ResourceAmount {
+	return a.MaxAllowedMemory
 }
 
 // MarkNotAutoscaled registers that this container state is not controlled by
@@ -373,6 +383,13 @@ func (a *AggregateContainerState) UpdateFromPolicy(resourcePolicy *vpa_types.Con
 				klog.InfoS("memoryAggregationIntervalCount is set but %s feature gate is disabled, falling back to default value", features.PerVPAConfig)
 			}
 		}
+
+		// Set MaxAllowedMemory equal to 0 if no value is provided.
+		if maxMem, ok := resourcePolicy.MaxAllowed[corev1.ResourceMemory]; ok {
+			a.MaxAllowedMemory = ResourceAmount(maxMem.Value())
+		} else {
+			a.MaxAllowedMemory = 0
+		}
 	}
 }
 
@@ -461,4 +478,10 @@ func (p *ContainerStateAggregatorProxy) GetOOMBumpUpRatio() float64 {
 func (p *ContainerStateAggregatorProxy) GetMemoryAggregationIntervalDuration() time.Duration {
 	aggregator := p.cluster.findOrCreateAggregateContainerState(p.containerID)
 	return aggregator.GetMemoryAggregationIntervalDuration()
+}
+
+// GetMaxAllowedMemory returns the maximum allowed memory from the VPA policy.
+func (p *ContainerStateAggregatorProxy) GetMaxAllowedMemory() ResourceAmount {
+	aggregator := p.cluster.findOrCreateAggregateContainerState(p.containerID)
+	return aggregator.GetMaxAllowedMemory()
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -147,6 +147,12 @@ func (container *ContainerState) GetMemoryAggregationIntervalDuration() time.Dur
 	return container.aggregator.GetMemoryAggregationIntervalDuration()
 }
 
+// GetMaxAllowedMemory returns the maximum allowed memory from the VPA policy.
+// It delegates to the aggregator's implementation.
+func (container *ContainerState) GetMaxAllowedMemory() ResourceAmount {
+	return container.aggregator.GetMaxAllowedMemory()
+}
+
 func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, isOOM bool) bool {
 	ts := sample.MeasureStart
 	// We always process OOM samples.
@@ -218,6 +224,12 @@ func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory 
 	memoryUsed := ResourceAmountMax(requestedMemory, container.memoryPeak)
 	memoryNeeded := ResourceAmountMax(memoryUsed+MemoryAmountFromBytes(container.GetOOMMinBumpUp()),
 		ScaleResource(memoryUsed, container.GetOOMBumpUpRatio()))
+	// Cap synthetic OOM samples at maxAllowed to prevent a feedback loop where
+	// bumped up values exceed the max get capped back, trigger another OOM, and
+	// re insert the incorrect value (kubernetes/autoscaler#9521).
+	if maxAllowed := container.GetMaxAllowedMemory(); maxAllowed > 0 && memoryNeeded > maxAllowed {
+		memoryNeeded = maxAllowed
+	}
 
 	oomMemorySample := ContainerUsageSample{
 		MeasureStart: timestamp,

--- a/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
@@ -329,6 +329,52 @@ func TestRecordOOMInNewWindowWithCustomInterval(t *testing.T) {
 	test.mockMemoryHistogram.AssertExpectations(t)
 }
 
+// TestRecordOOMMaxAllowedCapping verifies that OOM synthetic memory samples are capped
+// at maxAllowed to prevent the feedback loop in issue kubernetes/autoscaler#9521.
+func TestRecordOOMMaxAllowedCapping(t *testing.T) {
+	cases := []struct {
+		name            string
+		oomBumpUpRatio  float64
+		maxAllowedMem   ResourceAmount
+		requestedMemory ResourceAmount
+		expectedSample  float64
+	}{
+		{
+			name:            "Capped when bump up exceeds maxAllowed",
+			oomBumpUpRatio:  2.0,
+			maxAllowedMem:   ResourceAmount(30 * 1024 * mb),
+			requestedMemory: ResourceAmount(30 * 1024 * mb),
+			expectedSample:  float64(30 * 1024 * mb),
+		},
+		{
+			name:            "Not capped when bump up is below maxAllowed",
+			oomBumpUpRatio:  1.2,
+			maxAllowedMem:   ResourceAmount(100 * 1024 * mb),
+			requestedMemory: ResourceAmount(1000 * mb),
+			expectedSample:  1200.0 * mb,
+		},
+		{
+			name:            "No cap when maxAllowed is unset",
+			oomBumpUpRatio:  1.2,
+			maxAllowedMem:   0,
+			requestedMemory: ResourceAmount(1000 * mb),
+			expectedSample:  1200.0 * mb,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			test := newContainerTest()
+			test.aggregateContainerState.OOMBumpUpRatio = tc.oomBumpUpRatio
+			test.aggregateContainerState.MaxAllowedMemory = tc.maxAllowedMem
+			windowEnd := testTimestamp.Add(GetAggregationsConfig().MemoryAggregationIntervalDuration)
+
+			test.mockMemoryHistogram.On("AddSample", tc.expectedSample, 1.0, windowEnd)
+			assert.NoError(t, test.container.RecordOOM(testTimestamp, tc.requestedMemory))
+			test.mockMemoryHistogram.AssertExpectations(t)
+		})
+	}
+}
+
 // Tests with custom MemoryAggregationIntervalCount to verify the per-VPA
 // MemoryAggregationIntervalCount setting affects container behavior.
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -153,6 +153,14 @@ func ResourceAmountMax(amount1, amount2 ResourceAmount) ResourceAmount {
 	return amount2
 }
 
+// ResourceAmountMin returns the smaller of two resource amounts.
+func ResourceAmountMin(amount1, amount2 ResourceAmount) ResourceAmount {
+	if amount1 < amount2 {
+		return amount1
+	}
+	return amount2
+}
+
 func resourceAmountFromFloat(amount float64) ResourceAmount {
 	if amount > float64(MaxResourceAmount) {
 		return MaxResourceAmount


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
VPA goes into a feedback loop that inflates the memory, ignoring real usage. Example if the actual peak memory was 5GB, VPA's uncapped target may be 15GB. From local testing and the original issue; seems that `uncappedTarget` is abut 3x the actually memory used.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9521 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
VPA: Fixed OOM feedback loop that inflated uncappedTarget memory to 3x its actual usage.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
