### PR TITLE
Azure: invalidate instance cache after ETag refresh

### DIFF
--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set.go
@@ -606,6 +606,13 @@ func (scaleSet *ScaleSet) retryCreateOrUpdateWithFreshETag(ctx context.Context, 
 	// Persist the freshly-fetched VMSS (ETag and capacity) for subsequent operations.
 	scaleSet.manager.azureCache.setScaleSet(scaleSet.Name, fresh)
 
+	// The 412 means another writer changed the VMSS between our read and this write, so
+	// the instance cache (which backs Nodes() and instance-state queries) now reflects a
+	// pre-conflict view of the scale set. Invalidate it so instance-derived data is
+	// recomputed from fresh Azure state rather than a stale snapshot. Callers of this
+	// method hold sizeMutex; invalidateInstanceCache guards the instance cache separately.
+	scaleSet.invalidateInstanceCache()
+
 	// If another writer already grew the VMSS to at least our target, the desired floor
 	// is already met; don't issue a PUT that would shrink it back down. Return the fresh
 	// object (nil poller) so the caller publishes its actual capacity, not a stale target.

--- a/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_scale_set_test.go
@@ -2581,6 +2581,63 @@ func TestScaleSetETagRetrySkippedWhenAlreadyAtTarget(t *testing.T) {
 	assert.Equal(t, 1, putCalls, "expected no second PUT when VMSS already at target")
 }
 
+// TestScaleSetETagRefreshInvalidatesInstanceCache verifies that the ETag refresh
+// invalidates the instance cache. A 412 means another writer changed the VMSS between
+// CA's read and its write, so the instance cache (which backs Nodes() and instance-state
+// queries) is stale after the refresh and must be recomputed from fresh Azure state.
+func TestScaleSetETagRefreshInvalidatesInstanceCache(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	manager := newTestAzureManager(t)
+	manager.config.EnableVMSSEtag = true
+
+	vmssName := "vmss-etag-invalidate"
+	orchMode := armcompute.OrchestrationModeUniform
+
+	manager.azureCache.setScaleSet(vmssName, &armcompute.VirtualMachineScaleSet{
+		Name:       ptr.To(vmssName),
+		SKU:        &armcompute.SKU{Capacity: ptr.To[int64](3)},
+		Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+		Etag:       ptr.To(`W/"stale"`),
+	})
+
+	// The refresh GET returns a fresh VMSS already at/above the target so the retry takes
+	// the skip path (GET only, no second PUT). The cache invalidation runs regardless.
+	mockVMSSClient := mock_virtualmachinescalesetclient.NewMockInterface(ctrl)
+	mockVMSSClient.EXPECT().Get(gomock.Any(), manager.config.ResourceGroup, vmssName, gomock.Any()).
+		Return(&armcompute.VirtualMachineScaleSet{
+			Name:       ptr.To(vmssName),
+			SKU:        &armcompute.SKU{Capacity: ptr.To[int64](5)},
+			Properties: &armcompute.VirtualMachineScaleSetProperties{OrchestrationMode: &orchMode},
+			Etag:       ptr.To(`W/"fresh"`),
+		}, nil).Times(1)
+	mockVMSSClient.EXPECT().List(gomock.Any(), manager.config.ResourceGroup).
+		Return([]*armcompute.VirtualMachineScaleSet{}, nil).AnyTimes()
+	manager.azClient.virtualMachineScaleSetsClient = mockVMSSClient
+
+	scaleSet := newTestScaleSet(manager, vmssName)
+	scaleSet.instancesRefreshPeriod = time.Hour
+	// Mark the instance cache freshly refreshed so we can observe the invalidation.
+	scaleSet.lastInstanceRefresh = time.Now()
+	assert.True(t, scaleSet.lastInstanceRefresh.Add(scaleSet.instancesRefreshPeriod).After(time.Now()),
+		"precondition: instance cache should start valid")
+
+	ctx, cancel := getContextWithTimeout(asyncContextTimeout)
+	defer cancel()
+
+	fresh, poller, err := scaleSet.retryCreateOrUpdateWithFreshETag(ctx, 4)
+	assert.NoError(t, err)
+	assert.Nil(t, poller, "already-at-target refresh should skip the retry PUT")
+	if assert.NotNil(t, fresh) && assert.NotNil(t, fresh.SKU) && assert.NotNil(t, fresh.SKU.Capacity) {
+		assert.Equal(t, int64(5), *fresh.SKU.Capacity)
+	}
+
+	assert.False(t, scaleSet.lastInstanceRefresh.Add(scaleSet.instancesRefreshPeriod).After(time.Now()),
+		"ETag refresh should invalidate the instance cache")
+}
+
 // TestScaleSetETagReconcilesConcurrentWriter exercises the core scenario ETag mode is
 // meant to protect: another writer mutates the VMSS between CA's read and its write.
 // Using a mock that enforces optimistic concurrency like the real API, CA's first PUT


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area provider/azure
/area cluster-autoscaler

#### What this PR does / why we need it:

When a VMSS capacity update hits an ETag precondition failure (HTTP 412), `retryCreateOrUpdateWithFreshETag` fetches the current VMSS and refreshes the size cache via `setScaleSet`, but it does not touch the instance cache on the success/skip paths (the instance cache is only invalidated on the GET/PUT failure paths via `invalidateForPreconditionFailure`).

A 412 means another writer changed the VMSS between the autoscaler's read and its write, so the instance cache — which backs `Nodes()` and the instance-state queries — reflects a pre-conflict view of the scale set until the next natural refresh.

This change invalidates the instance cache after persisting the refreshed VMSS, so instance-derived data is recomputed from fresh Azure state rather than a stale snapshot. It follows up the ETag optimistic-concurrency feature added in #9783.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- Scoped to the ETag refresh path; no behavioral change when `EnableVMSSEtag` is disabled.
- `invalidateInstanceCache` guards the instance cache with its own mutex, so it is safe to call while the caller holds `sizeMutex`.
- Adds `TestScaleSetETagRefreshInvalidatesInstanceCache`.

#### Does this PR introduce a user-facing change?

```release-note
Azure: invalidate the instance cache after an ETag precondition refresh so instance-derived data is recomputed from fresh state
```
