### PR TITLE
AEP-9936: Per-VPA Observation Window

### DIFF
--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -53,7 +53,7 @@ This feature moves the sequencing into the VPA API itself. Operators declare "wa
 ### Non-Goals
 
 - **Recommender-confidence-based gating.** This feature is a user-declared policy, not a recommender-computed signal. Interoperation with `LowConfidence` / `RecommendationProvided` is left for future work.
-- **Reset semantics on PATCH of other fields.** Changing `resourcePolicy`, `targetRef`, or the target workload does not reset the window. The window is anchored on `vpa.CreationTimestamp`; users who need to re-observe a workload after a material change should delete and recreate the VPA.
+- **Reset semantics on modification of other fields.** Changing `resourcePolicy`, `targetRef`, or the target workload does not reset the window. The window is anchored on `vpa.CreationTimestamp`; users who need to re-observe a workload after a material change should delete and recreate the VPA.
 - **Cluster-wide default windows.** Different applications and different VPAs on the same target want different windows; this is a per-VPA concern.
 
 ## Proposal

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -12,6 +12,7 @@
   - [Gate Evaluation](#gate-evaluation)
   - [Interaction with <code>updateMode</code>](#interaction-with-updatemode)
   - [Interaction with CPU Startup Boost](#interaction-with-cpu-startup-boost)
+  - [Interaction with Checkpoints](#interaction-with-checkpoints)
   - [Validation](#validation)
   - [Status Condition](#status-condition)
   - [Metric](#metric)
@@ -185,6 +186,16 @@ The interaction appears at boost expiry, when the Updater performs the post-boos
 
 - Delay window still active → the pod is scaled down to its original spec resources; no recommendation is actuated.
 - Delay window elapsed → the pod is scaled down to the VPA recommendation, per normal post-boost behaviour.
+
+### Interaction with Checkpoints
+
+`VerticalPodAutoscalerCheckpoint` objects persist the Recommender's learned usage history for each VPA. When a VPA is deleted, its checkpoints are garbage-collected on the Recommender's next pass (`--checkpoints-gc-interval`, 10 minutes by default) — so if a VPA is recreated with the same name before that pass, the Recommender restores its history from the checkpoint and `status.recommendation` is immediately repopulated with mature values, rather than starting cold.
+
+This matters here because a recreated VPA can therefore hold mature recommendations while its delay window is still active, which raises the question of whether the gate should open early in that case.
+
+Proposed handling: the gate ignores checkpoints entirely. A recreated VPA always starts a fresh window anchored to the new object's `CreationTimestamp`, whether its recommendations were restored or rebuilt from scratch.
+
+Rationale: keeping the gate a pure function of `CreationTimestamp` and the spec value is the core simplicity of this design — making it checkpoint-aware would reintroduce state and turn the field into a confidence signal, which is an explicit [non-goal](#non-goals). Users who recreate a VPA and are satisfied with the restored recommendations already have an escape hatch: shorten or remove `initialDelaySeconds` on the new object to open the gate early.
 
 ### Validation
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -73,7 +73,7 @@ InitialDelaySeconds *int32 `json:"initialDelaySeconds,omitempty"`
 
 Behaviour, in one sentence: **the Updater and the Admission Controller treat the VPA as if `updateMode` were `Off` until `now >= vpa.CreationTimestamp + spec.updatePolicy.initialDelaySeconds`.** After that, the configured `updateMode` takes effect.
 
-Modifying the VPA's spec does not reset the window. The gate is a pure function of the immutable `vpa.CreationTimestamp` and the current value of `initialDelaySeconds`, re-evaluated on every reconcile — there is no per-object state to reset. The full modification semantics are enumerated in [Gate Evaluation](#gate-evaluation). While the gate is active, the [`InitialDelayActive` status condition](#status-condition) surfaces it on the VPA object.
+Modifying the VPA's spec does not reset the window. The gate is a pure function of the immutable `vpa.CreationTimestamp` and the current value of `initialDelaySeconds`, re-evaluated on every reconcile — there is no per-object state to reset. The full modification semantics are described in [Gate Evaluation](#gate-evaluation). While the gate is active, the [`InitialDelayActive` status condition](#status-condition) surfaces it on the VPA object.
 
 ## Design Details
 
@@ -169,16 +169,7 @@ When `inInitialDelayWindow` returns `true`, both components take the same code p
 
 The gate is stateless: it is a pure function of `CreationTimestamp` (immutable on the object) and the current spec value (mutable). No caching, no status writes.
 
-The gate consults exactly these two inputs. No other field — existing or added to the CRD in the future — participates in gate evaluation. The table below is therefore not a set of per-field policy decisions; it enumerates the consequences of that single formula:
-
-| Modification | Effect |
-| --- | --- |
-| Shorten `initialDelaySeconds` during window | Gate releases earlier on next reconcile. |
-| Extend `initialDelaySeconds` during window | Gate stays open longer. |
-| Extend `initialDelaySeconds` **after** expiry | Gate re-arms on the next reconcile **only if** the new expiry (`CreationTimestamp + newValue`) still lies in the future. A value whose expiry is already in the past leaves the gate open. |
-| Remove `initialDelaySeconds` (or set to zero) | Gate closes immediately on next reconcile. |
-| Modify `updateMode` | New mode takes effect when the window elapses (or immediately, if already elapsed). |
-| Modify `resourcePolicy` / `targetRef` | No effect on the gate. |
+No VPA spec change affects the gate **except** modifying `initialDelaySeconds` itself: the new value simply moves the expiry (`CreationTimestamp + initialDelaySeconds`), so on the next reconcile the gate may open earlier (value shortened or removed) or stay closed longer (value extended). No other field — existing or added to the CRD in the future — participates in gate evaluation; `updateMode` changes only what happens once the gate opens.
 
 Re-arm after expiry is possible but not guaranteed: because the window is anchored to `CreationTimestamp`, a modification re-arms the gate only when the new expiry still lies in the future. This is intentional — it lets users extend an observation window in response to observed instability without deleting the VPA, while a larger-but-already-elapsed value on an old VPA simply has no effect. If reviewers consider this a footgun serious enough to justify admission logic, we can add a check rejecting PATCHes that would push `expiry` past `now` once the window has already elapsed — see [Alternatives Considered](#alternatives-considered).
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -54,7 +54,7 @@ This feature moves the sequencing into the VPA API itself. Operators declare "wa
 
 - **Recommender-confidence-based gating.** This feature is a user-declared policy, not a recommender-computed signal. Interoperation with `LowConfidence` / `RecommendationProvided` is left for future work.
 - **Reset semantics on modification of other fields.** Changing `resourcePolicy`, `targetRef`, or the target workload does not reset the window. The window is anchored on `vpa.CreationTimestamp`; users who need to re-observe a workload after a material change should delete and recreate the VPA.
-- **Cluster-wide default windows.** Different applications and different VPAs on the same target want different windows; this is a per-VPA concern.
+- **Cluster-wide default windows.** Out of scope for this AEP; operators can inject a default with a Mutating Admission Policy (see [Alternatives Considered](#alternatives-considered), item 3).
 
 ## Proposal
 
@@ -378,7 +378,45 @@ Pods created during the first hour receive their `Deployment`-spec resources unc
 
 **2. Recommender-side confidence gate.** Block `RecommendationProvided` from becoming `True` for N hours or until a confidence threshold is met. Cleaner conceptually but hides visibility — operators would see no recommendation at all in `status.recommendation` during the window, defeating the "collect first, inspect, then apply" workflow this feature is meant to support.
 
-**3. Global Updater flag** (e.g. `--default-observation-window-seconds`). Wrong axis: different applications in the same cluster want different windows, and different VPAs on the same target want different windows.
+**3. Global default flag** (e.g. `--default-initial-delay-seconds`). A sane cluster-wide default is genuinely useful, but the flag would need to be added to — and kept in sync between — both the Updater and the Admission Controller, since both evaluate the gate. Operators who want a cluster-wide default can instead inject one at admission time with a [Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/), with no new VPA configuration surface. For example, to default every VPA that does not set the field to a one-hour window:
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: vpa-default-initial-delay
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["autoscaling.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["verticalpodautoscalers"]
+  matchConditions:
+  - name: no-explicit-initial-delay
+    expression: "!has(object.spec.updatePolicy) || !has(object.spec.updatePolicy.initialDelaySeconds)"
+  failurePolicy: Ignore
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: >
+        Object{
+          spec: Object.spec{
+            updatePolicy: Object.spec.updatePolicy{
+              initialDelaySeconds: 3600
+            }
+          }
+        }
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: vpa-default-initial-delay-binding
+spec:
+  policyName: vpa-default-initial-delay
+```
+
+A component flag can be revisited as a follow-up if the policy route proves insufficient.
 
 **4. Do nothing; rely on operator tooling.** The status quo. Ships the complexity downstream to every VPA operator; the CronJob-plus-patch-controller dance ends up reinvented per environment.
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -11,6 +11,7 @@
   - [API Changes](#api-changes)
   - [Gate Evaluation](#gate-evaluation)
   - [Interaction with <code>updateMode</code>](#interaction-with-updatemode)
+  - [Interaction with CPU Startup Boost](#interaction-with-cpu-startup-boost)
   - [Validation](#validation)
   - [Status Condition](#status-condition)
   - [Metric](#metric)
@@ -27,9 +28,9 @@
 
 ## Summary
 
-Add an optional `observationPeriodSeconds` field to `PodUpdatePolicy` that tells the Updater to refrain from applying recommendations for a configurable duration after a VPA's creation. During the window the Recommender continues to compute and publish recommendations to `status.recommendation` normally — only the Updater is gated. Once the window elapses, the configured `updateMode` takes effect automatically with no operator action.
+Add an optional `initialDelaySeconds` field to `PodUpdatePolicy` that delays actuation of recommendations for a configurable duration after a VPA's creation. During the window the Recommender continues to compute and publish recommendations to `status.recommendation` normally, but nothing actuates them: the Updater performs no evictions or in-place resizes, and the Admission Controller does not apply recommendations to pods created during the window. The VPA behaves exactly as if `updateMode` were `Off`. Once the window elapses, the configured `updateMode` takes effect automatically with no operator action.
 
-The window is computed as a pure function of `vpa.CreationTimestamp` and the current spec value, evaluated on every reconcile. No status writes are required.
+The window is computed as a pure function of `vpa.CreationTimestamp` and the current spec value, evaluated on every reconcile. No status writes are required. Modifying an existing VPA's spec does not reset the window — the anchor (`CreationTimestamp`) is immutable, and changing `initialDelaySeconds` itself simply moves the expiry relative to that anchor (see [Gate Evaluation](#gate-evaluation) for the full PATCH semantics).
 
 ## Motivation
 
@@ -41,11 +42,11 @@ This feature moves the sequencing into the VPA API itself. Operators declare "wa
 
 ### Goals
 
-- Provide a declarative per-VPA field that delays Updater actuation for a configurable duration after VPA creation.
+- Provide a declarative per-VPA field that delays all actuation — evictions, in-place resizes, and admission-time injection into newly created pods — for a configurable duration after VPA creation.
 - Keep the Recommender's behaviour unchanged: recommendations are still computed and published to `status.recommendation` during the window, so operators can inspect them.
 - Work uniformly across `Recreate`, `InPlaceOrRecreate`, `InPlace`, and `Initial`.
-- Require no status writes and no admission-side PATCH restrictions in v1: the gate is a pure function of `CreationTimestamp` and the current spec value.
-- Surface the gate state through both a status condition (`ObservationPeriodActive`) and a Prometheus gauge (`vpa_in_observation_window`), so operators and dashboards can see when a VPA is gated without inspecting `spec`.
+- Require no status writes and no PATCH-blocking admission validation in v1: the gate is a pure function of `CreationTimestamp` and the current spec value.
+- Surface the gate state through both a status condition (`InitialDelayActive`) and a Prometheus gauge (`vpa_initial_delay_active`), so operators and dashboards can see when a VPA is gated without inspecting `spec`.
 
 ### Non-Goals
 
@@ -58,25 +59,31 @@ This feature moves the sequencing into the VPA API itself. Operators declare "wa
 Add a single optional field to `PodUpdatePolicy` (autoscaling.k8s.io/v1):
 
 ```go
-// ObservationPeriodSeconds is the duration in seconds after this VPA's
-// creation during which the Updater will refrain from applying
-// recommendations, regardless of the configured UpdateMode.
+// InitialDelaySeconds is the duration in seconds after this VPA's
+// creation during which recommendations are not actuated: the Updater
+// performs no evictions or in-place resizes, and the Admission
+// Controller does not apply recommendations to newly created pods,
+// regardless of the configured UpdateMode.
 // +optional
 // +kubebuilder:validation:Minimum=1
-ObservationPeriodSeconds *int32 `json:"observationPeriodSeconds,omitempty"`
+// +kubebuilder:validation:Maximum=7776000
+InitialDelaySeconds *int32 `json:"initialDelaySeconds,omitempty"`
 ```
 
-Behaviour, in one sentence: **the Updater treats the VPA as if `updateMode` were `Off` until `now >= vpa.CreationTimestamp + spec.updatePolicy.observationPeriodSeconds`.** After that, the configured `updateMode` takes effect.
+Behaviour, in one sentence: **the Updater and the Admission Controller treat the VPA as if `updateMode` were `Off` until `now >= vpa.CreationTimestamp + spec.updatePolicy.initialDelaySeconds`.** After that, the configured `updateMode` takes effect.
+
+Modifying the VPA's spec does not reset the window. The gate is a pure function of the immutable `vpa.CreationTimestamp` and the current value of `initialDelaySeconds`, re-evaluated on every reconcile — there is no per-object state to reset. The full PATCH semantics are enumerated in [Gate Evaluation](#gate-evaluation). While the gate is active, the [`InitialDelayActive` status condition](#status-condition) surfaces it on the VPA object.
 
 ## Design Details
 
 ### Workflow
 
-1. The user creates a VPA with a non-`Off` `updateMode` and `observationPeriodSeconds: N` set on `spec.updatePolicy`.
+1. The user creates a VPA with a non-`Off` `updateMode` and `initialDelaySeconds: N` set on `spec.updatePolicy`.
 2. The Recommender begins computing recommendations on the normal schedule and populates `status.recommendation`. It is unaware of and unaffected by the observation window.
-3. On every Updater reconcile, before deciding whether the VPA is eligible for actuation, the Updater evaluates the gate. If the gate is active, the VPA is treated as if `updateMode` were `Off` for that reconcile: no pods are evicted (`Recreate` / `InPlaceOrRecreate`), no in-place resize is attempted (`InPlace` / `InPlaceOrRecreate`), and no admission-controller-side injection happens on new-pod creation (`Initial`).
-4. The Updater sets the `ObservationPeriodActive` status condition to `True` while the gate is active and `False` once it has elapsed. It emits the `vpa_in_observation_window` gauge accordingly.
-5. On the first reconcile after `CreationTimestamp + observationPeriodSeconds`, the gate opens and the configured `updateMode` takes effect on subsequent reconciles.
+3. On every Updater reconcile, before deciding whether the VPA is eligible for actuation, the Updater evaluates the gate. If the gate is active, the VPA is treated as if `updateMode` were `Off` for that reconcile: no pods are evicted (`Recreate` / `InPlaceOrRecreate`) and no in-place resize is attempted (`InPlace` / `InPlaceOrRecreate`).
+4. The Admission Controller evaluates the same gate whenever a pod matching the VPA's target is created. While the gate is active it does not patch the pod's resources — the pod is admitted with its original spec, exactly as under `updateMode: Off`. This applies to every mode, not just `Initial`: without it, pods created during the window (scale-ups, node replacements, crash restarts) would receive un-stabilised recommendations at admission time.
+5. The Updater sets the `InitialDelayActive` status condition to `True` while the gate is active and `False` once it has elapsed. It emits the `vpa_initial_delay_active` gauge accordingly.
+6. On the first reconcile after `CreationTimestamp + initialDelaySeconds`, the gate opens and the configured `updateMode` takes effect on subsequent reconciles and pod creations.
 
 ### API Changes
 
@@ -87,55 +94,68 @@ type PodUpdatePolicy struct {
     // ... existing fields (UpdateMode, MinReplicas, EvictionRequirements,
     //                     EvictAfterOOMSeconds) ...
 
-    // ObservationPeriodSeconds is the duration in seconds after this
-    // VPA's creation during which the Updater will refrain from applying
-    // recommendations, regardless of the configured UpdateMode.
+    // InitialDelaySeconds is the duration in seconds after this
+    // VPA's creation during which recommendations are not actuated,
+    // regardless of the configured UpdateMode.
     //
     // During the window, the Recommender continues to compute and
     // publish recommendations to status.recommendation as usual, but the
-    // Updater treats the VPA as if UpdateMode were Off. After the window
-    // elapses (now >= CreationTimestamp + ObservationPeriodSeconds), the
-    // configured UpdateMode takes effect on subsequent reconciles.
+    // Updater and the Admission Controller treat the VPA as if
+    // UpdateMode were Off: no evictions, no in-place resizes, and no
+    // recommendation injection into newly created pods. After the window
+    // elapses (now >= CreationTimestamp + InitialDelaySeconds), the
+    // configured UpdateMode takes effect on subsequent reconciles and
+    // pod creations.
     //
     // The window is computed as a pure function of vpa.CreationTimestamp
     // and this spec field. PATCH is allowed; the new value takes effect
     // on the next reconcile. Removing the field or setting it to zero
-    // closes the gate immediately. Extending the value after the window
-    // has already expired will re-arm the gate.
+    // closes the gate immediately. Setting a larger value after the
+    // window has expired re-arms the gate only if the new expiry
+    // (CreationTimestamp + InitialDelaySeconds) still lies in the
+    // future; otherwise the gate stays open.
     //
     // If UpdateMode is Off, this field has no effect: Off already
     // suppresses Updater actuation indefinitely.
     //
-    // Must be >= 1 if set.
+    // Must be between 1 and 7776000 (90 days) if set.
     // +optional
     // +kubebuilder:validation:Minimum=1
-    ObservationPeriodSeconds *int32 `json:"observationPeriodSeconds,omitempty"`
+    // +kubebuilder:validation:Maximum=7776000
+    InitialDelaySeconds *int32 `json:"initialDelaySeconds,omitempty"`
 }
 ```
 
-Follows the shape of `EvictAfterOOMSeconds` (the only existing time-based field on the same struct) and `DurationSeconds` from AEP-7862.
+Follows the shape of `EvictAfterOOMSeconds` (the only existing time-based field on the same struct) and `DurationSeconds` from AEP-7862; the name matches `initialDelaySeconds` on Pod probes.
+
+Gate state is surfaced via the [`InitialDelayActive` condition](#status-condition).
 
 ### Gate Evaluation
 
-Reference implementation, invoked at the beginning of the Updater's per-VPA eligibility path:
+Reference implementation, exposed from a shared package (`pkg/utils/vpa`) and consumed by both actuating components:
 
 ```go
-// inObservationWindow returns true if the VPA is currently within its
-// declared observation window and the Updater should refrain from
-// applying recommendations.
-func inObservationWindow(vpa *vpa_types.VerticalPodAutoscaler, now time.Time) bool {
+// inInitialDelayWindow returns true if the VPA is currently within its
+// declared observation window and the Updater and Admission Controller
+// should refrain from actuating recommendations.
+func inInitialDelayWindow(vpa *vpa_types.VerticalPodAutoscaler, now time.Time) bool {
     p := vpa.Spec.UpdatePolicy
-    if p == nil || p.ObservationPeriodSeconds == nil || *p.ObservationPeriodSeconds < 1 {
+    if p == nil || p.InitialDelaySeconds == nil || *p.InitialDelaySeconds < 1 {
         return false
     }
     expiry := vpa.CreationTimestamp.Add(
-        time.Duration(*p.ObservationPeriodSeconds) * time.Second,
+        time.Duration(*p.InitialDelaySeconds) * time.Second,
     )
     return now.Before(expiry)
 }
 ```
 
-Insertion point: at the top of the Updater's eligibility check in `pkg/updater/logic/updater.go`, at the same call site where `UpdateModeOff` and `UpdateModeInitial` currently short-circuit the eviction path. When `inObservationWindow` returns `true`, the Updater takes the same code path it takes for `UpdateModeOff` today.
+Insertion points:
+
+- **Updater** — at the top of the eligibility check in `pkg/updater/logic/updater.go`, at the same call site where `UpdateModeOff` and `UpdateModeInitial` currently short-circuit the eviction path.
+- **Admission Controller** — at the existing `UpdateModeOff` short-circuits in `pkg/admission-controller/resource/vpa/matcher.go` and `pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go`, so pods created during the window are admitted with their original spec resources.
+
+When `inInitialDelayWindow` returns `true`, both components take the same code path they take for `UpdateModeOff` today.
 
 The gate is stateless: it is a pure function of `CreationTimestamp` (immutable on the object) and the current spec value (mutable). No caching, no status writes.
 
@@ -143,30 +163,39 @@ Consequences that fall out of this design:
 
 | PATCH operation | Effect |
 | --- | --- |
-| Shorten `observationPeriodSeconds` during window | Gate releases earlier on next reconcile. |
-| Extend `observationPeriodSeconds` during window | Gate stays open longer. |
-| Extend `observationPeriodSeconds` **after** expiry | Gate re-arms on next reconcile. |
-| Remove `observationPeriodSeconds` (or set to zero) | Gate closes immediately on next reconcile. |
+| Shorten `initialDelaySeconds` during window | Gate releases earlier on next reconcile. |
+| Extend `initialDelaySeconds` during window | Gate stays open longer. |
+| Extend `initialDelaySeconds` **after** expiry | Gate re-arms on the next reconcile **only if** the new expiry (`CreationTimestamp + newValue`) still lies in the future. A value whose expiry is already in the past leaves the gate open. |
+| Remove `initialDelaySeconds` (or set to zero) | Gate closes immediately on next reconcile. |
 | Modify `updateMode` | New mode takes effect when the window elapses (or immediately, if already elapsed). |
 | Modify `resourcePolicy` / `targetRef` | No effect on the gate. |
 
-The re-arm-after-expiry behaviour is intentional: it lets users manually extend an observation window in response to observed instability without deleting the VPA. If reviewers consider this a footgun serious enough to justify admission logic, we can add a check rejecting PATCHes that would push `expiry` past `now` once the window has already elapsed — see [Alternatives Considered](#alternatives-considered).
+Re-arm after expiry is possible but not guaranteed: because the window is anchored to `CreationTimestamp`, a PATCH re-arms the gate only when the new expiry still lies in the future. This is intentional — it lets users extend an observation window in response to observed instability without deleting the VPA, while a larger-but-already-elapsed value on an old VPA simply has no effect. If reviewers consider this a footgun serious enough to justify admission logic, we can add a check rejecting PATCHes that would push `expiry` past `now` once the window has already elapsed — see [Alternatives Considered](#alternatives-considered).
 
 ### Interaction with `updateMode`
 
-The observation window is orthogonal to `updateMode`. While the gate is active, the Updater behaves as if `updateMode` were `Off` regardless of the configured value. Once the gate opens, the configured mode takes effect normally:
+The observation window is orthogonal to `updateMode`. While the gate is active, the Updater and the Admission Controller behave as if `updateMode` were `Off` regardless of the configured value: no evictions, no in-place resizes, and no recommendation injection into pods created during the window. Once the gate opens, the configured mode takes effect normally:
 
 - `Recreate` → the Updater is now eligible to evict pods to apply recommendations.
 - `InPlaceOrRecreate` → the Updater attempts in-place resize first, falling back to eviction.
 - `InPlace` → the Updater attempts in-place resize only; no evictions.
 - `Initial` → the admission-controller-side injection is now eligible to run on subsequent new-pod creations. Pods created during the window (or pods that pre-dated the VPA) are unaffected, matching the standard `Initial` semantics.
-- `Off` → `observationPeriodSeconds` has no effect. `Off` already suppresses actuation indefinitely, so combining the two is a valid (but redundant) configuration that silently no-ops. No error, no warning; the field is simply ignored.
+- `Off` → `initialDelaySeconds` has no effect; `Off` already suppresses actuation indefinitely.
+
+### Interaction with CPU Startup Boost
+
+CPU Startup Boost (AEP-7862) still applies during the delay window: the boost is a startup-safety mechanism computed from the pod's own spec, not a recommendation, and the Admission Controller already applies it even under `updateMode: Off` (the `Off` short-circuit in `resource/vpa/matcher.go` is bypassed for VPAs with a boost). The gate reuses the same `Off` semantics, so boosted containers remain boosted.
+
+The interaction appears at boost expiry, when the Updater performs the post-boost in-place downscale:
+
+- Delay window still active → the pod is scaled down to its original spec resources; no recommendation is actuated.
+- Delay window elapsed → the pod is scaled down to the VPA recommendation, per normal post-boost behaviour.
 
 ### Validation
 
 Enforced via CRD schema:
 
-- `observationPeriodSeconds` must be an integer `>= 1` if set.
+- `initialDelaySeconds` must be an integer between `1` and `7776000` (90 days) if set. The upper bound follows the [API conventions for numeric fields](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#numeric-fields); observation windows are realistically hours to days, so 90 days is generous headroom while still rejecting absurd values.
 
 No dynamic (admission-webhook) validation is required in v1. All lifecycle transitions are handled declaratively by the gate.
 
@@ -174,41 +203,41 @@ No dynamic (admission-webhook) validation is required in v1. All lifecycle trans
 
 Add a new value to the existing `VerticalPodAutoscalerStatus.Conditions` slice:
 
-- **Type:** `ObservationPeriodActive`
+- **Type:** `InitialDelayActive`
 - **Status:** `True` while the gate is active, `False` once it has elapsed.
 - **Reason:** `WindowActive` (True) / `WindowExpired` (False).
 - **Message:** human-readable summary including expiry timestamp.
 
-This lets `kubectl describe vpa` surface the gate without an operator having to compute `CreationTimestamp + observationPeriodSeconds` mentally.
+This lets `kubectl describe vpa` surface the gate without an operator having to compute `CreationTimestamp + initialDelaySeconds` mentally.
 
 ### Metric
 
 Emit a new gauge from the Updater:
 
 ```
-vpa_in_observation_window{namespace, name} = 0 | 1
+vpa_initial_delay_active{namespace, name} = 0 | 1
 ```
 
 Value is `1` while the gate is active for that VPA, `0` otherwise. Enables fleet-wide visibility into how many VPAs are currently gated, useful for dashboards and alerting on stuck windows.
 
 ### Feature Enablement and Rollback
 
-Feature gate: **`VPAObservationWindow`**.
+Feature gate: **`VPAInitialDelay`**.
 
 Components consuming the gate:
 
-- `updater` — reads `observationPeriodSeconds` and honours the gate.
-- `admission-controller` — gates acceptance of the field on new/updated VPAs behind the feature gate.
+- `updater` — reads `initialDelaySeconds` and honours the gate.
+- `admission-controller` — gates acceptance of the field on new/updated VPAs behind the feature gate, and honours the gate by skipping recommendation injection for pods created during an active window.
 
 Enabling the feature gate causes:
 
-- `admission-controller` to accept `observationPeriodSeconds` on new/updated VPAs.
+- `admission-controller` to accept `initialDelaySeconds` on new/updated VPAs, and to skip recommendation injection for pods created while a VPA's window is active.
 - `updater` to honour the gate.
 
 Disabling the feature gate causes:
 
-- `admission-controller` to reject new VPAs that set `observationPeriodSeconds`, with a descriptive error message indicating the feature gate is disabled.
-- `updater` to ignore the field on existing objects — the VPA behaves as if the field were not set (fail-open). This is deliberate: disabling the gate should never *increase* actuation restrictions on existing objects.
+- `admission-controller` to reject new VPAs that set `initialDelaySeconds`, with a descriptive error message indicating the feature gate is disabled.
+- `updater` and `admission-controller` to ignore the field on existing objects — the VPA behaves as if the field were not set (fail-open). This is deliberate: disabling the gate should never *increase* actuation restrictions on existing objects.
 
 ### Kubernetes Version Compatibility
 
@@ -218,27 +247,30 @@ This feature is entirely internal to the VPA controllers and depends on no new K
 
 **Unit tests** (`pkg/updater/logic/`):
 
-- `inObservationWindow` returns `true` when `now < CreationTimestamp + observationPeriodSeconds`.
-- `inObservationWindow` returns `false` when `now >= CreationTimestamp + observationPeriodSeconds`.
-- `inObservationWindow` returns `false` when `observationPeriodSeconds` is `nil`, `0`, or absent.
+- `inInitialDelayWindow` returns `true` when `now < CreationTimestamp + initialDelaySeconds`.
+- `inInitialDelayWindow` returns `false` when `now >= CreationTimestamp + initialDelaySeconds`.
+- `inInitialDelayWindow` returns `false` when `initialDelaySeconds` is `nil`, `0`, or absent.
 - Gate short-circuits the eligibility path identically to `updateMode: Off` for `Recreate`, `InPlaceOrRecreate`, `InPlace`, `Initial`.
 - Gate has no effect when `updateMode: Off` — behavior matches plain `updateMode: Off` regardless of the field's value.
 - Metric and condition are set correctly on both sides of the transition.
-- PATCH scenarios: shortening releases the gate, extending stays gated, removing closes the gate, extending after expiry re-arms.
+- PATCH scenarios: shortening releases the gate, extending stays gated, removing closes the gate, extending after expiry re-arms only when the new expiry still lies in the future.
 
-**Admission-controller / CRD validation tests:**
+**Admission-controller tests:**
 
-- Accept `observationPeriodSeconds >= 1` on all update modes, including `Off` (no-op semantics).
-- Reject `observationPeriodSeconds < 1` via CRD schema validation.
-- Reject `observationPeriodSeconds` on any VPA when the `VPAObservationWindow` feature gate is disabled.
+- Accept `initialDelaySeconds >= 1` on all update modes, including `Off` (no-op semantics).
+- Reject `initialDelaySeconds < 1` and `initialDelaySeconds > 7776000` via CRD schema validation.
+- Reject `initialDelaySeconds` on any VPA when the `VPAInitialDelay` feature gate is disabled.
+- Pods created while the gate is active are admitted with their original spec resources, for every update mode.
+- Pods created after the window elapses receive recommendation injection per the configured mode's normal semantics.
 
 **E2E tests** (`e2e/`):
 
-- Create a VPA with `updateMode: Recreate` and `observationPeriodSeconds: 60`. Verify no eviction occurs during the first 60 s. Advance time past the window; verify the next reconcile evicts as expected.
+- Create a VPA with `updateMode: Recreate` and `initialDelaySeconds: 60`. Verify no eviction occurs during the first 60 s. Advance time past the window; verify the next reconcile evicts as expected.
 - Repeat for `InPlaceOrRecreate`, `InPlace`, and `Initial` (with pod-creation-timing tests for the last).
-- Create a VPA with `observationPeriodSeconds: 3600`, PATCH to `60` after 30 s, verify eviction becomes eligible around the 60 s mark.
-- Create a VPA with `observationPeriodSeconds: 60`, wait for expiry, PATCH to `3600`, verify the gate re-arms and eviction is again suppressed until the new expiry.
-- Verify the `ObservationPeriodActive` condition and `vpa_in_observation_window` gauge match the gate state throughout each scenario.
+- Create a VPA with `updateMode: Recreate` and `initialDelaySeconds: 3600`; scale the target Deployment up during the window and verify the new pod keeps its template resources (no admission-time injection). After expiry, verify newly created pods receive injected resources.
+- Create a VPA with `initialDelaySeconds: 3600`, PATCH to `60` after 30 s, verify eviction becomes eligible around the 60 s mark.
+- Create a VPA with `initialDelaySeconds: 60`, wait for expiry, PATCH to `3600`, verify the gate re-arms (the new expiry, `CreationTimestamp + 3600s`, still lies in the future) and eviction is again suppressed until the new expiry.
+- Verify the `InitialDelayActive` condition and `vpa_initial_delay_active` gauge match the gate state throughout each scenario.
 
 ## Examples
 
@@ -259,10 +291,10 @@ spec:
     name: web
   updatePolicy:
     updateMode: Recreate
-    observationPeriodSeconds: 21600   # 6 hours
+    initialDelaySeconds: 21600   # 6 hours
 ```
 
-For the first six hours after creation, `web` pods are not evicted by the updater regardless of recommendations. After the window, `Recreate` behaviour takes effect.
+For the first six hours after creation, `web` pods are not evicted by the Updater regardless of recommendations, and pods created during the window (scale-ups, restarts) keep the resources from the `Deployment` spec — no admission-time injection occurs. After the window, `Recreate` behaviour takes effect.
 
 ### Fast iteration: `InPlace` with a short window
 
@@ -281,7 +313,7 @@ spec:
     name: staging-svc
   updatePolicy:
     updateMode: InPlace
-    observationPeriodSeconds: 300     # 5 minutes
+    initialDelaySeconds: 300     # 5 minutes
 ```
 
 ### Pod-creation gating: `Initial` with a one-hour window
@@ -301,7 +333,7 @@ spec:
     name: worker
   updatePolicy:
     updateMode: Initial
-    observationPeriodSeconds: 3600    # 1 hour
+    initialDelaySeconds: 3600    # 1 hour
 ```
 
 Pods created during the first hour receive their `Deployment`-spec resources unchanged. Pods created after the window get VPA-injected resources.
@@ -316,11 +348,11 @@ Pods created during the first hour receive their `Deployment`-spec resources unc
 
 **4. Do nothing; rely on operator tooling.** The status quo. Ships the complexity downstream to every VPA operator; the CronJob-plus-patch-controller dance ends up reinvented per environment.
 
-**5. Immutable field after creation.** Reject PATCH that modifies `observationPeriodSeconds` via admission. Simpler in that it eliminates the re-arm and shortening cases, but forces users into delete-and-recreate to change the window — an expensive operation that also discards the VPA's recommendation history. The proposed stateless-gate design gets the same "one-line mental model" without that cost.
+**5. Immutable field after creation.** Reject PATCH that modifies `initialDelaySeconds` via admission. Simpler in that it eliminates the re-arm and shortening cases, but forces users into delete-and-recreate to change the window — an expensive operation that also discards the VPA's recommendation history. The proposed stateless-gate design gets the same "one-line mental model" without that cost.
 
 **6. Reset on "material" spec changes** (`resourcePolicy`, `targetRef`). Arguably more correct — a workload with a different target really does have different history semantics — but forces us to define "material" and requires a status field to track the current anchor. Deferred: this AEP does not preclude adding such semantics in a future revision, and the `CreationTimestamp` anchor is a strict subset of any future anchor policy.
 
-**7. Reject PATCH that re-arms an expired gate.** Split the difference on (5) and the proposed design: allow PATCH freely during the window, but reject PATCHes that would push `expiry` past `now` once the window has already elapsed. Rejected because it makes the admission logic dependent on real time (surprising) and does not eliminate the underlying "PATCHes can change gate state" surprise — the `ObservationPeriodActive` condition and gauge already surface any re-arm immediately.
+**7. Reject PATCH that re-arms an expired gate.** Split the difference on (5) and the proposed design: allow PATCH freely during the window, but reject PATCHes that would push `expiry` past `now` once the window has already elapsed. Rejected because it makes the admission logic dependent on real time (surprising) and does not eliminate the underlying "PATCHes can change gate state" surprise — the `InitialDelayActive` condition and gauge already surface any re-arm immediately.
 
 ## Implementation History
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -262,7 +262,7 @@ spec:
     observationPeriodSeconds: 21600   # 6 hours
 ```
 
-For the first six hours after creation, `web` pods are not evicted regardless of recommendations. After the window, `Recreate` behaviour takes effect.
+For the first six hours after creation, `web` pods are not evicted by the updater regardless of recommendations. After the window, `Recreate` behaviour takes effect.
 
 ### Fast iteration: `InPlace` with a short window
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -175,12 +175,7 @@ Re-arm after expiry is possible but not guaranteed: because the window is anchor
 
 ### Interaction with `updateMode`
 
-The observation window is orthogonal to `updateMode`. While the gate is active, the Updater and the Admission Controller behave as if `updateMode` were `Off` regardless of the configured value: no evictions, no in-place resizes, and no recommendation injection into pods created during the window. Once the gate opens, the configured mode takes effect normally:
-
-- `Recreate` → the Updater is now eligible to evict pods to apply recommendations.
-- `InPlaceOrRecreate` → the Updater attempts in-place resize first, falling back to eviction.
-- `InPlace` → the Updater attempts in-place resize only; no evictions.
-- `Initial` → the admission-controller-side injection is now eligible to run on subsequent new-pod creations. Pods created during the window (or pods that pre-dated the VPA) are unaffected, matching the standard `Initial` semantics.
+The observation window is orthogonal to `updateMode`. While the gate is active, the Updater and the Admission Controller behave as if `updateMode` were `Off` regardless of the configured value: no evictions, no in-place resizes, and no recommendation injection into pods created during the window.
 
 ### Interaction with CPU Startup Boost
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -1,0 +1,332 @@
+# AEP-9936: Per-VPA Observation Window
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+- [Design Details](#design-details)
+  - [Workflow](#workflow)
+  - [API Changes](#api-changes)
+  - [Gate Evaluation](#gate-evaluation)
+  - [Interaction with <code>updateMode</code>](#interaction-with-updatemode)
+  - [Validation](#validation)
+  - [Status Condition](#status-condition)
+  - [Metric](#metric)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Kubernetes Version Compatibility](#kubernetes-version-compatibility)
+- [Test Plan](#test-plan)
+- [Examples](#examples)
+  - [Basic: <code>Recreate</code> with a six-hour window](#basic-recreate-with-a-six-hour-window)
+  - [Fast iteration: <code>InPlace</code> with a short window](#fast-iteration-inplace-with-a-short-window)
+  - [Pod-creation gating: <code>Initial</code> with a one-hour window](#pod-creation-gating-initial-with-a-one-hour-window)
+- [Alternatives Considered](#alternatives-considered)
+- [Implementation History](#implementation-history)
+<!-- /toc -->
+
+## Summary
+
+Add an optional `observationPeriodSeconds` field to `PodUpdatePolicy` that tells the Updater to refrain from applying recommendations for a configurable duration after a VPA's creation. During the window the Recommender continues to compute and publish recommendations to `status.recommendation` normally — only the Updater is gated. Once the window elapses, the configured `updateMode` takes effect automatically with no operator action.
+
+The window is computed as a pure function of `vpa.CreationTimestamp` and the current spec value, evaluated on every reconcile. No status writes are required.
+
+## Motivation
+
+When new `Deployment` objects are provisioned automatically — by CI, per-tenant provisioning, on-demand application creation, etc. — a VPA created alongside them and configured with a non-`Off` `updateMode` will start actuating on recommendations that have not stabilised yet. Recommendations are especially unstable in the first few hours of a workload's life because the recommender has few usage samples, and applying those recommendations causes disruptive churn: pods are restarted with the wrong resource requests, then restarted again a few minutes later with different requests.
+
+The safe pattern is to run the VPA in `Off` mode for the first N hours to let recommendations stabilise, then flip to `Recreate` / `InPlaceOrRecreate` / `InPlace` / `Initial`. Doing that manually for every new VPA does not scale: cluster operators end up building external controllers, CronJobs, or admission-side patch scripts to sequence the mode transition. Every environment reinvents the same workflow.
+
+This feature moves the sequencing into the VPA API itself. Operators declare "wait N seconds after creation before touching pods" alongside the update mode, and the Updater honours it.
+
+### Goals
+
+- Provide a declarative per-VPA field that delays Updater actuation for a configurable duration after VPA creation.
+- Keep the Recommender's behaviour unchanged: recommendations are still computed and published to `status.recommendation` during the window, so operators can inspect them.
+- Work uniformly across `Recreate`, `InPlaceOrRecreate`, `InPlace`, and `Initial`.
+- Require no status writes and no admission-side PATCH restrictions in v1: the gate is a pure function of `CreationTimestamp` and the current spec value.
+- Surface the gate state through both a status condition (`ObservationPeriodActive`) and a Prometheus gauge (`vpa_in_observation_window`), so operators and dashboards can see when a VPA is gated without inspecting `spec`.
+
+### Non-Goals
+
+- **Recommender-confidence-based gating.** This feature is a user-declared policy, not a recommender-computed signal. Interoperation with `LowConfidence` / `RecommendationProvided` is left for future work.
+- **Reset semantics on PATCH of other fields.** Changing `resourcePolicy`, `targetRef`, or the target workload does not reset the window. The window is anchored on `vpa.CreationTimestamp`; users who need to re-observe a workload after a material change should delete and recreate the VPA.
+- **Cluster-wide default windows.** Different applications and different VPAs on the same target want different windows; this is a per-VPA concern.
+
+## Proposal
+
+Add a single optional field to `PodUpdatePolicy` (autoscaling.k8s.io/v1):
+
+```go
+// ObservationPeriodSeconds is the duration in seconds after this VPA's
+// creation during which the Updater will refrain from applying
+// recommendations, regardless of the configured UpdateMode.
+// +optional
+// +kubebuilder:validation:Minimum=1
+ObservationPeriodSeconds *int32 `json:"observationPeriodSeconds,omitempty"`
+```
+
+Behaviour, in one sentence: **the Updater treats the VPA as if `updateMode` were `Off` until `now >= vpa.CreationTimestamp + spec.updatePolicy.observationPeriodSeconds`.** After that, the configured `updateMode` takes effect.
+
+## Design Details
+
+### Workflow
+
+1. The user creates a VPA with a non-`Off` `updateMode` and `observationPeriodSeconds: N` set on `spec.updatePolicy`.
+2. The Recommender begins computing recommendations on the normal schedule and populates `status.recommendation`. It is unaware of and unaffected by the observation window.
+3. On every Updater reconcile, before deciding whether the VPA is eligible for actuation, the Updater evaluates the gate. If the gate is active, the VPA is treated as if `updateMode` were `Off` for that reconcile: no pods are evicted (`Recreate` / `InPlaceOrRecreate`), no in-place resize is attempted (`InPlace` / `InPlaceOrRecreate`), and no admission-controller-side injection happens on new-pod creation (`Initial`).
+4. The Updater sets the `ObservationPeriodActive` status condition to `True` while the gate is active and `False` once it has elapsed. It emits the `vpa_in_observation_window` gauge accordingly.
+5. On the first reconcile after `CreationTimestamp + observationPeriodSeconds`, the gate opens and the configured `updateMode` takes effect on subsequent reconciles.
+
+### API Changes
+
+Extended `PodUpdatePolicy`:
+
+```go
+type PodUpdatePolicy struct {
+    // ... existing fields (UpdateMode, MinReplicas, EvictionRequirements,
+    //                     EvictAfterOOMSeconds) ...
+
+    // ObservationPeriodSeconds is the duration in seconds after this
+    // VPA's creation during which the Updater will refrain from applying
+    // recommendations, regardless of the configured UpdateMode.
+    //
+    // During the window, the Recommender continues to compute and
+    // publish recommendations to status.recommendation as usual, but the
+    // Updater treats the VPA as if UpdateMode were Off. After the window
+    // elapses (now >= CreationTimestamp + ObservationPeriodSeconds), the
+    // configured UpdateMode takes effect on subsequent reconciles.
+    //
+    // The window is computed as a pure function of vpa.CreationTimestamp
+    // and this spec field. PATCH is allowed; the new value takes effect
+    // on the next reconcile. Removing the field or setting it to zero
+    // closes the gate immediately. Extending the value after the window
+    // has already expired will re-arm the gate.
+    //
+    // If UpdateMode is Off, this field has no effect: Off already
+    // suppresses Updater actuation indefinitely.
+    //
+    // Must be >= 1 if set.
+    // +optional
+    // +kubebuilder:validation:Minimum=1
+    ObservationPeriodSeconds *int32 `json:"observationPeriodSeconds,omitempty"`
+}
+```
+
+Follows the shape of `EvictAfterOOMSeconds` (the only existing time-based field on the same struct) and `DurationSeconds` from AEP-7862.
+
+### Gate Evaluation
+
+Reference implementation, invoked at the beginning of the Updater's per-VPA eligibility path:
+
+```go
+// inObservationWindow returns true if the VPA is currently within its
+// declared observation window and the Updater should refrain from
+// applying recommendations.
+func inObservationWindow(vpa *vpa_types.VerticalPodAutoscaler, now time.Time) bool {
+    p := vpa.Spec.UpdatePolicy
+    if p == nil || p.ObservationPeriodSeconds == nil || *p.ObservationPeriodSeconds < 1 {
+        return false
+    }
+    expiry := vpa.CreationTimestamp.Add(
+        time.Duration(*p.ObservationPeriodSeconds) * time.Second,
+    )
+    return now.Before(expiry)
+}
+```
+
+Insertion point: at the top of the Updater's eligibility check in `pkg/updater/logic/updater.go`, at the same call site where `UpdateModeOff` and `UpdateModeInitial` currently short-circuit the eviction path. When `inObservationWindow` returns `true`, the Updater takes the same code path it takes for `UpdateModeOff` today.
+
+The gate is stateless: it is a pure function of `CreationTimestamp` (immutable on the object) and the current spec value (mutable). No caching, no status writes.
+
+Consequences that fall out of this design:
+
+| PATCH operation | Effect |
+| --- | --- |
+| Shorten `observationPeriodSeconds` during window | Gate releases earlier on next reconcile. |
+| Extend `observationPeriodSeconds` during window | Gate stays open longer. |
+| Extend `observationPeriodSeconds` **after** expiry | Gate re-arms on next reconcile. |
+| Remove `observationPeriodSeconds` (or set to zero) | Gate closes immediately on next reconcile. |
+| PATCH `updateMode` | New mode takes effect when the window elapses (or immediately, if already elapsed). |
+| PATCH `resourcePolicy` / `targetRef` | No effect on the gate. |
+
+The re-arm-after-expiry behaviour is intentional: it lets users manually extend an observation window in response to observed instability without deleting the VPA. If reviewers consider this a footgun serious enough to justify admission logic, we can add a check rejecting PATCHes that would push `expiry` past `now` once the window has already elapsed — see [Alternatives Considered](#alternatives-considered).
+
+### Interaction with `updateMode`
+
+The observation window is orthogonal to `updateMode`. While the gate is active, the Updater behaves as if `updateMode` were `Off` regardless of the configured value. Once the gate opens, the configured mode takes effect normally:
+
+- `Recreate` → the Updater is now eligible to evict pods to apply recommendations.
+- `InPlaceOrRecreate` → the Updater attempts in-place resize first, falling back to eviction.
+- `InPlace` → the Updater attempts in-place resize only; no evictions.
+- `Initial` → the admission-controller-side injection is now eligible to run on subsequent new-pod creations. Pods created during the window (or pods that pre-dated the VPA) are unaffected, matching the standard `Initial` semantics.
+- `Off` → `observationPeriodSeconds` has no effect. `Off` already suppresses actuation indefinitely, so combining the two is a valid (but redundant) configuration that silently no-ops. No error, no warning; the field is simply ignored.
+
+### Validation
+
+Enforced via CRD schema:
+
+- `observationPeriodSeconds` must be an integer `>= 1` if set.
+
+No dynamic (admission-webhook) validation is required in v1. All lifecycle transitions are handled declaratively by the gate.
+
+### Status Condition
+
+Add a new value to the existing `VerticalPodAutoscalerStatus.Conditions` slice:
+
+- **Type:** `ObservationPeriodActive`
+- **Status:** `True` while the gate is active, `False` once it has elapsed.
+- **Reason:** `WindowActive` (True) / `WindowExpired` (False).
+- **Message:** human-readable summary including expiry timestamp.
+
+This lets `kubectl describe vpa` surface the gate without an operator having to compute `CreationTimestamp + observationPeriodSeconds` mentally.
+
+### Metric
+
+Emit a new gauge from the Updater:
+
+```
+vpa_in_observation_window{namespace, name} = 0 | 1
+```
+
+Value is `1` while the gate is active for that VPA, `0` otherwise. Enables fleet-wide visibility into how many VPAs are currently gated, useful for dashboards and alerting on stuck windows.
+
+### Feature Enablement and Rollback
+
+Feature gate: **`VPAObservationWindow`**.
+
+Components consuming the gate:
+
+- `updater` — reads `observationPeriodSeconds` and honours the gate.
+- `admission-controller` — gates acceptance of the field on new/updated VPAs behind the feature gate.
+
+Enabling the feature gate causes:
+
+- `admission-controller` to accept `observationPeriodSeconds` on new/updated VPAs.
+- `updater` to honour the gate.
+
+Disabling the feature gate causes:
+
+- `admission-controller` to reject new VPAs that set `observationPeriodSeconds`, with a descriptive error message indicating the feature gate is disabled.
+- `updater` to ignore the field on existing objects — the VPA behaves as if the field were not set (fail-open). This is deliberate: disabling the gate should never *increase* actuation restrictions on existing objects.
+
+### Kubernetes Version Compatibility
+
+This feature is entirely internal to the VPA controllers and depends on no new Kubernetes APIs. It is compatible with any Kubernetes version supported by the corresponding VPA release.
+
+## Test Plan
+
+**Unit tests** (`pkg/updater/logic/`):
+
+- `inObservationWindow` returns `true` when `now < CreationTimestamp + observationPeriodSeconds`.
+- `inObservationWindow` returns `false` when `now >= CreationTimestamp + observationPeriodSeconds`.
+- `inObservationWindow` returns `false` when `observationPeriodSeconds` is `nil`, `0`, or absent.
+- Gate short-circuits the eligibility path identically to `updateMode: Off` for `Recreate`, `InPlaceOrRecreate`, `InPlace`, `Initial`.
+- Gate has no effect when `updateMode: Off` — behavior matches plain `updateMode: Off` regardless of the field's value.
+- Metric and condition are set correctly on both sides of the transition.
+- PATCH scenarios: shortening releases the gate, extending stays gated, removing closes the gate, extending after expiry re-arms.
+
+**Admission-controller / CRD validation tests:**
+
+- Accept `observationPeriodSeconds >= 1` on all update modes, including `Off` (no-op semantics).
+- Reject `observationPeriodSeconds < 1` via CRD schema validation.
+- Reject `observationPeriodSeconds` on any VPA when the `VPAObservationWindow` feature gate is disabled.
+
+**E2E tests** (`e2e/`):
+
+- Create a VPA with `updateMode: Recreate` and `observationPeriodSeconds: 60`. Verify no eviction occurs during the first 60 s. Advance time past the window; verify the next reconcile evicts as expected.
+- Repeat for `InPlaceOrRecreate`, `InPlace`, and `Initial` (with pod-creation-timing tests for the last).
+- Create a VPA with `observationPeriodSeconds: 3600`, PATCH to `60` after 30 s, verify eviction becomes eligible around the 60 s mark.
+- Create a VPA with `observationPeriodSeconds: 60`, wait for expiry, PATCH to `3600`, verify the gate re-arms and eviction is again suppressed until the new expiry.
+- Verify the `ObservationPeriodActive` condition and `vpa_in_observation_window` gauge match the gate state throughout each scenario.
+
+## Examples
+
+### Basic: `Recreate` with a six-hour window
+
+Typical "let this new service settle for a work-day" configuration.
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: web-vpa
+  namespace: production
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: web
+  updatePolicy:
+    updateMode: Recreate
+    observationPeriodSeconds: 21600   # 6 hours
+```
+
+For the first six hours after creation, `web` pods are not evicted regardless of recommendations. After the window, `Recreate` behaviour takes effect.
+
+### Fast iteration: `InPlace` with a short window
+
+CI-provisioned staging environments where operators want quick feedback but still want to avoid churn on the very first samples.
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: staging-svc-vpa
+  namespace: ci-runs
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: staging-svc
+  updatePolicy:
+    updateMode: InPlace
+    observationPeriodSeconds: 300     # 5 minutes
+```
+
+### Pod-creation gating: `Initial` with a one-hour window
+
+Services created by a per-tenant provisioner: the operator wants VPA-injected resources at pod-creation time, but only after an hour of stable recommendations.
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: tenant-worker-vpa
+  namespace: tenant-42
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: worker
+  updatePolicy:
+    updateMode: Initial
+    observationPeriodSeconds: 3600    # 1 hour
+```
+
+Pods created during the first hour receive their `Deployment`-spec resources unchanged. Pods created after the window get VPA-injected resources.
+
+## Alternatives Considered
+
+**1. Extend `EvictionRequirements` with a `TimeSinceCreationExceeds` value.** Reuses an existing extensibility hook (AEP-4831), but forces a duration to be encoded inside an enum meant for direction-of-change comparisons (`TargetHigherThanRequests` / `TargetLowerThanRequests`). Awkward and probably a design regression on that API.
+
+**2. Recommender-side confidence gate.** Block `RecommendationProvided` from becoming `True` for N hours or until a confidence threshold is met. Cleaner conceptually but hides visibility — operators would see no recommendation at all in `status.recommendation` during the window, defeating the "collect first, inspect, then apply" workflow this feature is meant to support.
+
+**3. Global Updater flag** (e.g. `--default-observation-window-seconds`). Wrong axis: different applications in the same cluster want different windows, and different VPAs on the same target want different windows.
+
+**4. Do nothing; rely on operator tooling.** The status quo. Ships the complexity downstream to every VPA operator; the CronJob-plus-patch-controller dance ends up reinvented per environment.
+
+**5. Immutable field after creation.** Reject PATCH that modifies `observationPeriodSeconds` via admission. Simpler in that it eliminates the re-arm and shortening cases, but forces users into delete-and-recreate to change the window — an expensive operation that also discards the VPA's recommendation history. The proposed stateless-gate design gets the same "one-line mental model" without that cost.
+
+**6. Reset on "material" spec changes** (`resourcePolicy`, `targetRef`). Arguably more correct — a workload with a different target really does have different history semantics — but forces us to define "material" and requires a status field to track the current anchor. Deferred: this AEP does not preclude adding such semantics in a future revision, and the `CreationTimestamp` anchor is a strict subset of any future anchor policy.
+
+**7. Reject PATCH that re-arms an expired gate.** Split the difference on (5) and the proposed design: allow PATCH freely during the window, but reject PATCHes that would push `expiry` past `now` once the window has already elapsed. Rejected because it makes the admission logic dependent on real time (surprising) and does not eliminate the underlying "PATCHes can change gate state" surprise — the `ObservationPeriodActive` condition and gauge already surface any re-arm immediately.
+
+## Implementation History
+
+- (issue filed) 2026-07-06 — Issue [kubernetes/autoscaler#9936](https://github.com/kubernetes/autoscaler/issues/9936) filed.
+- (triage accepted) 2026-07-07 — `/triage accepted` from SIG member.
+- (AEP PR opened) TBD.
+- (initial implementation) TBD.
+- (alpha) TBD.
+- (beta) TBD.

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -147,8 +147,8 @@ Consequences that fall out of this design:
 | Extend `observationPeriodSeconds` during window | Gate stays open longer. |
 | Extend `observationPeriodSeconds` **after** expiry | Gate re-arms on next reconcile. |
 | Remove `observationPeriodSeconds` (or set to zero) | Gate closes immediately on next reconcile. |
-| PATCH `updateMode` | New mode takes effect when the window elapses (or immediately, if already elapsed). |
-| PATCH `resourcePolicy` / `targetRef` | No effect on the gate. |
+| Modify `updateMode` | New mode takes effect when the window elapses (or immediately, if already elapsed). |
+| Modify `resourcePolicy` / `targetRef` | No effect on the gate. |
 
 The re-arm-after-expiry behaviour is intentional: it lets users manually extend an observation window in response to observed instability without deleting the VPA. If reviewers consider this a footgun serious enough to justify admission logic, we can add a check rejecting PATCHes that would push `expiry` past `now` once the window has already elapsed — see [Alternatives Considered](#alternatives-considered).
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -254,7 +254,7 @@ Disabling the feature gate causes:
 - No open bugs against the feature gate.
 - Positive user feedback on the field semantics (in particular the `CreationTimestamp`-anchored PATCH behaviour).
 
-**Beta → GA (gate locked on, then removed):**
+**Beta → GA (gate locked to enabled):**
 
 - No bug reports attributable to the feature for two consecutive releases.
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -169,7 +169,7 @@ When `inInitialDelayWindow` returns `true`, both components take the same code p
 
 The gate is stateless: it is a pure function of `CreationTimestamp` (immutable on the object) and the current spec value (mutable). No caching, no status writes.
 
-Consequences that fall out of this design:
+The gate consults exactly these two inputs. No other field — existing or added to the CRD in the future — participates in gate evaluation. The table below is therefore not a set of per-field policy decisions; it enumerates the consequences of that single formula:
 
 | Modification | Effect |
 | --- | --- |

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -298,7 +298,7 @@ This feature is entirely internal to the VPA controllers and depends on no new K
 - Pods created while the gate is active are admitted with their original spec resources, for every update mode.
 - Pods created after the window elapses receive recommendation injection per the configured mode's normal semantics.
 
-**E2E tests** (`e2e/`):
+**Integration tests** (updater and admission-controller):
 
 - Create a VPA with `updateMode: Recreate`, `initialDelaySeconds: 60`, and a recommendation far enough from the pod's requests that eviction is expected. Watch for `InitialDelayActive=True` and verify no pods are evicted. Patch `initialDelaySeconds` to `1`; watch for `InitialDelayActive=False` and verify pods are evicted.
 - Repeat for `InPlaceOrRecreate`, `InPlace`, and `Initial` (for `Initial`, assert on injection at new-pod creation instead of eviction).

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -283,7 +283,7 @@ This feature is entirely internal to the VPA controllers and depends on no new K
 
 ## Test Plan
 
-**Unit tests** (`pkg/updater/logic/`):
+**Updater tests:**
 
 - `inInitialDelayWindow` returns `true` when `now < CreationTimestamp + initialDelaySeconds`.
 - `inInitialDelayWindow` returns `false` when `now >= CreationTimestamp + initialDelaySeconds`.

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -32,7 +32,7 @@
 
 Add an optional `initialDelaySeconds` field to `PodUpdatePolicy` that delays actuation of recommendations for a configurable duration after a VPA's creation. During the window the Recommender continues to compute and publish recommendations to `status.recommendation` normally, but nothing actuates them: the Updater performs no evictions or in-place resizes, and the Admission Controller does not apply recommendations to pods created during the window. The VPA behaves exactly as if `updateMode` were `Off`. Once the window elapses, the configured `updateMode` takes effect automatically with no operator action.
 
-The window is computed as a pure function of `vpa.CreationTimestamp` and the current spec value, evaluated on every reconcile. No status writes are required. Modifying an existing VPA's spec does not reset the window — the anchor (`CreationTimestamp`) is immutable, and changing `initialDelaySeconds` itself simply moves the expiry relative to that anchor (see [Gate Evaluation](#gate-evaluation) for the full PATCH semantics).
+The window is computed as a pure function of `vpa.CreationTimestamp` and the current spec value, evaluated on every reconcile. No status writes are required. Modifying an existing VPA's spec does not reset the window — the anchor (`CreationTimestamp`) is immutable, and changing `initialDelaySeconds` itself simply moves the expiry relative to that anchor (see [Gate Evaluation](#gate-evaluation) for the full modification semantics).
 
 ## Motivation
 
@@ -44,10 +44,9 @@ This feature moves the sequencing into the VPA API itself. Operators declare "wa
 
 ### Goals
 
-- Provide a declarative per-VPA field that delays all actuation — evictions, in-place resizes, and admission-time injection into newly created pods — for a configurable duration after VPA creation.
+- Provide a declarative per-VPA field that delays actuation of recommendations — evictions, in-place resizes, and admission-time injection into newly created pods — for a configurable duration after VPA creation. CPU Startup Boost is not delayed (see [Interaction with CPU Startup Boost](#interaction-with-cpu-startup-boost)).
 - Keep the Recommender's behaviour unchanged: recommendations are still computed and published to `status.recommendation` during the window, so operators can inspect them.
 - Work uniformly across `Recreate`, `InPlaceOrRecreate`, `InPlace`, and `Initial`.
-- Require no status writes and no PATCH-blocking admission validation in v1: the gate is a pure function of `CreationTimestamp` and the current spec value.
 - Surface the gate state through both a status condition (`InitialDelayActive`) and a Prometheus gauge (`vpa_initial_delay_active`), so operators and dashboards can see when a VPA is gated without inspecting `spec`.
 
 ### Non-Goals
@@ -74,7 +73,7 @@ InitialDelaySeconds *int32 `json:"initialDelaySeconds,omitempty"`
 
 Behaviour, in one sentence: **the Updater and the Admission Controller treat the VPA as if `updateMode` were `Off` until `now >= vpa.CreationTimestamp + spec.updatePolicy.initialDelaySeconds`.** After that, the configured `updateMode` takes effect.
 
-Modifying the VPA's spec does not reset the window. The gate is a pure function of the immutable `vpa.CreationTimestamp` and the current value of `initialDelaySeconds`, re-evaluated on every reconcile — there is no per-object state to reset. The full PATCH semantics are enumerated in [Gate Evaluation](#gate-evaluation). While the gate is active, the [`InitialDelayActive` status condition](#status-condition) surfaces it on the VPA object.
+Modifying the VPA's spec does not reset the window. The gate is a pure function of the immutable `vpa.CreationTimestamp` and the current value of `initialDelaySeconds`, re-evaluated on every reconcile — there is no per-object state to reset. The full modification semantics are enumerated in [Gate Evaluation](#gate-evaluation). While the gate is active, the [`InitialDelayActive` status condition](#status-condition) surfaces it on the VPA object.
 
 ## Design Details
 
@@ -110,8 +109,8 @@ type PodUpdatePolicy struct {
     // pod creations.
     //
     // The window is computed as a pure function of vpa.CreationTimestamp
-    // and this spec field. PATCH is allowed; the new value takes effect
-    // on the next reconcile. Removing the field or setting it to zero
+    // and this spec field. The field may be modified at any time; the
+    // new value takes effect on the next reconcile. Removing the field or setting it to zero
     // closes the gate immediately. Setting a larger value after the
     // window has expired re-arms the gate only if the new expiry
     // (CreationTimestamp + InitialDelaySeconds) still lies in the
@@ -130,7 +129,16 @@ type PodUpdatePolicy struct {
 
 Follows the shape of `EvictAfterOOMSeconds` (the only existing time-based field on the same struct) and `DurationSeconds` from AEP-7862; the name matches `initialDelaySeconds` on Pod probes.
 
-Gate state is surfaced via the [`InitialDelayActive` condition](#status-condition).
+In addition to the spec field, a new `VerticalPodAutoscalerConditionType` value is added:
+
+```go
+// InitialDelayActive indicates whether the VPA is currently within its
+// configured initial delay window. It is True while the window is
+// active and False once it has elapsed.
+InitialDelayActive VerticalPodAutoscalerConditionType = "InitialDelayActive"
+```
+
+Reasons and message format are described in [Status Condition](#status-condition).
 
 ### Gate Evaluation
 
@@ -163,7 +171,7 @@ The gate is stateless: it is a pure function of `CreationTimestamp` (immutable o
 
 Consequences that fall out of this design:
 
-| PATCH operation | Effect |
+| Modification | Effect |
 | --- | --- |
 | Shorten `initialDelaySeconds` during window | Gate releases earlier on next reconcile. |
 | Extend `initialDelaySeconds` during window | Gate stays open longer. |
@@ -172,7 +180,7 @@ Consequences that fall out of this design:
 | Modify `updateMode` | New mode takes effect when the window elapses (or immediately, if already elapsed). |
 | Modify `resourcePolicy` / `targetRef` | No effect on the gate. |
 
-Re-arm after expiry is possible but not guaranteed: because the window is anchored to `CreationTimestamp`, a PATCH re-arms the gate only when the new expiry still lies in the future. This is intentional — it lets users extend an observation window in response to observed instability without deleting the VPA, while a larger-but-already-elapsed value on an old VPA simply has no effect. If reviewers consider this a footgun serious enough to justify admission logic, we can add a check rejecting PATCHes that would push `expiry` past `now` once the window has already elapsed — see [Alternatives Considered](#alternatives-considered).
+Re-arm after expiry is possible but not guaranteed: because the window is anchored to `CreationTimestamp`, a modification re-arms the gate only when the new expiry still lies in the future. This is intentional — it lets users extend an observation window in response to observed instability without deleting the VPA, while a larger-but-already-elapsed value on an old VPA simply has no effect. If reviewers consider this a footgun serious enough to justify admission logic, we can add a check rejecting PATCHes that would push `expiry` past `now` once the window has already elapsed — see [Alternatives Considered](#alternatives-considered).
 
 ### Interaction with `updateMode`
 
@@ -182,7 +190,6 @@ The observation window is orthogonal to `updateMode`. While the gate is active, 
 - `InPlaceOrRecreate` → the Updater attempts in-place resize first, falling back to eviction.
 - `InPlace` → the Updater attempts in-place resize only; no evictions.
 - `Initial` → the admission-controller-side injection is now eligible to run on subsequent new-pod creations. Pods created during the window (or pods that pre-dated the VPA) are unaffected, matching the standard `Initial` semantics.
-- `Off` → `initialDelaySeconds` has no effect; `Off` already suppresses actuation indefinitely.
 
 ### Interaction with CPU Startup Boost
 
@@ -195,11 +202,14 @@ The interaction appears at boost expiry, when the Updater performs the post-boos
 
 ### Validation
 
-Enforced via CRD schema:
+`initialDelaySeconds` must be an integer between `1` and `7776000` (90 days) if set. The upper bound follows the [API conventions for numeric fields](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#numeric-fields); observation windows are realistically hours to days, so 90 days is generous headroom while still rejecting absurd values.
 
-- `initialDelaySeconds` must be an integer between `1` and `7776000` (90 days) if set. The upper bound follows the [API conventions for numeric fields](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#numeric-fields); observation windows are realistically hours to days, so 90 days is generous headroom while still rejecting absurd values.
+The range is enforced in two places:
 
-No dynamic (admission-webhook) validation is required in v1. All lifecycle transitions are handled declaratively by the gate.
+- **CRD schema** — `Minimum=1`, `Maximum=7776000`, as the backstop.
+- **Admission webhook** — the same check added to the existing VPA validation in `pkg/admission-controller/resource/vpa/validation.go`, which returns descriptive error messages, and which is also where the field is rejected when the `VPAInitialDelay` feature gate is disabled.
+
+No cross-field validation or restrictions on modifying the field are required: all lifecycle transitions are handled declaratively by the gate.
 
 ### Status Condition
 
@@ -252,11 +262,11 @@ Disabling the feature gate causes:
 
 - E2e tests stable for at least one release.
 - No open bugs against the feature gate.
-- Positive user feedback on the field semantics (in particular the `CreationTimestamp`-anchored PATCH behaviour).
+- Positive user feedback on the field semantics.
 
 **Beta → GA (gate locked to enabled):**
 
-- No bug reports attributable to the feature for two consecutive releases.
+- No bug reports attributable to the feature during the beta release.
 
 ### Version Skew
 
@@ -281,7 +291,7 @@ This feature is entirely internal to the VPA controllers and depends on no new K
 - Gate short-circuits the eligibility path identically to `updateMode: Off` for `Recreate`, `InPlaceOrRecreate`, `InPlace`, `Initial`.
 - Gate has no effect when `updateMode: Off` — behavior matches plain `updateMode: Off` regardless of the field's value.
 - Metric and condition are set correctly on both sides of the transition.
-- PATCH scenarios: shortening releases the gate, extending stays gated, removing closes the gate, extending after expiry re-arms only when the new expiry still lies in the future.
+- Modification scenarios: shortening releases the gate, extending stays gated, removing closes the gate, extending after expiry re-arms only when the new expiry still lies in the future.
 
 **Admission-controller tests:**
 
@@ -293,12 +303,11 @@ This feature is entirely internal to the VPA controllers and depends on no new K
 
 **E2E tests** (`e2e/`):
 
-- Create a VPA with `updateMode: Recreate` and `initialDelaySeconds: 60`. Verify no eviction occurs during the first 60 s. Advance time past the window; verify the next reconcile evicts as expected.
-- Repeat for `InPlaceOrRecreate`, `InPlace`, and `Initial` (with pod-creation-timing tests for the last).
-- Create a VPA with `updateMode: Recreate` and `initialDelaySeconds: 3600`; scale the target Deployment up during the window and verify the new pod keeps its template resources (no admission-time injection). After expiry, verify newly created pods receive injected resources.
-- Create a VPA with `initialDelaySeconds: 3600`, PATCH to `60` after 30 s, verify eviction becomes eligible around the 60 s mark.
-- Create a VPA with `initialDelaySeconds: 60`, wait for expiry, PATCH to `3600`, verify the gate re-arms (the new expiry, `CreationTimestamp + 3600s`, still lies in the future) and eviction is again suppressed until the new expiry.
-- Verify the `InitialDelayActive` condition and `vpa_initial_delay_active` gauge match the gate state throughout each scenario.
+- Create a VPA with `updateMode: Recreate`, `initialDelaySeconds: 60`, and a recommendation far enough from the pod's requests that eviction is expected. Watch for `InitialDelayActive=True` and verify no pods are evicted. Patch `initialDelaySeconds` to `1`; watch for `InitialDelayActive=False` and verify pods are evicted.
+- Repeat for `InPlaceOrRecreate`, `InPlace`, and `Initial` (for `Initial`, assert on injection at new-pod creation instead of eviction).
+- Admission gating: while `InitialDelayActive=True`, scale the target Deployment up and verify the new pod keeps its template resources; after patching `initialDelaySeconds` to `1` and observing `InitialDelayActive=False`, verify newly created pods receive injected resources.
+- Re-arm: create a VPA with `initialDelaySeconds: 1`; watch for `InitialDelayActive=False`. Patch to `3600` (new expiry still lies in the future); watch for `InitialDelayActive=True` and verify actuation is suppressed again.
+- Throughout each scenario, verify the `vpa_initial_delay_active` gauge matches the condition.
 
 ## Examples
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -16,6 +16,8 @@
   - [Status Condition](#status-condition)
   - [Metric](#metric)
   - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Version Skew](#version-skew)
   - [Kubernetes Version Compatibility](#kubernetes-version-compatibility)
 - [Test Plan](#test-plan)
 - [Examples](#examples)
@@ -239,6 +241,32 @@ Disabling the feature gate causes:
 - `admission-controller` to reject new VPAs that set `initialDelaySeconds`, with a descriptive error message indicating the feature gate is disabled.
 - `updater` and `admission-controller` to ignore the field on existing objects — the VPA behaves as if the field were not set (fail-open). This is deliberate: disabling the gate should never *increase* actuation restrictions on existing objects.
 
+### Graduation Criteria
+
+**Alpha (initial release):**
+
+- Feature gate `VPAInitialDelay` disabled by default.
+- Unit and e2e coverage as described in the [Test Plan](#test-plan).
+
+**Alpha → Beta (gate enabled by default):**
+
+- E2e tests stable for at least one release.
+- No open bugs against the feature gate.
+- Positive user feedback on the field semantics (in particular the `CreationTimestamp`-anchored PATCH behaviour).
+
+**Beta → GA (gate locked on, then removed):**
+
+- No bug reports attributable to the feature for two consecutive releases.
+
+### Version Skew
+
+The Recommender is unaffected by this feature. The gate is fully effective only when both the Updater and the Admission Controller run a version that supports it, with the feature gate enabled on both. During a rollout with mixed versions, an older component simply ignores the field and behaves as it does today (fail-open, matching the gate-disabled semantics in [Feature Enablement and Rollback](#feature-enablement-and-rollback)):
+
+- **Old Updater, new Admission Controller** — pods created during the window are admitted without injection, but the Updater may still evict or resize during the window.
+- **New Updater, old Admission Controller** — no evictions or resizes during the window, but pods created during the window still receive recommendation injection.
+
+Neither skew causes errors or corrupted state; the failure mode is only that part of the gate is not honoured until the rollout completes. Operators who need strict gating should enable the feature gate only after all components are upgraded.
+
 ### Kubernetes Version Compatibility
 
 This feature is entirely internal to the VPA controllers and depends on no new Kubernetes APIs. It is compatible with any Kubernetes version supported by the corresponding VPA release.
@@ -358,7 +386,7 @@ Pods created during the first hour receive their `Deployment`-spec resources unc
 
 - (issue filed) 2026-07-06 — Issue [kubernetes/autoscaler#9936](https://github.com/kubernetes/autoscaler/issues/9936) filed.
 - (triage accepted) 2026-07-07 — `/triage accepted` from SIG member.
-- (AEP PR opened) TBD.
+- (AEP PR opened) 2026-07-10 — PR [kubernetes/autoscaler#9962](https://github.com/kubernetes/autoscaler/pull/9962).
 - (initial implementation) TBD.
 - (alpha) TBD.
 - (beta) TBD.

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -216,7 +216,7 @@ vpa_initial_delay_active{namespace, name} = 0 | 1
 
 Value is `1` while the gate is active for that VPA, `0` otherwise. Enables fleet-wide visibility into how many VPAs are currently gated, useful for dashboards and alerting on stuck windows.
 
-Both the `InitialDelayActive` condition and this gauge report the window state itself — a pure function of `CreationTimestamp` and `initialDelaySeconds` — independent of `updateMode`. Under `updateMode: Off` the window changes no behavior, but while it has not elapsed the condition and gauge still report it as active; they describe whether the window is open, not whether actuation is currently being suppressed.
+The condition and gauge report the window state, not effective suppression — so under `updateMode: Off` they still read active until the window elapses.
 
 ### Feature Enablement and Rollback
 
@@ -258,7 +258,7 @@ The Recommender is unaffected by this feature. The gate is fully effective only 
 
 Neither skew causes errors or corrupted state; the failure mode is only that part of the gate is not honoured until the rollout completes. Operators who need strict gating should enable the feature gate only after all components are upgraded.
 
-**CRD schema skew.** `initialDelaySeconds` is added to the VPA CRD schema. Apply the updated CRD before or together with the controller upgrade. If a controller that supports the field runs against an older CRD that does not yet include it, the apiserver prunes the unknown field on write, so it is simply absent and the VPA behaves as if unset (fail-open) — no errors. Rolling the CRD back after the field is in use drops any stored values on the next write, again fail-open. The field carries no defaulting, so an absent field and an explicit unset are equivalent.
+**CRD schema skew.** Apply the updated CRD with (or before) the controller upgrade; a newer controller against an older CRD simply has the field pruned by the apiserver and treats it as unset (fail-open).
 
 ### Kubernetes Version Compatibility
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -33,7 +33,7 @@
 
 Add an optional `initialDelaySeconds` field to `PodUpdatePolicy` that delays actuation of recommendations for a configurable duration after a VPA's creation. During the window the Recommender continues to compute and publish recommendations to `status.recommendation` normally, but nothing actuates them: the Updater performs no evictions or in-place resizes, and the Admission Controller does not apply recommendations to pods created during the window. The VPA behaves exactly as if `updateMode` were `Off`. Once the window elapses, the configured `updateMode` takes effect automatically with no operator action.
 
-The window is computed as a pure function of `vpa.CreationTimestamp` and the current spec value, evaluated on every reconcile. No status writes are required. Modifying an existing VPA's spec does not reset the window — the anchor (`CreationTimestamp`) is immutable, and changing `initialDelaySeconds` itself simply moves the expiry relative to that anchor (see [Gate Evaluation](#gate-evaluation) for the full modification semantics).
+The window is computed as a pure function of `vpa.CreationTimestamp` and the current spec value, evaluated on every reconcile. Modifying an existing VPA's spec does not reset the window — the anchor (`CreationTimestamp`) is immutable, and changing `initialDelaySeconds` itself simply moves the expiry relative to that anchor (see [Gate Evaluation](#gate-evaluation) for the full modification semantics).
 
 ## Motivation
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -72,7 +72,7 @@ Add a single optional field to `PodUpdatePolicy` (autoscaling.k8s.io/v1):
 InitialDelaySeconds *int32 `json:"initialDelaySeconds,omitempty"`
 ```
 
-Behaviour, in one sentence: **the Updater and the Admission Controller treat the VPA as if `updateMode` were `Off` until `now >= vpa.CreationTimestamp + spec.updatePolicy.initialDelaySeconds`.** After that, the configured `updateMode` takes effect.
+With the new `initialDelaySeconds`, the Updater and the Admission Controller treat the VPA as if `updateMode` were `Off` until `now >= vpa.CreationTimestamp + spec.updatePolicy.initialDelaySeconds`. After that, the configured `updateMode` takes effect.
 
 Modifying the VPA's spec does not reset the window. The gate is a pure function of the immutable `vpa.CreationTimestamp` and the current value of `initialDelaySeconds`, re-evaluated on every reconcile — there is no per-object state to reset. The full modification semantics are described in [Gate Evaluation](#gate-evaluation). While the gate is active, the [`InitialDelayActive` status condition](#status-condition) surfaces it on the VPA object.
 
@@ -362,9 +362,4 @@ Pods created during the first hour receive their `Deployment`-spec resources unc
 
 ## Implementation History
 
-- (issue filed) 2026-07-06 — Issue [kubernetes/autoscaler#9936](https://github.com/kubernetes/autoscaler/issues/9936) filed.
-- (triage accepted) 2026-07-07 — `/triage accepted` from SIG member.
-- (AEP PR opened) 2026-07-10 — PR [kubernetes/autoscaler#9962](https://github.com/kubernetes/autoscaler/pull/9962).
-- (initial implementation) TBD.
-- (alpha) TBD.
-- (beta) TBD.
+* 2026-07-10: Initial version.

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -85,7 +85,7 @@ Modifying the VPA's spec does not reset the window. The gate is a pure function 
 3. On every Updater reconcile, before deciding whether the VPA is eligible for actuation, the Updater evaluates the gate. If the gate is active, the VPA is treated as if `updateMode` were `Off` for that reconcile: no pods are evicted (`Recreate` / `InPlaceOrRecreate`) and no in-place resize is attempted (`InPlace` / `InPlaceOrRecreate`).
 4. The Admission Controller evaluates the same gate whenever a pod matching the VPA's target is created. While the gate is active it does not patch the pod's resources — the pod is admitted with its original spec, exactly as under `updateMode: Off`. This applies to every mode, not just `Initial`: without it, pods created during the window (scale-ups, node replacements, crash restarts) would receive un-stabilised recommendations at admission time.
 5. The Updater sets the `InitialDelayActive` status condition to `True` while the gate is active and `False` once it has elapsed. It emits the `vpa_initial_delay_active` gauge accordingly.
-6. On the first reconcile after `CreationTimestamp + initialDelaySeconds`, the gate opens and the configured `updateMode` takes effect on subsequent reconciles and pod creations.
+6. After the window elapses (i.e. `now >= CreationTimestamp + InitialDelaySeconds`), the gate opens and the configured `updateMode` takes effect on subsequent reconciles and pod creations.
 
 ### API Changes
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -169,10 +169,10 @@ The observation window is orthogonal to `updateMode`. While the gate is active, 
 
 CPU Startup Boost (AEP-7862) still applies during the delay window: the boost is a startup-safety mechanism computed from the pod's own spec, not a recommendation, and the Admission Controller already applies it even under `updateMode: Off` (the `Off` short-circuit in `resource/vpa/matcher.go` is bypassed for VPAs with a boost). The gate reuses the same `Off` semantics, so boosted containers remain boosted.
 
-The interaction appears at boost expiry, when the Updater performs the post-boost in-place downscale:
+The interaction appears at boost expiry, when the Updater performs the post-boost in-place resize:
 
 - Delay window still active → the pod is scaled down to its original spec resources; no recommendation is actuated.
-- Delay window elapsed → the pod is scaled down to the VPA recommendation, per normal post-boost behaviour.
+- Delay window elapsed → the pod is resized to the VPA recommendation, per normal post-boost behaviour.
 
 ### Interaction with Checkpoints
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -133,10 +133,10 @@ Reasons and message format are described in [Status Condition](#status-condition
 Reference implementation, exposed from a shared package (`pkg/utils/vpa`) and consumed by both actuating components:
 
 ```go
-// inInitialDelayWindow returns true if the VPA is currently within its
+// InInitialDelayWindow returns true if the VPA is currently within its
 // declared observation window and the Updater and Admission Controller
 // should refrain from actuating recommendations.
-func inInitialDelayWindow(vpa *vpa_types.VerticalPodAutoscaler, now time.Time) bool {
+func InInitialDelayWindow(vpa *vpa_types.VerticalPodAutoscaler, now time.Time) bool {
     p := vpa.Spec.UpdatePolicy
     if p == nil || p.InitialDelaySeconds == nil || *p.InitialDelaySeconds < 1 {
         return false
@@ -153,7 +153,9 @@ Insertion points:
 - **Updater** — at the top of the eligibility check in `pkg/updater/logic/updater.go`, at the same call site where `UpdateModeOff` and `UpdateModeInitial` currently short-circuit the eviction path.
 - **Admission Controller** — at the existing `UpdateModeOff` short-circuits in `pkg/admission-controller/resource/vpa/matcher.go` and `pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go`, so pods created during the window are admitted with their original spec resources.
 
-When `inInitialDelayWindow` returns `true`, both components take the same code path they take for `UpdateModeOff` today.
+When `InInitialDelayWindow` returns `true`, both components take the same code path they take for `UpdateModeOff` today.
+
+`InInitialDelayWindow` is exported from the shared `pkg/utils/vpa` package so both the Updater and the Admission Controller consume the identical implementation. Each call site first checks the `VPAInitialDelay` feature gate (`features.Enabled(features.VPAInitialDelay)`); when the gate is disabled the helper is not consulted and the component behaves exactly as it does today (fail-open).
 
 The gate is stateless: it is a pure function of `CreationTimestamp` (immutable on the object) and the current spec value (mutable). No caching, no status writes.
 
@@ -208,11 +210,13 @@ This lets `kubectl describe vpa` surface the gate without an operator having to 
 
 Emit a new gauge from the Updater:
 
-```
+```text
 vpa_initial_delay_active{namespace, name} = 0 | 1
 ```
 
 Value is `1` while the gate is active for that VPA, `0` otherwise. Enables fleet-wide visibility into how many VPAs are currently gated, useful for dashboards and alerting on stuck windows.
+
+Both the `InitialDelayActive` condition and this gauge report the window state itself — a pure function of `CreationTimestamp` and `initialDelaySeconds` — independent of `updateMode`. Under `updateMode: Off` the window changes no behavior, but while it has not elapsed the condition and gauge still report it as active; they describe whether the window is open, not whether actuation is currently being suppressed.
 
 ### Feature Enablement and Rollback
 
@@ -254,6 +258,8 @@ The Recommender is unaffected by this feature. The gate is fully effective only 
 
 Neither skew causes errors or corrupted state; the failure mode is only that part of the gate is not honoured until the rollout completes. Operators who need strict gating should enable the feature gate only after all components are upgraded.
 
+**CRD schema skew.** `initialDelaySeconds` is added to the VPA CRD schema. Apply the updated CRD before or together with the controller upgrade. If a controller that supports the field runs against an older CRD that does not yet include it, the apiserver prunes the unknown field on write, so it is simply absent and the VPA behaves as if unset (fail-open) — no errors. Rolling the CRD back after the field is in use drops any stored values on the next write, again fail-open. The field carries no defaulting, so an absent field and an explicit unset are equivalent.
+
 ### Kubernetes Version Compatibility
 
 This feature is entirely internal to the VPA controllers and depends on no new Kubernetes APIs. It is compatible with any Kubernetes version supported by the corresponding VPA release.
@@ -262,9 +268,9 @@ This feature is entirely internal to the VPA controllers and depends on no new K
 
 **Updater tests:**
 
-- `inInitialDelayWindow` returns `true` when `now < CreationTimestamp + initialDelaySeconds`.
-- `inInitialDelayWindow` returns `false` when `now >= CreationTimestamp + initialDelaySeconds`.
-- `inInitialDelayWindow` returns `false` when `initialDelaySeconds` is `nil`, `0`, or absent.
+- `InInitialDelayWindow` returns `true` when `now < CreationTimestamp + initialDelaySeconds`.
+- `InInitialDelayWindow` returns `false` when `now >= CreationTimestamp + initialDelaySeconds`.
+- `InInitialDelayWindow` returns `false` when `initialDelaySeconds` is `nil`, `0`, or absent.
 - Gate short-circuits the eligibility path identically to `updateMode: Off` for `Recreate`, `InPlaceOrRecreate`, `InPlace`, `Initial`.
 - Gate has no effect when `updateMode: Off` — behavior matches plain `updateMode: Off` regardless of the field's value.
 - Metric and condition are set correctly on both sides of the transition.

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -52,7 +52,7 @@ This feature moves the sequencing into the VPA API itself. Operators declare "wa
 
 ### Non-Goals
 
-- **Recommender-confidence-based gating.** This feature is a user-declared policy, not a recommender-computed signal. Interoperation with `LowConfidence` / `RecommendationProvided` is left for future work.
+- **Recommender-confidence-based gating.** This feature is a user-declared policy, not a recommender-computed signal.
 - **Reset semantics on modification of other fields.** Changing `resourcePolicy`, `targetRef`, or the target workload does not reset the window. The window is anchored on `vpa.CreationTimestamp`; users who need to re-observe a workload after a material change should delete and recreate the VPA.
 - **Cluster-wide default windows.** Out of scope for this AEP; operators can inject a default with a Mutating Admission Policy (see [Alternatives Considered](#alternatives-considered), item 3).
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -25,7 +25,7 @@
   - [Basic: <code>Recreate</code> with a six-hour window](#basic-recreate-with-a-six-hour-window)
   - [Fast iteration: <code>InPlace</code> with a short window](#fast-iteration-inplace-with-a-short-window)
   - [Pod-creation gating: <code>Initial</code> with a one-hour window](#pod-creation-gating-initial-with-a-one-hour-window)
-- [Alternatives Considered](#alternatives-considered)
+- [Alternatives](#alternatives)
 - [Implementation History](#implementation-history)
 <!-- /toc -->
 
@@ -54,7 +54,7 @@ This feature moves the sequencing into the VPA API itself. Operators declare "wa
 
 - **Recommender-confidence-based gating.** This feature is a user-declared policy, not a recommender-computed signal.
 - **Reset semantics on modification of other fields.** Changing `resourcePolicy`, `targetRef`, or the target workload does not reset the window. The window is anchored on `vpa.CreationTimestamp`; users who need to re-observe a workload after a material change should delete and recreate the VPA.
-- **Cluster-wide default windows.** Out of scope for this AEP; operators can inject a default with a Mutating Admission Policy (see [Alternatives Considered](#alternatives-considered), item 3).
+- **Cluster-wide default windows.** Out of scope for this AEP; operators can inject a default with a Mutating Admission Policy (see [Alternatives](#alternatives)).
 
 ## Proposal
 
@@ -159,7 +159,7 @@ The gate is stateless: it is a pure function of `CreationTimestamp` (immutable o
 
 No VPA spec change affects the gate **except** modifying `initialDelaySeconds` itself: the new value simply moves the expiry (`CreationTimestamp + initialDelaySeconds`), so on the next reconcile the gate may open earlier (value shortened or removed) or stay closed longer (value extended). No other field — existing or added to the CRD in the future — participates in gate evaluation; `updateMode` changes only what happens once the gate opens.
 
-Re-arm after expiry is possible but not guaranteed: because the window is anchored to `CreationTimestamp`, a modification re-arms the gate only when the new expiry still lies in the future. This is intentional — it lets users extend an observation window in response to observed instability without deleting the VPA, while a larger-but-already-elapsed value on an old VPA simply has no effect. If reviewers consider this a footgun serious enough to justify admission logic, we can add a check rejecting PATCHes that would push `expiry` past `now` once the window has already elapsed — see [Alternatives Considered](#alternatives-considered).
+Re-arm after expiry is possible but not guaranteed: because the window is anchored to `CreationTimestamp`, a modification re-arms the gate only when the new expiry still lies in the future. This is intentional — it lets users extend an observation window in response to observed instability without deleting the VPA, while a larger-but-already-elapsed value on an old VPA simply has no effect. If reviewers consider this a footgun serious enough to justify admission logic, we can add a check rejecting PATCHes that would push `expiry` past `now` once the window has already elapsed.
 
 ### Interaction with `updateMode`
 
@@ -352,21 +352,13 @@ spec:
 
 Pods created during the first hour receive their `Deployment`-spec resources unchanged. Pods created after the window get VPA-injected resources.
 
-## Alternatives Considered
+## Alternatives
 
-**1. Extend `EvictionRequirements` with a `TimeSinceCreationExceeds` value.** Reuses an existing extensibility hook (AEP-4831), but forces a duration to be encoded inside an enum meant for direction-of-change comparisons (`TargetHigherThanRequests` / `TargetLowerThanRequests`). Awkward and probably a design regression on that API.
+**1. External tooling (today's status quo).** Without this feature, you get the same behavior by creating the VPA in `Off` mode and flipping it to an active mode after N hours — a CronJob or a small controller that patches `updateMode`. It works, but every team rebuilds the same automation, and there's no per-VPA declarative way to say "wait N hours before acting."
 
-**2. Recommender-side confidence gate.** Block `RecommendationProvided` from becoming `True` for N hours or until a confidence threshold is met. Cleaner conceptually but hides visibility — operators would see no recommendation at all in `status.recommendation` during the window, defeating the "collect first, inspect, then apply" workflow this feature is meant to support.
+**2. Extend `EvictionRequirements` with a time-based condition.** `EvictionRequirements` (AEP-4831) already gates eviction on conditions. A duration doesn't fit its enum, which compares the recommendation against requests (`TargetHigherThanRequests` / `TargetLowerThanRequests`), and it only covers eviction — not admission-time injection or in-place resize.
 
-**3. Global default flag** (e.g. `--default-initial-delay-seconds`). A global default would have to be added to — and kept in sync between — both the Updater and the Admission Controller, since both evaluate the gate. Operators who want a default can instead apply a native [Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) to inject the field, needing no new VPA configuration surface.
-
-**4. Do nothing; rely on operator tooling.** The status quo. Ships the complexity downstream to every VPA operator; the CronJob-plus-patch-controller dance ends up reinvented per environment.
-
-**5. Immutable field after creation.** Reject PATCH that modifies `initialDelaySeconds` via admission. Simpler in that it eliminates the re-arm and shortening cases, but forces users into delete-and-recreate to change the window — an expensive operation that also discards the VPA's recommendation history. The proposed stateless-gate design gets the same "one-line mental model" without that cost.
-
-**6. Reset on "material" spec changes** (`resourcePolicy`, `targetRef`). Arguably more correct — a workload with a different target really does have different history semantics — but forces us to define "material" and requires a status field to track the current anchor. Deferred: this AEP does not preclude adding such semantics in a future revision, and the `CreationTimestamp` anchor is a strict subset of any future anchor policy.
-
-**7. Reject PATCH that re-arms an expired gate.** Split the difference on (5) and the proposed design: allow PATCH freely during the window, but reject PATCHes that would push `expiry` past `now` once the window has already elapsed. Rejected because it makes the admission logic dependent on real time (surprising) and does not eliminate the underlying "PATCHes can change gate state" surprise — the `InitialDelayActive` condition and gauge already surface any re-arm immediately.
+**3. Default the field with a Mutating Admission Policy.** For a cluster-wide default, a [Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) can set `initialDelaySeconds` on VPAs that don't specify it, using native Kubernetes with no VPA-side flag. This complements the field rather than replacing it.
 
 ## Implementation History
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -378,7 +378,7 @@ Pods created during the first hour receive their `Deployment`-spec resources unc
 
 **2. Recommender-side confidence gate.** Block `RecommendationProvided` from becoming `True` for N hours or until a confidence threshold is met. Cleaner conceptually but hides visibility — operators would see no recommendation at all in `status.recommendation` during the window, defeating the "collect first, inspect, then apply" workflow this feature is meant to support.
 
-**3. Global default flag** (e.g. `--default-initial-delay-seconds`). A global default would have to be added to — and kept in sync between — both the Updater and the Admission Controller, since both evaluate the gate. Operators who want a default can instead apply a native [Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) to inject the field, needing no new VPA configuration surface; a component flag can be revisited as a follow-up if that proves insufficient.
+**3. Global default flag** (e.g. `--default-initial-delay-seconds`). A global default would have to be added to — and kept in sync between — both the Updater and the Admission Controller, since both evaluate the gate. Operators who want a default can instead apply a native [Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) to inject the field, needing no new VPA configuration surface.
 
 **4. Do nothing; rely on operator tooling.** The status quo. Ships the complexity downstream to every VPA operator; the CronJob-plus-patch-controller dance ends up reinvented per environment.
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -218,20 +218,15 @@ Value is `1` while the gate is active for that VPA, `0` otherwise. Enables fleet
 
 Feature gate: **`VPAInitialDelay`**.
 
-Components consuming the gate:
+Both the `updater` and the `admission-controller` read `initialDelaySeconds` and honour the `VPAInitialDelay` feature gate. While the window is active:
 
-- `updater` — reads `initialDelaySeconds` and honours the gate.
-- `admission-controller` — gates acceptance of the field on new/updated VPAs behind the feature gate, and honours the gate by skipping recommendation injection for pods created during an active window.
+- `updater` — makes no evictions or in-place resizes for the VPA.
+- `admission-controller` — skips recommendation injection for newly created pods. It also validates the field on write and rejects it when the gate is disabled.
 
-Enabling the feature gate causes:
+Disabling the gate causes:
 
-- `admission-controller` to accept `initialDelaySeconds` on new/updated VPAs, and to skip recommendation injection for pods created while a VPA's window is active.
-- `updater` to honour the gate.
-
-Disabling the feature gate causes:
-
-- `admission-controller` to reject new VPAs that set `initialDelaySeconds`, with a descriptive error message indicating the feature gate is disabled.
-- `updater` and `admission-controller` to ignore the field on existing objects — the VPA behaves as if the field were not set (fail-open). This is deliberate: disabling the gate should never *increase* actuation restrictions on existing objects.
+- the `admission-controller` to reject new VPAs that set `initialDelaySeconds`, with a descriptive error.
+- both components to ignore the field on existing objects, so the VPA behaves as if it were unset (fail-open).
 
 ### Graduation Criteria
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -54,7 +54,7 @@ This feature moves the sequencing into the VPA API itself. Operators declare "wa
 
 - **Recommender-confidence-based gating.** This feature is a user-declared policy, not a recommender-computed signal.
 - **Reset semantics on modification of other fields.** Changing `resourcePolicy`, `targetRef`, or the target workload does not reset the window. The window is anchored on `vpa.CreationTimestamp`; users who need to re-observe a workload after a material change should delete and recreate the VPA.
-- **Cluster-wide default windows.** Out of scope for this AEP; operators can inject a default with a Mutating Admission Policy (see [Alternatives](#alternatives)).
+- **Cluster-wide default windows.** Out of scope for this AEP; operators can inject a default with a Mutating Admission Policy.
 
 ## Proposal
 
@@ -363,8 +363,6 @@ Pods created during the first hour receive their `Deployment`-spec resources unc
 **1. External tooling (today's status quo).** Without this feature, you get the same behavior by creating the VPA in `Off` mode and flipping it to an active mode after N hours — a CronJob or a small controller that patches `updateMode`. It works, but every team rebuilds the same automation, and there's no per-VPA declarative way to say "wait N hours before acting."
 
 **2. Extend `EvictionRequirements` with a time-based condition.** `EvictionRequirements` (AEP-4831) already gates eviction on conditions. A duration doesn't fit its enum, which compares the recommendation against requests (`TargetHigherThanRequests` / `TargetLowerThanRequests`), and it only covers eviction — not admission-time injection or in-place resize.
-
-**3. Default the field with a Mutating Admission Policy.** For a cluster-wide default, a [Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) can set `initialDelaySeconds` on VPAs that don't specify it, using native Kubernetes with no VPA-side flag. This complements the field rather than replacing it.
 
 ## Implementation History
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -176,13 +176,11 @@ The interaction appears at boost expiry, when the Updater performs the post-boos
 
 ### Interaction with Checkpoints
 
-`VerticalPodAutoscalerCheckpoint` objects persist the Recommender's learned usage history for each VPA. When a VPA is deleted, its checkpoints are garbage-collected on the Recommender's next pass (`--checkpoints-gc-interval`, 10 minutes by default) — so if a VPA is recreated with the same name before that pass, the Recommender restores its history from the checkpoint and `status.recommendation` is immediately repopulated with mature values, rather than starting cold.
+A VPA's checkpoint stores the recommender's history for that VPA. Checkpoints are keyed by VPA name, not by a unique object ID, and one is only deleted once no VPA with that name exists (the recommender's GC pass, every 10 minutes by default via `--checkpoints-gc-interval`).
 
-This matters here because a recreated VPA can therefore hold mature recommendations while its delay window is still active, which raises the question of whether the gate should open early in that case.
+So deleting a VPA and recreating it with the same name hands the new object the old checkpoint, as long as GC hasn't removed it yet. The recommender loads that history and fills `status.recommendation` with mature values almost immediately, even though the new VPA has a fresh UID and creation time.
 
-Proposed handling: the gate ignores checkpoints entirely. A recreated VPA always starts a fresh window anchored to the new object's `CreationTimestamp`, whether its recommendations were restored or rebuilt from scratch.
-
-Rationale: keeping the gate a pure function of `CreationTimestamp` and the spec value is the core simplicity of this design — making it checkpoint-aware would reintroduce state and turn the field into a confidence signal, which is an explicit [non-goal](#non-goals). Users who recreate a VPA and are satisfied with the restored recommendations already have an escape hatch: shorten or remove `initialDelaySeconds` on the new object to open the gate early.
+This matters for the delay window, because a freshly recreated VPA can already hold mature recommendations while its window is still active. The window still starts from the new object's `CreationTimestamp`, whether the recommendations were restored from a checkpoint or built from scratch. Making the gate look at checkpoints would add state and turn `initialDelaySeconds` into a confidence signal, which is a [non-goal](#non-goals). Anyone who recreates a VPA and is happy with the restored recommendations can just set a smaller `initialDelaySeconds`, or leave it off, on the new object.
 
 ### Validation
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -33,7 +33,7 @@
 
 Add an optional `initialDelaySeconds` field to `PodUpdatePolicy` that delays actuation of recommendations for a configurable duration after a VPA's creation. During the window the Recommender continues to compute and publish recommendations to `status.recommendation` normally, but nothing actuates them: the Updater performs no evictions or in-place resizes, and the Admission Controller does not apply recommendations to pods created during the window. The VPA behaves exactly as if `updateMode` were `Off`. Once the window elapses, the configured `updateMode` takes effect automatically with no operator action.
 
-The window is computed as a pure function of `vpa.CreationTimestamp` and the current spec value, evaluated on every reconcile. Modifying an existing VPA's spec does not reset the window — the anchor (`CreationTimestamp`) is immutable, and changing `initialDelaySeconds` itself simply moves the expiry relative to that anchor (see [Gate Evaluation](#gate-evaluation) for the full modification semantics).
+The window is computed as a pure function of `vpa.CreationTimestamp` and the current `initialDelaySeconds` value, evaluated on every reconcile. Modifying an existing VPA's spec does not reset the window — the anchor (`CreationTimestamp`) is immutable, and changing `initialDelaySeconds` itself simply moves the expiry relative to that anchor (see [Gate Evaluation](#gate-evaluation) for the full modification semantics).
 
 ## Motivation
 
@@ -157,7 +157,7 @@ When `InInitialDelayWindow` returns `true`, both components take the same code p
 
 `InInitialDelayWindow` is exported from the shared `pkg/utils/vpa` package so both the Updater and the Admission Controller consume the identical implementation. Each call site first checks the `VPAInitialDelay` feature gate (`features.Enabled(features.VPAInitialDelay)`); when the gate is disabled the helper is not consulted and the component behaves exactly as it does today (fail-open).
 
-The gate is stateless: it is a pure function of `CreationTimestamp` (immutable on the object) and the current spec value (mutable). No caching, no status writes.
+The gate is stateless: it is a pure function of `CreationTimestamp` (immutable on the object) and the current `initialDelaySeconds` value (mutable). No caching, no status writes.
 
 No VPA spec change affects the gate **except** modifying `initialDelaySeconds` itself: the new value simply moves the expiry (`CreationTimestamp + initialDelaySeconds`), so on the next reconcile the gate may open earlier (value shortened or removed) or stay closed longer (value extended). No other field — existing or added to the CRD in the future — participates in gate evaluation; `updateMode` changes only what happens once the gate opens.
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -378,45 +378,7 @@ Pods created during the first hour receive their `Deployment`-spec resources unc
 
 **2. Recommender-side confidence gate.** Block `RecommendationProvided` from becoming `True` for N hours or until a confidence threshold is met. Cleaner conceptually but hides visibility — operators would see no recommendation at all in `status.recommendation` during the window, defeating the "collect first, inspect, then apply" workflow this feature is meant to support.
 
-**3. Global default flag** (e.g. `--default-initial-delay-seconds`). A sane cluster-wide default is genuinely useful, but the flag would need to be added to — and kept in sync between — both the Updater and the Admission Controller, since both evaluate the gate. Operators who want a cluster-wide default can instead inject one at admission time with a [Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/), with no new VPA configuration surface. For example, to default every VPA that does not set the field to a one-hour window:
-
-```yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingAdmissionPolicy
-metadata:
-  name: vpa-default-initial-delay
-spec:
-  matchConstraints:
-    resourceRules:
-    - apiGroups: ["autoscaling.k8s.io"]
-      apiVersions: ["v1"]
-      operations: ["CREATE"]
-      resources: ["verticalpodautoscalers"]
-  matchConditions:
-  - name: no-explicit-initial-delay
-    expression: "!has(object.spec.updatePolicy) || !has(object.spec.updatePolicy.initialDelaySeconds)"
-  failurePolicy: Ignore
-  mutations:
-  - patchType: ApplyConfiguration
-    applyConfiguration:
-      expression: >
-        Object{
-          spec: Object.spec{
-            updatePolicy: Object.spec.updatePolicy{
-              initialDelaySeconds: 3600
-            }
-          }
-        }
----
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingAdmissionPolicyBinding
-metadata:
-  name: vpa-default-initial-delay-binding
-spec:
-  policyName: vpa-default-initial-delay
-```
-
-A component flag can be revisited as a follow-up if the policy route proves insufficient.
+**3. Global default flag** (e.g. `--default-initial-delay-seconds`). A global default would have to be added to — and kept in sync between — both the Updater and the Admission Controller, since both evaluate the gate. Operators who want a default can instead apply a native [Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) to inject the field, needing no new VPA configuration surface; a component flag can be revisited as a follow-up if that proves insufficient.
 
 **4. Do nothing; rely on operator tooling.** The status quo. Ships the complexity downstream to every VPA operator; the CronJob-plus-patch-controller dance ends up reinvented per environment.
 

--- a/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
+++ b/vertical-pod-autoscaler/enhancements/9936-vpa-observation-window/README.md
@@ -96,31 +96,18 @@ type PodUpdatePolicy struct {
     // ... existing fields (UpdateMode, MinReplicas, EvictionRequirements,
     //                     EvictAfterOOMSeconds) ...
 
-    // InitialDelaySeconds is the duration in seconds after this
-    // VPA's creation during which recommendations are not actuated,
+    // InitialDelaySeconds specifies the number of seconds to wait after
+    // the VPA object is created before recommendations are actuated,
     // regardless of the configured UpdateMode.
     //
-    // During the window, the Recommender continues to compute and
-    // publish recommendations to status.recommendation as usual, but the
-    // Updater and the Admission Controller treat the VPA as if
-    // UpdateMode were Off: no evictions, no in-place resizes, and no
-    // recommendation injection into newly created pods. After the window
-    // elapses (now >= CreationTimestamp + InitialDelaySeconds), the
-    // configured UpdateMode takes effect on subsequent reconciles and
-    // pod creations.
+    // During the window, the Recommender still computes and publishes
+    // recommendations to status.recommendation, but the Updater and
+    // Admission Controller treat the VPA as if UpdateMode were Off: no
+    // evictions, in-place resizes, or injection into new pods. The
+    // configured UpdateMode takes effect once the window elapses.
     //
-    // The window is computed as a pure function of vpa.CreationTimestamp
-    // and this spec field. The field may be modified at any time; the
-    // new value takes effect on the next reconcile. Removing the field or setting it to zero
-    // closes the gate immediately. Setting a larger value after the
-    // window has expired re-arms the gate only if the new expiry
-    // (CreationTimestamp + InitialDelaySeconds) still lies in the
-    // future; otherwise the gate stays open.
-    //
-    // If UpdateMode is Off, this field has no effect: Off already
-    // suppresses Updater actuation indefinitely.
-    //
-    // Must be between 1 and 7776000 (90 days) if set.
+    // If UpdateMode is Off, this field has no effect. Must be between
+    // 1 and 7776000 (90 days) if set.
     // +optional
     // +kubebuilder:validation:Minimum=1
     // +kubebuilder:validation:Maximum=7776000


### PR DESCRIPTION
This is the AEP for #9936 (Per-VPA Observation Window).

The proposal adds an optional `initialDelaySeconds` field on `PodUpdatePolicy` (named to match Pod probes). During the window, the Updater and the Admission Controller treat the VPA as if `updateMode` were `Off`, regardless of the configured mode: no evictions, no in-place resizes, and no recommendation injection into pods created during the window. The Recommender is unaffected and continues to publish recommendations to `status.recommendation`. After the window elapses, the configured mode takes effect. Works uniformly across `Recreate`, `InPlaceOrRecreate`, `InPlace`, and `Initial`. `Off + initialDelaySeconds` silently no-ops.

The gate is a pure function of `vpa.CreationTimestamp` and the current `initialDelaySeconds` value, re-evaluated on every reconcile. Gate state is surfaced via an `InitialDelayActive` status condition and a `vpa_initial_delay_active` gauge, behind a `VPAInitialDelay` feature gate.

Refs #9936.

/kind feature
/area vertical-pod-autoscaler
/sig autoscaling
/assign

/cc @omerap12 @adrianmoisey

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design proposal for configurable observation windows per Vertical Pod Autoscaler.
  * Documents an optional initial delay before automated pod updates and admission-time recommendation injection.
  * Recommendations continue to be published during the configured delay.
  * Covers validation limits, status conditions, metrics, feature-gate behavior, version compatibility, testing, examples, alternatives, and implementation history.
  * Defines the proposed delay setting and its evaluation based on VPA creation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

