### PR TITLE
Update versioning schema overview table

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -51,7 +51,8 @@ Starting from Kubernetes 1.12, versioning scheme was changed to match Kubernetes
 
 | Kubernetes Version | CA Version               | Chart Version |
 |--------------------|--------------------------|---------------|
-| 1.34.x             | 1.34.x                   |9.51.0+|
+| 1.35.x             | 1.35.x                   |9.55.1+|
+| 1.34.x             | 1.34.x                   |9.52.0+|
 | 1.33.x             | 1.33.x                   |9.47.0+|
 | 1.32.x             | 1.32.x                   |9.45.0+|
 | 1.31.x             | 1.31.x                   |9.38.0+|


### PR DESCRIPTION
Updated the versioning table to fix Chart version for Kubernetes 1.34.x and include Kubernetes 1.35.x and its corresponding CA and Chart versions.

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/8891

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
