### PR TITLE
cleanup: use helper for update modes in recommender tests

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package recommender
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -30,11 +32,6 @@ import (
 )
 
 func TestObjectCounter(t *testing.T) {
-	updateModeOff := vpa_types.UpdateModeOff
-	updateModeInitial := vpa_types.UpdateModeInitial
-	updateModeRecreate := vpa_types.UpdateModeRecreate
-	updateModeAuto := vpa_types.UpdateModeAuto //nolint:staticcheck
-	updateModeInPlaceOrRecreate := vpa_types.UpdateModeInPlaceOrRecreate
 	// We verify that other update modes are handled correctly as validation
 	// may not happen if there are issues with the admission controller.
 	updateModeUserDefined := vpa_types.UpdateMode("userDefined")
@@ -98,66 +95,6 @@ func TestObjectCounter(t *testing.T) {
 			},
 			wantMetrics: map[string]float64{
 				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
-			},
-		},
-		{
-			name: "report update mode auto",
-			add: []*model.Vpa{
-				{
-					APIVersion: "v1",
-					UpdateMode: &updateModeAuto,
-				},
-			},
-			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Auto,": 1,
-			},
-		},
-		{
-			name: "report update mode initial",
-			add: []*model.Vpa{
-				{
-					APIVersion: "v1",
-					UpdateMode: &updateModeInitial,
-				},
-			},
-			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Initial,": 1,
-			},
-		},
-		{
-			name: "report update mode recreate",
-			add: []*model.Vpa{
-				{
-					APIVersion: "v1",
-					UpdateMode: &updateModeRecreate,
-				},
-			},
-			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Recreate,": 1,
-			},
-		},
-		{
-			name: "report update mode off",
-			add: []*model.Vpa{
-				{
-					APIVersion: "v1",
-					UpdateMode: &updateModeOff,
-				},
-			},
-			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=Off,": 1,
-			},
-		},
-		{
-			name: "report update mode InPlaceOrRecreate",
-			add: []*model.Vpa{
-				{
-					APIVersion: "v1",
-					UpdateMode: &updateModeInPlaceOrRecreate,
-				},
-			},
-			wantMetrics: map[string]float64{
-				"api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=InPlaceOrRecreate,": 1,
 			},
 		},
 		{
@@ -281,6 +218,26 @@ func TestObjectCounter(t *testing.T) {
 		},
 	}
 
+	for _, mode := range sortedUpdateModes() {
+		mode := mode
+		cases = append(cases, struct {
+			name        string
+			add         []*model.Vpa
+			wantMetrics map[string]float64
+		}{
+			name: fmt.Sprintf("report update mode %s", mode),
+			add: []*model.Vpa{
+				{
+					APIVersion: "v1",
+					UpdateMode: &mode,
+				},
+			},
+			wantMetrics: map[string]float64{
+				fmt.Sprintf("api=v1,has_recommendation=false,matches_pods=true,unsupported_config=false,update_mode=%s,", mode): 1,
+			},
+		})
+	}
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			counter := NewObjectCounter()
@@ -336,6 +293,19 @@ func TestObjectCounter(t *testing.T) {
 	}
 }
 
