### PR TITLE
Cluster Autoscaler: Fix flaky unit test & re-enable printf vet check

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -1,10 +1,8 @@
 ALL_ARCH = amd64 arm64 s390x
 all: $(addprefix build-arch-,$(ALL_ARCH))
 
-# TODO: #8127 - Use default analyzers set by `go test` to include `printf` analyzer.
-# Default analyzers that go test runs according to https://github.com/golang/go/blob/52624e533fe52329da5ba6ebb9c37712048168e0/src/cmd/go/internal/test/test.go#L649
-# This doesn't include the `printf` analyzer until cluster-autoscaler libraries are updated.
-GO_TEST_DEFAULT_ANALYZERS?=atomic,bool,buildtags,directive,errorsas,ifaceassert,nilfunc,slog,stringintconv,tests
+GO_TEST_DEFAULT_ANALYZERS?=all
+GO_TEST_EXCLUDE_REGEX?=/cloudprovider/oci/vendor-internal/
 TAG?=dev
 FLAGS=
 LDFLAGS?=-s
@@ -79,16 +77,16 @@ test-build-tags:
 	done
 
 test-unit: clean build
-	go test -race ./... -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}
+	go test -race $$(go list ./... | grep -v ${GO_TEST_EXCLUDE_REGEX} ) -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}
 
 test-controllers: setup-envtest clean build
 	ginkgo --race --vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG} ./test/integration/controllers/...
 
 test-ci: setup-envtest
-	go test -race ./... -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}
+	go test -race $$(go list ./... | grep -v ${GO_TEST_EXCLUDE_REGEX} ) -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}
 
 benchmark:
-	go test ./... -bench=. -run='^$$' -vet="${GO_TEST_DEFAULT_ANALYZERS}"
+	go test $$(go list ./... | grep -v ${GO_TEST_EXCLUDE_REGEX} ) -bench=. -run='^$$' -vet="${GO_TEST_DEFAULT_ANALYZERS}"
 
 dev-release: dev-release-arch-$(GOARCH)
 
@@ -161,7 +159,7 @@ container-arch-%: build-in-docker-arch-% make-image-arch-%
 	@echo "Full in-docker image ${TAG}${FOR_PROVIDER}-$* completed"
 
 test-in-docker: clean docker-builder
-	docker run ${RM_FLAG} -v `pwd`:/cluster-autoscaler/:Z autoscaling-builder:latest bash -c 'cd /cluster-autoscaler && go test -race ./... -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}'
+	docker run ${RM_FLAG} -v `pwd`:/cluster-autoscaler/:Z autoscaling-builder:latest bash -c 'cd /cluster-autoscaler && go test -race $$(go list ./... | grep -v ${GO_TEST_EXCLUDE_REGEX} ) -vet="${GO_TEST_DEFAULT_ANALYZERS}" ${TAGS_FLAG}'
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/util/util.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/util/util.go
@@ -566,7 +566,7 @@ func Debug(title, message string) {
 		klog.V(5).Infof("----------------------------DEBUG: start of %s ----------------------------", title)
 	}
 
