### PR TITLE
Implement RefreshMigInfo

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -284,7 +284,7 @@ func (m *gceManagerImpl) DeleteInstances(instances []GceRef) error {
 			return fmt.Errorf("cannot delete instances which don't belong to the same MIG.")
 		}
 	}
-	m.cache.InvalidateMigTargetSize(commonMig.GceRef())
+	m.migInfoProvider.RefreshMigInfo(commonMig.GceRef())
 	m.cache.InvalidateMigInstances(commonMig.GceRef())
 	return m.GceService.DeleteInstances(commonMig.GceRef(), instances)
 }

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -59,6 +59,8 @@ type MigInfoProvider interface {
 	GetListManagedInstancesResults(migRef GceRef) (string, error)
 	// GetMigIsStable returns whether given MIG is stable. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.
 	GetMigIsStable(migRef GceRef) (bool, error)
+	// RefreshMigInfo updates the cached information for a specific MIG without rebuilding the full zone cache
+	RefreshMigInfo(migRef GceRef) error
 }
 
 type timeProvider interface {
@@ -525,6 +527,11 @@ func (c *cachingMigInfoProvider) fillMigInfoCache() error {
 	}
 
 	return nil
+}
+
+// RefreshMigInfo updates the cached information for a specific MIG without rebuilding the full zone cache
+func (c *cachingMigInfoProvider) RefreshMigInfo(migRef GceRef) error {
+	return c.fillSingleMigInfo(migRef)
 }
 
 func (c *cachingMigInfoProvider) fillSingleMigInfo(migRef GceRef) error {

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -830,6 +830,59 @@ func TestGetMigTargetSize(t *testing.T) {
 	}
 }
 
+func TestRefreshMigInfo(t *testing.T) {
+	targetSize := int64(42)
+	instanceGroupManager := &gce.InstanceGroupManager{
+		Zone:       mig.GceRef().Zone,
+		Name:       mig.GceRef().Name,
+		TargetSize: targetSize,
+		SelfLink:   fmt.Sprintf("projects/%s/zones/%s/instanceGroups/%s", mig.GceRef().Project, mig.GceRef().Zone, mig.GceRef().Name),
+	}
+
+	testCases := []struct {
+		name               string
+		cache              *GceCache
+		migQuery           *gceMig
+		fetchMig           func(GceRef) (*gce.InstanceGroupManager, error)
+		expectedTargetSize int64
+		expectedErr        error
+	}{
+		{
+			name:               "refresh cache success",
+			cache:              emptyCache(),
+			fetchMig:           fetchMigConst(instanceGroupManager),
+			expectedTargetSize: targetSize,
+			migQuery:           mig,
+		},
+		{
+			name:        "refresh cache failure",
+			cache:       emptyCache(),
+			fetchMig:    fetchMigFail,
+			expectedErr: errFetchMig,
+			migQuery:    mig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &mockAutoscalingGceClient{
+				fetchMig: tc.fetchMig,
+			}
+			migLister := NewMigLister(tc.cache)
+			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, true)
+
+			err := provider.RefreshMigInfo(tc.migQuery.GceRef())
+			assert.Equal(t, tc.expectedErr, err)
+
+			cachedTargetSize, found := tc.cache.GetMigTargetSize(tc.migQuery.GceRef())
+			assert.Equal(t, tc.expectedErr == nil, found)
+			if tc.expectedErr == nil {
+				assert.Equal(t, tc.expectedTargetSize, cachedTargetSize)
+			}
+		})
+	}
+}
+
 func TestGetMigBasename(t *testing.T) {
 	basename := "base-instance-name"
 	instanceGroupManager := &gce.InstanceGroupManager{


### PR DESCRIPTION
Implement a public MigInfoProvider method to refresh a cached data for a single MIG.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This method adds a way to refresh cached info for a single MIG and calls it in DeleteInstances() implementation of GCE provider.   

When target size cache is cold, we refill mig info cache for all migs. This makes sense overall because we invalidate info cache for all MIGs every loop, but during scaledown this may lead to cache thrashing  as multiple goroutines delete instances from the same MIG concurrently. 

This change refreshes cached info for a single MIG proactively after a scaledown. This way we execute a single Get call instead of a List call next time the target size is accessed. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[GCE] Cached info for a MIG is refreshed proactively after a scaledown.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
