### PR TITLE
Benchmarking scaledown strategies

### DIFF
--- a/.github/workflows/ca-benchmark.yaml
+++ b/.github/workflows/ca-benchmark.yaml
@@ -37,13 +37,13 @@ jobs:
         shell: bash
         run: |
           cd base/cluster-autoscaler
-          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./core/bench/... -args -gc true | tee ../../base.txt
+          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./core/bench/... | tee ../../base.txt
 
       - name: Run Benchmark (PR)
         shell: bash
         run: |
           cd pr/cluster-autoscaler
-          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./core/bench/... -args -gc true | tee ../../pr.txt
+          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./core/bench/... | tee ../../pr.txt
 
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest

--- a/cluster-autoscaler/core/bench/benchmark_runonce_test.go
+++ b/cluster-autoscaler/core/bench/benchmark_runonce_test.go
@@ -91,7 +91,7 @@ const (
 var (
 	runOnceCpuProfile = flag.String("profile-cpu", "", "If set, the benchmark writes a CPU profile to this file, covering the RunOnce execution during the first iteration.")
 	runOnceTrace      = flag.String("trace", "", "If set, the benchmark writes an execution trace to this file, covering the RunOnce execution during the first iteration.")
-	withGC            = flag.Bool("gc", false, "If set to false, the benchmark disables garbage collection to stabilize the runtime.")
+	withGC            = flag.Bool("gc", true, "If set to false, the benchmark disables garbage collection to stabilize the runtime.")
 )
 
 type scenario struct {

--- a/cluster-autoscaler/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
+++ b/cluster-autoscaler/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efficiency
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	cacontext "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/planner"
+	. "k8s.io/autoscaler/cluster-autoscaler/core/test"
+	"k8s.io/autoscaler/cluster-autoscaler/processors"
+	processorstest "k8s.io/autoscaler/cluster-autoscaler/processors/test"
+	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
+	kubeutil "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	klog.InitFlags(nil)
+}
+
+// scaleDownScenario packs initialClusterState, metricsTracker, and optional config.AutoscalingOptions into one struct for individual scaledown run execution.
+type scaleDownScenario struct {
+	Name                string
+	InitialClusterState *initialClusterState
+	Metrics             *metricsTracker
+	AutoscalingOpts     func(opts *config.AutoscalingOptions)
+}
+
+type scaleDownDependencies struct {
+	AutoscalingCtx *cacontext.AutoscalingContext
+	Processors     *processors.AutoscalingProcessors
+	Planner        *planner.Planner
+	Actuator       *fakeActuator
+	MetricsTracker *metricsTracker
+}
+
+func defaultAutoscalingOptions() config.AutoscalingOptions {
+	return config.AutoscalingOptions{
+		ScaleDownEnabled:           true,
+		MaxScaleDownParallelism:    1,
+		ScaleDownSimulationTimeout: 10 * time.Second,
+		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+			ScaleDownUtilizationThreshold: 1.0,
+			ScaleDownUnneededTime:         0,
+		},
+	}
+}
+
+func buildScaleDownDependencies(b *testing.B, cs *initialClusterState, autoscalingOpts config.AutoscalingOptions) scaleDownDependencies {
+	var allNodes []*apiv1.Node
+	var allPods []*apiv1.Pod
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+
+	for _, ng := range cs.NodeGroups {
+		allNodes = append(allNodes, ng.Nodes...)
+		allPods = append(allPods, ng.Pods...)
+		provider.AddNodeGroupWithCustomOptions(ng.Name, ng.MinSize, ng.MaxSize, len(ng.Nodes), ng.NodeGroupOptions)
+		for _, node := range ng.Nodes {
+			provider.AddNode(ng.Name, node)
+		}
+	}
+
+	procs, templateRegistry := processorstest.NewTestProcessors(autoscalingOpts)
+	registry := kubeutil.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOpts, &fake.Clientset{}, registry, provider, nil, nil, templateRegistry)
+	if err != nil {
+		b.Fatalf("failed to instantiate AutoscalingContext: %v", err)
+	}
+	clustersnapshot.InitializeClusterSnapshotOrDie(b, autoscalingCtx.ClusterSnapshot, allNodes, allPods)
+
+	a := NewFakeActuator(autoscalingCtx, &fakeActuationStatus{}, b)
+	factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: procs.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
+	p := planner.New(&autoscalingCtx, procs, options.NodeDeleteOptions{}, nil, factory)
+
+	return scaleDownDependencies{
+		AutoscalingCtx: &autoscalingCtx,
+		Processors:     procs,
+		Planner:        p,
+		Actuator:       a,
+	}
+}
+
+// Crucial to pass -benchtime=1x to let the Loop know to run scaledown strategy exactly once.
+func (scenario scaleDownScenario) runIteration(b *testing.B) {
+	klog.Infof("iteration: %d", b.N)
+
+	opts := defaultAutoscalingOptions()
+	if scenario.AutoscalingOpts != nil {
+		scenario.AutoscalingOpts(&opts)
+	}
+	mt := scenario.Metrics
+	sdDeps := buildScaleDownDependencies(b, scenario.InitialClusterState, opts)
+
+	nodeInfos, err := sdDeps.AutoscalingCtx.ClusterSnapshot.ListNodeInfos()
+	if err != nil {
+		b.Fatalf("failed to list node infos from snapshot: %s", err.Error())
+	}
+	metricsDeps := metricsDependencies{
+		scaledDownNodes: nil,
+		nodeInfos:       nodeInfos,
+		currentTime:     time.Now(),
+	}
+
+	mt.ComputeMetrics(metricsDeps, b)
+
+	var scaleDownCandidates []*apiv1.Node
+	var podDestinations []*apiv1.Node
+
+	for scaleDownLoop := 1; ; scaleDownLoop++ {
+		infos, err := sdDeps.AutoscalingCtx.ClusterSnapshot.ListNodeInfos()
+		if err != nil {
+			b.Fatalf("error retrieving nodes from cluster snapshot, err %s", err.Error())
+		}
+
+		var currentNodes []*apiv1.Node
+		for _, nodeInfo := range infos {
+			currentNodes = append(currentNodes, nodeInfo.Node())
+		}
+
+		if sdDeps.Processors == nil || sdDeps.Processors.ScaleDownNodeProcessor == nil {
+			scaleDownCandidates = currentNodes
+			podDestinations = currentNodes
+		} else {
+			scaleDownCandidates, err = sdDeps.Processors.ScaleDownNodeProcessor.GetScaleDownCandidates(
+				sdDeps.AutoscalingCtx, currentNodes)
+			if err != nil {
+				b.Fatalf("error getting scale-down candidates: %s", err.Error())
+			}
+		}
+
+		currentTime := time.Now()
+		err = sdDeps.Planner.UpdateClusterState(podDestinations, scaleDownCandidates, sdDeps.Actuator.actuationStatus, currentTime)
+		if err != nil {
+			b.Fatalf("error updating cluster state: %s", err.Error())
+		}
+
+		empty, needDrain := sdDeps.Planner.NodesToDelete(currentTime)
+		// No more nodes to delete, final state reached.
+		if len(empty) == 0 && len(needDrain) == 0 {
+			b.ReportMetric(float64(scaleDownLoop), "loops")
+			break
+		}
+		_, scaledDownNodes, typedErr := sdDeps.Actuator.startDeletion(empty, needDrain)
+		if typedErr != nil {
+			b.Errorf("error deleting nodes in fake actuator, err %s", typedErr.Error())
+		}
+		ni, err := sdDeps.AutoscalingCtx.ClusterSnapshot.ListNodeInfos()
+		if err != nil {
+			b.Fatalf("error listing node infos: %s", err.Error())
+		}
+
+		metricsDeps.nodeInfos = ni
+		metricsDeps.scaledDownNodes = scaledDownNodes
+		metricsDeps.currentTime = currentTime
+		mt.ComputeMetrics(metricsDeps, b)
+	}
+	mt.ReportToBenchmark(b)
+}
+
+func BenchmarkScaledownEfficiency(b *testing.B) {
+	s := scaleDownScenario{
+		Name:                "three ng, basic setup",
+		InitialClusterState: differentNodeSizesMemIrrelevant(),
+		Metrics: NewMetricsTracker(
+			NewResourceUtilizationMetric(apiv1.ResourceCPU),
+			NewResourceUtilizationMetric(apiv1.ResourceMemory),
+		),
+		AutoscalingOpts: func(opts *config.AutoscalingOptions) {
+			opts.NodeGroupDefaults.ScaleDownUtilizationThreshold = 0.75
+		},
+	}
+	s.runIteration(b)
+}