-	klog.V(5).Infof(message)
+	klog.V(5).Infof("%s", message)
 
 	if title != "" {
 		klog.V(5).Infof("----------------------------DEBUG: end of %s------------------------------", title)

--- a/cluster-autoscaler/cloudprovider/civo/civo-cloud-sdk-go/errors.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo-cloud-sdk-go/errors.go
@@ -1072,7 +1072,7 @@ func decodeError(err error) error {
 			err := errors.New(msg.String())
 			return KubernetesClusterInvalidNameError.wrap(err)
 		default:
-			err := fmt.Errorf(fmt.Sprintf("Unknown error response - status: %s, code: %d, reason: %s", errorData.Status, errorData.Code, errorData.Reason))
+			err := fmt.Errorf("Unknown error response - status: %s, code: %d, reason: %s", errorData.Status, errorData.Code, errorData.Reason)
 			return CommonError.wrap(err)
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/equinixmetal/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/cloud_provider.go
@@ -69,14 +69,14 @@ func init() {
 type equinixMetalCloudProvider struct {
 	equinixMetalManager equinixMetalManager
 	resourceLimiter     *cloudprovider.ResourceLimiter
-	nodeGroups          []equinixMetalNodeGroup
+	nodeGroups          []*equinixMetalNodeGroup
 }
 
 func buildEquinixMetalCloudProvider(metalManager equinixMetalManager, resourceLimiter *cloudprovider.ResourceLimiter) (cloudprovider.CloudProvider, error) {
 	pcp := &equinixMetalCloudProvider{
 		equinixMetalManager: metalManager,
 		resourceLimiter:     resourceLimiter,
-		nodeGroups:          []equinixMetalNodeGroup{},
+		nodeGroups:          []*equinixMetalNodeGroup{},
 	}
 	return pcp, nil
 }
@@ -106,13 +106,13 @@ func (pcp *equinixMetalCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudp
 func (pcp *equinixMetalCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 	groups := make([]cloudprovider.NodeGroup, len(pcp.nodeGroups))
 	for i := range pcp.nodeGroups {
-		groups[i] = &pcp.nodeGroups[i]
+		groups[i] = pcp.nodeGroups[i]
 	}
 	return groups
 }
 
 // AddNodeGroup appends a node group to the list of node groups managed by this cloud provider.
-func (pcp *equinixMetalCloudProvider) AddNodeGroup(group equinixMetalNodeGroup) {
+func (pcp *equinixMetalCloudProvider) AddNodeGroup(group *equinixMetalNodeGroup) {
 	pcp.nodeGroups = append(pcp.nodeGroups, group)
 }
 
@@ -138,9 +138,9 @@ func (pcp *equinixMetalCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudp
 	if err != nil {
 		return nil, err
 	}
-	for i, nodeGroup := range pcp.nodeGroups {
+	for _, nodeGroup := range pcp.nodeGroups {
 		if nodeGroup.Id() == nodeGroupId {
-			return &(pcp.nodeGroups[i]), nil
+			return nodeGroup, nil
 		}
 	}
 	return nil, fmt.Errorf("Could not find group for node: %s", node.Spec.ProviderID)
@@ -245,7 +245,7 @@ func BuildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.No
 		if err != nil {
 			klog.Fatalf("Could not set current nodes in node group: %v", err)
 		}
-		provider.(*equinixMetalCloudProvider).AddNodeGroup(ng)
+		provider.(*equinixMetalCloudProvider).AddNodeGroup(&ng)
 	}
 
 	return provider

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr/types.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr/types.go
@@ -133,5 +133,5 @@ func (sr ServiceResponseError) Error() string {
 	if err != nil {
 		return fmt.Sprintf("{\"ErrorMessage\": \"%s\",\"ErrorCode\": \"%s\"}", sr.ErrorMessage, sr.ErrorCode)
 	}
-	return fmt.Sprintf(string(data))
+	return string(data)
 }

--- a/cluster-autoscaler/cloudprovider/magnum/fixtures/fixtures_all_states.go
+++ b/cluster-autoscaler/cloudprovider/magnum/fixtures/fixtures_all_states.go
@@ -87,29 +87,29 @@ func f(index int) string {
 // ExpectedInstances are the instances that should be returned for a node group with nodes defined by AllNodes.
 var ExpectedInstances = []cloudprovider.Instance{
 	// Running nodes
-	{p(AllNodes[0].UUID), &cloudprovider.InstanceStatus{cloudprovider.InstanceRunning, nil}},
-	{p(AllNodes[1].UUID), &cloudprovider.InstanceStatus{cloudprovider.InstanceRunning, nil}},
-	{p(AllNodes[2].UUID), &cloudprovider.InstanceStatus{cloudprovider.InstanceRunning, nil}},
+	{Id: p(AllNodes[0].UUID), Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning}},
+	{Id: p(AllNodes[1].UUID), Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning}},
+	{Id: p(AllNodes[2].UUID), Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceRunning}},
 
 	// Creating nodes
-	{f(AllNodes[3].Index), &cloudprovider.InstanceStatus{cloudprovider.InstanceCreating, nil}},
-	{f(AllNodes[4].Index), &cloudprovider.InstanceStatus{cloudprovider.InstanceCreating, nil}},
-	{p(AllNodes[5].UUID), &cloudprovider.InstanceStatus{cloudprovider.InstanceCreating, nil}},
-	{f(AllNodes[6].Index), &cloudprovider.InstanceStatus{cloudprovider.InstanceCreating, nil}},
-	{f(AllNodes[7].Index), &cloudprovider.InstanceStatus{cloudprovider.InstanceCreating, nil}},
+	{Id: f(AllNodes[3].Index), Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating}},
+	{Id: f(AllNodes[4].Index), Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating}},
+	{Id: p(AllNodes[5].UUID), Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating}},
+	{Id: f(AllNodes[6].Index), Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating}},
+	{Id: f(AllNodes[7].Index), Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating}},
 
 	// Deleting nodes
