### PR TITLE
[VPA] Enable revive rules - 6

### DIFF
--- a/vertical-pod-autoscaler/.golangci.yaml
+++ b/vertical-pod-autoscaler/.golangci.yaml
@@ -70,6 +70,8 @@ linters:
         - name: redundant-import-alias
         - name: confusing-results
         - name: unused-receiver
+        - name: identical-switch-branches
+        - name: use-slices-sort
 
         # Below lists the rules disabled
 

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/helpers.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/helpers.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package v1
 
-import "sort"
+import "slices"
 
 // GetUpdateModes returns all UpdateModes
 func GetUpdateModes() map[UpdateMode]any {
@@ -40,7 +40,7 @@ func GetUpdateModesList() []string {
 			result = append(result, string(mode))
 		}
 	}
-	sort.Strings(result)
+	slices.Sort(result)
 	return result
 }
 
@@ -59,6 +59,6 @@ func GetPossibleScalingModes() []string {
 	for mode := range modes {
 		result = append(result, string(mode))
 	}
-	sort.Strings(result)
+	slices.Sort(result)
 	return result
 }

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -19,7 +19,7 @@ package checkpoint
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -66,8 +66,8 @@ func getVpasToCheckpoint(clusterVpas map[model.VpaID]*model.Vpa) []*model.Vpa {
 		}
 		vpas = append(vpas, vpa)
 	}
-	sort.Slice(vpas, func(i, j int) bool {
-		return vpas[i].CheckpointWritten.Before(vpas[j].CheckpointWritten)
+	slices.SortFunc(vpas, func(a, b *model.Vpa) int {
+		return a.CheckpointWritten.Compare(b.CheckpointWritten)
 	})
 	return vpas
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/history/history_provider.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -383,7 +383,9 @@ func (p *prometheusHistoryProvider) GetClusterHistory() (map[model.PodID]*PodHis
 	}
 	for _, podHistory := range res {
 		for _, samples := range podHistory.Samples {
-			sort.Slice(samples, func(i, j int) bool { return samples[i].MeasureStart.Before(samples[j].MeasureStart) })
+			slices.SortFunc(samples, func(a, b model.ContainerUsageSample) int {
+				return a.MeasureStart.Compare(b.MeasureStart)
+			})
 		}
 	}
 	err = p.readLastLabels(res, p.config.PodLabelsMetricName)

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -17,7 +17,7 @@ limitations under the License.
 package logic
 
 import (
-	"sort"
+	"slices"
 	"time"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -199,7 +199,7 @@ func MapToListOfRecommendedContainerResources(resources RecommendedPodResources,
 	for containerName := range resources {
 		containerNames = append(containerNames, containerName)
 	}
-	sort.Strings(containerNames)
+	slices.Sort(containerNames)
 	// Create the list of recommendations for each container.
 	for _, name := range containerNames {
 		containerResources = append(containerResources, vpa_types.RecommendedContainerResources{

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -17,8 +17,9 @@ limitations under the License.
 package model
 
 import (
+	"cmp"
 	"maps"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -68,8 +69,8 @@ func (conditionsMap *vpaConditionsMap) AsList() []vpa_types.VerticalPodAutoscale
 	}
 
 	// Sort conditions by type to avoid elements floating on the list
-	sort.Slice(conditions, func(i, j int) bool {
-		return conditions[i].Type < conditions[j].Type
+	slices.SortFunc(conditions, func(a, b vpa_types.VerticalPodAutoscalerCondition) int {
+		return cmp.Compare(a.Type, b.Type)
 	})
 
 	return conditions

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -523,16 +523,13 @@ func filterNonInPlaceUpdatablePods(pods []*corev1.Pod, inplaceRestriction restri
 		switch decision {
 		case utils.InPlaceApproved:
 			return true
-		case utils.InPlaceInfeasible:
-			// For InPlace mode, include infeasible pods to retry (no backoff for alpha)
+		case utils.InPlaceInfeasible, utils.InPlaceDeferred:
+			// For InPlace mode, include infeasible/deferred pods to retry (no backoff for alpha)
+			// or to check if recommendation changed and apply a new patch while a previous update is in progress
 			return updateMode == vpa_types.UpdateModeInPlace
 		case utils.InPlaceEvict:
 			// For InPlaceOrRecreate, include so they can be redirected to eviction in the loop
 			return updateMode == vpa_types.UpdateModeInPlaceOrRecreate
-		case utils.InPlaceDeferred:
-			// For InPlace mode, include deferred pods so we can check if recommendation
-			// changed and apply a new patch while a previous update is in progress
-			return updateMode == vpa_types.UpdateModeInPlace
 		case utils.InPlaceInfeasibleCached:
 			// Cached infeasibility means we've already determined this pod cannot be
 			// updated in-place and cached the result to avoid redundant checks

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -17,7 +17,7 @@ limitations under the License.
 package priority
 
 import (
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -160,7 +160,15 @@ func (calc *UpdatePriorityCalculator) AddPod(pod *corev1.Pod, now time.Time, inf
 
 // GetSortedPods returns a list of pods ordered by update priority (highest update priority first)
 func (calc *UpdatePriorityCalculator) GetSortedPods(admission PodEvictionAdmission) []*corev1.Pod {
-	sort.Sort(byPriorityDesc(calc.pods))
+	slices.SortFunc(calc.pods, func(a, b prioritizedPod) int {
+		if b.priority.Less(a.priority) {
+			return -1
+		}
+		if a.priority.Less(b.priority) {
+			return 1
+		}
+		return 0
+	})
 
 	result := []*corev1.Pod{}
 	for _, podPrio := range calc.pods {
@@ -291,21 +299,6 @@ type PodPriority struct {
 	ScaleUp bool
 	// Relative difference between the total requested and total recommended resources.
 	ResourceDiff float64
-}
-
-type byPriorityDesc []prioritizedPod
-
-func (list byPriorityDesc) Len() int {
-	return len(list)
-}
-func (list byPriorityDesc) Swap(i, j int) {
-	list[i], list[j] = list[j], list[i]
-}
-
-// Less implements reverse ordering by priority (highest priority first).
-// This means we return true if priority at index j is lower than at index i.
-func (list byPriorityDesc) Less(i, j int) bool {
-	return list[j].priority.Less(list[i].priority)
 }
 
 // Less returns true if p is lower than other.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Enables few revive rules.

Below are the revive linter rules enabled as part of this PR
        - name: use-slices-sort - Use slices sort instead of sort package (not recommended). Learnt that there is **10-15%** increase in making use of slices sortFunc
        - name: identical-switch-branches - Ensures that if return value is same across multiple cases then simply use comma seperated cases.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Updates #8986

#### Special notes for your reviewer:
Continuation from this [PR](https://github.com/kubernetes/autoscaler/pull/9254)
Also on slices sort perfomance benchmark article: [here](https://medium.com/@mahes0/best-slice-sorting-approach-using-golang-in-2024-c5e1e0d56bcf)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: [here](https://help.github.com/en/articles/getting-permanent-links-to-files)

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
