### PR TITLE
Move VPA audo mode warning into validation files

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server.go
@@ -35,17 +35,11 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa"
-	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
 	metrics_admission "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/admission"
 )
 
 const (
-	vpaGroup               = "autoscaling.k8s.io"
-	vpaResource            = "verticalpodautoscalers"
-	autoDeprecationWarning = `UpdateMode "Auto" is deprecated and will be removed in a future API version. ` +
-		`Use explicit update modes like "Recreate", "Initial", or "InPlaceOrRecreate" instead. ` +
-		`See https://github.com/kubernetes/autoscaler/issues/8424 for more details.`
 	// maxAdmissionPayloadSize limits the size of the incoming admission request payload
 	// to prevent OOM (Denial of Service) attacks. A typical AdmissionReview is well under 100KB,
 	// and etcd limits objects to 1.5MB. With updates including both the new and old object,
@@ -74,37 +68,6 @@ func NewAdmissionServer(podPreProcessor pod.PreProcessor,
 // RegisterResourceHandler allows to register a custom logic for handling given types of resources.
 func (s *AdmissionServer) RegisterResourceHandler(resourceHandler resource.Handler) {
 	s.resourceHandlers[resourceHandler.GroupResource()] = resourceHandler
-}
-
-// addDeprecationWarnings adds deprecation warnings to the admission response for VPA objects using deprecated modes
-func (*AdmissionServer) addDeprecationWarnings(req *admissionv1.AdmissionRequest, resp *admissionv1.AdmissionResponse) {
-	if req.Object.Raw == nil {
-		return
-	}
-
-	// Check if this is a VPA object
-	admittedGroupResource := metav1.GroupResource{
-		Group:    req.Resource.Group,
-		Resource: req.Resource.Resource,
-	}
-
-	if admittedGroupResource.Group != vpaGroup || admittedGroupResource.Resource != vpaResource {
-		return
-	}
-
-	var vpa vpa_types.VerticalPodAutoscaler
-	if err := json.Unmarshal(req.Object.Raw, &vpa); err != nil {
-		klog.V(4).InfoS("Failed to unmarshal VPA object for deprecation warning check", "err", err)
-		return
-	}
-
-	if vpa.Spec.UpdatePolicy != nil && vpa.Spec.UpdatePolicy.UpdateMode != nil &&
-		*vpa.Spec.UpdatePolicy.UpdateMode == vpa_types.UpdateModeAuto { //nolint:staticcheck
-		if resp.Warnings == nil {
-			resp.Warnings = []string{}
-		}
-		resp.Warnings = append(resp.Warnings, autoDeprecationWarning)
-	}
 }
 
 func (s *AdmissionServer) admit(ctx context.Context, data []byte) (*admissionv1.AdmissionResponse, metrics_admission.AdmissionStatus, metrics_admission.AdmissionResource) {
@@ -183,9 +146,6 @@ func (s *AdmissionServer) admit(ctx context.Context, data []byte) (*admissionv1.
 	if resource == metrics_admission.Pod {
 		metrics_admission.OnAdmittedPod(status == metrics_admission.Applied)
 	}
-
-	// Add deprecation warnings for VPA objects using deprecated modes
-	s.addDeprecationWarnings(ar.Request, &response)
 
 	return &response, status, resource
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation.go
@@ -144,7 +144,9 @@ func validateVPASpec(spec *vpa_types.VerticalPodAutoscalerSpec, fldPath *field.P
 	}
 
 	if spec.UpdatePolicy != nil {
-		allErrs = append(allErrs, validateVPASpecUpdatePolicy(spec.UpdatePolicy, fldPath.Child("updatePolicy"), opts)...)
+		updatePolicyWarnings, updatePolicyErrs := validateVPASpecUpdatePolicy(spec.UpdatePolicy, fldPath.Child("updatePolicy"), opts)
+		warnings = append(warnings, updatePolicyWarnings...)
+		allErrs = append(allErrs, updatePolicyErrs...)
 	}
 
 	if spec.ResourcePolicy != nil {
@@ -164,8 +166,9 @@ func validateVPASpec(spec *vpa_types.VerticalPodAutoscalerSpec, fldPath *field.P
 	return warnings, allErrs
 }
 
-func validateVPASpecUpdatePolicy(updatePolicy *vpa_types.PodUpdatePolicy, fldPath *field.Path, opts VPAValidationOptions) field.ErrorList {
+func validateVPASpecUpdatePolicy(updatePolicy *vpa_types.PodUpdatePolicy, fldPath *field.Path, opts VPAValidationOptions) ([]string, field.ErrorList) {
 	allErrs := field.ErrorList{}
+	var warnings []string
 
 	mode := updatePolicy.UpdateMode
 	if mode == nil {
@@ -173,6 +176,9 @@ func validateVPASpecUpdatePolicy(updatePolicy *vpa_types.PodUpdatePolicy, fldPat
 	} else {
 		if _, found := vpa_types.GetUpdateModes()[*mode]; !found {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("updateMode"), *mode, vpa_types.GetUpdateModesList()))
+		}
+		if *mode == vpa_types.UpdateModeAuto { //nolint:staticcheck
+			warnings = append(warnings, fmt.Sprintf("%s: %q mode is deprecated and will be removed in a future API version. Use explicit update modes like: %s. See https://github.com/kubernetes/autoscaler/issues/8424 for more details.", fldPath, *mode, vpa_types.GetUpdateModesList()))
 		}
 
 		if *mode == vpa_types.UpdateModeInPlace && !opts.AllowInPlace {
@@ -193,7 +199,7 @@ func validateVPASpecUpdatePolicy(updatePolicy *vpa_types.PodUpdatePolicy, fldPat
 		}
 	}
 
-	return allErrs
+	return warnings, allErrs
 }
 
 func validateVPASpecResourcePolicy(resourcePolicy *vpa_types.PodResourcePolicy, fldPath *field.Path, opts VPAValidationOptions) ([]string, field.ErrorList) {

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/validation_test.go
@@ -257,6 +257,7 @@ func TestValidateVPA(t *testing.T) {
 	controlledValuesRequestsAndLimits := vpa_types.ContainerControlledValuesRequestsAndLimits
 	inPlaceOrRecreateUpdateMode := vpa_types.UpdateModeInPlaceOrRecreate
 	inPlaceUpdateMode := vpa_types.UpdateModeInPlace
+	autoUpdateMode := vpa_types.UpdateModeAuto //nolint:staticcheck
 	badCPUBoostFactor := int32(0)
 	validCPUBoostFactor := int32(2)
 	badCPUBoostQuantity := resource.MustParse("187500u")
@@ -323,6 +324,21 @@ func TestValidateVPA(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "deprecated Auto update mode set",
+			vpa: vpa_types.VerticalPodAutoscaler{
+				Spec: vpa_types.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "my-app",
+					},
+					UpdatePolicy: &vpa_types.PodUpdatePolicy{
+						UpdateMode: &autoUpdateMode,
+					},
+				},
+			},
+			expectWarnings: []string{fmt.Sprintf("spec.updatePolicy: %q mode is deprecated and will be removed in a future API version. Use explicit update modes like: %s. See https://github.com/kubernetes/autoscaler/issues/8424 for more details.", autoUpdateMode, vpa_types.GetUpdateModesList())},
 		},
 		{
 			name: "zero minReplicas",


### PR DESCRIPTION
Now that we have nice validation files, I moved the Auto warning into the same area

They have tests and also now support warnings

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Over in https://github.com/kubernetes/autoscaler/pull/9951 I added the ability for the validation functions to return warnings.
Now that we have that ability, I decided to move the warning for Auto into those functions.
It removes the need to parse AdmissionRequest an additional time, and the functions are testable. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
