### PR TITLE
[GCE cloud provider] Do not list MIGs in GetMigTargetSize() when cache is warm

### DIFF
--- a/cluster-autoscaler/cloudprovider/gce/cache.go
+++ b/cluster-autoscaler/cloudprovider/gce/cache.go
@@ -343,6 +343,18 @@ func (gc *GceCache) SetMigTargetSize(ref GceRef, size int64) {
 	gc.migTargetSizeCache[ref] = size
 }
 
+// IsMigTargetSizeCacheEmpty returns true if no migs have a cached target size
+// A note on race conditions:
+// This check is done under a mutex which is released the moment the value is returned.
+// GceManager has access to GceCache and can invalidate or set target size for a specific MIG.
+// Only cachingMigInfoProvider can populate the whole mig target size cache, and it does it under its own migInfoMutex.
+func (gc *GceCache) IsMigTargetSizeCacheEmpty() bool {
+	gc.cacheMutex.Lock()
+	defer gc.cacheMutex.Unlock()
+
+	return len(gc.migTargetSizeCache) == 0
+}
+
 // InvalidateMigTargetSize clears the target size cache
 func (gc *GceCache) InvalidateMigTargetSize(ref GceRef) {
 	gc.cacheMutex.Lock()

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager.go
@@ -284,7 +284,7 @@ func (m *gceManagerImpl) DeleteInstances(instances []GceRef) error {
 			return fmt.Errorf("cannot delete instances which don't belong to the same MIG.")
 		}
 	}
-	m.migInfoProvider.RefreshMigInfo(commonMig.GceRef())
+	m.cache.InvalidateMigTargetSize(commonMig.GceRef())
 	m.cache.InvalidateMigInstances(commonMig.GceRef())
 	return m.GceService.DeleteInstances(commonMig.GceRef(), instances)
 }

--- a/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_manager_test.go
@@ -600,16 +600,8 @@ func TestGetAndSetMigSize(t *testing.T) {
 	// register another pool: extraPool2; pool uses mig in different zone
 	extraPool2Mig := setupTestExtraPool2(g, true)
 
-	// query for size of resized extraPool2Mig; execting API call refreshing target sizes
-	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers").Return(
-		buildListInstanceGroupManagersResponse(
-			buildListInstanceGroupManagersResponsePart(defaultPoolMigName, zoneB, 7),
-			buildListInstanceGroupManagersResponsePart(extraPoolMigName, zoneB, 8),
-		)).Once()
-	server.On("handle", "/projects/project1/zones/us-central1-c/instanceGroupManagers").Return(
-		buildListInstanceGroupManagersResponse(
-			buildListInstanceGroupManagersResponsePart(extraPool2MigName, zoneC, 9)),
-	).Once()
+	// query for size of resized extraPool2Mig; execting API call refreshing target size for this MIG
+	server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-c/instanceGroupManagers/%s", extraPool2MigName)).Return(buildInstanceGroupManagerResponse(zoneC, extraPool2MigName, 9)).Once()
 
 	extraPool2MigSize, err := g.GetMigSize(extraPool2Mig)
 	assert.NoError(t, err)
@@ -666,14 +658,10 @@ func TestGetMigSizeListCallFails(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(7), defaultPoolMigSize)
 
-	// Querying another mig will yet again try to list all migs
-	server.On("handle", "/projects/project1/zones/us-central1-b/instanceGroupManagers").Return(
-		buildListInstanceGroupManagersResponse(
-			buildListInstanceGroupManagersResponsePart(defaultPoolMigName, zoneB, 7),
-			buildListInstanceGroupManagersResponsePart(extraPoolMigName, zoneB, 8),
-		)).Once()
+	// Querying another mig will execute a Get for this mig
+	server.On("handle", fmt.Sprintf("/projects/project1/zones/us-central1-b/instanceGroupManagers/%s", extraPoolMigName)).Return(buildInstanceGroupManagerResponse(zoneB, extraPoolMigName, 8)).Once()
 