--- a/cluster-autoscaler/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
+++ b/cluster-autoscaler/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
@@ -106,8 +106,6 @@ func buildScaleDownDependencies(b *testing.B, cs *initialClusterState, autoscali
 
 // Crucial to pass -benchtime=1x to let the Loop know to run scaledown strategy exactly once.
 func (scenario scaleDownScenario) runIteration(b *testing.B) {
-	klog.Infof("iteration: %d", b.N)
-
 	opts := defaultAutoscalingOptions()
 	if scenario.AutoscalingOpts != nil {
 		scenario.AutoscalingOpts(&opts)

--- a/cluster-autoscaler/core/bench/scaledown/efficiency/clusterstate_factory.go
+++ b/cluster-autoscaler/core/bench/scaledown/efficiency/clusterstate_factory.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efficiency
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	testutils "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+// cloudProviderMockOptions overrides constraints enforced by the cloud provider infrastructure.
+type cloudProviderMockOptions struct {
+	NodeToNodeGroup   map[string]string
+	NodeGroupMinSizes map[string]int
+}
+
+// nodeGroup represents a named node group with Nodes and Pods.
+type nodeGroup struct {
+	Name    string
+	MinSize int
+	MaxSize int
+	Nodes   []*apiv1.Node
+	Pods    []*apiv1.Pod
+
+	// Optional node group overrides to customize autoscaling of a given nodeGroup.
+	NodeGroupOptions *config.NodeGroupAutoscalingOptions
+}
+
+type initialClusterState struct {
+	Name                 string
+	NodeGroups           []*nodeGroup
+	CloudProviderOptions *cloudProviderMockOptions
+}
+
+func differentNodeSizesMemIrrelevant() *initialClusterState {
+	return &initialClusterState{
+		Name: "different node sizes, memory irrelevant",
+		NodeGroups: []*nodeGroup{
+			{
+				Name:    "ng-small",
+				MinSize: 0,
+				MaxSize: 10,
+				Nodes: []*apiv1.Node{
+					testutils.BuildTestNode("small-node-1", 1000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "s-class"})),
+					testutils.BuildTestNode("small-node-2", 1000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "s-class"})),
+				},
+				Pods: []*apiv1.Pod{
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-s1", 1000, 100, "small-node-1"), "rs"),
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-s2", 1000, 100, "small-node-2"), "rs"),
+				},
+			},
+			{
+				Name:    "ng-moderate",
+				MinSize: 0,
+				MaxSize: 10,
+				Nodes: []*apiv1.Node{
+					testutils.BuildTestNode("mod-node-1", 4000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "m-class"})),
+					testutils.BuildTestNode("mod-node-2", 4000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "m-class"})),
+					testutils.BuildTestNode("mod-node-3", 4000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "m-class"})),
+				},
+				Pods: []*apiv1.Pod{
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-m1", 1000, 100, "mod-node-1"), "rs"),
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-m2", 1000, 100, "mod-node-2"), "rs"),
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-m3", 1000, 100, "mod-node-3"), "rs"),
+				},
+			},
+			{
+				Name:    "ng-big",
+				MinSize: 0,
+				MaxSize: 10,
+				Nodes: []*apiv1.Node{
+					testutils.BuildTestNode("big-node-1", 9000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "xl-class"})),
+				},
+				Pods: []*apiv1.Pod{
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-b1", 1000, 100, "big-node-1"), "rs"),
+				},
+			},
+		},
+	}
+}

