### PR TITLE
VPA: Pods should not get into an eviction loop when a Pod LimitRange object is present

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -19,6 +19,8 @@ package api
 import (
 	"errors"
 	"fmt"
+	"math"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -107,6 +109,7 @@ func (c *cappingRecommendationProcessor) Apply(
 		}
 		updatedRecommendations = append(updatedRecommendations, *updatedContainerResources)
 	}
+	updatedRecommendations = ensureBoundsAreValid(updatedRecommendations)
 	return &vpa_types.RecommendedPodResources{ContainerRecommendations: updatedRecommendations}, containerToAnnotationsMap, nil
 }
 
@@ -536,3 +539,210 @@ func (c *cappingRecommendationProcessor) capProportionallyToPodLimitRange(
 	containerRecommendations = applyPodLimitRange(containerRecommendations, pod, *podLimitRange, corev1.ResourceMemory, getLower)
 	return containerRecommendations, nil
 }
+
+// ensureBoundsAreValid ensures that for each container-level recommendation,
+// LowerBound <= Target <= UpperBound always holds.
+//
+// The function treats Target as the reference value and adjusts LowerBound
+// and UpperBound as needed to maintain valid bounds.
+//
+// When a violation occurs, for example when a container's UpperBound is lower than its Target,
+// the function caps the UpperBound to its Target to fix the violation.
+// Because we need to keep the sum of all UpperBounds the same as before,
+// we subtract the delta (calculated as Target - UpperBound in this case) proportionally across other containers.
+//
+// When there is a violation between a LowerBound and Target, the delta is proportionally distributed among containers where there is room to do so.
+func ensureBoundsAreValid(recs []vpa_types.RecommendedContainerResources) []vpa_types.RecommendedContainerResources {
+	// fixBound repairs violations of isBoundValid for a single resource/bound pair (e.g. "CPU LowerBound")
+	fixBound := func(
+		getBound func(vpa_types.RecommendedContainerResources) *corev1.ResourceList,
+		resourceName corev1.ResourceName,
+		isBoundValid func(bound, target resource.Quantity) bool,
+		subtract bool,
+	) {
+		var total resource.Quantity
+		// This variable contains the value to redistribute across containers without violations.
+		// Redistribution is done proportionally by increasing or decreasing values based on available capacity.
+		var totalDelta float64
+		eligibleIdxs := make([]int, 0, len(recs))
+
+		for i := range recs {
+			target, targetOK := (*getTarget(recs[i]))[resourceName]
+			boundRL := getBound(recs[i])
+			bound, boundOK := (*boundRL)[resourceName]
+			if !targetOK || !boundOK {
+				continue
+			}
+			if !isBoundValid(bound, target) {
+				totalDelta += math.Abs(float64(scalarValue(target, resourceName) - scalarValue(bound, resourceName)))
+				// Fix the violation for a container,
+				// in other words, set its LowerBound or UpperBound equal to the target
+				(*boundRL)[resourceName] = target
+				continue
+			}
+			eligibleIdxs = append(eligibleIdxs, i)
+			total.Add(bound)
+		}
+
+		if totalDelta == 0 || len(eligibleIdxs) == 0 || total.IsZero() {
+			return
+		}
+
+		weights := make([]float64, 0, len(eligibleIdxs))
+		constraints := make([]float64, 0, len(eligibleIdxs))
+		for _, idx := range eligibleIdxs {
+			bound := (*getBound(recs[idx]))[resourceName]
+			target := (*getTarget(recs[idx]))[resourceName]
+
+			weight, err := calculateWeight(total, bound, resourceName)
+			if err != nil {
+				return
+			}
+			weights = append(weights, *weight)
+			constraints = append(constraints, math.Abs(float64(scalarValue(bound, resourceName)-scalarValue(target, resourceName))))
+		}
+
+		// Calculate how much resources each container - where there is no violation - can give up or absorb
+		allocations, _ := iterativeWaterfilling(totalDelta, weights, constraints)
+		hasPositive := slices.ContainsFunc(allocations, func(n float64) bool {
+			return n > 0
+		})
+		if !hasPositive {
+			return
+		}
+		allocations = roundPreservingSum(allocations)
+
+		for i, idx := range eligibleIdxs {
+			boundRL := getBound(recs[idx])
+			bound := (*boundRL)[resourceName]
+			delta := newQuantity(int64(allocations[i]), bound.Format, resourceName)
+			adjusted := bound.DeepCopy()
+			if subtract {
+				adjusted.Sub(delta)
+			} else {
+				adjusted.Add(delta)
+			}
+			(*boundRL)[resourceName] = adjusted
+		}
+	}
+
+	lowerValid := func(lowerBound, target resource.Quantity) bool { return lowerBound.Cmp(target) <= 0 }
+	upperValid := func(upperBound, target resource.Quantity) bool { return upperBound.Cmp(target) >= 0 }
+
+	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		fixBound(getLower, resourceName, lowerValid, false) // LowerBound must not exceed Target
+		fixBound(getUpper, resourceName, upperValid, true)  // UpperBound must not be below Target
+	}
+	return recs
+}
+
+func scalarValue(q resource.Quantity, resourceName corev1.ResourceName) int64 {
+	if resourceName == corev1.ResourceCPU {
+		return q.MilliValue()
+	}
+	return q.Value()
+}
+
+func newQuantity(value int64, format resource.Format, resourceName corev1.ResourceName) resource.Quantity {
+	if resourceName == corev1.ResourceCPU {
+		return *resource.NewMilliQuantity(value, format)
+	}
+	return *resource.NewQuantity(value, format)
+}
+
+// iterativeWaterfilling distributes total among channels proportionally to weights, enforcing per-channel
+// constraints. As the name suggests, the function implements an iterative water-filling algorithm.
+func iterativeWaterfilling(total float64, weights []float64, constraints []float64) ([]float64, error) {
+	if len(weights) != len(constraints) {
+		return nil, fmt.Errorf("weights and constraints must have equal length: %d vs %d", len(weights), len(constraints))
+	}
+
+	allocs := make([]float64, len(weights))
+	saturated := make([]bool, len(weights))
+
+	w := make([]float64, len(weights))
+	copy(w, weights)
+
+	for {
+		var newlySaturatedBudget float64
+		var unsaturatedWeightSum float64
+		anySaturated := false
+
+		for i := range w {
+			if saturated[i] {
+				continue
+			}
+			allocs[i] = w[i] * total
+			if allocs[i] >= constraints[i] {
+				allocs[i] = constraints[i]
+				saturated[i] = true
+				newlySaturatedBudget += constraints[i]
+				anySaturated = true
+			} else {
+				unsaturatedWeightSum += w[i]
+			}
+		}
+
+		// Either no new saturations, or all channels are saturated.
+		if !anySaturated || unsaturatedWeightSum == 0 {
+			return allocs, nil
+		}
+
+		total -= newlySaturatedBudget
+
+		// Renormalize so unsaturated weights sum to 1 for the next iteration
+		for i := range w {
+			if !saturated[i] {
+				w[i] /= unsaturatedWeightSum
+			}
+		}
+	}
+}
+
+func calculateWeight(total, value resource.Quantity, res corev1.ResourceName) (*float64, error) {
+	if total.IsZero() {
+		return nil, fmt.Errorf("total %s is zero", res)
+	}
+
+	var t, v float64
+	switch res {
+	case corev1.ResourceMemory:
+		t, v = float64(total.Value()), float64(value.Value())
+	case corev1.ResourceCPU:
+		t, v = float64(total.MilliValue()), float64(value.MilliValue())
+	default:
+		return nil, fmt.Errorf("unsupported resource type %q", res)
+	}
+
+	w := v / t
+	return &w, nil
+}
+
+// roundPreservingSum floors every element, then distributes the leftover
+// remainder (assumed to be at most 1) to the element with the largest integer value,
+// ensuring that the rounded slice still sums to the original total.
+// This function prevents losing fractional CPU (less than 1m) and fractional bytes.
+func roundPreservingSum(floats []float64) []float64 {
+	if len(floats) == 0 {
+		return floats
+	}
+	var sum, flooredSum float64
+	maxIdx, maxVal := 0, floats[0]
+
+	for i, f := range floats {
+		if f > maxVal {
+			maxIdx, maxVal = i, f
+		}
+		sum += f
+		floats[i] = math.Floor(f)
+		flooredSum += floats[i]
+	}
+	if sum != flooredSum {
+		floats[maxIdx]++
+	}
+	return floats
+}
+
+func getLower(rl vpa_types.RecommendedContainerResources) *corev1.ResourceList  { return &rl.LowerBound }
+func getTarget(rl vpa_types.RecommendedContainerResources) *corev1.ResourceList { return &rl.Target }
+func getUpper(rl vpa_types.RecommendedContainerResources) *corev1.ResourceList  { return &rl.UpperBound }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -553,7 +553,7 @@ func (c *cappingRecommendationProcessor) capProportionallyToPodLimitRange(
 //
 // When there is a violation between a LowerBound and Target, the delta is proportionally distributed among containers where there is room to do so.
 func ensureBoundsAreValid(recs []vpa_types.RecommendedContainerResources) []vpa_types.RecommendedContainerResources {
-	// fixBound repairs violations of isBoundValid for a single resource/bound pair (e.g. "CPU LowerBound")
+	// fixBound repairs violations for a single resource/bound pair (e.g. "CPU LowerBound") across all containers
 	fixBound := func(
 		getBound func(vpa_types.RecommendedContainerResources) *corev1.ResourceList,
 		resourceName corev1.ResourceName,
@@ -603,11 +603,9 @@ func ensureBoundsAreValid(recs []vpa_types.RecommendedContainerResources) []vpa_
 		}
 
 		// Calculate how much resources each container - where there is no violation - can give up or absorb
-		allocations, _ := iterativeWaterfilling(totalDelta, weights, constraints)
-		hasPositive := slices.ContainsFunc(allocations, func(n float64) bool {
-			return n > 0
-		})
-		if !hasPositive {
+		allocations, hasAllocation, _ := iterativeWaterfilling(totalDelta, weights, constraints)
+		// All constraints are already saturated at zero, exit early
+		if !hasAllocation {
 			return
 		}
 		allocations = roundPreservingSum(allocations)
@@ -650,13 +648,13 @@ func newQuantity(value int64, format resource.Format, resourceName corev1.Resour
 	return *resource.NewQuantity(value, format)
 }
 
-// iterativeWaterfilling distributes total among channels proportionally to weights, enforcing per-channel
-// constraints. As the name suggests, the function implements an iterative water-filling algorithm.
-func iterativeWaterfilling(total float64, weights []float64, constraints []float64) ([]float64, error) {
+// iterativeWaterfilling distributes total proportionally to weights
+// while respecting the per-element constraints.
+// As the name suggests, the function implements an iterative water-filling algorithm.
+func iterativeWaterfilling(total float64, weights []float64, constraints []float64) ([]float64, bool, error) {
 	if len(weights) != len(constraints) {
-		return nil, fmt.Errorf("weights and constraints must have equal length: %d vs %d", len(weights), len(constraints))
+		return nil, false, fmt.Errorf("weights and constraints must have equal length: %d vs %d", len(weights), len(constraints))
 	}
-
 	allocs := make([]float64, len(weights))
 	saturated := make([]bool, len(weights))
 
@@ -685,7 +683,13 @@ func iterativeWaterfilling(total float64, weights []float64, constraints []float
 
 		// Either no new saturations, or all channels are saturated.
 		if !anySaturated || unsaturatedWeightSum == 0 {
-			return allocs, nil
+			hasAllocation := slices.ContainsFunc(allocs, func(n float64) bool {
+				return n > 0
+			})
+			if !hasAllocation {
+				return nil, false, nil
+			}
+			return allocs, true, nil
 		}
 
 		total -= newlySaturatedBudget
@@ -718,9 +722,9 @@ func calculateWeight(total, value resource.Quantity, res corev1.ResourceName) (*
 	return &w, nil
 }
 
-// roundPreservingSum floors every element, then distributes the leftover
-// remainder (assumed to be at most 1) to the element with the largest integer value,
-// ensuring that the rounded slice still sums to the original total.
+// roundPreservingSum floors every element in the slice, then increments the
+// largest element by one. If multiple elements share the largest integer value,
+// the first occurrence is incremented.
 // This function prevents losing fractional CPU (less than 1m) and fractional bytes.
 func roundPreservingSum(floats []float64) []float64 {
 	if len(floats) == 0 {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -567,10 +567,13 @@ func ensureBoundsAreValid(recs []vpa_types.RecommendedContainerResources) []vpa_
 		eligibleIdxs := make([]int, 0, len(recs))
 
 		for i := range recs {
-			target, targetOK := (*getTarget(recs[i]))[resourceName]
+			target, targetOK := recs[i].Target[resourceName]
+			if !targetOK {
+				continue
+			}
 			boundRL := getBound(recs[i])
 			bound, boundOK := (*boundRL)[resourceName]
-			if !targetOK || !boundOK {
+			if !boundOK {
 				continue
 			}
 			if !isBoundValid(bound, target) {
@@ -592,10 +595,11 @@ func ensureBoundsAreValid(recs []vpa_types.RecommendedContainerResources) []vpa_
 		constraints := make([]float64, 0, len(eligibleIdxs))
 		for _, idx := range eligibleIdxs {
 			bound := (*getBound(recs[idx]))[resourceName]
-			target := (*getTarget(recs[idx]))[resourceName]
+			target := recs[idx].Target[resourceName]
 
 			weight, err := calculateWeight(total, bound, resourceName)
 			if err != nil {
+				klog.V(2).InfoS("Skipping bound redistribution", "recommendations", recs, "error", err)
 				return
 			}
 			weights = append(weights, *weight)
@@ -603,7 +607,7 @@ func ensureBoundsAreValid(recs []vpa_types.RecommendedContainerResources) []vpa_
 		}
 
 		// Calculate how much resources each container - where there is no violation - can give up or absorb
-		allocations, hasAllocation, _ := iterativeWaterfilling(totalDelta, weights, constraints)
+		allocations, hasAllocation := iterativeWaterfilling(totalDelta, weights, constraints)
 		// All constraints are already saturated at zero, exit early
 		if !hasAllocation {
 			return
@@ -626,6 +630,9 @@ func ensureBoundsAreValid(recs []vpa_types.RecommendedContainerResources) []vpa_
 
 	lowerValid := func(lowerBound, target resource.Quantity) bool { return lowerBound.Cmp(target) <= 0 }
 	upperValid := func(upperBound, target resource.Quantity) bool { return upperBound.Cmp(target) >= 0 }
+
+	getLower := func(rl vpa_types.RecommendedContainerResources) *corev1.ResourceList { return &rl.LowerBound }
+	getUpper := func(rl vpa_types.RecommendedContainerResources) *corev1.ResourceList { return &rl.UpperBound }
 
 	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 		fixBound(getLower, resourceName, lowerValid, false) // LowerBound must not exceed Target
@@ -651,9 +658,9 @@ func newQuantity(value int64, format resource.Format, resourceName corev1.Resour
 // iterativeWaterfilling distributes total proportionally to weights
 // while respecting the per-element constraints.
 // As the name suggests, the function implements an iterative water-filling algorithm.
-func iterativeWaterfilling(total float64, weights []float64, constraints []float64) ([]float64, bool, error) {
+func iterativeWaterfilling(total float64, weights []float64, constraints []float64) ([]float64, bool) {
 	if len(weights) != len(constraints) {
-		return nil, false, fmt.Errorf("weights and constraints must have equal length: %d vs %d", len(weights), len(constraints))
+		return nil, false
 	}
 	allocs := make([]float64, len(weights))
 	saturated := make([]bool, len(weights))
@@ -687,9 +694,9 @@ func iterativeWaterfilling(total float64, weights []float64, constraints []float
 				return n > 0
 			})
 			if !hasAllocation {
-				return nil, false, nil
+				return nil, false
 			}
-			return allocs, true, nil
+			return allocs, true
 		}
 
 		total -= newlySaturatedBudget
@@ -746,7 +753,3 @@ func roundPreservingSum(floats []float64) []float64 {
 	}
 	return floats
 }
-
-func getLower(rl vpa_types.RecommendedContainerResources) *corev1.ResourceList  { return &rl.LowerBound }
-func getTarget(rl vpa_types.RecommendedContainerResources) *corev1.ResourceList { return &rl.Target }
-func getUpper(rl vpa_types.RecommendedContainerResources) *corev1.ResourceList  { return &rl.UpperBound }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -267,10 +267,10 @@ var podRecommendation *vpa_types.RecommendedPodResources = &vpa_types.Recommende
 	ContainerRecommendations: []vpa_types.RecommendedContainerResources{
 		{
 			ContainerName: "ctr-name",
-			Target: corev1.ResourceList{
+			LowerBound: corev1.ResourceList{
 				corev1.ResourceCPU:    *resource.NewScaledQuantity(5, 1),
 				corev1.ResourceMemory: *resource.NewScaledQuantity(10, 1)},
-			LowerBound: corev1.ResourceList{
+			Target: corev1.ResourceList{
 				corev1.ResourceCPU:    *resource.NewScaledQuantity(50, 1),
 				corev1.ResourceMemory: *resource.NewScaledQuantity(100, 1)},
 			UpperBound: corev1.ResourceList{
@@ -1781,6 +1781,605 @@ func TestCapPodMemoryWithUnderByteSplit(t *testing.T) {
 			processedRecommendation, _, err := processor.Apply(vpa, &pod)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedRecommendation, *processedRecommendation)
+		})
+	}
+}
+
+func TestEnsureValidBounds(t *testing.T) {
+	tests := []struct {
+		name               string
+		containerLevelRecs []vpa_types.RecommendedContainerResources
+		expected           []vpa_types.RecommendedContainerResources
+	}{
+		{
+			// Here, LowerBound <= Target <= UpperBound holds for all containers, so no action is required.
+			name: "no violation",
+			containerLevelRecs: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+			},
+			expected: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+			},
+		},
+		{
+			// Here, LowerBound <= Target <= UpperBound holds for all containers, so no action is required.
+			name: "no violation",
+			containerLevelRecs: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+			},
+			expected: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+			},
+		},
+		{
+			name: "cpu and memory lower bounds are violated in c1, but no additional delta can be added to c2",
+			containerLevelRecs: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("25m"),
+						corev1.ResourceMemory: resource.MustParse("25Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+				},
+			},
+			expected: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),  // -5m
+						corev1.ResourceMemory: resource.MustParse("20Mi"), // -5Mi
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+				},
+			},
+		},
+		{
+			name: "cpu and memory lower bounds are violated in c1, add delta proportionally",
+			containerLevelRecs: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("28m"),
+						corev1.ResourceMemory: resource.MustParse("28Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+				{
+					ContainerName: "c3",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+				},
+				{
+					ContainerName: "c4",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+			},
+			// There is a violation in c1, as the LowerBound is greater than the Target. To fix this violation, we need to lower c1's LowerBound to 20m and 20Mi,
+			// since the reference point (i.e. c1's Target) is 20m and 20Mi.
+			// Then, we need to add 8 millicores and 8 MiB proportionally to the others so that the sum of LowerBound values still equals 128m and 128Mi.
+			expected: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),  // -8m
+						corev1.ResourceMemory: resource.MustParse("20Mi"), // -8Mi
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(32, resource.DecimalSI), // + 2
+						corev1.ResourceMemory: *resource.NewQuantity(33973862, resource.BinarySI), // 31457280 + floor(8388608 x 0,3)
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+				{
+					ContainerName: "c3",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(44, resource.DecimalSI), // + 4
+						corev1.ResourceMemory: *resource.NewQuantity(45298484, resource.BinarySI), // 41943040 + ceil(8388608 x 0,4)
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+				},
+				{
+					ContainerName: "c4",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(32, resource.DecimalSI), // + 2
+						corev1.ResourceMemory: *resource.NewQuantity(33973862, resource.BinarySI), // 31457280 + floor(8388608 x 0,3)
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+			},
+		},
+		{
+			name: "cpu and memory lower bounds are violated in c1, add delta proportionally, except in c2",
+			containerLevelRecs: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("28m"),
+						corev1.ResourceMemory: resource.MustParse("28Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+				{
+					ContainerName: "c3",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("60m"),
+						corev1.ResourceMemory: resource.MustParse("60Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("80m"),
+						corev1.ResourceMemory: resource.MustParse("80Mi"),
+					},
+				},
+				{
+					ContainerName: "c4",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("80m"),
+						corev1.ResourceMemory: resource.MustParse("80Mi"),
+					},
+				},
+			},
+			// There is a violation in c1, as the LowerBound is greater than the Target. To fix this violation, we need to lower c1's LowerBound to 20m and 20Mi,
+			// since the reference point (i.e. c1's Target) is 20m and 20Mi.
+			// In this case, we cannot add values to c2, as its Target equals its LowerBound.
+			// Then, we need to add 8 millicores and 8 MiB proportionally to the others so that the sum of LowerBound values still equals 168m and 168Mi.
+			expected: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),  // -8m
+						corev1.ResourceMemory: resource.MustParse("20Mi"), // -8Mi
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(40, resource.DecimalSI), // 40m
+						corev1.ResourceMemory: *resource.NewQuantity(41943040, resource.BinarySI), // 40Mi
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+				{
+					ContainerName: "c3",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(65, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(67947725, resource.BinarySI), // 62914560 + (8388608 x 0,6)
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("80m"),
+						corev1.ResourceMemory: resource.MustParse("80Mi"),
+					},
+				},
+				{
+					ContainerName: "c4",
+					LowerBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(43, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(45298483, resource.BinarySI), // 41943040 + (8388608 x 0,4)
+					},
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("80m"),
+						corev1.ResourceMemory: resource.MustParse("80Mi"),
+					},
+				},
+			},
+		},
+		{
+			name: "cpu and memory upper bounds are violated in c1, subtract delta proportionally",
+			containerLevelRecs: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("12m"),
+						corev1.ResourceMemory: resource.MustParse("12Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+				},
+				{
+					ContainerName: "c3",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+				{
+					ContainerName: "c4",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+				},
+			},
+			// There is a violation in c1, as the UpperBound is lower than the Target. To fix this violation, we need to increase c1's UpperBound to 20m and 20Mi,
+			// since the reference point (i.e. c1's Target) is 20m and 20Mi.
+			// Then, we need to subtract 8 millicores and 8 MiB proportionally from the others so that the sum of UpperBound values still equals 112m and 112Mi.
+			expected: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),  // +8
+						corev1.ResourceMemory: resource.MustParse("20Mi"), // +8
+					},
+				},
+				{
+					ContainerName: "c2",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(28, resource.DecimalSI), // -2
+						corev1.ResourceMemory: *resource.NewQuantity(28940698, resource.BinarySI), // 31457280 - floor(8388608 x 0.3)
+					},
+				},
+				{
+					ContainerName: "c3",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(36, resource.DecimalSI), // -4
+						corev1.ResourceMemory: *resource.NewQuantity(38587596, resource.BinarySI), // 41943040 - ceil(8388608 x 0.4)
+					},
+				},
+				{
+					ContainerName: "c4",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(28, resource.DecimalSI), // -2
+						corev1.ResourceMemory: *resource.NewQuantity(28940698, resource.BinarySI), // 31457280 - floor(8388608 x 0.3)
+					},
+				},
+			},
+		},
+		{
+			name: "cpu and memory upper bounds are violated in c1, subtract delta proportionally, except in c2",
+			containerLevelRecs: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("12m"),
+						corev1.ResourceMemory: resource.MustParse("12Mi"),
+					},
+				},
+				{
+					ContainerName: "c2",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+				},
+				{
+					ContainerName: "c3",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("40m"),
+						corev1.ResourceMemory: resource.MustParse("40Mi"),
+					},
+				},
+				{
+					ContainerName: "c4",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("60m"),
+						corev1.ResourceMemory: resource.MustParse("60Mi"),
+					},
+				},
+			},
+			// There is a violation in c1, as the UpperBound is lower than the Target. To fix this violation, we need to increase c1's UpperBound to 20m and 20Mi,
+			// since the reference point (i.e. c1's Target) is 20m and 20Mi.
+			// In this case, we cannot subtract values from c2, as its Target equals its UpperBound.
+			// Then, we need to subtract 8m and 8Mi proportionally from the others so that the sum of UpperBound values still equals 142m and 142Mi.
+			expected: []vpa_types.RecommendedContainerResources{
+				{
+					ContainerName: "c1",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),  // +8m
+						corev1.ResourceMemory: resource.MustParse("20Mi"), // +8Mi
+					},
+				},
+				{
+					ContainerName: "c2",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("30m"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(30, resource.DecimalSI), // 30m
+						corev1.ResourceMemory: *resource.NewQuantity(31457280, resource.BinarySI), // 30Mi
+					},
+				},
+				{
+					ContainerName: "c3",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(37, resource.DecimalSI), // -3
+						corev1.ResourceMemory: *resource.NewQuantity(38587597, resource.BinarySI), // 41943040 - floor(8388608 x 0.4)
+					},
+				},
+				{
+					ContainerName: "c4",
+					Target: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+					UpperBound: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewMilliQuantity(55, resource.DecimalSI), // -5
+						corev1.ResourceMemory: *resource.NewQuantity(57881395, resource.BinarySI), // 62914560 - ceil(8388608 x 0.6)
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ensureBoundsAreValid(tt.containerLevelRecs)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func Test_roundPreservingSum(t *testing.T) {
+	tests := []struct {
+		name           string
+		floats         []float64
+		expectedFloats []float64
+	}{
+		{
+			name:           "example1",
+			floats:         []float64{0, 1, 3.5, 3.5},
+			expectedFloats: []float64{0, 1, 4, 3},
+		},
+		{
+			name:           "example2",
+			floats:         []float64{0, 1, 2.8, 3.2},
+			expectedFloats: []float64{0, 1, 2, 4},
+		},
+		{
+			name:           "example3",
+			floats:         []float64{0, 1, 3, 3},
+			expectedFloats: []float64{0, 1, 3, 3},
+		},
+		{
+			name:           "example4",
+			floats:         []float64{0, 0, 0},
+			expectedFloats: []float64{0, 0, 0},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			floats := roundPreservingSum(tt.floats)
+			assert.Equal(t, tt.expectedFloats, floats)
 		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package api
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1792,8 +1793,8 @@ func TestEnsureValidBounds(t *testing.T) {
 		expected           []vpa_types.RecommendedContainerResources
 	}{
 		{
-			// Here, LowerBound <= Target <= UpperBound holds for all containers, so no action is required.
-			name: "no violation",
+			// Here, LowerBound <= Target holds for all containers, so no action is required.
+			name: "no violation between LowerBound and Target",
 			containerLevelRecs: []vpa_types.RecommendedContainerResources{
 				{
 					ContainerName: "c1",
@@ -1844,8 +1845,8 @@ func TestEnsureValidBounds(t *testing.T) {
 			},
 		},
 		{
-			// Here, LowerBound <= Target <= UpperBound holds for all containers, so no action is required.
-			name: "no violation",
+			// Here, Target <= UpperBound holds for all containers, so no action is required.
+			name: "no violation between Target and UpperBound",
 			containerLevelRecs: []vpa_types.RecommendedContainerResources{
 				{
 					ContainerName: "c1",
@@ -2349,29 +2350,39 @@ func TestEnsureValidBounds(t *testing.T) {
 	}
 }
 
-func Test_roundPreservingSum(t *testing.T) {
+func TestRoundPreservingSum(t *testing.T) {
 	tests := []struct {
 		name           string
 		floats         []float64
 		expectedFloats []float64
 	}{
 		{
-			name:           "example1",
-			floats:         []float64{0, 1, 3.5, 3.5},
-			expectedFloats: []float64{0, 1, 4, 3},
-		},
-		{
-			name:           "example2",
+			name:           "increment the largest value",
 			floats:         []float64{0, 1, 2.8, 3.2},
 			expectedFloats: []float64{0, 1, 2, 4},
 		},
 		{
-			name:           "example3",
-			floats:         []float64{0, 1, 3, 3},
-			expectedFloats: []float64{0, 1, 3, 3},
+			name:           "increment the first occurrence of the largest value",
+			floats:         []float64{0, 1, 3.5, 3.5},
+			expectedFloats: []float64{0, 1, 4, 3},
 		},
 		{
-			name:           "example4",
+			name:           "sum of remainder is less than 1",
+			floats:         []float64{0, 1, 2.1, 3.1},
+			expectedFloats: []float64{0, 1, 2, 4},
+		},
+		{
+			name:           "sum of remainder is greater than 1",
+			floats:         []float64{0, 1, 2.9, 3.9},
+			expectedFloats: []float64{0, 1, 2, 4},
+		},
+		{
+			name:           "no remainder",
+			floats:         []float64{0, 1, 4, 3},
+			expectedFloats: []float64{0, 1, 4, 3},
+		},
+		{
+			name:           "slice where all elements are zero",
 			floats:         []float64{0, 0, 0},
 			expectedFloats: []float64{0, 0, 0},
 		},
@@ -2380,6 +2391,106 @@ func Test_roundPreservingSum(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			floats := roundPreservingSum(tt.floats)
 			assert.Equal(t, tt.expectedFloats, floats)
+		})
+	}
+}
+
+func TestIterativeWaterfilling(t *testing.T) {
+	neverSaturates := 999999.0
+	tests := []struct {
+		name                  string
+		total                 float64
+		weights               []float64
+		constraints           []float64
+		expectedDistributions []float64
+		expectedHasAllocation bool
+		expectedError         error
+	}{
+		// The first element should receive 10% of the total, the second 50%, and so on...
+		{
+			name:                  "no violation",
+			total:                 10,
+			weights:               []float64{0.1, 0.5, 0.3, 0.1},
+			constraints:           []float64{10, 10, 10, 10},
+			expectedDistributions: []float64{1, 5, 3, 1},
+			expectedHasAllocation: true,
+			expectedError:         nil,
+		},
+		{
+			name:                  "all constraints violated",
+			total:                 10,
+			weights:               []float64{0.1, 0.5, 0.3, 0.1},
+			constraints:           []float64{0, 0, 0, 0},
+			expectedDistributions: nil,
+			expectedHasAllocation: false,
+			expectedError:         nil,
+		},
+		{
+			name:                  "one element saturates, remainder absorbed by the other",
+			total:                 10,
+			weights:               []float64{0.5, 0.5},
+			constraints:           []float64{3, neverSaturates},
+			expectedDistributions: []float64{3, 7},
+			expectedHasAllocation: true,
+			expectedError:         nil,
+		},
+		{
+			name:                  "cascading saturation across multiple rounds",
+			total:                 100,
+			weights:               []float64{0.5, 0.3, 0.2},
+			constraints:           []float64{10, 50, neverSaturates},
+			expectedDistributions: []float64{10, 50, 40},
+			expectedHasAllocation: true,
+			expectedError:         nil,
+		},
+		{
+			name:                  "length mismatch",
+			total:                 10,
+			weights:               []float64{0.1, 0.9},
+			constraints:           []float64{1, 2, 3},
+			expectedDistributions: nil,
+			expectedHasAllocation: false,
+			expectedError:         fmt.Errorf("weights and constraints must have equal length: %d vs %d", 2, 3),
+		},
+		{
+			name:                  "all weights zero",
+			total:                 10,
+			weights:               []float64{0, 0},
+			constraints:           []float64{5, 5},
+			expectedDistributions: nil,
+			expectedHasAllocation: false,
+			expectedError:         nil,
+		},
+		{
+			name:                  "zero total",
+			total:                 0,
+			weights:               []float64{0.3, 0.7},
+			constraints:           []float64{5, 5},
+			expectedDistributions: nil,
+			expectedHasAllocation: false,
+			expectedError:         nil,
+		},
+		{
+			name:                  "empty slices",
+			total:                 10,
+			weights:               []float64{},
+			constraints:           []float64{},
+			expectedDistributions: nil,
+			expectedHasAllocation: false,
+			expectedError:         nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			floats, hasPositiveAllocation, err := iterativeWaterfilling(tt.total, tt.weights, tt.constraints)
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedHasAllocation, hasPositiveAllocation)
+			assert.Equal(t, tt.expectedDistributions, floats)
 		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package api
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2404,7 +2403,6 @@ func TestIterativeWaterfilling(t *testing.T) {
 		constraints           []float64
 		expectedDistributions []float64
 		expectedHasAllocation bool
-		expectedError         error
 	}{
 		// The first element should receive 10% of the total, the second 50%, and so on...
 		{
@@ -2414,7 +2412,6 @@ func TestIterativeWaterfilling(t *testing.T) {
 			constraints:           []float64{10, 10, 10, 10},
 			expectedDistributions: []float64{1, 5, 3, 1},
 			expectedHasAllocation: true,
-			expectedError:         nil,
 		},
 		{
 			name:                  "all constraints violated",
@@ -2423,7 +2420,6 @@ func TestIterativeWaterfilling(t *testing.T) {
 			constraints:           []float64{0, 0, 0, 0},
 			expectedDistributions: nil,
 			expectedHasAllocation: false,
-			expectedError:         nil,
 		},
 		{
 			name:                  "one element saturates, remainder absorbed by the other",
@@ -2432,7 +2428,6 @@ func TestIterativeWaterfilling(t *testing.T) {
 			constraints:           []float64{3, neverSaturates},
 			expectedDistributions: []float64{3, 7},
 			expectedHasAllocation: true,
-			expectedError:         nil,
 		},
 		{
 			name:                  "cascading saturation across multiple rounds",
@@ -2441,7 +2436,6 @@ func TestIterativeWaterfilling(t *testing.T) {
 			constraints:           []float64{10, 50, neverSaturates},
 			expectedDistributions: []float64{10, 50, 40},
 			expectedHasAllocation: true,
-			expectedError:         nil,
 		},
 		{
 			name:                  "length mismatch",
@@ -2450,7 +2444,6 @@ func TestIterativeWaterfilling(t *testing.T) {
 			constraints:           []float64{1, 2, 3},
 			expectedDistributions: nil,
 			expectedHasAllocation: false,
-			expectedError:         fmt.Errorf("weights and constraints must have equal length: %d vs %d", 2, 3),
 		},
 		{
 			name:                  "all weights zero",
@@ -2459,7 +2452,6 @@ func TestIterativeWaterfilling(t *testing.T) {
 			constraints:           []float64{5, 5},
 			expectedDistributions: nil,
 			expectedHasAllocation: false,
-			expectedError:         nil,
 		},
 		{
 			name:                  "zero total",
@@ -2468,7 +2460,6 @@ func TestIterativeWaterfilling(t *testing.T) {
 			constraints:           []float64{5, 5},
 			expectedDistributions: nil,
 			expectedHasAllocation: false,
-			expectedError:         nil,
 		},
 		{
 			name:                  "empty slices",
@@ -2477,18 +2468,11 @@ func TestIterativeWaterfilling(t *testing.T) {
 			constraints:           []float64{},
 			expectedDistributions: nil,
 			expectedHasAllocation: false,
-			expectedError:         nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			floats, hasPositiveAllocation, err := iterativeWaterfilling(tt.total, tt.weights, tt.constraints)
-			if tt.expectedError != nil {
-				assert.Error(t, err)
-				assert.Equal(t, tt.expectedError.Error(), err.Error())
-			} else {
-				assert.NoError(t, err)
-			}
+			floats, hasPositiveAllocation := iterativeWaterfilling(tt.total, tt.weights, tt.constraints)
 			assert.Equal(t, tt.expectedHasAllocation, hasPositiveAllocation)
 			assert.Equal(t, tt.expectedDistributions, floats)
 		})

--- a/vertical-pod-autoscaler/test/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/actuation.go
@@ -753,6 +753,141 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 		ginkgo.By(fmt.Sprintf("Waiting for pods to be evicted, hoping it won't happen, sleep for %s", VpaEvictionTimeout.String()))
 		CheckNoPodsEvicted(f, podSet)
 	})
+
+	// Tests for the issue described here: https://github.com/kubernetes/autoscaler/pull/9935
+	f.It("should not get into an eviction loop when Pod LimitRange object with Max field is present", func() {
+		d := utils.NewNHamstersDeployment(f, 2)
+		InstallLimitRangeWithMax(f, "200m", "200Mi", apiv1.LimitTypePod)
+
+		// Request-to-limit ratio is 1:1 for all containers
+		d.Spec.Template.Spec.Containers[0].Resources.Requests = apiv1.ResourceList{
+			apiv1.ResourceCPU:    ParseQuantityOrDie("200m"),
+			apiv1.ResourceMemory: ParseQuantityOrDie("200Mi"),
+		}
+		d.Spec.Template.Spec.Containers[0].Resources.Limits = apiv1.ResourceList{
+			apiv1.ResourceCPU:    ParseQuantityOrDie("200m"),
+			apiv1.ResourceMemory: ParseQuantityOrDie("200Mi"),
+		}
+		d.Spec.Template.Spec.Containers[1].Resources.Requests = apiv1.ResourceList{
+			apiv1.ResourceCPU:    ParseQuantityOrDie("200m"),
+			apiv1.ResourceMemory: ParseQuantityOrDie("200Mi"),
+		}
+		d.Spec.Template.Spec.Containers[1].Resources.Limits = apiv1.ResourceList{
+			apiv1.ResourceCPU:    ParseQuantityOrDie("200m"),
+			apiv1.ResourceMemory: ParseQuantityOrDie("200Mi"),
+		}
+		container1Name := utils.GetHamsterContainerNameByIndex(0)
+		container2Name := utils.GetHamsterContainerNameByIndex(1)
+
+		ginkgo.By("Setting up a VPA CRD")
+		vpaCRD := test.VerticalPodAutoscaler().
+			WithName("hamster-vpa").
+			WithNamespace(f.Namespace.Name).
+			WithTargetRef(utils.HamsterTargetRef).
+			WithUpdateMode(vpa_types.UpdateModeRecreate).
+			WithContainer(container1Name).
+			AppendRecommendation(
+				test.Recommendation().
+					WithContainer(container1Name).
+					WithLowerBound("80m", "80Mi").
+					WithTarget("80m", "80Mi").
+					WithUpperBound("80m", "80Mi").
+					GetContainerResources()).
+			WithContainer(container2Name).
+			AppendRecommendation(
+				test.Recommendation().
+					WithContainer(container2Name).
+					WithLowerBound("20m", "20Mi").
+					WithTarget("100m", "100Mi").
+					WithUpperBound("300m", "300Mi").
+					GetContainerResources()).
+			Get()
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Setting up a hamster deployment")
+		podList := utils.StartDeploymentPods(f, d)
+
+		for _, pod := range podList.Items {
+			observedContainers, ok := pod.GetAnnotations()[annotations.VpaObservedContainersLabel]
+			gomega.Expect(ok).To(gomega.Equal(true))
+			containers, err := annotations.ParseVpaObservedContainersValue(observedContainers)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(containers).To(gomega.HaveLen(2))
+			gomega.Expect(pod.Spec.Containers).To(gomega.HaveLen(2))
+		}
+
+		podSet := MakePodSet(podList)
+		ginkgo.By(fmt.Sprintf("Waiting for pods to be evicted, hoping it won't happen, sleep for %s", VpaEvictionTimeout.String()))
+		CheckNoPodsEvicted(f, podSet)
+	})
+
+	// Tests for the issue described here: https://github.com/kubernetes/autoscaler/pull/9935
+	f.It("should not get into an eviction loop when Pod LimitRange with Min field object is present", func() {
+		d := utils.NewNHamstersDeployment(f, 2)
+		InstallLimitRangeWithMin(f, "150m", "150Mi", apiv1.LimitTypePod)
+
+		// Request-to-limit ratio is 1:1 for all containers
+		d.Spec.Template.Spec.Containers[0].Resources.Requests = apiv1.ResourceList{
+			apiv1.ResourceCPU:    ParseQuantityOrDie("200m"),
+			apiv1.ResourceMemory: ParseQuantityOrDie("200Mi"),
+		}
+		d.Spec.Template.Spec.Containers[0].Resources.Limits = apiv1.ResourceList{
+			apiv1.ResourceCPU:    ParseQuantityOrDie("200m"),
+			apiv1.ResourceMemory: ParseQuantityOrDie("200Mi"),
+		}
+		d.Spec.Template.Spec.Containers[1].Resources.Requests = apiv1.ResourceList{
+			apiv1.ResourceCPU:    ParseQuantityOrDie("200m"),
+			apiv1.ResourceMemory: ParseQuantityOrDie("200Mi"),
+		}
+		d.Spec.Template.Spec.Containers[1].Resources.Limits = apiv1.ResourceList{
+			apiv1.ResourceCPU:    ParseQuantityOrDie("200m"),
+			apiv1.ResourceMemory: ParseQuantityOrDie("200Mi"),
+		}
+		container1Name := utils.GetHamsterContainerNameByIndex(0)
+		container2Name := utils.GetHamsterContainerNameByIndex(1)
+
+		ginkgo.By("Setting up a VPA CRD")
+		vpaCRD := test.VerticalPodAutoscaler().
+			WithName("hamster-vpa").
+			WithNamespace(f.Namespace.Name).
+			WithTargetRef(utils.HamsterTargetRef).
+			WithUpdateMode(vpa_types.UpdateModeRecreate).
+			WithContainer(container1Name).
+			AppendRecommendation(
+				test.Recommendation().
+					WithContainer(container1Name).
+					WithLowerBound("80m", "80Mi").
+					WithTarget("80m", "80Mi").
+					WithUpperBound("80m", "80Mi").
+					GetContainerResources()).
+			WithContainer(container2Name).
+			AppendRecommendation(
+				test.Recommendation().
+					WithContainer(container2Name).
+					WithLowerBound("20m", "20Mi").
+					WithTarget("100m", "100Mi").
+					WithUpperBound("300m", "300Mi").
+					GetContainerResources()).
+			Get()
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Setting up a hamster deployment")
+		podList := utils.StartDeploymentPods(f, d)
+
+		for _, pod := range podList.Items {
+			observedContainers, ok := pod.GetAnnotations()[annotations.VpaObservedContainersLabel]
+			gomega.Expect(ok).To(gomega.Equal(true))
+			containers, err := annotations.ParseVpaObservedContainersValue(observedContainers)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(containers).To(gomega.HaveLen(2))
+			gomega.Expect(pod.Spec.Containers).To(gomega.HaveLen(2))
+		}
+
+		podSet := MakePodSet(podList)
+		ginkgo.By(fmt.Sprintf("Waiting for pods to be evicted, hoping it won't happen, sleep for %s", VpaEvictionTimeout.String()))
+		CheckNoPodsEvicted(f, podSet)
+	})
+
 })
 
 func getCPURequest(podSpec apiv1.PodSpec) resource.Quantity {

--- a/vertical-pod-autoscaler/test/e2e/v1/actuation.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/actuation.go
@@ -754,7 +754,7 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 		CheckNoPodsEvicted(f, podSet)
 	})
 
-	// Tests for the issue described here: https://github.com/kubernetes/autoscaler/pull/9935
+	// Tests for the issue described here: https://github.com/kubernetes/autoscaler/pull/8776
 	f.It("should not get into an eviction loop when Pod LimitRange object with Max field is present", func() {
 		d := utils.NewNHamstersDeployment(f, 2)
 		InstallLimitRangeWithMax(f, "200m", "200Mi", apiv1.LimitTypePod)
@@ -821,8 +821,8 @@ var _ = ActuationSuiteE2eDescribe("Actuation", func() {
 		CheckNoPodsEvicted(f, podSet)
 	})
 
-	// Tests for the issue described here: https://github.com/kubernetes/autoscaler/pull/9935
-	f.It("should not get into an eviction loop when Pod LimitRange with Min field object is present", func() {
+	// Tests for the issue described here: https://github.com/kubernetes/autoscaler/pull/8776
+	f.It("should not get into an eviction loop when a Pod LimitRange object with a Min field is present", func() {
 		d := utils.NewNHamstersDeployment(f, 2)
 		InstallLimitRangeWithMin(f, "150m", "150Mi", apiv1.LimitTypePod)
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/area vertical-pod-autoscaler

#### What this PR does / why we need it:

When a Pod with multiple containers is managed by VPA, and one of the container recommendations is stable (i.e. the lower bound, target, and upper bound values are very close to each other), and a Pod LimitRange object is present in the cluster, the Pod can enter an eviction loop.

This happens due to the current way VPA fixes Pod LimitRange violations across all containers. The mechanism operates "vertically", meaning it sums all lower bound values and then adjusts them proportionally based on constraints defined by the Pod LimitRange object.

As a result, some container recommendations may be modified in a way that no longer satisfies LowerBound <= Target <= UpperBound for a given container.

This leads to returning the following PodPriority struct:

`PodPriority {OutsideRecommendedRange: true, ScaleUp: false, ResourceDiff: 0}`

This in turn causes the Pod to be evicted at every interval, even when there is no valid reason to do so.

This PR adds a final validation step in the `Apply` method within capping.go to detect and fix such violations. If any are found, it restores consistency by using the target values as reference points.

For example, consider a Pod with two containers and the following recommendations:

container1 - LowerBound: 20m, Target: 20m, UpperBound: 20m
container2 - LowerBound: 50m, Target: 100m, UpperBound: 200m

Pod LimitRange with a Min field exists in the cluster: 100m.

After the `Apply` method runs, the lower bound recommendations are changed to the following, as they violate the LimitRange object:

container1 - LowerBound: 29m, Target: 20m, UpperBound: 20m
container2 - LowerBound: 72m, Target: 100m, UpperBound: 200m

Even though the sum of container targets does not violate the LimitRange constraint, container1's bounds are no longer valid. In the current VPA implementation, the updater would continue evicting the Pod on every iteration until container1's target and upper bound is increased to at least 29m.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

The goal of this PR is to fix the bug reported in: https://github.com/kubernetes/autoscaler/issues/8776

#### Special notes for your reviewer:

I added two new e2e tests that reproduce the issue when the `ensureBoundsAreValid` function call is removed from the `Apply` method.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to keep CPU and memory recommendations within consistent lower and upper bounds.
  * Preserved total recommended resources while correcting invalid bounds and distributing adjustments across eligible containers.
  * Prevented eviction loops when pod-level minimum or maximum resource constraints are configured.

* **Tests**
  * Added coverage for bound correction, resource allocation, rounding, and limit-range eviction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->