### PR TITLE
recommender: defer pod deletion until after metrics are loaded

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -476,9 +476,6 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 
 // LoadPods loads pod into the cluster state.
 func (feeder *clusterStateFeeder) LoadPods() {
-	// Clean up any pending deletions from a previous iteration in case the caller forgot.
-	feeder.DeleteRemovedPods()
-
 	podSpecs, err := feeder.specClient.GetPodSpecs()
 	if err != nil {
 		klog.ErrorS(err, "Cannot get SimplePodSpecs, skipping LoadPods cycle")

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -73,6 +73,9 @@ type ClusterStateFeeder interface {
 	// LoadRealTimeMetrics updates clusterState with current usage metrics of containers.
 	LoadRealTimeMetrics(ctx context.Context)
 
+	// DeleteRemovedPods deletes pods that were identified as removed in the last LoadPods call.
+	DeleteRemovedPods()
+
 	// GarbageCollectCheckpoints removes historical checkpoints that don't have a matching VPA.
 	GarbageCollectCheckpoints(ctx context.Context)
 }
@@ -224,6 +227,7 @@ type clusterStateFeeder struct {
 	recommenderName     string
 	ignoredNamespaces   []string
 	vpaObjectNamespace  string
+	podsToDelete        []model.PodID
 }
 
 func (feeder *clusterStateFeeder) InitFromHistoryProvider(historyProvider history.HistoryProvider) {
@@ -472,6 +476,9 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 
 // LoadPods loads pod into the cluster state.
 func (feeder *clusterStateFeeder) LoadPods() {
+	// Clean up any pending deletions from a previous iteration in case the caller forgot.
+	feeder.DeleteRemovedPods()
+
 	podSpecs, err := feeder.specClient.GetPodSpecs()
 	if err != nil {
 		klog.ErrorS(err, "Cannot get SimplePodSpecs, skipping LoadPods cycle")
@@ -481,10 +488,12 @@ func (feeder *clusterStateFeeder) LoadPods() {
 	for _, spec := range podSpecs {
 		pods[spec.ID] = spec
 	}
+	feeder.podsToDelete = nil
 	for key := range feeder.clusterState.Pods() {
+		// The pods aren't deleted from the clusterState while loading pods since OomInfo from these removed containers
+		// may still need to be processed. We delete these pods after the OomInfo is processed.
 		if _, exists := pods[key]; !exists {
-			klog.V(3).InfoS("Deleting Pod", "pod", klog.KRef(key.Namespace, key.PodName))
-			feeder.clusterState.DeletePod(key)
+			feeder.podsToDelete = append(feeder.podsToDelete, key)
 		}
 	}
 	for _, pod := range pods {
@@ -505,6 +514,15 @@ func (feeder *clusterStateFeeder) LoadPods() {
 			klog.V(0).InfoS("Failed to set init containers", "pod", klog.KRef(pod.ID.Namespace, pod.ID.PodName), "error", err)
 		}
 	}
+}
+
+// DeleteRemovedPods deletes pods that were identified as removed in the last LoadPods call.
+func (feeder *clusterStateFeeder) DeleteRemovedPods() {
+	for _, key := range feeder.podsToDelete {
+		klog.V(3).InfoS("Deleting Pod", "pod", klog.KRef(key.Namespace, key.PodName))
+		feeder.clusterState.DeletePod(key)
+	}
+	feeder.podsToDelete = nil
 }
 
 func (feeder *clusterStateFeeder) LoadRealTimeMetrics(ctx context.Context) {

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -96,6 +96,7 @@ type ClusterStateFeederFactory struct {
 	RecommenderName     string
 	IgnoredNamespaces   []string
 	VpaObjectNamespace  string
+	podsToDelete        []model.PodID
 }
 
 // Make creates new ClusterStateFeeder with internal data providers, based on kube client.
@@ -115,6 +116,7 @@ func (m ClusterStateFeederFactory) Make() *clusterStateFeeder {
 		recommenderName:     m.RecommenderName,
 		ignoredNamespaces:   m.IgnoredNamespaces,
 		vpaObjectNamespace:  m.VpaObjectNamespace,
+		podsToDelete:        m.podsToDelete,
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -38,6 +38,7 @@ import (
 	fakeautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/typed/autoscaling.k8s.io/v1/fake"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/metrics"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/oom"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/spec"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
@@ -548,37 +549,6 @@ func TestClusterStateFeeder_LoadPods_PodDeletion(t *testing.T) {
 	assert.NotContains(t, feeder.clusterState.Pods(), pod2ID)
 }
 
-func TestClusterStateFeeder_LoadPods_PodDeletionSafeguard(t *testing.T) {
-	pod1ID := model.PodID{Namespace: "default", PodName: "Pod1"}
-	pod1 := newTestPodSpec(pod1ID, nil, nil)
-	pod2ID := model.PodID{Namespace: "default", PodName: "Pod2"}
-	pod2 := newTestPodSpec(pod2ID, nil, nil)
-
-	client := &testSpecClient{pods: []*spec.BasicPodSpec{pod1, pod2}}
-	clusterState := model.NewClusterState(testGcPeriod)
-
-	feeder := clusterStateFeeder{
-		specClient:     client,
-		memorySaveMode: false,
-		clusterState:   clusterState,
-	}
-
-	feeder.LoadPods()
-	assert.Len(t, feeder.clusterState.Pods(), 2)
-
-	client.pods = []*spec.BasicPodSpec{pod1}
-	feeder.LoadPods()
-
-	// Without calling DeleteRemovedPods(), pod2 still exists.
-	assert.Len(t, feeder.clusterState.Pods(), 2)
-	assert.Contains(t, feeder.clusterState.Pods(), pod2ID)
-
-	// Calling LoadPods() again (next cycle) should trigger the safeguard and delete pod2.
-	feeder.LoadPods()
-	assert.Len(t, feeder.clusterState.Pods(), 1)
-	assert.NotContains(t, feeder.clusterState.Pods(), pod2ID)
-}
-
 func TestClusterStateFeeder_LoadPods_MemorySaverMode(t *testing.T) {
 	for _, tc := range []struct {
 		Name              string
@@ -767,6 +737,95 @@ func TestClusterStateFeeder_LoadRealTimeMetrics(t *testing.T) {
 
 	_, samplesForExtraContainerExist := clusterState.addedSamples[extraContainer]
 	assert.False(t, samplesForExtraContainerExist)
+}
+
+func TestClusterStateFeeder_LoadRealTimeMetrics_OOMEventsWithDeletedPods(t *testing.T) {
+	_, tctx := ktesting.NewTestContext(t)
+	pod1ID := model.PodID{Namespace: "default", PodName: "Pod1"}
+	pod2ID := model.PodID{Namespace: "default", PodName: "Pod2"}
+
+	containerSpecs1 := []spec.BasicContainerSpec{
+		newTestContainerSpec(pod1ID, "containerA", 500, 512*1024*1024),
+	}
+	pod1 := newTestPodSpec(pod1ID, containerSpecs1, nil)
+
+	containerSpecs2 := []spec.BasicContainerSpec{
+		newTestContainerSpec(pod2ID, "containerB", 500, 512*1024*1024),
+	}
+	pod2 := newTestPodSpec(pod2ID, containerSpecs2, nil)
+
+	client := &testSpecClient{pods: []*spec.BasicPodSpec{pod1, pod2}}
+	clusterState := model.NewClusterState(testGcPeriod)
+	oomChan := make(chan oom.OomInfo, 10)
+
+	feeder := clusterStateFeeder{
+		specClient:     client,
+		memorySaveMode: false,
+		clusterState:   clusterState,
+		oomChan:        oomChan,
+		metricsClient:  fakeMetricsClient{snapshots: nil},
+	}
+
+	// Add two pods to the clusterState.
+	feeder.LoadPods()
+	assert.Len(t, feeder.clusterState.Pods(), 2)
+
+	// Add OOM events for both pods to the oomChan.
+	timestamp1 := time.Now()
+	oomChan <- oom.OomInfo{
+		Timestamp:   timestamp1,
+		Memory:      model.ResourceAmount(1024 * 1024 * 1024),
+		ContainerID: model.ContainerID{PodID: pod1ID, ContainerName: "containerA"},
+	}
+	oomChan <- oom.OomInfo{
+		Timestamp:   timestamp1,
+		Memory:      model.ResourceAmount(1024 * 1024 * 1024),
+		ContainerID: model.ContainerID{PodID: pod2ID, ContainerName: "containerB"},
+	}
+
+	feeder.LoadRealTimeMetrics(tctx)
+
+	// Asserting both OomInfo has been processed.
+	c1State := feeder.clusterState.GetContainer(model.ContainerID{PodID: pod1ID, ContainerName: "containerA"})
+	c2State := feeder.clusterState.GetContainer(model.ContainerID{PodID: pod2ID, ContainerName: "containerB"})
+	assert.NotNil(t, c1State)
+	assert.NotNil(t, c2State)
+	assert.Greater(t, int64(c1State.GetMaxMemoryPeak()), int64(0))
+	assert.Greater(t, int64(c2State.GetMaxMemoryPeak()), int64(0))
+
+	// Add new higher memory OOM events to oomChan for both pods
+	timestamp2 := timestamp1.Add(time.Minute)
+	oomChan <- oom.OomInfo{
+		Timestamp:   timestamp2,
+		Memory:      model.ResourceAmount(2048 * 1024 * 1024),
+		ContainerID: model.ContainerID{PodID: pod1ID, ContainerName: "containerA"},
+	}
+	oomChan <- oom.OomInfo{
+		Timestamp:   timestamp2,
+		Memory:      model.ResourceAmount(2048 * 1024 * 1024),
+		ContainerID: model.ContainerID{PodID: pod2ID, ContainerName: "containerB"},
+	}
+
+	// Remove pod2 from spec client, simulating its eviction.
+	client.pods = []*spec.BasicPodSpec{pod1}
+	feeder.LoadPods()
+
+	// Pod2 should still exist in clusterState.
+	assert.Len(t, feeder.clusterState.Pods(), 2)
+	assert.Contains(t, feeder.clusterState.Pods(), pod2ID)
+
+	peak1Before := c1State.GetMaxMemoryPeak()
+	peak2Before := c2State.GetMaxMemoryPeak()
+
+	// Load Real-time metrics. OomInfo of Pod2 must be processed.
+	feeder.LoadRealTimeMetrics(tctx)
+	assert.Greater(t, int64(c1State.GetMaxMemoryPeak()), int64(peak1Before))
+	assert.Greater(t, int64(c2State.GetMaxMemoryPeak()), int64(peak2Before))
+
+	// Call DeleteRemovedPods to delete pod2.
+	feeder.DeleteRemovedPods()
+	assert.Len(t, feeder.clusterState.Pods(), 1)
+	assert.NotContains(t, feeder.clusterState.Pods(), pod2ID)
 }
 
 type fakeHistoryProvider struct {

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -517,6 +517,68 @@ func TestClusterStateFeeder_LoadPods_ContainerTracking(t *testing.T) {
 	assert.Equal(t, len(feeder.clusterState.Pods()[podWithoutInitContainersID].InitContainers), 0)
 }
 
+func TestClusterStateFeeder_LoadPods_PodDeletion(t *testing.T) {
+	pod1ID := model.PodID{Namespace: "default", PodName: "Pod1"}
+	pod1 := newTestPodSpec(pod1ID, nil, nil)
+	pod2ID := model.PodID{Namespace: "default", PodName: "Pod2"}
+	pod2 := newTestPodSpec(pod2ID, nil, nil)
+
+	client := &testSpecClient{pods: []*spec.BasicPodSpec{pod1, pod2}}
+	clusterState := model.NewClusterState(testGcPeriod)
+
+	feeder := clusterStateFeeder{
+		specClient:     client,
+		memorySaveMode: false,
+		clusterState:   clusterState,
+	}
+
+	feeder.LoadPods()
+	assert.Len(t, feeder.clusterState.Pods(), 2)
+
+	client.pods = []*spec.BasicPodSpec{pod1}
+	feeder.LoadPods()
+
+	// Since deletion is shifted, pod2 should still exist in clusterState.
+	assert.Len(t, feeder.clusterState.Pods(), 2)
+	assert.Contains(t, feeder.clusterState.Pods(), pod2ID)
+
+	feeder.DeleteRemovedPods()
+	// Now pod2 should be deleted.
+	assert.Len(t, feeder.clusterState.Pods(), 1)
+	assert.NotContains(t, feeder.clusterState.Pods(), pod2ID)
+}
+
+func TestClusterStateFeeder_LoadPods_PodDeletionSafeguard(t *testing.T) {
+	pod1ID := model.PodID{Namespace: "default", PodName: "Pod1"}
+	pod1 := newTestPodSpec(pod1ID, nil, nil)
+	pod2ID := model.PodID{Namespace: "default", PodName: "Pod2"}
+	pod2 := newTestPodSpec(pod2ID, nil, nil)
+
+	client := &testSpecClient{pods: []*spec.BasicPodSpec{pod1, pod2}}
+	clusterState := model.NewClusterState(testGcPeriod)
+
+	feeder := clusterStateFeeder{
+		specClient:     client,
+		memorySaveMode: false,
+		clusterState:   clusterState,
+	}
+
+	feeder.LoadPods()
+	assert.Len(t, feeder.clusterState.Pods(), 2)
+
+	client.pods = []*spec.BasicPodSpec{pod1}
+	feeder.LoadPods()
+
+	// Without calling DeleteRemovedPods(), pod2 still exists.
+	assert.Len(t, feeder.clusterState.Pods(), 2)
+	assert.Contains(t, feeder.clusterState.Pods(), pod2ID)
+
+	// Calling LoadPods() again (next cycle) should trigger the safeguard and delete pod2.
+	feeder.LoadPods()
+	assert.Len(t, feeder.clusterState.Pods(), 1)
+	assert.NotContains(t, feeder.clusterState.Pods(), pod2ID)
+}
+
 func TestClusterStateFeeder_LoadPods_MemorySaverMode(t *testing.T) {
 	for _, tc := range []struct {
 		Name              string

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -178,6 +178,10 @@ func (r *recommender) RunOnce() {
 
 	r.clusterStateFeeder.LoadRealTimeMetrics(ctx)
 	timer.ObserveStep("LoadMetrics")
+
+	r.clusterStateFeeder.DeleteRemovedPods()
+	timer.ObserveStep("DeleteRemovedPods")
+
 	klog.V(3).InfoS("ClusterState is tracking", "pods", len(r.clusterState.Pods()), "vpas", len(r.clusterState.VPAs()))
 
 	r.UpdateVPAs()


### PR DESCRIPTION
Shifts the deletion of terminated pods to execute after LoadRealTimeMetrics. This prevents missing OOM events for pods that are removed from the spec before their OOM events can be processed.

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, in the recommender’s run loop (`RunOnce`), `LoadPods` runs before `LoadRealTimeMetrics`. When a pod terminates, it is removed from the cluster representation during `LoadPods`. However, OOM events for these terminated containers are processed in the subsequent `LoadRealTimeMetrics` step. Because the containers are sometimes deleted from the model before their OOM events can be recorded, these events are dropped, causing the recommender to miss critical OOM events.

To resolve this, this PR defers the deletion of removed pods to run after real-time metrics and OOMs have been processed.
#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/autoscaler/issues/6705
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