--- a/cluster-autoscaler/core/bench/scaledown/efficiency/fake_actuator.go
+++ b/cluster-autoscaler/core/bench/scaledown/efficiency/fake_actuator.go
@@ -1,0 +1,147 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efficiency
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	cacontext "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
+	caerrors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+)
+
+type fakeActuationStatus struct {
+	recentEvictions []*apiv1.Pod
+}
+
+// RecentEvictions implements the scaledown.ActuationStatus interface, demanded by UpdateClusterState.
+func (f *fakeActuationStatus) RecentEvictions() []*apiv1.Pod {
+	return f.recentEvictions
+}
+
+// RegisterEviction implements the scaledown.ActuationStatus interface, demanded by UpdateClusterState.
+func (f *fakeActuationStatus) RegisterEviction(pod *apiv1.Pod) {
+	f.recentEvictions = append(f.recentEvictions, pod)
+}
+
+// DeletionsInProgress implements the scaledown.ActuationStatus interface, demanded by UpdateClusterState.
+func (f *fakeActuationStatus) DeletionsInProgress() ([]string, []string) {
+	return nil, nil
+}
+
+// DeletionsCount implements the scaledown.ActuationStatus interface, demanded by UpdateClusterState.
+func (f *fakeActuationStatus) DeletionsCount(nodeGroup string) int {
+	return 0
+}
+
+type fakeActuator struct {
+	autoscalingCtx  cacontext.AutoscalingContext
+	t               testing.TB
+	actuationStatus *fakeActuationStatus
+}
+
+// NewFakeActuator returns new instance of fakeActuator.
+func NewFakeActuator(ctx cacontext.AutoscalingContext, status *fakeActuationStatus, t testing.TB) *fakeActuator {
+	return &fakeActuator{
+		autoscalingCtx:  ctx,
+		t:               t,
+		actuationStatus: status,
+	}
+}
+
+// startDeletion "manually" removes nodes and ensures pods rescheduling.
+// Clustersnapshot.fork/commit/revert not present as Pod rescheduling should succeed if nodes were marked as candidates (consistent with planner's decisions on candidate nodes).
+func (f *fakeActuator) startDeletion(empty, needDrain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, caerrors.AutoscalerError) {
+	if len(empty) == 0 && len(needDrain) == 0 {
+		return status.ScaleDownNoNodeDeleted, nil, nil
+	}
+
+	var scaledDownNodes []*status.ScaleDownNode
+
+	for _, node := range empty {
+		err := f.autoscalingCtx.ClusterSnapshot.RemoveNodeInfo(node.Name)
+		if err != nil {
+			f.t.Logf("cannot remove node info, err: %v", err.Error())
+			return status.ScaleDownError, nil, nil
+		}
+		scaledDownNodes = append(scaledDownNodes, &status.ScaleDownNode{
+			Node:        node,
+			EvictedPods: nil,
+		})
+	}
+
+	needDrain = needDrain[:1]
+	schedSimulator := scheduling.NewHintingSimulator()
+
+	for _, n := range needDrain {
+		nodeInfo, err := f.autoscalingCtx.ClusterSnapshot.GetNodeInfo(n.Name)
+		assert.NoError(f.t, err)
+
+		var podsToReschedule []*apiv1.Pod
+		for _, podInfo := range nodeInfo.Pods() {
+			podInfo.Pod.Spec.NodeName = ""
+			podsToReschedule = append(podsToReschedule, podInfo.Pod)
+		}
+
+		err = f.autoscalingCtx.ClusterSnapshot.RemoveNodeInfo(n.Name)
+		if err != nil {
+			f.t.Errorf("error removing node info from cluster snapshot, error: %s", err.Error())
+		}
+
+		if len(podsToReschedule) > 0 {
+			schedulingResult, err := schedSimulator.TrySchedulePods(context.Background(), f.autoscalingCtx.ClusterSnapshot, podsToReschedule, false,
+				clustersnapshot.SchedulingOptions{
+					IsNodeAcceptable: scheduling.ScheduleAnywhere,
+				})
+			if err != nil {
+				f.t.Errorf("cannot scale down, an unexpected error occurred: %s", err.Error())
+			}
+
+			scheduledPods := make(map[string]bool)
+			for _, s := range schedulingResult.Statuses {
+				scheduledPods[s.Pod.Namespace+"/"+s.Pod.Name] = true
+			}
+
+			// Any pod not in scheduledPods was not successful and is registered as eviction.
+			// Theoretically, all Pods evicted from a drained node could be registered as an eviction.
+			// Depends on the interpretation of eviction.
+			for _, pod := range podsToReschedule {
+				if !scheduledPods[pod.Namespace+"/"+pod.Name] {
+					f.t.Logf("Pod %s/%s failed to reschedule!", pod.Namespace, pod.Name)
+					if f.actuationStatus != nil {
+						f.actuationStatus.RegisterEviction(pod)
+					}
+				}
+			}
+
+			if len(schedulingResult.Statuses) != len(podsToReschedule) {
+				f.t.Logf("failed to reschedule all pods from node %s: scheduled %d out of %d pods", n.Name, len(schedulingResult.Statuses), len(podsToReschedule))
+				continue
+			}
+		}
+		scaledDownNodes = append(scaledDownNodes, &status.ScaleDownNode{
+			Node:        n,
+			EvictedPods: podsToReschedule,
+		})
+	}
+	return status.ScaleDownNodeDeleteStarted, scaledDownNodes, nil
+}