-	{p(AllNodes[8].UUID), &cloudprovider.InstanceStatus{cloudprovider.InstanceDeleting, nil}},
+	{Id: p(AllNodes[8].UUID), Status: &cloudprovider.InstanceStatus{State: cloudprovider.InstanceDeleting}},
 	// node 9 is deleted so it is not reported
 
 	// Failed nodes
-	{f(AllNodes[10].Index), &cloudprovider.InstanceStatus{
-		cloudprovider.InstanceCreating, &cloudprovider.InstanceErrorInfo{
-			cloudprovider.OutOfResourcesErrorClass, "", "out of quota"}},
+	{Id: f(AllNodes[10].Index), Status: &cloudprovider.InstanceStatus{
+		State: cloudprovider.InstanceCreating, ErrorInfo: &cloudprovider.InstanceErrorInfo{
+			ErrorClass: cloudprovider.OutOfResourcesErrorClass, ErrorCode: "", ErrorMessage: "out of quota"}},
 	},
-	{f(AllNodes[11].Index), &cloudprovider.InstanceStatus{
-		cloudprovider.InstanceCreating, &cloudprovider.InstanceErrorInfo{
-			cloudprovider.OtherErrorClass, "", "other error"}},
+	{Id: f(AllNodes[11].Index), Status: &cloudprovider.InstanceStatus{
+		State: cloudprovider.InstanceCreating, ErrorInfo: &cloudprovider.InstanceErrorInfo{
+			ErrorClass: cloudprovider.OtherErrorClass, ErrorCode: "", ErrorMessage: "other error"}},
 	},
 	// node 12 is not reported
 }

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
@@ -373,7 +373,7 @@ func (c *instancePoolCache) setSize(instancePoolID string, size int) error {
 		InstancePoolId: common.String(instancePoolID),
 	})
 	if err != nil {
-		klog.V(4).Infof("GetInstancePool for %s failed: %v", common.String(instancePoolID), err)
+		klog.V(4).Infof("GetInstancePool for %s failed: %v", instancePoolID, err)
 		return err
 	}
 
@@ -390,7 +390,7 @@ func (c *instancePoolCache) setSize(instancePoolID string, size int) error {
 		UpdateInstancePoolDetails: updateDetails,
 	})
 	if err != nil {
-		klog.V(4).Infof("UpdateInstancePool for %s failed: %v", common.String(instancePoolID), err)
+		klog.V(4).Infof("UpdateInstancePool for %s failed: %v", instancePoolID, err)
 		return err
 	}
 

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_instance_pool_cache.go
@@ -414,7 +414,8 @@ func (c *instancePoolCache) setSize(instancePoolID string, size int) error {
 		return err
 	}
 	// Allow an additional time for the pool State to reach Running
