### PR TITLE
[CapacityBuffer] Fix replicas and percentage sizing logic

### DIFF
--- a/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
+++ b/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
@@ -126,9 +126,10 @@ type CapacityBufferSpec struct {
 	ScalableRef *ScalableRef `json:"scalableRef,omitempty" protobuf:"bytes,3,opt,name=scalableRef"`
 
 	// Replicas defines the desired number of buffer chunks to provision.
-	// If neither `replicas` nor `percentage` is set, as many chunks as fit within
-	// defined resource limits (if any) will be created. If both are set, the maximum
-	// of the two will be used.
+	// The desired number is determined by taking the maximum of `replicas` and
+	// the computed replicas from `percentage` (whichever are defined), and is then capped
+	// by the defined resource `limits` (if defined). If neither `replicas` nor `percentage`
+	// is set, as many chunks as fit within the `limits` will be created.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:ExclusiveMinimum=false

--- a/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
+++ b/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1alpha1/types.go
@@ -137,7 +137,7 @@ type CapacityBufferSpec struct {
 
 	// Percentage defines the desired buffer capacity as a percentage of the
 	// `scalableRef`'s current replicas. This is only applicable if `scalableRef` is set.
-	// The absolute number of replicas is calculated from the percentage by rounding up to a minimum of 1.
+	// The absolute number of replicas is calculated from the percentage by rounding up to the nearest integer.
 	// For example, if `scalableRef` has 10 replicas and `percentage` is 20, 2 buffer chunks will be created.
 	// +optional
 	// +kubebuilder:validation:Minimum=0

--- a/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1/types.go
@@ -126,9 +126,10 @@ type CapacityBufferSpec struct {
 	ScalableRef *ScalableRef `json:"scalableRef,omitempty" protobuf:"bytes,3,opt,name=scalableRef"`
 
 	// Replicas defines the desired number of buffer chunks to provision.
-	// If neither `replicas` nor `percentage` is set, as many chunks as fit within
-	// defined resource limits (if any) will be created. If both are set, the maximum
-	// of the two will be used.
+	// The desired number is determined by taking the maximum of `replicas` and
+	// the computed replicas from `percentage` (whichever are defined), and is then capped
+	// by the defined resource `limits` (if defined). If neither `replicas` nor `percentage`
+	// is set, as many chunks as fit within the `limits` will be created.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:ExclusiveMinimum=false

--- a/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1/types.go
+++ b/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1/types.go
@@ -137,7 +137,7 @@ type CapacityBufferSpec struct {
 
 	// Percentage defines the desired buffer capacity as a percentage of the
 	// `scalableRef`'s current replicas. This is only applicable if `scalableRef` is set.
-	// The absolute number of replicas is calculated from the percentage by rounding up to a minimum of 1.
+	// The absolute number of replicas is calculated from the percentage by rounding up to the nearest integer.
 	// For example, if `scalableRef` has 10 replicas and `percentage` is 20, 2 buffer chunks will be created.
 	// +optional
 	// +kubebuilder:validation:Minimum=0

--- a/cluster-autoscaler/capacitybuffer/translators/replicas.go
+++ b/cluster-autoscaler/capacitybuffer/translators/replicas.go
@@ -56,7 +56,10 @@ func getBufferNumberOfPods(buffer *apiv1.CapacityBuffer, podTemplate corev1.PodT
 }
 
 func replicasFromPercentage(percentage int32, scalableReplicas int32) int32 {
-	return max(0, (percentage)*(scalableReplicas)/100)
+	if percentage <= 0 || scalableReplicas <= 0 {
+		return 0
+	}
+	return (percentage*scalableReplicas + 99) / 100
 }
 
 func limitNumberOfPodsForResource(podTemplate corev1.PodTemplateSpec, limits apiv1.ResourceList) (int32, error) {

--- a/cluster-autoscaler/capacitybuffer/translators/replicas.go
+++ b/cluster-autoscaler/capacitybuffer/translators/replicas.go
@@ -28,18 +28,13 @@ import (
 // getBufferNumberOfPods calculates the desired number of pods for a buffer.
 // scalableReplicas is only provided if the buffer uses a scalable object.
 func getBufferNumberOfPods(buffer *apiv1.CapacityBuffer, podTemplate corev1.PodTemplateSpec, scalableReplicas *int32) (int32, error) {
-	var resolved bool
-	replicas := int32(math.MaxInt32)
+	replicas := int32(-1)
 
 	if buffer.Spec.Replicas != nil {
-		specReplicas := max(0, *buffer.Spec.Replicas)
-		replicas = min(replicas, specReplicas)
-		resolved = true
+		replicas = max(0, *buffer.Spec.Replicas)
 	}
-
 	if buffer.Spec.Percentage != nil && scalableReplicas != nil {
-		replicas = min(replicas, replicasFromPercentage(*buffer.Spec.Percentage, *scalableReplicas))
-		resolved = true
+		replicas = max(replicas, replicasFromPercentage(*buffer.Spec.Percentage, *scalableReplicas))
 	}
 
 	if buffer.Spec.Limits != nil {
@@ -47,14 +42,17 @@ func getBufferNumberOfPods(buffer *apiv1.CapacityBuffer, podTemplate corev1.PodT
 		if err != nil {
 			return 0, err
 		}
-		replicas = min(replicas, limitsReplicas)
-		resolved = true
+		if replicas >= 0 {
+			return min(replicas, limitsReplicas), nil
+		}
+		return limitsReplicas, nil
 	}
 
-	if !resolved {
-		return 0, errors.New("replicas, percentage and limits are not defined")
+	if replicas >= 0 {
+		return replicas, nil
 	}
-	return replicas, nil
+
+	return 0, errors.New("replicas, percentage and limits are not defined")
 }
 
 func replicasFromPercentage(percentage int32, scalableReplicas int32) int32 {

--- a/cluster-autoscaler/capacitybuffer/translators/replicas_test.go
+++ b/cluster-autoscaler/capacitybuffer/translators/replicas_test.go
@@ -62,6 +62,12 @@ func TestGetBufferNumberOfPods(t *testing.T) {
 			expectedReplicas: 20,
 		},
 		{
+			name:             "Only Percentage Rounding Up",
+			percentage:       ptr.To[int32](33), // 33% of 10 = 3.3 -> ceil(3.3) = 4
+			scalableReplicas: ptr.To[int32](10),
+			expectedReplicas: 4,
+		},
+		{
 			name:             "Replicas and Percentage (Replicas larger)",
 			replicas:         ptr.To[int32](25),
 			percentage:       ptr.To[int32](200), // 200% * 10 = 20
@@ -162,10 +168,10 @@ func TestReplicasFromPercentage(t *testing.T) {
 			expected:         0,
 		},
 		{
-			name:             "Rounding down (3.3 -> 3)",
+			name:             "Rounding up (3.3 -> 4)",
 			percentage:       33,
 			scalableReplicas: 10,
-			expected:         3,
+			expected:         4,
 		},
 	}
 

--- a/cluster-autoscaler/capacitybuffer/translators/replicas_test.go
+++ b/cluster-autoscaler/capacitybuffer/translators/replicas_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
+	"k8s.io/utils/ptr"
+)
+
+func TestGetBufferNumberOfPods(t *testing.T) {
+	podTemplate := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		replicas         *int32
+		percentage       *int32
+		limits           *v1.ResourceList
+		scalableReplicas *int32
+		expectedReplicas int32
+		expectError      bool
+	}{
+		{
+			name:             "Only Replicas",
+			replicas:         ptr.To[int32](5),
+			expectedReplicas: 5,
+		},
+		{
+			name:             "Only Percentage",
+			percentage:       ptr.To[int32](200), // 200% * 10 = 20
+			scalableReplicas: ptr.To[int32](10),
+			expectedReplicas: 20,
+		},
+		{
+			name:             "Replicas and Percentage (Replicas larger)",
+			replicas:         ptr.To[int32](25),
+			percentage:       ptr.To[int32](200), // 200% * 10 = 20
+			scalableReplicas: ptr.To[int32](10),
+			expectedReplicas: 25,
+		},
+		{
+			name:             "Replicas and Percentage (Percentage larger)",
+			replicas:         ptr.To[int32](15),
+			percentage:       ptr.To[int32](200), // 200% * 10 = 20
+			scalableReplicas: ptr.To[int32](10),
+			expectedReplicas: 20,
+		},
+		{
+			name:             "Replicas and Limits (Limits smaller)",
+			replicas:         ptr.To[int32](25),
+			limits:           &v1.ResourceList{v1.ResourceName(corev1.ResourceCPU): resource.MustParse("20")},
+			expectedReplicas: 20,
+		},
+		{
+			name:             "Replicas and Limits (Replicas smaller)",
+			replicas:         ptr.To[int32](15),
+			limits:           &v1.ResourceList{v1.ResourceName(corev1.ResourceCPU): resource.MustParse("20")},
+			expectedReplicas: 15,
+		},
+		{
+			name:             "Percentage and Limits (Limits smaller)",
+			percentage:       ptr.To[int32](250), // 250% * 10 = 25
+			scalableReplicas: ptr.To[int32](10),
+			limits:           &v1.ResourceList{v1.ResourceName(corev1.ResourceCPU): resource.MustParse("20")},
+			expectedReplicas: 20,
+		},
+		{
+			name:             "Only Limits",
+			limits:           &v1.ResourceList{v1.ResourceName(corev1.ResourceCPU): resource.MustParse("20")},
+			expectedReplicas: 20,
+		},
+		{
+			name:        "Nothing specified",
+			expectError: true,
+		},
+		{
+			name:        "Percentage present but scalableReplicas nil",
+			percentage:  ptr.To[int32](200),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			buffer := &v1.CapacityBuffer{
+				Spec: v1.CapacityBufferSpec{
+					Replicas:   tc.replicas,
+					Percentage: tc.percentage,
+					Limits:     tc.limits,
+				},
+			}
+			actual, err := getBufferNumberOfPods(buffer, podTemplate, tc.scalableReplicas)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedReplicas, actual)
+			}
+		})
+	}
+}
+
+func TestReplicasFromPercentage(t *testing.T) {
+	testCases := []struct {
+		name             string
+		percentage       int32
+		scalableReplicas int32
+		expected         int32
+	}{
+		{
+			name:             "200% of 10",
+			percentage:       200,
+			scalableReplicas: 10,
+			expected:         20,
+		},
+		{
+			name:             "50% of 10",
+			percentage:       50,
+			scalableReplicas: 10,
+			expected:         5,
+		},
+		{
+			name:             "0% of 10",
+			percentage:       0,
+			scalableReplicas: 10,
+			expected:         0,
+		},
+		{
+			name:             "50% of 0",
+			percentage:       50,
+			scalableReplicas: 0,
+			expected:         0,
+		},
+		{
+			name:             "Rounding down (3.3 -> 3)",
+			percentage:       33,
+			scalableReplicas: 10,
+			expected:         3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := replicasFromPercentage(tc.percentage, tc.scalableReplicas)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestCalculateMaxPodsFromLimits(t *testing.T) {
+	podRequests := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("100m"),
+		corev1.ResourceMemory: resource.MustParse("200Mi"),
+	}
+
+	limits := v1.ResourceList{
+		v1.ResourceName(corev1.ResourceCPU):    resource.MustParse("2"),
+		v1.ResourceName(corev1.ResourceMemory): resource.MustParse("2000Mi"),
+	}
+
+	maxPods, err := calculateMaxPodsFromLimits(podRequests, limits)
+	assert.NoError(t, err)
+	// CPU allows 2 / 0.1 = 20
+	// Memory allows 2000 / 200 = 10
+	// Should be the min of these -> 10
+	assert.Equal(t, int32(10), maxPods)
+}

--- a/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator_test.go
+++ b/cluster-autoscaler/capacitybuffer/translators/scalable_objects_translator_test.go
@@ -156,6 +156,20 @@ func TestScalableObjectsTranslator(t *testing.T) {
 				}, ptr.To[int32](200), ptr.To[int32](15)),
 			},
 			expectedStatus: []*v1.CapacityBufferStatus{
+				testutil.GetBufferStatus(&v1.LocalObjectRef{Name: "capacitybuffer-buffer1-pod-template"}, ptr.To[int32](20), ptr.To[int64](0), nil, testutil.GetConditionReady()),
+			},
+			expectedNumberOfErrors: 0,
+		},
+		{
+			name: "A buffer referencing replica set with percentage 50% and replicas 15",
+			buffers: []*v1.CapacityBuffer{
+				getTestBufferWithScalableAttributes("buffer1", &v1.ScalableRef{
+					Name:     "replicaSet1",
+					Kind:     "ReplicaSet",
+					APIGroup: "apps",
+				}, ptr.To[int32](50), ptr.To[int32](15)),
+			},
+			expectedStatus: []*v1.CapacityBufferStatus{
 				testutil.GetBufferStatus(&v1.LocalObjectRef{Name: "capacitybuffer-buffer1-pod-template"}, ptr.To[int32](15), ptr.To[int64](0), nil, testutil.GetConditionReady()),
 			},
 			expectedNumberOfErrors: 0,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR fixes issues with how the desired number of buffer chunks is computed in `CapacityBuffer`:
- **Corrects Replicas vs Percentage logic**: Fixes `getBufferNumberOfPods` to correctly take the `max` of the `replicas` and `percentage` fields (instead of `min`) when both are specified, adhering to the original design proposal.
- **Fixes Percentage Rounding**: Modifies the `percentage` computation (`replicasFromPercentage`) to correctly round up fractional chunks to the nearest integer using standard ceiling division, rather than incorrectly truncating them.
- **Clarifies API Documentation**: Updates the struct field comments for `Replicas` and `Percentage` in the `v1alpha1` and `v1beta1` APIs to clearly explain the sizing logic and rounding behavior.
- **Adds Test Coverage**: Introduces comprehensive table-driven unit tests in `replicas_test.go` to ensure correctness across all combinations of `replicas`, `percentage`, and `limits`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9948

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug in `CapacityBuffer` where specifying both `replicas` and `percentage` resulted in the minimum of the two values being used instead of the maximum. Additionally, calculating chunks from a `percentage` now correctly rounds up fractional values to the nearest integer.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