--- a/cluster-autoscaler/core/bench/scaledown/efficiency/metrics.go
+++ b/cluster-autoscaler/core/bench/scaledown/efficiency/metrics.go
@@ -1,0 +1,78 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efficiency
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+)
+
+type metricsDependencies struct {
+	scaledDownNodes []*status.ScaleDownNode
+	nodeInfos       []*framework.NodeInfo
+	currentTime     time.Time
+}
+
+// scaleDownMetric is the unified interface all metrics implement.
+type scaleDownMetric interface {
+	// Name returns name of the scaleDownMetric.
+	Name() string
+	// Compute calculates single cluster-level metric value using metricsDependencies.
+	Compute(dependencies metricsDependencies) (float64, error)
+	// Summarize processes metric recorded timeline and derives final benchmarking values returned in a map.
+	Summarize(metricValues []float64) map[string]float64
+}
+
+// metricsTracker orchestrates the computation, storing, and reporting of multiple scaleDownMetric.
+type metricsTracker struct {
+	metrics         []scaleDownMetric
+	metricsTimeline map[string][]float64
+}
+
+// NewMetricsTracker creates a new instance of metricsTracker with given list of scaleDownMetrics.
+func NewMetricsTracker(metrics ...scaleDownMetric) *metricsTracker {
+	return &metricsTracker{
+		metrics:         metrics,
+		metricsTimeline: make(map[string][]float64),
+	}
+}
+
+// ReportToBenchmark registers final benchmark values to benchmark runner across a set of configured scaleDownMetrics.
+func (mt *metricsTracker) ReportToBenchmark(b *testing.B) {
+	for _, m := range mt.metrics {
+		metricValues := mt.metricsTimeline[m.Name()]
+		benchVals := m.Summarize(metricValues)
+		for name, val := range benchVals {
+			b.ReportMetric(val, name)
+		}
+	}
+}
+
+// ComputeMetrics computes metric value across a set of configured scaleDownMetrics.
+func (mt *metricsTracker) ComputeMetrics(dependencies metricsDependencies, t testing.TB) {
+	for _, m := range mt.metrics {
+		val, err := m.Compute(dependencies)
+		if err != nil {
+			t.Errorf("failed to compute metric %s, err %v", m.Name(), err)
+			continue
+		}
+		mt.metricsTimeline[m.Name()] = append(mt.metricsTimeline[m.Name()], val)
+	}
+}