-	// getting size for defaultPoolMig should trigger listing all the InstanceGroupManagers
+	// getting size for extraPoolMig should trigger get call for this MIG
 	extraPoolMigSize, err := g.GetMigSize(extraPoolMig)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(8), extraPoolMigSize)

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -353,12 +353,21 @@ func (c *cachingMigInfoProvider) GetMigTargetSize(migRef GceRef) (int64, error) 
 		return targetSize, nil
 	}
 
-	err := c.fillMigInfoCache()
+	var err error
+	if c.cache.IsMigTargetSizeCacheEmpty() {
+		// Cache is cold after Refresh() -- list all MIGs and populate the cache.
+		err = c.fillMigInfoCache()
+	}
+
 	targetSize, found = c.cache.GetMigTargetSize(migRef)
-	if err == nil && found {
+	if found && err == nil {
 		return targetSize, nil
 	}
 
+	// We get here in one of 3 cases:
+	//  * InvalidateMigTargetSize was called for this specific mig, so it's not found in cache
+	//  * fillMigInfoCache returned an error
+	//  * MIG not found
 	err = c.fillSingleMigInfo(migRef)
 	if err != nil {
 		return 0, err

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider_test.go
@@ -830,6 +830,60 @@ func TestGetMigTargetSize(t *testing.T) {
 	}
 }
 
+func TestGetMigTargetSize_Optimization(t *testing.T) {
+	targetSize := int64(42)
+	igm := &gce.InstanceGroupManager{
+		TargetSize: targetSize,
+		SelfLink:   fmt.Sprintf("projects/%s/zones/%s/instanceGroups/%s", mig.GceRef().Project, mig.GceRef().Zone, mig.GceRef().Name),
+	}
+
+	testCases := []struct {
+		name                   string
+		cache                  *GceCache
+		shouldCallFetchAllMigs bool
+	}{
+		{
+			name:                   "cold cache",
+			cache:                  emptyCache(),
+			shouldCallFetchAllMigs: true,
+		},
+		{
+			name: "warm cache & cache hit",
+			cache: NewGceCache().
+				WithMigs(map[GceRef]Mig{mig.GceRef(): mig}).
+				WithMigTargetSize(map[GceRef]int64{mig.GceRef(): targetSize}),
+			shouldCallFetchAllMigs: false,
+		},
+		{
+			name: "warm cache & cache miss",
+			cache: NewGceCache().
+				WithMigs(map[GceRef]Mig{mig.GceRef(): mig, mig1.GceRef(): mig1}).
+				WithMigTargetSize(map[GceRef]int64{mig1.GceRef(): targetSize}),
+			shouldCallFetchAllMigs: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fetchAllMigsCalled := false
+			client := &mockAutoscalingGceClient{
+				fetchMigs: func(zone string) ([]*gce.InstanceGroupManager, error) {
+					fetchAllMigsCalled = true
+					return []*gce.InstanceGroupManager{igm}, nil
+				},
+				fetchMig: fetchMigConst(igm),
+			}
+			migLister := NewMigLister(tc.cache)
+			provider := NewCachingMigInfoProvider(tc.cache, migLister, client, mig.GceRef().Project, 1, 0*time.Second, false, true)
+
+			size, err := provider.GetMigTargetSize(mig.GceRef())
+			assert.NoError(t, err)
+			assert.Equal(t, targetSize, size)
+			assert.Equal(t, tc.shouldCallFetchAllMigs, fetchAllMigsCalled, "FetchAllMigs call status mismatch")
+		})
+	}
+}
+
 func TestRefreshMigInfo(t *testing.T) {
 	targetSize := int64(42)
 	instanceGroupManager := &gce.InstanceGroupManager{


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Fixes a bug introduced in https://github.com/kubernetes/autoscaler/pull/9915 - refreshing mig info cache is done before instances are deleted, which does nothing useful.

This PR reverts changes to DeleteInstances() implementation in GCE cloud provider introduced by the PR above, and modifies GetMigTargetSize to ensure that MIGs are listed only if cache is cold.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[GCE] If MIG info cache is warm, do not refill the whole cache on cache miss. Fetch info for a single MIG  instead.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
