### PR TITLE
Add categories=all for VPA object

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
@@ -230,6 +230,8 @@ metadata:
 spec:
   group: autoscaling.k8s.io
   names:
+    categories:
+    - all
     kind: VerticalPodAutoscaler
     listKind: VerticalPodAutoscalerList
     plural: verticalpodautoscalers

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -230,6 +230,8 @@ metadata:
 spec:
   group: autoscaling.k8s.io
   names:
+    categories:
+    - all
     kind: VerticalPodAutoscaler
     listKind: VerticalPodAutoscalerList
     plural: verticalpodautoscalers

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -39,7 +39,7 @@ type VerticalPodAutoscalerList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
-// +kubebuilder:resource:shortName=vpa
+// +kubebuilder:resource:shortName=vpa,categories=all
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Mode",type="string",JSONPath=".spec.updatePolicy.updateMode"
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".status.recommendation.containerRecommendations[0].target.cpu"

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
@@ -38,7 +38,7 @@ type VerticalPodAutoscalerList struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName=vpa
+// +kubebuilder:resource:shortName=vpa,categories=all
 // +kubebuilder:subresource:status
 // +k8s:prerelease-lifecycle-gen=true
 // +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes/kubernetes/pull/63797"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
User-facing resources should be included in the output of `kubectl get all`.
This PR adds VPA resources to the `kubectl get all` output, consistent with how HPA resources are displayed.
Checkpoints resources are intentionally not included, as they are not a  user-facing resources:
```bash
 ~/Desktop/omerap12/autoscaler/ [vpa-categories] k get all
NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
service/kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP   19m

NAME                                                  MODE       CPU   MEM   PROVIDED   AGE
verticalpodautoscaler.autoscaling.k8s.io/my-app-vpa   Recreate               False      5m17s
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
VerticalPodAutoscaler (VPA) resources are now included in the output of `kubectl get all` (via the `all` category).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
