### PR TITLE
[Scaledown] Implement two-pass unneded node evaluation

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -385,6 +385,8 @@ type AutoscalingOptions struct {
 	PendingPodsBatchingTimeout time.Duration
 	// GracefulDegradationEnabled tells if graceful degradation for unschedulable pods is enabled.
 	GracefulDegradationEnabled bool
+	// HighThroughputScaledownEnabled enables the scaledown throughput optimizations
+	HighThroughputScaledownEnabled bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -106,15 +106,16 @@ var (
 			"for scale down when some candidates from previous iteration are no longer valid."+
 			"When calculating the pool size for additional candidates we take"+
 			"max(#nodes * scale-down-candidates-pool-ratio, scale-down-candidates-pool-min-count).")
-	schedulerConfigFile         = flag.String(config.SchedulerConfigFileFlag, "", "scheduler-config allows changing configuration of in-tree scheduler plugins acting on PreFilter and Filter extension points")
-	nodeDeletionDelayTimeout    = flag.Duration("node-deletion-delay-timeout", 2*time.Minute, "Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node.")
-	nodeDeletionBatcherInterval = flag.Duration("node-deletion-batcher-interval", 0*time.Second, "How long CA ScaleDown gather nodes to delete them in batch.")
-	scanInterval                = flag.Duration("scan-interval", config.DefaultScanInterval, "How often cluster is reevaluated for scale up or down")
-	maxNodesTotal               = flag.Int("max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
-	coresTotal                  = flag.String("cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
-	memoryTotal                 = flag.String("memory-total", minMaxFlagString(0, config.DefaultMaxClusterMemory), "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
-	gpuTotal                    = multiStringFlag("gpu-total", "Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE.")
-	cloudProviderFlag           = flag.String("cloud-provider", cloudBuilder.DefaultCloudProvider(),
+	highThroughputScaleDownEnabled = flag.Bool("high-throughput-scaledown-enabled", false, "Whether to enable high-throughput scaledown changes, which include increased scaledown parallelism, KCP QPS, evaluate empty nodes before non-empty ones, and async failed taints cleanup.")
+	schedulerConfigFile            = flag.String(config.SchedulerConfigFileFlag, "", "scheduler-config allows changing configuration of in-tree scheduler plugins acting on PreFilter and Filter extension points")
+	nodeDeletionDelayTimeout       = flag.Duration("node-deletion-delay-timeout", 2*time.Minute, "Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node.")
+	nodeDeletionBatcherInterval    = flag.Duration("node-deletion-batcher-interval", 0*time.Second, "How long CA ScaleDown gather nodes to delete them in batch.")
+	scanInterval                   = flag.Duration("scan-interval", config.DefaultScanInterval, "How often cluster is reevaluated for scale up or down")
+	maxNodesTotal                  = flag.Int("max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
+	coresTotal                     = flag.String("cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
+	memoryTotal                    = flag.String("memory-total", minMaxFlagString(0, config.DefaultMaxClusterMemory), "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
+	gpuTotal                       = multiStringFlag("gpu-total", "Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE.")
+	cloudProviderFlag              = flag.String("cloud-provider", cloudBuilder.DefaultCloudProvider(),
 		"Cloud provider type. Available values: ["+strings.Join(cloudBuilder.AvailableCloudProviders(), ",")+"]")
 	maxBulkSoftTaintCount      = flag.Int("max-bulk-soft-taint-count", 10, "Maximum number of nodes that can be tainted/untainted PreferNoSchedule at the same time. Set to 0 to turn off such tainting.")
 	maxBulkSoftTaintTime       = flag.Duration("max-bulk-soft-taint-time", 3*time.Second, "Maximum duration of tainting/untainting nodes as PreferNoSchedule at the same time.")
@@ -381,6 +382,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ScaleDownNonEmptyCandidatesCount: *scaleDownNonEmptyCandidatesCount,
 		ScaleDownCandidatesPoolRatio:     *scaleDownCandidatesPoolRatio,
 		ScaleDownCandidatesPoolMinCount:  *scaleDownCandidatesPoolMinCount,
+		HighThroughputScaledownEnabled:   *highThroughputScaleDownEnabled,
 		DrainPriorityConfig:              drainPriorityConfigMap,
 		SchedulerConfig:                  parsedSchedConfig,
 		WriteStatusConfigMap:             *writeStatusConfigMapFlag,

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/utilization"
@@ -297,7 +298,37 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 	}
 	p.nodeUtilizationMap = utilizationMap
 	timer := time.NewTimer(p.autoscalingCtx.ScaleDownSimulationTimeout)
+	defer timer.Stop()
 	var skippedNodes []string
+
+	if p.autoscalingCtx.AutoscalingOptions.HighThroughputScaledownEnabled {
+		// Nodes that have pods to reschedule require binpacking simulations and are slower to categorize.
+		// To process as many nodes within ScaleDownSimulationTimeout as possible,
+		// we want to first evaluate any nodes that have no pods to reschedule ("empty nodes"),
+		// and then evaluate the rest of the nodes.
+		var emptyNodes []string
+		var nonEmptyNodes []string
+		for _, nodeName := range currentlyUnneededNodeNames {
+			nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+			if err != nil {
+				nonEmptyNodes = append(nonEmptyNodes, nodeName)
+				continue
+			}
+
+			// If a node has pods that are neither daemonsets nor static pods, those pods may need to be rescheduled on other nodes,
+			// and binpacking simulations for such nodes can be expensive.
+			if nodeMayHavePodsToReschedule(nodeInfo) {
+				nonEmptyNodes = append(nonEmptyNodes, nodeName)
+				continue
+			}
+			// If a node has only daemonsets and static pods, there's nothing to reschedule.
+			// Binpacking simulations for such nodes are cheap.
+			emptyNodes = append(emptyNodes, nodeName)
+
+		}
+		// Nodes that are quick to categorize come first.
+		currentlyUnneededNodeNames = append(emptyNodes, nonEmptyNodes...)
+	}
 
 	for i, node := range currentlyUnneededNodeNames {
 		if timedOut(timer) {
@@ -335,6 +366,19 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 	if unremovableCount > 0 {
 		klog.V(1).Infof("%v nodes found to be unremovable in simulation, will re-check them at %v", unremovableCount, unremovableTimeout)
 	}
+}
+
+// nodeMayHavePodsToReschedule returns true if a node has at least one pod that's neither a daemonset nor a static pod.
+func nodeMayHavePodsToReschedule(nodeInfo *framework.NodeInfo) bool {
+	hasPodsToReschedule := false
+	for _, podInfo := range nodeInfo.Pods() {
+		// "mirror pod" is synonymous with "static pod"
+		if !pod_util.IsDaemonSetPod(podInfo.Pod) && !pod_util.IsMirrorPod(podInfo.Pod) {
+			hasPodsToReschedule = true
+			break
+		}
+	}
+	return hasPodsToReschedule
 }
 
 // atomicScaleDownNode checks if the removable node would be considered for atomic scale down.

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -1262,14 +1262,16 @@ func (f *fakeEligibilityChecker) FilterOutUnremovable(autoscalingCtx *ca_context
 }
 
 type fakeRemovalSimulator struct {
-	nodes []*apiv1.Node
-	sleep time.Duration
+	nodes          []*apiv1.Node
+	sleep          time.Duration
+	evaluatedNodes []string
 }
 
 func (r *fakeRemovalSimulator) DropOldHints() {}
 
 func (r *fakeRemovalSimulator) SimulateNodeRemoval(name string, _ map[string]bool, _ time.Time, _ pdb.RemainingPdbTracker) (*simulator.NodeToBeRemoved, *simulator.UnremovableNode) {
 	time.Sleep(r.sleep)
+	r.evaluatedNodes = append(r.evaluatedNodes, name)
 	node := &apiv1.Node{}
 	for _, n := range r.nodes {
 		if n.Name == name {
@@ -1299,4 +1301,169 @@ func TestAtomicScaleDownNodeNilGroup(t *testing.T) {
 
 	result := p.atomicScaleDownNode(node)
 	assert.False(t, result)
+}
+func TestScaledownThroughputOptimizations(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		highThroughputEnabled bool
+		setupNodes            func() []*apiv1.Node
+		setupPods             func() []*apiv1.Pod
+		setupSnapshotNodes    func([]*apiv1.Node) []*apiv1.Node
+		verify                func(t *testing.T, evaluatedNodes []string)
+	}{
+		{
+			name:                  "Enabled - Empty node prioritized",
+			highThroughputEnabled: true,
+			setupNodes: func() []*apiv1.Node {
+				return []*apiv1.Node{
+					BuildTestNode("n1", 1000, 1000),
+					BuildTestNode("n2", 1000, 1000),
+					BuildTestNode("n3", 1000, 1000),
+				}
+			},
+			setupPods: func() []*apiv1.Pod {
+				return []*apiv1.Pod{
+					BuildScheduledTestPod("p1", 500, 1, "n1"),
+					BuildScheduledTestPod("p2", 500, 1, "n3"),
+				}
+			},
+			setupSnapshotNodes: func(nodes []*apiv1.Node) []*apiv1.Node {
+				return nodes
+			},
+			verify: func(t *testing.T, evaluatedNodes []string) {
+				assert.Equal(t, 3, len(evaluatedNodes))
+				if len(evaluatedNodes) > 0 {
+					assert.Equal(t, "n2", evaluatedNodes[0])
+				}
+			},
+		},
+		{
+			name:                  "Disabled - Nodes evaluated in order",
+			highThroughputEnabled: false,
+			setupNodes: func() []*apiv1.Node {
+				return []*apiv1.Node{
+					BuildTestNode("n1", 1000, 1000),
+					BuildTestNode("n2", 1000, 1000),
+					BuildTestNode("n3", 1000, 1000),
+				}
+			},
+			setupPods: func() []*apiv1.Pod {
+				return []*apiv1.Pod{
+					BuildScheduledTestPod("p1", 500, 1, "n1"),
+					BuildScheduledTestPod("p2", 500, 1, "n3"),
+				}
+			},
+			setupSnapshotNodes: func(nodes []*apiv1.Node) []*apiv1.Node {
+				return nodes
+			},
+			verify: func(t *testing.T, evaluatedNodes []string) {
+				assert.Equal(t, 3, len(evaluatedNodes))
+				if len(evaluatedNodes) > 0 {
+					assert.Equal(t, "n1", evaluatedNodes[0])
+				}
+			},
+		},
+		{
+			name:                  "Enabled - GetNodeInfo Error",
+			highThroughputEnabled: true,
+			setupNodes: func() []*apiv1.Node {
+				return []*apiv1.Node{
+					BuildTestNode("n1", 1000, 1000),
+					BuildTestNode("n2", 1000, 1000),
+					BuildTestNode("n3", 1000, 1000),
+				}
+			},
+			setupPods: func() []*apiv1.Pod {
+				return []*apiv1.Pod{}
+			},
+			setupSnapshotNodes: func(nodes []*apiv1.Node) []*apiv1.Node {
+				// We do NOT add n1 to the cluster snapshot, so GetNodeInfo(n1) will return an error
+				return []*apiv1.Node{nodes[1], nodes[2]}
+			},
+			verify: func(t *testing.T, evaluatedNodes []string) {
+				assert.Equal(t, 3, len(evaluatedNodes))
+				if len(evaluatedNodes) == 3 {
+					assert.NotEqual(t, "n1", evaluatedNodes[0])
+					assert.Equal(t, "n1", evaluatedNodes[2])
+				}
+			},
+		},
+		{
+			name:                  "Enabled - Topology",
+			highThroughputEnabled: true,
+			setupNodes: func() []*apiv1.Node {
+				n1 := BuildTestNode("n1", 1000, 1000)
+				n2 := BuildTestNode("n2", 1000, 1000)
+				n3 := BuildTestNode("n3", 1000, 1000)
+				n1.Labels = map[string]string{"topology.kubernetes.io/zone": "zone-a"}
+				n2.Labels = map[string]string{"topology.kubernetes.io/zone": "zone-b"}
+				n3.Labels = map[string]string{"topology.kubernetes.io/zone": "zone-c"}
+				return []*apiv1.Node{n1, n2, n3}
+			},
+			setupPods: func() []*apiv1.Pod {
+				// n1 will be non-empty, n2 and n3 will be empty
+				return []*apiv1.Pod{
+					BuildScheduledTestPod("p1", 500, 1, "n1"),
+				}
+			},
+			setupSnapshotNodes: func(nodes []*apiv1.Node) []*apiv1.Node {
+				return nodes
+			},
+			verify: func(t *testing.T, evaluatedNodes []string) {
+				assert.Equal(t, 3, len(evaluatedNodes))
+				if len(evaluatedNodes) == 3 {
+					assert.True(t, evaluatedNodes[0] == "n2" || evaluatedNodes[0] == "n3")
+					assert.True(t, evaluatedNodes[1] == "n2" || evaluatedNodes[1] == "n3")
+					assert.Equal(t, "n1", evaluatedNodes[2])
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			nodes := tc.setupNodes()
+			pods := tc.setupPods()
+			snapshotNodes := tc.setupSnapshotNodes(nodes)
+
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
+			provider.AddNodeGroup("ng1", 0, 0, 0)
+			for _, n := range nodes {
+				provider.AddNode("ng1", n)
+			}
+
+			autoscalingOptions := config.AutoscalingOptions{
+				HighThroughputScaledownEnabled: tc.highThroughputEnabled,
+				ScaleDownSimulationTimeout:     5 * time.Minute,
+				MaxScaleDownParallelism:        10,
+			}
+			processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(autoscalingOptions)
+			autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOptions, &fake.Clientset{}, nil, provider, nil, nil, templateNodeInfoRegistry)
+			assert.NoError(t, err)
+
+			// We skip ListerRegistry.Stop() here as it caused compilation issues, and test setup teardown is handled differently if needed.
+
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, snapshotNodes, pods)
+
+			deleteOptions := options.NodeDeleteOptions{}
+			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
+			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
+
+			rs := &fakeRemovalSimulator{
+				nodes: nodes,
+			}
+			p.rs = rs
+
+			eligible := map[string]bool{}
+			for _, n := range nodes {
+				eligible[n.Name] = true
+			}
+			p.eligibilityChecker = &fakeEligibilityChecker{eligible: eligible}
+
+			err = p.UpdateClusterState(nodes, nodes, &fakeActuationStatus{}, time.Now())
+			assert.NoError(t, err)
+
+			tc.verify(t, rs.evaluatedNodes)
+		})
+	}
 }


### PR DESCRIPTION
First find all empty nodes, then continue to binpacking. This allows us to process more nodes within timeout.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This change adds
1.  A feature flag for high-thoughput scaledown optimizations 
2. In categorizeNodes(), pre-selects nodes that do not have pods to reschedule so that we can categorize as many nodes as possible within timeout.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --high-throughput-scaledown-enabled feature flag. Speed up categorizing uneeded nodes in scaledown by evaluating nodes that do not have pods to reschedule before other nodes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