-	ctx, _ = context.WithTimeout(ctx, 10*time.Minute)
+	ctx, cancelFunc = context.WithTimeout(ctx, 10*time.Minute)
+	defer cancelFunc()
 	err = c.waitForState(ctx, instancePoolID, core.InstancePoolLifecycleStateRunning)
 	if err != nil {
 		return err

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_provider_test.go
@@ -116,7 +116,7 @@ func TestNodeGroups(t *testing.T) {
 			}
 
 			if len(provider.NodeGroups()) != tc.expectedGroups {
-				t.Fatalf("expected %q groups, got %q", tc.expectedGroups, len(provider.NodeGroups()))
+				t.Fatalf("expected %d groups, got %d", tc.expectedGroups, len(provider.NodeGroups()))
 			}
 		})
 	}

--- a/cluster-autoscaler/cloudprovider/utho/utho_node_group.go
+++ b/cluster-autoscaler/cloudprovider/utho/utho_node_group.go
@@ -167,7 +167,7 @@ func (n *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 		if _, err := n.client.DeleteNode(ctx, param); err != nil {
 			klog.Errorf("DeleteNodes: API error for cluster %d pool %s node %s: %v",
 				n.clusterID, n.id, nodeID, err)
-			return fmt.Errorf("deleting node failed for cluster %q node pool %q node %q: %w",
+			return fmt.Errorf("deleting node failed for cluster %d node pool %q node %q: %w",
 				n.clusterID, n.id, nodeID, err)
 		}
 		klog.V(4).Infof("DeleteNodes: provider confirmed deletion of node %s in pool %s", nodeID, n.id)

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/credentials/sts_provider.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine-go-sdk/volcengine/credentials/sts_provider.go
@@ -62,7 +62,7 @@ func (s *StsProvider) Retrieve() (Value, error) {
 			if _err != nil {
 				return Value{}, _err
 			}
-			return Value{}, fmt.Errorf(string(bb))
+			return Value{}, fmt.Errorf("%s", string(bb))
 		}
 		return Value{}, err
 	}

--- a/cluster-autoscaler/config/flags/flags_test.go
+++ b/cluster-autoscaler/config/flags/flags_test.go
@@ -138,8 +138,8 @@ func TestParseShutdownGracePeriodsAndPriorities(t *testing.T) {
 			name:  "parsable input",
 			input: "1:2,3:4",
 			want: []kubelet_config.ShutdownGracePeriodByPodPriority{
-				{1, 2},
-				{3, 4},
+				{Priority: 1, ShutdownGracePeriodSeconds: 2},
+				{Priority: 3, ShutdownGracePeriodSeconds: 4},
 			},
 		},
 	}

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -1193,7 +1193,7 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
 
-	// Mark unneeded nodes.
+	// Mark unneeded nodes. Use a short time advance (< ScaleDownUnneededTime) so that n1 is not yet eligible for deletion.
 	readyNodeLister.SetNodes([]*apiv1.Node{n1, n2, n3})
 	allNodeLister.SetNodes([]*apiv1.Node{n1, n2, n3})
 	allPodListerMock.On("List").Return([]*apiv1.Pod{p1, p2, p3, p4, p5}, nil).Once()
@@ -1202,20 +1202,20 @@ func TestStaticAutoscalerRunOncePodsWithPriorities(t *testing.T) {
 
 	ng2.SetTargetSize(2)
 
-	err = autoscaler.RunOnce(t.Context(), time.Now().Add(2*time.Hour))
+	err = autoscaler.RunOnce(t.Context(), time.Now().Add(30*time.Second))
 	assert.NoError(t, err)
 	mock.AssertExpectationsForObjects(t, allPodListerMock,
 		podDisruptionBudgetListerMock, daemonSetListerMock, onScaleUpMock, onScaleDownMock)
 
-	// Scale down.
+	// Scale down. n1 has been unneeded long enough now. Reschedule p4 to n2.
 	readyNodeLister.SetNodes([]*apiv1.Node{n1, n2, n3})
 	allNodeLister.SetNodes([]*apiv1.Node{n1, n2, n3})
-	allPodListerMock.On("List").Return([]*apiv1.Pod{p1, p2, p3, p4, p5}, nil).Twice()
+	p4Scheduled := p4.DeepCopy()
+	p4Scheduled.Spec.NodeName = "n2"
+	allPodListerMock.On("List").Return([]*apiv1.Pod{p1, p2, p3, p4Scheduled, p5}, nil).Twice()
 	daemonSetListerMock.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil).Once()
 	podDisruptionBudgetListerMock.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil).Once()
 	onScaleDownMock.On("ScaleDown", "ng1", "n1").Return(nil).Once()
