### PR TITLE
Cherry-pick #9546 to cluster-autoscaler-release-1.35: use application/json for ProvisioningRequest client

### DIFF
--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -145,6 +145,9 @@ func buildAutoscaler(ctx context.Context, debuggingSnapshotter debuggingsnapshot
 		podListProcessor.AddProcessor(provreq.NewProvisioningRequestPodsFilter(provreq.NewDefautlEventManager()))
 
 		restConfig := kube_util.GetKubeConfig(autoscalingOptions.KubeClientOpts)
+		// Use a static JSON content type config for ProvisioningRequest CRD data exchange
+		// to adhere to CRD requirements.
+		restConfig.ContentType = "application/json"
 		client, err := provreqclient.NewProvisioningRequestClient(restConfig)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
This is a manual cherry-pick of #9546 ("Use application/json for ProvisioningRequest client config") to `cluster-autoscaler-release-1.35`.

The auto cherry-pick failed is because the rest client code for ProvisioningRequest moved from main.go after 1.35 was released. For 1.35 and below we update main.go

**Why:** ProvisioningRequest is a CRD and cannot be protobuf-encoded. Without `ContentType = "application/json"`, Cluster Autoscaler fails to write the `Accepted` condition with:

```
failed add Accepted condition to ProvReq ...: object *v1.ProvisioningRequest does not implement the protobuf marshalling interface and cannot be encoded to a protobuf message
```

so ProvisioningRequests never become Accepted/Provisioned and no scale-up occurs. `rest.CopyConfig` is used to avoid mutating the shared config consumed by other clients.

/kind bug
/area cluster-autoscaler

```release-note
Use application/json for ProvisioningRequest client config
```