+// sortedUpdateModes returns all UpdateModes known to the API, via the shared
+// vpa_types.GetUpdateModes helper, in a deterministic order. Sourcing the
+// modes from the helper (instead of a hardcoded list) ensures these tests
+// automatically pick up any new UpdateMode added to the API.
+func sortedUpdateModes() []vpa_types.UpdateMode {
+	modes := make([]vpa_types.UpdateMode, 0, len(vpa_types.GetUpdateModes()))
+	for mode := range vpa_types.GetUpdateModes() {
+		modes = append(modes, mode)
+	}
+	sort.Slice(modes, func(i, j int) bool { return modes[i] < modes[j] })
+	return modes
+}
+
 func labelsToKey(labels []*dto.LabelPair) string {
 	key := strings.Builder{}
 	for _, label := range labels {
@@ -348,15 +318,7 @@ func labelsToKey(labels []*dto.LabelPair) string {
 }
 
 func TestObjectCounterResetsAllUpdateModes(t *testing.T) {
-	updatesModes := []vpa_types.UpdateMode{
-		vpa_types.UpdateModeOff,
-		vpa_types.UpdateModeInitial,
-		vpa_types.UpdateModeAuto, //nolint:staticcheck
-		vpa_types.UpdateModeRecreate,
-		vpa_types.UpdateModeInPlaceOrRecreate,
-	}
-
-	for _, mode := range updatesModes {
+	for _, mode := range sortedUpdateModes() {
 		t.Run(string(mode), func(t *testing.T) {
 			t.Cleanup(func() {
 				vpaObjectCount.Reset()

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
@@ -18,7 +18,6 @@ package recommender
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -218,7 +217,7 @@ func TestObjectCounter(t *testing.T) {
 		},
 	}
 
-	for _, mode := range sortedUpdateModes() {
+	for mode := range vpa_types.GetUpdateModes() {
 		cases = append(cases, struct {
 			name        string
 			add         []*model.Vpa
@@ -292,19 +291,6 @@ func TestObjectCounter(t *testing.T) {
 	}
 }
 
-// sortedUpdateModes returns all UpdateModes known to the API, via the shared
-// vpa_types.GetUpdateModes helper, in a deterministic order. Sourcing the
-// modes from the helper (instead of a hardcoded list) ensures these tests
-// automatically pick up any new UpdateMode added to the API.
-func sortedUpdateModes() []vpa_types.UpdateMode {
-	modes := make([]vpa_types.UpdateMode, 0, len(vpa_types.GetUpdateModes()))
-	for mode := range vpa_types.GetUpdateModes() {
-		modes = append(modes, mode)
-	}
-	slices.Sort(modes)
-	return modes
-}
-
 func labelsToKey(labels []*dto.LabelPair) string {
 	key := strings.Builder{}
 	for _, label := range labels {
@@ -317,7 +303,7 @@ func labelsToKey(labels []*dto.LabelPair) string {
 }
 
 func TestObjectCounterResetsAllUpdateModes(t *testing.T) {
-	for _, mode := range sortedUpdateModes() {
+	for mode := range vpa_types.GetUpdateModes() {
 		t.Run(string(mode), func(t *testing.T) {
 			t.Cleanup(func() {
 				vpaObjectCount.Reset()

--- a/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/recommender/recommender_test.go
@@ -18,7 +18,7 @@ package recommender
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -219,7 +219,6 @@ func TestObjectCounter(t *testing.T) {
 	}
 
 	for _, mode := range sortedUpdateModes() {
-		mode := mode
 		cases = append(cases, struct {
 			name        string
 			add         []*model.Vpa
@@ -302,7 +301,7 @@ func sortedUpdateModes() []vpa_types.UpdateMode {
 	for mode := range vpa_types.GetUpdateModes() {
 		modes = append(modes, mode)
 	}
-	sort.Slice(modes, func(i, j int) bool { return modes[i] < modes[j] })
+	slices.Sort(modes)
 	return modes
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Both `TestObjectCounter` and `TestObjectCounterResetsAllUpdateModes` in `recommender_test.go` hardcoded the list of VPA update modes, so they silently missed `InPlace` and would miss any future mode as well.

This PR adds a shared `sortedUpdateModes()` helper (derived from `vpa_types.GetUpdateModes()`) and uses it in both tests, keeping test coverage in sync with the supported API update modes and eliminating the need to manually update multiple test cases whenever a new mode is added.

#### Which issue(s) this PR fixes:

Fixes #9971

#### Special notes for your reviewer:

Verified that all update modes returned by `GetUpdateModes()`, including `InPlace`, are covered by both tests.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