-
-	p4.Spec.NodeName = "n2"
 
 	err = autoscaler.RunOnce(t.Context(), time.Now().Add(3*time.Hour))
 	waitForDeleteToFinish(t, deleteFinished)

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -778,8 +778,8 @@ func TestStaticAutoscalerRunOnceWithAutoprovisionedEnabled(t *testing.T) {
 	onScaleDownMock := &onScaleDownMock{}
 	onNodeGroupCreateMock := &onNodeGroupCreateMock{}
 	onNodeGroupDeleteMock := &onNodeGroupDeleteMock{}
-	nodeGroupManager := &MockAutoprovisioningNodeGroupManager{t, 0}
-	nodeGroupListProcessor := &MockAutoprovisioningNodeGroupListProcessor{t}
+	nodeGroupManager := &MockAutoprovisioningNodeGroupManager{T: t, ExtraGroups: 0}
+	nodeGroupListProcessor := &MockAutoprovisioningNodeGroupListProcessor{T: t}
 	deleteFinished := make(chan bool, 1)
 
 	n1 := BuildTestNode("n1", 100, 1000)

--- a/cluster-autoscaler/expander/grpcplugin/grpc_client_test.go
+++ b/cluster-autoscaler/expander/grpcplugin/grpc_client_test.go
@@ -217,7 +217,7 @@ func TestBestOptionsEmpty(t *testing.T) {
 			mockResponse: protos.BestOptionsResponse{Options: []*protos.Option{}},
 		},
 	}
-	for _, tc := range testCases {
+	for i := range testCases {
 		grpcNodeBytesMap := populateNodeInfoForGRPC(makeFakeNodeInfos())
 		assert.NotNil(t, grpcNodeBytesMap)
 		mockClient.EXPECT().BestOptions(
@@ -225,7 +225,7 @@ func TestBestOptionsEmpty(t *testing.T) {
 				&protos.BestOptionsRequest{
 					Options:      []*protos.Option{&grpcEoT2Micro, &grpcEoT2Large, &grpcEoT3Large, &grpcEoM44XLarge},
 					NodeBytesMap: grpcNodeBytesMap,
-				})).Return(&tc.mockResponse, nil)
+				})).Return(&testCases[i].mockResponse, nil)
 		resp := g.BestOptions(options, makeFakeNodeInfos())
 
 		assert.Nil(t, resp)
@@ -281,18 +281,18 @@ func TestBestOptionsErrors(t *testing.T) {
 			errResponse:  nil,
 		},
 	}
-	for _, tc := range testCases {
-		grpcNodeBytesMap := populateNodeInfoForGRPC(tc.nodeInfo)
+	for i := range testCases {
+		grpcNodeBytesMap := populateNodeInfoForGRPC(testCases[i].nodeInfo)
 		assert.NotNil(t, grpcNodeBytesMap)
-		if tc.client.grpcClient != nil {
+		if testCases[i].client.grpcClient != nil {
 			mockClient.EXPECT().BestOptions(
 				gomock.Any(), gomock.Eq(
 					&protos.BestOptionsRequest{
 						Options:      []*protos.Option{&grpcEoT2Micro, &grpcEoT2Large, &grpcEoT3Large, &grpcEoM44XLarge},
 						NodeBytesMap: grpcNodeBytesMap,
-					})).Return(&tc.mockResponse, tc.errResponse)
+					})).Return(&testCases[i].mockResponse, testCases[i].errResponse)
 		}
