### PR TITLE
Add podautoscalers category to VerticalPodAutoscaler CRD

### DIFF
--- a/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml
@@ -230,6 +230,8 @@ metadata:
 spec:
   group: autoscaling.k8s.io
   names:
+    categories:
+    - podautoscalers
     kind: VerticalPodAutoscaler
     listKind: VerticalPodAutoscalerList
     plural: verticalpodautoscalers

--- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
@@ -230,6 +230,8 @@ metadata:
 spec:
   group: autoscaling.k8s.io
   names:
+    categories:
+    - podautoscalers
     kind: VerticalPodAutoscaler
     listKind: VerticalPodAutoscalerList
     plural: verticalpodautoscalers

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -39,7 +39,7 @@ type VerticalPodAutoscalerList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
-// +kubebuilder:resource:shortName=vpa
+// +kubebuilder:resource:shortName=vpa,categories=podautoscalers
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Mode",type="string",JSONPath=".spec.updatePolicy.updateMode"
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".status.recommendation.containerRecommendations[0].target.cpu"

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2/types.go
@@ -38,7 +38,7 @@ type VerticalPodAutoscalerList struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName=vpa
+// +kubebuilder:resource:shortName=vpa,categories=podautoscalers
 // +kubebuilder:subresource:status
 // +k8s:prerelease-lifecycle-gen=true
 // +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes/kubernetes/pull/63797"


### PR DESCRIPTION
### What type of PR is this?
/kind feature
/area vertical-pod-autoscaler

### What this PR does :
Following the discussion in #9995 this adds a **podautoscalers** category to the VerticalPodAutoscaler CRD (v1 and v1beta2) rather than adding VPA to the built-in **all** category as originally proposed in #9987  
per maintainer feedback that **all** should not be extended further.

Once the corresponding upstream change lands in kubernetes/kubernetes to add the same category to HorizontalPodAutoscaler (kubernetes/kubectl#1852, tracked in kubernetes/kubernetes#140781) 
users will be able to run:

    kubectl get podautoscalers

to list both HPA and VPA resources together.

**VerticalPodAutoscalerCheckpoint** is intentionally not included, as it is not a user-facing resource.

### Which issue this PR fixes :
Relates to #9995

**Special notes for your reviewer :**
This PR should not be merged until kubernetes/kubernetes#140781 (or equivalent) adding p**odautoscalers** to HorizontalPodAutoscaler has merged upstream per @omerap12 's note in #9995


```release-note
VerticalPodAutoscaler (VPA) resources now support the podautoscalers category, allowing them to be listed via kubectl get podautoscalers once the corresponding upstream support for HorizontalPodAutoscaler is merged.
```

