### PR TITLE
🐛(metrics) Initialize failed_node_creations_total metric at startup

### DIFF
--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -605,6 +605,7 @@ func (m *caMetrics) InitMetrics() {
 
 	for _, reason := range []FailedScaleUpReason{CloudProviderError, APIError, Timeout} {
 		m.failedScaleUpCount.WithLabelValues(string(reason), "", "", "").Add(0)
+		m.failedNodeCreationCount.WithLabelValues(string(reason)).Add(0)
 	}
 
 	for _, reason := range []NodeScaleDownReason{Underutilized, Empty, Unready} {

--- a/cluster-autoscaler/metrics/metrics_test.go
+++ b/cluster-autoscaler/metrics/metrics_test.go
@@ -73,6 +73,20 @@ func TestUpdateNodesCount(t *testing.T) {
 	assert.Equal(t, 6, int(testutil.ToFloat64(m.nodesCount.GaugeVec.WithLabelValues(unregisteredLabel))))
 }
 
+func TestInitMetricsInitializesFailedNodeCreations(t *testing.T) {
+	reg := metrics.NewKubeRegistry()
+	m := newCaMetricsWithRegistry(reg)
+	m.RegisterAll(false)
+
+	m.InitMetrics()
+
+	// failed_node_creations_total is only incremented when a scale-up fails, so
+	// without initialization it would be absent from the exposition until the
+	// first failure. InitMetrics should pre-create a zero-valued series for each
+	// FailedScaleUpReason, matching what it already does for failedScaleUpCount.
+	assert.Equal(t, 3, testutil.CollectAndCount(m.failedNodeCreationCount.CounterVec))
+}
+
 func TestUpdateScaleDownNodeRemovalLatency(t *testing.T) {
 	reg := metrics.NewKubeRegistry()
 	m := newCaMetricsWithRegistry(reg)


### PR DESCRIPTION
- Initialize failed_node_creations_total to zero for each FailedScaleUpReason at startup

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Follow-up to #7449. `failed_node_creations_total` is labeled only by `reason`, the same bounded `FailedScaleUpReason` enum already initialized for `failed_scale_ups_total`, but it was left out of the `InitMetrics` loop. As a result it stays absent from the Prometheus exposition until the first failed node creation, which prevents alerting rules from distinguishing zero failures from a missing series.

#### Which issue(s) this PR fixes:
Relates #7448

#### Special notes for your reviewer:
The regression test asserts the series count via `testutil.CollectAndCount` instead of `WithLabelValues`, since calling `WithLabelValues` would itself create the series and mask the bug.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```