-		resp := tc.client.BestOptions(options, tc.nodeInfo)
+		resp := testCases[i].client.BestOptions(options, testCases[i].nodeInfo)
 
 		assert.Equal(t, resp, options)
 	}

--- a/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
+++ b/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
@@ -75,7 +75,7 @@ func OnEmptyCluster(autoscalingCtx *ca_context.AutoscalingContext, status string
 		utils.WriteStatusConfigMap(autoscalingCtx.ClientSet, autoscalingCtx.ConfigNamespace, api.ClusterAutoscalerStatus{AutoscalerStatus: api.ClusterAutoscalerInitializing, Message: status}, autoscalingCtx.LogRecorder, autoscalingCtx.StatusConfigMapName, time.Now())
 	}
 	if emitEvent {
-		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", status)
+		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", "%s", status)
 	}
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/scheduling_error.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/scheduling_error.go
@@ -102,7 +102,7 @@ func (se *schedulingError) Error() string {
 	case NoNodesPassingPredicatesFoundError:
 		msg = fmt.Sprintf("couldn't find a matching Node with passing predicates")
 	default:
-		msg = fmt.Sprintf("SchedulingErrorType type %q unknown - this shouldn't happen", se.errorType)
+		msg = fmt.Sprintf("SchedulingErrorType type %v unknown - this shouldn't happen", se.errorType)
 	}
 
 	return fmt.Sprintf("can't schedule pod %s/%s: %s", se.pod.Namespace, se.pod.Name, msg)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

Fixes #8127

When #8121 landed, it updated to Go 1.24 which started flagging lots of format string validation failures and so disabled the printf vet check. This PR re-enables the printf vet check, fixes the remaining printf-style failures and excludes `cloudprovider/oci/vendor-internal/` from the checks since it doesn't make sense for us to be flagging or fixing an upstream package (and since the vast majority of failures were in that subdirectory).

In addition, there are some flaky unit tests with race conditions  in `TestStaticAutoscalerRunOncePodsWithPriorities`
 which were flaking on me, so I have fixed those.

