### PR TITLE
VPA: skip empty resource patches when there is no recommendation

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates.go
@@ -112,19 +112,27 @@ func (c *resourcesUpdatesPatchCalculator) CalculatePatches(pod *corev1.Pod, vpa 
 
 func getContainerPatch(pod *corev1.Pod, i int, annotationsPerContainer vpa_api_util.ContainerToAnnotationsMap, containerResources vpa_api_util.ContainerResources) ([]resource_admission.PatchRecord, string) {
 	var patches []resource_admission.PatchRecord
-	// Add empty resources object if missing.
 	requests, limits := resourcehelpers.ContainerRequestsAndLimits(pod.Spec.Containers[i].Name, pod)
-	if limits == nil && requests == nil {
-		patches = append(patches, GetPatchInitializingEmptyResources(i))
-	}
 
 	annotations, found := annotationsPerContainer[pod.Spec.Containers[i].Name]
 	if !found {
 		annotations = make([]string, 0)
 	}
 
-	patches, annotations = appendPatchesAndAnnotations(patches, annotations, requests, i, containerResources.Requests, "requests", "request")
-	patches, annotations = appendPatchesAndAnnotations(patches, annotations, limits, i, containerResources.Limits, "limits", "limit")
+	var resourcePatches []resource_admission.PatchRecord
+	resourcePatches, annotations = appendPatchesAndAnnotations(resourcePatches, annotations, requests, i, containerResources.Requests, "requests", "request")
+	resourcePatches, annotations = appendPatchesAndAnnotations(resourcePatches, annotations, limits, i, containerResources.Limits, "limits", "limit")
+
+	// Only initialize an empty resources object when we have recommendations to apply.
+	// Otherwise admission patches empty /resources and a useless vpaUpdates annotation
+	// even when there is no recommendation (see kubernetes/autoscaler#9795).
+	if len(resourcePatches) == 0 {
+		return nil, ""
+	}
+	if limits == nil && requests == nil {
+		patches = append(patches, GetPatchInitializingEmptyResources(i))
+	}
+	patches = append(patches, resourcePatches...)
 
 	updatesAnnotation := fmt.Sprintf("container %d: ", i) + strings.Join(annotations, ", ")
 	return patches, updatesAnnotation

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch/resource_updates_test.go
@@ -304,6 +304,20 @@ func TestCalculatePatches_ResourceUpdates(t *testing.T) {
 			recommendAnnotations: vpa_api_util.ContainerToAnnotationsMap{},
 			expectPatches:        []resource_admission.PatchRecord{},
 		},
+		{
+			// Admission-time pods often have empty Spec resources and no status yet.
+			// With no recommendation we must not patch empty /resources or vpaUpdates.
+			name: "no recommendation and empty pod resources",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{}},
+				},
+			},
+			namespace:            "default",
+			recommendResources:   make([]vpa_api_util.ContainerResources, 1),
+			recommendAnnotations: vpa_api_util.ContainerToAnnotationsMap{},
+			expectPatches:        []resource_admission.PatchRecord{},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the VPA admission controller has no recommendation yet, it still emitted empty `/spec/containers/*/resources` patches and a hollow `vpaUpdates` annotation. That produces useless patches on pods that never had requests/limits.

Skip emitting those empty resource patches (and the annotation) when there is nothing to apply.

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/autoscaler/issues/9795

#### Special notes for your reviewer:

Unit test added: no recommendation + empty pod resources expects zero patches.
`go test ./pkg/admission-controller/resource/pod/patch/ -count=1` under `vertical-pod-autoscaler`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```