### PR TITLE
VPA Fix flake: Pods under VPA with Recreate updateMode have memory requests growing with usage

### DIFF
--- a/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
@@ -137,9 +137,11 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 
 			// consume more memory to get a higher recommendation
 			// NOTE: large range given due to unpredictability of actual memory usage
+			// NOTE: longer timeout: the memory recommendation grows slower than CPU
+			// and the updater then applies it to the pods serially, ~1-2 min apart.
 			rc.ConsumeMem(1024 * replicas)
 			err = waitForResourceRequestInRangeInPods(
-				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
+				f, 2*utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
 				ParseQuantityOrDie("900Mi"), ParseQuantityOrDie("4000Mi"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
@@ -208,9 +210,11 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 
 			// consume more memory to get a higher recommendation
 			// NOTE: large range given due to unpredictability of actual memory usage
+			// NOTE: longer timeout: the memory recommendation grows slower than CPU
+			// and the updater then evicts the pods serially, ~1-2 min apart.
 			rc.ConsumeMem(1024 * replicas)
 			err = waitForResourceRequestInRangeInPods(
-				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
+				f, 2*utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
 				ParseQuantityOrDie("900Mi"), ParseQuantityOrDie("4000Mi"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

We had a flake: https://prow.k8s.io/bc7baa62-7836-436c-b284-26594ad5d53e

```
I0712 13:08:49.870222   51620 full_vpa.go:676] Pod hamster-774bd97b-pqrjt container 0: Comparing memory request {{262144000 0} {<nil>} 250Mi BinarySI} against range of ({{943718400 0} {<nil>} 900Mi BinarySI}, {{4194304000 0} {<nil>}  BinarySI})
[FAILED] Unexpected error:
    <*errors.errorString | 0x3150e4bc42b0>: 
    error waiting for resource requests in range [{Index:0 ResourceName:memory LowerBound:{i:{value:943718400 scale:0} d:{Dec:<nil>} s:900Mi Format:BinarySI} UpperBound:{i:{value:4194304000 scale:0} d:{Dec:<nil>} s: Format:BinarySI}}] for pods: {TypeMeta:{Kind: APIVersion:} LabelSelector:name=hamster FieldSelector: Watch:false AllowWatchBookmarks:false ResourceVersion: ResourceVersionMatch: TimeoutSeconds:<nil> Limit:0 Continue: SendInitialEvents:<nil> ShardSelector:}
    {
        s: "error waiting for resource requests in range [{Index:0 ResourceName:memory LowerBound:{i:{value:943718400 scale:0} d:{Dec:<nil>} s:900Mi Format:BinarySI} UpperBound:{i:{value:4194304000 scale:0} d:{Dec:<nil>} s: Format:BinarySI}}] for pods: {TypeMeta:{Kind: APIVersion:} LabelSelector:name=hamster FieldSelector: Watch:false AllowWatchBookmarks:false ResourceVersion: ResourceVersionMatch: TimeoutSeconds:<nil> Limit:0 Continue: SendInitialEvents:<nil> ShardSelector:}",
    }
occurred
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