--- a/cluster-autoscaler/core/bench/scaledown/efficiency/metrics.go
+++ b/cluster-autoscaler/core/bench/scaledown/efficiency/metrics.go
@@ -17,11 +17,15 @@ limitations under the License.
 package efficiency
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/utilization"
+	"k8s.io/klog/v2"
 )
 
 type metricsDependencies struct {
@@ -75,4 +79,88 @@ func (mt *metricsTracker) ComputeMetrics(dependencies metricsDependencies, t tes
 		}
 		mt.metricsTimeline[m.Name()] = append(mt.metricsTimeline[m.Name()], val)
 	}
+}
+
+type resource struct {
+	allocatable float64
+	requested   float64
+}
+
+func resourceAllocatableRequested(resourceName apiv1.ResourceName, nodeInfo *framework.NodeInfo, nodeName string, currentTime time.Time) (resource, error) {
+	var r resource
+	util, err := utilization.CalculateUtilizationOfResource(nodeInfo, resourceName, true, true, currentTime)
+	if err != nil {
+		return r, err
+	}
+	r.requested = util
+	allocatable, found := nodeInfo.Node().Status.Allocatable[resourceName]
+	if !found {
+		return r, fmt.Errorf("failed to get allocatable %v from %s", resourceName, nodeName)
+	}
+	if resourceName == apiv1.ResourceCPU {
+		r.allocatable = float64(allocatable.MilliValue())
+	} else {
+		r.allocatable = float64(allocatable.Value())
+	}
+	return r, nil
+}
+
+func computeResourceUtilization(metricName string, resourceName apiv1.ResourceName, dependencies metricsDependencies) (float64, error) {
+	var totalRequested, totalAllocatable, ratio float64
+	for _, nodeInfo := range dependencies.nodeInfos {
+		if nodeInfo == nil || nodeInfo.Node() == nil {
+			continue
+		}
+		nodeName := nodeInfo.Node().Name
+		res, err := resourceAllocatableRequested(resourceName, nodeInfo, nodeName, dependencies.currentTime)
+		if err != nil {
+			klog.V(5).ErrorS(err, fmt.Sprintf("failed to calculate node resource %s", resourceName.String()))
+			return 0, err
+		}
+		nodeRequested := res.requested * res.allocatable
+		totalRequested += nodeRequested
+		totalAllocatable += res.allocatable
+	}
+
+	if totalAllocatable > 0 {
+		ratio = totalRequested / totalAllocatable
+	}
+
+	klog.V(5).Infof("Metric: %s, Allocated: %.2f, Allocatable: %.2f, Ratio: %.2f",
+		metricName, totalRequested, totalAllocatable, ratio)
+	return ratio, nil
+}
+
+// resourceUtilizationMetric computes utilization ratio for given resource of generic ResourceName.
+type resourceUtilizationMetric struct {
+	resourceName apiv1.ResourceName
+}
+
+// NewResourceUtilizationMetric creates a new instance of resourceUtilizationMetric.
+func NewResourceUtilizationMetric(rn apiv1.ResourceName) *resourceUtilizationMetric {
+	return &resourceUtilizationMetric{resourceName: rn}
+}
+
+func (m *resourceUtilizationMetric) Name() string {
+	return fmt.Sprintf("%s_utilization", m.resourceName.String())
+}
+
+func (m *resourceUtilizationMetric) Compute(dependencies metricsDependencies) (float64, error) {
+	ratio, err := computeResourceUtilization(m.Name(), m.resourceName, dependencies)
+	if err != nil {
+		return 0, err
+	}
+	return ratio, nil
+}
+
+func (m *resourceUtilizationMetric) Summarize(metricValues []float64) map[string]float64 {
+	first := metricValues[0]
+	last := metricValues[len(metricValues)-1]
+	diff := last - first
+	r := map[string]float64{
+		fmt.Sprintf("%s_%%_init", m.Name()):     first * 100,
+		fmt.Sprintf("%s_%%_final", m.Name()):    last * 100,
+		fmt.Sprintf("%s_%%_improved", m.Name()): diff * 100,
+	}
+	return r
 }

