### PR TITLE
scaleway: report node in error as InstanceCreating so CA detects it faster

### DIFF
--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group.go
@@ -276,6 +276,7 @@ func fromScwStatus(status scalewaygo.NodeStatus) *cloudprovider.InstanceStatus {
 	case scalewaygo.NodeStatusDeleting:
 		st.State = cloudprovider.InstanceDeleting
 	case scalewaygo.NodeStatusCreationError:
+		st.State = cloudprovider.InstanceCreating
 		st.ErrorInfo = &cloudprovider.InstanceErrorInfo{
 			ErrorCode:    string(scalewaygo.NodeStatusCreationError),
 			ErrorMessage: "scaleway node could not be created",

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_node_group_test.go
@@ -652,10 +652,11 @@ func TestFromScwStatus(t *testing.T) {
 			errorCode:    "deleted",
 		},
 		{
-			name:         "creation_error",
-			status:       scalewaygo.NodeStatusCreationError,
-			hasErrorInfo: true,
-			errorCode:    "creation_error",
+			name:          "creation_error",
+			status:        scalewaygo.NodeStatusCreationError,
+			expectedState: cloudprovider.InstanceCreating,
+			hasErrorInfo:  true,
+			errorCode:     "creation_error",
 		},
 		{
 			name:          "upgrading",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

report node in error as InstanceCreating so CA detects it faster

#### Which issue(s) this PR fixes:

n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
scaleway: report node in error as InstanceCreating so CA detects it faster
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