Before: 
```
$ go test -race -run TestStaticAutoscalerRunOncePodsWithPriorities -count=30000 ./core/
...
WARNING: DATA RACE
Read at 0x00c0009861d0 by goroutine 1086:
  k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes.isScheduled()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:158 +0x445
  k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes.ScheduledPods()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:171 +0x456
  k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*Actuator).createSnapshot()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:417 +0x534
  k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*Actuator).deleteNodesAsync()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:300 +0x1ce
  k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*Actuator).deleteAsyncEmpty.gowrap1()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:190 +0xbc

Previous write at 0x00c0009861d0 by goroutine 1076:
  k8s.io/autoscaler/cluster-autoscaler/core.TestStaticAutoscalerRunOncePodsWithPriorities()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler_test.go:1218 +0x43c9
  k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:399 +0x2178
  k8s.io/autoscaler/cluster-autoscaler/core.TestStaticAutoscalerRunOncePodsWithPriorities()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler_test.go:1205 +0x398e
  k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:530 +0x42a1
  k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:399 +0x2178
  k8s.io/autoscaler/cluster-autoscaler/core.TestStaticAutoscalerRunOncePodsWithPriorities()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler_test.go:1191 +0x3044
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/lib/golang/src/testing/testing.go:2101 +0x38

Goroutine 1086 (running) created at:
  k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*Actuator).deleteAsyncEmpty()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:190 +0x707
  k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*Actuator).startDeletion()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:151 +0x349
  k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*Actuator).StartDeletion()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:122 +0x93
  k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).scaleDown()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:827 +0x12ad
  k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:605 +0x4d84
  k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:530 +0x42a1
  k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:399 +0x2178
  k8s.io/autoscaler/cluster-autoscaler/core.TestStaticAutoscalerRunOncePodsWithPriorities()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler_test.go:1205 +0x398e
  k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:530 +0x42a1
  k8s.io/autoscaler/cluster-autoscaler/core.(*StaticAutoscaler).RunOnce()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler.go:399 +0x2178
  k8s.io/autoscaler/cluster-autoscaler/core.TestStaticAutoscalerRunOncePodsWithPriorities()
      /go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler_test.go:1191 +0x3044
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/lib/golang/src/testing/testing.go:2101 +0x38

Goroutine 1076 (running) created at:
  testing.(*T).Run()
      /usr/lib/golang/src/testing/testing.go:2101 +0xb12
  testing.runTests.func1()
      /usr/lib/golang/src/testing/testing.go:2585 +0x84
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:2036 +0x21c
  testing.runTests()
      /usr/lib/golang/src/testing/testing.go:2583 +0x9e9
  testing.(*M).Run()
      /usr/lib/golang/src/testing/testing.go:2443 +0xf4b
  main.main()
      _testmain.go:112 +0x164
```
or
```
$ go test -race -run TestStaticAutoscalerRunOncePodsWithPriorities -count=30000 ./core/
I0709 01:39:07.127815 1942014 static_autoscaler.go:1403] Found 6 pods in the cluster: 3 scheduled, 1 with nominated node, 2 unschedulable, 0 unprocessed by scheduler, 0 ignored by allowed schedulers (most likely using custom scheduler), 0 ignored due to dissallowed schedulers
W0709 01:39:07.128111 1942014 mixed_nodeinfos_processor.go:178] Built template for ng1 based on unready/unschedulable node n1
W0709 01:39:07.128197 1942014 mixed_nodeinfos_processor.go:178] Built template for ng2 based on unready/unschedulable node n2
W0709 01:39:07.128225 1942014 clusterstate.go:579] AcceptableRanges have not been populated yet. Skip checking
W0709 01:39:07.128237 1942014 clusterstate.go:579] AcceptableRanges have not been populated yet. Skip checking
I0709 01:39:07.129412 1942014 executor.go:166] Scale-up: setting group ng2 size to 3
I0709 01:39:07.129472 1942014 static_autoscaler_test.go:141] Scale up: ng2 1
W0709 01:39:07.130252 1942014 dra_processor.go:60] Cannot filter out nodes with unready DRA resources. The DRA snapshot is nil. Processing will be skipped.
I0709 01:39:07.130337 1942014 static_autoscaler.go:1403] Found 5 pods in the cluster: 3 scheduled, 1 with nominated node, 1 unschedulable, 0 unprocessed by scheduler, 0 ignored by allowed schedulers (most likely using custom scheduler), 0 ignored due to dissallowed schedulers
I0709 01:39:07.144788 1942014 actuator.go:176] Scale-down: removing empty node "n1"
W0709 01:39:07.145833 1942014 dra_processor.go:60] Cannot filter out nodes with unready DRA resources. The DRA snapshot is nil. Processing will be skipped.
I0709 01:39:07.146142 1942014 static_autoscaler.go:1403] Found 5 pods in the cluster: 4 scheduled, 1 with nominated node, 0 unschedulable, 0 unprocessed by scheduler, 0 ignored by allowed schedulers (most likely using custom scheduler), 0 ignored due to dissallowed schedulers
I0709 01:39:07.146504 1942014 actuator.go:296] Scale-down: waiting 1ms before trying to delete nodes
I0709 01:39:07.148080 1942014 static_autoscaler_test.go:151] Scale down: ng1 n1
W0709 01:39:07.148251 1942014 delete_in_batch.go:224] Failed to get template node info for a node group: Not implemented
W0709 01:39:07.152430 1942014 dra_processor.go:60] Cannot filter out nodes with unready DRA resources. The DRA snapshot is nil. Processing will be skipped.
I0709 01:39:07.152544 1942014 static_autoscaler.go:1403] Found 6 pods in the cluster: 3 scheduled, 1 with nominated node, 2 unschedulable, 0 unprocessed by scheduler, 0 ignored by allowed schedulers (most likely using custom scheduler), 0 ignored due to dissallowed schedulers
W0709 01:39:07.153225 1942014 mixed_nodeinfos_processor.go:178] Built template for ng1 based on unready/unschedulable node n1
W0709 01:39:07.153564 1942014 mixed_nodeinfos_processor.go:178] Built template for ng2 based on unready/unschedulable node n2
W0709 01:39:07.153706 1942014 clusterstate.go:579] AcceptableRanges have not been populated yet. Skip checking
W0709 01:39:07.153774 1942014 clusterstate.go:579] AcceptableRanges have not been populated yet. Skip checking
I0709 01:39:07.156176 1942014 executor.go:166] Scale-up: setting group ng2 size to 3
I0709 01:39:07.156261 1942014 static_autoscaler_test.go:141] Scale up: ng2 1
W0709 01:39:07.157217 1942014 dra_processor.go:60] Cannot filter out nodes with unready DRA resources. The DRA snapshot is nil. Processing will be skipped.
I0709 01:39:07.157440 1942014 static_autoscaler.go:1403] Found 5 pods in the cluster: 3 scheduled, 1 with nominated node, 1 unschedulable, 0 unprocessed by scheduler, 0 ignored by allowed schedulers (most likely using custom scheduler), 0 ignored due to dissallowed schedulers
I0709 01:39:07.159477 1942014 actuator.go:176] Scale-down: removing empty node "n1"
I0709 01:39:07.159641 1942014 actuator.go:296] Scale-down: waiting 1ms before trying to delete nodes
panic: 
        assert: mock: The method has been called over 1 times.
                Either do one more Mock.On("List").Return(...), or remove extra call.
                This call was unexpected:
                        List()

                at: [/home/jsmith/go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler_test.go:99 /home/jsmith/go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:412 /home/jsmith/go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:300 /home/jsmith/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64/src/runtime/asm_amd64.s:1771]

goroutine 197619 [running]:
github.com/stretchr/testify/mock.(*Mock).fail(0xc01ee0b630, {0x478b686, 0xa4}, {0xc01e9740c0, 0x4, 0x4})
        /home/jsmith/go/pkg/mod/github.com/stretchr/testify@v1.11.1/mock/mock.go:359 +0x1ac
github.com/stretchr/testify/mock.(*Mock).MethodCalled(0xc01ee0b630, {0x5292dd5, 0x4}, {0x0, 0x0, 0x0})
        /home/jsmith/go/pkg/mod/github.com/stretchr/testify@v1.11.1/mock/mock.go:507 +0x345
github.com/stretchr/testify/mock.(*Mock).Called(0xc01ee0b630, {0x0, 0x0, 0x0})
        /home/jsmith/go/pkg/mod/github.com/stretchr/testify@v1.11.1/mock/mock.go:491 +0x192
k8s.io/autoscaler/cluster-autoscaler/core.(*podListerMock).List(0xc01ee0b630)
        /home/jsmith/go/src/k8s.io/autoscaler/cluster-autoscaler/core/static_autoscaler_test.go:99 +0x45
k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*Actuator).createSnapshot(0xc01ee51ce0, {0xc01b8d41b8, 0x1, 0x1})
        /home/jsmith/go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:412 +0x382
k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*Actuator).deleteNodesAsync(0xc01ee51ce0, {0xc01b8d41b8, 0x1, 0x1}, {0x4879560, 0xc01ee22b80}, 0x0, 0x0, 0x0, 0xf4240)
        /home/jsmith/go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:300 +0x1cf
created by k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation.(*Actuator).deleteAsyncEmpty in goroutine 197596
        /home/jsmith/go/src/k8s.io/autoscaler/cluster-autoscaler/core/scaledown/actuation/actuator.go:190 +0x708
FAIL    k8s.io/autoscaler/cluster-autoscaler/core       73.311s
FAIL
```

After:
```
$ go test -race -run TestStaticAutoscalerRunOncePodsWithPriorities -count=30000 ./core/
ok      k8s.io/autoscaler/cluster-autoscaler/core       193.565s
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: