### PR TITLE
cluster-autoscaler: honor AWS SDK endpoint environment variables for Auto Scaling

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -81,8 +81,23 @@ func createAWSManagerInternal(
 	klog.Infof("AWS SDK Version: %s", aws.SDKVersion)
 
 	if awsService == nil {
+
+		var autoScalingClientOpts []func(*autoscaling.Options)
+
+		for _, override := range awsSDKProvider.cloudConfig.ServiceOverride {
+			if override.Service == "autoscaling" {
+				autoScalingClientOpts = append(
+					autoScalingClientOpts,
+					autoscaling.WithEndpointResolver(
+						newAutoscalingOverrideResolver(awsSDKProvider.cloudConfig),
+					),
+				)
+				break
+			}
+		}
+
 		awsService = &awsWrapper{
-			autoScalingI: autoscaling.NewFromConfig(awsSDKProvider.cfg, autoscaling.WithEndpointResolver(newAutoscalingOverrideResolver(awsSDKProvider.cloudConfig))),
+			autoScalingI: autoscaling.NewFromConfig(awsSDKProvider.cfg, autoScalingClientOpts...),
 			ec2I:         ec2.NewFromConfig(awsSDKProvider.cfg, ec2.WithEndpointResolver(newEc2OverrideResolver(awsSDKProvider.cloudConfig))),
 			eksI:         eks.NewFromConfig(awsSDKProvider.cfg, eks.WithEndpointResolver(newEksOverrideResolver(awsSDKProvider.cloudConfig))),
 		}


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the AWS Auto Scaling client always installs a custom endpoint resolver, even when no `ServiceOverride` is configured.

Because the custom endpoint resolver is installed unconditionally, the AWS SDK v2 default endpoint resolution is bypassed. As a result, AWS SDK service-specific endpoint environment variables such as:

- `AWS_ENDPOINT_URL_AUTO_SCALING`

are not honored.

This change installs the custom Auto Scaling endpoint resolver only when an Auto Scaling `ServiceOverride` is configured. Otherwise, the AWS SDK default endpoint resolution is preserved.

Fixes #9974

---

## Background

The AWS SDK configuration is loaded through:

```go
config.LoadDefaultConfig(...)
```

which already supports service-specific endpoint environment variables.

However, the Auto Scaling client is currently created with an unconditional custom endpoint resolver:

```go
autoscaling.NewFromConfig(
    awsSDKProvider.cfg,
    autoscaling.WithEndpointResolver(
        newAutoscalingOverrideResolver(
            awsSDKProvider.cloudConfig,
        ),
    ),
)
```

The custom resolver only evaluates `ServiceOverride` entries from the cloud provider configuration and otherwise falls back to the SDK's default endpoint resolver.

When no `ServiceOverride` is configured, installing the custom resolver provides no additional functionality while preventing the SDK's native endpoint configuration mechanism from being used.

---

## Solution

This PR changes the Auto Scaling client initialization so that the custom endpoint resolver is only installed when an Auto Scaling `ServiceOverride` exists.

Behavior after this change:

- When `ServiceOverride` is configured:
  - Existing custom endpoint override behavior is preserved.
- When `ServiceOverride` is not configured:
  - The AWS SDK default endpoint resolution is used.
  - Service-specific endpoint environment variables (for example `AWS_ENDPOINT_URL_AUTO_SCALING`) can be honored by the SDK.

---

## Scope

This change intentionally updates only the Auto Scaling client because the reported issue occurs during Auto Scaling API initialization (`DescribeAutoScalingGroups`).

Other AWS service clients are left unchanged to keep this fix scoped to the reported issue.

---

## Testing

### Unit Tests

-  `go test ./cloudprovider/aws/...`

### Build

-  Successfully built Cluster Autoscaler
-  Successfully built the project Docker image

### Runtime verification

Runtime verification on an EKS cluster could not be completed because no EKS cluster was available in the current AWS account during development.

---

## Notes

This is a minimal change that preserves the existing `ServiceOverride` behavior while allowing the AWS SDK's default endpoint resolution to be used when no override is configured.

---

```release-note
Cluster Autoscaler now preserves the AWS SDK default endpoint resolution for the Auto Scaling client when no cloud provider ServiceOverride is configured, allowing AWS SDK endpoint environment variables such as AWS_ENDPOINT_URL_AUTO_SCALING to be honored.
```