--- a/cluster-autoscaler/simulator/clustersnapshot/test_utils.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/test_utils.go
@@ -32,7 +32,7 @@ import (
 // InitializeClusterSnapshotOrDie clears cluster snapshot and then initializes it with given set of nodes and pods.
 // Both Spec.NodeName and Status.NominatedNodeName are used when simulating scheduling pods.
 func InitializeClusterSnapshotOrDie(
-	t *testing.T,
+	t testing.TB,
 	snapshot ClusterSnapshot,
 	nodes []*apiv1.Node,
 	pods []*apiv1.Pod) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This project aims to develop a system for benchmarking various scaledown strategies and evaluating how chosen strategy affects final cluster efficiency. Because the definition of scaledown efficiency depends on the objective (most nodes scaled down? lowest final price? least pods disrupted?), it is essential to first develop several metrics that assess the scaledown outcome. 

The initial work involves:
- Defining a set of metrics
- Building a benchmark utility to simulate scaledown from a fixed starting cluster configuration
- Measuring and reporting the defined metrics before and after the scaledown loop finishes. 

Current design forces certain behaviour (e.g. pick only one node for scaledown, "manual" node removal from cluster snapshot when draining with fake actuator, continue the scaledown only until no new candidate nodes are present, fixed pricing for machine types) and will be modified depending on the direction of the project. 

#### Structure
- **Metrics and Costs**
  _Files_: `machine_types.go`, `metrics.go`
  _Goal_: Introduce the encapsulated `scaleDownEfficiencyMetric` interface, central `metricsTracker` orchestrator, and machine types pricing logic.  Currently, six metrics are implemented with the possibility to easily add more thanks to the interface.

- **Simulation Ecosystem**
  _Files_: `fake_actuator.go`, `clusterstate_factory.go`
  _Goal_: Introduce the  `fakeActuator` which performs node removal from clustersnapshot to simulate scaledown actuation without external cloud provider communication. Introduce the `clusterStateFactory` for generating initial, predetermined cluster topologies for the scaledown algorithm to execute against.

- **Scaledown Strategy and Benchmark**
  _Files_: `scaledownstrategy_factory.go`, `benchmark_scaledown_test.go`
  _Goal_: Introduce `scaleDownStrategyFactory` which encapsulates the core scaledown algorithm inside and allows to define different scaledown strategies, currently with a simple implementation of `vanillaScaleDownStrategy`. The benchmark runner requires running a single execution loop (`-benchtime=1x`) per scenario to guarantee the extraction of raw metric outputs.  Averaging would lead to smoothing the actual results and we are interested in the variance.                                                                    
                                                                                                                                                                                                                                                                                                                 
A small change introduced to _simulator/clustersnaphot/test_utils.go_, func _InitializeClusterSnapshotOrDie_ - parameter `t *testing.T`  changed to` t testing.TB` to enable reusing the function from the benchmark.


#### Run
Benchmark can be run from cmdl e.g.  `go test -v -run='^$' -bench='^BenchmarkRunOnceScaleDown$' -benchtime=1x -count=7 ./core/bench/scaledown/efficiency/` which will run full scaledown loop until no new scaledown candidates are found 7 times on fresh initial cluster state and report raw metrics for these 7 executions. If the output is redirected to results file, it can be fed to benchstat.