### PR TITLE
Emit "InitializationStarted" event when CA started and emit "InitializationFinished" event when CA completes its first loop

### DIFF
--- a/cluster-autoscaler/builder/autoscaler.go
+++ b/cluster-autoscaler/builder/autoscaler.go
@@ -175,7 +175,6 @@ func (b *AutoscalerBuilder) Build(ctx context.Context) (core.Autoscaler, *loop.L
 		KubeClientNew:          b.manager.GetClient(),
 		KubeCache:              b.manager.GetCache(),
 	}
-
 	opts.Processors = ca_processors.DefaultProcessors(autoscalingOptions)
 	opts.Processors.TemplateNodeInfoProvider = nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(&autoscalingOptions.NodeInfoCacheExpireTime, autoscalingOptions.ForceDaemonSets)
 	podListProcessor := podlistprocessor.NewDefaultPodListProcessor(scheduling.ScheduleAnywhere)

--- a/cluster-autoscaler/builder/autoscaler_factory.go
+++ b/cluster-autoscaler/builder/autoscaler_factory.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strings"
 
+	apiv1 "k8s.io/api/core/v1"
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core"
@@ -48,6 +49,7 @@ func NewAutoscaler(ctx context.Context, opts coreoptions.AutoscalerOptions, info
 	if err != nil {
 		return nil, errors.ToAutoscalerError(errors.InternalError, err)
 	}
+	opts.AutoscalingKubeClients.LogRecorder.Eventf(apiv1.EventTypeNormal, "InitializationStarted", "Autoscaler initialization started after (re)start.")
 	return core.NewStaticAutoscaler(
 		opts.AutoscalingOptions,
 		opts.FrameworkHandle,

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -102,6 +102,7 @@ type StaticAutoscaler struct {
 	initialized                bool
 	taintConfig                taints.TaintConfig
 	capacityBufferPodsRegistry *fakepods.Registry
+	firstLoopFinished          bool
 }
 
 type staticAutoscalerProcessorCallbacks struct {
@@ -623,6 +624,11 @@ func (a *StaticAutoscaler) RunOnce(ctx context.Context, currentTime time.Time) c
 			return a.scaleUpOrchestrator.ScaleUpToNodeGroupMinSize(nodes, templateNodeInfos)
 		}
 		_, scaleUpStatus, typedErr = a.instrumentedScaleUp(currentTime, scaleUpFn)
+	}
+
+	if !a.firstLoopFinished {
+		a.LogRecorder.Eventf(apiv1.EventTypeNormal, "InitializationFinished", "Autoscaler initialization finished after (re)start.")
+		a.firstLoopFinished = true
 	}
 
 	return nil


### PR DESCRIPTION


#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Emit "InitializationStarted" event when CA started and emit "InitializationFinished" event when CA completes its first loop

This PR improves the observability around slow CA startup. In relatively large clusters CA startup could be very slow because of fetching cold caches. This fetches include calling cloud provider APIs to fetch node group and instance information etc.

With this new events users could know when CA started and finished its initializations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Two new k8s events are added. CA will emit new events when starting its first control loop and after the end of its first control loop.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
