### PR TITLE
GCE cloud provider: minor performance optimization for URL parsing and MIG caching

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_url.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url.go
@@ -112,9 +112,10 @@ func InstanceTemplateNameFromUrl(instanceTemplateLink string) (InstanceTemplateN
 	if err != nil {
 		return InstanceTemplateName{}, err
 	}
-	regional := IsInstanceTemplateRegional(templateUrl.String())
-
 	_, templateName := path.Split(templateUrl.EscapedPath())
+
+	regional := IsInstanceTemplateRegional(instanceTemplateLink)
+
 	return InstanceTemplateName{templateName, regional}, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/gce_url.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url.go
@@ -29,25 +29,31 @@ const (
 	anyHttpsUrlPattern = "https://.*/"
 )
 
-var regionalInstanceTemplateRe = regexp.MustCompile("(/projects/.*[A-Za-z0-9]+.*/regions/)")
+var (
+	regionalInstanceTemplateRe = regexp.MustCompile("(/projects/.*[A-Za-z0-9]+.*/regions/)")
+	migUrlRe                   = regexp.MustCompile(anyHttpsUrlPattern + "projects/(.*)/zones/(.*)/instanceGroups/(.*)")
+	igmUrlRe                   = regexp.MustCompile(anyHttpsUrlPattern + "projects/(.*)/zones/(.*)/instanceGroupManagers/(.*)")
+	igmRefUrlRe                = regexp.MustCompile("projects/(.*)/zones/(.*)/instanceGroupManagers/(.*)")
+	instanceUrlRe              = regexp.MustCompile(anyHttpsUrlPattern + "projects/(.*)/zones/(.*)/instances/(.*)")
+)
 
 // ParseMigUrl expects url in format:
 // https://.*/projects/<project-id>/zones/<zone>/instanceGroups/<name>
 func ParseMigUrl(url string) (project string, zone string, name string, err error) {
-	return parseGceUrl(anyHttpsUrlPattern, url, "instanceGroups")
+	return parseGceUrl(url, migUrlRe, anyHttpsUrlPattern, "instanceGroups")
 }
 
 // ParseIgmUrl expects url in format:
 // https://.*/<project-id>/zones/<zone>/instanceGroupManagers/<name>
 func ParseIgmUrl(url string) (project string, zone string, name string, err error) {
-	return parseGceUrl(anyHttpsUrlPattern, url, "instanceGroupManagers")
+	return parseGceUrl(url, igmUrlRe, anyHttpsUrlPattern, "instanceGroupManagers")
 }
 
 // ParseIgmUrlRef expects url in format:
 // projects/<project-id>/zones/<zone>/instanceGroupManagers/<name>
 // and returns a GceRef struct for it.
 func ParseIgmUrlRef(url string) (GceRef, error) {
-	project, zone, name, err := parseGceUrl("", url, "instanceGroupManagers")
+	project, zone, name, err := parseGceUrl(url, igmRefUrlRe, "", "instanceGroupManagers")
 	if err != nil {
 		return GceRef{}, err
 	}
@@ -61,14 +67,14 @@ func ParseIgmUrlRef(url string) (GceRef, error) {
 // ParseInstanceUrl expects url in format:
 // https://.*/<project-id>/zones/<zone>/instances/<name>
 func ParseInstanceUrl(url string) (project string, zone string, name string, err error) {
-	return parseGceUrl(anyHttpsUrlPattern, url, "instances")
+	return parseGceUrl(url, instanceUrlRe, anyHttpsUrlPattern, "instances")
 }
 
 // ParseInstanceUrlRef expects url in format:
 // https://.*/projects/<project-id>/zones/<zone>/instances/<name>
 // and returns a GceRef struct for it.
 func ParseInstanceUrlRef(url string) (GceRef, error) {
-	project, zone, name, err := parseGceUrl(anyHttpsUrlPattern, url, "instances")
+	project, zone, name, err := ParseInstanceUrl(url)
 	if err != nil {
 		return GceRef{}, err
 	}
@@ -112,16 +118,10 @@ func InstanceTemplateNameFromUrl(instanceTemplateLink string) (InstanceTemplateN
 	return InstanceTemplateName{templateName, regional}, nil
 }
 
-func parseGceUrl(prefix, url, expectedResource string) (project string, zone string, name string, err error) {
-	reg := regexp.MustCompile(prefix + "projects/.*/zones/.*/" + expectedResource + "/.*")
-	errMsg := fmt.Errorf("wrong url: expected format %sprojects/<project-id>/zones/<zone>/%s/<name>, got %s", prefix, expectedResource, url)
-	if !reg.MatchString(url) {
-		return "", "", "", errMsg
+func parseGceUrl(url string, re *regexp.Regexp, prefix, expectedResource string) (project string, zone string, name string, err error) {
+	subMatches := re.FindStringSubmatch(url)
+	if len(subMatches) < 4 {
+		return "", "", "", fmt.Errorf("wrong url: expected format %sprojects/<project-id>/zones/<zone>/%s/<name>, got %s", prefix, expectedResource, url)
 	}
-
-	subMatches := regexp.MustCompile(prefix + "projects/(.*)/zones/(.*)/" + expectedResource + "/(.*)").FindStringSubmatch(url)
-	project = subMatches[1]
-	zone = subMatches[2]
-	name = subMatches[3]
-	return project, zone, name, nil
+	return subMatches[1], subMatches[2], subMatches[3], nil
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_url.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url.go
@@ -29,6 +29,8 @@ const (
 	anyHttpsUrlPattern = "https://.*/"
 )
 
+var regionalInstanceTemplateRe = regexp.MustCompile("(/projects/.*[A-Za-z0-9]+.*/regions/)")
+
 // ParseMigUrl expects url in format:
 // https://.*/projects/<project-id>/zones/<zone>/instanceGroups/<name>
 func ParseMigUrl(url string) (project string, zone string, name string, err error) {
@@ -94,8 +96,8 @@ func GenerateMigUrl(domainUrl string, ref GceRef) string {
 }
 
 // IsInstanceTemplateRegional determines whether or not an instance template is regional based on the url
-func IsInstanceTemplateRegional(templateUrl string) (bool, error) {
-	return regexp.MatchString("(/projects/.*[A-Za-z0-9]+.*/regions/)", templateUrl)
+func IsInstanceTemplateRegional(templateUrl string) bool {
+	return regionalInstanceTemplateRe.MatchString(templateUrl)
 }
 
 // InstanceTemplateNameFromUrl retrieves name of the Instance Template from the url.
@@ -104,10 +106,7 @@ func InstanceTemplateNameFromUrl(instanceTemplateLink string) (InstanceTemplateN
 	if err != nil {
 		return InstanceTemplateName{}, err
 	}
-	regional, err := IsInstanceTemplateRegional(templateUrl.String())
-	if err != nil {
-		return InstanceTemplateName{}, err
-	}
+	regional := IsInstanceTemplateRegional(templateUrl.String())
 
 	_, templateName := path.Split(templateUrl.EscapedPath())
 	return InstanceTemplateName{templateName, regional}, nil

--- a/cluster-autoscaler/cloudprovider/gce/gce_url_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_url_test.go
@@ -312,7 +312,6 @@ func TestIsInstanceTemplateRegional(t *testing.T) {
 		name           string
 		templateUrl    string
 		expectRegional bool
-		wantErr        error
 	}{
 		{
 			name:           "Has regional instance url",
@@ -328,11 +327,7 @@ func TestIsInstanceTemplateRegional(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			regional, err := IsInstanceTemplateRegional(tt.templateUrl)
-			assert.Equal(t, tt.wantErr, err)
-			if tt.wantErr != nil {
-				return
-			}
+			regional := IsInstanceTemplateRegional(tt.templateUrl)
 			assert.Equal(t, tt.expectRegional, regional)
 		})
 	}

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -552,12 +552,8 @@ func (c *cachingMigInfoProvider) setMigInfoCache(migRef GceRef, mig *gce.Instanc
 	templateUrl, err := url.Parse(mig.InstanceTemplate)
 	if err == nil {
 		_, templateName := path.Split(templateUrl.EscapedPath())
-		regional, err := IsInstanceTemplateRegional(templateUrl.String())
-		if err != nil {
-			klog.Errorf("Error parsing instance template url: %v; err=%v ", templateUrl.String(), err)
-		} else {
-			c.cache.SetMigInstanceTemplateName(migRef, InstanceTemplateName{templateName, regional})
-		}
+		regional := IsInstanceTemplateRegional(templateUrl.String())
+		c.cache.SetMigInstanceTemplateName(migRef, InstanceTemplateName{templateName, regional})
 	}
 }
 

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -19,7 +19,6 @@ package gce
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"path"
 	"regexp"
 	"strings"
@@ -549,12 +548,9 @@ func (c *cachingMigInfoProvider) setMigInfoCache(migRef GceRef, mig *gce.Instanc
 	c.cache.SetListManagedInstancesResults(migRef, mig.ListManagedInstancesResults)
 	c.cache.SetMigInstancesStateCount(migRef, createInstancesStateCount(mig.TargetSize, mig.CurrentActions))
 
-	templateUrl, err := url.Parse(mig.InstanceTemplate)
-	if err == nil {
-		_, templateName := path.Split(templateUrl.EscapedPath())
-		regional := IsInstanceTemplateRegional(templateUrl.String())
-		c.cache.SetMigInstanceTemplateName(migRef, InstanceTemplateName{templateName, regional})
-	}
+	_, templateName := path.Split(mig.InstanceTemplate)
+	regional := IsInstanceTemplateRegional(mig.InstanceTemplate)
+	c.cache.SetMigInstanceTemplateName(migRef, InstanceTemplateName{templateName, regional})
 }
 
 func (c *cachingMigInfoProvider) GetMigIsStable(migRef GceRef) (bool, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR optimizes GCE URL parsing and GCE MIG caching by:
1. Precompiling regexes: Precompiles GCE URL regular expressions in `gce_url.go` to avoid runtime compilation. This also allows simplifying `IsInstanceTemplateRegional` to no longer return an error (since matching with a precompiled regex cannot fail).
2. Reducing allocations: Reduces string allocations in `mig_info_provider.go` when caching MIG information. It replaces a costly `url.Parse` call with a simpler `path.Split` on the raw URL string to extract the template name.

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:
n/a

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```