### PR TITLE
Build cluster-autoscaler with gce tag to prevent OOM in GCE E2E tests

### DIFF
--- a/cluster-autoscaler/hack/e2e/run-e2e.sh
+++ b/cluster-autoscaler/hack/e2e/run-e2e.sh
@@ -43,8 +43,9 @@ gcloud auth configure-docker -q
 GIT_COMMIT="$(git describe --always --dirty --exclude '*')"
 TAG="dev-${GIT_COMMIT}-$(date +%s)"
 REGISTRY="gcr.io/$(gcloud config get core/project)"
-make -C "${CA_ROOT}" execute-release REGISTRY=${REGISTRY} TAG=${TAG}
-CA_IMAGE="${REGISTRY}/cluster-autoscaler:${TAG}"
+BUILD_TAGS="gce"
+make -C "${CA_ROOT}" execute-release REGISTRY=${REGISTRY} TAG=${TAG} BUILD_TAGS="${BUILD_TAGS}"
+CA_IMAGE="${REGISTRY}/cluster-autoscaler-${BUILD_TAGS}:${TAG}"
 
 echo "### STEP 1: Standard Autoscaling tests ###"
 ${CA_ROOT}/hack/e2e/deploy-ca-on-gce-for-e2e.sh "${CA_IMAGE}"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
During the GCE E2E test runs, the compilation of the Cluster Autoscaler Docker image was failing with an out-of-memory (OOM) error:
  ResourceExhausted: cannot allocate memory

When Go concurrently compiles extremely
large generated dependency packages—specifically `aws-sdk-go-v2/service/ec2` the aggregate memory usage of these concurrent compiler processes exceeds the strict 6Gi memory limit allocated to this CI job, triggering the kernel OOM-killer.

To fix this, configure `cluster-autoscaler/hack/e2e/run-e2e.sh` to compile using the `gce` build tag. Since these are GCE E2E tests, compiling code or importing dependencies for other cloud providers (such as AWS, Azure, DigitalOcean, etc.) is unnecessary.

Latest run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gci-gce-autoscaling/2079159058044030976
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
