### PR TITLE
Contextual logging migration

### DIFF
--- a/cluster-autoscaler/capacitybuffer/controller/controller.go
+++ b/cluster-autoscaler/capacitybuffer/controller/controller.go
@@ -383,7 +383,7 @@ func (c *bufferController) reconcileNamespace(namespace string) error {
 
 	// Filter the desired provisioning strategy
 	// Note: We process ALL buffers in the namespace that match the strategy.
-	filteredBuffers, filteredOutBuffers := c.strategyFilter.Filter(buffers)
+	filteredBuffers, filteredOutBuffers := c.strategyFilter.Filter(context.TODO(), buffers)
 
 	// Update reconciliation time for filtered out buffers
 	c.updateReconciliationTimeCache(filteredOutBuffers)

--- a/cluster-autoscaler/capacitybuffer/filters/filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/filter.go
@@ -17,12 +17,13 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 )
 
 // Filter filters CapacityBuffer based on some criteria.
 type Filter interface {
-	Filter(buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer)
+	Filter(ctx context.Context, buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer)
 	CleanUp()
 }
 
@@ -42,10 +43,10 @@ func (f *combinedAnyFilter) AddFilter(filter Filter) {
 }
 
 // Filter runs sub-filters sequentially
-func (f *combinedAnyFilter) Filter(buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
+func (f *combinedAnyFilter) Filter(ctx context.Context, buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
 	var toBeProcessedBuffers []*v1.CapacityBuffer
 	for _, buffersFilter := range f.filters {
-		filteredToBeProcessed, filteredOut := buffersFilter.Filter(buffers)
+		filteredToBeProcessed, filteredOut := buffersFilter.Filter(ctx, buffers)
 		buffers = filteredOut
 		toBeProcessedBuffers = append(toBeProcessedBuffers, filteredToBeProcessed...)
 	}

--- a/cluster-autoscaler/capacitybuffer/filters/filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/filter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,7 +104,7 @@ func TestCombinedAnyFilter(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			filter := NewCombinedAnyFilter(test.filters)
-			filtered, filteredOut := filter.Filter(test.buffers)
+			filtered, filteredOut := filter.Filter(context.TODO(), test.buffers)
 			assert.ElementsMatch(t, test.expectedFilteredBuffers, filtered)
 			assert.ElementsMatch(t, test.expectedFilteredOutBuffers, filteredOut)
 		})
@@ -118,7 +119,7 @@ type testGenerationFilter struct {
 	filerGeneration int64
 }
 
-func (f *testGenerationFilter) Filter(buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
+func (f *testGenerationFilter) Filter(ctx context.Context, buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
 	filteredBuffers := []*v1.CapacityBuffer{}
 	filteredOutBuffers := []*v1.CapacityBuffer{}
 	for _, buffer := range buffers {

--- a/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter.go
@@ -51,6 +51,7 @@ func (f *podTemplateGenerationChangedFilter) Filter(ctx context.Context, buffers
 }
 
 func (f *podTemplateGenerationChangedFilter) podTemplateGenerationChanged(ctx context.Context, buffer *v1.CapacityBuffer) bool {
+	logger := klog.FromContext(ctx)
 	if buffer.Status.PodTemplateRef == nil || buffer.Status.PodTemplateGeneration == nil {
 		return false
 	}
@@ -58,7 +59,7 @@ func (f *podTemplateGenerationChangedFilter) podTemplateGenerationChanged(ctx co
 	podTemplate, err := f.client.GetPodTemplate(buffer.Namespace, buffer.Status.PodTemplateRef.Name)
 
 	if err != nil {
-		klog.Errorf("Couldn't get pod template defined in buffer %v, with error: %v", buffer.Name, err.Error())
+		logger.Error(err, "Couldn't get pod template defined in buffer", "buffer", buffer.Name)
 		return false
 	}
 	podTemplateGeneration := podTemplate.Generation

--- a/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	cbclient "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/client"
 	"k8s.io/klog/v2"
@@ -35,12 +36,12 @@ func NewPodTemplateGenerationChangedFilter(client *cbclient.CapacityBufferClient
 }
 
 // Filter filters the passed buffers based on buffer status conditions
-func (f *podTemplateGenerationChangedFilter) Filter(buffersToFilter []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
+func (f *podTemplateGenerationChangedFilter) Filter(ctx context.Context, buffersToFilter []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
 	var buffers []*v1.CapacityBuffer
 	var filteredOutBuffers []*v1.CapacityBuffer
 
 	for _, buffer := range buffersToFilter {
-		if f.podTemplateGenerationChanged(buffer) {
+		if f.podTemplateGenerationChanged(ctx, buffer) {
 			buffers = append(buffers, buffer)
 		} else {
 			filteredOutBuffers = append(filteredOutBuffers, buffer)
@@ -49,7 +50,7 @@ func (f *podTemplateGenerationChangedFilter) Filter(buffersToFilter []*v1.Capaci
 	return buffers, filteredOutBuffers
 }
 
-func (f *podTemplateGenerationChangedFilter) podTemplateGenerationChanged(buffer *v1.CapacityBuffer) bool {
+func (f *podTemplateGenerationChangedFilter) podTemplateGenerationChanged(ctx context.Context, buffer *v1.CapacityBuffer) bool {
 	if buffer.Status.PodTemplateRef == nil || buffer.Status.PodTemplateGeneration == nil {
 		return false
 	}

--- a/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/podtemplate_generation_filter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,7 +102,7 @@ func TestPodTemplateGenerationFilter(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			generationFilter := NewPodTemplateGenerationChangedFilter(fakeCapacityBuffersClient)
-			filtered, filteredOut := generationFilter.Filter(test.buffers)
+			filtered, filteredOut := generationFilter.Filter(context.TODO(), test.buffers)
 			assert.ElementsMatch(t, test.expectedFilteredBuffers, filtered)
 			assert.ElementsMatch(t, test.expectedFilteredOutBuffers, filteredOut)
 		})

--- a/cluster-autoscaler/capacitybuffer/filters/status_filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/status_filter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 )
 
@@ -33,7 +34,7 @@ func NewStatusFilter(conditionsToFilterOut map[string]string) *statusFilter {
 }
 
 // Filter filters the passed buffers based on buffer status conditions
-func (f *statusFilter) Filter(buffersToFilter []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
+func (f *statusFilter) Filter(ctx context.Context, buffersToFilter []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
 	var buffers []*v1.CapacityBuffer
 	var filteredOutBuffers []*v1.CapacityBuffer
 

--- a/cluster-autoscaler/capacitybuffer/filters/status_filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/status_filter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,7 +75,7 @@ func TestStatusFilter(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			statusFilter := NewStatusFilter(test.conditionsToFilterOut)
-			filtered, filteredOut := statusFilter.Filter(test.buffers)
+			filtered, filteredOut := statusFilter.Filter(context.TODO(), test.buffers)
 			assert.ElementsMatch(t, test.expectedFilteredBuffers, filtered)
 			assert.ElementsMatch(t, test.expectedFilteredOutBuffers, filteredOut)
 		})

--- a/cluster-autoscaler/capacitybuffer/filters/strategy_filter.go
+++ b/cluster-autoscaler/capacitybuffer/filters/strategy_filter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 )
 
@@ -38,7 +39,7 @@ func NewStrategyFilter(strategiesToUse []string) *strategyFilter {
 }
 
 // Filter filters out buffers with provisioning strategies not defined in strategiesToUseMap
-func (f *strategyFilter) Filter(buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
+func (f *strategyFilter) Filter(ctx context.Context, buffers []*v1.CapacityBuffer) ([]*v1.CapacityBuffer, []*v1.CapacityBuffer) {
 
 	var filteredBuffers []*v1.CapacityBuffer
 	var filteredOutBuffers []*v1.CapacityBuffer

--- a/cluster-autoscaler/capacitybuffer/filters/strategy_filter_test.go
+++ b/cluster-autoscaler/capacitybuffer/filters/strategy_filter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,7 +87,7 @@ func TestStrategyFilter(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			strategyFilter := NewStrategyFilter(test.strategiesToConsider)
-			filtered, filteredOut := strategyFilter.Filter(test.buffers)
+			filtered, filteredOut := strategyFilter.Filter(context.TODO(), test.buffers)
 			assert.ElementsMatch(t, test.expectedFilteredBuffers, filtered)
 			assert.ElementsMatch(t, test.expectedFilteredOutBuffers, filteredOut)
 		})

--- a/cluster-autoscaler/capacitybuffer/metrics/reconciliation_collector.go
+++ b/cluster-autoscaler/capacitybuffer/metrics/reconciliation_collector.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -91,7 +92,7 @@ func (c *reconciliationTimestampCollector) Collect(ch chan<- prometheus.Metric) 
 	// Delete buffers that no longer exist from cache
 	c.reconciledBuffers.Prune(buffers)
 
-	supportedBuffers, _ := c.supportedBuffersFilter.Filter(buffers)
+	supportedBuffers, _ := c.supportedBuffersFilter.Filter(context.TODO(), buffers)
 	reconciledBuffersSnapshot := c.reconciledBuffers.Snapshot()
 
 	now := c.clock.Now()

--- a/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/mig_info_provider.go
@@ -218,7 +218,7 @@ func (c *cachingMigInfoProvider) listInstancesInAllZonesWithMigs() ([]GceInstanc
 	var allInstances []GceInstance
 	errors := make([]error, len(zones))
 	zoneInstances := make([][]GceInstance, len(zones))
-	defer metrics.UpdateDurationFromStart(metrics.BulkListAllGceInstances, time.Now())
+	defer metrics.UpdateDurationFromStart(context.TODO(), metrics.BulkListAllGceInstances, time.Now())
 
 	workqueue.ParallelizeUntil(context.Background(), len(zones), len(zones), func(piece int) {
 		zoneInstances[piece], errors[piece] = c.gceClient.FetchAllInstances(c.projectId, zones[piece], "")
@@ -269,7 +269,7 @@ func (c *cachingMigInfoProvider) isMigCreatingOrDeletingInstances(mig Mig) bool 
 
 // updateMigInstancesCache updates the mig instances for each mig
 func (c *cachingMigInfoProvider) updateMigInstancesCache(migToInstances map[GceRef][]GceInstance) error {
-	defer metrics.UpdateDurationFromStart(metrics.BulkListMigInstances, time.Now())
+	defer metrics.UpdateDurationFromStart(context.TODO(), metrics.BulkListMigInstances, time.Now())
 	inconsistentInstancesMigsCount := 0
 	defer func() {
 		if inconsistentInstancesMigsCount > 0 {

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -286,9 +286,10 @@ func (csr *ClusterStateRegistry) NodeGroupScaleUpTime(nodeGroup cloudprovider.No
 }
 
 func (csr *ClusterStateRegistry) registerOrUpdateScaleUpNoLock(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time) {
+	logger := klog.FromContext(ctx)
 	maxNodeProvisionTime, err := csr.MaxNodeProvisionTime(nodeGroup)
 	if err != nil {
-		klog.Warningf("Couldn't update scale up request: failed to get maxNodeProvisionTime for node group %s: %v", nodeGroup.Id(), err)
+		logger.Info("Couldn't update scale up request: failed to get maxNodeProvisionTime for node group", "nodeGroupId", nodeGroup.Id(), "err", err)
 		return
 	}
 
@@ -341,6 +342,7 @@ func (csr *ClusterStateRegistry) RegisterScaleDown(nodeGroup cloudprovider.NodeG
 // To be executed under a lock.
 func (csr *ClusterStateRegistry) updateScaleRequests(ctx context.Context, currentTime time.Time) {
 	// clean up stale backoff info
+	logger := klog.FromContext(ctx)
 	csr.backoff.RemoveStaleBackoffData(currentTime)
 
 	for nodeGroupName, scaleUpRequest := range csr.scaleUpRequests {
@@ -350,14 +352,12 @@ func (csr *ClusterStateRegistry) updateScaleRequests(ctx context.Context, curren
 		if !csr.areThereUpcomingNodesInNodeGroup(ctx, nodeGroupName) {
 			// scale up finished successfully, remove request
 			delete(csr.scaleUpRequests, nodeGroupName)
-			klog.V(4).Infof("Scale up in group %v finished successfully in %v",
-				nodeGroupName, currentTime.Sub(scaleUpRequest.Time))
+			logger.V(4).Info("Scale up in group finished successfully", "nodeGroup", nodeGroupName, "duration", currentTime.Sub(scaleUpRequest.Time))
 			continue
 		}
 
 		if scaleUpRequest.ExpectedAddTime.Before(currentTime) {
-			klog.Warningf("Scale-up timed out for node group %v after %v",
-				nodeGroupName, currentTime.Sub(scaleUpRequest.Time))
+			logger.Info("Scale-up timed out for node group after", "nodeGroup", nodeGroupName, "duration", currentTime.Sub(scaleUpRequest.Time))
 			csr.logRecorder.Eventf(apiv1.EventTypeWarning, "ScaleUpTimedOut",
 				"Nodes added to group %s failed to register within %v",
 				scaleUpRequest.NodeGroup.Id(), currentTime.Sub(scaleUpRequest.Time))
@@ -370,11 +370,10 @@ func (csr *ClusterStateRegistry) updateScaleRequests(ctx context.Context, curren
 			// Attempt to revert the failed scale-up by decreasing target size.
 			// This prevents cloud providers from indefinitely retrying failed provisioning attempts.
 			if scaleUpRequest.Increase > 0 {
-				klog.Warningf("Reverting timed-out scale-up for node group %v by decreasing target size by %d",
-					nodeGroupName, scaleUpRequest.Increase)
+				logger.Info("Reverting timed-out scale-up for node group by decreasing target size", "nodeGroup", nodeGroupName, "increase", scaleUpRequest.Increase)
 				err := scaleUpRequest.NodeGroup.DecreaseTargetSize(-scaleUpRequest.Increase)
 				if err != nil {
-					klog.Warningf("Failed to revert timed-out scale-up for node group %v: %v", nodeGroupName, err)
+					logger.Info("Failed to revert timed-out scale-up for node group", "nodeGroup", nodeGroupName, "err", err)
 					csr.logRecorder.Eventf(apiv1.EventTypeWarning, "FailedToRevertScaleUp",
 						"Failed to decrease target size for group %s after scale-up timeout: %v",
 						scaleUpRequest.NodeGroup.Id(), err)
@@ -396,13 +395,14 @@ func (csr *ClusterStateRegistry) updateScaleRequests(ctx context.Context, curren
 
 // Doesn't need csr lock, because both templateNodeInfoRegistry and backoff are thread-safe.
 func (csr *ClusterStateRegistry) backoffNodeGroup(ctx context.Context, nodeGroup cloudprovider.NodeGroup, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
+	logger := klog.FromContext(ctx)
 	nodeGroupInfo, found := csr.templateNodeInfoRegistry.GetNodeInfo(nodeGroup.Id())
 	if !found {
-		klog.Errorf("Cannot backoff node group %v: failed to get template node info", nodeGroup.Id())
+		logger.Error(nil, "Cannot backoff node group: failed to get template node info", "nodeGroupId", nodeGroup.Id())
 		return
 	}
 	backoffUntil := csr.backoff.Backoff(nodeGroup, nodeGroupInfo, errorInfo, currentTime)
-	klog.Warningf("Disabling scale-up for node group %v until %v; errorClass=%v; errorCode=%v", nodeGroup.Id(), backoffUntil, errorInfo.ErrorClass, errorInfo.ErrorCode)
+	logger.Info("Disabling scale-up for node group until", "nodeGroupId", nodeGroup.Id(), "backoffUntil", backoffUntil, "errorClass", errorInfo.ErrorClass, "errorCode", errorInfo.ErrorCode)
 }
 
 // RegisterFailedScaleUp should be called after getting error from cloudprovider
@@ -465,9 +465,10 @@ func (csr *ClusterStateRegistry) updateClusterStateRegistry(ctx context.Context,
 
 // Recalculate cluster state after scale-ups or scale-downs were registered.
 func (csr *ClusterStateRegistry) Recalculate(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	targetSizes, err := getTargetSizes(csr.cloudProvider)
 	if err != nil {
-		klog.Warningf("Failed to get target sizes, when trying to recalculate cluster state: %v", err)
+		logger.Info("Failed to get target sizes, when trying to recalculate cluster state", "err", err)
 	}
 
 	csr.Lock()
@@ -505,9 +506,10 @@ func (csr *ClusterStateRegistry) IsClusterHealthy() bool {
 
 // IsNodeGroupHealthy returns true if the node group health is within the acceptable limits
 func (csr *ClusterStateRegistry) IsNodeGroupHealthy(ctx context.Context, nodeGroupName string) bool {
+	logger := klog.FromContext(ctx)
 	acceptable, found := csr.acceptableRanges[nodeGroupName]
 	if !found {
-		klog.V(5).Infof("Failed to find acceptable ranges for %v", nodeGroupName)
+		logger.V(5).Info("Failed to find acceptable ranges", "nodeGroup", nodeGroupName)
 		return false
 	}
 
@@ -517,7 +519,7 @@ func (csr *ClusterStateRegistry) IsNodeGroupHealthy(ctx context.Context, nodeGro
 		if acceptable.CurrentTarget == 0 || (acceptable.MinNodes == 0 && acceptable.CurrentTarget > 0) {
 			return true
 		}
-		klog.V(5).Infof("Failed to find readiness information for %v", nodeGroupName)
+		logger.V(5).Info("Failed to find readiness information", "nodeGroup", nodeGroupName)
 		return false
 	}
 
@@ -552,9 +554,10 @@ func (csr *ClusterStateRegistry) updateNodeGroupMetrics() {
 
 // BackoffStatusForNodeGroup queries the backoff status of the node group
 func (csr *ClusterStateRegistry) BackoffStatusForNodeGroup(ctx context.Context, nodeGroup cloudprovider.NodeGroup, now time.Time) backoff.Status {
+	logger := klog.FromContext(ctx)
 	nodeGroupInfo, found := csr.templateNodeInfoRegistry.GetNodeInfo(nodeGroup.Id())
 	if !found {
-		klog.Errorf("Cannot get backoff status for node group %v: failed to get template node info", nodeGroup.Id())
+		logger.Error(nil, "Cannot get backoff status for node group: failed to get template node info", "nodeGroupId", nodeGroup.Id())
 		return backoff.Status{IsBackedOff: false}
 	}
 	return csr.backoff.BackoffStatus(nodeGroup, nodeGroupInfo, now)
@@ -562,11 +565,12 @@ func (csr *ClusterStateRegistry) BackoffStatusForNodeGroup(ctx context.Context, 
 
 // NodeGroupScaleUpSafety returns information about node group safety to be scaled up now.
 func (csr *ClusterStateRegistry) NodeGroupScaleUpSafety(ctx context.Context, nodeGroup cloudprovider.NodeGroup, now time.Time) NodeGroupScalingSafety {
+	logger := klog.FromContext(ctx)
 	isHealthy := csr.IsNodeGroupHealthy(ctx, nodeGroup.Id())
 	var backoffStatus backoff.Status
 	nodeGroupInfo, found := csr.templateNodeInfoRegistry.GetNodeInfo(nodeGroup.Id())
 	if !found {
-		klog.Errorf("Cannot get backoff status for node group %v: failed to get template node info", nodeGroup.Id())
+		logger.Error(nil, "Cannot get backoff status for node group: failed to get template node info", "nodeGroupId", nodeGroup.Id())
 		backoffStatus = backoff.Status{IsBackedOff: false}
 	} else {
 		backoffStatus = csr.backoff.BackoffStatus(nodeGroup, nodeGroupInfo, now)
@@ -575,14 +579,16 @@ func (csr *ClusterStateRegistry) NodeGroupScaleUpSafety(ctx context.Context, nod
 }
 
 func (csr *ClusterStateRegistry) getUpcomingNodesInNodeGroup(ctx context.Context, nodeGroupName string) (upcoming int, ok bool) {
+	logger := klog.FromContext(ctx)
 	if len(csr.acceptableRanges) == 0 {
-		klog.Warningf("AcceptableRanges have not been populated yet. Skip checking")
+		logger.Info("AcceptableRanges have not been populated yet. Skip checking")
+
 		return 0, false
 	}
 
 	acceptable, found := csr.acceptableRanges[nodeGroupName]
 	if !found {
-		klog.Warningf("Failed to find acceptable ranges for %v", nodeGroupName)
+		logger.Info("Failed to find acceptable ranges", "nodeGroup", nodeGroupName)
 		return 0, false
 	}
 
@@ -590,7 +596,7 @@ func (csr *ClusterStateRegistry) getUpcomingNodesInNodeGroup(ctx context.Context
 	if !found {
 		if acceptable.MinNodes != 0 {
 			// No need to warn if node group has size 0 (was scaled to 0 before).
-			klog.Warningf("Failed to find readiness information for %v", nodeGroupName)
+			logger.Info("Failed to find readiness information", "nodeGroup", nodeGroupName)
 		}
 		return acceptable.CurrentTarget, true
 	}
@@ -717,6 +723,7 @@ func isSuspendedNode(node *apiv1.Node) bool {
 }
 
 func (csr *ClusterStateRegistry) updateReadinessStats(ctx context.Context, currentTime time.Time) {
+	logger := klog.FromContext(ctx)
 	perNodeGroup := make(map[string]Readiness)
 	total := Readiness{Time: currentTime}
 	maxNodeStartupTime := MaxNodeStartupTime
@@ -727,7 +734,7 @@ func (csr *ClusterStateRegistry) updateReadinessStats(ctx context.Context, curre
 				maxNodeStartupTime = startupTime
 			}
 		}
-		klog.V(5).Infof("Node %s: using maxNodeStartupTime = %v", node.Name, maxNodeStartupTime)
+		logger.V(5).Info("Node: using maxNodeStartupTime =", "node", node.Name, "maxNodeStartupTime", maxNodeStartupTime)
 		current.Registered = append(current.Registered, node.Name)
 		if _, isDeleted := csr.deletedNodes[node.Name]; isDeleted {
 			current.Deleted = append(current.Deleted, node.Name)
@@ -753,10 +760,10 @@ func (csr *ClusterStateRegistry) updateReadinessStats(ctx context.Context, curre
 		// Node is most likely not autoscaled, however check the errors.
 		if nodeGroup == nil {
 			if errNg != nil {
-				klog.Warningf("Failed to get nodegroup for %s: %v", node.Name, errNg)
+				logger.Info("Failed to get nodegroup", "node", node.Name, "err", errNg)
 			}
 			if errReady != nil {
-				klog.Warningf("Failed to get readiness info for %s: %v", node.Name, errReady)
+				logger.Info("Failed to get readiness info", "node", node.Name, "err", errReady)
 			}
 		} else {
 			perNodeGroup[nodeGroup.Id()] = update(perNodeGroup[nodeGroup.Id()], node, nr)
@@ -767,17 +774,17 @@ func (csr *ClusterStateRegistry) updateReadinessStats(ctx context.Context, curre
 	for _, unregistered := range csr.unregisteredNodes {
 		nodeGroup, errNg := csr.cloudProvider.NodeGroupForNode(unregistered.Node)
 		if errNg != nil {
-			klog.Warningf("Failed to get nodegroup for %s: %v", unregistered.Node.Name, errNg)
+			logger.Info("Failed to get nodegroup", "node", unregistered.Node.Name, "err", errNg)
 			continue
 		}
 		if nodeGroup == nil {
-			klog.Warningf("Nodegroup is nil for %s", unregistered.Node.Name)
+			logger.Info("Nodegroup is nil", "node", unregistered.Node.Name)
 			continue
 		}
 		perNgCopy := perNodeGroup[nodeGroup.Id()]
 		maxNodeProvisionTime, err := csr.MaxNodeProvisionTime(nodeGroup)
 		if err != nil {
-			klog.Warningf("Failed to get maxNodeProvisionTime for node %s in node group %s: %v", unregistered.Node.Name, nodeGroup.Id(), err)
+			logger.Info("Failed to get maxNodeProvisionTime for node in node group", "node", unregistered.Node.Name, "nodeGroupId", nodeGroup.Id(), "err", err)
 			continue
 		}
 		if unregistered.UnregisteredSince.Add(maxNodeProvisionTime).Before(currentTime) {
@@ -790,7 +797,7 @@ func (csr *ClusterStateRegistry) updateReadinessStats(ctx context.Context, curre
 		perNodeGroup[nodeGroup.Id()] = perNgCopy
 	}
 	if len(total.LongUnregistered) > 0 {
-		klog.V(3).Infof("Found longUnregistered Nodes %s", total.LongUnregistered)
+		logger.V(3).Info("Found longUnregistered Nodes", "longUnregistered", total.LongUnregistered)
 	}
 
 	for ngId, ngReadiness := range perNodeGroup {
@@ -803,18 +810,19 @@ func (csr *ClusterStateRegistry) updateReadinessStats(ctx context.Context, curre
 
 // Calculates which node groups have incorrect size.
 func (csr *ClusterStateRegistry) updateIncorrectNodeGroupSizes(ctx context.Context, currentTime time.Time) {
+	logger := klog.FromContext(ctx)
 	result := make(map[string]IncorrectNodeGroupSize)
 	for _, nodeGroup := range csr.getRunningNodeGroups() {
 		acceptableRange, found := csr.acceptableRanges[nodeGroup.Id()]
 		if !found {
-			klog.Warningf("Acceptable range for node group %s not found", nodeGroup.Id())
+			logger.Info("Acceptable range for node group not found", "nodeGroupId", nodeGroup.Id())
 			continue
 		}
 		readiness, found := csr.perNodeGroupReadiness[nodeGroup.Id()]
 		if !found {
 			// if MinNodes == 0 node group has been scaled to 0 and everything's fine
 			if acceptableRange.MinNodes != 0 {
-				klog.Warningf("Readiness for node group %s not found", nodeGroup.Id())
+				logger.Info("Readiness for node group not found", "nodeGroupId", nodeGroup.Id())
 			}
 			continue
 		}
@@ -873,11 +881,12 @@ func (csr *ClusterStateRegistry) updateCloudProviderDeletedNodes(deletedNodes []
 
 // UpdateScaleDownCandidates updates scale down candidates
 func (csr *ClusterStateRegistry) UpdateScaleDownCandidates(ctx context.Context, nodes []*scaledown.UnneededNode, now time.Time) {
+	logger := klog.FromContext(ctx)
 	result := make(map[string][]string)
 	for _, node := range nodes {
 		group, err := csr.cloudProvider.NodeGroupForNode(node.Node)
 		if err != nil {
-			klog.Warningf("Failed to get node group for %s: %v", node.Node.Name, err)
+			logger.Info("Failed to get node group", "node", node.Node.Name, "err", err)
 			continue
 		}
 		if group == nil {
@@ -1100,6 +1109,7 @@ func (csr *ClusterStateRegistry) GetIncorrectNodeGroupSize(nodeGroupName string)
 // The function may overestimate the number of nodes. The second return value contains the names of upcoming nodes
 // that are already registered in the cluster.
 func (csr *ClusterStateRegistry) GetUpcomingNodes(ctx context.Context) (upcomingCounts map[string]int, registeredNodeNames map[string][]string) {
+	logger := klog.FromContext(ctx)
 	csr.Lock()
 	defer csr.Unlock()
 
@@ -1129,11 +1139,11 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes(ctx context.Context) (upcoming
 		// schedulable, preventing ScaleUp from ever being called and considering
 		// alternative node groups.
 		if _, hasScaleUpRequest := csr.scaleUpRequests[id]; !hasScaleUpRequest {
-			klog.V(4).Infof("Skipping %d upcoming nodes for node group %s: no active scale-up request", newNodes, id)
+			logger.V(4).Info("Skipping upcoming nodes for node group: no active scale-up request", "newNodes", newNodes, "id", id)
 			continue
 		}
 		if backoffStatus := csr.BackoffStatusForNodeGroup(ctx, nodeGroup, time.Now()); backoffStatus.IsBackedOff {
-			klog.V(4).Infof("Skipping %d upcoming nodes for backed-off node group %s: %s", newNodes, id, backoffStatus.ErrorInfo.ErrorMessage)
+			logger.V(4).Info("Skipping upcoming nodes for backed-off node group", "newNodes", newNodes, "id", id, "errorMessage", backoffStatus.ErrorInfo.ErrorMessage)
 			continue
 		}
 		upcomingCounts[id] = newNodes
@@ -1213,12 +1223,13 @@ func (csr *ClusterStateRegistry) getCloudProviderDeletedNodes(ctx context.Contex
 }
 
 func (csr *ClusterStateRegistry) hasCloudProviderInstance(ctx context.Context, node *apiv1.Node) bool {
+	logger := klog.FromContext(ctx)
 	exists, err := csr.cloudProvider.HasInstance(node)
 	if err == nil {
 		return exists
 	}
 	if !errors.Is(err, cloudprovider.ErrNotImplemented) {
-		klog.Warningf("Failed to check cloud provider has instance for %s: %v", node.Name, err)
+		logger.Info("Failed to check cloud provider has instance", "node", node.Name, "err", err)
 	}
 	return !taints.HasToBeDeletedTaint(node)
 }
@@ -1255,12 +1266,13 @@ func (csr *ClusterStateRegistry) handleInstanceCreationErrorsForNodeGroup(
 	previousInstances []cloudprovider.Instance,
 	currentTime time.Time) {
 
+	logger := klog.FromContext(ctx)
 	_, currentUniqueErrorMessagesForErrorCode, currentErrorCodeToInstance := csr.buildInstanceToErrorCodeMappings(currentInstances)
 	previousInstanceToErrorCode, _, _ := csr.buildInstanceToErrorCodeMappings(previousInstances)
 
 	for errorCode, instances := range currentErrorCodeToInstance {
 		if len(instances) > 0 {
-			klog.V(4).Infof("Found %v instances with errorCode %v in nodeGroup %v", len(instances), errorCode, nodeGroup.Id())
+			logger.V(4).Info("Found instances with errorCode in nodeGroup", "instancesCount", len(instances), "errorCode", errorCode, "nodeGroupId", nodeGroup.Id())
 		}
 	}
 
@@ -1277,8 +1289,7 @@ func (csr *ClusterStateRegistry) handleInstanceCreationErrorsForNodeGroup(
 				unseenInstanceIds = append(unseenInstanceIds, instance.Id)
 			}
 		}
-
-		klog.V(1).Infof("Failed adding %v nodes (%v unseen previously) to group %v due to %v; errorMessages=%#v", len(instances), len(unseenInstanceIds), nodeGroup.Id(), errorCode, currentUniqueErrorMessagesForErrorCode[errorCode])
+		logger.V(1).Info("Failed adding nodes (unseen previously) to group", "instancesCount", len(instances), "unseenInstanceIdsCount", len(unseenInstanceIds), "nodeGroupId", nodeGroup.Id(), "errorCode", errorCode, "currentUniqueErrorMessagesForErrorCode", currentUniqueErrorMessagesForErrorCode[errorCode])
 		if len(unseenInstanceIds) > 0 && csr.IsNodeGroupScalingUp(ctx, nodeGroup.Id()) {
 			csr.logRecorder.Eventf(
 				apiv1.EventTypeWarning,

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusterstate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -259,10 +260,10 @@ func (csr *ClusterStateRegistry) Stop() {
 }
 
 // RegisterScaleUp registers scale-up for give node group
-func (csr *ClusterStateRegistry) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time) {
+func (csr *ClusterStateRegistry) RegisterScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time) {
 	csr.Lock()
 	defer csr.Unlock()
-	csr.registerOrUpdateScaleUpNoLock(nodeGroup, delta, currentTime)
+	csr.registerOrUpdateScaleUpNoLock(ctx, nodeGroup, delta, currentTime)
 }
 
 // MaxNodeProvisionTime returns MaxNodeProvisionTime value that should be used for the given NodeGroup.
@@ -284,7 +285,7 @@ func (csr *ClusterStateRegistry) NodeGroupScaleUpTime(nodeGroup cloudprovider.No
 	return scaleUpRequest.Time, nil
 }
 
-func (csr *ClusterStateRegistry) registerOrUpdateScaleUpNoLock(nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time) {
+func (csr *ClusterStateRegistry) registerOrUpdateScaleUpNoLock(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time) {
 	maxNodeProvisionTime, err := csr.MaxNodeProvisionTime(nodeGroup)
 	if err != nil {
 		klog.Warningf("Couldn't update scale up request: failed to get maxNodeProvisionTime for node group %s: %v", nodeGroup.Id(), err)
@@ -338,7 +339,7 @@ func (csr *ClusterStateRegistry) RegisterScaleDown(nodeGroup cloudprovider.NodeG
 }
 
 // To be executed under a lock.
-func (csr *ClusterStateRegistry) updateScaleRequests(currentTime time.Time) {
+func (csr *ClusterStateRegistry) updateScaleRequests(ctx context.Context, currentTime time.Time) {
 	// clean up stale backoff info
 	csr.backoff.RemoveStaleBackoffData(currentTime)
 
@@ -346,7 +347,7 @@ func (csr *ClusterStateRegistry) updateScaleRequests(currentTime time.Time) {
 		if csr.asyncNodeGroupStateChecker.IsUpcoming(scaleUpRequest.NodeGroup) {
 			continue
 		}
-		if !csr.areThereUpcomingNodesInNodeGroup(nodeGroupName) {
+		if !csr.areThereUpcomingNodesInNodeGroup(ctx, nodeGroupName) {
 			// scale up finished successfully, remove request
 			delete(csr.scaleUpRequests, nodeGroupName)
 			klog.V(4).Infof("Scale up in group %v finished successfully in %v",
@@ -360,7 +361,7 @@ func (csr *ClusterStateRegistry) updateScaleRequests(currentTime time.Time) {
 			csr.logRecorder.Eventf(apiv1.EventTypeWarning, "ScaleUpTimedOut",
 				"Nodes added to group %s failed to register within %v",
 				scaleUpRequest.NodeGroup.Id(), currentTime.Sub(scaleUpRequest.Time))
-			csr.scaleStateNotifier.RegisterFailedScaleUp(scaleUpRequest.NodeGroup, scaleUpRequest.Increase, cloudprovider.InstanceErrorInfo{
+			csr.scaleStateNotifier.RegisterFailedScaleUp(ctx, scaleUpRequest.NodeGroup, scaleUpRequest.Increase, cloudprovider.InstanceErrorInfo{
 				ErrorClass:   cloudprovider.OtherErrorClass,
 				ErrorCode:    string(metrics.Timeout),
 				ErrorMessage: fmt.Sprintf("Scale-up timed out for node group %v after %v", nodeGroupName, currentTime.Sub(scaleUpRequest.Time)),
@@ -394,7 +395,7 @@ func (csr *ClusterStateRegistry) updateScaleRequests(currentTime time.Time) {
 }
 
 // Doesn't need csr lock, because both templateNodeInfoRegistry and backoff are thread-safe.
-func (csr *ClusterStateRegistry) backoffNodeGroup(nodeGroup cloudprovider.NodeGroup, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
+func (csr *ClusterStateRegistry) backoffNodeGroup(ctx context.Context, nodeGroup cloudprovider.NodeGroup, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
 	nodeGroupInfo, found := csr.templateNodeInfoRegistry.GetNodeInfo(nodeGroup.Id())
 	if !found {
 		klog.Errorf("Cannot backoff node group %v: failed to get template node info", nodeGroup.Id())
@@ -407,8 +408,8 @@ func (csr *ClusterStateRegistry) backoffNodeGroup(nodeGroup cloudprovider.NodeGr
 // RegisterFailedScaleUp should be called after getting error from cloudprovider
 // when trying to scale-up node group. It will mark this group as not safe to autoscale
 // for some time.
-func (csr *ClusterStateRegistry) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
-	csr.backoffNodeGroup(nodeGroup, errorInfo, currentTime)
+func (csr *ClusterStateRegistry) RegisterFailedScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
+	csr.backoffNodeGroup(ctx, nodeGroup, errorInfo, currentTime)
 }
 
 // RegisterFailedScaleDown records failed scale-down for a nodegroup.
@@ -417,7 +418,7 @@ func (csr *ClusterStateRegistry) RegisterFailedScaleDown(_ cloudprovider.NodeGro
 }
 
 // UpdateNodes updates the state of the nodes in the ClusterStateRegistry and recalculates the stats
-func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, currentTime time.Time) error {
+func (csr *ClusterStateRegistry) UpdateNodes(ctx context.Context, nodes []*apiv1.Node, currentTime time.Time) error {
 	csr.updateNodeGroupMetrics()
 	targetSizes, err := getTargetSizes(csr.cloudProvider)
 	if err != nil {
@@ -425,12 +426,11 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, currentTime ti
 	}
 	metrics.UpdateNodeGroupTargetSize(targetSizes)
 
-	cloudProviderNodeInstances, err := csr.getCloudProviderNodeInstances()
+	cloudProviderNodeInstances, err := csr.getCloudProviderNodeInstances(ctx)
 	if err != nil {
 		return err
 	}
-	csr.updateClusterStateRegistry(
-		nodes,
+	csr.updateClusterStateRegistry(ctx, nodes,
 		cloudProviderNodeInstances,
 		currentTime,
 		targetSizes,
@@ -438,9 +438,9 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, currentTime ti
 	return nil
 }
 
-func (csr *ClusterStateRegistry) updateClusterStateRegistry(nodes []*apiv1.Node,
+func (csr *ClusterStateRegistry) updateClusterStateRegistry(ctx context.Context, nodes []*apiv1.Node,
 	cloudProviderNodeInstances map[string][]cloudprovider.Instance, currentTime time.Time, targetSizes map[string]int) {
-	cloudProviderNodesRemoved := csr.getCloudProviderDeletedNodes(nodes)
+	cloudProviderNodesRemoved := csr.getCloudProviderDeletedNodes(ctx, nodes)
 	notRegistered := getNotRegisteredNodes(nodes, cloudProviderNodeInstances, currentTime)
 
 	csr.Lock()
@@ -451,20 +451,20 @@ func (csr *ClusterStateRegistry) updateClusterStateRegistry(nodes []*apiv1.Node,
 
 	csr.updateUnregisteredNodes(notRegistered)
 	csr.updateCloudProviderDeletedNodes(cloudProviderNodesRemoved)
-	csr.updateReadinessStats(currentTime)
+	csr.updateReadinessStats(ctx, currentTime)
 
 	// update acceptable ranges based on requests from last loop and targetSizes
 	// updateScaleRequests relies on acceptableRanges being up to date
 	csr.updateAcceptableRanges(targetSizes)
-	csr.updateScaleRequests(currentTime)
-	csr.handleInstanceCreationErrors(currentTime)
+	csr.updateScaleRequests(ctx, currentTime)
+	csr.handleInstanceCreationErrors(ctx, currentTime)
 	//  recalculate acceptable ranges after removing timed out requests
 	csr.updateAcceptableRanges(targetSizes)
-	csr.updateIncorrectNodeGroupSizes(currentTime)
+	csr.updateIncorrectNodeGroupSizes(ctx, currentTime)
 }
 
 // Recalculate cluster state after scale-ups or scale-downs were registered.
-func (csr *ClusterStateRegistry) Recalculate() {
+func (csr *ClusterStateRegistry) Recalculate(ctx context.Context) {
 	targetSizes, err := getTargetSizes(csr.cloudProvider)
 	if err != nil {
 		klog.Warningf("Failed to get target sizes, when trying to recalculate cluster state: %v", err)
@@ -504,7 +504,7 @@ func (csr *ClusterStateRegistry) IsClusterHealthy() bool {
 }
 
 // IsNodeGroupHealthy returns true if the node group health is within the acceptable limits
-func (csr *ClusterStateRegistry) IsNodeGroupHealthy(nodeGroupName string) bool {
+func (csr *ClusterStateRegistry) IsNodeGroupHealthy(ctx context.Context, nodeGroupName string) bool {
 	acceptable, found := csr.acceptableRanges[nodeGroupName]
 	if !found {
 		klog.V(5).Infof("Failed to find acceptable ranges for %v", nodeGroupName)
@@ -551,7 +551,7 @@ func (csr *ClusterStateRegistry) updateNodeGroupMetrics() {
 }
 
 // BackoffStatusForNodeGroup queries the backoff status of the node group
-func (csr *ClusterStateRegistry) BackoffStatusForNodeGroup(nodeGroup cloudprovider.NodeGroup, now time.Time) backoff.Status {
+func (csr *ClusterStateRegistry) BackoffStatusForNodeGroup(ctx context.Context, nodeGroup cloudprovider.NodeGroup, now time.Time) backoff.Status {
 	nodeGroupInfo, found := csr.templateNodeInfoRegistry.GetNodeInfo(nodeGroup.Id())
 	if !found {
 		klog.Errorf("Cannot get backoff status for node group %v: failed to get template node info", nodeGroup.Id())
@@ -561,8 +561,8 @@ func (csr *ClusterStateRegistry) BackoffStatusForNodeGroup(nodeGroup cloudprovid
 }
 
 // NodeGroupScaleUpSafety returns information about node group safety to be scaled up now.
-func (csr *ClusterStateRegistry) NodeGroupScaleUpSafety(nodeGroup cloudprovider.NodeGroup, now time.Time) NodeGroupScalingSafety {
-	isHealthy := csr.IsNodeGroupHealthy(nodeGroup.Id())
+func (csr *ClusterStateRegistry) NodeGroupScaleUpSafety(ctx context.Context, nodeGroup cloudprovider.NodeGroup, now time.Time) NodeGroupScalingSafety {
+	isHealthy := csr.IsNodeGroupHealthy(ctx, nodeGroup.Id())
 	var backoffStatus backoff.Status
 	nodeGroupInfo, found := csr.templateNodeInfoRegistry.GetNodeInfo(nodeGroup.Id())
 	if !found {
@@ -574,7 +574,7 @@ func (csr *ClusterStateRegistry) NodeGroupScaleUpSafety(nodeGroup cloudprovider.
 	return NodeGroupScalingSafety{SafeToScale: isHealthy && !backoffStatus.IsBackedOff, Healthy: isHealthy, BackoffStatus: backoffStatus}
 }
 
-func (csr *ClusterStateRegistry) getUpcomingNodesInNodeGroup(nodeGroupName string) (upcoming int, ok bool) {
+func (csr *ClusterStateRegistry) getUpcomingNodesInNodeGroup(ctx context.Context, nodeGroupName string) (upcoming int, ok bool) {
 	if len(csr.acceptableRanges) == 0 {
 		klog.Warningf("AcceptableRanges have not been populated yet. Skip checking")
 		return 0, false
@@ -598,8 +598,8 @@ func (csr *ClusterStateRegistry) getUpcomingNodesInNodeGroup(nodeGroupName strin
 	return calculateUpcomingNodesInNodeGroup(readiness, acceptable), true
 }
 
-func (csr *ClusterStateRegistry) areThereUpcomingNodesInNodeGroup(nodeGroupName string) bool {
-	upcoming, ok := csr.getUpcomingNodesInNodeGroup(nodeGroupName)
+func (csr *ClusterStateRegistry) areThereUpcomingNodesInNodeGroup(ctx context.Context, nodeGroupName string) bool {
+	upcoming, ok := csr.getUpcomingNodesInNodeGroup(ctx, nodeGroupName)
 	if !ok {
 		return false
 	}
@@ -614,7 +614,7 @@ func (csr *ClusterStateRegistry) IsNodeGroupRegistered(nodeGroupName string) boo
 
 // IsNodeGroupAtTargetSize returns true if the number of nodes provisioned in the group is equal to the target number of nodes.
 func (csr *ClusterStateRegistry) IsNodeGroupAtTargetSize(nodeGroupName string) bool {
-	upcoming, ok := csr.getUpcomingNodesInNodeGroup(nodeGroupName)
+	upcoming, ok := csr.getUpcomingNodesInNodeGroup(context.TODO(), nodeGroupName)
 	if !ok {
 		return false
 	}
@@ -622,8 +622,8 @@ func (csr *ClusterStateRegistry) IsNodeGroupAtTargetSize(nodeGroupName string) b
 }
 
 // IsNodeGroupScalingUp returns true if the node group is currently scaling up.
-func (csr *ClusterStateRegistry) IsNodeGroupScalingUp(nodeGroupName string) bool {
-	if !csr.areThereUpcomingNodesInNodeGroup(nodeGroupName) {
+func (csr *ClusterStateRegistry) IsNodeGroupScalingUp(ctx context.Context, nodeGroupName string) bool {
+	if !csr.areThereUpcomingNodesInNodeGroup(ctx, nodeGroupName) {
 		return false
 	}
 	_, found := csr.scaleUpRequests[nodeGroupName]
@@ -716,7 +716,7 @@ func isSuspendedNode(node *apiv1.Node) bool {
 	return false
 }
 
-func (csr *ClusterStateRegistry) updateReadinessStats(currentTime time.Time) {
+func (csr *ClusterStateRegistry) updateReadinessStats(ctx context.Context, currentTime time.Time) {
 	perNodeGroup := make(map[string]Readiness)
 	total := Readiness{Time: currentTime}
 	maxNodeStartupTime := MaxNodeStartupTime
@@ -802,7 +802,7 @@ func (csr *ClusterStateRegistry) updateReadinessStats(currentTime time.Time) {
 }
 
 // Calculates which node groups have incorrect size.
-func (csr *ClusterStateRegistry) updateIncorrectNodeGroupSizes(currentTime time.Time) {
+func (csr *ClusterStateRegistry) updateIncorrectNodeGroupSizes(ctx context.Context, currentTime time.Time) {
 	result := make(map[string]IncorrectNodeGroupSize)
 	for _, nodeGroup := range csr.getRunningNodeGroups() {
 		acceptableRange, found := csr.acceptableRanges[nodeGroup.Id()]
@@ -872,7 +872,7 @@ func (csr *ClusterStateRegistry) updateCloudProviderDeletedNodes(deletedNodes []
 }
 
 // UpdateScaleDownCandidates updates scale down candidates
-func (csr *ClusterStateRegistry) UpdateScaleDownCandidates(nodes []*scaledown.UnneededNode, now time.Time) {
+func (csr *ClusterStateRegistry) UpdateScaleDownCandidates(ctx context.Context, nodes []*scaledown.UnneededNode, now time.Time) {
 	result := make(map[string][]string)
 	for _, node := range nodes {
 		group, err := csr.cloudProvider.NodeGroupForNode(node.Node)
@@ -890,7 +890,7 @@ func (csr *ClusterStateRegistry) UpdateScaleDownCandidates(nodes []*scaledown.Un
 }
 
 // GetStatus returns ClusterAutoscalerStatus with the current cluster autoscaler status.
-func (csr *ClusterStateRegistry) GetStatus(now time.Time) *api.ClusterAutoscalerStatus {
+func (csr *ClusterStateRegistry) GetStatus(ctx context.Context, now time.Time) *api.ClusterAutoscalerStatus {
 	result := &api.ClusterAutoscalerStatus{
 		AutoscalerStatus: api.ClusterAutoscalerRunning,
 		NodeGroups:       make([]api.NodeGroupStatus, 0),
@@ -910,11 +910,10 @@ func (csr *ClusterStateRegistry) GetStatus(now time.Time) *api.ClusterAutoscaler
 
 		// Health.
 		nodeGroupStatus.Health = buildHealthStatusNodeGroup(
-			csr.IsNodeGroupHealthy(nodeGroup.Id()), readiness, acceptable, nodeGroup.MinSize(), nodeGroup.MaxSize(), nodeGroupLastStatus.Health)
+			csr.IsNodeGroupHealthy(ctx, nodeGroup.Id()), readiness, acceptable, nodeGroup.MinSize(), nodeGroup.MaxSize(), nodeGroupLastStatus.Health)
 
 		// Scale up.
-		nodeGroupStatus.ScaleUp = csr.buildScaleUpStatusNodeGroup(
-			nodeGroup,
+		nodeGroupStatus.ScaleUp = csr.buildScaleUpStatusNodeGroup(ctx, nodeGroup,
 			readiness,
 			acceptable, now, nodeGroupLastStatus.ScaleUp)
 
@@ -979,9 +978,9 @@ func buildHealthStatusNodeGroup(isHealthy bool, readiness Readiness, acceptable 
 	return condition
 }
 
-func (csr *ClusterStateRegistry) buildScaleUpStatusNodeGroup(nodeGroup cloudprovider.NodeGroup, readiness Readiness, acceptable AcceptableRange, now time.Time, lastStatus api.NodeGroupScaleUpCondition) api.NodeGroupScaleUpCondition {
-	isScaleUpInProgress := csr.IsNodeGroupScalingUp(nodeGroup.Id())
-	scaleUpSafety := csr.NodeGroupScaleUpSafety(nodeGroup, now)
+func (csr *ClusterStateRegistry) buildScaleUpStatusNodeGroup(ctx context.Context, nodeGroup cloudprovider.NodeGroup, readiness Readiness, acceptable AcceptableRange, now time.Time, lastStatus api.NodeGroupScaleUpCondition) api.NodeGroupScaleUpCondition {
+	isScaleUpInProgress := csr.IsNodeGroupScalingUp(ctx, nodeGroup.Id())
+	scaleUpSafety := csr.NodeGroupScaleUpSafety(ctx, nodeGroup, now)
 	condition := api.NodeGroupScaleUpCondition{
 		LastProbeTime: metav1.Time{Time: readiness.Time},
 	}
@@ -1100,7 +1099,7 @@ func (csr *ClusterStateRegistry) GetIncorrectNodeGroupSize(nodeGroupName string)
 // GetUpcomingNodes returns how many new nodes will be added shortly to the node groups or should become ready soon.
 // The function may overestimate the number of nodes. The second return value contains the names of upcoming nodes
 // that are already registered in the cluster.
-func (csr *ClusterStateRegistry) GetUpcomingNodes() (upcomingCounts map[string]int, registeredNodeNames map[string][]string) {
+func (csr *ClusterStateRegistry) GetUpcomingNodes(ctx context.Context) (upcomingCounts map[string]int, registeredNodeNames map[string][]string) {
 	csr.Lock()
 	defer csr.Unlock()
 
@@ -1133,7 +1132,7 @@ func (csr *ClusterStateRegistry) GetUpcomingNodes() (upcomingCounts map[string]i
 			klog.V(4).Infof("Skipping %d upcoming nodes for node group %s: no active scale-up request", newNodes, id)
 			continue
 		}
-		if backoffStatus := csr.BackoffStatusForNodeGroup(nodeGroup, time.Now()); backoffStatus.IsBackedOff {
+		if backoffStatus := csr.BackoffStatusForNodeGroup(ctx, nodeGroup, time.Now()); backoffStatus.IsBackedOff {
 			klog.V(4).Infof("Skipping %d upcoming nodes for backed-off node group %s: %s", newNodes, id, backoffStatus.ErrorInfo.ErrorMessage)
 			continue
 		}
@@ -1167,13 +1166,13 @@ func (csr *ClusterStateRegistry) getRunningNodeGroups() []cloudprovider.NodeGrou
 
 // getCloudProviderNodeInstances returns map keyed on node group id where value is list of node instances
 // as returned by NodeGroup.Nodes().
-func (csr *ClusterStateRegistry) getCloudProviderNodeInstances() (map[string][]cloudprovider.Instance, error) {
+func (csr *ClusterStateRegistry) getCloudProviderNodeInstances(ctx context.Context) (map[string][]cloudprovider.Instance, error) {
 	for _, nodeGroup := range csr.getRunningNodeGroups() {
-		if csr.IsNodeGroupScalingUp(nodeGroup.Id()) {
-			csr.cloudProviderNodeInstancesCache.InvalidateCacheEntry(nodeGroup)
+		if csr.IsNodeGroupScalingUp(ctx, nodeGroup.Id()) {
+			csr.cloudProviderNodeInstancesCache.InvalidateCacheEntry(ctx, nodeGroup)
 		}
 	}
-	return csr.cloudProviderNodeInstancesCache.GetCloudProviderNodeInstances()
+	return csr.cloudProviderNodeInstancesCache.GetCloudProviderNodeInstances(ctx)
 }
 
 // Calculates which of the existing cloud provider nodes are not yet registered in Kubernetes.
@@ -1203,17 +1202,17 @@ func expectedToRegister(instance cloudprovider.Instance) bool {
 }
 
 // Calculates which of the registered nodes in Kubernetes that do not exist in cloud provider.
-func (csr *ClusterStateRegistry) getCloudProviderDeletedNodes(allNodes []*apiv1.Node) []*apiv1.Node {
+func (csr *ClusterStateRegistry) getCloudProviderDeletedNodes(ctx context.Context, allNodes []*apiv1.Node) []*apiv1.Node {
 	nodesRemoved := make([]*apiv1.Node, 0)
 	for _, node := range allNodes {
-		if !csr.hasCloudProviderInstance(node) {
+		if !csr.hasCloudProviderInstance(ctx, node) {
 			nodesRemoved = append(nodesRemoved, node)
 		}
 	}
 	return nodesRemoved
 }
 
-func (csr *ClusterStateRegistry) hasCloudProviderInstance(node *apiv1.Node) bool {
+func (csr *ClusterStateRegistry) hasCloudProviderInstance(ctx context.Context, node *apiv1.Node) bool {
 	exists, err := csr.cloudProvider.HasInstance(node)
 	if err == nil {
 		return exists
@@ -1239,12 +1238,11 @@ func (csr *ClusterStateRegistry) GetAutoscaledNodesCount() (currentSize, targetS
 	return currentSize, targetSize
 }
 
-func (csr *ClusterStateRegistry) handleInstanceCreationErrors(currentTime time.Time) {
+func (csr *ClusterStateRegistry) handleInstanceCreationErrors(ctx context.Context, currentTime time.Time) {
 	nodeGroups := csr.getRunningNodeGroups()
 
 	for _, nodeGroup := range nodeGroups {
-		csr.handleInstanceCreationErrorsForNodeGroup(
-			nodeGroup,
+		csr.handleInstanceCreationErrorsForNodeGroup(ctx, nodeGroup,
 			csr.cloudProviderNodeInstances[nodeGroup.Id()],
 			csr.previousCloudProviderNodeInstances[nodeGroup.Id()],
 			currentTime)
@@ -1252,7 +1250,7 @@ func (csr *ClusterStateRegistry) handleInstanceCreationErrors(currentTime time.T
 }
 
 func (csr *ClusterStateRegistry) handleInstanceCreationErrorsForNodeGroup(
-	nodeGroup cloudprovider.NodeGroup,
+	ctx context.Context, nodeGroup cloudprovider.NodeGroup,
 	currentInstances []cloudprovider.Instance,
 	previousInstances []cloudprovider.Instance,
 	currentTime time.Time) {
@@ -1281,7 +1279,7 @@ func (csr *ClusterStateRegistry) handleInstanceCreationErrorsForNodeGroup(
 		}
 
 		klog.V(1).Infof("Failed adding %v nodes (%v unseen previously) to group %v due to %v; errorMessages=%#v", len(instances), len(unseenInstanceIds), nodeGroup.Id(), errorCode, currentUniqueErrorMessagesForErrorCode[errorCode])
-		if len(unseenInstanceIds) > 0 && csr.IsNodeGroupScalingUp(nodeGroup.Id()) {
+		if len(unseenInstanceIds) > 0 && csr.IsNodeGroupScalingUp(ctx, nodeGroup.Id()) {
 			csr.logRecorder.Eventf(
 				apiv1.EventTypeWarning,
 				"ScaleUpFailed",
@@ -1291,8 +1289,8 @@ func (csr *ClusterStateRegistry) handleInstanceCreationErrorsForNodeGroup(
 				errorCode,
 				csr.buildErrorMessageEventString(currentUniqueErrorMessagesForErrorCode[errorCode]))
 			// Decrease the scale up request by the number of deleted nodes
-			csr.registerOrUpdateScaleUpNoLock(nodeGroup, -len(unseenInstanceIds), currentTime)
-			csr.scaleStateNotifier.RegisterFailedScaleUp(nodeGroup, len(unseenInstanceIds), cloudprovider.InstanceErrorInfo{
+			csr.registerOrUpdateScaleUpNoLock(ctx, nodeGroup, -len(unseenInstanceIds), currentTime)
+			csr.scaleStateNotifier.RegisterFailedScaleUp(ctx, nodeGroup, len(unseenInstanceIds), cloudprovider.InstanceErrorInfo{
 				ErrorClass:   errorCode.class,
 				ErrorCode:    errorCode.code,
 				ErrorMessage: csr.buildErrorMessageEventString(currentUniqueErrorMessagesForErrorCode[errorCode]),
@@ -1378,8 +1376,8 @@ func (csr *ClusterStateRegistry) RefreshCloudProviderNodeInstancesCache() {
 }
 
 // InvalidateNodeInstancesCacheEntry removes a node group from the cloud provider node instances cache.
-func (csr *ClusterStateRegistry) InvalidateNodeInstancesCacheEntry(nodeGroup cloudprovider.NodeGroup) {
-	csr.cloudProviderNodeInstancesCache.InvalidateCacheEntry(nodeGroup)
+func (csr *ClusterStateRegistry) InvalidateNodeInstancesCacheEntry(ctx context.Context, nodeGroup cloudprovider.NodeGroup) {
+	csr.cloudProviderNodeInstancesCache.InvalidateCacheEntry(ctx, nodeGroup)
 }
 
 // FakeNode creates a fake node with Name field populated and FakeNodeReasonAnnotation added

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusterstate
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -99,20 +100,20 @@ func TestOKWithScaleUp(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: time.Minute}),
 		&emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 			MaxTotalUnreadyPercentage: 10,
 			OkTotalUnreadyCount:       1,
 		}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 4, time.Now())
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 4, time.Now())
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
 
-	status := clusterstate.GetStatus(now)
+	status := clusterstate.GetStatus(context.TODO(), now)
 	assert.Equal(t, api.ClusterAutoscalerInProgress, status.ClusterWide.ScaleUp.Status)
 	assert.Equal(t, 2, len(status.NodeGroups))
 	ng1Checked := false
@@ -139,7 +140,7 @@ func TestEmptyOK(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: time.Minute}),
@@ -147,24 +148,24 @@ func TestEmptyOK(t *testing.T) {
 			MaxTotalUnreadyPercentage: 10,
 			OkTotalUnreadyCount:       1,
 		}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{}, now.Add(-5*time.Second))
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now.Add(-5*time.Second))
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
-	assert.False(t, clusterstate.IsNodeGroupScalingUp("ng1"))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
+	assert.False(t, clusterstate.IsNodeGroupScalingUp(context.TODO(), "ng1"))
 	assert.False(t, clusterstate.HasNodeGroupStartedScaleUp("ng1"))
 
 	provider.AddNodeGroup("ng1", 0, 10, 3)
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 3, now.Add(-3*time.Second))
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 3, now.Add(-3*time.Second))
 	//	clusterstate.scaleUpRequests["ng1"].Time = now.Add(-3 * time.Second)
 	//	clusterstate.scaleUpRequests["ng1"].ExpectedAddTime = now.Add(1 * time.Minute)
-	err = clusterstate.UpdateNodes([]*apiv1.Node{}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
-	assert.True(t, clusterstate.IsNodeGroupScalingUp("ng1"))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
+	assert.True(t, clusterstate.IsNodeGroupScalingUp(context.TODO(), "ng1"))
 	assert.True(t, clusterstate.HasNodeGroupStartedScaleUp("ng1"))
 }
 
@@ -184,27 +185,27 @@ func TestHasNodeGroupStartedScaleUp(t *testing.T) {
 			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			provider.AddNodeGroup("ng1", 0, 5, tc.initialSize)
 			fakeClient := &fake.Clientset{}
-			fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+			fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 			clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: time.Minute}),
 				&emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 					MaxTotalUnreadyPercentage: 10,
 					OkTotalUnreadyCount:       1,
 				}))
-			err := clusterstate.UpdateNodes([]*apiv1.Node{}, now.Add(-5*time.Second))
+			err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now.Add(-5*time.Second))
 			assert.NoError(t, err)
-			assert.False(t, clusterstate.IsNodeGroupScalingUp("ng1"))
+			assert.False(t, clusterstate.IsNodeGroupScalingUp(context.TODO(), "ng1"))
 			assert.False(t, clusterstate.HasNodeGroupStartedScaleUp("ng1"))
 
 			provider.AddNodeGroup("ng1", 0, 5, tc.initialSize+tc.delta)
-			clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), tc.delta, now.Add(-3*time.Second))
-			err = clusterstate.UpdateNodes([]*apiv1.Node{}, now)
+			clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), tc.delta, now.Add(-3*time.Second))
+			err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 			assert.NoError(t, err)
-			assert.True(t, clusterstate.IsNodeGroupScalingUp("ng1"))
+			assert.True(t, clusterstate.IsNodeGroupScalingUp(context.TODO(), "ng1"))
 			assert.True(t, clusterstate.HasNodeGroupStartedScaleUp("ng1"))
 
 			provider.AddNodeGroup("ng1", 0, 5, tc.initialSize)
-			clusterstate.Recalculate()
-			assert.False(t, clusterstate.IsNodeGroupScalingUp("ng1"))
+			clusterstate.Recalculate(context.TODO())
+			assert.False(t, clusterstate.IsNodeGroupScalingUp(context.TODO(), "ng1"))
 			assert.True(t, clusterstate.HasNodeGroupStartedScaleUp("ng1"))
 		})
 	}
@@ -262,7 +263,7 @@ func TestRecalculateStateAfterNodeGroupSizeChanged(t *testing.T) {
 			provider := testprovider.NewTestCloudProviderBuilder().Build()
 			provider.AddNodeGroup(ngName, 0, 1000, tc.newTarget)
 
-			fakeLogRecorder, _ := utils.NewStatusMapRecorder(&fake.Clientset{}, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+			fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), &fake.Clientset{}, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 			clusterState := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{}), &emptyTemplateNodeInfoRegistry{})
 			clusterState.acceptableRanges = map[string]AcceptableRange{ngName: tc.acceptableRange}
 			clusterState.perNodeGroupReadiness = map[string]Readiness{ngName: tc.readiness}
@@ -270,9 +271,9 @@ func TestRecalculateStateAfterNodeGroupSizeChanged(t *testing.T) {
 				clusterState.scaleUpRequests = map[string]*ScaleUpRequest{ngName: tc.scaleUpRequest}
 			}
 
-			clusterState.Recalculate()
+			clusterState.Recalculate(context.TODO())
 			assert.Equal(t, tc.wantAcceptableRange, clusterState.acceptableRanges[ngName])
-			upcomingCounts, _ := clusterState.GetUpcomingNodes()
+			upcomingCounts, _ := clusterState.GetUpcomingNodes(context.TODO())
 			if upcoming, found := upcomingCounts[ngName]; found {
 				assert.Equal(t, tc.wantUpcoming, upcoming, "Unexpected upcoming nodes count, want: %d got: %d", tc.wantUpcoming, upcomingCounts[ngName])
 			}
@@ -296,20 +297,20 @@ func TestOKOneUnreadyNode(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
 
-	status := clusterstate.GetStatus(now)
+	status := clusterstate.GetStatus(context.TODO(), now)
 	assert.Equal(t, api.ClusterAutoscalerHealthy, status.ClusterWide.Health.Status)
 	assert.Equal(t, api.ClusterAutoscalerNoActivity, status.ClusterWide.ScaleUp.Status)
 
@@ -333,16 +334,16 @@ func TestNodeWithoutNodeGroupDontCrash(t *testing.T) {
 	provider.AddNode("no_ng", noNgNode)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{noNgNode}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{noNgNode}, now)
 	assert.NoError(t, err)
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
-	clusterstate.UpdateScaleDownCandidates([]*scaledown.UnneededNode{{Node: noNgNode}}, now)
+	clusterstate.UpdateScaleDownCandidates(context.TODO(), []*scaledown.UnneededNode{{Node: noNgNode}}, now)
 }
 
 func TestOKOneUnreadyNodeWithScaleDownCandidate(t *testing.T) {
@@ -361,21 +362,21 @@ func TestOKOneUnreadyNodeWithScaleDownCandidate(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
-	clusterstate.UpdateScaleDownCandidates([]*scaledown.UnneededNode{{Node: ng1_1}}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
+	clusterstate.UpdateScaleDownCandidates(context.TODO(), []*scaledown.UnneededNode{{Node: ng1_1}}, now)
 
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
 
-	status := clusterstate.GetStatus(now)
+	status := clusterstate.GetStatus(context.TODO(), now)
 	assert.Equal(t, api.ClusterAutoscalerHealthy, status.ClusterWide.Health.Status)
 	assert.Equal(t, api.ClusterAutoscalerNoActivity, status.ClusterWide.ScaleUp.Status)
 	assert.Equal(t, api.ClusterAutoscalerCandidatesPresent, status.ClusterWide.ScaleDown.Status)
@@ -416,19 +417,19 @@ func TestMissingNodes(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
-	assert.False(t, clusterstate.IsNodeGroupHealthy("ng1"))
+	assert.False(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
 
-	status := clusterstate.GetStatus(now)
+	status := clusterstate.GetStatus(context.TODO(), now)
 	assert.Equal(t, api.ClusterAutoscalerHealthy, status.ClusterWide.Health.Status)
 	assert.Equal(t, 2, len(status.NodeGroups))
 	ng1Checked := false
@@ -457,17 +458,17 @@ func TestTooManyUnready(t *testing.T) {
 
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 35 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.False(t, clusterstate.IsClusterHealthy())
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
 }
 
 func TestUnreadyLongAfterCreation(t *testing.T) {
@@ -487,16 +488,16 @@ func TestUnreadyLongAfterCreation(t *testing.T) {
 
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(clusterstate.GetClusterReadiness().Unready))
 	assert.Equal(t, 0, len(clusterstate.GetClusterReadiness().NotStarted))
-	upcoming, upcomingRegistered := clusterstate.GetUpcomingNodes()
+	upcoming, upcomingRegistered := clusterstate.GetUpcomingNodes(context.TODO())
 	assert.Equal(t, 0, upcoming["ng1"])
 	assert.Empty(t, upcomingRegistered["ng1"])
 }
@@ -518,16 +519,16 @@ func TestUnreadyAfterCreationWithIncreasedStartupTime(t *testing.T) {
 
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 35 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(clusterstate.GetClusterReadiness().Unready))
 	assert.Equal(t, 1, len(clusterstate.GetClusterReadiness().NotStarted))
-	upcoming, upcomingRegistered := clusterstate.GetUpcomingNodes()
+	upcoming, upcomingRegistered := clusterstate.GetUpcomingNodes(context.TODO())
 	assert.Equal(t, 0, upcoming["ng1"])
 	assert.Empty(t, upcomingRegistered["ng1"])
 }
@@ -550,26 +551,26 @@ func TestNotStarted(t *testing.T) {
 
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 35 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(clusterstate.GetClusterReadiness().NotStarted))
 	assert.Equal(t, 1, len(clusterstate.GetClusterReadiness().Ready))
 
 	// node ng2_1 moves condition to ready
 	SetNodeReadyState(ng2_1, true, now.Add(-4*time.Minute))
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(clusterstate.GetClusterReadiness().NotStarted))
 	assert.Equal(t, 1, len(clusterstate.GetClusterReadiness().Ready))
 
 	// node ng2_1 no longer has the taint
 	RemoveNodeNotReadyTaint(ng2_1)
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(clusterstate.GetClusterReadiness().NotStarted))
 	assert.Equal(t, 2, len(clusterstate.GetClusterReadiness().Ready))
@@ -592,19 +593,19 @@ func TestExpiredScaleUp(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 
 	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, withMetrics(mockMetrics, provider), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 4, now.Add(-3*time.Minute))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 4, now.Add(-3*time.Minute))
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, now)
 	assert.NoError(t, err)
 
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.Timeout, 4)
 	assert.True(t, clusterstate.IsClusterHealthy())
-	assert.False(t, clusterstate.IsNodeGroupHealthy("ng1"))
+	assert.False(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
 	assert.Equal(t, clusterstate.GetScaleUpFailures(), map[string][]scaleupfailures.Record{
 		"ng1": {
 			{
@@ -624,7 +625,7 @@ func TestRegisterScaleDown(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 35 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
@@ -633,7 +634,7 @@ func TestRegisterScaleDown(t *testing.T) {
 	now := time.Now()
 	clusterstate.RegisterScaleDown(provider.GetNodeGroup("ng1"), "ng1-1", now.Add(time.Minute), now)
 	assert.Equal(t, 1, len(clusterstate.scaleDownRequests))
-	clusterstate.updateScaleRequests(now.Add(5 * time.Minute))
+	clusterstate.updateScaleRequests(context.TODO(), now.Add(5*time.Minute))
 	assert.Equal(t, 0, len(clusterstate.scaleDownRequests))
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
 }
@@ -643,7 +644,7 @@ func TestNodeGroupScaleUpTime(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
@@ -662,7 +663,7 @@ func TestNodeGroupScaleUpTime(t *testing.T) {
 
 	// node group currently being scaled up
 	wantScaleUpTime := time.Now()
-	clusterstate.RegisterScaleUp(ng, 1, wantScaleUpTime)
+	clusterstate.RegisterScaleUp(context.TODO(), ng, 1, wantScaleUpTime)
 
 	gotScaleUpTime, err := clusterstate.NodeGroupScaleUpTime(ng)
 	assert.NoError(t, err)
@@ -718,21 +719,21 @@ func TestUpcomingNodes(t *testing.T) {
 
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 6, now)
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng2"), 1, now)
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng3"), 2, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 6, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng2"), 1, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng3"), 2, now)
 
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1, ng3_1, ng4_1, ng5_1, ng5_2}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1, ng3_1, ng4_1, ng5_1, ng5_2}, now)
 	assert.NoError(t, err)
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
 
-	upcomingNodes, upcomingRegistered := clusterstate.GetUpcomingNodes()
+	upcomingNodes, upcomingRegistered := clusterstate.GetUpcomingNodes(context.TODO())
 	assert.Equal(t, 6, upcomingNodes["ng1"])
 	assert.Empty(t, upcomingRegistered["ng1"]) // Only unregistered.
 	assert.Equal(t, 1, upcomingNodes["ng2"])
@@ -769,17 +770,17 @@ func TestTaintBasedNodeDeletion(t *testing.T) {
 
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	scaleUpFailuresRegistry := scaleupfailures.NewRegistry()
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_2}, now)
 	assert.NoError(t, err)
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
 
-	upcomingNodes, upcomingRegistered := clusterstate.GetUpcomingNodes()
+	upcomingNodes, upcomingRegistered := clusterstate.GetUpcomingNodes(context.TODO())
 	assert.Equal(t, 0, upcomingNodes["ng1"])
 	assert.Empty(t, upcomingRegistered["ng1"])
 }
@@ -791,26 +792,26 @@ func TestIncorrectSize(t *testing.T) {
 	provider.AddNode("ng1", ng1_1)
 	assert.NotNil(t, provider)
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
 	now := time.Now()
 
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, now.Add(-5*time.Minute))
+	clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, now.Add(-5*time.Minute))
 	incorrect := clusterstate.incorrectNodeGroupSizes["ng1"]
 	assert.Equal(t, 5, incorrect.ExpectedSize)
 	assert.Equal(t, 1, incorrect.CurrentSize)
 	assert.Equal(t, now.Add(-5*time.Minute), incorrect.FirstObserved)
 
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, now.Add(-4*time.Minute))
+	clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, now.Add(-4*time.Minute))
 	incorrect = clusterstate.incorrectNodeGroupSizes["ng1"]
 	assert.Equal(t, 5, incorrect.ExpectedSize)
 	assert.Equal(t, 1, incorrect.CurrentSize)
 	assert.Equal(t, now.Add(-5*time.Minute), incorrect.FirstObserved)
 
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1}, now.Add(-3*time.Minute))
+	clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_1}, now.Add(-3*time.Minute))
 	incorrect = clusterstate.incorrectNodeGroupSizes["ng1"]
 	assert.Equal(t, 5, incorrect.ExpectedSize)
 	assert.Equal(t, 2, incorrect.CurrentSize)
@@ -828,33 +829,33 @@ func TestUnregisteredNodes(t *testing.T) {
 	provider.AddNode("ng1", ng1_2)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 10 * time.Second}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 1, time.Now().Add(-time.Minute))
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 1, time.Now().Add(-time.Minute))
 
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, time.Now().Add(-time.Minute))
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, time.Now().Add(-time.Minute))
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(clusterstate.GetUnregisteredNodes()))
 	assert.Equal(t, "ng1-2", clusterstate.GetUnregisteredNodes()[0].Node.Name)
-	upcomingNodes, upcomingRegistered := clusterstate.GetUpcomingNodes()
+	upcomingNodes, upcomingRegistered := clusterstate.GetUpcomingNodes(context.TODO())
 	assert.Equal(t, 1, upcomingNodes["ng1"])
 	assert.Empty(t, upcomingRegistered["ng1"]) // Unregistered only.
 
 	// The node didn't come up in MaxNodeProvisionTime, it should no longer be
 	// counted as upcoming (but it is still an unregistered node)
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, time.Now().Add(time.Minute))
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, time.Now().Add(time.Minute))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(clusterstate.GetUnregisteredNodes()))
 	assert.Equal(t, "ng1-2", clusterstate.GetUnregisteredNodes()[0].Node.Name)
-	upcomingNodes, upcomingRegistered = clusterstate.GetUpcomingNodes()
+	upcomingNodes, upcomingRegistered = clusterstate.GetUpcomingNodes(context.TODO())
 	assert.Equal(t, 0, len(upcomingNodes))
 	assert.Empty(t, upcomingRegistered["ng1"])
 
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2}, time.Now().Add(time.Minute))
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_2}, time.Now().Add(time.Minute))
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(clusterstate.GetUnregisteredNodes()))
 }
@@ -879,13 +880,13 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	provider.AddNode("no_ng", noNgNode)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 10 * time.Second}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
 	now.Add(time.Minute)
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, noNgNode}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_2, noNgNode}, now)
 
 	// Nodes are registered correctly between Kubernetes and cloud provider.
 	assert.NoError(t, err)
@@ -896,10 +897,10 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	nodeGroup, err := provider.NodeGroupForNode(ng1_2)
 	assert.NoError(t, err)
 	provider.DeleteNode(ng1_2)
-	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
+	clusterstate.InvalidateNodeInstancesCacheEntry(context.TODO(), nodeGroup)
 	now.Add(time.Minute)
 
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, noNgNode}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_2, noNgNode}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 	assert.Equal(t, "ng1-2", GetCloudProviderDeletedNodeNames(clusterstate)[0])
@@ -908,7 +909,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	// The node is removed from Kubernetes
 	now.Add(time.Minute)
 
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, noNgNode}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 
@@ -917,10 +918,10 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	SetNodeReadyState(ng1_3, true, now.Add(-time.Minute))
 	ng1_3.Spec.ProviderID = "ng1-3"
 	provider.AddNode("ng1", ng1_3)
-	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
+	clusterstate.InvalidateNodeInstancesCacheEntry(context.TODO(), nodeGroup)
 	now.Add(time.Minute)
 
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_3, noNgNode}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_3, noNgNode}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 
@@ -929,10 +930,10 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	nodeGroup, err = provider.NodeGroupForNode(ng1_3)
 	assert.NoError(t, err)
 	provider.DeleteNode(ng1_3)
-	clusterstate.InvalidateNodeInstancesCacheEntry(nodeGroup)
+	clusterstate.InvalidateNodeInstancesCacheEntry(context.TODO(), nodeGroup)
 	now.Add(time.Minute)
 
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode, ng1_3}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, noNgNode, ng1_3}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 	assert.Equal(t, "ng1-3", GetCloudProviderDeletedNodeNames(clusterstate)[0])
@@ -942,7 +943,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	// until it is removed from Kubernetes
 	now.Add(time.Minute)
 
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode, ng1_3}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, noNgNode, ng1_3}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 	assert.Equal(t, "ng1-3", GetCloudProviderDeletedNodeNames(clusterstate)[0])
@@ -951,7 +952,7 @@ func TestCloudProviderDeletedNodes(t *testing.T) {
 	// The node is removed from Kubernetes
 	now.Add(time.Minute)
 
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, noNgNode}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, noNgNode}, now)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(GetCloudProviderDeletedNodeNames(clusterstate)))
 }
@@ -980,7 +981,7 @@ func TestScaleUpBackoff(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	nodeInfos := map[string]*framework.NodeInfo{
 		"ng1": framework.NewNodeInfo(ng1_1, nil),
 	}
@@ -992,13 +993,13 @@ func TestScaleUpBackoff(t *testing.T) {
 	}))
 
 	// After failed scale-up, node group should be still healthy, but should backoff from scale-ups
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 1, now.Add(-180*time.Second))
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, ng1_3}, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 1, now.Add(-180*time.Second))
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_2, ng1_3}, now)
 	assert.NoError(t, err)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.Timeout, 1)
 	assert.True(t, clusterstate.IsClusterHealthy())
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
 	assert.Equal(t, NodeGroupScalingSafety{
 		SafeToScale: false,
 		Healthy:     true,
@@ -1010,7 +1011,7 @@ func TestScaleUpBackoff(t *testing.T) {
 				ErrorMessage: "Scale-up timed out for node group ng1 after 3m0s",
 			},
 		},
-	}, clusterstate.NodeGroupScaleUpSafety(ng1, now))
+	}, clusterstate.NodeGroupScaleUpSafety(context.TODO(), ng1, now))
 	assert.Equal(t, backoff.Status{
 		IsBackedOff: true,
 		ErrorInfo: cloudprovider.InstanceErrorInfo{
@@ -1022,19 +1023,19 @@ func TestScaleUpBackoff(t *testing.T) {
 	// Backoff should expire after timeout
 	now = now.Add(5 * time.Minute /*InitialNodeGroupBackoffDuration*/).Add(time.Second)
 	assert.True(t, clusterstate.IsClusterHealthy())
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
-	assert.Equal(t, NodeGroupScalingSafety{SafeToScale: true, Healthy: true}, clusterstate.NodeGroupScaleUpSafety(ng1, now))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
+	assert.Equal(t, NodeGroupScalingSafety{SafeToScale: true, Healthy: true}, clusterstate.NodeGroupScaleUpSafety(context.TODO(), ng1, now))
 
 	// Reset target size (it was decreased when the previous scale-up timed out and was reverted)
 	ng1.(*testprovider.TestNodeGroup).SetTargetSize(4)
 
 	// Another failed scale up should cause longer backoff
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 1, now.Add(-121*time.Second))
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 1, now.Add(-121*time.Second))
 
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, ng1_3}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_2, ng1_3}, now)
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
 	assert.Equal(t, NodeGroupScalingSafety{
 		SafeToScale: false,
 		Healthy:     true,
@@ -1046,7 +1047,7 @@ func TestScaleUpBackoff(t *testing.T) {
 				ErrorMessage: "Scale-up timed out for node group ng1 after 2m1s",
 			},
 		},
-	}, clusterstate.NodeGroupScaleUpSafety(ng1, now))
+	}, clusterstate.NodeGroupScaleUpSafety(context.TODO(), ng1, now))
 
 	now = now.Add(5 * time.Minute /*InitialNodeGroupBackoffDuration*/).Add(time.Second)
 	assert.Equal(t, NodeGroupScalingSafety{
@@ -1060,17 +1061,17 @@ func TestScaleUpBackoff(t *testing.T) {
 				ErrorMessage: "Scale-up timed out for node group ng1 after 2m1s",
 			},
 		},
-	}, clusterstate.NodeGroupScaleUpSafety(ng1, now))
+	}, clusterstate.NodeGroupScaleUpSafety(context.TODO(), ng1, now))
 
 	// After successful scale-up, node group should still be backed off
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 1, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 1, now)
 	ng1_4 := BuildTestNode("ng1-4", 1000, 1000)
 	SetNodeReadyState(ng1_4, true, now.Add(-1*time.Minute))
 	provider.AddNode("ng1", ng1_4)
-	err = clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2, ng1_3, ng1_4}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_2, ng1_3, ng1_4}, now)
 	assert.NoError(t, err)
 	assert.True(t, clusterstate.IsClusterHealthy())
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
 	assert.Equal(t, NodeGroupScalingSafety{
 		SafeToScale: false,
 		Healthy:     true,
@@ -1082,7 +1083,7 @@ func TestScaleUpBackoff(t *testing.T) {
 				ErrorMessage: "Scale-up timed out for node group ng1 after 2m1s",
 			},
 		},
-	}, clusterstate.NodeGroupScaleUpSafety(ng1, now))
+	}, clusterstate.NodeGroupScaleUpSafety(context.TODO(), ng1, now))
 	assert.Equal(t, backoff.Status{
 		IsBackedOff: true,
 		ErrorInfo: cloudprovider.InstanceErrorInfo{
@@ -1114,27 +1115,27 @@ func TestGetClusterSize(t *testing.T) {
 	provider.AddNode("notAutoscaledNode", notAutoscaledNode)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
 
 	// There are 2 actual nodes in 2 node groups with target sizes of 5 and 1.
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng2_1, notAutoscaledNode}, now)
+	clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng2_1, notAutoscaledNode}, now)
 	currentSize, targetSize := clusterstate.GetAutoscaledNodesCount()
 	assert.Equal(t, 2, currentSize)
 	assert.Equal(t, 6, targetSize)
 
 	// Current size should increase after a new node is added.
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, now.Add(time.Minute))
+	clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, now.Add(time.Minute))
 	currentSize, targetSize = clusterstate.GetAutoscaledNodesCount()
 	assert.Equal(t, 3, currentSize)
 	assert.Equal(t, 6, targetSize)
 
 	// Target size should increase after a new node group is added.
 	provider.AddNodeGroup("ng3", 1, 10, 1)
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, now.Add(2*time.Minute))
+	clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, now.Add(2*time.Minute))
 	currentSize, targetSize = clusterstate.GetAutoscaledNodesCount()
 	assert.Equal(t, 3, currentSize)
 	assert.Equal(t, 7, targetSize)
@@ -1143,7 +1144,7 @@ func TestGetClusterSize(t *testing.T) {
 	for _, ng := range provider.NodeGroups() {
 		ng.(*testprovider.TestNodeGroup).SetTargetSize(10)
 	}
-	clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, now.Add(3*time.Minute))
+	clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_1, notAutoscaledNode, ng2_1}, now.Add(3*time.Minute))
 	currentSize, targetSize = clusterstate.GetAutoscaledNodesCount()
 	assert.Equal(t, 3, currentSize)
 	assert.Equal(t, 30, targetSize)
@@ -1157,7 +1158,7 @@ func TestUpdateScaleUp(t *testing.T) {
 	provider.AddNodeGroup("ng1", 1, 10, 5)
 	provider.AddNodeGroup("ng2", 1, 10, 5)
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	clusterstate := NewClusterStateRegistry(
 		provider,
 		fakeLogRecorder,
@@ -1171,29 +1172,29 @@ func TestUpdateScaleUp(t *testing.T) {
 	)
 
 	// Test cases for `RegisterScaleUp`
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 100, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 100, now)
 	assert.Equal(t, clusterstate.scaleUpRequests["ng1"].Increase, 100)
 	assert.Equal(t, clusterstate.scaleUpRequests["ng1"].Time, now)
 	assert.Equal(t, clusterstate.scaleUpRequests["ng1"].ExpectedAddTime, now.Add(10*time.Second))
 
 	// expect no change of times on negative delta
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), -20, later)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), -20, later)
 	assert.Equal(t, clusterstate.scaleUpRequests["ng1"].Increase, 80)
 	assert.Equal(t, clusterstate.scaleUpRequests["ng1"].Time, now)
 	assert.Equal(t, clusterstate.scaleUpRequests["ng1"].ExpectedAddTime, now.Add(10*time.Second))
 
 	// update times on positive delta
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 30, later)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 30, later)
 	assert.Equal(t, clusterstate.scaleUpRequests["ng1"].Increase, 110)
 	assert.Equal(t, clusterstate.scaleUpRequests["ng1"].Time, later)
 	assert.Equal(t, clusterstate.scaleUpRequests["ng1"].ExpectedAddTime, later.Add(10*time.Second))
 
 	// if we get below 0 scalup is deleted
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), -200, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), -200, now)
 	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
 
 	// If new scalup is registered with negative delta nothing should happen
-	clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), -200, now)
+	clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), -200, now)
 	assert.Nil(t, clusterstate.scaleUpRequests["ng1"])
 }
 
@@ -1206,7 +1207,7 @@ func TestScaleUpFailures(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
@@ -1215,13 +1216,13 @@ func TestScaleUpFailures(t *testing.T) {
 
 	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, withMetrics(mockMetrics, provider), withNotifiedScaleUpFailuresRegistry(scaleUpFailuresRegistry))
 
-	clusterstate.scaleStateNotifier.RegisterFailedScaleUp(provider.GetNodeGroup("ng1"), 3, cloudprovider.InstanceErrorInfo{ErrorCode: string(metrics.Timeout)}, now)
+	clusterstate.scaleStateNotifier.RegisterFailedScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 3, cloudprovider.InstanceErrorInfo{ErrorCode: string(metrics.Timeout)}, now)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.Timeout, 3)
-	clusterstate.scaleStateNotifier.RegisterFailedScaleUp(provider.GetNodeGroup("ng2"), 2, cloudprovider.InstanceErrorInfo{ErrorCode: string(metrics.Timeout)}, now)
+	clusterstate.scaleStateNotifier.RegisterFailedScaleUp(context.TODO(), provider.GetNodeGroup("ng2"), 2, cloudprovider.InstanceErrorInfo{ErrorCode: string(metrics.Timeout)}, now)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.Timeout, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.Timeout, 2)
-	clusterstate.scaleStateNotifier.RegisterFailedScaleUp(provider.GetNodeGroup("ng1"), 1, cloudprovider.InstanceErrorInfo{ErrorCode: string(metrics.APIError)}, now.Add(time.Minute))
+	clusterstate.scaleStateNotifier.RegisterFailedScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 1, cloudprovider.InstanceErrorInfo{ErrorCode: string(metrics.APIError)}, now.Add(time.Minute))
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.APIError, "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.APIError, 1)
 
@@ -1236,7 +1237,7 @@ func TestScaleUpFailures(t *testing.T) {
 		},
 	}, failures)
 
-	scaleUpFailuresRegistry.Refresh()
+	scaleUpFailuresRegistry.Refresh(context.TODO())
 	assert.Empty(t, clusterstate.GetScaleUpFailures())
 }
 
@@ -1557,7 +1558,7 @@ func TestUpdateIncorrectNodeGroupSizes(t *testing.T) {
 				asyncNodeGroupStateChecker: asyncnodegroups.NewDefaultAsyncNodeGroupStateChecker(),
 			}
 
-			clusterState.updateIncorrectNodeGroupSizes(timeNow)
+			clusterState.updateIncorrectNodeGroupSizes(context.TODO(), timeNow)
 			assert.Equal(t, tc.wantIncorrectSizes, clusterState.incorrectNodeGroupSizes)
 		})
 	}
@@ -1609,7 +1610,7 @@ func TestIsNodeGroupRegistered(t *testing.T) {
 	registeredNodeGroupName := "registered-node-group"
 	provider.AddNodeGroup(registeredNodeGroupName, 1, 10, 1)
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
 	clusterstate := NewClusterStateRegistry(
 		provider,
 		fakeLogRecorder,
@@ -1618,7 +1619,7 @@ func TestIsNodeGroupRegistered(t *testing.T) {
 		&emptyTemplateNodeInfoRegistry{},
 		WithConfig(ClusterStateRegistryConfig{MaxTotalUnreadyPercentage: 10, OkTotalUnreadyCount: 1}),
 	)
-	clusterstate.Recalculate()
+	clusterstate.Recalculate(context.TODO())
 
 	testCases := []struct {
 		nodeGroupName string
@@ -1694,7 +1695,7 @@ func TestUpcomingNodesFromUpcomingNodeGroups(t *testing.T) {
 
 		assert.NotNil(t, provider)
 		fakeClient := &fake.Clientset{}
-		fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
+		fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "some-map")
 
 		clusterstate := NewClusterStateRegistry(
 			provider,
@@ -1707,16 +1708,16 @@ func TestUpcomingNodesFromUpcomingNodeGroups(t *testing.T) {
 		)
 
 		for groupName, delta := range tc.scaleUpGroups {
-			clusterstate.RegisterScaleUp(provider.GetNodeGroup(groupName), delta, now)
+			clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup(groupName), delta, now)
 		}
 		if tc.updateNodes {
-			err := clusterstate.UpdateNodes([]*apiv1.Node{}, now)
+			err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 			assert.NoError(t, err)
 		}
 
 		assert.Equal(t, 0, len(clusterstate.GetClusterReadiness().Unready))
 		assert.Equal(t, 0, len(clusterstate.GetClusterReadiness().NotStarted))
-		upcoming, upcomingRegistered := clusterstate.GetUpcomingNodes()
+		upcoming, upcomingRegistered := clusterstate.GetUpcomingNodes(context.TODO())
 		for groupName, groupSize := range tc.expectedGroupsUpcomingNodesNumber {
 			assert.Equal(t, groupSize, upcoming[groupName])
 			assert.Empty(t, upcomingRegistered[groupName])
@@ -1763,15 +1764,15 @@ func TestHandleInstanceCreationErrors(t *testing.T) {
 	provider.InsertNodeGroup(mockedNodeGroup)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, withMetrics(mockMetrics, provider))
-	clusterstate.RegisterScaleUp(mockedNodeGroup, 1, now)
+	clusterstate.RegisterScaleUp(context.TODO(), mockedNodeGroup, 1, now)
 
 	// UpdateNodes will trigger handleInstanceCreationErrors
-	err := clusterstate.UpdateNodes([]*apiv1.Node{}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 	assert.NoError(t, err)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "", "", "")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 2)
@@ -1817,15 +1818,15 @@ func TestFailedScaleUpWithDra(t *testing.T) {
 	provider.InsertNodeGroup(mockedNodeGroup)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, withMetrics(mockMetrics, provider))
-	clusterstate.RegisterScaleUp(mockedNodeGroup, 1, now)
+	clusterstate.RegisterScaleUp(context.TODO(), mockedNodeGroup, 1, now)
 
 	// UpdateNodes will trigger handleInstanceCreationErrors
-	err := clusterstate.UpdateNodes([]*apiv1.Node{}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 	assert.NoError(t, err)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "", "", "custom.driver,dra.net")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 1)
@@ -1878,15 +1879,15 @@ func TestFailedScaleUpWithDraAndGpu(t *testing.T) {
 	provider.InsertNodeGroup(mockedNodeGroup)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
 	clusterstate := newTestClusterStateRegistry(provider, fakeLogRecorder, withMetrics(mockMetrics, provider))
-	clusterstate.RegisterScaleUp(mockedNodeGroup, 1, now)
+	clusterstate.RegisterScaleUp(context.TODO(), mockedNodeGroup, 1, now)
 
 	// UpdateNodes will trigger handleInstanceCreationErrors
-	err := clusterstate.UpdateNodes([]*apiv1.Node{}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 	assert.NoError(t, err)
 	mockMetrics.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), "dra_gpu-driver", "not-listed", "custom.driver,dra.net")
 	mockMetrics.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("RESOURCE_POOL_EXHAUSTED"), 1)
@@ -1905,7 +1906,7 @@ func TestGetUpcomingNodesSkipsWithoutScaleUpRequestOrBackoff(t *testing.T) {
 	provider.AddNode("ng1", ng1_1)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system",
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system",
 		kube_record.NewFakeRecorder(5), false, "configmap-1")
 
 	t.Run("no scale-up request means no upcoming nodes", func(t *testing.T) {
@@ -1917,10 +1918,10 @@ func TestGetUpcomingNodesSkipsWithoutScaleUpRequestOrBackoff(t *testing.T) {
 			}))
 
 		// NO RegisterScaleUp — simulates expired/removed request
-		err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, now)
+		err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, now)
 		assert.NoError(t, err)
 
-		upcomingNodes, _ := clusterstate.GetUpcomingNodes()
+		upcomingNodes, _ := clusterstate.GetUpcomingNodes(context.TODO())
 		// Bug fix: without a scale-up request, upcoming should be 0
 		// even though target (3) > ready nodes (1).
 		assert.Equal(t, 0, upcomingNodes["ng1"])
@@ -1935,11 +1936,11 @@ func TestGetUpcomingNodesSkipsWithoutScaleUpRequestOrBackoff(t *testing.T) {
 				OkTotalUnreadyCount:       1,
 			}))
 
-		clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 2, now)
-		err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, now)
+		clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 2, now)
+		err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, now)
 		assert.NoError(t, err)
 
-		upcomingNodes, _ := clusterstate.GetUpcomingNodes()
+		upcomingNodes, _ := clusterstate.GetUpcomingNodes(context.TODO())
 		assert.Equal(t, 2, upcomingNodes["ng1"])
 	})
 
@@ -1961,14 +1962,14 @@ func TestGetUpcomingNodesSkipsWithoutScaleUpRequestOrBackoff(t *testing.T) {
 		}))
 
 		// Register scale-up 3 minutes ago with 2-minute provision time → will timeout
-		clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 2, now.Add(-3*time.Minute))
-		err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1}, now)
+		clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 2, now.Add(-3*time.Minute))
+		err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, now)
 		assert.NoError(t, err)
 
 		// After timeout, group is in backoff. Register a new scale-up request.
-		clusterstate.RegisterScaleUp(provider.GetNodeGroup("ng1"), 2, now)
+		clusterstate.RegisterScaleUp(context.TODO(), provider.GetNodeGroup("ng1"), 2, now)
 
-		upcomingNodes, _ := clusterstate.GetUpcomingNodes()
+		upcomingNodes, _ := clusterstate.GetUpcomingNodes(context.TODO())
 		// Bug fix: backed-off group should not report upcoming nodes.
 		assert.Equal(t, 0, upcomingNodes["ng1"])
 	})
@@ -2005,11 +2006,11 @@ func TestSuspendedNodes(t *testing.T) {
 	provider.AddNode("ng1", ng1_2)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{},
 		WithConfig(ClusterStateRegistryConfig{MaxTotalUnreadyPercentage: 10, OkTotalUnreadyCount: 1}))
 
-	err := clusterstate.UpdateNodes([]*apiv1.Node{ng1_1, ng1_2}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1, ng1_2}, now)
 	assert.NoError(t, err)
 
 	// Check readiness stats
@@ -2024,15 +2025,15 @@ func TestSuspendedNodes(t *testing.T) {
 
 	// Check node group health - Suspended nodes should count towards health
 	// Target is 2, 1 Ready + 1 Suspended = 2. Should be healthy.
-	assert.True(t, clusterstate.IsNodeGroupHealthy("ng1"))
+	assert.True(t, clusterstate.IsNodeGroupHealthy(context.TODO(), "ng1"))
 
 	// Check upcoming nodes
 	// Target is 2, 1 Ready + 1 Suspended = 2. Upcoming should be 0.
-	upcomingNodes, _ := clusterstate.GetUpcomingNodes()
+	upcomingNodes, _ := clusterstate.GetUpcomingNodes(context.TODO())
 	assert.Equal(t, 0, upcomingNodes["ng1"])
 
 	// Check status
-	status := clusterstate.GetStatus(now)
+	status := clusterstate.GetStatus(context.TODO(), now)
 	assert.Equal(t, 1, status.ClusterWide.Health.NodeCounts.Registered.Suspended)
 }
 
@@ -2118,7 +2119,7 @@ func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
 	provider.InsertNodeGroup(mockedNodeGroup)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
@@ -2135,10 +2136,10 @@ func TestExpiredScaleUpRevertsTargetSize(t *testing.T) {
 	)
 
 	// Register scale up that started 3 minutes ago (exceeded 2 min max provision time)
-	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
+	clusterstate.RegisterScaleUp(context.TODO(), mockedNodeGroup, 4, now.Add(-3*time.Minute))
 
 	// UpdateNodes should detect the timeout and call DecreaseTargetSize
-	err := clusterstate.UpdateNodes([]*apiv1.Node{}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 	assert.NoError(t, err)
 
 	// Verify DecreaseTargetSize was called with negative delta equal to the increase
@@ -2183,7 +2184,7 @@ func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
 	// set up a fake recorder to capture events so we can assert on them later
 	fakeClient := &fake.Clientset{}
 	fakeRecorder := kube_record.NewFakeRecorder(10)
-	fakeLogRecorder, err := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, true, "my-cool-configmap")
+	fakeLogRecorder, err := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", fakeRecorder, true, "my-cool-configmap")
 	assert.Nil(t, err)
 
 	mockMetrics := &mockMetrics{}
@@ -2202,10 +2203,10 @@ func TestExpiredScaleUpRevertsTargetSizeHandlesError(t *testing.T) {
 	)
 
 	// Register scale up that started 3 minutes ago (exceeded 2 min max provision time)
-	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
+	clusterstate.RegisterScaleUp(context.TODO(), mockedNodeGroup, 4, now.Add(-3*time.Minute))
 
 	// UpdateNodes should detect the timeout and attempt to call DecreaseTargetSize
-	err = clusterstate.UpdateNodes([]*apiv1.Node{}, now)
+	err = clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 	assert.NoError(t, err)
 
 	// Verify DecreaseTargetSize was called even though it returned an error
@@ -2276,7 +2277,7 @@ func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
 	provider.InsertNodeGroup(mockedNodeGroup)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterFailedScaleUp", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockMetrics.On("RegisterFailedNodeCreations", mock.Anything, mock.Anything).Return()
@@ -2293,10 +2294,10 @@ func TestExpiredScaleUpRevertsPartialIncrease(t *testing.T) {
 	)
 
 	// Register scale up requesting 4 nodes that started 3 minutes ago
-	clusterstate.RegisterScaleUp(mockedNodeGroup, 4, now.Add(-3*time.Minute))
+	clusterstate.RegisterScaleUp(context.TODO(), mockedNodeGroup, 4, now.Add(-3*time.Minute))
 
 	// UpdateNodes should detect the timeout and revert the _entire_ recorded increase
-	err := clusterstate.UpdateNodes([]*apiv1.Node{node, node2}, now)
+	err := clusterstate.UpdateNodes(context.TODO(), []*apiv1.Node{node, node2}, now)
 	assert.NoError(t, err)
 
 	// Verify DecreaseTargetSize was called with the full original increase,

--- a/cluster-autoscaler/clusterstate/scaleupfailures/scale_up_failures.go
+++ b/cluster-autoscaler/clusterstate/scaleupfailures/scale_up_failures.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaleupfailures
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -44,7 +45,7 @@ func NewRegistry() *Registry {
 }
 
 // RegisterScaleUp records when the last scale up happened for a nodegroup.
-func (s *Registry) RegisterScaleUp(_ cloudprovider.NodeGroup,
+func (s *Registry) RegisterScaleUp(ctx context.Context, _ cloudprovider.NodeGroup,
 	_ int, _ time.Time) {
 }
 
@@ -54,7 +55,7 @@ func (s *Registry) RegisterScaleDown(_ cloudprovider.NodeGroup,
 }
 
 // RegisterFailedScaleUp records when the last scale up failed for a nodegroup.
-func (s *Registry) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int,
+func (s *Registry) RegisterFailedScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int,
 	errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -67,7 +68,7 @@ func (s *Registry) RegisterFailedScaleDown(_ cloudprovider.NodeGroup,
 }
 
 // Refresh clears the scale-up failures.
-func (s *Registry) Refresh() {
+func (s *Registry) Refresh(ctx context.Context) {
 	s.clear()
 }
 

--- a/cluster-autoscaler/clusterstate/utils/node_instances_cache.go
+++ b/cluster-autoscaler/clusterstate/utils/node_instances_cache.go
@@ -93,6 +93,7 @@ func (cache *CloudProviderNodeInstancesCache) removeEntriesForNonExistingNodeGro
 
 // GetCloudProviderNodeInstances returns cloud provider node instances for all node groups returned by cloud provider.
 func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstances(ctx context.Context) (map[string][]cloudprovider.Instance, error) {
+	logger := klog.FromContext(ctx)
 	nodeGroups := cache.cloudProvider.NodeGroups()
 
 	// Fetch missing node instances.
@@ -104,7 +105,7 @@ func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstances(ctx 
 			go func() {
 				defer wg.Done()
 				if _, err := cache.fetchCloudProviderNodeInstancesForNodeGroup(nodeGroup); err != nil {
-					klog.Errorf("Failed to fetch cloud provider node instances for %v, error %v", nodeGroup.Id(), err)
+					logger.Error(err, "Failed to fetch cloud provider node instances", "nodeGroupId", nodeGroup.Id())
 				}
 			}()
 		}
@@ -125,15 +126,16 @@ func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstances(ctx 
 
 // GetCloudProviderNodeInstancesForNodeGroup returns cloud provider node instances for the given node group.
 func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstancesForNodeGroup(ctx context.Context, nodeGroup cloudprovider.NodeGroup) ([]cloudprovider.Instance, error) {
+	logger := klog.FromContext(ctx)
 	cacheEntry, found := cache.getCacheEntryLocked(nodeGroup)
 	if found {
 		if cacheEntry.isStale() {
-			klog.Warningf("Entry cloudProviderNodeInstances is stale, refresh time is %v", cacheEntry.refreshTime)
+			logger.Info("Entry cloudProviderNodeInstances is stale, refresh time is", "refreshTime", cacheEntry.refreshTime)
 		}
-		klog.V(5).Infof("Get cached cloud provider node instances for %v", nodeGroup.Id())
+		logger.V(5).Info("Get cached cloud provider node instances", "nodeGroupId", nodeGroup.Id())
 		return cacheEntry.instances, nil
 	}
-	klog.V(5).Infof("Cloud provider node instances for %v hasn't been found in cache, fetch from cloud provider", nodeGroup.Id())
+	logger.V(5).Info("Cloud provider node instances hasn't been found in cache, fetch from cloud provider", "nodeGroupId", nodeGroup.Id())
 	return cache.fetchCloudProviderNodeInstancesForNodeGroup(nodeGroup)
 }
 
@@ -148,7 +150,8 @@ func (cache *CloudProviderNodeInstancesCache) fetchCloudProviderNodeInstancesFor
 
 // InvalidateCacheEntry removes entry for the given node group from cache.
 func (cache *CloudProviderNodeInstancesCache) InvalidateCacheEntry(ctx context.Context, nodeGroup cloudprovider.NodeGroup) {
-	klog.V(5).Infof("Invalidate entry in cloud provider node instances cache %v", nodeGroup.Id())
+	logger := klog.FromContext(ctx)
+	logger.V(5).Info("Invalidate entry in cloud provider node instances cache", "nodeGroupId", nodeGroup.Id())
 	cache.removeCacheEntryLocked(nodeGroup)
 }
 

--- a/cluster-autoscaler/clusterstate/utils/node_instances_cache.go
+++ b/cluster-autoscaler/clusterstate/utils/node_instances_cache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -91,7 +92,7 @@ func (cache *CloudProviderNodeInstancesCache) removeEntriesForNonExistingNodeGro
 }
 
 // GetCloudProviderNodeInstances returns cloud provider node instances for all node groups returned by cloud provider.
-func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstances() (map[string][]cloudprovider.Instance, error) {
+func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstances(ctx context.Context) (map[string][]cloudprovider.Instance, error) {
 	nodeGroups := cache.cloudProvider.NodeGroups()
 
 	// Fetch missing node instances.
@@ -113,7 +114,7 @@ func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstances() (m
 	// Get data from cache.
 	results := map[string][]cloudprovider.Instance{}
 	for _, nodeGroup := range nodeGroups {
-		nodeGroupInstances, err := cache.GetCloudProviderNodeInstancesForNodeGroup(nodeGroup)
+		nodeGroupInstances, err := cache.GetCloudProviderNodeInstancesForNodeGroup(ctx, nodeGroup)
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +124,7 @@ func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstances() (m
 }
 
 // GetCloudProviderNodeInstancesForNodeGroup returns cloud provider node instances for the given node group.
-func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstancesForNodeGroup(nodeGroup cloudprovider.NodeGroup) ([]cloudprovider.Instance, error) {
+func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstancesForNodeGroup(ctx context.Context, nodeGroup cloudprovider.NodeGroup) ([]cloudprovider.Instance, error) {
 	cacheEntry, found := cache.getCacheEntryLocked(nodeGroup)
 	if found {
 		if cacheEntry.isStale() {
@@ -146,7 +147,7 @@ func (cache *CloudProviderNodeInstancesCache) fetchCloudProviderNodeInstancesFor
 }
 
 // InvalidateCacheEntry removes entry for the given node group from cache.
-func (cache *CloudProviderNodeInstancesCache) InvalidateCacheEntry(nodeGroup cloudprovider.NodeGroup) {
+func (cache *CloudProviderNodeInstancesCache) InvalidateCacheEntry(ctx context.Context, nodeGroup cloudprovider.NodeGroup) {
 	klog.V(5).Infof("Invalidate entry in cloud provider node instances cache %v", nodeGroup.Id())
 	cache.removeCacheEntryLocked(nodeGroup)
 }

--- a/cluster-autoscaler/clusterstate/utils/node_instances_cache_test.go
+++ b/cluster-autoscaler/clusterstate/utils/node_instances_cache_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -71,21 +72,21 @@ func TestCloudProviderNodeInstancesCache(t *testing.T) {
 	}
 
 	// Fetch stale instances.
-	results, err := cache.GetCloudProviderNodeInstances()
+	results, err := cache.GetCloudProviderNodeInstances(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, map[string][]cloudprovider.Instance{"ng1": {instanceNg1_1}, "ng2": {instanceNg2_1}, "ng3": {instanceNg3_1}}, results)
 	assert.Equal(t, 4, len(cache.cloudProviderNodeInstances))
 
 	// Invalidate entry in cache.
-	cache.InvalidateCacheEntry(provider.GetNodeGroup("ng2"))
-	results, err = cache.GetCloudProviderNodeInstances()
+	cache.InvalidateCacheEntry(context.TODO(), provider.GetNodeGroup("ng2"))
+	results, err = cache.GetCloudProviderNodeInstances(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, map[string][]cloudprovider.Instance{"ng1": {instanceNg1_1}, "ng2": {instanceNg2_2}, "ng3": {instanceNg3_1}}, results)
 	assert.Equal(t, 4, len(cache.cloudProviderNodeInstances))
 
 	// Refresh cache.
 	cache.Refresh()
-	results, err = cache.GetCloudProviderNodeInstances()
+	results, err = cache.GetCloudProviderNodeInstances(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, map[string][]cloudprovider.Instance{"ng1": {instanceNg1_1}, "ng2": {instanceNg2_2}, "ng3": {instanceNg3_2}}, results)
 	assert.Equal(t, 3, len(cache.cloudProviderNodeInstances))

--- a/cluster-autoscaler/clusterstate/utils/status.go
+++ b/cluster-autoscaler/clusterstate/utils/status.go
@@ -92,6 +92,7 @@ func NewStatusMapRecorder(ctx context.Context, kubeClient kube_client.Interface,
 // ConfigMap if it doesn't exist. If logRecorder is passed and configmap update is successful
 // logRecorder's internal reference will be updated.
 func WriteStatusConfigMap(ctx context.Context, kubeClient kube_client.Interface, namespace string, status api.ClusterAutoscalerStatus, logRecorder *LogEventRecorder, statusConfigMapName string, currentTime time.Time) (*apiv1.ConfigMap, error) {
+	logger := klog.FromContext(ctx)
 	statusUpdateTime := currentTime.Format(ConfigMapLastUpdateFormat)
 	status.Time = statusUpdateTime
 	var configMap *apiv1.ConfigMap
@@ -135,10 +136,10 @@ func WriteStatusConfigMap(ctx context.Context, kubeClient kube_client.Interface,
 		errMsg = fmt.Sprintf("Failed to write status configmap: %v", writeStatusError)
 	}
 	if errMsg != "" {
-		klog.Error(errMsg)
+		logger.Error(nil, errMsg)
 		return nil, errors.New(errMsg)
 	}
-	klog.V(8).Infof("Successfully wrote status configmap with body \"%v\"", statusMsg)
+	logger.V(8).Info("Successfully wrote status configmap", "statusMsg", statusMsg)
 	// Having this as a side-effect is somewhat ugly
 	// But it makes error handling easier, as we get a free retry each loop
 	if logRecorder != nil {

--- a/cluster-autoscaler/clusterstate/utils/status.go
+++ b/cluster-autoscaler/clusterstate/utils/status.go
@@ -72,11 +72,11 @@ func EmptyClusterAutoscalerStatus() *api.ClusterAutoscalerStatus {
 // NewStatusMapRecorder creates a LogEventRecorder creating events on status configmap.
 // If the configmap doesn't exist it will be created (with 'Initializing' status).
 // If active == false the map will not be created and no events will be recorded.
-func NewStatusMapRecorder(kubeClient kube_client.Interface, namespace string, recorder record.EventRecorder, active bool, statusConfigMapName string) (*LogEventRecorder, error) {
+func NewStatusMapRecorder(ctx context.Context, kubeClient kube_client.Interface, namespace string, recorder record.EventRecorder, active bool, statusConfigMapName string) (*LogEventRecorder, error) {
 	var mapObj runtime.Object
 	var err error
 	if active {
-		mapObj, err = WriteStatusConfigMap(kubeClient, namespace, *EmptyClusterAutoscalerStatus(), nil, statusConfigMapName, time.Now())
+		mapObj, err = WriteStatusConfigMap(ctx, kubeClient, namespace, *EmptyClusterAutoscalerStatus(), nil, statusConfigMapName, time.Now())
 		if err != nil {
 			return nil, errors.New("Failed to init status ConfigMap")
 		}
@@ -91,14 +91,14 @@ func NewStatusMapRecorder(kubeClient kube_client.Interface, namespace string, re
 // WriteStatusConfigMap writes updates status ConfigMap with a given message or creates a new
 // ConfigMap if it doesn't exist. If logRecorder is passed and configmap update is successful
 // logRecorder's internal reference will be updated.
-func WriteStatusConfigMap(kubeClient kube_client.Interface, namespace string, status api.ClusterAutoscalerStatus, logRecorder *LogEventRecorder, statusConfigMapName string, currentTime time.Time) (*apiv1.ConfigMap, error) {
+func WriteStatusConfigMap(ctx context.Context, kubeClient kube_client.Interface, namespace string, status api.ClusterAutoscalerStatus, logRecorder *LogEventRecorder, statusConfigMapName string, currentTime time.Time) (*apiv1.ConfigMap, error) {
 	statusUpdateTime := currentTime.Format(ConfigMapLastUpdateFormat)
 	status.Time = statusUpdateTime
 	var configMap *apiv1.ConfigMap
 	var getStatusError, writeStatusError error
 	var errMsg string
 	maps := kubeClient.CoreV1().ConfigMaps(namespace)
-	configMap, getStatusError = maps.Get(context.TODO(), statusConfigMapName, metav1.GetOptions{})
+	configMap, getStatusError = maps.Get(ctx, statusConfigMapName, metav1.GetOptions{})
 	statusYaml, err := yaml.Marshal(status)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal status configmap: %v", err)
@@ -113,7 +113,7 @@ func WriteStatusConfigMap(kubeClient kube_client.Interface, namespace string, st
 			configMap.ObjectMeta.Annotations = make(map[string]string)
 		}
 		configMap.ObjectMeta.Annotations[ConfigMapLastUpdatedKey] = statusUpdateTime
-		configMap, writeStatusError = maps.Update(context.TODO(), configMap, metav1.UpdateOptions{})
+		configMap, writeStatusError = maps.Update(ctx, configMap, metav1.UpdateOptions{})
 	} else if kube_errors.IsNotFound(getStatusError) {
 		configMap = &apiv1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -127,7 +127,7 @@ func WriteStatusConfigMap(kubeClient kube_client.Interface, namespace string, st
 				"status": statusMsg,
 			},
 		}
-		configMap, writeStatusError = maps.Create(context.TODO(), configMap, metav1.CreateOptions{})
+		configMap, writeStatusError = maps.Create(ctx, configMap, metav1.CreateOptions{})
 	} else {
 		errMsg = fmt.Sprintf("Failed to retrieve status configmap for update: %v", getStatusError)
 	}
@@ -148,9 +148,9 @@ func WriteStatusConfigMap(kubeClient kube_client.Interface, namespace string, st
 }
 
 // DeleteStatusConfigMap deletes status configmap
-func DeleteStatusConfigMap(kubeClient kube_client.Interface, namespace string, statusConfigMapName string) error {
+func DeleteStatusConfigMap(ctx context.Context, kubeClient kube_client.Interface, namespace string, statusConfigMapName string) error {
 	maps := kubeClient.CoreV1().ConfigMaps(namespace)
-	err := maps.Delete(context.TODO(), statusConfigMapName, metav1.DeleteOptions{})
+	err := maps.Delete(ctx, statusConfigMapName, metav1.DeleteOptions{})
 	if err != nil {
 		klog.Error("Failed to delete status configmap")
 	}

--- a/cluster-autoscaler/clusterstate/utils/status_test.go
+++ b/cluster-autoscaler/clusterstate/utils/status_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"testing"
@@ -156,7 +157,7 @@ func TestWriteStatusConfigMap(t *testing.T) {
 			if tc.preprocessor != nil {
 				tc.preprocessor(ti)
 			}
-			result, err := WriteStatusConfigMap(ti.client, ti.namespace, clusterAutoscalerStatus, nil, "my-cool-configmap", currentTime)
+			result, err := WriteStatusConfigMap(context.TODO(), ti.client, ti.namespace, clusterAutoscalerStatus, nil, "my-cool-configmap", currentTime)
 			assert.Equal(t, tc.wantError, err)
 			assert.Equal(t, tc.wantConfigMap, result)
 			assert.Equal(t, tc.wantGetCalled, ti.getCalled)
@@ -253,7 +254,7 @@ func TestWriteStatusConfigMapMarshal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to Marshal %s: %v", statusYamlTestFile, err)
 	}
-	result, err := WriteStatusConfigMap(ti.client, ti.namespace, status, nil, "my-cool-configmap", time.Date(2023, 11, 24, 4, 28, 19, 546750398, time.UTC))
+	result, err := WriteStatusConfigMap(context.TODO(), ti.client, ti.namespace, status, nil, "my-cool-configmap", time.Date(2023, 11, 24, 4, 28, 19, 546750398, time.UTC))
 	if err != nil {
 		t.Fatalf("Expected WriteStatusConfigMap not to return error, got: %v", err)
 	}

--- a/cluster-autoscaler/context/autoscaling_context.go
+++ b/cluster-autoscaler/context/autoscaling_context.go
@@ -93,7 +93,7 @@ type TemplateNodeInfoRegistry interface {
 	// The results are cached until the next Recompute() call.
 	// The getters can be used by logic that happens before the Recompute() call in the main CA loop,
 	// but the caller has to handle no results during the first CA loop.
-	Recompute(autoscalingCtx *AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) errors.AutoscalerError
+	Recompute(ctx context.Context, autoscalingCtx *AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) errors.AutoscalerError
 }
 
 // AutoscalingKubeClients contains all Kubernetes API clients,
@@ -165,12 +165,12 @@ func NewAutoscalingContext(
 func NewAutoscalingKubeClients(ctx context.Context, opts config.AutoscalingOptions, kubeClient kube_client.Interface, informerFactory informers.SharedInformerFactory) *AutoscalingKubeClients {
 	listerRegistry := kube_util.NewListerRegistryWithDefaultListers(informerFactory)
 	kubeEventRecorder := kube_util.CreateEventRecorder(ctx, kubeClient, opts.RecordDuplicatedEvents)
-	logRecorder, err := utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, opts.WriteStatusConfigMap, opts.StatusConfigMapName)
+	logRecorder, err := utils.NewStatusMapRecorder(ctx, kubeClient, opts.ConfigNamespace, kubeEventRecorder, opts.WriteStatusConfigMap, opts.StatusConfigMapName)
 	if err != nil {
 		klog.Error("Failed to initialize status configmap, unable to write status events")
 		// Get a dummy, so we can at least safely call the methods
 		// TODO(maciekpytel): recover from this after successful status configmap update?
-		logRecorder, _ = utils.NewStatusMapRecorder(kubeClient, opts.ConfigNamespace, kubeEventRecorder, false, opts.StatusConfigMapName)
+		logRecorder, _ = utils.NewStatusMapRecorder(ctx, kubeClient, opts.ConfigNamespace, kubeEventRecorder, false, opts.StatusConfigMapName)
 	}
 
 	return &AutoscalingKubeClients{

--- a/cluster-autoscaler/core/podlistprocessor/clear_tpu_request.go
+++ b/cluster-autoscaler/core/podlistprocessor/clear_tpu_request.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/tpu"
@@ -31,7 +32,7 @@ func NewClearTPURequestsPodListProcessor() *clearTpuRequests {
 }
 
 // Process removes pods' tpu requests
-func (p *clearTpuRequests) Process(autoscalingCtx *ca_context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+func (p *clearTpuRequests) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	return tpu.ClearTPURequests(pods), nil
 }
 

--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
@@ -43,18 +43,19 @@ func (p *currentlyDrainedNodesPodListProcessor) CleanUp() {
 }
 
 func currentlyDrainedPods(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) []*apiv1.Pod {
+	logger := klog.FromContext(ctx)
 	var pods []*apiv1.Pod
 	_, nodeNames := autoscalingCtx.ScaleDownActuator.CheckStatus().DeletionsInProgress()
 	for _, nodeName := range nodeNames {
 		nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
 		if err != nil {
-			klog.Warningf("Couldn't get node %v info, assuming the node got deleted already: %v", nodeName, err)
+			logger.Info("Couldn't get node info, assuming the node got deleted already", "node", nodeName, "err", err)
 			continue
 		}
 		for _, podInfo := range nodeInfo.Pods() {
 			// Filter out pods that has deletion timestamp set
 			if podInfo.Pod.DeletionTimestamp != nil {
-				klog.Infof("Pod %v has deletion timestamp set, skipping injection to unschedulable pods list", podInfo.Pod.Name)
+				logger.Info("Pod has deletion timestamp set, skipping injection to unschedulable pods list", "pod", podInfo.Pod.Name)
 				continue
 			}
 			pods = append(pods, podInfo.Pod)

--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	pod_util "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
@@ -33,15 +34,15 @@ func NewCurrentlyDrainedNodesPodListProcessor() *currentlyDrainedNodesPodListPro
 }
 
 // Process adds recreatable pods from currently drained nodes
-func (p *currentlyDrainedNodesPodListProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
-	recreatablePods := pod_util.FilterRecreatablePods(currentlyDrainedPods(autoscalingCtx))
+func (p *currentlyDrainedNodesPodListProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	recreatablePods := pod_util.FilterRecreatablePods(currentlyDrainedPods(ctx, autoscalingCtx))
 	return append(unschedulablePods, pod_util.ClearPodNodeNames(recreatablePods)...), nil
 }
 
 func (p *currentlyDrainedNodesPodListProcessor) CleanUp() {
 }
 
-func currentlyDrainedPods(autoscalingCtx *ca_context.AutoscalingContext) []*apiv1.Pod {
+func currentlyDrainedPods(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) []*apiv1.Pod {
 	var pods []*apiv1.Pod
 	_, nodeNames := autoscalingCtx.ScaleDownActuator.CheckStatus().DeletionsInProgress()
 	for _, nodeName := range nodeNames {

--- a/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/currently_drained_nodes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -274,7 +275,7 @@ func TestCurrentlyDrainedNodesPodListProcessor(t *testing.T) {
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, tc.nodes, tc.pods)
 
 			processor := NewCurrentlyDrainedNodesPodListProcessor()
-			pods, err := processor.Process(&autoscalingCtx, tc.unschedulablePods)
+			pods, err := processor.Process(context.TODO(), &autoscalingCtx, tc.unschedulablePods)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.wantPods, pods)
 		})
@@ -285,11 +286,11 @@ type mockActuator struct {
 	status *mockActuationStatus
 }
 
-func (m *mockActuator) StartDeletion(_, _ []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
+func (m *mockActuator) StartDeletion(ctx context.Context, _, _ []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
 	return status.ScaleDownError, []*status.ScaleDownNode{}, nil
 }
 
-func (m *mockActuator) StartForceDeletion(_, _ []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
+func (m *mockActuator) StartForceDeletion(ctx context.Context, _, _ []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
 	return status.ScaleDownError, []*status.ScaleDownNode{}, nil
 }
 

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_daemon_sets.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_daemon_sets.go
@@ -38,14 +38,14 @@ func (p *filterOutDaemonSetPodListProcessor) Process(ctx context.Context, autosc
 	// for scheduling. To improve that we are filtering them here, as the CA won't be
 	// able to help them so there is no point to in passing them to scale-up logic.
 
+	logger := klog.FromContext(ctx)
 	var nonDaemonSetPods []*apiv1.Pod
 	for _, pod := range unschedulablePods {
 		if !podutils.IsDaemonSetPod(pod) {
 			nonDaemonSetPods = append(nonDaemonSetPods, pod)
 		}
 	}
-
-	klog.V(4).Infof("Filtered out %v daemon set pods, %v unschedulable pods left", len(unschedulablePods)-len(nonDaemonSetPods), len(nonDaemonSetPods))
+	logger.V(4).Info("Filtered out daemon set pods, unschedulable pods left", "unschedulablePodsCount", len(unschedulablePods)-len(nonDaemonSetPods), "nonDaemonSetPodsCount", len(nonDaemonSetPods))
 	return nonDaemonSetPods, nil
 }
 

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_daemon_sets.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_daemon_sets.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	podutils "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
@@ -32,7 +33,7 @@ func NewFilterOutDaemonSetPodListProcessor() *filterOutDaemonSetPodListProcessor
 }
 
 // Process filters out pods which are daemon set pods.
-func (p *filterOutDaemonSetPodListProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+func (p *filterOutDaemonSetPodListProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	// Scale-up cannot help unschedulable Daemon Set pods, as those require a specific node
 	// for scheduling. To improve that we are filtering them here, as the CA won't be
 	// able to help them so there is no point to in passing them to scale-up logic.

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_daemon_sets_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_daemon_sets_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,7 +70,7 @@ func TestFilterOutDaemonSetPodListProcessor(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			processor := NewFilterOutDaemonSetPodListProcessor()
-			pods, err := processor.Process(nil, tc.pods)
+			pods, err := processor.Process(context.TODO(), nil, tc.pods)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantPods, pods)
 		})

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_expendable.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_expendable.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	core_utils "k8s.io/autoscaler/cluster-autoscaler/core/utils"
@@ -31,7 +32,7 @@ func NewFilterOutExpendablePodListProcessor() *filterOutExpendable {
 }
 
 // Process filters out pods which are expendable and adds pods which is waiting for lower priority pods preemption to the cluster snapshot
-func (p *filterOutExpendable) Process(autoscalingCtx *ca_context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+func (p *filterOutExpendable) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	expendablePodsPriorityCutoff := autoscalingCtx.AutoscalingOptions.ExpendablePodsPriorityCutoff
 
 	unschedulablePods := core_utils.FilterOutExpendablePods(pods, expendablePodsPriorityCutoff)

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_expendable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_expendable_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -79,7 +80,7 @@ func TestFilterOutExpendable(t *testing.T) {
 			err := snapshot.SetClusterState(tc.nodes, nil, nil, nil)
 			assert.NoError(t, err)
 
-			pods, err := processor.Process(&ca_context.AutoscalingContext{
+			pods, err := processor.Process(context.TODO(), &ca_context.AutoscalingContext{
 				ClusterSnapshot: snapshot,
 				AutoscalingOptions: config.AutoscalingOptions{
 					ExpendablePodsPriorityCutoff: tc.priorityCutoff,

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable.go
@@ -62,8 +62,8 @@ func (p *filterOutSchedulablePodListProcessor) Process(ctx context.Context, auto
 	//
 	// With the check enabled the last point won't happen because CA will ignore a pod
 	// which is supposed to schedule on an existing node.
-
-	klog.V(4).Infof("Filtering out schedulables")
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("Filtering out schedulables")
 	filterOutSchedulableStart := time.Now()
 
 	unschedulablePodsToHelp, err := p.filterOutSchedulableByPacking(ctx, unschedulablePods, autoscalingCtx.ClusterSnapshot)
@@ -75,7 +75,7 @@ func (p *filterOutSchedulablePodListProcessor) Process(ctx context.Context, auto
 	metrics.UpdateDurationFromStart(ctx, metrics.FilterOutSchedulable, filterOutSchedulableStart)
 
 	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
-		klog.V(2).Info("Schedulable pods present")
+		logger.V(2).Info("Schedulable pods present")
 
 		if autoscalingCtx.DebuggingSnapshotter.IsDataCollectionAllowed() {
 			schedulablePods := findSchedulablePods(unschedulablePods, unschedulablePodsToHelp)
@@ -83,7 +83,7 @@ func (p *filterOutSchedulablePodListProcessor) Process(ctx context.Context, auto
 		}
 
 	} else {
-		klog.V(4).Info("No schedulable pods")
+		logger.V(4).Info("No schedulable pods")
 	}
 	return unschedulablePodsToHelp, nil
 }
@@ -97,6 +97,7 @@ func (p *filterOutSchedulablePodListProcessor) CleanUp() {
 // and will be scheduled after lower priority pod preemption.
 func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(ctx context.Context, unschedulableCandidates []*apiv1.Pod, clusterSnapshot clustersnapshot.ClusterSnapshot) ([]*apiv1.Pod, error) {
 	// Sort unschedulable pods by importance
+	logger := klog.FromContext(ctx)
 	sort.Slice(unschedulableCandidates, func(i, j int) bool {
 		return corev1helpers.PodPriority(unschedulableCandidates[i]) > corev1helpers.PodPriority(unschedulableCandidates[j])
 	})
@@ -120,7 +121,7 @@ func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(ctx
 	}
 
 	metrics.UpdateOverflowingControllers(overflowingControllerCount)
-	klog.V(4).Infof("%v pods marked as unschedulable can be scheduled.", len(unschedulableCandidates)-len(unschedulablePods))
+	logger.V(4).Info("pods marked as unschedulable can be scheduled.", "unschedulableCandidatesCount", len(unschedulableCandidates)-len(unschedulablePods))
 
 	p.schedulingSimulator.DropOldHints()
 	return unschedulablePods, nil

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -45,7 +46,7 @@ func NewFilterOutSchedulablePodListProcessor(nodeFilter func(*framework.NodeInfo
 }
 
 // Process filters out pods which are schedulable from list of unschedulable pods.
-func (p *filterOutSchedulablePodListProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+func (p *filterOutSchedulablePodListProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	// We need to check whether pods marked as unschedulable are actually unschedulable.
 	// It's likely we added a new node and the scheduler just haven't managed to put the
 	// pod on in yet. In this situation we don't want to trigger another scale-up.
@@ -65,20 +66,20 @@ func (p *filterOutSchedulablePodListProcessor) Process(autoscalingCtx *ca_contex
 	klog.V(4).Infof("Filtering out schedulables")
 	filterOutSchedulableStart := time.Now()
 
-	unschedulablePodsToHelp, err := p.filterOutSchedulableByPacking(unschedulablePods, autoscalingCtx.ClusterSnapshot)
+	unschedulablePodsToHelp, err := p.filterOutSchedulableByPacking(ctx, unschedulablePods, autoscalingCtx.ClusterSnapshot)
 
 	if err != nil {
 		return nil, err
 	}
 
-	metrics.UpdateDurationFromStart(metrics.FilterOutSchedulable, filterOutSchedulableStart)
+	metrics.UpdateDurationFromStart(ctx, metrics.FilterOutSchedulable, filterOutSchedulableStart)
 
 	if len(unschedulablePodsToHelp) != len(unschedulablePods) {
 		klog.V(2).Info("Schedulable pods present")
 
 		if autoscalingCtx.DebuggingSnapshotter.IsDataCollectionAllowed() {
 			schedulablePods := findSchedulablePods(unschedulablePods, unschedulablePodsToHelp)
-			autoscalingCtx.DebuggingSnapshotter.SetUnscheduledPodsCanBeScheduled(schedulablePods)
+			autoscalingCtx.DebuggingSnapshotter.SetUnscheduledPodsCanBeScheduled(ctx, schedulablePods)
 		}
 
 	} else {
@@ -94,13 +95,13 @@ func (p *filterOutSchedulablePodListProcessor) CleanUp() {
 // unschedulable can be scheduled on free capacity on existing nodes by trying to pack the pods. It
 // tries to pack the higher priority pods first. It takes into account pods that are bound to node
 // and will be scheduled after lower priority pod preemption.
-func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(unschedulableCandidates []*apiv1.Pod, clusterSnapshot clustersnapshot.ClusterSnapshot) ([]*apiv1.Pod, error) {
+func (p *filterOutSchedulablePodListProcessor) filterOutSchedulableByPacking(ctx context.Context, unschedulableCandidates []*apiv1.Pod, clusterSnapshot clustersnapshot.ClusterSnapshot) ([]*apiv1.Pod, error) {
 	// Sort unschedulable pods by importance
 	sort.Slice(unschedulableCandidates, func(i, j int) bool {
 		return corev1helpers.PodPriority(unschedulableCandidates[i]) > corev1helpers.PodPriority(unschedulableCandidates[j])
 	})
 
-	statuses, overflowingControllerCount, err := p.schedulingSimulator.TrySchedulePods(clusterSnapshot, unschedulableCandidates, false, clustersnapshot.SchedulingOptions{IsNodeAcceptable: p.nodeFilter})
+	statuses, overflowingControllerCount, err := p.schedulingSimulator.TrySchedulePods(ctx, clusterSnapshot, unschedulableCandidates, false, clustersnapshot.SchedulingOptions{IsNodeAcceptable: p.nodeFilter})
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
+++ b/cluster-autoscaler/core/podlistprocessor/filter_out_schedulable_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlistprocessor
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -191,7 +192,7 @@ func TestFilterOutSchedulable(t *testing.T) {
 			clusterSnapshot.Fork()
 
 			processor := NewFilterOutSchedulablePodListProcessor(tc.nodeFilter)
-			unschedulablePods, err := processor.filterOutSchedulableByPacking(tc.unschedulableCandidates, clusterSnapshot)
+			unschedulablePods, err := processor.filterOutSchedulableByPacking(context.TODO(), tc.unschedulableCandidates, clusterSnapshot)
 
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, unschedulablePods, tc.expectedUnscheduledPods, "unschedulable pods differ")
@@ -288,7 +289,7 @@ func BenchmarkFilterOutSchedulable(b *testing.B) {
 
 				for i := 0; i < b.N; i++ {
 					processor := NewFilterOutSchedulablePodListProcessor(scheduling.ScheduleAnywhere)
-					if stillPending, err := processor.filterOutSchedulableByPacking(pendingPods, clusterSnapshot); err != nil {
+					if stillPending, err := processor.filterOutSchedulableByPacking(context.TODO(), pendingPods, clusterSnapshot); err != nil {
 						assert.NoError(b, err)
 					} else if len(stillPending) < tc.pendingPods {
 						assert.Equal(b, len(stillPending), tc.pendingPods)

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -171,15 +171,16 @@ func (a *Actuator) startDeletion(ctx context.Context, empty, drain []*apiv1.Node
 // deleteAsyncEmpty immediately starts deletions asynchronously.
 // scaledDownNodes return value contains all nodes for which deletion successfully started.
 func (a *Actuator) deleteAsyncEmpty(ctx context.Context, NodeGroupViews []*budgets.NodeGroupView, nodeDeleteDelayAfterTaint time.Duration, force bool) (reportedSDNodes []*status.ScaleDownNode) {
+	logger := klog.FromContext(ctx)
 	for _, bucket := range NodeGroupViews {
 		for _, node := range bucket.Nodes {
-			klog.V(0).Infof("Scale-down: removing empty node %q", node.Name)
+			logger.V(0).Info("Scale-down: removing empty node", "node", node.Name)
 			a.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaleDownEmpty", "Scale-down: removing empty node %q", node.Name)
 
 			if sdNode, err := a.scaleDownNodeToReport(ctx, node, false); err == nil {
 				reportedSDNodes = append(reportedSDNodes, sdNode)
 			} else {
-				klog.Errorf("Scale-down: couldn't report scaled down node, err: %v", err)
+				logger.Error(err, "Scale-down: couldn't report scaled down node")
 			}
 
 			a.nodeDeletionTracker.StartDeletion(bucket.Group.Id(), node.Name)
@@ -263,14 +264,15 @@ func (a *Actuator) taintNodesSync(ctx context.Context, NodeGroupViews []*budgets
 // deleteAsyncDrain asynchronously starts deletions with drain for all provided nodes. scaledDownNodes return value contains all nodes for which
 // deletion successfully started.
 func (a *Actuator) deleteAsyncDrain(ctx context.Context, NodeGroupViews []*budgets.NodeGroupView, nodeDeleteDelayAfterTaint time.Duration, force bool) (reportedSDNodes []*status.ScaleDownNode) {
+	logger := klog.FromContext(ctx)
 	for _, bucket := range NodeGroupViews {
 		for _, drainNode := range bucket.Nodes {
 			if sdNode, err := a.scaleDownNodeToReport(ctx, drainNode, true); err == nil {
-				klog.V(0).Infof("Scale-down: removing node %s, utilization: %v, pods to reschedule: %s", drainNode.Name, sdNode.UtilInfo, joinPodNames(sdNode.EvictedPods))
+				logger.V(0).Info("Scale-down: removing node, utilization, pods to reschedule", "drainNode", drainNode.Name, "utilInfo", sdNode.UtilInfo, "evictedPods", joinPodNames(sdNode.EvictedPods))
 				a.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaleDown", "Scale-down: removing node %s, utilization: %v, pods to reschedule: %s", drainNode.Name, sdNode.UtilInfo, joinPodNames(sdNode.EvictedPods))
 				reportedSDNodes = append(reportedSDNodes, sdNode)
 			} else {
-				klog.Errorf("Scale-down: couldn't report scaled down node, err: %v", err)
+				logger.Error(err, "Scale-down: couldn't report scaled down node")
 			}
 
 			a.nodeDeletionTracker.StartDeletionWithDrain(bucket.Group.Id(), drainNode.Name)
@@ -285,6 +287,7 @@ func (a *Actuator) deleteAsyncDrain(ctx context.Context, NodeGroupViews []*budge
 }
 
 func (a *Actuator) deleteNodesAsync(ctx context.Context, nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool, force bool, batchSize int, nodeDeleteDelayAfterTaint time.Duration) {
+	logger := klog.FromContext(ctx)
 	var remainingPdbTracker pdb.RemainingPdbTracker
 	var registry kube_util.ListerRegistry
 
@@ -293,7 +296,7 @@ func (a *Actuator) deleteNodesAsync(ctx context.Context, nodes []*apiv1.Node, no
 	}
 
 	if nodeDeleteDelayAfterTaint > time.Duration(0) {
-		klog.V(0).Infof("Scale-down: waiting %v before trying to delete nodes", nodeDeleteDelayAfterTaint)
+		logger.V(0).Info("Scale-down: waiting before trying to delete nodes", "nodeDeleteDelayAfterTaint", nodeDeleteDelayAfterTaint)
 		time.Sleep(nodeDeleteDelayAfterTaint)
 	}
 

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -118,50 +118,50 @@ func (a *Actuator) DeletionResults() (map[string]status.NodeDeleteResult, time.T
 }
 
 // StartDeletion triggers a new deletion process.
-func (a *Actuator) StartDeletion(empty, drain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
-	return a.startDeletion(empty, drain, false)
+func (a *Actuator) StartDeletion(ctx context.Context, empty, drain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
+	return a.startDeletion(ctx, empty, drain, false)
 }
 
 // StartForceDeletion triggers a new forced deletion process. It will bypass PDBs and forcefully delete the pods and the nodes.
-func (a *Actuator) StartForceDeletion(empty, drain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
-	return a.startDeletion(empty, drain, true)
+func (a *Actuator) StartForceDeletion(ctx context.Context, empty, drain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
+	return a.startDeletion(ctx, empty, drain, true)
 }
 
 // startDeletion contains the shared logic for deleting nodes. It handles both
 // normal deletions (respecting PDBs) and forced deletions (bypassing PDBs),
 // determined by the 'force' parameter.
-func (a *Actuator) startDeletion(empty, drain []*apiv1.Node, force bool) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
+func (a *Actuator) startDeletion(ctx context.Context, empty, drain []*apiv1.Node, force bool) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError) {
 	a.nodeDeletionScheduler.ResetAndReportMetrics()
 	deletionStartTime := time.Now()
-	defer func() { metrics.UpdateDuration(metrics.ScaleDownNodeDeletion, time.Since(deletionStartTime)) }()
+	defer func() { metrics.UpdateDuration(ctx, metrics.ScaleDownNodeDeletion, time.Since(deletionStartTime)) }()
 
 	scaledDownNodes := make([]*status.ScaleDownNode, 0)
-	emptyToDelete, drainToDelete := a.budgetProcessor.CropNodes(a.nodeDeletionTracker, empty, drain)
+	emptyToDelete, drainToDelete := a.budgetProcessor.CropNodes(ctx, a.nodeDeletionTracker, empty, drain)
 	if len(emptyToDelete) == 0 && len(drainToDelete) == 0 {
 		return status.ScaleDownNoNodeDeleted, nil, nil
 	}
 
 	if len(emptyToDelete) > 0 {
 		// Taint all empty nodes synchronously
-		nodeDeleteDelayAfterTaint, err := a.taintNodesSync(emptyToDelete)
+		nodeDeleteDelayAfterTaint, err := a.taintNodesSync(ctx, emptyToDelete)
 		if err != nil {
 			return status.ScaleDownError, scaledDownNodes, err
 		}
 
-		emptyScaledDown := a.deleteAsyncEmpty(emptyToDelete, nodeDeleteDelayAfterTaint, force)
+		emptyScaledDown := a.deleteAsyncEmpty(ctx, emptyToDelete, nodeDeleteDelayAfterTaint, force)
 		scaledDownNodes = append(scaledDownNodes, emptyScaledDown...)
 	}
 
 	if len(drainToDelete) > 0 {
 		// Taint all nodes that need drain synchronously, but don't start any drain/deletion yet. Otherwise, pods evicted from one to-be-deleted node
 		// could get recreated on another.
-		nodeDeleteDelayAfterTaint, err := a.taintNodesSync(drainToDelete)
+		nodeDeleteDelayAfterTaint, err := a.taintNodesSync(ctx, drainToDelete)
 		if err != nil {
 			return status.ScaleDownError, scaledDownNodes, err
 		}
 
 		// All nodes involved in the scale-down should be tainted now - start draining and deleting nodes asynchronously.
-		drainScaledDown := a.deleteAsyncDrain(drainToDelete, nodeDeleteDelayAfterTaint, force)
+		drainScaledDown := a.deleteAsyncDrain(ctx, drainToDelete, nodeDeleteDelayAfterTaint, force)
 		scaledDownNodes = append(scaledDownNodes, drainScaledDown...)
 	}
 
@@ -170,13 +170,13 @@ func (a *Actuator) startDeletion(empty, drain []*apiv1.Node, force bool) (status
 
 // deleteAsyncEmpty immediately starts deletions asynchronously.
 // scaledDownNodes return value contains all nodes for which deletion successfully started.
-func (a *Actuator) deleteAsyncEmpty(NodeGroupViews []*budgets.NodeGroupView, nodeDeleteDelayAfterTaint time.Duration, force bool) (reportedSDNodes []*status.ScaleDownNode) {
+func (a *Actuator) deleteAsyncEmpty(ctx context.Context, NodeGroupViews []*budgets.NodeGroupView, nodeDeleteDelayAfterTaint time.Duration, force bool) (reportedSDNodes []*status.ScaleDownNode) {
 	for _, bucket := range NodeGroupViews {
 		for _, node := range bucket.Nodes {
 			klog.V(0).Infof("Scale-down: removing empty node %q", node.Name)
 			a.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaleDownEmpty", "Scale-down: removing empty node %q", node.Name)
 
-			if sdNode, err := a.scaleDownNodeToReport(node, false); err == nil {
+			if sdNode, err := a.scaleDownNodeToReport(ctx, node, false); err == nil {
 				reportedSDNodes = append(reportedSDNodes, sdNode)
 			} else {
 				klog.Errorf("Scale-down: couldn't report scaled down node, err: %v", err)
@@ -187,7 +187,7 @@ func (a *Actuator) deleteAsyncEmpty(NodeGroupViews []*budgets.NodeGroupView, nod
 	}
 
 	for _, bucket := range NodeGroupViews {
-		go a.deleteNodesAsync(bucket.Nodes, bucket.Group, false, force, bucket.BatchSize, nodeDeleteDelayAfterTaint)
+		go a.deleteNodesAsync(ctx, bucket.Nodes, bucket.Group, false, force, bucket.BatchSize, nodeDeleteDelayAfterTaint)
 	}
 
 	return reportedSDNodes
@@ -195,13 +195,13 @@ func (a *Actuator) deleteAsyncEmpty(NodeGroupViews []*budgets.NodeGroupView, nod
 
 // taintNodesSync synchronously taints all provided nodes with NoSchedule. If tainting fails for any of the nodes, already
 // applied taints are cleaned up.
-func (a *Actuator) taintNodesSync(NodeGroupViews []*budgets.NodeGroupView) (time.Duration, errors.AutoscalerError) {
+func (a *Actuator) taintNodesSync(ctx context.Context, NodeGroupViews []*budgets.NodeGroupView) (time.Duration, errors.AutoscalerError) {
 	nodesToTaint := make([]*apiv1.Node, 0)
 	var updateLatencyTracker *UpdateLatencyTracker
 	nodeDeleteDelayAfterTaint := a.nodeDeleteDelayAfterTaint
 	if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
 		updateLatencyTracker = NewUpdateLatencyTracker(a.autoscalingCtx.AutoscalingKubeClients.ListerRegistry.AllNodeLister())
-		go updateLatencyTracker.Start()
+		go updateLatencyTracker.Start(ctx)
 	}
 
 	for _, bucket := range NodeGroupViews {
@@ -219,7 +219,7 @@ func (a *Actuator) taintNodesSync(NodeGroupViews []*budgets.NodeGroupView) (time
 	taintedNodes := make(chan *apiv1.Node, len(nodesToTaint))
 	workqueue.ParallelizeUntil(context.Background(), maxConcurrentNodesTainting, len(nodesToTaint), func(piece int) {
 		node := nodesToTaint[piece]
-		err := a.taintNode(node)
+		err := a.taintNode(context.Background(), node)
 		if err != nil {
 			failedTaintedNodes <- struct {
 				node *apiv1.Node
@@ -237,7 +237,7 @@ func (a *Actuator) taintNodesSync(NodeGroupViews []*budgets.NodeGroupView) (time
 		}
 		// Clean up already applied taints in case of issues.
 		for taintedNode := range taintedNodes {
-			_, _ = taints.CleanToBeDeleted(taintedNode, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
+			_, _ = taints.CleanToBeDeleted(context.Background(), taintedNode, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
 		}
 		if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
 			close(updateLatencyTracker.AwaitOrStopChan)
@@ -262,10 +262,10 @@ func (a *Actuator) taintNodesSync(NodeGroupViews []*budgets.NodeGroupView) (time
 
 // deleteAsyncDrain asynchronously starts deletions with drain for all provided nodes. scaledDownNodes return value contains all nodes for which
 // deletion successfully started.
-func (a *Actuator) deleteAsyncDrain(NodeGroupViews []*budgets.NodeGroupView, nodeDeleteDelayAfterTaint time.Duration, force bool) (reportedSDNodes []*status.ScaleDownNode) {
+func (a *Actuator) deleteAsyncDrain(ctx context.Context, NodeGroupViews []*budgets.NodeGroupView, nodeDeleteDelayAfterTaint time.Duration, force bool) (reportedSDNodes []*status.ScaleDownNode) {
 	for _, bucket := range NodeGroupViews {
 		for _, drainNode := range bucket.Nodes {
-			if sdNode, err := a.scaleDownNodeToReport(drainNode, true); err == nil {
+			if sdNode, err := a.scaleDownNodeToReport(ctx, drainNode, true); err == nil {
 				klog.V(0).Infof("Scale-down: removing node %s, utilization: %v, pods to reschedule: %s", drainNode.Name, sdNode.UtilInfo, joinPodNames(sdNode.EvictedPods))
 				a.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaleDown", "Scale-down: removing node %s, utilization: %v, pods to reschedule: %s", drainNode.Name, sdNode.UtilInfo, joinPodNames(sdNode.EvictedPods))
 				reportedSDNodes = append(reportedSDNodes, sdNode)
@@ -278,13 +278,13 @@ func (a *Actuator) deleteAsyncDrain(NodeGroupViews []*budgets.NodeGroupView, nod
 	}
 
 	for _, bucket := range NodeGroupViews {
-		go a.deleteNodesAsync(bucket.Nodes, bucket.Group, true, force, bucket.BatchSize, nodeDeleteDelayAfterTaint)
+		go a.deleteNodesAsync(ctx, bucket.Nodes, bucket.Group, true, force, bucket.BatchSize, nodeDeleteDelayAfterTaint)
 	}
 
 	return reportedSDNodes
 }
 
-func (a *Actuator) deleteNodesAsync(nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool, force bool, batchSize int, nodeDeleteDelayAfterTaint time.Duration) {
+func (a *Actuator) deleteNodesAsync(ctx context.Context, nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool, force bool, batchSize int, nodeDeleteDelayAfterTaint time.Duration) {
 	var remainingPdbTracker pdb.RemainingPdbTracker
 	var registry kube_util.ListerRegistry
 
@@ -301,7 +301,7 @@ func (a *Actuator) deleteNodesAsync(nodes []*apiv1.Node, nodeGroup cloudprovider
 	if err != nil {
 		nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "createSnapshot returned error %v", err)}
 		for _, node := range nodes {
-			a.nodeDeletionScheduler.AbortNodeDeletionDueToError(node, nodeGroup.Id(), drain, "failed to create delete snapshot", nodeDeleteResult)
+			a.nodeDeletionScheduler.AbortNodeDeletionDueToError(ctx, node, nodeGroup.Id(), drain, "failed to create delete snapshot", nodeDeleteResult)
 		}
 		return
 	}
@@ -311,7 +311,7 @@ func (a *Actuator) deleteNodesAsync(nodes []*apiv1.Node, nodeGroup cloudprovider
 		if err != nil {
 			nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "podDisruptionBudgetLister.List returned error %v", err)}
 			for _, node := range nodes {
-				a.nodeDeletionScheduler.AbortNodeDeletionDueToError(node, nodeGroup.Id(), drain, "failed to fetch pod disruption budgets", nodeDeleteResult)
+				a.nodeDeletionScheduler.AbortNodeDeletionDueToError(ctx, node, nodeGroup.Id(), drain, "failed to fetch pod disruption budgets", nodeDeleteResult)
 			}
 			return
 		}
@@ -328,40 +328,40 @@ func (a *Actuator) deleteNodesAsync(nodes []*apiv1.Node, nodeGroup cloudprovider
 		nodeInfo, err := clusterSnapshot.GetNodeInfo(node.Name)
 		if err != nil {
 			nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "nodeInfos.Get for %q returned error: %v", node.Name, err)}
-			a.nodeDeletionScheduler.AbortNodeDeletionDueToError(node, nodeGroup.Id(), drain, "failed to get node info", nodeDeleteResult)
+			a.nodeDeletionScheduler.AbortNodeDeletionDueToError(ctx, node, nodeGroup.Id(), drain, "failed to get node info", nodeDeleteResult)
 			continue
 		}
 
-		podMoveInfo, err := simulator.GetPodsToMove(nodeInfo, a.deleteOptions, a.drainabilityRules, registry, remainingPdbTracker, time.Now())
+		podMoveInfo, err := simulator.GetPodsToMove(ctx, nodeInfo, a.deleteOptions, a.drainabilityRules, registry, remainingPdbTracker, time.Now())
 		if err != nil {
 			nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "GetPodsToMove for %q returned error: %v", node.Name, err)}
-			a.nodeDeletionScheduler.AbortNodeDeletion(node, nodeGroup.Id(), drain, "failed to get pods to move on node", nodeDeleteResult, true)
+			a.nodeDeletionScheduler.AbortNodeDeletion(ctx, node, nodeGroup.Id(), drain, "failed to get pods to move on node", nodeDeleteResult, true)
 			continue
 		}
 
 		if !drain {
 			if len(podMoveInfo.Pods) != 0 {
 				nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "failed to delete empty node %q, new pods scheduled", node.Name)}
-				a.nodeDeletionScheduler.AbortNodeDeletion(node, nodeGroup.Id(), drain, "node is not empty", nodeDeleteResult, true)
+				a.nodeDeletionScheduler.AbortNodeDeletion(ctx, node, nodeGroup.Id(), drain, "node is not empty", nodeDeleteResult, true)
 				continue
 			}
 			if len(podMoveInfo.OnCompletionPods) != 0 {
 				nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "failed to delete empty node %q, active on-completion pods present", node.Name)}
-				a.nodeDeletionScheduler.AbortNodeDeletion(node, nodeGroup.Id(), drain, "active on-completion pods present", nodeDeleteResult, true)
+				a.nodeDeletionScheduler.AbortNodeDeletion(ctx, node, nodeGroup.Id(), drain, "active on-completion pods present", nodeDeleteResult, true)
 				continue
 			}
 		}
 
 		if force {
-			go a.nodeDeletionScheduler.scheduleForceDeletion(nodeInfo, nodeGroup, batchSize, drain)
+			go a.nodeDeletionScheduler.scheduleForceDeletion(ctx, nodeInfo, nodeGroup, batchSize, drain)
 			continue
 		}
 
-		go a.nodeDeletionScheduler.ScheduleDeletion(nodeInfo, nodeGroup, batchSize, drain)
+		go a.nodeDeletionScheduler.ScheduleDeletion(ctx, nodeInfo, nodeGroup, batchSize, drain)
 	}
 }
 
-func (a *Actuator) scaleDownNodeToReport(node *apiv1.Node, drain bool) (*status.ScaleDownNode, error) {
+func (a *Actuator) scaleDownNodeToReport(ctx context.Context, node *apiv1.Node, drain bool) (*status.ScaleDownNode, error) {
 	nodeGroup, err := a.autoscalingCtx.CloudProvider.NodeGroupForNode(node)
 	if err != nil {
 		return nil, err
@@ -380,7 +380,7 @@ func (a *Actuator) scaleDownNodeToReport(node *apiv1.Node, drain bool) (*status.
 	}
 
 	gpuConfig := a.autoscalingCtx.CloudProvider.GetNodeGpuConfig(node)
-	utilInfo, err := utilization.Calculate(nodeInfo, ignoreDaemonSetsUtilization, a.autoscalingCtx.IgnoreMirrorPodsUtilization, a.autoscalingCtx.DynamicResourceAllocationEnabled, gpuConfig, time.Now())
+	utilInfo, err := utilization.Calculate(ctx, nodeInfo, ignoreDaemonSetsUtilization, a.autoscalingCtx.IgnoreMirrorPodsUtilization, a.autoscalingCtx.DynamicResourceAllocationEnabled, gpuConfig, time.Now())
 	if err != nil {
 		return nil, err
 	}
@@ -398,8 +398,8 @@ func (a *Actuator) scaleDownNodeToReport(node *apiv1.Node, drain bool) (*status.
 }
 
 // taintNode taints the node with NoSchedule to prevent new pods scheduling on it.
-func (a *Actuator) taintNode(node *apiv1.Node) error {
-	if _, err := taints.MarkToBeDeleted(node, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate); err != nil {
+func (a *Actuator) taintNode(ctx context.Context, node *apiv1.Node) error {
+	if _, err := taints.MarkToBeDeleted(ctx, node, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate); err != nil {
 		a.autoscalingCtx.Recorder.Eventf(node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to mark the node as toBeDeleted/unschedulable: %v", err)
 		return errors.ToAutoscalerError(errors.ApiCallError, err)
 	}

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -1282,9 +1283,9 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 	var gotScaleDownNodes []*status.ScaleDownNode
 	var gotErr error
 	if force {
-		gotResult, gotScaleDownNodes, gotErr = actuator.StartForceDeletion(allEmptyNodes, allDrainNodes)
+		gotResult, gotScaleDownNodes, gotErr = actuator.StartForceDeletion(context.TODO(), allEmptyNodes, allDrainNodes)
 	} else {
-		gotResult, gotScaleDownNodes, gotErr = actuator.StartDeletion(allEmptyNodes, allDrainNodes)
+		gotResult, gotScaleDownNodes, gotErr = actuator.StartDeletion(context.TODO(), allEmptyNodes, allDrainNodes)
 	}
 
 	if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
@@ -1556,7 +1557,7 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 			}
 
 			for _, nodes := range deleteNodes {
-				actuator.StartDeletion(nodes, []*apiv1.Node{})
+				actuator.StartDeletion(context.TODO(), nodes, []*apiv1.Node{})
 				time.Sleep(deleteInterval)
 			}
 			wantDeletedNodes := 0

--- a/cluster-autoscaler/core/scaledown/actuation/delay.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delay.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -37,7 +38,7 @@ const (
 
 // WaitForDelayDeletion waits until the provided node has no annotations beginning with DelayDeletionAnnotationPrefix,
 // or until the provided timeout is reached - whichever comes first.
-func WaitForDelayDeletion(node *apiv1.Node, nodeLister kubernetes.NodeLister, timeout time.Duration) errors.AutoscalerError {
+func WaitForDelayDeletion(ctx context.Context, node *apiv1.Node, nodeLister kubernetes.NodeLister, timeout time.Duration) errors.AutoscalerError {
 	if timeout != 0 && hasDelayDeletionAnnotation(node) {
 		klog.V(1).Infof("Wait for removing %s annotations on node %v", DelayDeletionAnnotationPrefix, node.Name)
 		err := wait.Poll(5*time.Second, timeout, func() (bool, error) {

--- a/cluster-autoscaler/core/scaledown/actuation/delay.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delay.go
@@ -39,10 +39,11 @@ const (
 // WaitForDelayDeletion waits until the provided node has no annotations beginning with DelayDeletionAnnotationPrefix,
 // or until the provided timeout is reached - whichever comes first.
 func WaitForDelayDeletion(ctx context.Context, node *apiv1.Node, nodeLister kubernetes.NodeLister, timeout time.Duration) errors.AutoscalerError {
+	logger := klog.FromContext(ctx)
 	if timeout != 0 && hasDelayDeletionAnnotation(node) {
-		klog.V(1).Infof("Wait for removing %s annotations on node %v", DelayDeletionAnnotationPrefix, node.Name)
+		logger.V(1).Info("Wait for removing annotations on node", "DelayDeletionAnnotationPrefix", DelayDeletionAnnotationPrefix, "node", node.Name)
 		err := wait.Poll(5*time.Second, timeout, func() (bool, error) {
-			klog.V(5).Infof("Waiting for removing %s annotations on node %v", DelayDeletionAnnotationPrefix, node.Name)
+			logger.V(5).Info("Waiting for removing annotations on node", "DelayDeletionAnnotationPrefix", DelayDeletionAnnotationPrefix, "node", node.Name)
 			freshNode, err := nodeLister.Get(node.Name)
 			if err != nil || freshNode == nil {
 				return false, fmt.Errorf("failed to get node %v: %v", node.Name, err)
@@ -53,9 +54,9 @@ func WaitForDelayDeletion(ctx context.Context, node *apiv1.Node, nodeLister kube
 			return errors.ToAutoscalerError(errors.ApiCallError, err)
 		}
 		if err == wait.ErrWaitTimeout {
-			klog.Warningf("Delay node deletion timed out for node %v, delay deletion annotation wasn't removed within %v, this might slow down scale down.", node.Name, timeout)
+			logger.Info("Delay node deletion timed out for node, delay deletion annotation wasn't removed within, this might slow down scale down.", "node", node.Name, "timeout", timeout)
 		} else {
-			klog.V(2).Infof("Annotation %s removed from node %v", DelayDeletionAnnotationPrefix, node.Name)
+			logger.V(2).Info("Annotation removed from node", "DelayDeletionAnnotationPrefix", DelayDeletionAnnotationPrefix, "node", node.Name)
 		}
 	}
 	return nil

--- a/cluster-autoscaler/core/scaledown/actuation/delay_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delay_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -80,9 +81,9 @@ func TestWaitForDelayDeletion(t *testing.T) {
 			}
 			var err error
 			if test.addAnnotation {
-				err = WaitForDelayDeletion(nodeWithAnnotation, allNodeLister, test.timeout)
+				err = WaitForDelayDeletion(context.TODO(), nodeWithAnnotation, allNodeLister, test.timeout)
 			} else {
-				err = WaitForDelayDeletion(node, allNodeLister, test.timeout)
+				err = WaitForDelayDeletion(context.TODO(), node, allNodeLister, test.timeout)
 			}
 			assert.NoError(t, err)
 		})

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -69,10 +70,10 @@ func NewNodeDeletionBatcher(autoscalingCtx *ca_context.AutoscalingContext, scale
 }
 
 // AddNodes adds node list to delete candidates and schedules deletion. The deletion is performed asynchronously.
-func (d *NodeDeletionBatcher) AddNodes(nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool) {
+func (d *NodeDeletionBatcher) AddNodes(ctx context.Context, nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool) {
 	// If delete interval is 0, than instantly start node deletion.
 	if d.deleteInterval == 0 {
-		go d.deleteNodesAndRegisterStatus(nodes, nodeGroup.Id(), drain)
+		go d.deleteNodesAndRegisterStatus(ctx, nodes, nodeGroup.Id(), drain)
 		return
 	}
 	first := d.addNodesToBucket(nodes, nodeGroup, drain)
@@ -80,19 +81,19 @@ func (d *NodeDeletionBatcher) AddNodes(nodes []*apiv1.Node, nodeGroup cloudprovi
 		// Just in case a node group implementation is not thread-safe, the async "remove" function will obtain a new instance of it to preform deletion.
 		go func(nodeGroupId string) {
 			time.Sleep(d.deleteInterval)
-			d.remove(nodeGroupId)
+			d.remove(ctx, nodeGroupId)
 		}(nodeGroup.Id())
 	}
 }
 
-func (d *NodeDeletionBatcher) deleteNodesAndRegisterStatus(nodes []*apiv1.Node, nodeGroupId string, drain bool) {
+func (d *NodeDeletionBatcher) deleteNodesAndRegisterStatus(ctx context.Context, nodes []*apiv1.Node, nodeGroupId string, drain bool) {
 	nodeGroup, err := deleteNodesFromCloudProvider(d.autoscalingCtx, d.scaleStateNotifier, nodes)
 	for _, node := range nodes {
 		if err != nil {
 			result := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: err}
-			CleanUpAndRecordErrorForFailedScaleDownEvent(d.autoscalingCtx, node, nodeGroupId, drain, d.nodeDeletionTracker, "", result)
+			CleanUpAndRecordErrorForFailedScaleDownEvent(ctx, d.autoscalingCtx, node, nodeGroupId, drain, d.nodeDeletionTracker, "", result)
 		} else {
-			RegisterAndRecordSuccessfulScaleDownEvent(d.autoscalingCtx, d.scaleStateNotifier, node, nodeGroup, drain, d.nodeDeletionTracker)
+			RegisterAndRecordSuccessfulScaleDownEvent(ctx, d.autoscalingCtx, d.scaleStateNotifier, node, nodeGroup, drain, d.nodeDeletionTracker)
 		}
 	}
 }
@@ -114,7 +115,7 @@ func (d *NodeDeletionBatcher) addNodesToBucket(nodes []*apiv1.Node, nodeGroup cl
 }
 
 // remove deletes nodes of a given nodeGroup, if successful, the deletion is recorded in CSR, and an event is emitted on the node.
-func (d *NodeDeletionBatcher) remove(nodeGroupId string) error {
+func (d *NodeDeletionBatcher) remove(ctx context.Context, nodeGroupId string) error {
 	d.Lock()
 	defer d.Unlock()
 	nodes, ok := d.deletionsPerNodeGroup[nodeGroupId]
@@ -135,9 +136,9 @@ func (d *NodeDeletionBatcher) remove(nodeGroupId string) error {
 			drain := drainedNodeDeletions[node.Name]
 			if err != nil {
 				result = status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: err}
-				CleanUpAndRecordErrorForFailedScaleDownEvent(d.autoscalingCtx, node, nodeGroupId, drain, d.nodeDeletionTracker, "", result)
+				CleanUpAndRecordErrorForFailedScaleDownEvent(ctx, d.autoscalingCtx, node, nodeGroupId, drain, d.nodeDeletionTracker, "", result)
 			} else {
-				RegisterAndRecordSuccessfulScaleDownEvent(d.autoscalingCtx, d.scaleStateNotifier, node, nodeGroup, drain, d.nodeDeletionTracker)
+				RegisterAndRecordSuccessfulScaleDownEvent(ctx, d.autoscalingCtx, d.scaleStateNotifier, node, nodeGroup, drain, d.nodeDeletionTracker)
 			}
 		}
 	}(nodes, drainedNodeDeletions)
@@ -163,7 +164,7 @@ func deleteNodesFromCloudProvider(autoscalingCtx *ca_context.AutoscalingContext,
 	return nodeGroup, nil
 }
 
-func nodeScaleDownReason(node *apiv1.Node, drain bool) metrics.NodeScaleDownReason {
+func nodeScaleDownReason(ctx context.Context, node *apiv1.Node, drain bool) metrics.NodeScaleDownReason {
 	readiness, err := kubernetes.GetNodeReadiness(node)
 	if err != nil {
 		klog.Errorf("Couldn't determine node %q readiness while scaling down - assuming unready: %v", node.Name, err)
@@ -186,12 +187,13 @@ func IsNodeBeingDeleted(node *apiv1.Node, timestamp time.Time) bool {
 }
 
 // CleanUpAndRecordErrorForFailedScaleDownEvent record failed scale down event and log an error.
-func CleanUpAndRecordErrorForFailedScaleDownEvent(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroupId string, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker, errMsg string, status status.NodeDeleteResult) {
-	CleanUpAndRecordFailedScaleDownEvent(autoscalingCtx, node, nodeGroupId, drain, nodeDeletionTracker, errMsg, status, false)
+func CleanUpAndRecordErrorForFailedScaleDownEvent(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroupId string, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker, errMsg string, status status.NodeDeleteResult) {
+	CleanUpAndRecordFailedScaleDownEvent(ctx, autoscalingCtx, node, nodeGroupId, drain, nodeDeletionTracker, errMsg, status, false)
 }
 
 // CleanUpAndRecordFailedScaleDownEvent record failed scale down event and log a warning or an error.
-func CleanUpAndRecordFailedScaleDownEvent(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroupId string, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker, errMsg string, status status.NodeDeleteResult, logAsWarning bool) {
+func CleanUpAndRecordFailedScaleDownEvent(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroupId string, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker, errMsg string, status status.NodeDeleteResult, logAsWarning bool) {
+	ctx = context.WithoutCancel(ctx)
 	var logMsgFormat, eventMsgFormat string
 	if drain {
 		logMsgFormat = "couldn't delete node %q with drain"
@@ -206,18 +208,18 @@ func CleanUpAndRecordFailedScaleDownEvent(autoscalingCtx *ca_context.Autoscaling
 		klog.Errorf("Scale-down: "+logMsgFormat+", %v, status error: %v", node.Name, errMsg, status.Err)
 	}
 	autoscalingCtx.Recorder.Eventf(node, apiv1.EventTypeWarning, "ScaleDownFailed", eventMsgFormat+": %v", status.Err)
-	taints.CleanToBeDeleted(node, autoscalingCtx.ClientSet, autoscalingCtx.CordonNodeBeforeTerminate)
-	nodeDeletionTracker.EndDeletion(nodeGroupId, node.Name, status)
+	taints.CleanToBeDeleted(ctx, node, autoscalingCtx.ClientSet, autoscalingCtx.CordonNodeBeforeTerminate)
+	nodeDeletionTracker.EndDeletion(ctx, nodeGroupId, node.Name, status)
 }
 
 // RegisterAndRecordSuccessfulScaleDownEvent register scale down and record successful scale down event.
-func RegisterAndRecordSuccessfulScaleDownEvent(autoscalingCtx *ca_context.AutoscalingContext, scaleStateNotifier nodegroupchange.NodeGroupChangeObserver, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker) {
+func RegisterAndRecordSuccessfulScaleDownEvent(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleStateNotifier nodegroupchange.NodeGroupChangeObserver, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker) {
 	autoscalingCtx.Recorder.Eventf(node, apiv1.EventTypeNormal, "ScaleDown", "nodes removed by cluster autoscaler")
 	currentTime := time.Now()
 	expectedDeleteTime := time.Now().Add(MaxCloudProviderNodeDeletionTime)
 	scaleStateNotifier.RegisterScaleDown(nodeGroup, node.Name, currentTime, expectedDeleteTime)
 	gpuConfig := autoscalingCtx.CloudProvider.GetNodeGpuConfig(node)
-	metricResourceName, metricGpuType := gpu.GetGpuInfoForMetrics(gpuConfig, autoscalingCtx.CloudProvider.GetAvailableGPUTypes(), node, nodeGroup)
+	metricResourceName, metricGpuType := gpu.GetGpuInfoForMetrics(ctx, gpuConfig, autoscalingCtx.CloudProvider.GetAvailableGPUTypes(), node, nodeGroup)
 	draDriverNames := ""
 	nodeInfo, err := nodeGroup.TemplateNodeInfo()
 	if err != nil {
@@ -225,11 +227,11 @@ func RegisterAndRecordSuccessfulScaleDownEvent(autoscalingCtx *ca_context.Autosc
 	} else {
 		draDriverNames = dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
 	}
-	metrics.RegisterScaleDown(1, metricResourceName, metricGpuType, nodeScaleDownReason(node, drain), draDriverNames)
+	metrics.RegisterScaleDown(1, metricResourceName, metricGpuType, nodeScaleDownReason(ctx, node, drain), draDriverNames)
 	if drain {
 		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaleDown", "Scale-down: node %s removed with drain", node.Name)
 	} else {
 		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaleDownEmpty", "Scale-down: empty node %s removed", node.Name)
 	}
-	nodeDeletionTracker.EndDeletion(nodeGroup.Id(), node.Name, status.NodeDeleteResult{ResultType: status.NodeDeleteOk})
+	nodeDeletionTracker.EndDeletion(ctx, nodeGroup.Id(), node.Name, status.NodeDeleteResult{ResultType: status.NodeDeleteOk})
 }

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
@@ -165,9 +165,10 @@ func deleteNodesFromCloudProvider(autoscalingCtx *ca_context.AutoscalingContext,
 }
 
 func nodeScaleDownReason(ctx context.Context, node *apiv1.Node, drain bool) metrics.NodeScaleDownReason {
+	logger := klog.FromContext(ctx)
 	readiness, err := kubernetes.GetNodeReadiness(node)
 	if err != nil {
-		klog.Errorf("Couldn't determine node %q readiness while scaling down - assuming unready: %v", node.Name, err)
+		logger.Error(err, "Couldn't determine node readiness while scaling down - assuming unready", "node", node.Name)
 		return metrics.Unready
 	}
 	if !readiness.Ready {
@@ -193,19 +194,26 @@ func CleanUpAndRecordErrorForFailedScaleDownEvent(ctx context.Context, autoscali
 
 // CleanUpAndRecordFailedScaleDownEvent record failed scale down event and log a warning or an error.
 func CleanUpAndRecordFailedScaleDownEvent(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroupId string, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker, errMsg string, status status.NodeDeleteResult, logAsWarning bool) {
+	logger := klog.FromContext(ctx)
 	ctx = context.WithoutCancel(ctx)
-	var logMsgFormat, eventMsgFormat string
+	var eventMsgFormat string
 	if drain {
-		logMsgFormat = "couldn't delete node %q with drain"
 		eventMsgFormat = "failed to drain and delete node"
 	} else {
-		logMsgFormat = "couldn't delete empty node %q"
 		eventMsgFormat = "failed to delete empty node"
 	}
 	if logAsWarning {
-		klog.Warningf("Scale-down: "+logMsgFormat+", %v, status error: %v", node.Name, errMsg, status.Err)
+		if drain {
+			logger.Info("Scale-down: failed to delete node with drain", "node", node.Name, "errMsg", errMsg, "err", status.Err)
+		} else {
+			logger.Info("Scale-down: failed to delete empty node", "node", node.Name, "errMsg", errMsg, "err", status.Err)
+		}
 	} else {
-		klog.Errorf("Scale-down: "+logMsgFormat+", %v, status error: %v", node.Name, errMsg, status.Err)
+		if drain {
+			logger.Error(status.Err, "Scale-down: failed to delete node with drain", "node", node.Name, "errMsg", errMsg)
+		} else {
+			logger.Error(status.Err, "Scale-down: failed to delete empty node", "node", node.Name, "errMsg", errMsg)
+		}
 	}
 	autoscalingCtx.Recorder.Eventf(node, apiv1.EventTypeWarning, "ScaleDownFailed", eventMsgFormat+": %v", status.Err)
 	taints.CleanToBeDeleted(ctx, node, autoscalingCtx.ClientSet, autoscalingCtx.CordonNodeBeforeTerminate)
@@ -214,6 +222,7 @@ func CleanUpAndRecordFailedScaleDownEvent(ctx context.Context, autoscalingCtx *c
 
 // RegisterAndRecordSuccessfulScaleDownEvent register scale down and record successful scale down event.
 func RegisterAndRecordSuccessfulScaleDownEvent(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleStateNotifier nodegroupchange.NodeGroupChangeObserver, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker) {
+	logger := klog.FromContext(ctx)
 	autoscalingCtx.Recorder.Eventf(node, apiv1.EventTypeNormal, "ScaleDown", "nodes removed by cluster autoscaler")
 	currentTime := time.Now()
 	expectedDeleteTime := time.Now().Add(MaxCloudProviderNodeDeletionTime)
@@ -223,7 +232,7 @@ func RegisterAndRecordSuccessfulScaleDownEvent(ctx context.Context, autoscalingC
 	draDriverNames := ""
 	nodeInfo, err := nodeGroup.TemplateNodeInfo()
 	if err != nil {
-		klog.Warningf("Failed to get template node info for a node group: %s", err)
+		logger.Info("Failed to get template node info for a node group", "err", err)
 	} else {
 		draDriverNames = dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
 	}

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch.go
@@ -71,6 +71,7 @@ func NewNodeDeletionBatcher(autoscalingCtx *ca_context.AutoscalingContext, scale
 
 // AddNodes adds node list to delete candidates and schedules deletion. The deletion is performed asynchronously.
 func (d *NodeDeletionBatcher) AddNodes(ctx context.Context, nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool) {
+	ctx = context.WithoutCancel(ctx)
 	// If delete interval is 0, than instantly start node deletion.
 	if d.deleteInterval == 0 {
 		go d.deleteNodesAndRegisterStatus(ctx, nodes, nodeGroup.Id(), drain)
@@ -195,7 +196,6 @@ func CleanUpAndRecordErrorForFailedScaleDownEvent(ctx context.Context, autoscali
 // CleanUpAndRecordFailedScaleDownEvent record failed scale down event and log a warning or an error.
 func CleanUpAndRecordFailedScaleDownEvent(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroupId string, drain bool, nodeDeletionTracker *deletiontracker.NodeDeletionTracker, errMsg string, status status.NodeDeleteResult, logAsWarning bool) {
 	logger := klog.FromContext(ctx)
-	ctx = context.WithoutCancel(ctx)
 	var eventMsgFormat string
 	if drain {
 		eventMsgFormat = "failed to drain and delete node"

--- a/cluster-autoscaler/core/scaledown/actuation/delete_in_batch_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/delete_in_batch_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -195,7 +196,7 @@ func TestRemove(t *testing.T) {
 				}
 			}
 
-			err = d.remove(nodeGroup.Id())
+			err = d.remove(context.TODO(), nodeGroup.Id())
 			if test.err {
 				if err == nil {
 					t.Errorf("remove() should return error, but return nil")

--- a/cluster-autoscaler/core/scaledown/actuation/drain.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain.go
@@ -78,37 +78,40 @@ func NewEvictor(evictionRegister evictionRegister, shutdownGracePeriodByPodPrior
 
 // DrainNode groups pods in the node in to priority groups and, evicts pods in the ascending order of priorities.
 // If priority evictor is not enable, eviction of daemonSet pods is the best effort.
-func (e Evictor) DrainNode(autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
-	return e.drainNode(autoscalingCtx, nodeInfo, false)
+func (e Evictor) DrainNode(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
+	ctx = context.WithoutCancel(ctx)
+	return e.drainNode(ctx, autoscalingCtx, nodeInfo, false)
 }
 
 // drainNodeForce performs similar logic to DrainNode, but forcefully deletes pods on drain failure.
-func (e Evictor) drainNodeForce(autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
-	return e.drainNode(autoscalingCtx, nodeInfo, true)
+func (e Evictor) drainNodeForce(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
+	ctx = context.WithoutCancel(ctx)
+	return e.drainNode(ctx, autoscalingCtx, nodeInfo, true)
 }
 
 // drainNode implements the shared logic for draining a node, with the 'force' parameter
 // determining whether to forcefully delete pods upon eviction failure.
-func (e Evictor) drainNode(autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo, force bool) (map[string]status.PodEvictionResult, error) {
+func (e Evictor) drainNode(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo, force bool) (map[string]status.PodEvictionResult, error) {
 	node := nodeInfo.Node()
 	dsPods, pods := podsToEvict(nodeInfo, autoscalingCtx.DaemonSetEvictionForOccupiedNodes)
 	if e.fullDsEviction {
-		return e.drainNodeWithPodsBasedOnPodPriority(autoscalingCtx, node, append(pods, dsPods...), nil, force)
+		return e.drainNodeWithPodsBasedOnPodPriority(ctx, autoscalingCtx, node, append(pods, dsPods...), nil, force)
 	}
-	return e.drainNodeWithPodsBasedOnPodPriority(autoscalingCtx, node, pods, dsPods, force)
+	return e.drainNodeWithPodsBasedOnPodPriority(ctx, autoscalingCtx, node, pods, dsPods, force)
 }
 
 // EvictDaemonSetPods creates eviction objects for all DaemonSet pods on the node.
 // Eviction of DaemonSet pods are best effort. Does not wait for evictions to finish.
-func (e Evictor) EvictDaemonSetPods(autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
+func (e Evictor) EvictDaemonSetPods(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
 	node := nodeInfo.Node()
 	dsPods, _ := podsToEvict(nodeInfo, autoscalingCtx.DaemonSetEvictionForEmptyNodes)
-	return e.drainNodeWithPodsBasedOnPodPriority(autoscalingCtx, node, nil, dsPods, false) // force option applies only to full eviction pods
+	ctx = context.WithoutCancel(ctx)
+	return e.drainNodeWithPodsBasedOnPodPriority(ctx, autoscalingCtx, node, nil, dsPods, false) // force option applies only to full eviction pods
 }
 
 // drainNodeWithPodsBasedOnPodPriority performs drain logic on the node based on pod priorities.
 // Removes all pods, giving each pod group up to ShutdownGracePeriodSeconds to finish. The list of pods to evict has to be provided.
-func (e Evictor) drainNodeWithPodsBasedOnPodPriority(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, fullEvictionPods, bestEffortEvictionPods []*apiv1.Pod, force bool) (map[string]status.PodEvictionResult, error) {
+func (e Evictor) drainNodeWithPodsBasedOnPodPriority(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, fullEvictionPods, bestEffortEvictionPods []*apiv1.Pod, force bool) (map[string]status.PodEvictionResult, error) {
 	evictionResults := make(map[string]status.PodEvictionResult)
 
 	groups := groupByPriority(e.shutdownGracePeriodByPodPriority, fullEvictionPods, bestEffortEvictionPods)
@@ -127,13 +130,13 @@ func (e Evictor) drainNodeWithPodsBasedOnPodPriority(autoscalingCtx *ca_context.
 		}
 
 		var err error
-		evictionResults, err = e.initiateEviction(autoscalingCtx, node, group.FullEvictionPods, group.BestEffortEvictionPods, evictionResults, group.ShutdownGracePeriodSeconds, force)
+		evictionResults, err = e.initiateEviction(ctx, autoscalingCtx, node, group.FullEvictionPods, group.BestEffortEvictionPods, evictionResults, group.ShutdownGracePeriodSeconds, force)
 		if err != nil {
 			return evictionResults, err
 		}
 
 		// Evictions created successfully, wait ShutdownGracePeriodSeconds + podEvictionHeadroom to see if fullEviction pods really disappeared.
-		evictionResults, err = e.waitPodsToDisappear(autoscalingCtx, node, group.FullEvictionPods, evictionResults, group.ShutdownGracePeriodSeconds)
+		evictionResults, err = e.waitPodsToDisappear(ctx, autoscalingCtx, node, group.FullEvictionPods, evictionResults, group.ShutdownGracePeriodSeconds)
 		if err != nil {
 			return evictionResults, err
 		}
@@ -142,13 +145,13 @@ func (e Evictor) drainNodeWithPodsBasedOnPodPriority(autoscalingCtx *ca_context.
 	return evictionResults, nil
 }
 
-func (e Evictor) waitPodsToDisappear(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, pods []*apiv1.Pod, evictionResults map[string]status.PodEvictionResult,
+func (e Evictor) waitPodsToDisappear(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, pods []*apiv1.Pod, evictionResults map[string]status.PodEvictionResult,
 	maxTermination int64) (map[string]status.PodEvictionResult, error) {
 	var allGone bool
 	for start := time.Now(); time.Now().Sub(start) < time.Duration(maxTermination)*time.Second+e.PodEvictionHeadroom; time.Sleep(5 * time.Second) {
 		allGone = true
 		for _, pod := range pods {
-			podReturned, err := autoscalingCtx.ClientSet.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+			podReturned, err := autoscalingCtx.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 			if err == nil && (podReturned == nil || podReturned.Spec.NodeName == node.Name) {
 				klog.V(1).Infof("Not deleted yet %s/%s", pod.Namespace, pod.Name)
 				allGone = false
@@ -166,7 +169,7 @@ func (e Evictor) waitPodsToDisappear(autoscalingCtx *ca_context.AutoscalingConte
 	}
 
 	for _, pod := range pods {
-		podReturned, err := autoscalingCtx.ClientSet.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		podReturned, err := autoscalingCtx.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err == nil && (podReturned == nil || podReturned.Name == "" || podReturned.Spec.NodeName == node.Name) {
 			evictionResults[pod.Name] = status.PodEvictionResult{Pod: pod, TimedOut: true, Err: nil}
 		} else if err != nil && !kube_errors.IsNotFound(err) {
@@ -179,7 +182,7 @@ func (e Evictor) waitPodsToDisappear(autoscalingCtx *ca_context.AutoscalingConte
 	return evictionResults, errors.NewAutoscalerErrorf(errors.TransientError, "Failed to drain node %s/%s: pods remaining after timeout", node.Namespace, node.Name)
 }
 
-func (e Evictor) initiateEviction(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, fullEvictionPods, bestEffortEvictionPods []*apiv1.Pod, evictionResults map[string]status.PodEvictionResult,
+func (e Evictor) initiateEviction(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, fullEvictionPods, bestEffortEvictionPods []*apiv1.Pod, evictionResults map[string]status.PodEvictionResult,
 	maxTermination int64, force bool) (map[string]status.PodEvictionResult, error) {
 
 	retryUntil := time.Now().Add(autoscalingCtx.MaxPodEvictionTime)
@@ -189,13 +192,13 @@ func (e Evictor) initiateEviction(autoscalingCtx *ca_context.AutoscalingContext,
 	for _, pod := range fullEvictionPods {
 		evictionResults[pod.Name] = status.PodEvictionResult{Pod: pod, TimedOut: true, Err: nil}
 		go func(pod *apiv1.Pod) {
-			fullEvictionConfirmations <- e.evictPod(autoscalingCtx, pod, retryUntil, maxTermination, true, force)
+			fullEvictionConfirmations <- e.evictPod(ctx, autoscalingCtx, pod, retryUntil, maxTermination, true, force)
 		}(pod)
 	}
 
 	for _, pod := range bestEffortEvictionPods {
 		go func(pod *apiv1.Pod) {
-			bestEffortEvictionConfirmations <- e.evictPod(autoscalingCtx, pod, retryUntil, maxTermination, false, false) // force option applies only to full eviction pods
+			bestEffortEvictionConfirmations <- e.evictPod(ctx, autoscalingCtx, pod, retryUntil, maxTermination, false, false) // force option applies only to full eviction pods
 		}(pod)
 	}
 
@@ -225,7 +228,7 @@ func (e Evictor) initiateEviction(autoscalingCtx *ca_context.AutoscalingContext,
 	return evictionResults, nil
 }
 
-func (e Evictor) evictPod(autoscalingCtx *ca_context.AutoscalingContext, podToEvict *apiv1.Pod, retryUntil time.Time, maxTermination int64, fullEvictionPod bool, force bool) status.PodEvictionResult {
+func (e Evictor) evictPod(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, podToEvict *apiv1.Pod, retryUntil time.Time, maxTermination int64, fullEvictionPod bool, force bool) status.PodEvictionResult {
 	autoscalingCtx.Recorder.Eventf(podToEvict, apiv1.EventTypeNormal, "ScaleDown", "deleting pod for node scale down")
 
 	termination := int64(apiv1.DefaultTerminationGracePeriodSeconds)
@@ -248,7 +251,7 @@ func (e Evictor) evictPod(autoscalingCtx *ca_context.AutoscalingContext, podToEv
 				GracePeriodSeconds: &termination,
 			},
 		}
-		lastError = autoscalingCtx.ClientSet.CoreV1().Pods(podToEvict.Namespace).Evict(context.TODO(), eviction)
+		lastError = autoscalingCtx.ClientSet.CoreV1().Pods(podToEvict.Namespace).Evict(ctx, eviction)
 		if lastError == nil || kube_errors.IsNotFound(lastError) {
 			if e.evictionRegister != nil {
 				e.evictionRegister.RegisterEviction(podToEvict)
@@ -260,7 +263,7 @@ func (e Evictor) evictPod(autoscalingCtx *ca_context.AutoscalingContext, podToEv
 	klog.Errorf("Failed to evict pod %s, error: %v", podToEvict.Name, lastError)
 	if force {
 		// If eviction failed, forcefully delete the pod
-		if err := forceDeletePod(autoscalingCtx, podToEvict); err != nil {
+		if err := forceDeletePod(ctx, autoscalingCtx, podToEvict); err != nil {
 			return status.PodEvictionResult{Pod: podToEvict, TimedOut: false, Err: err}
 		}
 		if e.evictionRegister != nil {
@@ -292,9 +295,9 @@ func podsToEvict(nodeInfo *framework.NodeInfo, evictDsByDefault bool) (dsPods, n
 	return dsPodsToEvict, nonDsPods
 }
 
-func forceDeletePod(autoscalingCtx *ca_context.AutoscalingContext, pod *apiv1.Pod) error {
+func forceDeletePod(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, pod *apiv1.Pod) error {
 	klog.Infof("Starting force deletion of pod %s", pod.Name)
-	if err := autoscalingCtx.ClientSet.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{}); err != nil {
+	if err := autoscalingCtx.ClientSet.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
 		klog.Errorf("Failed to forcefully delete pod %s, error: %v", pod.Name, err)
 		autoscalingCtx.Recorder.Eventf(pod, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to forcefully delete pod for ScaleDown")
 		return fmt.Errorf("failed to forcefully delete unevicted pod %s/%s (last error: %v)", pod.Namespace, pod.Name, err)

--- a/cluster-autoscaler/core/scaledown/actuation/drain.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain.go
@@ -112,6 +112,7 @@ func (e Evictor) EvictDaemonSetPods(ctx context.Context, autoscalingCtx *ca_cont
 // drainNodeWithPodsBasedOnPodPriority performs drain logic on the node based on pod priorities.
 // Removes all pods, giving each pod group up to ShutdownGracePeriodSeconds to finish. The list of pods to evict has to be provided.
 func (e Evictor) drainNodeWithPodsBasedOnPodPriority(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, fullEvictionPods, bestEffortEvictionPods []*apiv1.Pod, force bool) (map[string]status.PodEvictionResult, error) {
+	logger := klog.FromContext(ctx)
 	evictionResults := make(map[string]status.PodEvictionResult)
 
 	groups := groupByPriority(e.shutdownGracePeriodByPodPriority, fullEvictionPods, bestEffortEvictionPods)
@@ -141,24 +142,25 @@ func (e Evictor) drainNodeWithPodsBasedOnPodPriority(ctx context.Context, autosc
 			return evictionResults, err
 		}
 	}
-	klog.V(1).Infof("All pods removed from %s", node.Name)
+	logger.V(1).Info("All pods removed", "node", node.Name)
 	return evictionResults, nil
 }
 
 func (e Evictor) waitPodsToDisappear(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, pods []*apiv1.Pod, evictionResults map[string]status.PodEvictionResult,
 	maxTermination int64) (map[string]status.PodEvictionResult, error) {
+	logger := klog.FromContext(ctx)
 	var allGone bool
 	for start := time.Now(); time.Now().Sub(start) < time.Duration(maxTermination)*time.Second+e.PodEvictionHeadroom; time.Sleep(5 * time.Second) {
 		allGone = true
 		for _, pod := range pods {
 			podReturned, err := autoscalingCtx.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 			if err == nil && (podReturned == nil || podReturned.Spec.NodeName == node.Name) {
-				klog.V(1).Infof("Not deleted yet %s/%s", pod.Namespace, pod.Name)
+				logger.V(1).Info("Not deleted yet", "namespace", pod.Namespace, "pod", pod.Name)
 				allGone = false
 				break
 			}
 			if err != nil && !kube_errors.IsNotFound(err) {
-				klog.Errorf("Failed to check pod %s/%s: %v", pod.Namespace, pod.Name, err)
+				logger.Error(err, "Failed to check pod", "namespace", pod.Namespace, "pod", pod.Name)
 				allGone = false
 				break
 			}
@@ -229,6 +231,7 @@ func (e Evictor) initiateEviction(ctx context.Context, autoscalingCtx *ca_contex
 }
 
 func (e Evictor) evictPod(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, podToEvict *apiv1.Pod, retryUntil time.Time, maxTermination int64, fullEvictionPod bool, force bool) status.PodEvictionResult {
+	logger := klog.FromContext(ctx)
 	autoscalingCtx.Recorder.Eventf(podToEvict, apiv1.EventTypeNormal, "ScaleDown", "deleting pod for node scale down")
 
 	termination := int64(apiv1.DefaultTerminationGracePeriodSeconds)
@@ -259,10 +262,10 @@ func (e Evictor) evictPod(ctx context.Context, autoscalingCtx *ca_context.Autosc
 			return status.PodEvictionResult{Pod: podToEvict, TimedOut: false, Err: nil}
 		}
 	}
-
-	klog.Errorf("Failed to evict pod %s, error: %v", podToEvict.Name, lastError)
+	logger.Error(lastError, "Failed to evict pod", "podToEvict", podToEvict.Name)
+	// If eviction failed, forcefully delete the pod
 	if force {
-		// If eviction failed, forcefully delete the pod
+
 		if err := forceDeletePod(ctx, autoscalingCtx, podToEvict); err != nil {
 			return status.PodEvictionResult{Pod: podToEvict, TimedOut: false, Err: err}
 		}
@@ -296,9 +299,10 @@ func podsToEvict(nodeInfo *framework.NodeInfo, evictDsByDefault bool) (dsPods, n
 }
 
 func forceDeletePod(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, pod *apiv1.Pod) error {
-	klog.Infof("Starting force deletion of pod %s", pod.Name)
+	logger := klog.FromContext(ctx)
+	logger.Info("Starting force deletion of pod", "pod", pod.Name)
 	if err := autoscalingCtx.ClientSet.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
-		klog.Errorf("Failed to forcefully delete pod %s, error: %v", pod.Name, err)
+		logger.Error(err, "Failed to forcefully delete pod", "pod", pod.Name)
 		autoscalingCtx.Recorder.Eventf(pod, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to forcefully delete pod for ScaleDown")
 		return fmt.Errorf("failed to forcefully delete unevicted pod %s/%s (last error: %v)", pod.Namespace, pod.Name, err)
 	}

--- a/cluster-autoscaler/core/scaledown/actuation/drain.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain.go
@@ -79,13 +79,11 @@ func NewEvictor(evictionRegister evictionRegister, shutdownGracePeriodByPodPrior
 // DrainNode groups pods in the node in to priority groups and, evicts pods in the ascending order of priorities.
 // If priority evictor is not enable, eviction of daemonSet pods is the best effort.
 func (e Evictor) DrainNode(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
-	ctx = context.WithoutCancel(ctx)
 	return e.drainNode(ctx, autoscalingCtx, nodeInfo, false)
 }
 
 // drainNodeForce performs similar logic to DrainNode, but forcefully deletes pods on drain failure.
 func (e Evictor) drainNodeForce(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
-	ctx = context.WithoutCancel(ctx)
 	return e.drainNode(ctx, autoscalingCtx, nodeInfo, true)
 }
 
@@ -105,7 +103,6 @@ func (e Evictor) drainNode(ctx context.Context, autoscalingCtx *ca_context.Autos
 func (e Evictor) EvictDaemonSetPods(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeInfo *framework.NodeInfo) (map[string]status.PodEvictionResult, error) {
 	node := nodeInfo.Node()
 	dsPods, _ := podsToEvict(nodeInfo, autoscalingCtx.DaemonSetEvictionForEmptyNodes)
-	ctx = context.WithoutCancel(ctx)
 	return e.drainNodeWithPodsBasedOnPodPriority(ctx, autoscalingCtx, node, nil, dsPods, false) // force option applies only to full eviction pods
 }
 
@@ -231,6 +228,7 @@ func (e Evictor) initiateEviction(ctx context.Context, autoscalingCtx *ca_contex
 }
 
 func (e Evictor) evictPod(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, podToEvict *apiv1.Pod, retryUntil time.Time, maxTermination int64, fullEvictionPod bool, force bool) status.PodEvictionResult {
+	ctx = context.WithoutCancel(ctx)
 	logger := klog.FromContext(ctx)
 	autoscalingCtx.Recorder.Eventf(podToEvict, apiv1.EventTypeNormal, "ScaleDown", "deleting pod for node scale down")
 
@@ -299,6 +297,7 @@ func podsToEvict(nodeInfo *framework.NodeInfo, evictDsByDefault bool) (dsPods, n
 }
 
 func forceDeletePod(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, pod *apiv1.Pod) error {
+	ctx = context.WithoutCancel(ctx)
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting force deletion of pod", "pod", pod.Name)
 	if err := autoscalingCtx.ClientSet.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {

--- a/cluster-autoscaler/core/scaledown/actuation/drain_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/drain_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -154,7 +155,7 @@ func TestDaemonSetEvictionForEmptyNodes(t *testing.T) {
 			}
 			nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(n1.Name)
 			assert.NoError(t, err)
-			_, err = evictor.EvictDaemonSetPods(&autoscalingCtx, nodeInfo)
+			_, err = evictor.EvictDaemonSetPods(context.TODO(), &autoscalingCtx, nodeInfo)
 			if scenario.err != nil {
 				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), scenario.err.Error())
@@ -221,7 +222,7 @@ func TestDrainNodeWithPods(t *testing.T) {
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1}, []*apiv1.Pod{p1, p2, d1})
 	nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(n1.Name)
 	assert.NoError(t, err)
-	_, err = evictor.DrainNode(&autoscalingCtx, nodeInfo)
+	_, err = evictor.DrainNode(context.TODO(), &autoscalingCtx, nodeInfo)
 	assert.NoError(t, err)
 	deleted := make([]string, 0)
 	deleted = append(deleted, utils.GetStringFromChan(deletedPods))
@@ -285,7 +286,7 @@ func TestDrainNodeWithPodsWithRescheduled(t *testing.T) {
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1}, []*apiv1.Pod{p1, p2})
 	nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(n1.Name)
 	assert.NoError(t, err)
-	_, err = evictor.DrainNode(&autoscalingCtx, nodeInfo)
+	_, err = evictor.DrainNode(context.TODO(), &autoscalingCtx, nodeInfo)
 	assert.NoError(t, err)
 	deleted := make([]string, 0)
 	deleted = append(deleted, utils.GetStringFromChan(deletedPods))
@@ -354,7 +355,7 @@ func TestDrainNodeWithPodsWithRetries(t *testing.T) {
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1}, []*apiv1.Pod{p1, p2, p3, d1})
 	nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(n1.Name)
 	assert.NoError(t, err)
-	_, err = evictor.DrainNode(&autoscalingCtx, nodeInfo)
+	_, err = evictor.DrainNode(context.TODO(), &autoscalingCtx, nodeInfo)
 	assert.NoError(t, err)
 	deleted := make([]string, 0)
 	deleted = append(deleted, utils.GetStringFromChan(deletedPods))
@@ -429,7 +430,7 @@ func TestDrainNodeWithPodsDaemonSetEvictionFailure(t *testing.T) {
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1}, []*apiv1.Pod{p1, p2, d1, d2})
 	nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(n1.Name)
 	assert.NoError(t, err)
-	evictionResults, err := evictor.DrainNode(&autoscalingCtx, nodeInfo)
+	evictionResults, err := evictor.DrainNode(context.TODO(), &autoscalingCtx, nodeInfo)
 	assert.NoError(t, err)
 
 	assertPodEvictionResults(t, wantEvictionResults, evictionResults)
@@ -492,7 +493,7 @@ func TestDrainNodeWithPodsEvictionFailure(t *testing.T) {
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1}, []*apiv1.Pod{p1, p2, p3, p4})
 	nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(n1.Name)
 	assert.NoError(t, err)
-	evictionResults, err := evictor.DrainNode(&autoscalingCtx, nodeInfo)
+	evictionResults, err := evictor.DrainNode(context.TODO(), &autoscalingCtx, nodeInfo)
 	assert.Error(t, err)
 
 	assertPodEvictionResults(t, wantEvictionResults, evictionResults)
@@ -574,7 +575,7 @@ func TestDrainForceNodeWithPodsEvictionFailure(t *testing.T) {
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1}, []*apiv1.Pod{p1, p2, p3, p4})
 	nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(n1.Name)
 	assert.NoError(t, err)
-	evictionResults, err := evictor.drainNodeForce(&autoscalingCtx, nodeInfo)
+	evictionResults, err := evictor.drainNodeForce(context.TODO(), &autoscalingCtx, nodeInfo)
 	assert.Error(t, err)
 
 	assertPodEvictionResults(t, wantEvictionResults, evictionResults)
@@ -634,7 +635,7 @@ func TestDrainWithPodsNodeDisappearanceFailure(t *testing.T) {
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1}, []*apiv1.Pod{p1, p2, p3, p4})
 	nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(n1.Name)
 	assert.NoError(t, err)
-	evictionResults, err := evictor.DrainNode(&autoscalingCtx, nodeInfo)
+	evictionResults, err := evictor.DrainNode(context.TODO(), &autoscalingCtx, nodeInfo)
 	assert.Error(t, err)
 
 	assertPodEvictionResults(t, wantEvictionResults, evictionResults)

--- a/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
+++ b/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"sync"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -33,7 +34,7 @@ import (
 )
 
 type batcher interface {
-	AddNodes(nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool)
+	AddNodes(ctx context.Context, nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool)
 }
 
 // GroupDeletionScheduler is a wrapper over NodeDeletionBatcher responsible for grouping nodes for deletion
@@ -76,80 +77,80 @@ func (ds *GroupDeletionScheduler) ResetAndReportMetrics() {
 
 // ScheduleDeletion schedules deletion of the node. Nodes that should be deleted in groups are queued until whole group is scheduled for deletion,
 // other nodes are passed over to NodeDeletionBatcher immediately.
-func (ds *GroupDeletionScheduler) ScheduleDeletion(nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool) {
-	ds.scheduleDeletion(nodeInfo, nodeGroup, batchSize, drain, false)
+func (ds *GroupDeletionScheduler) ScheduleDeletion(ctx context.Context, nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool) {
+	ds.scheduleDeletion(ctx, nodeInfo, nodeGroup, batchSize, drain, false)
 }
 
 // scheduleForceDeletion schedules forced node deletion, similar to ScheduleDeletion but bypassing eviction errors and PDB checks.
-func (ds *GroupDeletionScheduler) scheduleForceDeletion(nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool) {
-	ds.scheduleDeletion(nodeInfo, nodeGroup, batchSize, drain, true)
+func (ds *GroupDeletionScheduler) scheduleForceDeletion(ctx context.Context, nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool) {
+	ds.scheduleDeletion(ctx, nodeInfo, nodeGroup, batchSize, drain, true)
 }
 
 // scheduleDeletion handles the common logic for scheduling node deletion, supporting
 // both normal and forced deletion based on the 'force' parameter.
-func (ds *GroupDeletionScheduler) scheduleDeletion(nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool, force bool) {
+func (ds *GroupDeletionScheduler) scheduleDeletion(ctx context.Context, nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool, force bool) {
 	opts, err := nodeGroup.GetOptions(ds.autoscalingCtx.NodeGroupDefaults)
 	if err != nil && err != cloudprovider.ErrNotImplemented {
 		nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "GetOptions returned error %v", err)}
-		ds.AbortNodeDeletionDueToError(nodeInfo.Node(), nodeGroup.Id(), drain, "failed to get autoscaling options for a node group", nodeDeleteResult)
+		ds.AbortNodeDeletionDueToError(ctx, nodeInfo.Node(), nodeGroup.Id(), drain, "failed to get autoscaling options for a node group", nodeDeleteResult)
 		return
 	}
 	if opts == nil {
 		opts = &config.NodeGroupAutoscalingOptions{}
 	}
 
-	nodeDeleteResult := ds.prepareNodeForDeletion(nodeInfo, drain, force)
+	nodeDeleteResult := ds.prepareNodeForDeletion(ctx, nodeInfo, drain, force)
 	if nodeDeleteResult.Err != nil {
 		if force {
 			klog.Infof("Starting force deletion of node %s", nodeInfo.Node().Name)
 			if err := nodeGroup.ForceDeleteNodes([]*apiv1.Node{nodeInfo.Node()}); err != nil {
 				focrefulNodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: err}
-				ds.AbortNodeDeletion(nodeInfo.Node(), nodeGroup.Id(), drain, "forceful node deletion failed", focrefulNodeDeleteResult, true)
+				ds.AbortNodeDeletion(ctx, nodeInfo.Node(), nodeGroup.Id(), drain, "forceful node deletion failed", focrefulNodeDeleteResult, true)
 				return
 			}
 		} else {
-			ds.AbortNodeDeletion(nodeInfo.Node(), nodeGroup.Id(), drain, "prepareNodeForDeletion failed", nodeDeleteResult, true)
+			ds.AbortNodeDeletion(ctx, nodeInfo.Node(), nodeGroup.Id(), drain, "prepareNodeForDeletion failed", nodeDeleteResult, true)
 			return
 		}
 	}
 
-	ds.addToBatcher(nodeInfo, nodeGroup, batchSize, drain, opts.ZeroOrMaxNodeScaling)
+	ds.addToBatcher(ctx, nodeInfo, nodeGroup, batchSize, drain, opts.ZeroOrMaxNodeScaling)
 }
 
 // prepareNodeForDeletion is a long-running operation, so it needs to avoid locking the AtomicDeletionScheduler object
-func (ds *GroupDeletionScheduler) prepareNodeForDeletion(nodeInfo *framework.NodeInfo, drain bool, force bool) status.NodeDeleteResult {
+func (ds *GroupDeletionScheduler) prepareNodeForDeletion(ctx context.Context, nodeInfo *framework.NodeInfo, drain bool, force bool) status.NodeDeleteResult {
 	node := nodeInfo.Node()
 	if drain {
 		var evictionResults map[string]status.PodEvictionResult
 		var err error
 		if force {
-			evictionResults, err = ds.evictor.drainNodeForce(ds.autoscalingCtx, nodeInfo)
+			evictionResults, err = ds.evictor.drainNodeForce(ctx, ds.autoscalingCtx, nodeInfo)
 		} else {
-			evictionResults, err = ds.evictor.DrainNode(ds.autoscalingCtx, nodeInfo)
+			evictionResults, err = ds.evictor.DrainNode(ctx, ds.autoscalingCtx, nodeInfo)
 		}
 		if err != nil {
 			return status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToEvictPods, Err: err, PodEvictionResults: evictionResults}
 		}
 	} else {
-		if _, err := ds.evictor.EvictDaemonSetPods(ds.autoscalingCtx, nodeInfo); err != nil {
+		if _, err := ds.evictor.EvictDaemonSetPods(ctx, ds.autoscalingCtx, nodeInfo); err != nil {
 			// Evicting DS pods is best-effort, so proceed with the deletion even if there are errors.
 			klog.Warningf("Error while evicting DS pods from an empty node %q: %v", node.Name, err)
 		}
 	}
-	if err := WaitForDelayDeletion(node, ds.autoscalingCtx.ListerRegistry.AllNodeLister(), ds.autoscalingCtx.AutoscalingOptions.NodeDeletionDelayTimeout); err != nil {
+	if err := WaitForDelayDeletion(ctx, node, ds.autoscalingCtx.ListerRegistry.AllNodeLister(), ds.autoscalingCtx.AutoscalingOptions.NodeDeletionDelayTimeout); err != nil {
 		return status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: err}
 	}
 	return status.NodeDeleteResult{ResultType: status.NodeDeleteOk}
 }
 
-func (ds *GroupDeletionScheduler) addToBatcher(nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain, atomic bool) {
+func (ds *GroupDeletionScheduler) addToBatcher(ctx context.Context, nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain, atomic bool) {
 	ds.Lock()
 	defer ds.Unlock()
 	ds.nodeQueue[nodeGroup.Id()] = append(ds.nodeQueue[nodeGroup.Id()], nodeInfo.Node())
 	if atomic {
 		if ds.failuresForGroup[nodeGroup.Id()] {
 			nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: errors.NewAutoscalerError(errors.TransientError, "couldn't scale down other nodes in this node group")}
-			CleanUpAndRecordErrorForFailedScaleDownEvent(ds.autoscalingCtx, nodeInfo.Node(), nodeGroup.Id(), drain, ds.nodeDeletionTracker, "scale down failed for node group as a whole", nodeDeleteResult)
+			CleanUpAndRecordErrorForFailedScaleDownEvent(ctx, ds.autoscalingCtx, nodeInfo.Node(), nodeGroup.Id(), drain, ds.nodeDeletionTracker, "scale down failed for node group as a whole", nodeDeleteResult)
 			delete(ds.nodeQueue, nodeGroup.Id())
 		}
 		if len(ds.nodeQueue[nodeGroup.Id()]) < batchSize {
@@ -157,27 +158,27 @@ func (ds *GroupDeletionScheduler) addToBatcher(nodeInfo *framework.NodeInfo, nod
 			return
 		}
 	}
-	ds.nodeDeletionBatcher.AddNodes(ds.nodeQueue[nodeGroup.Id()], nodeGroup, drain)
+	ds.nodeDeletionBatcher.AddNodes(ctx, ds.nodeQueue[nodeGroup.Id()], nodeGroup, drain)
 	ds.nodeQueue[nodeGroup.Id()] = []*apiv1.Node{}
 }
 
 // AbortNodeDeletionDueToError frees up a node that couldn't be deleted successfully. If it was a part of a group, the same is applied for other nodes queued for deletion.
-func (ds *GroupDeletionScheduler) AbortNodeDeletionDueToError(node *apiv1.Node, nodeGroupId string, drain bool, errMsg string, result status.NodeDeleteResult) {
-	ds.AbortNodeDeletion(node, nodeGroupId, drain, errMsg, result, false)
+func (ds *GroupDeletionScheduler) AbortNodeDeletionDueToError(ctx context.Context, node *apiv1.Node, nodeGroupId string, drain bool, errMsg string, result status.NodeDeleteResult) {
+	ds.AbortNodeDeletion(ctx, node, nodeGroupId, drain, errMsg, result, false)
 }
 
 // AbortNodeDeletion frees up a node that couldn't be deleted successfully. If it was a part of a group, the same is applied for other nodes queued for deletion.
-func (ds *GroupDeletionScheduler) AbortNodeDeletion(node *apiv1.Node, nodeGroupId string, drain bool, errMsg string, result status.NodeDeleteResult, logAsWarning bool) {
+func (ds *GroupDeletionScheduler) AbortNodeDeletion(ctx context.Context, node *apiv1.Node, nodeGroupId string, drain bool, errMsg string, result status.NodeDeleteResult, logAsWarning bool) {
 	ds.Lock()
 	defer ds.Unlock()
 	ds.failuresForGroup[nodeGroupId] = true
-	CleanUpAndRecordFailedScaleDownEvent(ds.autoscalingCtx, node, nodeGroupId, drain, ds.nodeDeletionTracker, errMsg, result, logAsWarning)
+	CleanUpAndRecordFailedScaleDownEvent(ctx, ds.autoscalingCtx, node, nodeGroupId, drain, ds.nodeDeletionTracker, errMsg, result, logAsWarning)
 	for _, otherNode := range ds.nodeQueue[nodeGroupId] {
 		if otherNode == node {
 			continue
 		}
 		nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: errors.NewAutoscalerError(errors.TransientError, "couldn't scale down other nodes in this node group")}
-		CleanUpAndRecordFailedScaleDownEvent(ds.autoscalingCtx, otherNode, nodeGroupId, drain, ds.nodeDeletionTracker, "scale down failed for node group as a whole", nodeDeleteResult, logAsWarning)
+		CleanUpAndRecordFailedScaleDownEvent(ctx, ds.autoscalingCtx, otherNode, nodeGroupId, drain, ds.nodeDeletionTracker, "scale down failed for node group as a whole", nodeDeleteResult, logAsWarning)
 	}
 	delete(ds.nodeQueue, nodeGroupId)
 }

--- a/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
+++ b/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
@@ -78,11 +78,13 @@ func (ds *GroupDeletionScheduler) ResetAndReportMetrics() {
 // ScheduleDeletion schedules deletion of the node. Nodes that should be deleted in groups are queued until whole group is scheduled for deletion,
 // other nodes are passed over to NodeDeletionBatcher immediately.
 func (ds *GroupDeletionScheduler) ScheduleDeletion(ctx context.Context, nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool) {
+	ctx = context.WithoutCancel(ctx)
 	ds.scheduleDeletion(ctx, nodeInfo, nodeGroup, batchSize, drain, false)
 }
 
 // scheduleForceDeletion schedules forced node deletion, similar to ScheduleDeletion but bypassing eviction errors and PDB checks.
 func (ds *GroupDeletionScheduler) scheduleForceDeletion(ctx context.Context, nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool) {
+	ctx = context.WithoutCancel(ctx)
 	ds.scheduleDeletion(ctx, nodeInfo, nodeGroup, batchSize, drain, true)
 }
 

--- a/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
+++ b/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler.go
@@ -89,6 +89,7 @@ func (ds *GroupDeletionScheduler) scheduleForceDeletion(ctx context.Context, nod
 // scheduleDeletion handles the common logic for scheduling node deletion, supporting
 // both normal and forced deletion based on the 'force' parameter.
 func (ds *GroupDeletionScheduler) scheduleDeletion(ctx context.Context, nodeInfo *framework.NodeInfo, nodeGroup cloudprovider.NodeGroup, batchSize int, drain bool, force bool) {
+	logger := klog.FromContext(ctx)
 	opts, err := nodeGroup.GetOptions(ds.autoscalingCtx.NodeGroupDefaults)
 	if err != nil && err != cloudprovider.ErrNotImplemented {
 		nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorInternal, Err: errors.NewAutoscalerErrorf(errors.InternalError, "GetOptions returned error %v", err)}
@@ -102,7 +103,8 @@ func (ds *GroupDeletionScheduler) scheduleDeletion(ctx context.Context, nodeInfo
 	nodeDeleteResult := ds.prepareNodeForDeletion(ctx, nodeInfo, drain, force)
 	if nodeDeleteResult.Err != nil {
 		if force {
-			klog.Infof("Starting force deletion of node %s", nodeInfo.Node().Name)
+			logger.Info("Starting force deletion of node", "node", nodeInfo.Node().Name, "err", nodeDeleteResult.Err)
+
 			if err := nodeGroup.ForceDeleteNodes([]*apiv1.Node{nodeInfo.Node()}); err != nil {
 				focrefulNodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: err}
 				ds.AbortNodeDeletion(ctx, nodeInfo.Node(), nodeGroup.Id(), drain, "forceful node deletion failed", focrefulNodeDeleteResult, true)
@@ -119,6 +121,7 @@ func (ds *GroupDeletionScheduler) scheduleDeletion(ctx context.Context, nodeInfo
 
 // prepareNodeForDeletion is a long-running operation, so it needs to avoid locking the AtomicDeletionScheduler object
 func (ds *GroupDeletionScheduler) prepareNodeForDeletion(ctx context.Context, nodeInfo *framework.NodeInfo, drain bool, force bool) status.NodeDeleteResult {
+	logger := klog.FromContext(ctx)
 	node := nodeInfo.Node()
 	if drain {
 		var evictionResults map[string]status.PodEvictionResult
@@ -134,7 +137,7 @@ func (ds *GroupDeletionScheduler) prepareNodeForDeletion(ctx context.Context, no
 	} else {
 		if _, err := ds.evictor.EvictDaemonSetPods(ctx, ds.autoscalingCtx, nodeInfo); err != nil {
 			// Evicting DS pods is best-effort, so proceed with the deletion even if there are errors.
-			klog.Warningf("Error while evicting DS pods from an empty node %q: %v", node.Name, err)
+			logger.Info("Error while evicting DS pods from an empty node", "node", node.Name, "err", err)
 		}
 	}
 	if err := WaitForDelayDeletion(ctx, node, ds.autoscalingCtx.ListerRegistry.AllNodeLister(), ds.autoscalingCtx.AutoscalingOptions.NodeDeletionDelayTimeout); err != nil {

--- a/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/group_deletion_scheduler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -173,7 +174,7 @@ func TestScheduleDeletion(t *testing.T) {
 				for _, bucket := range ti.toAbort {
 					for _, node := range bucket.Nodes {
 						nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: cmpopts.AnyError}
-						scheduler.AbortNodeDeletionDueToError(node, bucket.Group.Id(), false, "simulated abort", nodeDeleteResult)
+						scheduler.AbortNodeDeletionDueToError(context.TODO(), node, bucket.Group.Id(), false, "simulated abort", nodeDeleteResult)
 					}
 				}
 				if err := scheduleAll(ti.toScheduleAfterAbort, scheduler); err != nil {
@@ -203,7 +204,7 @@ type countingBatcher struct {
 	addedNodes int
 }
 
-func (b *countingBatcher) AddNodes(nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool) {
+func (b *countingBatcher) AddNodes(ctx context.Context, nodes []*apiv1.Node, nodeGroup cloudprovider.NodeGroup, drain bool) {
 	b.addedNodes += len(nodes)
 }
 
@@ -214,7 +215,7 @@ func scheduleAll(toSchedule []*budgets.NodeGroupView, scheduler *GroupDeletionSc
 			return fmt.Errorf("failed to get target size for node group %q: %s", bucket.Group.Id(), err)
 		}
 		for _, node := range bucket.Nodes {
-			scheduler.ScheduleDeletion(framework.NewTestNodeInfo(node), bucket.Group, bucketSize, false)
+			scheduler.ScheduleDeletion(context.TODO(), framework.NewTestNodeInfo(node), bucket.Group, bucketSize, false)
 		}
 	}
 	return nil

--- a/cluster-autoscaler/core/scaledown/actuation/priority_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/priority_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -98,7 +99,7 @@ func TestPriorityEvictor(t *testing.T) {
 	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1}, []*apiv1.Pod{p1, p2, p3})
 	nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(n1.Name)
 	assert.NoError(t, err)
-	_, err = evictor.DrainNode(&autoscalingCtx, nodeInfo)
+	_, err = evictor.DrainNode(context.TODO(), &autoscalingCtx, nodeInfo)
 	assert.NoError(t, err)
 	deleted := make([]string, 0)
 	deleted = append(deleted, utils.GetStringFromChan(deletedPods))

--- a/cluster-autoscaler/core/scaledown/actuation/softtaint.go
+++ b/cluster-autoscaler/core/scaledown/actuation/softtaint.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"time"
 
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
@@ -28,8 +29,8 @@ import (
 )
 
 // UpdateSoftDeletionTaints manages soft taints of unneeded nodes.
-func UpdateSoftDeletionTaints(autoscalingCtx *ca_context.AutoscalingContext, uneededNodes, neededNodes []*apiv1.Node) (errors []error) {
-	defer metrics.UpdateDurationFromStart(metrics.ScaleDownSoftTaintUnneeded, time.Now())
+func UpdateSoftDeletionTaints(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, uneededNodes, neededNodes []*apiv1.Node) (errors []error) {
+	defer metrics.UpdateDurationFromStart(ctx, metrics.ScaleDownSoftTaintUnneeded, time.Now())
 	b := &budgetTracker{
 		apiCallBudget: autoscalingCtx.AutoscalingOptions.MaxBulkSoftTaintCount,
 		timeBudget:    autoscalingCtx.AutoscalingOptions.MaxBulkSoftTaintTime,
@@ -44,7 +45,7 @@ func UpdateSoftDeletionTaints(autoscalingCtx *ca_context.AutoscalingContext, une
 			continue
 		}
 		b.processWithinBudget(func() {
-			_, err := taints.CleanDeletionCandidate(node, autoscalingCtx.ClientSet)
+			_, err := taints.CleanDeletionCandidate(ctx, node, autoscalingCtx.ClientSet)
 			if err != nil {
 				errors = append(errors, err)
 				klog.Warningf("Soft taint on %s removal error %v", node.Name, err)
@@ -60,14 +61,14 @@ func UpdateSoftDeletionTaints(autoscalingCtx *ca_context.AutoscalingContext, une
 			continue
 		}
 		b.processWithinBudget(func() {
-			_, err := taints.MarkDeletionCandidate(node, autoscalingCtx.ClientSet)
+			_, err := taints.MarkDeletionCandidate(ctx, node, autoscalingCtx.ClientSet)
 			if err != nil {
 				errors = append(errors, err)
 				klog.Warningf("Soft taint on %s adding error %v", node.Name, err)
 			}
 		})
 	}
-	b.reportExceededLimits()
+	b.reportExceededLimits(ctx)
 	return
 }
 
@@ -90,7 +91,7 @@ func (b *budgetTracker) processWithinBudget(f func()) {
 	f()
 }
 
-func (b *budgetTracker) reportExceededLimits() {
+func (b *budgetTracker) reportExceededLimits(ctx context.Context) {
 	if b.skippedNodes > 0 {
 		klog.V(4).Infof("Skipped adding/removing soft taints on %v nodes - API call or time limit exceeded", b.skippedNodes)
 	}

--- a/cluster-autoscaler/core/scaledown/actuation/softtaint.go
+++ b/cluster-autoscaler/core/scaledown/actuation/softtaint.go
@@ -30,6 +30,7 @@ import (
 
 // UpdateSoftDeletionTaints manages soft taints of unneeded nodes.
 func UpdateSoftDeletionTaints(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, uneededNodes, neededNodes []*apiv1.Node) (errors []error) {
+	logger := klog.FromContext(ctx)
 	defer metrics.UpdateDurationFromStart(ctx, metrics.ScaleDownSoftTaintUnneeded, time.Now())
 	b := &budgetTracker{
 		apiCallBudget: autoscalingCtx.AutoscalingOptions.MaxBulkSoftTaintCount,
@@ -48,7 +49,7 @@ func UpdateSoftDeletionTaints(ctx context.Context, autoscalingCtx *ca_context.Au
 			_, err := taints.CleanDeletionCandidate(ctx, node, autoscalingCtx.ClientSet)
 			if err != nil {
 				errors = append(errors, err)
-				klog.Warningf("Soft taint on %s removal error %v", node.Name, err)
+				logger.Info("Soft taint removal", "node", node.Name, "err", err)
 			}
 		})
 	}
@@ -64,7 +65,7 @@ func UpdateSoftDeletionTaints(ctx context.Context, autoscalingCtx *ca_context.Au
 			_, err := taints.MarkDeletionCandidate(ctx, node, autoscalingCtx.ClientSet)
 			if err != nil {
 				errors = append(errors, err)
-				klog.Warningf("Soft taint on %s adding error %v", node.Name, err)
+				logger.Info("Soft taint adding", "node", node.Name, "err", err)
 			}
 		})
 	}
@@ -92,7 +93,8 @@ func (b *budgetTracker) processWithinBudget(f func()) {
 }
 
 func (b *budgetTracker) reportExceededLimits(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	if b.skippedNodes > 0 {
-		klog.V(4).Infof("Skipped adding/removing soft taints on %v nodes - API call or time limit exceeded", b.skippedNodes)
+		logger.V(4).Info("Skipped adding removing soft taints nodes - API call or time limit exceeded", "skippedNodes", b.skippedNodes)
 	}
 }

--- a/cluster-autoscaler/core/scaledown/actuation/softtaint_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/softtaint_test.go
@@ -74,42 +74,42 @@ func TestSoftTaintUpdate(t *testing.T) {
 
 	// Test no superfluous nodes
 	nodes := getAllNodes(t, fakeClient)
-	errs := UpdateSoftDeletionTaints(&actx, nil, nodes)
+	errs := UpdateSoftDeletionTaints(context.TODO(), &actx, nil, nodes)
 	assert.Empty(t, errs)
 	assert.False(t, hasDeletionCandidateTaint(t, fakeClient, n1000.Name))
 	assert.False(t, hasDeletionCandidateTaint(t, fakeClient, n2000.Name))
 
 	// Test one unneeded node
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, []*apiv1.Node{n1000}, []*apiv1.Node{n2000})
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, []*apiv1.Node{n1000}, []*apiv1.Node{n2000})
 	assert.Empty(t, errs)
 	assert.True(t, hasDeletionCandidateTaint(t, fakeClient, n1000.Name))
 	assert.False(t, hasDeletionCandidateTaint(t, fakeClient, n2000.Name))
 
 	// Test remove soft taint
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nil, nodes)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nil, nodes)
 	assert.Empty(t, errs)
 	assert.False(t, hasDeletionCandidateTaint(t, fakeClient, n1000.Name))
 	assert.False(t, hasDeletionCandidateTaint(t, fakeClient, n2000.Name))
 
 	// Test bulk update taint limit
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nodes, nil)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nodes, nil)
 	assert.Empty(t, errs)
 	assert.Equal(t, 1, countDeletionCandidateTaints(t, fakeClient))
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nodes, nil)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nodes, nil)
 	assert.Empty(t, errs)
 	assert.Equal(t, 2, countDeletionCandidateTaints(t, fakeClient))
 
 	// Test bulk update untaint limit
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nil, nodes)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nil, nodes)
 	assert.Empty(t, errs)
 	assert.Equal(t, 1, countDeletionCandidateTaints(t, fakeClient))
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nil, nodes)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nil, nodes)
 	assert.Empty(t, errs)
 	assert.Equal(t, 0, countDeletionCandidateTaints(t, fakeClient))
 }
@@ -158,7 +158,7 @@ func TestSoftTaintTimeLimit(t *testing.T) {
 
 	// Test bulk taint
 	nodes := getAllNodes(t, fakeClient)
-	errs := UpdateSoftDeletionTaints(&actx, nodes, nil)
+	errs := UpdateSoftDeletionTaints(context.TODO(), &actx, nodes, nil)
 	assert.Empty(t, errs)
 	assert.Equal(t, 2, countDeletionCandidateTaints(t, fakeClient))
 	assert.True(t, hasDeletionCandidateTaint(t, fakeClient, n1.Name))
@@ -166,7 +166,7 @@ func TestSoftTaintTimeLimit(t *testing.T) {
 
 	// Test bulk untaint
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nil, nodes)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nil, nodes)
 	assert.Empty(t, errs)
 	assert.Equal(t, 0, countDeletionCandidateTaints(t, fakeClient))
 	assert.False(t, hasDeletionCandidateTaint(t, fakeClient, n1.Name))
@@ -176,21 +176,21 @@ func TestSoftTaintTimeLimit(t *testing.T) {
 
 	// Test duration limit of bulk taint
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nodes, nil)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nodes, nil)
 	assert.Empty(t, errs)
 	assert.Equal(t, 1, countDeletionCandidateTaints(t, fakeClient))
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nodes, nil)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nodes, nil)
 	assert.Empty(t, errs)
 	assert.Equal(t, 2, countDeletionCandidateTaints(t, fakeClient))
 
 	// Test duration limit of bulk untaint
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nil, nodes)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nil, nodes)
 	assert.Empty(t, errs)
 	assert.Equal(t, 1, countDeletionCandidateTaints(t, fakeClient))
 	nodes = getAllNodes(t, fakeClient)
-	errs = UpdateSoftDeletionTaints(&actx, nil, nodes)
+	errs = UpdateSoftDeletionTaints(context.TODO(), &actx, nil, nodes)
 	assert.Empty(t, errs)
 	assert.Equal(t, 0, countDeletionCandidateTaints(t, fakeClient))
 }

--- a/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker.go
@@ -92,13 +92,14 @@ func (u *UpdateLatencyTracker) Start(ctx context.Context) {
 }
 
 func (u *UpdateLatencyTracker) updateFinishTime(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	for nodeName := range u.startTimestamp {
 		if _, ok := u.finishTimestamp[nodeName]; ok {
 			continue
 		}
 		node, err := u.nodeLister.Get(nodeName)
 		if err != nil {
-			klog.Errorf("Error getting node: %v", err)
+			logger.Error(err, "Error getting node")
 			continue
 		}
 		if taints.HasToBeDeletedTaint(node) {
@@ -121,6 +122,7 @@ func (u *UpdateLatencyTracker) calculateLatency() time.Duration {
 }
 
 func (u *UpdateLatencyTracker) await(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	waitingForTaintingStartTime := time.Now()
 	for {
 		switch {
@@ -129,7 +131,8 @@ func (u *UpdateLatencyTracker) await(ctx context.Context) {
 			u.ResultChan <- latency
 			return
 		case time.Now().After(waitingForTaintingStartTime.Add(waitForTaintingTimeoutDuration)):
-			klog.Errorf("Timeout before tainting all nodes, latency measurement will be stale")
+			logger.Error(nil, "Timeout before tainting all nodes, latency measurement will be stale")
+
 			close(u.ResultChan)
 			return
 		default:

--- a/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -71,12 +72,12 @@ func NewUpdateLatencyTracker(nodeLister kubernetes.NodeLister) *UpdateLatencyTra
 
 // Start starts listening for node tainting start timestamps and update the timestamps that
 // the taint appears for the first time for a particular node. Listen AwaitOrStopChan for stop/await signals
-func (u *UpdateLatencyTracker) Start() {
+func (u *UpdateLatencyTracker) Start(ctx context.Context) {
 	for {
 		select {
 		case _, ok := <-u.AwaitOrStopChan:
 			if ok {
-				u.await()
+				u.await(ctx)
 			}
 			return
 		case ntst := <-u.StartTimeChan:
@@ -85,12 +86,12 @@ func (u *UpdateLatencyTracker) Start() {
 			continue
 		default:
 		}
-		u.updateFinishTime()
+		u.updateFinishTime(ctx)
 		time.Sleep(u.sleepDurationWhenPolling)
 	}
 }
 
-func (u *UpdateLatencyTracker) updateFinishTime() {
+func (u *UpdateLatencyTracker) updateFinishTime(ctx context.Context) {
 	for nodeName := range u.startTimestamp {
 		if _, ok := u.finishTimestamp[nodeName]; ok {
 			continue
@@ -119,7 +120,7 @@ func (u *UpdateLatencyTracker) calculateLatency() time.Duration {
 	return maxLatency
 }
 
-func (u *UpdateLatencyTracker) await() {
+func (u *UpdateLatencyTracker) await(ctx context.Context) {
 	waitingForTaintingStartTime := time.Now()
 	for {
 		switch {
@@ -133,7 +134,7 @@ func (u *UpdateLatencyTracker) await() {
 			return
 		default:
 			time.Sleep(u.sleepDurationWhenPolling)
-			u.updateFinishTime()
+			u.updateFinishTime(ctx)
 		}
 	}
 }

--- a/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actuation
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -182,7 +183,7 @@ func TestUpdateLatencyCalculation(t *testing.T) {
 			}
 			nodeLister := NewTestCustomNodeLister(nodes, tc.nodeTaintAfterNthGetCall)
 			updateLatencyTracker := NewUpdateLatencyTrackerForTesting(nodeLister, mc.Now)
-			go updateLatencyTracker.Start()
+			go updateLatencyTracker.Start(context.TODO())
 			for _, node := range nodes {
 				updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, tc.startTime}
 			}

--- a/cluster-autoscaler/core/scaledown/budgets/budgets.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets.go
@@ -17,6 +17,7 @@ limitations under the License.
 package budgets
 
 import (
+	"context"
 	"strconv"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -53,9 +54,9 @@ func NewScaleDownBudgetProcessor(autoscalingCtx *ca_context.AutoscalingContext) 
 // CropNodes crops the provided node lists to respect scale-down max parallelism budgets.
 // The returned nodes are grouped by a node group.
 // This function assumes that each node group may occur at most once in each of the "empty" and "drain" lists.
-func (bp *ScaleDownBudgetProcessor) CropNodes(as scaledown.ActuationStatus, empty, drain []*apiv1.Node) (emptyToDelete, drainToDelete []*NodeGroupView) {
-	emptyIndividual, emptyAtomic := bp.categorize(bp.group(empty))
-	drainIndividual, drainAtomic := bp.categorize(bp.group(drain))
+func (bp *ScaleDownBudgetProcessor) CropNodes(ctx context.Context, as scaledown.ActuationStatus, empty, drain []*apiv1.Node) (emptyToDelete, drainToDelete []*NodeGroupView) {
+	emptyIndividual, emptyAtomic := bp.categorize(ctx, bp.group(ctx, empty))
+	drainIndividual, drainAtomic := bp.categorize(ctx, bp.group(ctx, drain))
 
 	emptyAtomicMap := groupBuckets(emptyAtomic)
 	drainAtomicMap := groupBuckets(drainAtomic)
@@ -207,7 +208,7 @@ func cropIndividualNodes(toDelete []*NodeGroupView, groups []*NodeGroupView, bud
 	return toDelete, budget - remainingBudget
 }
 
-func (bp *ScaleDownBudgetProcessor) group(nodes []*apiv1.Node) []*NodeGroupView {
+func (bp *ScaleDownBudgetProcessor) group(ctx context.Context, nodes []*apiv1.Node) []*NodeGroupView {
 	groupMap := map[string]int{}
 	grouped := []*NodeGroupView{}
 	for _, node := range nodes {
@@ -229,7 +230,7 @@ func (bp *ScaleDownBudgetProcessor) group(nodes []*apiv1.Node) []*NodeGroupView 
 	return grouped
 }
 
-func (bp *ScaleDownBudgetProcessor) categorize(groups []*NodeGroupView) (individual, atomic []*NodeGroupView) {
+func (bp *ScaleDownBudgetProcessor) categorize(ctx context.Context, groups []*NodeGroupView) (individual, atomic []*NodeGroupView) {
 	for _, view := range groups {
 		autoscalingOptions, err := view.Group.GetOptions(bp.autoscalingCtx.NodeGroupDefaults)
 		if err != nil && err != cloudprovider.ErrNotImplemented {

--- a/cluster-autoscaler/core/scaledown/budgets/budgets.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets.go
@@ -55,6 +55,7 @@ func NewScaleDownBudgetProcessor(autoscalingCtx *ca_context.AutoscalingContext) 
 // The returned nodes are grouped by a node group.
 // This function assumes that each node group may occur at most once in each of the "empty" and "drain" lists.
 func (bp *ScaleDownBudgetProcessor) CropNodes(ctx context.Context, as scaledown.ActuationStatus, empty, drain []*apiv1.Node) (emptyToDelete, drainToDelete []*NodeGroupView) {
+	logger := klog.FromContext(ctx)
 	emptyIndividual, emptyAtomic := bp.categorize(ctx, bp.group(ctx, empty))
 	drainIndividual, drainAtomic := bp.categorize(ctx, bp.group(ctx, drain))
 
@@ -71,7 +72,7 @@ func (bp *ScaleDownBudgetProcessor) CropNodes(ctx context.Context, as scaledown.
 
 	allNodes, err := allNodes(bp.autoscalingCtx.ClusterSnapshot)
 	if err != nil {
-		klog.Errorf("failed to read all nodes from the cluster snapshot for nodes cropping, err: %s", err)
+		logger.Error(err, "failed to read all nodes from the cluster snapshot for nodes cropping")
 	}
 
 	for _, bucket := range emptyAtomic {
@@ -95,7 +96,7 @@ func (bp *ScaleDownBudgetProcessor) CropNodes(ctx context.Context, as scaledown.
 		var targetSize int
 		if targetSize, err = bucket.Group.TargetSize(); err != nil {
 			// Very unlikely to happen, as we've got this far with this group.
-			klog.Errorf("not scaling atomically scaled group %v: can't get target size, err: %v", bucket.Group.Id(), err)
+			logger.Error(err, "not scaling atomically scaled group: can't get target size", "groupId", bucket.Group.Id())
 			continue
 		}
 		bucket.BatchSize = targetSize
@@ -105,7 +106,7 @@ func (bp *ScaleDownBudgetProcessor) CropNodes(ctx context.Context, as scaledown.
 		// for such instances could block scale down indefinitely.
 		registeredNodes, err := bp.getAllRegisteredNodesForNodeGroup(allNodes, bucket.Group)
 		if err != nil {
-			klog.Errorf("failed to get registered nodes for node group %s: %v", bucket.Group.Id(), err)
+			logger.Error(err, "failed to get registered nodes for node group", "groupId", bucket.Group.Id())
 		}
 		currentSize := len(registeredNodes)
 		if len(bucket.Nodes) == currentSize {
@@ -114,7 +115,7 @@ func (bp *ScaleDownBudgetProcessor) CropNodes(ctx context.Context, as scaledown.
 
 		if len(bucket.Nodes)+len(drainNodes) != targetSize && len(bucket.Nodes)+len(drainNodes) != currentSize {
 			// We can't only partially scale down atomic group.
-			klog.Errorf("not scaling atomic group %v because not all nodes are candidates, target size: %v, current size: %v empty: %v, drainable: %v", bucket.Group.Id(), targetSize, currentSize, len(bucket.Nodes), len(drainNodes))
+			logger.Error(nil, "not scaling atomic group because not all nodes are candidates, target size, current size: empty, drainable", "groupId", bucket.Group.Id(), "targetSize", targetSize, "currentSize", currentSize, "nodesCount", len(bucket.Nodes), "drainNodesCount", len(drainNodes))
 			continue
 		}
 		emptyToDelete = append(emptyToDelete, bucket)
@@ -145,7 +146,7 @@ func (bp *ScaleDownBudgetProcessor) CropNodes(ctx context.Context, as scaledown.
 		var targetSize int
 		if targetSize, err = bucket.Group.TargetSize(); err != nil {
 			// Very unlikely to happen, as we've got this far with this group.
-			klog.Errorf("not scaling atomically scaled group %v: can't get target size, err: %v", bucket.Group.Id(), err)
+			logger.Error(err, "not scaling atomically scaled group: can't get target size", "groupId", bucket.Group.Id())
 			continue
 		}
 		bucket.BatchSize = targetSize
@@ -155,7 +156,7 @@ func (bp *ScaleDownBudgetProcessor) CropNodes(ctx context.Context, as scaledown.
 		// for such instances could block scale down indefinitely.
 		registeredNodes, err := bp.getAllRegisteredNodesForNodeGroup(allNodes, bucket.Group)
 		if err != nil {
-			klog.Errorf("Failed to get registered nodes for node group %s: %v", bucket.Group.Id(), err)
+			logger.Error(err, "Failed to get registered nodes for node group", "groupId", bucket.Group.Id())
 		}
 		currentSize := len(registeredNodes)
 		if len(bucket.Nodes) == currentSize {
@@ -164,7 +165,7 @@ func (bp *ScaleDownBudgetProcessor) CropNodes(ctx context.Context, as scaledown.
 
 		if len(bucket.Nodes) != targetSize && len(bucket.Nodes) != currentSize {
 			// We can't only partially scale down atomic group.
-			klog.Errorf("not scaling atomic group %v because not all nodes are candidates, target size: %v, current size: %v, empty: none, drainable: %v", bucket.Group.Id(), targetSize, currentSize, len(bucket.Nodes))
+			logger.Error(nil, "not scaling atomic group because not all nodes are candidates, target size, current size, empty: none, drainable", "groupId", bucket.Group.Id(), "targetSize", targetSize, "currentSize", currentSize, "nodesCount", len(bucket.Nodes))
 			continue
 		}
 		drainToDelete = append(drainToDelete, bucket)
@@ -209,12 +210,13 @@ func cropIndividualNodes(toDelete []*NodeGroupView, groups []*NodeGroupView, bud
 }
 
 func (bp *ScaleDownBudgetProcessor) group(ctx context.Context, nodes []*apiv1.Node) []*NodeGroupView {
+	logger := klog.FromContext(ctx)
 	groupMap := map[string]int{}
 	grouped := []*NodeGroupView{}
 	for _, node := range nodes {
 		nodeGroup, err := bp.autoscalingCtx.CloudProvider.NodeGroupForNode(node)
 		if err != nil || nodeGroup == nil {
-			klog.Errorf("Failed to find node group for %s: %v", node.Name, err)
+			logger.Error(err, "Failed to find node group", "node", node.Name)
 			continue
 		}
 		if idx, ok := groupMap[nodeGroup.Id()]; ok {
@@ -231,10 +233,11 @@ func (bp *ScaleDownBudgetProcessor) group(ctx context.Context, nodes []*apiv1.No
 }
 
 func (bp *ScaleDownBudgetProcessor) categorize(ctx context.Context, groups []*NodeGroupView) (individual, atomic []*NodeGroupView) {
+	logger := klog.FromContext(ctx)
 	for _, view := range groups {
 		autoscalingOptions, err := view.Group.GetOptions(bp.autoscalingCtx.NodeGroupDefaults)
 		if err != nil && err != cloudprovider.ErrNotImplemented {
-			klog.Errorf("Failed to get autoscaling options for node group %s: %v", view.Group.Id(), err)
+			logger.Error(err, "Failed to get autoscaling options for node group", "groupId", view.Group.Id())
 			continue
 		}
 		if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {

--- a/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
+++ b/cluster-autoscaler/core/scaledown/budgets/budgets_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package budgets
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -470,7 +471,7 @@ func TestCropNodesToBudgets(t *testing.T) {
 
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, allNodes, nil)
 			budgeter := NewScaleDownBudgetProcessor(&autoscalingCtx)
-			gotEmpty, gotDrain := budgeter.CropNodes(ndt, emptyList, drainList)
+			gotEmpty, gotDrain := budgeter.CropNodes(context.TODO(), ndt, emptyList, drainList)
 			if diff := cmp.Diff(tc.wantEmpty, gotEmpty, cmpopts.EquateEmpty(), transformNodeGroupView); diff != "" {
 				t.Errorf("cropNodesToBudgets empty nodes diff (-want +got):\n%s", diff)
 			}

--- a/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
+++ b/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deletiontracker
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -83,7 +84,7 @@ func (n *NodeDeletionTracker) StartDeletionWithDrain(nodeGroupId, nodeName strin
 }
 
 // EndDeletion decrements node deletion in progress counter for the given nodegroup.
-func (n *NodeDeletionTracker) EndDeletion(nodeGroupId, nodeName string, result status.NodeDeleteResult) {
+func (n *NodeDeletionTracker) EndDeletion(ctx context.Context, nodeGroupId, nodeName string, result status.NodeDeleteResult) {
 	n.Lock()
 	defer n.Unlock()
 

--- a/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
+++ b/cluster-autoscaler/core/scaledown/deletiontracker/nodedeletiontracker.go
@@ -85,17 +85,18 @@ func (n *NodeDeletionTracker) StartDeletionWithDrain(nodeGroupId, nodeName strin
 
 // EndDeletion decrements node deletion in progress counter for the given nodegroup.
 func (n *NodeDeletionTracker) EndDeletion(ctx context.Context, nodeGroupId, nodeName string, result status.NodeDeleteResult) {
+	logger := klog.FromContext(ctx)
 	n.Lock()
 	defer n.Unlock()
 
 	n.deletionResults.RegisterElement(&deletionResult{nodeName, result})
 	value, found := n.deletionsPerNodeGroup[nodeGroupId]
 	if !found {
-		klog.Errorf("This should never happen, counter for %s in NodeDeletionTracker wasn't found", nodeGroupId)
+		logger.Error(nil, "This should never happen, counter in NodeDeletionTracker wasn't found", "nodeGroupId", nodeGroupId)
 		return
 	}
 	if value <= 0 {
-		klog.Errorf("This should never happen, counter for %s in NodeDeletionTracker isn't greater than 0, counter value is %d", nodeGroupId, value)
+		logger.Error(nil, "This should never happen, counter in NodeDeletionTracker isn't greater than 0, counter value is", "nodeGroupId", nodeGroupId, "value", value)
 	}
 	n.deletionsPerNodeGroup[nodeGroupId]--
 	if n.deletionsPerNodeGroup[nodeGroupId] <= 0 {

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eligibility
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -64,7 +65,7 @@ func NewChecker(configGetter nodeGroupConfigGetter) *Checker {
 // utilization info.
 // TODO(x13n): Node utilization could actually be calculated independently for
 // all nodes and just used here. Next refactor...
-func (c *Checker) FilterOutUnremovable(autoscalingCtx *ca_context.AutoscalingContext, scaleDownCandidates []*apiv1.Node, timestamp time.Time, unremovableNodes *unremovable.Nodes) ([]string, map[string]utilization.Info, []*simulator.UnremovableNode) {
+func (c *Checker) FilterOutUnremovable(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownCandidates []*apiv1.Node, timestamp time.Time, unremovableNodes *unremovable.Nodes) ([]string, map[string]utilization.Info, []*simulator.UnremovableNode) {
 	ineligible := []*simulator.UnremovableNode{}
 	skipped := 0
 	utilizationMap := make(map[string]utilization.Info)
@@ -86,7 +87,7 @@ func (c *Checker) FilterOutUnremovable(autoscalingCtx *ca_context.AutoscalingCon
 			continue
 		}
 
-		reason, utilInfo := c.unremovableReasonAndNodeUtilization(autoscalingCtx, timestamp, nodeInfo, utilLogsQuota)
+		reason, utilInfo := c.unremovableReasonAndNodeUtilization(ctx, autoscalingCtx, timestamp, nodeInfo, utilLogsQuota)
 		if utilInfo != nil {
 			utilizationMap[node.Name] = *utilInfo
 		}
@@ -105,7 +106,7 @@ func (c *Checker) FilterOutUnremovable(autoscalingCtx *ca_context.AutoscalingCon
 	return currentlyUnneededNodeNames, utilizationMap, ineligible
 }
 
-func (c *Checker) unremovableReasonAndNodeUtilization(autoscalingCtx *ca_context.AutoscalingContext, timestamp time.Time, nodeInfo *framework.NodeInfo, utilLogsQuota *klogx.Quota) (simulator.UnremovableReason, *utilization.Info) {
+func (c *Checker) unremovableReasonAndNodeUtilization(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, timestamp time.Time, nodeInfo *framework.NodeInfo, utilLogsQuota *klogx.Quota) (simulator.UnremovableReason, *utilization.Info) {
 	node := nodeInfo.Node()
 
 	if actuation.IsNodeBeingDeleted(node, timestamp) {
@@ -138,7 +139,7 @@ func (c *Checker) unremovableReasonAndNodeUtilization(autoscalingCtx *ca_context
 	}
 
 	gpuConfig := autoscalingCtx.CloudProvider.GetNodeGpuConfig(node)
-	utilInfo, err := utilization.Calculate(nodeInfo, ignoreDaemonSetsUtilization, autoscalingCtx.IgnoreMirrorPodsUtilization, autoscalingCtx.DynamicResourceAllocationEnabled, gpuConfig, timestamp)
+	utilInfo, err := utilization.Calculate(ctx, nodeInfo, ignoreDaemonSetsUtilization, autoscalingCtx.IgnoreMirrorPodsUtilization, autoscalingCtx.DynamicResourceAllocationEnabled, gpuConfig, timestamp)
 	if err != nil {
 		klog.Warningf("Failed to calculate utilization for %s: %v", node.Name, err)
 		return simulator.UnexpectedError, nil

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility.go
@@ -66,6 +66,7 @@ func NewChecker(configGetter nodeGroupConfigGetter) *Checker {
 // TODO(x13n): Node utilization could actually be calculated independently for
 // all nodes and just used here. Next refactor...
 func (c *Checker) FilterOutUnremovable(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownCandidates []*apiv1.Node, timestamp time.Time, unremovableNodes *unremovable.Nodes) ([]string, map[string]utilization.Info, []*simulator.UnremovableNode) {
+	logger := klog.FromContext(ctx)
 	ineligible := []*simulator.UnremovableNode{}
 	skipped := 0
 	utilizationMap := make(map[string]utilization.Info)
@@ -75,7 +76,7 @@ func (c *Checker) FilterOutUnremovable(ctx context.Context, autoscalingCtx *ca_c
 	for _, node := range scaleDownCandidates {
 		nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(node.Name)
 		if err != nil {
-			klog.Errorf("Can't retrieve scale-down candidate %s from snapshot, err: %v", node.Name, err)
+			logger.Error(err, "Can't retrieve scale-down candidate from snapshot", "node", node.Name)
 			ineligible = append(ineligible, &simulator.UnremovableNode{Node: node, Reason: simulator.UnexpectedError})
 			continue
 		}
@@ -101,47 +102,48 @@ func (c *Checker) FilterOutUnremovable(ctx context.Context, autoscalingCtx *ca_c
 
 	klogx.V(4).Over(utilLogsQuota).Infof("Skipped logging utilization for %d other nodes", -utilLogsQuota.Left())
 	if skipped > 0 {
-		klog.V(1).Infof("Scale-down calculation: ignoring %v nodes unremovable in the last %v", skipped, autoscalingCtx.AutoscalingOptions.UnremovableNodeRecheckTimeout)
+		logger.V(1).Info("Scale-down calculation: ignoring nodes unremovable in the last", "skipped", skipped, "unremovableNodeRecheckTimeout", autoscalingCtx.AutoscalingOptions.UnremovableNodeRecheckTimeout)
 	}
 	return currentlyUnneededNodeNames, utilizationMap, ineligible
 }
 
 func (c *Checker) unremovableReasonAndNodeUtilization(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, timestamp time.Time, nodeInfo *framework.NodeInfo, utilLogsQuota *klogx.Quota) (simulator.UnremovableReason, *utilization.Info) {
+	logger := klog.FromContext(ctx)
 	node := nodeInfo.Node()
 
 	if actuation.IsNodeBeingDeleted(node, timestamp) {
-		klog.V(1).Infof("Skipping %s from delete consideration - the node is currently being deleted", node.Name)
+		logger.V(1).Info("Skipping from delete consideration - the node is currently being deleted", "node", node.Name)
 		return simulator.CurrentlyBeingDeleted, nil
 	}
 
 	// Skip nodes marked with no scale down annotation
 	if HasNoScaleDownAnnotation(node) {
-		klog.V(1).Infof("Skipping %s from delete consideration - the node is marked as no scale down", node.Name)
+		logger.V(1).Info("Skipping from delete consideration - the node is marked as no scale down", "node", node.Name)
 		return simulator.ScaleDownDisabledAnnotation, nil
 	}
 
 	nodeGroup, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)
 	if err != nil {
-		klog.Warningf("Node group not found for node %v: %v", node.Name, err)
+		logger.Info("Node group not found for node", "node", node.Name, "err", err)
 		return simulator.UnexpectedError, nil
 	}
 	if nodeGroup == nil {
 		// We should never get here as non-autoscaled nodes should not be included in scaleDownCandidates list
 		// (and the default PreFilteringScaleDownNodeProcessor would indeed filter them out).
-		klog.Warningf("Skipped %s from delete consideration - the node is not autoscaled", node.Name)
+		logger.Info("Skipped from delete consideration - the node is not autoscaled", "node", node.Name)
 		return simulator.NotAutoscaled, nil
 	}
 
 	ignoreDaemonSetsUtilization, err := c.configGetter.GetIgnoreDaemonSetsUtilization(nodeGroup)
 	if err != nil {
-		klog.Warningf("Couldn't retrieve `IgnoreDaemonSetsUtilization` option for node %v: %v", node.Name, err)
+		logger.Info("Couldn't retrieve `IgnoreDaemonSetsUtilization` option for node", "node", node.Name, "err", err)
 		return simulator.UnexpectedError, nil
 	}
 
 	gpuConfig := autoscalingCtx.CloudProvider.GetNodeGpuConfig(node)
 	utilInfo, err := utilization.Calculate(ctx, nodeInfo, ignoreDaemonSetsUtilization, autoscalingCtx.IgnoreMirrorPodsUtilization, autoscalingCtx.DynamicResourceAllocationEnabled, gpuConfig, timestamp)
 	if err != nil {
-		klog.Warningf("Failed to calculate utilization for %s: %v", node.Name, err)
+		logger.Info("Failed to calculate utilization", "node", node.Name, "err", err)
 		return simulator.UnexpectedError, nil
 	}
 
@@ -149,18 +151,18 @@ func (c *Checker) unremovableReasonAndNodeUtilization(ctx context.Context, autos
 	if !autoscalingCtx.ScaleDownUnreadyEnabled {
 		ready, _, _ := kube_util.GetReadinessState(node)
 		if !ready {
-			klog.V(4).Infof("Skipping unready node %s from delete consideration - scale-down of unready nodes is disabled", node.Name)
+			logger.V(4).Info("Skipping unready node from delete consideration - scale-down of unready nodes is disabled", "node", node.Name)
 			return simulator.ScaleDownUnreadyDisabled, nil
 		}
 	}
 
 	underutilized, err := c.isNodeAtOrBelowUtilizationThreshold(autoscalingCtx, node, nodeGroup, utilInfo)
 	if err != nil {
-		klog.Warningf("Failed to check utilization thresholds for %s: %v", node.Name, err)
+		logger.Info("Failed to check utilization thresholds", "node", node.Name, "err", err)
 		return simulator.UnexpectedError, nil
 	}
 	if !underutilized {
-		klog.V(4).Infof("Node %s unremovable: %s requested (%.6g%% of allocatable) is above the scale-down utilization threshold", node.Name, utilInfo.ResourceName, utilInfo.Utilization*100)
+		logger.V(4).Info("Node unremovable: requested (% of allocatable) is above the scale-down utilization threshold", "node", node.Name, "resourceName", utilInfo.ResourceName, "utilization", utilInfo.Utilization*100)
 		return simulator.NotUnderutilized, &utilInfo
 	}
 

--- a/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
+++ b/cluster-autoscaler/core/scaledown/eligibility/eligibility_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eligibility
 
 import (
+	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -318,7 +319,7 @@ func TestFilterOutUnremovable(t *testing.T) {
 				t.Fatalf("Could not SetClusterState: %v", err)
 			}
 			unremovableNodes := unremovable.NewNodes()
-			gotUnneeded, _, gotUnremovable := c.FilterOutUnremovable(&autoscalingCtx, tc.nodes, now, unremovableNodes)
+			gotUnneeded, _, gotUnremovable := c.FilterOutUnremovable(context.TODO(), &autoscalingCtx, tc.nodes, now, unremovableNodes)
 			if diff := cmp.Diff(tc.wantUnneeded, gotUnneeded); diff != "" {
 				t.Errorf("FilterOutUnremovable(): unexpected unneeded (-want +got): %s", diff)
 			}

--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package latencytracker
 
 import (
+	"context"
 	"maps"
 	"slices"
 	"time"
@@ -60,7 +61,7 @@ func NewNodeLatencyTracker(wrapped processor.ScaleDownStatusProcessor) *NodeLate
 }
 
 // UpdateScaleDownCandidates updates tracked unneeded nodes and reports those that became needed again.
-func (t *NodeLatencyTracker) UpdateScaleDownCandidates(list []*scaledown.UnneededNode, timestamp time.Time) {
+func (t *NodeLatencyTracker) UpdateScaleDownCandidates(ctx context.Context, list []*scaledown.UnneededNode, timestamp time.Time) {
 	currentSet := make(map[string]struct{}, len(list))
 	for _, candidate := range list {
 		nodeName := candidate.Node.Name
@@ -81,21 +82,21 @@ func (t *NodeLatencyTracker) UpdateScaleDownCandidates(list []*scaledown.Unneede
 	}
 	for nodeName := range t.unneededNodes {
 		if _, exists := currentSet[nodeName]; !exists {
-			t.recordAndCleanup(nodeName, false)
+			t.recordAndCleanup(ctx, nodeName, false)
 		}
 	}
 }
 
 // Process updates unremovableNodes and reports node removal latency based on scale-down status.
-func (t *NodeLatencyTracker) Process(autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus) {
+func (t *NodeLatencyTracker) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus) {
 	if t.wrapped != nil {
-		t.wrapped.Process(autoscalingCtx, status)
+		t.wrapped.Process(ctx, autoscalingCtx, status)
 	}
 
-	t.updateLatestDelayReasons(status.UnremovableNodes)
+	t.updateLatestDelayReasons(ctx, status.UnremovableNodes)
 
 	for _, node := range status.ScaledDownNodes {
-		t.recordAndCleanup(node.Node.Name, true)
+		t.recordAndCleanup(ctx, node.Node.Name, true)
 	}
 
 	if klog.V(6).Enabled() {
@@ -107,7 +108,7 @@ func (t *NodeLatencyTracker) Process(autoscalingCtx *ca_context.AutoscalingConte
 
 // recordAndCleanup calculates the time a node spent in the "unneeded" state, updates
 // relevant Prometheus metrics, and removes the node from internal tracking.
-func (t *NodeLatencyTracker) recordAndCleanup(nodeName string, isRemoved bool) {
+func (t *NodeLatencyTracker) recordAndCleanup(ctx context.Context, nodeName string, isRemoved bool) {
 	info, exists := t.unneededNodes[nodeName]
 	if !exists {
 		return
@@ -129,7 +130,7 @@ func (t *NodeLatencyTracker) recordAndCleanup(nodeName string, isRemoved bool) {
 			nodeName, duration, info.removalThreshold, latency, isRemoved, delayReason)
 	}
 	if isRemoved {
-		t.logDeletion(nodeName, duration, info.removalThreshold, latency)
+		t.logDeletion(ctx, nodeName, duration, info.removalThreshold, latency)
 	} else {
 		klog.V(4).Infof("Node %q became needed again (unneeded for %s). Blocker: %q. Latency: %s",
 			nodeName, duration, delayReason, latency)
@@ -138,7 +139,7 @@ func (t *NodeLatencyTracker) recordAndCleanup(nodeName string, isRemoved bool) {
 
 // logDeletion handles the logging for scaled-down nodes,
 // using a higher verbosity (V2) if the latency exceeds the configured threshold.
-func (t *NodeLatencyTracker) logDeletion(nodeName string, duration, threshold, latency time.Duration) {
+func (t *NodeLatencyTracker) logDeletion(ctx context.Context, nodeName string, duration, threshold, latency time.Duration) {
 	level := klog.Level(6)
 	if latency > scaleDownLatencyLogThreshold {
 		level = klog.Level(2)
@@ -160,7 +161,7 @@ func (t *NodeLatencyTracker) CleanUp() {
 	}
 }
 
-func (t *NodeLatencyTracker) updateLatestDelayReasons(unremovableNodes []*status.UnremovableNode) {
+func (t *NodeLatencyTracker) updateLatestDelayReasons(ctx context.Context, unremovableNodes []*status.UnremovableNode) {
 	for _, val := range unremovableNodes {
 		if info, exists := t.unneededNodes[val.Node.Name]; exists {
 			if isBlocker(val.Reason) {

--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker.go
@@ -62,6 +62,7 @@ func NewNodeLatencyTracker(wrapped processor.ScaleDownStatusProcessor) *NodeLate
 
 // UpdateScaleDownCandidates updates tracked unneeded nodes and reports those that became needed again.
 func (t *NodeLatencyTracker) UpdateScaleDownCandidates(ctx context.Context, list []*scaledown.UnneededNode, timestamp time.Time) {
+	logger := klog.FromContext(ctx)
 	currentSet := make(map[string]struct{}, len(list))
 	for _, candidate := range list {
 		nodeName := candidate.Node.Name
@@ -71,12 +72,12 @@ func (t *NodeLatencyTracker) UpdateScaleDownCandidates(ctx context.Context, list
 				unneededSince:    timestamp,
 				removalThreshold: candidate.RemovalThreshold,
 			}
-			klog.V(6).Infof("Started tracking unneeded node %s at %v with removal threshold %v.", nodeName, timestamp, candidate.RemovalThreshold)
+			logger.V(6).Info("Started tracking unneeded node with removal threshold.", "node", nodeName, "timestamp", timestamp, "removalThreshold", candidate.RemovalThreshold)
 		} else {
 			if info.removalThreshold != candidate.RemovalThreshold {
 				info.removalThreshold = candidate.RemovalThreshold
 				t.unneededNodes[nodeName] = info
-				klog.V(6).Infof("Updated removal threshold for tracked node %s to %v.", nodeName, candidate.RemovalThreshold)
+				logger.V(6).Info("Updated removal threshold for tracked node.", "node", nodeName, "removalThreshold", candidate.RemovalThreshold)
 			}
 		}
 	}
@@ -89,6 +90,7 @@ func (t *NodeLatencyTracker) UpdateScaleDownCandidates(ctx context.Context, list
 
 // Process updates unremovableNodes and reports node removal latency based on scale-down status.
 func (t *NodeLatencyTracker) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus) {
+	logger := klog.FromContext(ctx)
 	if t.wrapped != nil {
 		t.wrapped.Process(ctx, autoscalingCtx, status)
 	}
@@ -99,9 +101,9 @@ func (t *NodeLatencyTracker) Process(ctx context.Context, autoscalingCtx *ca_con
 		t.recordAndCleanup(ctx, node.Node.Name, true)
 	}
 
-	if klog.V(6).Enabled() {
+	if logger.V(6).Enabled() {
 		for nodeName := range t.unneededNodes {
-			klog.Infof("Node %q remains in unneeded list (not scaled down). Continuing to track latency.", nodeName)
+			logger.V(6).Info("Node remains in unneeded list (not scaled down). Continuing to track latency.", "node", nodeName)
 		}
 	}
 }
@@ -109,6 +111,7 @@ func (t *NodeLatencyTracker) Process(ctx context.Context, autoscalingCtx *ca_con
 // recordAndCleanup calculates the time a node spent in the "unneeded" state, updates
 // relevant Prometheus metrics, and removes the node from internal tracking.
 func (t *NodeLatencyTracker) recordAndCleanup(ctx context.Context, nodeName string, isRemoved bool) {
+	logger := klog.FromContext(ctx)
 	info, exists := t.unneededNodes[nodeName]
 	if !exists {
 		return
@@ -126,26 +129,24 @@ func (t *NodeLatencyTracker) recordAndCleanup(ctx context.Context, nodeName stri
 	if latency > 0 {
 		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, delayReason, latency)
 	} else {
-		klog.V(6).Infof("Node %q was unneeded for %s (threshold %s). Latency %s is <= 0, skipping metric. isRemoved: %v, delayReason: %v",
-			nodeName, duration, info.removalThreshold, latency, isRemoved, delayReason)
+		logger.V(6).Info("Node was unneeded (threshold). Latency is <= 0, skipping metric. isRemoved, delayReason", "node", nodeName, "duration", duration, "removalThreshold", info.removalThreshold, "latency", latency, "isRemoved", isRemoved, "delayReason", delayReason)
 	}
 	if isRemoved {
 		t.logDeletion(ctx, nodeName, duration, info.removalThreshold, latency)
 	} else {
-		klog.V(4).Infof("Node %q became needed again (unneeded for %s). Blocker: %q. Latency: %s",
-			nodeName, duration, delayReason, latency)
+		logger.V(4).Info("Node became needed again (unneeded). Blocker. Latency", "node", nodeName, "duration", duration, "delayReason", delayReason, "latency", latency)
 	}
 }
 
 // logDeletion handles the logging for scaled-down nodes,
 // using a higher verbosity (V2) if the latency exceeds the configured threshold.
 func (t *NodeLatencyTracker) logDeletion(ctx context.Context, nodeName string, duration, threshold, latency time.Duration) {
+	logger := klog.FromContext(ctx)
 	level := klog.Level(6)
 	if latency > scaleDownLatencyLogThreshold {
 		level = klog.Level(2)
 	}
-	klog.V(level).Infof("Observing deletion for node %s, unneeded for %s (removal threshold was %s).",
-		nodeName, duration, threshold)
+	logger.V(int(level)).Info("Observing deletion for node, unneeded (removal threshold was).", "node", nodeName, "duration", duration, "threshold", threshold)
 }
 
 // getTrackedNodes returns the names of all nodes currently tracked as unneeded.
@@ -162,13 +163,14 @@ func (t *NodeLatencyTracker) CleanUp() {
 }
 
 func (t *NodeLatencyTracker) updateLatestDelayReasons(ctx context.Context, unremovableNodes []*status.UnremovableNode) {
+	logger := klog.FromContext(ctx)
 	for _, val := range unremovableNodes {
 		if info, exists := t.unneededNodes[val.Node.Name]; exists {
 			if isBlocker(val.Reason) {
 				reasonStr := val.Reason.String()
 				info.latestDelayReason = reasonStr
 				t.unneededNodes[val.Node.Name] = info
-				klog.V(6).Infof("Tracking latest delay reason %s for node %s.", reasonStr, val.Node.Name)
+				logger.V(6).Info("Tracking latest delay reason for node.", "reasonStr", reasonStr, "node", val.Node.Name)
 			}
 		}
 	}

--- a/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
+++ b/cluster-autoscaler/core/scaledown/latencytracker/node_latency_tracker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package latencytracker
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -36,7 +37,7 @@ func TestNodeLatencyTracker_Decorator(t *testing.T) {
 	mock := &mockStatusProcessor{}
 	tracker := NewNodeLatencyTracker(mock)
 
-	tracker.Process(&ca_context.AutoscalingContext{}, &status.ScaleDownStatus{})
+	tracker.Process(context.TODO(), &ca_context.AutoscalingContext{}, &status.ScaleDownStatus{})
 
 	if !mock.processCalled {
 		t.Errorf("Process() did not call wrapped.Process()")
@@ -209,7 +210,7 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 				stepTime := baseTime.Add(time.Duration(i+1) * testStepDuration)
 
 				candidates := candidatesFromNames(step.unneededList, step.thresholds)
-				tracker.UpdateScaleDownCandidates(candidates, stepTime)
+				tracker.UpdateScaleDownCandidates(context.TODO(), candidates, stepTime)
 
 				var sd *status.ScaleDownStatus
 				if step.unremovableReason != nil {
@@ -217,7 +218,7 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 				} else {
 					sd = newScaleDownStatus(step.scaledDownList, step.unremovableList)
 				}
-				tracker.Process(&ca_context.AutoscalingContext{}, sd)
+				tracker.Process(context.TODO(), &ca_context.AutoscalingContext{}, sd)
 
 				gotTracked := tracker.getTrackedNodes()
 				gotSet := sets.New(gotTracked...)
@@ -291,7 +292,7 @@ type mockStatusProcessor struct {
 	cleanUpCalled bool
 }
 
-func (m *mockStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus) {
+func (m *mockStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus) {
 	m.processCalled = true
 }
 

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -119,6 +119,7 @@ func New(autoscalingCtx *ca_context.AutoscalingContext, processors *processors.A
 // up-to-date information about the cluster.
 // Planner will evaluate scaleDownCandidates in the order provided here.
 func (p *Planner) UpdateClusterState(ctx context.Context, podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, currentTime time.Time) errors.AutoscalerError {
+	logger := klog.FromContext(ctx)
 	updateInterval := currentTime.Sub(p.latestUpdate)
 	if updateInterval < p.minUpdateInterval {
 		p.minUpdateInterval = updateInterval
@@ -130,7 +131,8 @@ func (p *Planner) UpdateClusterState(ctx context.Context, podDestinations, scale
 	defer p.autoscalingCtx.ClusterSnapshot.Revert()
 	err := p.injectRecentlyEvictedPods(ctx)
 	if err != nil {
-		klog.Warningf("Not all recently evicted pods could be injected")
+		logger.Info("Not all recently evicted pods could be injected", "err", err)
+
 	}
 	deletions := asMap(merged(as.DeletionsInProgress()))
 	podDestinations = filterOutOngoingDeletions(podDestinations, deletions)
@@ -150,17 +152,18 @@ func (p *Planner) CleanUpUnneededNodes(ctx context.Context) {
 // NodesToDelete returns all Nodes that could be removed right now, according
 // to the Planner.
 func (p *Planner) NodesToDelete(ctx context.Context, _ time.Time) (empty, needDrain []*apiv1.Node) {
+	logger := klog.FromContext(ctx)
 	empty, needDrain = []*apiv1.Node{}, []*apiv1.Node{}
 
 	nodes, err := allNodes(p.autoscalingCtx.ClusterSnapshot)
 	if err != nil {
-		klog.Errorf("Failed to list nodes for final limit check: %v", err)
+		logger.Error(err, "Failed to list nodes for final limit check")
 		return nil, nil
 	}
 
 	tracker, err := p.quotasTrackerFactory.NewMinQuotasTracker(ctx, p.autoscalingCtx, nodes)
 	if err != nil {
-		klog.Errorf("Failed to create tracker for final limit check: %v", err)
+		logger.Error(err, "Failed to create tracker for final limit check")
 		return nil, nil
 	}
 	p.scaleDownContext.Tracker = tracker
@@ -176,7 +179,7 @@ func (p *Planner) NodesToDelete(ctx context.Context, _ time.Time) (empty, needDr
 
 	for _, nodeToRemove := range nodesToRemove {
 		if len(nodeToRemove.OnCompletionPods) > 0 {
-			klog.V(2).Infof("Node %s has active on-completion pods, delaying scale down", nodeToRemove.Node.Name)
+			logger.V(2).Info("Node has active on-completion pods, delaying scale down", "node", nodeToRemove.Node.Name)
 			p.addUnremovableNodes([]simulator.UnremovableNode{{
 				Node:   nodeToRemove.Node,
 				Reason: simulator.BlockedByOnCompletionPod,
@@ -285,6 +288,7 @@ func (p *Planner) injectPods(ctx context.Context, pods []*apiv1.Pod) error {
 // categorizeNodes determines, for each node, whether it can be eventually
 // removed or if there are reasons preventing that.
 func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[string]bool, scaleDownCandidates []*apiv1.Node) {
+	logger := klog.FromContext(ctx)
 	unremovableTimeout := p.latestUpdate.Add(p.autoscalingCtx.AutoscalingOptions.UnremovableNodeRecheckTimeout)
 	unremovableCount := 0
 	var removableList []simulator.NodeToBeRemoved
@@ -301,12 +305,12 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 	for i, node := range currentlyUnneededNodeNames {
 		if timedOut(timer) {
 			skippedNodes = currentlyUnneededNodeNames[i:]
-			klog.Warningf("%d out of %d nodes skipped in scale down simulation due to timeout.", len(currentlyUnneededNodeNames)-i, len(currentlyUnneededNodeNames))
+			logger.Info("Nodes skipped in scale down simulation due to timeout", "skippedCount", len(currentlyUnneededNodeNames)-i, "totalCount", len(currentlyUnneededNodeNames))
 			break
 		}
 		if len(removableList)-atomicScaleDownNodesCount >= p.unneededNodesLimit() {
 			skippedNodes = currentlyUnneededNodeNames[i:]
-			klog.V(4).Infof("%d out of %d nodes skipped in scale down simulation: there are already %d unneeded nodes so no point in looking for more. Total atomic scale down nodes: %d", len(currentlyUnneededNodeNames)-i, len(currentlyUnneededNodeNames), len(removableList), atomicScaleDownNodesCount)
+			logger.V(4).Info("Nodes skipped in scale down simulation: too many unneeded nodes", "skippedCount", len(currentlyUnneededNodeNames)-i, "totalCount", len(currentlyUnneededNodeNames), "unneededCount", len(removableList), "atomicScaleDownCount", atomicScaleDownNodesCount)
 			break
 		}
 
@@ -321,7 +325,7 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 			removableList = append(removableList, *removable)
 			if p.atomicScaleDownNode(ctx, removable) {
 				atomicScaleDownNodesCount++
-				klog.V(2).Infof("Considering node %s for atomic scale down. Total atomic scale down nodes count: %d", removable.Node.Name, atomicScaleDownNodesCount)
+				logger.V(2).Info("Considering node for atomic scale down. Total atomic scale down nodes count", "node", removable.Node.Name, "atomicScaleDownNodesCount", atomicScaleDownNodesCount)
 			}
 		}
 		if unremovable != nil {
@@ -332,24 +336,25 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 	p.handleUnprocessedNodes(skippedNodes)
 	p.unneededNodes.Update(ctx, p.autoscalingCtx, removableList, p.latestUpdate)
 	if unremovableCount > 0 {
-		klog.V(1).Infof("%v nodes found to be unremovable in simulation, will re-check them at %v", unremovableCount, unremovableTimeout)
+		logger.V(1).Info("nodes found to be unremovable in simulation, will re-check them", "unremovableCount", unremovableCount, "unremovableTimeout", unremovableTimeout)
 	}
 }
 
 // atomicScaleDownNode checks if the removable node would be considered for atomic scale down.
 func (p *Planner) atomicScaleDownNode(ctx context.Context, node *simulator.NodeToBeRemoved) bool {
+	logger := klog.FromContext(ctx)
 	nodeGroup, err := p.autoscalingCtx.CloudProvider.NodeGroupForNode(node.Node)
 	if err != nil {
-		klog.Errorf("failed to get node info for %v: %s", node.Node.Name, err)
+		logger.Error(err, "failed to get node info", "node", node.Node.Name)
 		return false
 	}
 	if nodeGroup == nil {
-		klog.Errorf("Node group for node %s not found", node.Node.Name)
+		logger.Error(nil, "Node group for node not found", "node", node.Node.Name)
 		return false
 	}
 	autoscalingOptions, err := nodeGroup.GetOptions(p.autoscalingCtx.NodeGroupDefaults)
 	if err != nil && err != cloudprovider.ErrNotImplemented {
-		klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
+		logger.Error(err, "Failed to get autoscaling options for node group", "nodeGroupId", nodeGroup.Id())
 		return false
 	}
 	if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -17,6 +17,7 @@ limitations under the License.
 package planner
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -45,12 +46,12 @@ import (
 )
 
 type eligibilityChecker interface {
-	FilterOutUnremovable(autoscalingCtx *ca_context.AutoscalingContext, scaleDownCandidates []*apiv1.Node, timestamp time.Time, unremovableNodes *unremovable.Nodes) ([]string, map[string]utilization.Info, []*simulator.UnremovableNode)
+	FilterOutUnremovable(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownCandidates []*apiv1.Node, timestamp time.Time, unremovableNodes *unremovable.Nodes) ([]string, map[string]utilization.Info, []*simulator.UnremovableNode)
 }
 
 type removalSimulator interface {
 	DropOldHints()
-	SimulateNodeRemoval(node string, podDestinations map[string]bool, timestamp time.Time, remainingPdbTracker pdb.RemainingPdbTracker) (*simulator.NodeToBeRemoved, *simulator.UnremovableNode)
+	SimulateNodeRemoval(ctx context.Context, node string, podDestinations map[string]bool, timestamp time.Time, remainingPdbTracker pdb.RemainingPdbTracker) (*simulator.NodeToBeRemoved, *simulator.UnremovableNode)
 }
 
 // controllerReplicasCalculator calculates a number of target and expected replicas for a given controller.
@@ -117,7 +118,7 @@ func New(autoscalingCtx *ca_context.AutoscalingContext, processors *processors.A
 // UpdateClusterState needs to be periodically invoked to provide Planner with
 // up-to-date information about the cluster.
 // Planner will evaluate scaleDownCandidates in the order provided here.
-func (p *Planner) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, currentTime time.Time) errors.AutoscalerError {
+func (p *Planner) UpdateClusterState(ctx context.Context, podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, currentTime time.Time) errors.AutoscalerError {
 	updateInterval := currentTime.Sub(p.latestUpdate)
 	if updateInterval < p.minUpdateInterval {
 		p.minUpdateInterval = updateInterval
@@ -127,14 +128,14 @@ func (p *Planner) UpdateClusterState(podDestinations, scaleDownCandidates []*api
 	// Avoid persisting changes done by the simulation.
 	p.autoscalingCtx.ClusterSnapshot.Fork()
 	defer p.autoscalingCtx.ClusterSnapshot.Revert()
-	err := p.injectRecentlyEvictedPods()
+	err := p.injectRecentlyEvictedPods(ctx)
 	if err != nil {
 		klog.Warningf("Not all recently evicted pods could be injected")
 	}
 	deletions := asMap(merged(as.DeletionsInProgress()))
 	podDestinations = filterOutOngoingDeletions(podDestinations, deletions)
 	scaleDownCandidates = filterOutOngoingDeletions(scaleDownCandidates, deletions)
-	p.categorizeNodes(asMap(nodeNames(podDestinations)), scaleDownCandidates)
+	p.categorizeNodes(ctx, asMap(nodeNames(podDestinations)), scaleDownCandidates)
 	p.rs.DropOldHints()
 	p.actuationInjector.DropOldHints()
 	return nil
@@ -142,13 +143,13 @@ func (p *Planner) UpdateClusterState(podDestinations, scaleDownCandidates []*api
 
 // CleanUpUnneededNodes forces Planner to forget about all nodes considered
 // unneeded so far.
-func (p *Planner) CleanUpUnneededNodes() {
-	p.unneededNodes.Clear()
+func (p *Planner) CleanUpUnneededNodes(ctx context.Context) {
+	p.unneededNodes.Clear(ctx)
 }
 
 // NodesToDelete returns all Nodes that could be removed right now, according
 // to the Planner.
-func (p *Planner) NodesToDelete(_ time.Time) (empty, needDrain []*apiv1.Node) {
+func (p *Planner) NodesToDelete(ctx context.Context, _ time.Time) (empty, needDrain []*apiv1.Node) {
 	empty, needDrain = []*apiv1.Node{}, []*apiv1.Node{}
 
 	nodes, err := allNodes(p.autoscalingCtx.ClusterSnapshot)
@@ -157,20 +158,20 @@ func (p *Planner) NodesToDelete(_ time.Time) (empty, needDrain []*apiv1.Node) {
 		return nil, nil
 	}
 
-	tracker, err := p.quotasTrackerFactory.NewMinQuotasTracker(p.autoscalingCtx, nodes)
+	tracker, err := p.quotasTrackerFactory.NewMinQuotasTracker(ctx, p.autoscalingCtx, nodes)
 	if err != nil {
 		klog.Errorf("Failed to create tracker for final limit check: %v", err)
 		return nil, nil
 	}
 	p.scaleDownContext.Tracker = tracker
 
-	emptyRemovableNodes, needDrainRemovableNodes, unremovableNodes := p.unneededNodes.RemovableAt(p.autoscalingCtx, *p.scaleDownContext, p.latestUpdate)
+	emptyRemovableNodes, needDrainRemovableNodes, unremovableNodes := p.unneededNodes.RemovableAt(ctx, p.autoscalingCtx, *p.scaleDownContext, p.latestUpdate)
 	p.addUnremovableNodes(unremovableNodes)
 
 	needDrainRemovableNodes = sortByRisk(needDrainRemovableNodes)
 	candidatesToBeRemoved := append(emptyRemovableNodes, needDrainRemovableNodes...)
 
-	nodesToRemove, unremovableNodes := p.scaleDownSetProcessor.FilterUnremovableNodes(p.autoscalingCtx, p.scaleDownContext, candidatesToBeRemoved)
+	nodesToRemove, unremovableNodes := p.scaleDownSetProcessor.FilterUnremovableNodes(ctx, p.autoscalingCtx, p.scaleDownContext, candidatesToBeRemoved)
 	p.addUnremovableNodes(unremovableNodes)
 
 	for _, nodeToRemove := range nodesToRemove {
@@ -236,9 +237,9 @@ func (p *Planner) NodeUtilizationMap() map[string]utilization.Info {
 //
 // For pods that are controlled by controller known by CA, it will check whether
 // they have been recreated and will inject only not yet recreated pods.
-func (p *Planner) injectRecentlyEvictedPods() error {
+func (p *Planner) injectRecentlyEvictedPods(ctx context.Context) error {
 	recentlyEvictedRecreatablePods := pod_util.FilterRecreatablePods(p.scaleDownContext.ActuationStatus.RecentEvictions())
-	return p.injectPods(filterOutRecreatedPods(recentlyEvictedRecreatablePods, p.cc))
+	return p.injectPods(ctx, filterOutRecreatedPods(recentlyEvictedRecreatablePods, p.cc))
 }
 
 func filterOutRecreatedPods(pods []*apiv1.Pod, cc controllerReplicasCalculator) []*apiv1.Pod {
@@ -267,11 +268,11 @@ func filterOutRecreatedPods(pods []*apiv1.Pod, cc controllerReplicasCalculator) 
 	return podsToInject
 }
 
-func (p *Planner) injectPods(pods []*apiv1.Pod) error {
+func (p *Planner) injectPods(ctx context.Context, pods []*apiv1.Pod) error {
 	pods = pod_util.ClearPodNodeNames(pods)
 	// Note: We're using ScheduleAnywhere, but the pods won't schedule back
 	// on the drained nodes due to taints.
-	statuses, _, err := p.actuationInjector.TrySchedulePods(p.autoscalingCtx.ClusterSnapshot, pods, true, clustersnapshot.SchedulingOptions{IsNodeAcceptable: scheduling.ScheduleAnywhere})
+	statuses, _, err := p.actuationInjector.TrySchedulePods(ctx, p.autoscalingCtx.ClusterSnapshot, pods, true, clustersnapshot.SchedulingOptions{IsNodeAcceptable: scheduling.ScheduleAnywhere})
 	if err != nil {
 		return fmt.Errorf("cannot scale down, an unexpected error occurred: %v", err)
 	}
@@ -283,13 +284,13 @@ func (p *Planner) injectPods(pods []*apiv1.Pod) error {
 
 // categorizeNodes determines, for each node, whether it can be eventually
 // removed or if there are reasons preventing that.
-func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCandidates []*apiv1.Node) {
+func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[string]bool, scaleDownCandidates []*apiv1.Node) {
 	unremovableTimeout := p.latestUpdate.Add(p.autoscalingCtx.AutoscalingOptions.UnremovableNodeRecheckTimeout)
 	unremovableCount := 0
 	var removableList []simulator.NodeToBeRemoved
 	atomicScaleDownNodesCount := 0
-	p.unremovableNodes.Update(p.autoscalingCtx.ClusterSnapshot, p.latestUpdate)
-	currentlyUnneededNodeNames, utilizationMap, ineligible := p.eligibilityChecker.FilterOutUnremovable(p.autoscalingCtx, scaleDownCandidates, p.latestUpdate, p.unremovableNodes)
+	p.unremovableNodes.Update(ctx, p.autoscalingCtx.ClusterSnapshot, p.latestUpdate)
+	currentlyUnneededNodeNames, utilizationMap, ineligible := p.eligibilityChecker.FilterOutUnremovable(ctx, p.autoscalingCtx, scaleDownCandidates, p.latestUpdate, p.unremovableNodes)
 	for _, n := range ineligible {
 		p.unremovableNodes.Add(n)
 	}
@@ -309,7 +310,7 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 			break
 		}
 
-		removable, unremovable := p.rs.SimulateNodeRemoval(node, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
+		removable, unremovable := p.rs.SimulateNodeRemoval(ctx, node, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
 		if removable != nil {
 			_, inParallel, _ := p.autoscalingCtx.RemainingPdbTracker.CanRemovePods(removable.PodsToReschedule)
 			if !inParallel {
@@ -318,7 +319,7 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 			delete(podDestinations, removable.Node.Name)
 			p.autoscalingCtx.RemainingPdbTracker.RemovePods(removable.PodsToReschedule)
 			removableList = append(removableList, *removable)
-			if p.atomicScaleDownNode(removable) {
+			if p.atomicScaleDownNode(ctx, removable) {
 				atomicScaleDownNodesCount++
 				klog.V(2).Infof("Considering node %s for atomic scale down. Total atomic scale down nodes count: %d", removable.Node.Name, atomicScaleDownNodesCount)
 			}
@@ -329,14 +330,14 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 		}
 	}
 	p.handleUnprocessedNodes(skippedNodes)
-	p.unneededNodes.Update(p.autoscalingCtx, removableList, p.latestUpdate)
+	p.unneededNodes.Update(ctx, p.autoscalingCtx, removableList, p.latestUpdate)
 	if unremovableCount > 0 {
 		klog.V(1).Infof("%v nodes found to be unremovable in simulation, will re-check them at %v", unremovableCount, unremovableTimeout)
 	}
 }
 
 // atomicScaleDownNode checks if the removable node would be considered for atomic scale down.
-func (p *Planner) atomicScaleDownNode(node *simulator.NodeToBeRemoved) bool {
+func (p *Planner) atomicScaleDownNode(ctx context.Context, node *simulator.NodeToBeRemoved) bool {
 	nodeGroup, err := p.autoscalingCtx.CloudProvider.NodeGroupForNode(node.Node)
 	if err != nil {
 		klog.Errorf("failed to get node info for %v: %s", node.Node.Name, err)

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package planner
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/autoscaler/cluster-autoscaler/resourcequotas"
@@ -520,7 +521,7 @@ func TestUpdateClusterState(t *testing.T) {
 				p.rs = rs
 			}
 			// TODO(x13n): test subsets of nodes passed as podDestinations/scaleDownCandidates.
-			assert.NoError(t, p.UpdateClusterState(tc.nodes, tc.nodes, tc.actuationStatus, time.Now()))
+			assert.NoError(t, p.UpdateClusterState(context.TODO(), tc.nodes, tc.nodes, tc.actuationStatus, time.Now()))
 			wantUnneeded := asMap(tc.wantUnneeded)
 			wantUnremovable := asMap(tc.wantUnremovable)
 			for _, n := range tc.nodes {
@@ -711,8 +712,8 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(nodeNames(nodes))}
 			p.minUpdateInterval = tc.updateInterval
-			p.unneededNodes.Update(&autoscalingCtx, previouslyUnneeded, time.Now())
-			assert.NoError(t, p.UpdateClusterState(nodes, nodes, &fakeActuationStatus{}, time.Now()))
+			p.unneededNodes.Update(context.TODO(), &autoscalingCtx, previouslyUnneeded, time.Now())
+			assert.NoError(t, p.UpdateClusterState(context.TODO(), nodes, nodes, &fakeActuationStatus{}, time.Now()))
 			assert.Equal(t, tc.wantUnneeded, len(p.unneededNodes.AsList()))
 		})
 	}
@@ -1120,9 +1121,9 @@ func TestNodesToDelete(t *testing.T) {
 			}
 
 			p.scaleDownContext.ActuationStatus = deletiontracker.NewNodeDeletionTracker(0 * time.Second)
-			p.unneededNodes.Update(&autoscalingCtx, allRemovables, time.Now().Add(-1*time.Hour))
+			p.unneededNodes.Update(context.TODO(), &autoscalingCtx, allRemovables, time.Now().Add(-1*time.Hour))
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(nodeNames(allNodes))}
-			empty, drain := p.NodesToDelete(time.Now())
+			empty, drain := p.NodesToDelete(context.TODO(), time.Now())
 			assert.ElementsMatch(t, tc.wantEmpty, empty)
 			assert.ElementsMatch(t, tc.wantDrain, drain)
 
@@ -1247,7 +1248,7 @@ type fakeEligibilityChecker struct {
 	eligible map[string]bool
 }
 
-func (f *fakeEligibilityChecker) FilterOutUnremovable(autoscalingCtx *ca_context.AutoscalingContext, scaleDownCandidates []*apiv1.Node, timestamp time.Time, unremovableNodes *unremovable.Nodes) ([]string, map[string]utilization.Info, []*simulator.UnremovableNode) {
+func (f *fakeEligibilityChecker) FilterOutUnremovable(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownCandidates []*apiv1.Node, timestamp time.Time, unremovableNodes *unremovable.Nodes) ([]string, map[string]utilization.Info, []*simulator.UnremovableNode) {
 	eligible := []string{}
 	utilMap := make(map[string]utilization.Info)
 	for _, n := range scaleDownCandidates {
@@ -1268,7 +1269,7 @@ type fakeRemovalSimulator struct {
 
 func (r *fakeRemovalSimulator) DropOldHints() {}
 
-func (r *fakeRemovalSimulator) SimulateNodeRemoval(name string, _ map[string]bool, _ time.Time, _ pdb.RemainingPdbTracker) (*simulator.NodeToBeRemoved, *simulator.UnremovableNode) {
+func (r *fakeRemovalSimulator) SimulateNodeRemoval(ctx context.Context, name string, _ map[string]bool, _ time.Time, _ pdb.RemainingPdbTracker) (*simulator.NodeToBeRemoved, *simulator.UnremovableNode) {
 	time.Sleep(r.sleep)
 	node := &apiv1.Node{}
 	for _, n := range r.nodes {
@@ -1297,6 +1298,6 @@ func TestAtomicScaleDownNodeNilGroup(t *testing.T) {
 		Node: n1,
 	}
 
-	result := p.atomicScaleDownNode(node)
+	result := p.atomicScaleDownNode(context.TODO(), node)
 	assert.False(t, result)
 }

--- a/cluster-autoscaler/core/scaledown/scaledown.go
+++ b/cluster-autoscaler/core/scaledown/scaledown.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaledown
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
@@ -30,12 +31,12 @@ import (
 // Planner is responsible for selecting nodes that should be removed.
 type Planner interface {
 	// UpdateClusterState provides the Planner with information about the cluster.
-	UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as ActuationStatus, currentTime time.Time) errors.AutoscalerError
+	UpdateClusterState(ctx context.Context, podDestinations, scaleDownCandidates []*apiv1.Node, as ActuationStatus, currentTime time.Time) errors.AutoscalerError
 	// CleanUpUnneededNodes resets internal state of the Planner.
-	CleanUpUnneededNodes()
+	CleanUpUnneededNodes(context.Context)
 	// NodesToDelete returns a list of nodes that can be deleted right now,
 	// according to the Planner.
-	NodesToDelete(currentTime time.Time) (empty, needDrain []*apiv1.Node)
+	NodesToDelete(ctx context.Context, currentTime time.Time) (empty, needDrain []*apiv1.Node)
 	// UnneededNodes returns a list of nodes that either can be deleted
 	// right now or in a near future, assuming nothing will change in the
 	// cluster.
@@ -56,9 +57,9 @@ type Actuator interface {
 	// function are not guaranteed to be deleted, it is possible for the
 	// Actuator to ignore some of them e.g. if max configured level of
 	// parallelism is reached.
-	StartDeletion(empty, needDrain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError)
+	StartDeletion(ctx context.Context, empty, needDrain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError)
 	// StartForceDeletion triggers a new forced deletion process. It bypasses PDBs and forcefully deletes the pods and the nodes.
-	StartForceDeletion(empty, needDrain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError)
+	StartForceDeletion(ctx context.Context, empty, needDrain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, errors.AutoscalerError)
 	// CheckStatus returns an immutable snapshot of ongoing deletions.
 	CheckStatus() ActuationStatus
 	// ClearResultsNotNewerThan removes information about deletions finished

--- a/cluster-autoscaler/core/scaledown/status/status.go
+++ b/cluster-autoscaler/core/scaledown/status/status.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -38,7 +39,7 @@ type ScaleDownStatus struct {
 }
 
 // SetUnremovableNodesInfo sets the status of nodes that were found to be unremovable.
-func (s *ScaleDownStatus) SetUnremovableNodesInfo(unremovableNodes []*simulator.UnremovableNode, nodeUtilizationMap map[string]utilization.Info, cp cloudprovider.CloudProvider) {
+func (s *ScaleDownStatus) SetUnremovableNodesInfo(ctx context.Context, unremovableNodes []*simulator.UnremovableNode, nodeUtilizationMap map[string]utilization.Info, cp cloudprovider.CloudProvider) {
 	s.UnremovableNodes = make([]*UnremovableNode, 0, len(unremovableNodes))
 
 	for _, unremovableNode := range unremovableNodes {

--- a/cluster-autoscaler/core/scaledown/status/status.go
+++ b/cluster-autoscaler/core/scaledown/status/status.go
@@ -40,16 +40,17 @@ type ScaleDownStatus struct {
 
 // SetUnremovableNodesInfo sets the status of nodes that were found to be unremovable.
 func (s *ScaleDownStatus) SetUnremovableNodesInfo(ctx context.Context, unremovableNodes []*simulator.UnremovableNode, nodeUtilizationMap map[string]utilization.Info, cp cloudprovider.CloudProvider) {
+	logger := klog.FromContext(ctx)
 	s.UnremovableNodes = make([]*UnremovableNode, 0, len(unremovableNodes))
 
 	for _, unremovableNode := range unremovableNodes {
 		nodeGroup, err := cp.NodeGroupForNode(unremovableNode.Node)
 		if err != nil {
-			klog.Errorf("Couldn't find node group for unremovable node in cloud provider %s", unremovableNode.Node.Name)
+			logger.Error(err, "Couldn't find node group for unremovable node in cloud provider", "node", unremovableNode.Node.Name)
 			continue
 		}
 		if nodeGroup == nil {
-			klog.Errorf("Unremovable node %s has no node group", unremovableNode.Node.Name)
+			logger.Error(nil, "Unremovable node has no node group", "node", unremovableNode.Node.Name)
 			continue
 		}
 

--- a/cluster-autoscaler/core/scaledown/status/status_test.go
+++ b/cluster-autoscaler/core/scaledown/status/status_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,7 +62,7 @@ func TestSetUnremovableNodesInfo(t *testing.T) {
 	}
 
 	s := &ScaleDownStatus{}
-	s.SetUnremovableNodesInfo(unremovableNodes, nodeUtilizationMap, provider)
+	s.SetUnremovableNodesInfo(context.TODO(), unremovableNodes, nodeUtilizationMap, provider)
 
 	assert.Equal(t, 1, len(s.UnremovableNodes))
 	assert.Equal(t, "n1", s.UnremovableNodes[0].Node.Name)

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package unneeded
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -104,7 +105,7 @@ func (n *Nodes) LoadFromExistingTaints(autoscalingCtx *ca_context.AutoscalingCon
 // It sets the initial state of unneeded nodes reflect the taint status of nodes in the cluster.
 // This is in order the avoid state loss between deployment restarts.
 func (n *Nodes) initialize(autoscalingCtx *ca_context.AutoscalingContext, nodes []simulator.NodeToBeRemoved, ts time.Time) {
-	n.updateInternalState(autoscalingCtx, nodes, ts, func(nn simulator.NodeToBeRemoved) *time.Time {
+	n.updateInternalState(context.TODO(), autoscalingCtx, nodes, ts, func(nn simulator.NodeToBeRemoved) *time.Time {
 		name := nn.Node.Name
 		if since, err := taints.GetDeletionCandidateTime(nn.Node); err == nil {
 			klog.V(4).Infof("Found node %s with deletion candidate taint from %s", name, since.String())
@@ -120,13 +121,13 @@ func (n *Nodes) initialize(autoscalingCtx *ca_context.AutoscalingContext, nodes 
 
 // Update stores nodes along with a time at which they were found to be
 // unneeded. Previously existing timestamps are preserved.
-func (n *Nodes) Update(autoscalingCtx *ca_context.AutoscalingContext, nodes []simulator.NodeToBeRemoved, ts time.Time) {
-	n.updateInternalState(autoscalingCtx, nodes, ts, func(nn simulator.NodeToBeRemoved) *time.Time {
+func (n *Nodes) Update(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodes []simulator.NodeToBeRemoved, ts time.Time) {
+	n.updateInternalState(ctx, autoscalingCtx, nodes, ts, func(nn simulator.NodeToBeRemoved) *time.Time {
 		return nil
 	})
 }
 
-func (n *Nodes) updateInternalState(autoscalingCtx *ca_context.AutoscalingContext, nodes []simulator.NodeToBeRemoved, ts time.Time, timestampGetter func(simulator.NodeToBeRemoved) *time.Time) {
+func (n *Nodes) updateInternalState(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodes []simulator.NodeToBeRemoved, ts time.Time, timestampGetter func(simulator.NodeToBeRemoved) *time.Time) {
 	updated := make(map[string]*node, len(nodes))
 	for _, nn := range nodes {
 		name := nn.Node.Name
@@ -137,10 +138,10 @@ func (n *Nodes) updateInternalState(autoscalingCtx *ca_context.AutoscalingContex
 				ntbr:  nn,
 				since: val.since,
 			}
-			n.lookupAndSetRemovalThreshold(newNodeState, autoscalingCtx.CloudProvider)
+			n.lookupAndSetRemovalThreshold(ctx, newNodeState, autoscalingCtx.CloudProvider)
 			updated[name] = newNodeState
 		} else {
-			updated[name] = n.newNode(nn, timestampGetter, ts, autoscalingCtx.CloudProvider)
+			updated[name] = n.newNode(ctx, nn, timestampGetter, ts, autoscalingCtx.CloudProvider)
 		}
 	}
 	n.byName = updated
@@ -152,7 +153,7 @@ func (n *Nodes) updateInternalState(autoscalingCtx *ca_context.AutoscalingContex
 	}
 }
 
-func (n *Nodes) newNode(nn simulator.NodeToBeRemoved, timestampGetter func(simulator.NodeToBeRemoved) *time.Time, ts time.Time, cp cloudprovider.CloudProvider) *node {
+func (n *Nodes) newNode(ctx context.Context, nn simulator.NodeToBeRemoved, timestampGetter func(simulator.NodeToBeRemoved) *time.Time, ts time.Time, cp cloudprovider.CloudProvider) *node {
 	var since time.Time
 	if existingts := timestampGetter(nn); existingts != nil {
 		since = *existingts
@@ -165,14 +166,14 @@ func (n *Nodes) newNode(nn simulator.NodeToBeRemoved, timestampGetter func(simul
 		since: since,
 	}
 
-	n.lookupAndSetRemovalThreshold(newNode, cp)
+	n.lookupAndSetRemovalThreshold(ctx, newNode, cp)
 
 	return newNode
 }
 
 // Clear resets the internal state, dropping information about all tracked nodes.
-func (n *Nodes) Clear() {
-	n.Update(nil, nil, time.Time{})
+func (n *Nodes) Clear(ctx context.Context) {
+	n.Update(ctx, nil, nil, time.Time{})
 }
 
 // Contains returns true iff a given node is unneeded.
@@ -204,13 +205,13 @@ func (n *Nodes) Drop(node string) {
 // RemovableAt returns all nodes that can be removed at a given time, divided
 // into empty and non-empty node lists, as well as a list of nodes that were
 // unneeded, but are not removable, annotated by reason.
-func (n *Nodes) RemovableAt(autoscalingCtx *ca_context.AutoscalingContext, scaleDownContext nodes.ScaleDownContext, ts time.Time) (empty, needDrain []simulator.NodeToBeRemoved, unremovable []simulator.UnremovableNode) {
-	nodeGroupSize := utils.GetNodeGroupSizeMap(autoscalingCtx.CloudProvider)
+func (n *Nodes) RemovableAt(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownContext nodes.ScaleDownContext, ts time.Time) (empty, needDrain []simulator.NodeToBeRemoved, unremovable []simulator.UnremovableNode) {
+	nodeGroupSize := utils.GetNodeGroupSizeMap(ctx, autoscalingCtx.CloudProvider)
 	emptyNodes, drainNodes := n.splitEmptyAndNonEmptyNodes()
 
 	for nodeName, v := range emptyNodes {
 		klog.V(2).Infof("%s was unneeded for %s", nodeName, ts.Sub(v.since).String())
-		if r := n.unremovableReason(autoscalingCtx, scaleDownContext, v, ts, nodeGroupSize); r != simulator.NoReason {
+		if r := n.unremovableReason(ctx, autoscalingCtx, scaleDownContext, v, ts, nodeGroupSize); r != simulator.NoReason {
 			unremovable = append(unremovable, simulator.UnremovableNode{Node: v.ntbr.Node, Reason: r})
 			continue
 		}
@@ -218,7 +219,7 @@ func (n *Nodes) RemovableAt(autoscalingCtx *ca_context.AutoscalingContext, scale
 	}
 	for nodeName, v := range drainNodes {
 		klog.V(2).Infof("%s was unneeded for %s", nodeName, ts.Sub(v.since).String())
-		if r := n.unremovableReason(autoscalingCtx, scaleDownContext, v, ts, nodeGroupSize); r != simulator.NoReason {
+		if r := n.unremovableReason(ctx, autoscalingCtx, scaleDownContext, v, ts, nodeGroupSize); r != simulator.NoReason {
 			unremovable = append(unremovable, simulator.UnremovableNode{Node: v.ntbr.Node, Reason: r})
 			continue
 		}
@@ -228,7 +229,7 @@ func (n *Nodes) RemovableAt(autoscalingCtx *ca_context.AutoscalingContext, scale
 }
 
 // lookupAndSetRemovalThreshold gets the unneeded/unready time for a node and updates the node struct.
-func (n *Nodes) lookupAndSetRemovalThreshold(v *node, cp cloudprovider.CloudProvider) {
+func (n *Nodes) lookupAndSetRemovalThreshold(ctx context.Context, v *node, cp cloudprovider.CloudProvider) {
 	nodeGroup, err := cp.NodeGroupForNode(v.ntbr.Node)
 	if err != nil {
 		klog.Warningf("Error determining node group for %s: %v", v.ntbr.Node.Name, err)
@@ -257,7 +258,7 @@ func (n *Nodes) lookupAndSetRemovalThreshold(v *node, cp cloudprovider.CloudProv
 	v.removalThreshold = removalThreshold
 }
 
-func (n *Nodes) unremovableReason(autoscalingCtx *ca_context.AutoscalingContext, scaleDownContext nodes.ScaleDownContext, v *node, ts time.Time, nodeGroupSize map[string]int) simulator.UnremovableReason {
+func (n *Nodes) unremovableReason(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownContext nodes.ScaleDownContext, v *node, ts time.Time, nodeGroupSize map[string]int) simulator.UnremovableReason {
 	if v.thresholdRetrievalFailed {
 		return simulator.UnexpectedError
 	}
@@ -283,11 +284,11 @@ func (n *Nodes) unremovableReason(autoscalingCtx *ca_context.AutoscalingContext,
 		return simulator.NotAutoscaled
 	}
 
-	if reason := verifyMinSize(node.Name, nodeGroup, nodeGroupSize, scaleDownContext.ActuationStatus); reason != simulator.NoReason {
+	if reason := verifyMinSize(ctx, node.Name, nodeGroup, nodeGroupSize, scaleDownContext.ActuationStatus); reason != simulator.NoReason {
 		return reason
 	}
 
-	checkResult, err := scaleDownContext.Tracker.ConsumeQuota(autoscalingCtx, nodeGroup, node, 1)
+	checkResult, err := scaleDownContext.Tracker.ConsumeQuota(ctx, autoscalingCtx, nodeGroup, node, 1)
 	if err != nil {
 		klog.Errorf("Failed to check limits for %s: %v", node.Name, err)
 		return simulator.UnexpectedError
@@ -315,7 +316,7 @@ func (n *Nodes) splitEmptyAndNonEmptyNodes() (empty, needDrain map[string]*node)
 	return
 }
 
-func verifyMinSize(nodeName string, nodeGroup cloudprovider.NodeGroup, nodeGroupSize map[string]int, as scaledown.ActuationStatus) simulator.UnremovableReason {
+func verifyMinSize(ctx context.Context, nodeName string, nodeGroup cloudprovider.NodeGroup, nodeGroupSize map[string]int, as scaledown.ActuationStatus) simulator.UnremovableReason {
 	size, found := nodeGroupSize[nodeGroup.Id()]
 	if !found {
 		klog.Errorf("Error while checking node group size %s: group size not found in cache", nodeGroup.Id())

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes.go
@@ -128,6 +128,7 @@ func (n *Nodes) Update(ctx context.Context, autoscalingCtx *ca_context.Autoscali
 }
 
 func (n *Nodes) updateInternalState(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodes []simulator.NodeToBeRemoved, ts time.Time, timestampGetter func(simulator.NodeToBeRemoved) *time.Time) {
+	logger := klog.FromContext(ctx)
 	updated := make(map[string]*node, len(nodes))
 	for _, nn := range nodes {
 		name := nn.Node.Name
@@ -146,9 +147,9 @@ func (n *Nodes) updateInternalState(ctx context.Context, autoscalingCtx *ca_cont
 	}
 	n.byName = updated
 	n.cachedList = nil
-	if klog.V(4).Enabled() {
+	if logger.V(4).Enabled() {
 		for k, v := range n.byName {
-			klog.Infof("%s is unneeded since %s duration %s", k, v.since, ts.Sub(v.since))
+			logger.V(4).Info("Tracking unneeded node", "node", k, "since", v.since, "duration", ts.Sub(v.since))
 		}
 	}
 }
@@ -206,11 +207,12 @@ func (n *Nodes) Drop(node string) {
 // into empty and non-empty node lists, as well as a list of nodes that were
 // unneeded, but are not removable, annotated by reason.
 func (n *Nodes) RemovableAt(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownContext nodes.ScaleDownContext, ts time.Time) (empty, needDrain []simulator.NodeToBeRemoved, unremovable []simulator.UnremovableNode) {
+	logger := klog.FromContext(ctx)
 	nodeGroupSize := utils.GetNodeGroupSizeMap(ctx, autoscalingCtx.CloudProvider)
 	emptyNodes, drainNodes := n.splitEmptyAndNonEmptyNodes()
 
 	for nodeName, v := range emptyNodes {
-		klog.V(2).Infof("%s was unneeded for %s", nodeName, ts.Sub(v.since).String())
+		logger.V(2).Info("was unneeded", "node", nodeName, "duration", ts.Sub(v.since).String())
 		if r := n.unremovableReason(ctx, autoscalingCtx, scaleDownContext, v, ts, nodeGroupSize); r != simulator.NoReason {
 			unremovable = append(unremovable, simulator.UnremovableNode{Node: v.ntbr.Node, Reason: r})
 			continue
@@ -218,7 +220,7 @@ func (n *Nodes) RemovableAt(ctx context.Context, autoscalingCtx *ca_context.Auto
 		empty = append(empty, v.ntbr)
 	}
 	for nodeName, v := range drainNodes {
-		klog.V(2).Infof("%s was unneeded for %s", nodeName, ts.Sub(v.since).String())
+		logger.V(2).Info("was unneeded", "node", nodeName, "duration", ts.Sub(v.since).String())
 		if r := n.unremovableReason(ctx, autoscalingCtx, scaleDownContext, v, ts, nodeGroupSize); r != simulator.NoReason {
 			unremovable = append(unremovable, simulator.UnremovableNode{Node: v.ntbr.Node, Reason: r})
 			continue
@@ -230,13 +232,14 @@ func (n *Nodes) RemovableAt(ctx context.Context, autoscalingCtx *ca_context.Auto
 
 // lookupAndSetRemovalThreshold gets the unneeded/unready time for a node and updates the node struct.
 func (n *Nodes) lookupAndSetRemovalThreshold(ctx context.Context, v *node, cp cloudprovider.CloudProvider) {
+	logger := klog.FromContext(ctx)
 	nodeGroup, err := cp.NodeGroupForNode(v.ntbr.Node)
 	if err != nil {
-		klog.Warningf("Error determining node group for %s: %v", v.ntbr.Node.Name, err)
+		logger.Info("Error determining node group", "node", v.ntbr.Node.Name, "err", err)
 		return
 	}
 	if nodeGroup == nil {
-		klog.V(4).Infof("Skipping %s - no node group config", v.ntbr.Node.Name)
+		logger.V(4).Info("Skipping - no node group config", "node", v.ntbr.Node.Name)
 		return
 	}
 
@@ -250,7 +253,7 @@ func (n *Nodes) lookupAndSetRemovalThreshold(ctx context.Context, v *node, cp cl
 	}
 
 	if err != nil {
-		klog.Warningf("Failed to get scale down unneeded/unready time for %s: %v", v.ntbr.Node.Name, err)
+		logger.Info("Failed to get scale down unneeded unready time", "node", v.ntbr.Node.Name, "err", err)
 		v.thresholdRetrievalFailed = true
 		return
 	}
@@ -259,13 +262,14 @@ func (n *Nodes) lookupAndSetRemovalThreshold(ctx context.Context, v *node, cp cl
 }
 
 func (n *Nodes) unremovableReason(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownContext nodes.ScaleDownContext, v *node, ts time.Time, nodeGroupSize map[string]int) simulator.UnremovableReason {
+	logger := klog.FromContext(ctx)
 	if v.thresholdRetrievalFailed {
 		return simulator.UnexpectedError
 	}
 	node := v.ntbr.Node
 	// Check if node is marked with no scale down annotation.
 	if eligibility.HasNoScaleDownAnnotation(node) {
-		klog.V(4).Infof("Skipping %s - scale down disabled annotation found", node.Name)
+		logger.V(4).Info("Skipping - scale down disabled annotation found", "node", node.Name)
 		return simulator.ScaleDownDisabledAnnotation
 	}
 
@@ -280,7 +284,7 @@ func (n *Nodes) unremovableReason(ctx context.Context, autoscalingCtx *ca_contex
 
 	nodeGroup, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)
 	if err != nil || nodeGroup == nil {
-		klog.V(4).Infof("Skipping %s - no node group config", node.Name)
+		logger.V(4).Info("Skipping - no node group config", "node", node.Name)
 		return simulator.NotAutoscaled
 	}
 
@@ -290,12 +294,12 @@ func (n *Nodes) unremovableReason(ctx context.Context, autoscalingCtx *ca_contex
 
 	checkResult, err := scaleDownContext.Tracker.ConsumeQuota(ctx, autoscalingCtx, nodeGroup, node, 1)
 	if err != nil {
-		klog.Errorf("Failed to check limits for %s: %v", node.Name, err)
+		logger.Error(err, "Failed to check limits", "node", node.Name)
 		return simulator.UnexpectedError
 	}
 
 	if checkResult.Exceeded() {
-		klog.V(2).Infof("Skipping scale down of %s in this batch - would violate minimum limits", node.Name)
+		logger.V(2).Info("Skipping scale down in this batch - would violate minimum limits", "node", node.Name)
 		return simulator.MinimalResourceLimitExceeded
 	}
 
@@ -317,14 +321,15 @@ func (n *Nodes) splitEmptyAndNonEmptyNodes() (empty, needDrain map[string]*node)
 }
 
 func verifyMinSize(ctx context.Context, nodeName string, nodeGroup cloudprovider.NodeGroup, nodeGroupSize map[string]int, as scaledown.ActuationStatus) simulator.UnremovableReason {
+	logger := klog.FromContext(ctx)
 	size, found := nodeGroupSize[nodeGroup.Id()]
 	if !found {
-		klog.Errorf("Error while checking node group size %s: group size not found in cache", nodeGroup.Id())
+		logger.Error(nil, "Error while checking node group size: group size not found in cache", "nodeGroupId", nodeGroup.Id())
 		return simulator.UnexpectedError
 	}
 	deletionsInProgress := as.DeletionsCount(nodeGroup.Id())
 	if size-deletionsInProgress <= nodeGroup.MinSize() {
-		klog.V(1).Infof("Skipping %s - node group min size reached", nodeName)
+		logger.V(1).Info("Skipping - node group min size reached", "node", nodeName)
 		return simulator.NodeGroupMinSizeReached
 	}
 	return simulator.NoReason

--- a/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
+++ b/cluster-autoscaler/core/scaledown/unneeded/nodes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package unneeded
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -154,8 +155,8 @@ func TestUpdate(t *testing.T) {
 			nodes := NewNodes(fakeTimeGetter)
 			ctx := &ca_context.AutoscalingContext{CloudProvider: provider}
 
-			nodes.Update(ctx, tc.initialNodes, initialTimestamp)
-			nodes.Update(ctx, tc.finalNodes, finalTimestamp)
+			nodes.Update(context.TODO(), ctx, tc.initialNodes, initialTimestamp)
+			nodes.Update(context.TODO(), ctx, tc.finalNodes, finalTimestamp)
 
 			wantNodes := len(tc.wantTimestamps)
 			assert.Equal(t, wantNodes, len(nodes.AsList()))
@@ -269,7 +270,7 @@ func TestRemovableAt(t *testing.T) {
 			}
 			n := NewNodes(fakeTimeGetter)
 
-			n.Update(&autoscalingCtx, removableNodes, time.Now().Add(-10*time.Minute)) //add -10 min to work correctly with unneeded time threshold
+			n.Update(context.TODO(), &autoscalingCtx, removableNodes, time.Now().Add(-10*time.Minute)) //add -10 min to work correctly with unneeded time threshold
 
 			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
 				QuotaProvider:            resourcequotas.NewFakeProvider([]resourcequotas.Quota{}),
@@ -279,9 +280,9 @@ func TestRemovableAt(t *testing.T) {
 			for _, n := range removableNodes {
 				nodes = append(nodes, n.Node)
 			}
-			tracker, _ := factory.NewMinQuotasTracker(&autoscalingCtx, nodes)
+			tracker, _ := factory.NewMinQuotasTracker(context.TODO(), &autoscalingCtx, nodes)
 
-			gotEmptyToRemove, gotDrainToRemove, _ := n.RemovableAt(&autoscalingCtx, nodeprocessors.ScaleDownContext{
+			gotEmptyToRemove, gotDrainToRemove, _ := n.RemovableAt(context.TODO(), &autoscalingCtx, nodeprocessors.ScaleDownContext{
 				ActuationStatus: as,
 				Tracker:         tracker,
 			}, time.Now())
@@ -468,7 +469,7 @@ func TestRemovableAt_UnremovableReasons(t *testing.T) {
 			}
 			n := NewNodes(timeGetter)
 
-			n.Update(&autoscalingCtx, nodesToProcess, now.Add(tc.nodeConfig.sinceOffset))
+			n.Update(context.TODO(), &autoscalingCtx, nodesToProcess, now.Add(tc.nodeConfig.sinceOffset))
 
 			sdCtx := nodeprocessors.ScaleDownContext{
 				ActuationStatus: &fakeActuationStatus{deletionCount: map[string]int{}},
@@ -478,10 +479,10 @@ func TestRemovableAt_UnremovableReasons(t *testing.T) {
 				QuotaProvider:            resourcequotas.NewFakeProvider(tc.quotas),
 				CustomResourcesProcessor: customresources.NewDefaultCustomResourcesProcessor(false, false),
 			})
-			tracker, _ := factory.NewMinQuotasTracker(&autoscalingCtx, []*apiv1.Node{node})
+			tracker, _ := factory.NewMinQuotasTracker(context.TODO(), &autoscalingCtx, []*apiv1.Node{node})
 
 			sdCtx.Tracker = tracker
-			gotEmptyToRemove, gotDrainToRemove, gotUnremovable := n.RemovableAt(&autoscalingCtx, sdCtx, now)
+			gotEmptyToRemove, gotDrainToRemove, gotUnremovable := n.RemovableAt(context.TODO(), &autoscalingCtx, sdCtx, now)
 
 			assert.Empty(t, gotEmptyToRemove, "Expected no empty nodes to be removable")
 			assert.Empty(t, gotDrainToRemove, "Expected no drain nodes to be removable")

--- a/cluster-autoscaler/core/scaledown/unremovable/nodes.go
+++ b/cluster-autoscaler/core/scaledown/unremovable/nodes.go
@@ -49,6 +49,7 @@ type nodeInfoGetter interface {
 // Update updates the internal structure according to current state of the
 // cluster. Removes the nodes that are no longer in the nodes list.
 func (n *Nodes) Update(ctx context.Context, nodeInfos nodeInfoGetter, timestamp time.Time) {
+	logger := klog.FromContext(ctx)
 	n.reasons = make(map[string]*simulator.UnremovableNode)
 	if len(n.ttls) <= 0 {
 		return
@@ -57,7 +58,7 @@ func (n *Nodes) Update(ctx context.Context, nodeInfos nodeInfoGetter, timestamp 
 	for name, ttl := range n.ttls {
 		if _, err := nodeInfos.GetNodeInfo(name); err != nil {
 			// Not logging on error level as most likely cause is that node is no longer in the cluster.
-			klog.Infof("Can't retrieve node %s from snapshot, removing from unremovable nodes, err: %v", name, err)
+			logger.Info("Can't retrieve node from snapshot, removing from unremovable nodes", "name", name, "err", err)
 			continue
 		}
 		if ttl.After(timestamp) {

--- a/cluster-autoscaler/core/scaledown/unremovable/nodes.go
+++ b/cluster-autoscaler/core/scaledown/unremovable/nodes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package unremovable
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
@@ -47,7 +48,7 @@ type nodeInfoGetter interface {
 
 // Update updates the internal structure according to current state of the
 // cluster. Removes the nodes that are no longer in the nodes list.
-func (n *Nodes) Update(nodeInfos nodeInfoGetter, timestamp time.Time) {
+func (n *Nodes) Update(ctx context.Context, nodeInfos nodeInfoGetter, timestamp time.Time) {
 	n.reasons = make(map[string]*simulator.UnremovableNode)
 	if len(n.ttls) <= 0 {
 		return

--- a/cluster-autoscaler/core/scaledown/unremovable/nodes_test.go
+++ b/cluster-autoscaler/core/scaledown/unremovable/nodes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package unremovable
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -73,7 +74,7 @@ func TestUpdate(t *testing.T) {
 		for name, timeout := range tc.unremovable {
 			n.AddTimeout(makeUnremovableNode(name), timeout)
 		}
-		n.Update(niGetter, updateTime)
+		n.Update(context.TODO(), niGetter, updateTime)
 		got := len(n.ttls)
 		if got != tc.want {
 			t.Errorf("%s: got %d nodes, want %d", desc, got, tc.want)
@@ -95,7 +96,7 @@ func TestContains(t *testing.T) {
 		}
 	}
 	//remove nodes
-	n.Update(newFakeNodeInfoGetter(nodes), time.Now().Add(-1*time.Minute))
+	n.Update(context.TODO(), newFakeNodeInfoGetter(nodes), time.Now().Add(-1*time.Minute))
 	for _, node := range nodes {
 		if n.Contains(node) {
 			t.Errorf("n.Contains(%s) return true, want false", node)

--- a/cluster-autoscaler/core/scaleup/orchestrator/async_initializer.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/async_initializer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -116,7 +117,7 @@ func (s *AsyncNodeGroupInitializer) InitializeNodeGroup(result nodegroups.AsyncN
 	mainCreatedNodeGroup := result.CreationResult.MainCreatedNodeGroup
 	// If possible replace candidate node-info with node info based on crated node group. The latter
 	// one should be more in line with nodes which will be created by node group.
-	nodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(mainCreatedNodeGroup, s.daemonSets, s.taintConfig)
+	nodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(context.TODO(), mainCreatedNodeGroup, s.daemonSets, s.taintConfig)
 	if aErr != nil {
 		klog.Warningf("Cannot build node info for newly created main node group %s. Using fallback. Error: %v", mainCreatedNodeGroup.Id(), aErr)
 		nodeInfo = s.nodeInfo
@@ -130,7 +131,7 @@ func (s *AsyncNodeGroupInitializer) InitializeNodeGroup(result nodegroups.AsyncN
 	}
 
 	klog.Infof("Starting scale-up for async created node groups. Scale ups: %v", scaleUpInfos)
-	err, failedNodeGroups := s.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, nodeInfos, time.Now(), s.atomicScaleUp)
+	err, failedNodeGroups := s.scaleUpExecutor.ExecuteScaleUps(context.TODO(), scaleUpInfos, nodeInfos, time.Now(), s.atomicScaleUp)
 	if err != nil {
 		var failedNodeGroupIds []string
 		for _, failedNodeGroup := range failedNodeGroups {
@@ -188,5 +189,5 @@ func (s *AsyncNodeGroupInitializer) emitScaleUpStatus(scaleUpStatus *status.Scal
 	if err != nil {
 		status.UpdateScaleUpError(scaleUpStatus, err)
 	}
-	s.scaleUpStatusProcessor.Process(s.autoscalingCtx, scaleUpStatus)
+	s.scaleUpStatusProcessor.Process(context.TODO(), s.autoscalingCtx, scaleUpStatus)
 }

--- a/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/async_initializer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	gocontext "context"
 	"fmt"
 	"testing"
 
@@ -123,7 +124,7 @@ type fakeScaleUpStatusProcessor struct {
 	lastStatus *status.ScaleUpStatus
 }
 
-func (f *fakeScaleUpStatusProcessor) Process(_ *ca_context.AutoscalingContext, status *status.ScaleUpStatus) {
+func (f *fakeScaleUpStatusProcessor) Process(ctx gocontext.Context, _ *ca_context.AutoscalingContext, status *status.ScaleUpStatus) {
 	f.lastStatus = status
 }
 

--- a/cluster-autoscaler/core/scaleup/orchestrator/executor.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/executor.go
@@ -80,11 +80,12 @@ func (e *scaleUpExecutor) executeScaleUpsSync(
 	now time.Time,
 	atomic bool,
 ) (errors.AutoscalerError, []cloudprovider.NodeGroup) {
+	logger := klog.FromContext(ctx)
 	availableGPUTypes := e.autoscalingCtx.CloudProvider.GetAvailableGPUTypes()
 	for _, scaleUpInfo := range scaleUpInfos {
 		nodeInfo, ok := nodeInfos[scaleUpInfo.Group.Id()]
 		if !ok {
-			klog.Errorf("ExecuteScaleUp: failed to get node info for node group %s", scaleUpInfo.Group.Id())
+			logger.Error(nil, "ExecuteScaleUp: failed to get node info for node group", "groupId", scaleUpInfo.Group.Id())
 			continue
 		}
 		if aErr := e.executeScaleUp(ctx, scaleUpInfo, nodeInfo, availableGPUTypes, now, atomic); aErr != nil {
@@ -100,6 +101,7 @@ func (e *scaleUpExecutor) executeScaleUpsParallel(
 	now time.Time,
 	atomic bool,
 ) (errors.AutoscalerError, []cloudprovider.NodeGroup) {
+	logger := klog.FromContext(ctx)
 	if err := checkUniqueNodeGroups(scaleUpInfos); err != nil {
 		return err, extractNodeGroups(scaleUpInfos)
 	}
@@ -117,7 +119,7 @@ func (e *scaleUpExecutor) executeScaleUpsParallel(
 			defer wg.Done()
 			nodeInfo, ok := nodeInfos[info.Group.Id()]
 			if !ok {
-				klog.Errorf("ExecuteScaleUp: failed to get node info for node group %s", info.Group.Id())
+				logger.Error(nil, "ExecuteScaleUp: failed to get node info for node group", "groupId", info.Group.Id())
 				return
 			}
 			if aErr := e.executeScaleUp(ctx, info, nodeInfo, availableGPUTypes, now, atomic); aErr != nil {
@@ -161,10 +163,11 @@ func (e *scaleUpExecutor) executeScaleUp(
 	now time.Time,
 	atomic bool,
 ) errors.AutoscalerError {
+	logger := klog.FromContext(ctx)
 	gpuConfig := e.autoscalingCtx.CloudProvider.GetNodeGpuConfig(nodeInfo.Node())
 	gpuResourceName, gpuType := gpu.GetGpuInfoForMetrics(ctx, gpuConfig, availableGPUTypes, nodeInfo.Node(), nil)
 	draDriverNames := dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
-	klog.V(0).Infof("Scale-up: setting group %s size to %d", info.Group.Id(), info.NewSize)
+	logger.V(0).Info("Scale-up: setting group size", "groupId", info.Group.Id(), "newSize", info.NewSize)
 	e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
 		"Scale-up: setting group %s size to %d instead of %d (max: %d)", info.Group.Id(), info.NewSize, info.CurrentSize, info.MaxSize)
 	increase := info.NewSize - info.CurrentSize

--- a/cluster-autoscaler/core/scaleup/orchestrator/executor.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/executor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -61,20 +62,20 @@ func newScaleUpExecutor(
 // In case of issues returns an error and a scale up info which failed to execute.
 // If there were multiple concurrent errors one combined error is returned.
 func (e *scaleUpExecutor) ExecuteScaleUps(
-	scaleUpInfos []nodegroupset.ScaleUpInfo,
+	ctx context.Context, scaleUpInfos []nodegroupset.ScaleUpInfo,
 	nodeInfos map[string]*framework.NodeInfo,
 	now time.Time,
 	atomic bool,
 ) (errors.AutoscalerError, []cloudprovider.NodeGroup) {
 	options := e.autoscalingCtx.AutoscalingOptions
 	if options.ParallelScaleUp {
-		return e.executeScaleUpsParallel(scaleUpInfos, nodeInfos, now, atomic)
+		return e.executeScaleUpsParallel(ctx, scaleUpInfos, nodeInfos, now, atomic)
 	}
-	return e.executeScaleUpsSync(scaleUpInfos, nodeInfos, now, atomic)
+	return e.executeScaleUpsSync(ctx, scaleUpInfos, nodeInfos, now, atomic)
 }
 
 func (e *scaleUpExecutor) executeScaleUpsSync(
-	scaleUpInfos []nodegroupset.ScaleUpInfo,
+	ctx context.Context, scaleUpInfos []nodegroupset.ScaleUpInfo,
 	nodeInfos map[string]*framework.NodeInfo,
 	now time.Time,
 	atomic bool,
@@ -86,7 +87,7 @@ func (e *scaleUpExecutor) executeScaleUpsSync(
 			klog.Errorf("ExecuteScaleUp: failed to get node info for node group %s", scaleUpInfo.Group.Id())
 			continue
 		}
-		if aErr := e.executeScaleUp(scaleUpInfo, nodeInfo, availableGPUTypes, now, atomic); aErr != nil {
+		if aErr := e.executeScaleUp(ctx, scaleUpInfo, nodeInfo, availableGPUTypes, now, atomic); aErr != nil {
 			return aErr, []cloudprovider.NodeGroup{scaleUpInfo.Group}
 		}
 	}
@@ -94,7 +95,7 @@ func (e *scaleUpExecutor) executeScaleUpsSync(
 }
 
 func (e *scaleUpExecutor) executeScaleUpsParallel(
-	scaleUpInfos []nodegroupset.ScaleUpInfo,
+	ctx context.Context, scaleUpInfos []nodegroupset.ScaleUpInfo,
 	nodeInfos map[string]*framework.NodeInfo,
 	now time.Time,
 	atomic bool,
@@ -119,7 +120,7 @@ func (e *scaleUpExecutor) executeScaleUpsParallel(
 				klog.Errorf("ExecuteScaleUp: failed to get node info for node group %s", info.Group.Id())
 				return
 			}
-			if aErr := e.executeScaleUp(info, nodeInfo, availableGPUTypes, now, atomic); aErr != nil {
+			if aErr := e.executeScaleUp(ctx, info, nodeInfo, availableGPUTypes, now, atomic); aErr != nil {
 				errResults <- errResult{err: aErr, info: &info}
 			}
 		}(scaleUpInfo)
@@ -154,14 +155,14 @@ func (e *scaleUpExecutor) increaseSize(nodeGroup cloudprovider.NodeGroup, increa
 }
 
 func (e *scaleUpExecutor) executeScaleUp(
-	info nodegroupset.ScaleUpInfo,
+	ctx context.Context, info nodegroupset.ScaleUpInfo,
 	nodeInfo *framework.NodeInfo,
 	availableGPUTypes map[string]struct{},
 	now time.Time,
 	atomic bool,
 ) errors.AutoscalerError {
 	gpuConfig := e.autoscalingCtx.CloudProvider.GetNodeGpuConfig(nodeInfo.Node())
-	gpuResourceName, gpuType := gpu.GetGpuInfoForMetrics(gpuConfig, availableGPUTypes, nodeInfo.Node(), nil)
+	gpuResourceName, gpuType := gpu.GetGpuInfoForMetrics(ctx, gpuConfig, availableGPUTypes, nodeInfo.Node(), nil)
 	draDriverNames := dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
 	klog.V(0).Infof("Scale-up: setting group %s size to %d", info.Group.Id(), info.NewSize)
 	e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
@@ -170,7 +171,7 @@ func (e *scaleUpExecutor) executeScaleUp(
 	if err := e.increaseSize(info.Group, increase, atomic); err != nil {
 		e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "FailedToScaleUpGroup", "Scale-up failed for group %s: %v", info.Group.Id(), err)
 		aerr := errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to increase node group size: ")
-		e.scaleStateNotifier.RegisterFailedScaleUp(info.Group, increase, cloudprovider.InstanceErrorInfo{
+		e.scaleStateNotifier.RegisterFailedScaleUp(ctx, info.Group, increase, cloudprovider.InstanceErrorInfo{
 			ErrorClass:   cloudprovider.OtherErrorClass,
 			ErrorCode:    string(aerr.Type()),
 			ErrorMessage: aerr.Error(),
@@ -185,7 +186,7 @@ func (e *scaleUpExecutor) executeScaleUp(
 		// the node group is created, during initial scale up.
 		return nil
 	}
-	e.scaleStateNotifier.RegisterScaleUp(info.Group, increase, time.Now())
+	e.scaleStateNotifier.RegisterScaleUp(ctx, info.Group, increase, time.Now())
 	metrics.RegisterScaleUp(increase, gpuResourceName, gpuType, draDriverNames)
 	e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
 		"Scale-up: group %s size set to %d instead of %d (max: %d)", info.Group.Id(), info.NewSize, info.CurrentSize, info.MaxSize)

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -93,6 +93,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	nodeInfos map[string]*framework.NodeInfo,
 	allOrNothing bool, // Either request enough capacity for all unschedulablePods, or don't request it at all.
 ) (*status.ScaleUpStatus, errors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	if !o.initialized {
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "ScaleUpOrchestrator is not initialized"))
 	}
@@ -118,7 +119,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 			aErr.AddPrefix("could not get upcoming nodes: "),
 		)
 	}
-	klog.V(4).Infof("Upcoming %d nodes", len(upcomingNodes))
+	logger.V(4).Info("Upcoming nodes", "upcomingNodesCount", len(upcomingNodes))
 	if o.processors != nil && o.processors.NodeGroupListProcessor != nil {
 		var err error
 		nodeGroups, nodeInfos, err = o.processors.NodeGroupListProcessor.Process(o.autoscalingCtx, nodeGroups, nodeInfos, unschedulablePods)
@@ -175,7 +176,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	}
 
 	// Execute scale up.
-	klog.V(1).Infof("Final scale-up plan: %v", plan.scaleUpInfos)
+	logger.V(1).Info("Final scale-up plan", "scaleUpInfos", plan.scaleUpInfos)
 	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(ctx, plan.scaleUpInfos, nodeInfos, now, allOrNothing)
 	if aErr != nil {
 		failedGroupsMap := o.buildFailedGroupsMap(failedNodeGroups, plan.scaleUpInfos)
@@ -204,10 +205,11 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 }
 
 func (o *ScaleUpOrchestrator) applyLimits(ctx context.Context, newNodes int, tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfos map[string]*framework.NodeInfo) (int, errors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	nodeInfo, found := nodeInfos[nodeGroup.Id()]
 	if !found {
 		// This should never happen, as we already should have retrieved nodeInfo for any considered nodegroup.
-		klog.Errorf("No node info for: %s", nodeGroup.Id())
+		logger.Error(nil, "No node info for", "nodeGroupId", nodeGroup.Id())
 		return 0, errors.NewAutoscalerError(errors.CloudProviderError, "No node info for best expansion option!")
 	}
 	checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, nodeGroup, nodeInfo.Node(), newNodes)
@@ -225,6 +227,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 	ctx context.Context, nodes []*apiv1.Node,
 	nodeInfos map[string]*framework.NodeInfo,
 ) (*status.ScaleUpStatus, errors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	if !o.initialized {
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerError(errors.InternalError, "ScaleUpOrchestrator is not initialized"))
 	}
@@ -240,48 +243,48 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 
 	for _, ng := range nodeGroups {
 		if !ng.Exist() {
-			klog.Warningf("ScaleUpToNodeGroupMinSize: NodeGroup %s does not exist", ng.Id())
+			logger.Info("ScaleUpToNodeGroupMinSize: NodeGroup does not exist", "nodeGroupId", ng.Id())
 			continue
 		}
 
 		targetSize, err := ng.TargetSize()
 		if err != nil {
-			klog.Warningf("ScaleUpToNodeGroupMinSize: failed to get target size of node group %s", ng.Id())
+			logger.Info("ScaleUpToNodeGroupMinSize: failed to get target size of node group", "nodeGroupId", ng.Id(), "err", err)
+
 			continue
 		}
-
-		klog.V(4).Infof("ScaleUpToNodeGroupMinSize: NodeGroup %s, TargetSize %d, MinSize %d, MaxSize %d", ng.Id(), targetSize, ng.MinSize(), ng.MaxSize())
+		logger.V(4).Info("ScaleUpToNodeGroupMinSize: NodeGroup, TargetSize, MinSize, MaxSize", "nodeGroupId", ng.Id(), "targetSize", targetSize, "minSize", ng.MinSize(), "maxSize", ng.MaxSize())
 		if targetSize >= ng.MinSize() {
 			continue
 		}
 
 		if skipReason := o.IsNodeGroupReadyToScaleUp(ctx, ng, now); skipReason != nil {
-			klog.Warningf("ScaleUpToNodeGroupMinSize: node group is ready to scale up: %v", skipReason)
+			logger.Info("ScaleUpToNodeGroupMinSize: node group is ready to scale up", "skipReason", skipReason)
 			continue
 		}
 
 		nodeInfo, found := nodeInfos[ng.Id()]
 		if !found {
-			klog.Warningf("ScaleUpToNodeGroupMinSize: no node info for %s", ng.Id())
+			logger.Info("ScaleUpToNodeGroupMinSize: no node info", "nodeGroupId", ng.Id())
 			continue
 		}
 
 		if skipReason := o.IsNodeGroupResourceExceeded(ctx, tracker, ng, nodeInfo, 1); skipReason != nil {
-			klog.Warningf("ScaleUpToNodeGroupMinSize: node group resource excceded: %v", skipReason)
+			logger.Info("ScaleUpToNodeGroupMinSize: node group resource excceded", "skipReason", skipReason)
 			continue
 		}
 
 		newNodeCount := ng.MinSize() - targetSize
 		checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, ng, nodeInfo.Node(), newNodeCount)
 		if err != nil {
-			klog.Warningf("ScaleUpToNodeGroupMinSize: failed to check resource quotas: %v", err)
+			logger.Info("ScaleUpToNodeGroupMinSize: failed to check resource quotas", "err", err)
 			continue
 		}
 		newNodeCount = checkResult.AllowedDelta
 
 		newNodeCount, err = o.GetCappedNewNodeCount(ctx, newNodeCount, targetSize)
 		if err != nil {
-			klog.Warningf("ScaleUpToNodeGroupMinSize: failed to get capped node count: %v", err)
+			logger.Info("ScaleUpToNodeGroupMinSize: failed to get capped node count", "err", err)
 			continue
 		}
 
@@ -295,11 +298,10 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 	}
 
 	if len(scaleUpInfos) == 0 {
-		klog.V(1).Info("ScaleUpToNodeGroupMinSize: scale up not needed")
+		logger.V(1).Info("ScaleUpToNodeGroupMinSize: scale up not needed")
 		return &status.ScaleUpStatus{Result: status.ScaleUpNotNeeded}, nil
 	}
-
-	klog.V(1).Infof("ScaleUpToNodeGroupMinSize: final scale-up plan: %v", scaleUpInfos)
+	logger.V(1).Info("ScaleUpToNodeGroupMinSize: final scale-up plan", "scaleUpInfos", scaleUpInfos)
 	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(ctx, scaleUpInfos, nodeInfos, now, false /* allOrNothing disabled */)
 	if aErr != nil {
 		return status.UpdateScaleUpError(
@@ -326,6 +328,7 @@ func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 	currentNodeCount int,
 	now time.Time,
 ) ([]cloudprovider.NodeGroup, map[string]status.Reasons) {
+	logger := klog.FromContext(ctx)
 	var validNodeGroups []cloudprovider.NodeGroup
 	skippedNodeGroups := map[string]status.Reasons{}
 
@@ -337,24 +340,24 @@ func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 
 		currentTargetSize, err := nodeGroup.TargetSize()
 		if err != nil {
-			klog.Errorf("Failed to get node group size: %v", err)
+			logger.Error(err, "Failed to get node group size")
 			skippedNodeGroups[nodeGroup.Id()] = NotReadyReason
 			continue
 		}
 		if currentTargetSize >= nodeGroup.MaxSize() {
-			klog.V(4).Infof("Skipping node group %s - max size reached", nodeGroup.Id())
+			logger.V(4).Info("Skipping node group - max size reached", "nodeGroupId", nodeGroup.Id())
 			skippedNodeGroups[nodeGroup.Id()] = MaxLimitReachedReason
 			continue
 		}
 		autoscalingOptions, err := nodeGroup.GetOptions(o.autoscalingCtx.NodeGroupDefaults)
 		if err != nil && err != cloudprovider.ErrNotImplemented {
-			klog.Errorf("Couldn't get autoscaling options for ng: %v", nodeGroup.Id())
+			logger.Error(nil, "Couldn't get autoscaling options for ng", "nodeGroupId", nodeGroup.Id())
 		}
 		numNodes := 1
 		if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
 			numNodes = nodeGroup.MaxSize() - currentTargetSize
 			if o.autoscalingCtx.MaxNodesTotal != 0 && currentNodeCount+numNodes > o.autoscalingCtx.MaxNodesTotal {
-				klog.V(4).Infof("Skipping node group %s - atomic scale-up exceeds cluster node count limit", nodeGroup.Id())
+				logger.V(4).Info("Skipping node group - atomic scale-up exceeds cluster node count limit", "nodeGroupId", nodeGroup.Id())
 				skippedNodeGroups[nodeGroup.Id()] = NewSkippedReasons("atomic scale-up exceeds cluster node count limit")
 				continue
 			}
@@ -362,7 +365,7 @@ func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 
 		nodeInfo, found := nodeInfos[nodeGroup.Id()]
 		if !found {
-			klog.Errorf("No node info for: %s", nodeGroup.Id())
+			logger.Error(nil, "No node info for", "nodeGroupId", nodeGroup.Id())
 			skippedNodeGroups[nodeGroup.Id()] = NotReadyReason
 			continue
 		}
@@ -385,6 +388,7 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 	now time.Time,
 	allOrNothing bool,
 ) expander.Option {
+	logger := klog.FromContext(ctx)
 	option := expander.Option{NodeGroup: nodeGroup}
 	podGroups := schedulablePodGroups[nodeGroup.Id()]
 	nodeInfo := nodeInfos[nodeGroup.Id()]
@@ -400,10 +404,10 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 		for _, sng := range option.SimilarNodeGroups {
 			similarNodeGroupIds = append(similarNodeGroupIds, sng.Id())
 		}
-		klog.V(5).Infof("Found %d similar node groups: %v", len(option.SimilarNodeGroups), similarNodeGroupIds)
+		logger.V(5).Info("Found similar node groups", "similarNodeGroupsCount", len(option.SimilarNodeGroups), "similarNodeGroupIds", similarNodeGroupIds)
 	} else if o.autoscalingCtx.BalanceSimilarNodeGroups {
 		// if no similar node groups are found and the flag is enabled, log about it
-		klog.V(5).Info("No similar node groups found")
+		logger.V(5).Info("No similar node groups found")
 	}
 
 	estimateStart := time.Now()
@@ -416,7 +420,7 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 
 	autoscalingOptions, err := nodeGroup.GetOptions(o.autoscalingCtx.NodeGroupDefaults)
 	if err != nil && err != cloudprovider.ErrNotImplemented {
-		klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
+		logger.Error(err, "Failed to get autoscaling options for node group", "nodeGroupId", nodeGroup.Id())
 	}
 
 	// Special handling for groups that only scale from zero to max.
@@ -474,6 +478,7 @@ func (o *ScaleUpOrchestrator) processCreateNodeGroupResult(
 	result nodegroups.CreateNodeGroupResult,
 	aErr errors.AutoscalerError,
 ) ([]nodegroups.CreateNodeGroupResult, *status.ScaleUpStatus, errors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	if aErr != nil {
 		status, err := status.UpdateScaleUpError(
 			&status.ScaleUpStatus{FailedCreationNodeGroups: []cloudprovider.NodeGroup{initialOption.NodeGroup}, PodsTriggeredScaleUp: initialOption.Pods},
@@ -494,7 +499,7 @@ func (o *ScaleUpOrchestrator) processCreateNodeGroupResult(
 	if aErr == nil {
 		nodeInfos[newId] = mainCreatedNodeInfo
 	} else {
-		klog.Warningf("Cannot build node info for newly created main node group %v; balancing similar node groups may not work; err=%v", newId, aErr)
+		logger.Info("Cannot build node info for newly created main node group; balancing similar node groups may not work", "newId", newId, "err", aErr)
 	}
 
 	// schedulablePodGroups entry will only be used for balancing similar node groups.
@@ -517,7 +522,7 @@ func (o *ScaleUpOrchestrator) processCreateNodeGroupResult(
 	for _, nodeGroup := range result.ExtraCreatedNodeGroups {
 		nodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(ctx, nodeGroup, daemonSets, o.taintConfig)
 		if aErr != nil {
-			klog.Warningf("Cannot build node info for newly created extra node group %v; balancing similar node groups will not work; err=%v", nodeGroup.Id(), aErr)
+			logger.Info("Cannot build node info for newly created extra node group; balancing similar node groups will not work", "nodeGroupId", nodeGroup.Id(), "err", aErr)
 			continue
 		}
 		nodeInfos[nodeGroup.Id()] = nodeInfo
@@ -538,12 +543,13 @@ func (o *ScaleUpOrchestrator) SchedulablePodGroups(
 	nodeGroup cloudprovider.NodeGroup,
 	nodeInfo *framework.NodeInfo,
 ) []estimator.PodEquivalenceGroup {
+	logger := klog.FromContext(ctx)
 	o.autoscalingCtx.ClusterSnapshot.Fork()
 	defer o.autoscalingCtx.ClusterSnapshot.Revert()
 
 	// Add test node to snapshot.
 	if err := o.autoscalingCtx.ClusterSnapshot.AddNodeInfo(nodeInfo); err != nil {
-		klog.Errorf("Error while adding test Node: %v", err)
+		logger.Error(err, "Error while adding test Node")
 		return []estimator.PodEquivalenceGroup{}
 	}
 
@@ -559,9 +565,9 @@ func (o *ScaleUpOrchestrator) SchedulablePodGroups(
 			eg.Schedulable = true
 			eg.SchedulableGroups = append(eg.SchedulableGroups, nodeGroup.Id())
 		} else {
-			klog.V(2).Infof("Pod %s/%s can't be scheduled on %s, predicate checking error: %v", samplePod.Namespace, samplePod.Name, nodeGroup.Id(), err)
+			logger.V(2).Info("Pod can't be scheduled, predicate checking", "namespace", samplePod.Namespace, "samplePod", samplePod.Name, "nodeGroupId", nodeGroup.Id(), "err", err)
 			if podCount := len(eg.Pods); podCount > 1 {
-				klog.V(2).Infof("%d other pods similar to %s can't be scheduled on %s", podCount-1, samplePod.Name, nodeGroup.Id())
+				logger.V(2).Info("other pods similar can't be scheduled", "podCount", podCount-1, "samplePod", samplePod.Name, "nodeGroupId", nodeGroup.Id())
 			}
 			eg.SchedulingErrors[nodeGroup.Id()] = err
 		}
@@ -589,15 +595,16 @@ func (o *ScaleUpOrchestrator) UpcomingNodes(ctx context.Context, nodeInfos map[s
 // IsNodeGroupReadyToScaleUp returns nil if node group is ready to be scaled up, otherwise a reason is provided.
 func (o *ScaleUpOrchestrator) IsNodeGroupReadyToScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, now time.Time) *SkippedReasons {
 	// Non-existing node groups are created later so skip check for them.
+	logger := klog.FromContext(ctx)
 	if !nodeGroup.Exist() {
 		return nil
 	}
 	if scaleUpSafety := o.clusterStateRegistry.NodeGroupScaleUpSafety(ctx, nodeGroup, now); !scaleUpSafety.SafeToScale {
 		if !scaleUpSafety.Healthy {
-			klog.Warningf("Node group %s is not ready for scaleup - unhealthy", nodeGroup.Id())
+			logger.Info("Node group is not ready for scaleup - unhealthy", "nodeGroupId", nodeGroup.Id())
 			return NotReadyReason
 		}
-		klog.Warningf("Node group %s is not ready for scaleup - backoff with status: %v", nodeGroup.Id(), scaleUpSafety.BackoffStatus)
+		logger.Info("Node group is not ready for scaleup - backoff with status", "nodeGroupId", nodeGroup.Id(), "backoffStatus", scaleUpSafety.BackoffStatus)
 		return BackoffReason
 	}
 	return nil
@@ -605,18 +612,18 @@ func (o *ScaleUpOrchestrator) IsNodeGroupReadyToScaleUp(ctx context.Context, nod
 
 // IsNodeGroupResourceExceeded returns nil if node group resource limits are not exceeded, otherwise a reason is provided.
 func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(ctx context.Context, tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfo *framework.NodeInfo, numNodes int) status.Reasons {
+	logger := klog.FromContext(ctx)
 	checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, nodeGroup, nodeInfo.Node(), numNodes)
 	if err != nil {
-		klog.Errorf("Skipping node group %s; error checking resource quotas: %v", nodeGroup.Id(), err)
+		logger.Error(err, "Skipping node group; error checking resource quotas", "nodeGroupId", nodeGroup.Id())
 		return NotReadyReason
 	}
 
 	if checkResult.Exceeded() {
 		resources := make(sets.Set[string])
 		for _, quota := range checkResult.ExceededQuotas {
-			klog.V(4).Infof(
-				"Skipping node group %s; %q quota exceeded, resources: %v", nodeGroup.Id(), quota.ID, quota.ExceededResources,
-			)
+			logger.V(4).Info("Skipping node group; quota exceeded, resources", "nodeGroupId", nodeGroup.Id(), "quotaId", quota.ID, "exceededResources", quota.ExceededResources)
+
 			for _, resource := range quota.ExceededResources {
 				if resources.Has(resource) {
 					continue
@@ -639,8 +646,9 @@ func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(ctx context.Context, t
 
 // GetCappedNewNodeCount caps resize according to cluster wide node count limit.
 func (o *ScaleUpOrchestrator) GetCappedNewNodeCount(ctx context.Context, newNodeCount, currentNodeCount int) (int, errors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	if o.autoscalingCtx.MaxNodesTotal > 0 && newNodeCount+currentNodeCount > o.autoscalingCtx.MaxNodesTotal {
-		klog.V(1).Infof("Capping size to max cluster total size (%d)", o.autoscalingCtx.MaxNodesTotal)
+		logger.V(1).Info("Capping size to max cluster total size", "maxNodesTotal", o.autoscalingCtx.MaxNodesTotal)
 		newNodeCount = o.autoscalingCtx.MaxNodesTotal - currentNodeCount
 		o.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "MaxNodesTotalReached", "Max total nodes in cluster reached: %v", o.autoscalingCtx.MaxNodesTotal)
 		if newNodeCount < 1 {
@@ -659,6 +667,7 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 	tracker *resourcequotas.Tracker,
 ) ([]nodegroupset.ScaleUpInfo, errors.AutoscalerError) {
 	// Recompute similar node groups in case they need to be updated
+	logger := klog.FromContext(ctx)
 	similarNodeGroups := o.ComputeSimilarNodeGroups(ctx, nodeGroup, nodeInfos, schedulablePodGroups, now)
 
 	if similarNodeGroups != nil {
@@ -667,10 +676,10 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 		for _, sng := range similarNodeGroups {
 			similarNodeGroupIds = append(similarNodeGroupIds, sng.Id())
 		}
-		klog.V(2).Infof("Found %d similar node groups: %v", len(similarNodeGroups), similarNodeGroupIds)
+		logger.V(2).Info("Found similar node groups", "similarNodeGroupsCount", len(similarNodeGroups), "similarNodeGroupIds", similarNodeGroupIds)
 	} else if o.autoscalingCtx.BalanceSimilarNodeGroups {
 		// if no similar node groups are found and the flag is enabled, log about it
-		klog.V(2).Info("No similar node groups found")
+		logger.V(2).Info("No similar node groups found")
 	}
 
 	// Filter out similar node groups that already exceed their quota.
@@ -681,7 +690,7 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 			continue
 		}
 		if skipReason := o.IsNodeGroupResourceExceeded(ctx, tracker, ng, nodeInfo, 1); skipReason != nil {
-			klog.V(2).Infof("Ignoring node group %s when balancing: quota exceeded", ng.Id())
+			logger.V(2).Info("Ignoring node group when balancing: quota exceeded", "nodeGroupId", ng.Id())
 			continue
 		}
 		quotaValidGroups = append(quotaValidGroups, ng)
@@ -698,7 +707,7 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 		for _, ng := range targetNodeGroups {
 			names = append(names, ng.Id())
 		}
-		klog.V(1).Infof("Splitting scale-up between %v similar node groups: {%v}", len(targetNodeGroups), strings.Join(names, ", "))
+		logger.V(1).Info("Splitting scale-up between similar node groups: { }", "targetNodeGroupsCount", len(targetNodeGroups), "names", strings.Join(names, ", "))
 	}
 	scaleUpInfos, aErr := o.processors.NodeGroupSetProcessor.BalanceScaleUpBetweenGroups(ctx, o.autoscalingCtx, targetNodeGroups, newNodes)
 	if aErr != nil {
@@ -718,6 +727,7 @@ func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
 	nodeInfos map[string]*framework.NodeInfo,
 	tracker *resourcequotas.Tracker,
 ) []nodegroupset.ScaleUpInfo {
+	logger := klog.FromContext(ctx)
 	for i := range scaleUpInfos {
 		sui := &scaleUpInfos[i]
 		delta := sui.NewSize - sui.CurrentSize
@@ -730,17 +740,17 @@ func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
 		}
 		checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, sui.Group, nodeInfo.Node(), delta)
 		if err != nil {
-			klog.Errorf("Failed to check quota for balanced group %s: %v", sui.Group.Id(), err)
+			logger.Error(err, "Failed to check quota for balanced group", "groupId", sui.Group.Id())
 			continue
 		}
 		allowedDelta := checkResult.AllowedDelta
 		if allowedDelta < delta {
-			klog.V(1).Infof("Capping scale-up of %s from %d to %d nodes due to quota", sui.Group.Id(), delta, allowedDelta)
+			logger.V(1).Info("Capping scale-up nodes due to quota", "groupId", sui.Group.Id(), "delta", delta, "allowedDelta", allowedDelta)
 			sui.NewSize = sui.CurrentSize + allowedDelta
 		}
 		if allowedDelta > 0 {
 			if _, err := tracker.ConsumeQuota(ctx, o.autoscalingCtx, sui.Group, nodeInfo.Node(), allowedDelta); err != nil {
-				klog.Errorf("Failed to apply quota delta for balanced group %s: %v", sui.Group.Id(), err)
+				logger.Error(err, "Failed to apply quota delta for balanced group", "groupId", sui.Group.Id())
 			}
 		}
 	}
@@ -763,13 +773,14 @@ func (o *ScaleUpOrchestrator) ComputeSimilarNodeGroups(
 	schedulablePodGroups map[string][]estimator.PodEquivalenceGroup,
 	now time.Time,
 ) []cloudprovider.NodeGroup {
+	logger := klog.FromContext(ctx)
 	if !o.autoscalingCtx.BalanceSimilarNodeGroups {
 		return nil
 	}
 
 	autoscalingOptions, err := nodeGroup.GetOptions(o.autoscalingCtx.NodeGroupDefaults)
 	if err != nil && err != cloudprovider.ErrNotImplemented {
-		klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
+		logger.Error(err, "Failed to get autoscaling options for node group", "nodeGroupId", nodeGroup.Id())
 	}
 	if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
 		return nil
@@ -782,7 +793,7 @@ func (o *ScaleUpOrchestrator) ComputeSimilarNodeGroups(
 
 	similarNodeGroups, err := o.processors.NodeGroupSetProcessor.FindSimilarNodeGroups(ctx, o.autoscalingCtx, nodeGroup, nodeInfos)
 	if err != nil {
-		klog.Errorf("Failed to find similar node groups: %v", err)
+		logger.Error(err, "Failed to find similar node groups")
 		return nil
 	}
 
@@ -790,7 +801,7 @@ func (o *ScaleUpOrchestrator) ComputeSimilarNodeGroups(
 	for _, ng := range similarNodeGroups {
 		// Non-existing node groups are created later so skip check for them.
 		if ng.Exist() && !o.clusterStateRegistry.NodeGroupScaleUpSafety(ctx, ng, now).SafeToScale {
-			klog.V(2).Infof("Ignoring node group %s when balancing: group is not ready for scaleup", ng.Id())
+			logger.V(2).Info("Ignoring node group when balancing: group is not ready for scaleup", "nodeGroupId", ng.Id())
 		} else if similarPodGroups, found := schedulablePodGroups[ng.Id()]; found && matchingSchedulablePodGroups(podGroups, similarPodGroups) {
 			validSimilarNodeGroups = append(validSimilarNodeGroups, ng)
 		}
@@ -831,6 +842,7 @@ func (o *ScaleUpOrchestrator) GetRemainingPods(ctx context.Context, egs []*equiv
 }
 
 func (o *ScaleUpOrchestrator) getRemainingPodsConsideringSkippedNodeGroups(ctx context.Context, egs []*equivalence.PodGroup, nodeGroups []cloudprovider.NodeGroup, skipped map[string]status.Reasons, nodeInfos map[string]*framework.NodeInfo) []status.NoScaleUpInfo {
+	logger := klog.FromContext(ctx)
 	remaining := []status.NoScaleUpInfo{}
 	// Perform the SchedulablePodGroups simulation for the skipped node groups.
 	for _, nodeGroup := range nodeGroups {
@@ -840,7 +852,7 @@ func (o *ScaleUpOrchestrator) getRemainingPodsConsideringSkippedNodeGroups(ctx c
 		}
 		nodeInfo, found := nodeInfos[nodeGroupId]
 		if !found {
-			klog.Errorf("No node info for: %s", nodeGroupId)
+			logger.Error(nil, "No node info for", "nodeGroupId", nodeGroupId)
 			continue
 		}
 		// We ignore the return value here, because we are not interested in which egs are now (theoretically) schedulable or not. We are only interested in the rejected node groups per eg.
@@ -895,7 +907,8 @@ func (o *ScaleUpOrchestrator) noOptionsAvailableStatus(ctx context.Context, args
 
 func (o *ScaleUpOrchestrator) abortAllOrNothing(ctx context.Context, args scaleUpCtx) *status.ScaleUpStatus {
 	// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
-	klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
+	logger := klog.FromContext(ctx)
+	logger.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
 	args.podEquivalenceGroups = markAllGroupsAsUnschedulable(args.podEquivalenceGroups, AllOrNothingReason)
 	return o.noOptionsAvailableStatus(ctx, args)
 }
@@ -1043,6 +1056,7 @@ type scaleUpPlan struct {
 
 func (o *ScaleUpOrchestrator) prepareScaleUp(ctx context.Context, args scaleUpCtx) (scaleUpPlan, *status.ScaleUpStatus, errors.AutoscalerError) {
 	// Calculate expansion options
+	logger := klog.FromContext(ctx)
 	schedulablePodGroups := map[string][]estimator.PodEquivalenceGroup{}
 	var options []expander.Option
 
@@ -1056,9 +1070,9 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(ctx context.Context, args scaleUpCt
 		o.processors.BinpackingLimiter.MarkProcessed(o.autoscalingCtx, nodeGroup.Id())
 
 		if len(option.Pods) == 0 || option.NodeCount == 0 {
-			klog.V(4).Infof("No pod can fit to %s", nodeGroup.Id())
+			logger.V(4).Info("No pod can fit", "nodeGroupId", nodeGroup.Id())
 		} else if args.allOrNothing && len(option.Pods) < len(args.unschedulablePods) {
-			klog.V(4).Infof("Some pods can't fit to %s, giving up due to all-or-nothing scale-up strategy", nodeGroup.Id())
+			logger.V(4).Info("Some pods can't fit, giving up due to all-or-nothing scale-up strategy", "nodeGroupId", nodeGroup.Id())
 		} else {
 			options = append(options, option)
 		}
@@ -1072,22 +1086,22 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(ctx context.Context, args scaleUpCt
 	o.processors.BinpackingLimiter.FinalizeBinpacking(o.autoscalingCtx, options)
 
 	if len(options) == 0 {
-		klog.V(1).Info("No expansion options")
+		logger.V(1).Info("No expansion options")
 		return scaleUpPlan{}, o.noOptionsAvailableStatus(ctx, args), nil
 	}
 
 	// Pick some expansion option.
 	bestOption := o.autoscalingCtx.ExpanderStrategy.BestOption(ctx, options, args.nodeInfos)
 	if bestOption == nil || bestOption.NodeCount <= 0 {
-		klog.Infof("Expander filtered out all options, valid options: %d", len(options))
+		logger.Info("Expander filtered out all options, valid options", "optionsCount", len(options))
 		args.podEquivalenceGroups = markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ExpansionOptionsFilteredOutReason)
 		return scaleUpPlan{}, o.noOptionsAvailableStatus(ctx, args), nil
 	}
-	klog.V(1).Infof("Best option to resize: %s", bestOption.NodeGroup.Id())
+	logger.V(1).Info("Best option to resize", "nodeGroupId", bestOption.NodeGroup.Id())
 	if len(bestOption.Debug) > 0 {
-		klog.V(1).Info(bestOption.Debug)
+		logger.V(1).Info(bestOption.Debug)
 	}
-	klog.V(1).Infof("Estimated %d nodes needed in %s", bestOption.NodeCount, bestOption.NodeGroup.Id())
+	logger.V(1).Info("Estimated nodes needed", "nodeCount", bestOption.NodeCount, "nodeGroupId", bestOption.NodeGroup.Id())
 
 	// Cap new nodes to supported number of nodes in the cluster.
 	newNodes, aErr := o.GetCappedNewNodeCount(ctx, bestOption.NodeCount, len(args.nodes))
@@ -1117,7 +1131,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(ctx context.Context, args scaleUpCt
 	}
 
 	if newNodes < bestOption.NodeCount {
-		klog.V(1).Infof("Only %d nodes can be added to %s due to resource quotas", newNodes, bestOption.NodeGroup.Id())
+		logger.V(1).Info("Only nodes can be added due to resource quotas", "newNodes", newNodes, "nodeGroupId", bestOption.NodeGroup.Id())
 		if args.allOrNothing {
 			return scaleUpPlan{}, o.abortAllOrNothing(ctx, args), nil
 		}
@@ -1127,7 +1141,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(ctx context.Context, args scaleUpCt
 	createNodeGroupResults := make([]nodegroups.CreateNodeGroupResult, 0)
 	if !bestOption.NodeGroup.Exist() && !o.processors.AsyncNodeGroupStateChecker.IsUpcoming(bestOption.NodeGroup) {
 		if args.allOrNothing && bestOption.NodeGroup.MaxSize() < newNodes {
-			klog.V(1).Infof("Can only create a new node group with max %d nodes, need %d nodes", bestOption.NodeGroup.MaxSize(), newNodes)
+			logger.V(1).Info("Can only create a new node group with max nodes, need nodes", "maxSize", bestOption.NodeGroup.MaxSize(), "newNodes", newNodes)
 			return scaleUpPlan{}, o.abortAllOrNothing(ctx, args), nil
 		}
 		var scaleUpStatus *status.ScaleUpStatus
@@ -1164,7 +1178,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(ctx context.Context, args scaleUpCt
 		totalCapacity += sui.NewSize - sui.CurrentSize
 	}
 	if totalCapacity < newNodes {
-		klog.V(1).Infof("Can only add %d nodes due to node group limits, need %d nodes", totalCapacity, newNodes)
+		logger.V(1).Info("Can only add nodes due to node group limits, need nodes", "totalCapacity", totalCapacity, "newNodes", newNodes)
 		if args.allOrNothing {
 			return scaleUpPlan{}, o.abortAllOrNothing(ctx, args), nil
 		}

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	"slices"
 	"strings"
 	"time"
@@ -86,7 +87,7 @@ func (o *ScaleUpOrchestrator) Initialize(
 // an unexpected error occurred. Assumes that all nodes in the cluster are ready
 // and in sync with instance groups.
 func (o *ScaleUpOrchestrator) ScaleUp(
-	unschedulablePods []*apiv1.Pod,
+	ctx context.Context, unschedulablePods []*apiv1.Pod,
 	nodes []*apiv1.Node,
 	daemonSets []*appsv1.DaemonSet,
 	nodeInfos map[string]*framework.NodeInfo,
@@ -104,15 +105,15 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 
 	buildPodEquivalenceGroupsStart := time.Now()
 	podEquivalenceGroups := equivalence.BuildPodGroups(unschedulablePods)
-	metrics.UpdateDurationFromStart(metrics.BuildPodEquivalenceGroups, buildPodEquivalenceGroupsStart)
+	metrics.UpdateDurationFromStart(ctx, metrics.BuildPodEquivalenceGroups, buildPodEquivalenceGroupsStart)
 
 	nodeGroups := o.autoscalingCtx.CloudProvider.NodeGroups()
-	upcomingNodes, aErr := o.UpcomingNodes(nodeInfos)
+	upcomingNodes, aErr := o.UpcomingNodes(ctx, nodeInfos)
 	if aErr != nil {
 		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
 		return status.UpdateScaleUpError(
 			&status.ScaleUpStatus{
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, map[string]status.Reasons{}, nodeInfos),
+				PodsRemainUnschedulable: o.GetRemainingPods(ctx, markedEquivalenceGroups, nodeGroups, map[string]status.Reasons{}, nodeInfos),
 			},
 			aErr.AddPrefix("could not get upcoming nodes: "),
 		)
@@ -125,7 +126,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 			markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
 			return status.UpdateScaleUpError(
 				&status.ScaleUpStatus{
-					PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, map[string]status.Reasons{}, nodeInfos),
+					PodsRemainUnschedulable: o.GetRemainingPods(ctx, markedEquivalenceGroups, nodeGroups, map[string]status.Reasons{}, nodeInfos),
 				},
 				errors.ToAutoscalerError(errors.InternalError, err),
 			)
@@ -135,12 +136,12 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	// Initialise binpacking limiter.
 	o.processors.BinpackingLimiter.InitBinpacking(o.autoscalingCtx, nodeGroups)
 
-	tracker, err := o.quotasTrackerFactory.NewQuotasTracker(o.autoscalingCtx, nodes)
+	tracker, err := o.quotasTrackerFactory.NewQuotasTracker(ctx, o.autoscalingCtx, nodes)
 	if err != nil {
 		markedEquivalenceGroups := markAllGroupsAsUnschedulable(podEquivalenceGroups, ScaleUpExecutionErrorReason)
 		return status.UpdateScaleUpError(
 			&status.ScaleUpStatus{
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, nodeGroups, map[string]status.Reasons{}, nodeInfos),
+				PodsRemainUnschedulable: o.GetRemainingPods(ctx, markedEquivalenceGroups, nodeGroups, map[string]status.Reasons{}, nodeInfos),
 			},
 			errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("could not create quotas tracker: "),
 		)
@@ -149,14 +150,14 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	now := time.Now()
 
 	// Filter out invalid node groups
-	validNodeGroups, skippedNodeGroups := o.filterValidScaleUpNodeGroups(nodeGroups, nodeInfos, tracker, len(nodes), now)
+	validNodeGroups, skippedNodeGroups := o.filterValidScaleUpNodeGroups(ctx, nodeGroups, nodeInfos, tracker, len(nodes), now)
 
 	// Mark skipped node groups as processed.
 	for nodegroupID := range skippedNodeGroups {
 		o.processors.BinpackingLimiter.MarkProcessed(o.autoscalingCtx, nodegroupID)
 	}
 
-	plan, st, aErr := o.prepareScaleUp(scaleUpCtx{
+	plan, st, aErr := o.prepareScaleUp(ctx, scaleUpCtx{
 		validNodeGroups:      validNodeGroups,
 		podEquivalenceGroups: podEquivalenceGroups,
 		nodeInfos:            nodeInfos,
@@ -175,7 +176,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 
 	// Execute scale up.
 	klog.V(1).Infof("Final scale-up plan: %v", plan.scaleUpInfos)
-	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(plan.scaleUpInfos, nodeInfos, now, allOrNothing)
+	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(ctx, plan.scaleUpInfos, nodeInfos, now, allOrNothing)
 	if aErr != nil {
 		failedGroupsMap := o.buildFailedGroupsMap(failedNodeGroups, plan.scaleUpInfos)
 		markedEquivalenceGroups := markFailedGroupsAsUnschedulable(podEquivalenceGroups, failedGroupsMap, ScaleUpExecutionErrorReason)
@@ -184,17 +185,17 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 				CreateNodeGroupResults:  plan.createNodeGroupResults,
 				FailedResizeNodeGroups:  failedNodeGroups,
 				PodsTriggeredScaleUp:    plan.bestOption.Pods,
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, plan.nodeGroups, skippedNodeGroups, nodeInfos),
+				PodsRemainUnschedulable: o.GetRemainingPods(ctx, markedEquivalenceGroups, plan.nodeGroups, skippedNodeGroups, nodeInfos),
 			},
 			aErr,
 		)
 	}
 
-	o.clusterStateRegistry.Recalculate()
+	o.clusterStateRegistry.Recalculate(ctx)
 	return &status.ScaleUpStatus{
 		Result:                  status.ScaleUpSuccessful,
 		ScaleUpInfos:            plan.scaleUpInfos,
-		PodsRemainUnschedulable: o.GetRemainingPods(podEquivalenceGroups, plan.nodeGroups, skippedNodeGroups, nodeInfos),
+		PodsRemainUnschedulable: o.GetRemainingPods(ctx, podEquivalenceGroups, plan.nodeGroups, skippedNodeGroups, nodeInfos),
 		ConsideredNodeGroups:    plan.nodeGroups,
 		CreateNodeGroupResults:  plan.createNodeGroupResults,
 		PodsTriggeredScaleUp:    plan.bestOption.Pods,
@@ -202,14 +203,14 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 	}, nil
 }
 
-func (o *ScaleUpOrchestrator) applyLimits(newNodes int, tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfos map[string]*framework.NodeInfo) (int, errors.AutoscalerError) {
+func (o *ScaleUpOrchestrator) applyLimits(ctx context.Context, newNodes int, tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfos map[string]*framework.NodeInfo) (int, errors.AutoscalerError) {
 	nodeInfo, found := nodeInfos[nodeGroup.Id()]
 	if !found {
 		// This should never happen, as we already should have retrieved nodeInfo for any considered nodegroup.
 		klog.Errorf("No node info for: %s", nodeGroup.Id())
 		return 0, errors.NewAutoscalerError(errors.CloudProviderError, "No node info for best expansion option!")
 	}
-	checkResult, err := tracker.CheckQuota(o.autoscalingCtx, nodeGroup, nodeInfo.Node(), newNodes)
+	checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, nodeGroup, nodeInfo.Node(), newNodes)
 	if err != nil {
 		return 0, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("failed to check resource quotas: ")
 	}
@@ -221,7 +222,7 @@ func (o *ScaleUpOrchestrator) applyLimits(newNodes int, tracker *resourcequotas.
 // size is the TargetSize queried directly from cloud providers. Returns
 // appropriate status or error if an unexpected error occurred.
 func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
-	nodes []*apiv1.Node,
+	ctx context.Context, nodes []*apiv1.Node,
 	nodeInfos map[string]*framework.NodeInfo,
 ) (*status.ScaleUpStatus, errors.AutoscalerError) {
 	if !o.initialized {
@@ -232,7 +233,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 	nodeGroups := o.autoscalingCtx.CloudProvider.NodeGroups()
 	scaleUpInfos := make([]nodegroupset.ScaleUpInfo, 0)
 
-	tracker, err := o.quotasTrackerFactory.NewQuotasTracker(o.autoscalingCtx, nodes)
+	tracker, err := o.quotasTrackerFactory.NewQuotasTracker(ctx, o.autoscalingCtx, nodes)
 	if err != nil {
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("could not create quotas tracker: "))
 	}
@@ -254,7 +255,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 			continue
 		}
 
-		if skipReason := o.IsNodeGroupReadyToScaleUp(ng, now); skipReason != nil {
+		if skipReason := o.IsNodeGroupReadyToScaleUp(ctx, ng, now); skipReason != nil {
 			klog.Warningf("ScaleUpToNodeGroupMinSize: node group is ready to scale up: %v", skipReason)
 			continue
 		}
@@ -265,20 +266,20 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 			continue
 		}
 
-		if skipReason := o.IsNodeGroupResourceExceeded(tracker, ng, nodeInfo, 1); skipReason != nil {
+		if skipReason := o.IsNodeGroupResourceExceeded(ctx, tracker, ng, nodeInfo, 1); skipReason != nil {
 			klog.Warningf("ScaleUpToNodeGroupMinSize: node group resource excceded: %v", skipReason)
 			continue
 		}
 
 		newNodeCount := ng.MinSize() - targetSize
-		checkResult, err := tracker.CheckQuota(o.autoscalingCtx, ng, nodeInfo.Node(), newNodeCount)
+		checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, ng, nodeInfo.Node(), newNodeCount)
 		if err != nil {
 			klog.Warningf("ScaleUpToNodeGroupMinSize: failed to check resource quotas: %v", err)
 			continue
 		}
 		newNodeCount = checkResult.AllowedDelta
 
-		newNodeCount, err = o.GetCappedNewNodeCount(newNodeCount, targetSize)
+		newNodeCount, err = o.GetCappedNewNodeCount(ctx, newNodeCount, targetSize)
 		if err != nil {
 			klog.Warningf("ScaleUpToNodeGroupMinSize: failed to get capped node count: %v", err)
 			continue
@@ -299,7 +300,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 	}
 
 	klog.V(1).Infof("ScaleUpToNodeGroupMinSize: final scale-up plan: %v", scaleUpInfos)
-	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, nodeInfos, now, false /* allOrNothing disabled */)
+	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(ctx, scaleUpInfos, nodeInfos, now, false /* allOrNothing disabled */)
 	if aErr != nil {
 		return status.UpdateScaleUpError(
 			&status.ScaleUpStatus{
@@ -309,7 +310,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 		)
 	}
 
-	o.clusterStateRegistry.Recalculate()
+	o.clusterStateRegistry.Recalculate(ctx)
 	return &status.ScaleUpStatus{
 		Result:               status.ScaleUpSuccessful,
 		ScaleUpInfos:         scaleUpInfos,
@@ -319,7 +320,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 
 // filterValidScaleUpNodeGroups filters the node groups that are valid for scale-up
 func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
-	nodeGroups []cloudprovider.NodeGroup,
+	ctx context.Context, nodeGroups []cloudprovider.NodeGroup,
 	nodeInfos map[string]*framework.NodeInfo,
 	tracker *resourcequotas.Tracker,
 	currentNodeCount int,
@@ -329,7 +330,7 @@ func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 	skippedNodeGroups := map[string]status.Reasons{}
 
 	for _, nodeGroup := range nodeGroups {
-		if skipReason := o.IsNodeGroupReadyToScaleUp(nodeGroup, now); skipReason != nil {
+		if skipReason := o.IsNodeGroupReadyToScaleUp(ctx, nodeGroup, now); skipReason != nil {
 			skippedNodeGroups[nodeGroup.Id()] = skipReason
 			continue
 		}
@@ -365,7 +366,7 @@ func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 			skippedNodeGroups[nodeGroup.Id()] = NotReadyReason
 			continue
 		}
-		if skipReason := o.IsNodeGroupResourceExceeded(tracker, nodeGroup, nodeInfo, numNodes); skipReason != nil {
+		if skipReason := o.IsNodeGroupResourceExceeded(ctx, tracker, nodeGroup, nodeInfo, numNodes); skipReason != nil {
 			skippedNodeGroups[nodeGroup.Id()] = skipReason
 			continue
 		}
@@ -377,7 +378,7 @@ func (o *ScaleUpOrchestrator) filterValidScaleUpNodeGroups(
 
 // ComputeExpansionOption computes expansion option based on pending pods and cluster state.
 func (o *ScaleUpOrchestrator) ComputeExpansionOption(
-	nodeGroup cloudprovider.NodeGroup,
+	ctx context.Context, nodeGroup cloudprovider.NodeGroup,
 	schedulablePodGroups map[string][]estimator.PodEquivalenceGroup,
 	nodeInfos map[string]*framework.NodeInfo,
 	currentNodeCount int,
@@ -392,7 +393,7 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 		return option
 	}
 
-	option.SimilarNodeGroups = o.ComputeSimilarNodeGroups(nodeGroup, nodeInfos, schedulablePodGroups, now)
+	option.SimilarNodeGroups = o.ComputeSimilarNodeGroups(ctx, nodeGroup, nodeInfos, schedulablePodGroups, now)
 	if option.SimilarNodeGroups != nil {
 		// if similar node groups are found, log about them
 		similarNodeGroupIds := make([]string, 0)
@@ -410,8 +411,8 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 		o.autoscalingCtx.ClusterSnapshot,
 		estimator.NewEstimationContext(o.autoscalingCtx.MaxNodesTotal, option.SimilarNodeGroups, currentNodeCount),
 	)
-	option.NodeCount, option.Pods = expansionEstimator.Estimate(podGroups, nodeInfo, nodeGroup)
-	metrics.UpdateDurationFromStart(metrics.Estimate, estimateStart)
+	option.NodeCount, option.Pods = expansionEstimator.Estimate(ctx, podGroups, nodeInfo, nodeGroup)
+	metrics.UpdateDurationFromStart(ctx, metrics.Estimate, estimateStart)
 
 	autoscalingOptions, err := nodeGroup.GetOptions(o.autoscalingCtx.NodeGroupDefaults)
 	if err != nil && err != cloudprovider.ErrNotImplemented {
@@ -438,7 +439,7 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 
 // CreateNodeGroup will try to create a new node group based on the initialOption.
 func (o *ScaleUpOrchestrator) CreateNodeGroup(
-	initialOption *expander.Option,
+	ctx context.Context, initialOption *expander.Option,
 	nodeInfos map[string]*framework.NodeInfo,
 	schedulablePodGroups map[string][]estimator.PodEquivalenceGroup,
 	podEquivalenceGroups []*equivalence.PodGroup,
@@ -446,12 +447,12 @@ func (o *ScaleUpOrchestrator) CreateNodeGroup(
 ) ([]nodegroups.CreateNodeGroupResult, *status.ScaleUpStatus, errors.AutoscalerError) {
 	oldId := initialOption.NodeGroup.Id()
 	res, aErr := o.processors.NodeGroupManager.CreateNodeGroup(o.autoscalingCtx, initialOption.NodeGroup)
-	return o.processCreateNodeGroupResult(initialOption, oldId, nodeInfos, schedulablePodGroups, podEquivalenceGroups, daemonSets, res, aErr)
+	return o.processCreateNodeGroupResult(ctx, initialOption, oldId, nodeInfos, schedulablePodGroups, podEquivalenceGroups, daemonSets, res, aErr)
 }
 
 // CreateNodeGroupAsync will try to create a new node group asynchronously based on the initialOption.
 func (o *ScaleUpOrchestrator) CreateNodeGroupAsync(
-	initialOption *expander.Option,
+	ctx context.Context, initialOption *expander.Option,
 	nodeInfos map[string]*framework.NodeInfo,
 	schedulablePodGroups map[string][]estimator.PodEquivalenceGroup,
 	podEquivalenceGroups []*equivalence.PodGroup,
@@ -460,11 +461,11 @@ func (o *ScaleUpOrchestrator) CreateNodeGroupAsync(
 ) ([]nodegroups.CreateNodeGroupResult, *status.ScaleUpStatus, errors.AutoscalerError) {
 	oldId := initialOption.NodeGroup.Id()
 	res, aErr := o.processors.NodeGroupManager.CreateNodeGroupAsync(o.autoscalingCtx, initialOption.NodeGroup, initializer)
-	return o.processCreateNodeGroupResult(initialOption, oldId, nodeInfos, schedulablePodGroups, podEquivalenceGroups, daemonSets, res, aErr)
+	return o.processCreateNodeGroupResult(ctx, initialOption, oldId, nodeInfos, schedulablePodGroups, podEquivalenceGroups, daemonSets, res, aErr)
 }
 
 func (o *ScaleUpOrchestrator) processCreateNodeGroupResult(
-	initialOption *expander.Option,
+	ctx context.Context, initialOption *expander.Option,
 	initialOptionId string,
 	nodeInfos map[string]*framework.NodeInfo,
 	schedulablePodGroups map[string][]estimator.PodEquivalenceGroup,
@@ -489,7 +490,7 @@ func (o *ScaleUpOrchestrator) processCreateNodeGroupResult(
 
 	// If possible, replace candidate node-info with node info based on created node group.
 	// The latter should be more in line with nodes which will be created by node group.
-	mainCreatedNodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(result.MainCreatedNodeGroup, daemonSets, o.taintConfig)
+	mainCreatedNodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(ctx, result.MainCreatedNodeGroup, daemonSets, o.taintConfig)
 	if aErr == nil {
 		nodeInfos[newId] = mainCreatedNodeInfo
 	} else {
@@ -503,7 +504,7 @@ func (o *ScaleUpOrchestrator) processCreateNodeGroupResult(
 	if aErr == nil && len(result.ExtraCreatedNodeGroups) > 0 {
 		// Remove reference to initial id to prevent stale/duplicate entries in scheduling error reports
 		deletePodEquivalenceGroupsId(podEquivalenceGroups, initialOptionId)
-		schedulablePodGroups[newId] = o.SchedulablePodGroups(podEquivalenceGroups, result.MainCreatedNodeGroup, mainCreatedNodeInfo)
+		schedulablePodGroups[newId] = o.SchedulablePodGroups(ctx, podEquivalenceGroups, result.MainCreatedNodeGroup, mainCreatedNodeInfo)
 	} else {
 		patchPodEquivalenceGroupsId(podEquivalenceGroups, initialOptionId, newId)
 	}
@@ -514,26 +515,26 @@ func (o *ScaleUpOrchestrator) processCreateNodeGroupResult(
 	}
 
 	for _, nodeGroup := range result.ExtraCreatedNodeGroups {
-		nodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(nodeGroup, daemonSets, o.taintConfig)
+		nodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(ctx, nodeGroup, daemonSets, o.taintConfig)
 		if aErr != nil {
 			klog.Warningf("Cannot build node info for newly created extra node group %v; balancing similar node groups will not work; err=%v", nodeGroup.Id(), aErr)
 			continue
 		}
 		nodeInfos[nodeGroup.Id()] = nodeInfo
-		schedulablePodGroups[nodeGroup.Id()] = o.SchedulablePodGroups(podEquivalenceGroups, nodeGroup, nodeInfo)
+		schedulablePodGroups[nodeGroup.Id()] = o.SchedulablePodGroups(ctx, podEquivalenceGroups, nodeGroup, nodeInfo)
 	}
 
 	// Update ClusterStateRegistry so similar nodegroups rebalancing works.
 	// TODO(lukaszos) when pursuing scalability update this call with one which takes list of changed node groups so we do not
 	//                do extra API calls. (the call at the bottom of ScaleUp() could be also changed then)
-	o.clusterStateRegistry.Recalculate()
+	o.clusterStateRegistry.Recalculate(ctx)
 	return []nodegroups.CreateNodeGroupResult{result}, nil, nil
 }
 
 // SchedulablePodGroups returns a list of pods that could be scheduled
 // in a given node group after a scale up.
 func (o *ScaleUpOrchestrator) SchedulablePodGroups(
-	podEquivalenceGroups []*equivalence.PodGroup,
+	ctx context.Context, podEquivalenceGroups []*equivalence.PodGroup,
 	nodeGroup cloudprovider.NodeGroup,
 	nodeInfo *framework.NodeInfo,
 ) []estimator.PodEquivalenceGroup {
@@ -549,7 +550,7 @@ func (o *ScaleUpOrchestrator) SchedulablePodGroups(
 	var schedulablePodGroups []estimator.PodEquivalenceGroup
 	for _, eg := range podEquivalenceGroups {
 		samplePod := eg.Pods[0]
-		if err := o.autoscalingCtx.ClusterSnapshot.CheckPredicates(samplePod, nodeInfo.Node().Name); err == nil {
+		if err := o.autoscalingCtx.ClusterSnapshot.CheckPredicates(ctx, samplePod, nodeInfo.Node().Name); err == nil {
 			// Add pods to option.
 			schedulablePodGroups = append(schedulablePodGroups, estimator.PodEquivalenceGroup{
 				Pods: eg.Pods,
@@ -570,8 +571,8 @@ func (o *ScaleUpOrchestrator) SchedulablePodGroups(
 }
 
 // UpcomingNodes returns a list of nodes that are not ready but should be.
-func (o *ScaleUpOrchestrator) UpcomingNodes(nodeInfos map[string]*framework.NodeInfo) ([]*framework.NodeInfo, errors.AutoscalerError) {
-	upcomingCounts, _ := o.clusterStateRegistry.GetUpcomingNodes()
+func (o *ScaleUpOrchestrator) UpcomingNodes(ctx context.Context, nodeInfos map[string]*framework.NodeInfo) ([]*framework.NodeInfo, errors.AutoscalerError) {
+	upcomingCounts, _ := o.clusterStateRegistry.GetUpcomingNodes(ctx)
 	upcomingNodes := make([]*framework.NodeInfo, 0)
 	for nodeGroup, numberOfNodes := range upcomingCounts {
 		nodeTemplate, found := nodeInfos[nodeGroup]
@@ -586,12 +587,12 @@ func (o *ScaleUpOrchestrator) UpcomingNodes(nodeInfos map[string]*framework.Node
 }
 
 // IsNodeGroupReadyToScaleUp returns nil if node group is ready to be scaled up, otherwise a reason is provided.
-func (o *ScaleUpOrchestrator) IsNodeGroupReadyToScaleUp(nodeGroup cloudprovider.NodeGroup, now time.Time) *SkippedReasons {
+func (o *ScaleUpOrchestrator) IsNodeGroupReadyToScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, now time.Time) *SkippedReasons {
 	// Non-existing node groups are created later so skip check for them.
 	if !nodeGroup.Exist() {
 		return nil
 	}
-	if scaleUpSafety := o.clusterStateRegistry.NodeGroupScaleUpSafety(nodeGroup, now); !scaleUpSafety.SafeToScale {
+	if scaleUpSafety := o.clusterStateRegistry.NodeGroupScaleUpSafety(ctx, nodeGroup, now); !scaleUpSafety.SafeToScale {
 		if !scaleUpSafety.Healthy {
 			klog.Warningf("Node group %s is not ready for scaleup - unhealthy", nodeGroup.Id())
 			return NotReadyReason
@@ -603,8 +604,8 @@ func (o *ScaleUpOrchestrator) IsNodeGroupReadyToScaleUp(nodeGroup cloudprovider.
 }
 
 // IsNodeGroupResourceExceeded returns nil if node group resource limits are not exceeded, otherwise a reason is provided.
-func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfo *framework.NodeInfo, numNodes int) status.Reasons {
-	checkResult, err := tracker.CheckQuota(o.autoscalingCtx, nodeGroup, nodeInfo.Node(), numNodes)
+func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(ctx context.Context, tracker *resourcequotas.Tracker, nodeGroup cloudprovider.NodeGroup, nodeInfo *framework.NodeInfo, numNodes int) status.Reasons {
+	checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, nodeGroup, nodeInfo.Node(), numNodes)
 	if err != nil {
 		klog.Errorf("Skipping node group %s; error checking resource quotas: %v", nodeGroup.Id(), err)
 		return NotReadyReason
@@ -637,7 +638,7 @@ func (o *ScaleUpOrchestrator) IsNodeGroupResourceExceeded(tracker *resourcequota
 }
 
 // GetCappedNewNodeCount caps resize according to cluster wide node count limit.
-func (o *ScaleUpOrchestrator) GetCappedNewNodeCount(newNodeCount, currentNodeCount int) (int, errors.AutoscalerError) {
+func (o *ScaleUpOrchestrator) GetCappedNewNodeCount(ctx context.Context, newNodeCount, currentNodeCount int) (int, errors.AutoscalerError) {
 	if o.autoscalingCtx.MaxNodesTotal > 0 && newNodeCount+currentNodeCount > o.autoscalingCtx.MaxNodesTotal {
 		klog.V(1).Infof("Capping size to max cluster total size (%d)", o.autoscalingCtx.MaxNodesTotal)
 		newNodeCount = o.autoscalingCtx.MaxNodesTotal - currentNodeCount
@@ -650,7 +651,7 @@ func (o *ScaleUpOrchestrator) GetCappedNewNodeCount(newNodeCount, currentNodeCou
 }
 
 func (o *ScaleUpOrchestrator) balanceScaleUps(
-	now time.Time,
+	ctx context.Context, now time.Time,
 	nodeGroup cloudprovider.NodeGroup,
 	newNodes int,
 	nodeInfos map[string]*framework.NodeInfo,
@@ -658,7 +659,7 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 	tracker *resourcequotas.Tracker,
 ) ([]nodegroupset.ScaleUpInfo, errors.AutoscalerError) {
 	// Recompute similar node groups in case they need to be updated
-	similarNodeGroups := o.ComputeSimilarNodeGroups(nodeGroup, nodeInfos, schedulablePodGroups, now)
+	similarNodeGroups := o.ComputeSimilarNodeGroups(ctx, nodeGroup, nodeInfos, schedulablePodGroups, now)
 
 	if similarNodeGroups != nil {
 		// if similar node groups are found, log about them
@@ -679,7 +680,7 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 		if !found {
 			continue
 		}
-		if skipReason := o.IsNodeGroupResourceExceeded(tracker, ng, nodeInfo, 1); skipReason != nil {
+		if skipReason := o.IsNodeGroupResourceExceeded(ctx, tracker, ng, nodeInfo, 1); skipReason != nil {
 			klog.V(2).Infof("Ignoring node group %s when balancing: quota exceeded", ng.Id())
 			continue
 		}
@@ -699,11 +700,11 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 		}
 		klog.V(1).Infof("Splitting scale-up between %v similar node groups: {%v}", len(targetNodeGroups), strings.Join(names, ", "))
 	}
-	scaleUpInfos, aErr := o.processors.NodeGroupSetProcessor.BalanceScaleUpBetweenGroups(o.autoscalingCtx, targetNodeGroups, newNodes)
+	scaleUpInfos, aErr := o.processors.NodeGroupSetProcessor.BalanceScaleUpBetweenGroups(ctx, o.autoscalingCtx, targetNodeGroups, newNodes)
 	if aErr != nil {
 		return nil, aErr
 	}
-	return o.capScaleUpsByQuota(scaleUpInfos, nodeInfos, tracker), nil
+	return o.capScaleUpsByQuota(ctx, scaleUpInfos, nodeInfos, tracker), nil
 }
 
 // capScaleUpsByQuota caps each group's scale-up delta by its available quota and filters
@@ -713,7 +714,7 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 // a group capped below its balanced delta may leave some pods unschedulable until the
 // next autoscaler cycle.
 func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
-	scaleUpInfos []nodegroupset.ScaleUpInfo,
+	ctx context.Context, scaleUpInfos []nodegroupset.ScaleUpInfo,
 	nodeInfos map[string]*framework.NodeInfo,
 	tracker *resourcequotas.Tracker,
 ) []nodegroupset.ScaleUpInfo {
@@ -727,7 +728,7 @@ func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
 		if !found {
 			continue
 		}
-		checkResult, err := tracker.CheckQuota(o.autoscalingCtx, sui.Group, nodeInfo.Node(), delta)
+		checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, sui.Group, nodeInfo.Node(), delta)
 		if err != nil {
 			klog.Errorf("Failed to check quota for balanced group %s: %v", sui.Group.Id(), err)
 			continue
@@ -738,7 +739,7 @@ func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
 			sui.NewSize = sui.CurrentSize + allowedDelta
 		}
 		if allowedDelta > 0 {
-			if _, err := tracker.ConsumeQuota(o.autoscalingCtx, sui.Group, nodeInfo.Node(), allowedDelta); err != nil {
+			if _, err := tracker.ConsumeQuota(ctx, o.autoscalingCtx, sui.Group, nodeInfo.Node(), allowedDelta); err != nil {
 				klog.Errorf("Failed to apply quota delta for balanced group %s: %v", sui.Group.Id(), err)
 			}
 		}
@@ -757,7 +758,7 @@ func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
 // ComputeSimilarNodeGroups finds similar node groups which can schedule the same
 // set of pods as the main node group.
 func (o *ScaleUpOrchestrator) ComputeSimilarNodeGroups(
-	nodeGroup cloudprovider.NodeGroup,
+	ctx context.Context, nodeGroup cloudprovider.NodeGroup,
 	nodeInfos map[string]*framework.NodeInfo,
 	schedulablePodGroups map[string][]estimator.PodEquivalenceGroup,
 	now time.Time,
@@ -779,7 +780,7 @@ func (o *ScaleUpOrchestrator) ComputeSimilarNodeGroups(
 		return nil
 	}
 
-	similarNodeGroups, err := o.processors.NodeGroupSetProcessor.FindSimilarNodeGroups(o.autoscalingCtx, nodeGroup, nodeInfos)
+	similarNodeGroups, err := o.processors.NodeGroupSetProcessor.FindSimilarNodeGroups(ctx, o.autoscalingCtx, nodeGroup, nodeInfos)
 	if err != nil {
 		klog.Errorf("Failed to find similar node groups: %v", err)
 		return nil
@@ -788,7 +789,7 @@ func (o *ScaleUpOrchestrator) ComputeSimilarNodeGroups(
 	var validSimilarNodeGroups []cloudprovider.NodeGroup
 	for _, ng := range similarNodeGroups {
 		// Non-existing node groups are created later so skip check for them.
-		if ng.Exist() && !o.clusterStateRegistry.NodeGroupScaleUpSafety(ng, now).SafeToScale {
+		if ng.Exist() && !o.clusterStateRegistry.NodeGroupScaleUpSafety(ctx, ng, now).SafeToScale {
 			klog.V(2).Infof("Ignoring node group %s when balancing: group is not ready for scaleup", ng.Id())
 		} else if similarPodGroups, found := schedulablePodGroups[ng.Id()]; found && matchingSchedulablePodGroups(podGroups, similarPodGroups) {
 			validSimilarNodeGroups = append(validSimilarNodeGroups, ng)
@@ -800,7 +801,7 @@ func (o *ScaleUpOrchestrator) ComputeSimilarNodeGroups(
 
 // GetRemainingPods returns information about pods which CA is unable to help
 // at this moment.
-func (o *ScaleUpOrchestrator) GetRemainingPods(egs []*equivalence.PodGroup, nodeGroups []cloudprovider.NodeGroup, skipped map[string]status.Reasons, nodeInfos map[string]*framework.NodeInfo) []status.NoScaleUpInfo {
+func (o *ScaleUpOrchestrator) GetRemainingPods(ctx context.Context, egs []*equivalence.PodGroup, nodeGroups []cloudprovider.NodeGroup, skipped map[string]status.Reasons, nodeInfos map[string]*framework.NodeInfo) []status.NoScaleUpInfo {
 	if !o.autoscalingCtx.ScaleUpSimulationForSkippedNodeGroupsEnabled {
 		remaining := []status.NoScaleUpInfo{}
 		for _, eg := range egs {
@@ -826,10 +827,10 @@ func (o *ScaleUpOrchestrator) GetRemainingPods(egs []*equivalence.PodGroup, node
 			nonSchedulableEgs = append(nonSchedulableEgs, eg)
 		}
 	}
-	return o.getRemainingPodsConsideringSkippedNodeGroups(nonSchedulableEgs, nodeGroups, skipped, nodeInfos)
+	return o.getRemainingPodsConsideringSkippedNodeGroups(ctx, nonSchedulableEgs, nodeGroups, skipped, nodeInfos)
 }
 
-func (o *ScaleUpOrchestrator) getRemainingPodsConsideringSkippedNodeGroups(egs []*equivalence.PodGroup, nodeGroups []cloudprovider.NodeGroup, skipped map[string]status.Reasons, nodeInfos map[string]*framework.NodeInfo) []status.NoScaleUpInfo {
+func (o *ScaleUpOrchestrator) getRemainingPodsConsideringSkippedNodeGroups(ctx context.Context, egs []*equivalence.PodGroup, nodeGroups []cloudprovider.NodeGroup, skipped map[string]status.Reasons, nodeInfos map[string]*framework.NodeInfo) []status.NoScaleUpInfo {
 	remaining := []status.NoScaleUpInfo{}
 	// Perform the SchedulablePodGroups simulation for the skipped node groups.
 	for _, nodeGroup := range nodeGroups {
@@ -843,7 +844,7 @@ func (o *ScaleUpOrchestrator) getRemainingPodsConsideringSkippedNodeGroups(egs [
 			continue
 		}
 		// We ignore the return value here, because we are not interested in which egs are now (theoretically) schedulable or not. We are only interested in the rejected node groups per eg.
-		_ = o.SchedulablePodGroups(egs, nodeGroup, nodeInfo)
+		_ = o.SchedulablePodGroups(ctx, egs, nodeGroup, nodeInfo)
 	}
 	// For all egs here we need to generate the NoScaleUpInfo object because we only considered egs that are unschedulable in the first place.
 	// eg.SchedulingErrors will contain scheduling errors of this eg for not skipped nodegroups from the previous simulation + errors for skipped nodegroups from current simulation.
@@ -884,19 +885,19 @@ func deletePodEquivalenceGroupsId(podEquivalenceGroups []*equivalence.PodGroup, 
 	}
 }
 
-func (o *ScaleUpOrchestrator) noOptionsAvailableStatus(args scaleUpCtx) *status.ScaleUpStatus {
+func (o *ScaleUpOrchestrator) noOptionsAvailableStatus(ctx context.Context, args scaleUpCtx) *status.ScaleUpStatus {
 	return &status.ScaleUpStatus{
 		Result:                  status.ScaleUpNoOptionsAvailable,
-		PodsRemainUnschedulable: o.GetRemainingPods(args.podEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+		PodsRemainUnschedulable: o.GetRemainingPods(ctx, args.podEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
 		ConsideredNodeGroups:    args.nodeGroups,
 	}
 }
 
-func (o *ScaleUpOrchestrator) abortAllOrNothing(args scaleUpCtx) *status.ScaleUpStatus {
+func (o *ScaleUpOrchestrator) abortAllOrNothing(ctx context.Context, args scaleUpCtx) *status.ScaleUpStatus {
 	// Can't execute a scale-up that will accommodate all pods, so nothing is considered schedulable.
 	klog.V(1).Info("Not attempting scale-up due to all-or-nothing strategy: not all pods would be accommodated")
 	args.podEquivalenceGroups = markAllGroupsAsUnschedulable(args.podEquivalenceGroups, AllOrNothingReason)
-	return o.noOptionsAvailableStatus(args)
+	return o.noOptionsAvailableStatus(ctx, args)
 }
 
 func findSkippedNodeGroupsSatisfyingPodPredicates(eg *equivalence.PodGroup, skipped map[string]status.Reasons) map[string]status.Reasons {
@@ -1040,18 +1041,18 @@ type scaleUpPlan struct {
 	nodeGroups             []cloudprovider.NodeGroup
 }
 
-func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *status.ScaleUpStatus, errors.AutoscalerError) {
+func (o *ScaleUpOrchestrator) prepareScaleUp(ctx context.Context, args scaleUpCtx) (scaleUpPlan, *status.ScaleUpStatus, errors.AutoscalerError) {
 	// Calculate expansion options
 	schedulablePodGroups := map[string][]estimator.PodEquivalenceGroup{}
 	var options []expander.Option
 
 	// This code here runs a simulation to see which pods can be scheduled on which node groups.
 	for _, nodeGroup := range args.validNodeGroups {
-		schedulablePodGroups[nodeGroup.Id()] = o.SchedulablePodGroups(args.podEquivalenceGroups, nodeGroup, args.nodeInfos[nodeGroup.Id()])
+		schedulablePodGroups[nodeGroup.Id()] = o.SchedulablePodGroups(ctx, args.podEquivalenceGroups, nodeGroup, args.nodeInfos[nodeGroup.Id()])
 	}
 
 	for _, nodeGroup := range args.validNodeGroups {
-		option := o.ComputeExpansionOption(nodeGroup, schedulablePodGroups, args.nodeInfos, len(args.nodes), args.now, args.allOrNothing)
+		option := o.ComputeExpansionOption(ctx, nodeGroup, schedulablePodGroups, args.nodeInfos, len(args.nodes), args.now, args.allOrNothing)
 		o.processors.BinpackingLimiter.MarkProcessed(o.autoscalingCtx, nodeGroup.Id())
 
 		if len(option.Pods) == 0 || option.NodeCount == 0 {
@@ -1062,7 +1063,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 			options = append(options, option)
 		}
 
-		if o.processors.BinpackingLimiter.StopBinpacking(o.autoscalingCtx, options) {
+		if o.processors.BinpackingLimiter.StopBinpacking(ctx, o.autoscalingCtx, options) {
 			break
 		}
 	}
@@ -1072,15 +1073,15 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 
 	if len(options) == 0 {
 		klog.V(1).Info("No expansion options")
-		return scaleUpPlan{}, o.noOptionsAvailableStatus(args), nil
+		return scaleUpPlan{}, o.noOptionsAvailableStatus(ctx, args), nil
 	}
 
 	// Pick some expansion option.
-	bestOption := o.autoscalingCtx.ExpanderStrategy.BestOption(options, args.nodeInfos)
+	bestOption := o.autoscalingCtx.ExpanderStrategy.BestOption(ctx, options, args.nodeInfos)
 	if bestOption == nil || bestOption.NodeCount <= 0 {
 		klog.Infof("Expander filtered out all options, valid options: %d", len(options))
 		args.podEquivalenceGroups = markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ExpansionOptionsFilteredOutReason)
-		return scaleUpPlan{}, o.noOptionsAvailableStatus(args), nil
+		return scaleUpPlan{}, o.noOptionsAvailableStatus(ctx, args), nil
 	}
 	klog.V(1).Infof("Best option to resize: %s", bestOption.NodeGroup.Id())
 	if len(bestOption.Debug) > 0 {
@@ -1089,26 +1090,26 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 	klog.V(1).Infof("Estimated %d nodes needed in %s", bestOption.NodeCount, bestOption.NodeGroup.Id())
 
 	// Cap new nodes to supported number of nodes in the cluster.
-	newNodes, aErr := o.GetCappedNewNodeCount(bestOption.NodeCount, len(args.nodes))
+	newNodes, aErr := o.GetCappedNewNodeCount(ctx, bestOption.NodeCount, len(args.nodes))
 	if aErr != nil {
 		markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ScaleUpExecutionErrorReason)
 		st, err := status.UpdateScaleUpError(
 			&status.ScaleUpStatus{
 				PodsTriggeredScaleUp:    bestOption.Pods,
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+				PodsRemainUnschedulable: o.GetRemainingPods(ctx, markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
 			},
 			aErr,
 		)
 		return scaleUpPlan{}, st, err
 	}
 
-	newNodes, aErr = o.applyLimits(newNodes, args.tracker, bestOption.NodeGroup, args.nodeInfos)
+	newNodes, aErr = o.applyLimits(ctx, newNodes, args.tracker, bestOption.NodeGroup, args.nodeInfos)
 	if aErr != nil {
 		markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ScaleUpExecutionErrorReason)
 		st, err := status.UpdateScaleUpError(
 			&status.ScaleUpStatus{
 				PodsTriggeredScaleUp:    bestOption.Pods,
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+				PodsRemainUnschedulable: o.GetRemainingPods(ctx, markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
 			},
 			aErr,
 		)
@@ -1118,7 +1119,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 	if newNodes < bestOption.NodeCount {
 		klog.V(1).Infof("Only %d nodes can be added to %s due to resource quotas", newNodes, bestOption.NodeGroup.Id())
 		if args.allOrNothing {
-			return scaleUpPlan{}, o.abortAllOrNothing(args), nil
+			return scaleUpPlan{}, o.abortAllOrNothing(ctx, args), nil
 		}
 	}
 
@@ -1127,15 +1128,15 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 	if !bestOption.NodeGroup.Exist() && !o.processors.AsyncNodeGroupStateChecker.IsUpcoming(bestOption.NodeGroup) {
 		if args.allOrNothing && bestOption.NodeGroup.MaxSize() < newNodes {
 			klog.V(1).Infof("Can only create a new node group with max %d nodes, need %d nodes", bestOption.NodeGroup.MaxSize(), newNodes)
-			return scaleUpPlan{}, o.abortAllOrNothing(args), nil
+			return scaleUpPlan{}, o.abortAllOrNothing(ctx, args), nil
 		}
 		var scaleUpStatus *status.ScaleUpStatus
 		oldId := bestOption.NodeGroup.Id()
 		if o.autoscalingCtx.AsyncNodeGroupsEnabled {
 			initializer := NewAsyncNodeGroupInitializer(bestOption, args.nodeInfos[oldId], o.scaleUpExecutor, o.taintConfig, args.daemonSets, o.processors.ScaleUpStatusProcessor, o.autoscalingCtx, args.allOrNothing)
-			createNodeGroupResults, scaleUpStatus, aErr = o.CreateNodeGroupAsync(bestOption, args.nodeInfos, schedulablePodGroups, args.podEquivalenceGroups, args.daemonSets, initializer)
+			createNodeGroupResults, scaleUpStatus, aErr = o.CreateNodeGroupAsync(ctx, bestOption, args.nodeInfos, schedulablePodGroups, args.podEquivalenceGroups, args.daemonSets, initializer)
 		} else {
-			createNodeGroupResults, scaleUpStatus, aErr = o.CreateNodeGroup(bestOption, args.nodeInfos, schedulablePodGroups, args.podEquivalenceGroups, args.daemonSets)
+			createNodeGroupResults, scaleUpStatus, aErr = o.CreateNodeGroup(ctx, bestOption, args.nodeInfos, schedulablePodGroups, args.podEquivalenceGroups, args.daemonSets)
 		}
 		if aErr != nil {
 			return scaleUpPlan{}, scaleUpStatus, aErr
@@ -1143,14 +1144,14 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 		args.nodeGroups = appendCreatedNodeGroups(args.nodeGroups, oldId, createNodeGroupResults)
 	}
 
-	scaleUpInfos, aErr := o.balanceScaleUps(args.now, bestOption.NodeGroup, newNodes, args.nodeInfos, schedulablePodGroups, args.tracker)
+	scaleUpInfos, aErr := o.balanceScaleUps(ctx, args.now, bestOption.NodeGroup, newNodes, args.nodeInfos, schedulablePodGroups, args.tracker)
 	if aErr != nil {
 		markedEquivalenceGroups := markAllGroupsAsUnschedulable(args.podEquivalenceGroups, ScaleUpExecutionErrorReason)
 		st, err := status.UpdateScaleUpError(
 			&status.ScaleUpStatus{
 				CreateNodeGroupResults:  createNodeGroupResults,
 				PodsTriggeredScaleUp:    bestOption.Pods,
-				PodsRemainUnschedulable: o.GetRemainingPods(markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
+				PodsRemainUnschedulable: o.GetRemainingPods(ctx, markedEquivalenceGroups, args.nodeGroups, args.skippedNodeGroups, args.nodeInfos),
 			},
 			aErr,
 		)
@@ -1165,7 +1166,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(args scaleUpCtx) (scaleUpPlan, *sta
 	if totalCapacity < newNodes {
 		klog.V(1).Infof("Can only add %d nodes due to node group limits, need %d nodes", totalCapacity, newNodes)
 		if args.allOrNothing {
-			return scaleUpPlan{}, o.abortAllOrNothing(args), nil
+			return scaleUpPlan{}, o.abortAllOrNothing(ctx, args), nil
 		}
 	}
 

--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -1216,12 +1217,12 @@ func runSimpleScaleUpTest(t *testing.T, testConfig *ScaleUpTestConfig) *ScaleUpT
 	assert.NoError(t, err)
 	err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, kube_util.ScheduledPods(pods), nil, nil)
 	assert.NoError(t, err)
-	err = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+	err = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 	assert.NoError(t, err)
 	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
 	processors.ScaleStateNotifier.Register(nodegroupchange.NewNodeGroupChangeMetricsProducer(provider, metrics.DefaultMetrics))
-	clusterState.UpdateNodes(nodes, time.Now())
+	clusterState.UpdateNodes(context.TODO(), nodes, time.Now())
 	processors.NodeGroupSetProcessor = nodegroupset.NewDefaultNodeGroupSetProcessor([]string{nodeGroupLabel}, config.NodeGroupDifferenceRatios{})
 	if testConfig.EnableAutoprovisioning {
 		processors.NodeGroupListProcessor = &MockAutoprovisioningNodeGroupListProcessor{T: t}
@@ -1239,8 +1240,8 @@ func runSimpleScaleUpTest(t *testing.T, testConfig *ScaleUpTestConfig) *ScaleUpT
 	autoscalingCtx.ExpanderStrategy = expander
 
 	// scale up
-	scaleUpStatus, scaleUpErr := orchestrator.ScaleUp(extraPods, nodes, []*appsv1.DaemonSet{}, nodeInfos, testConfig.AllOrNothing)
-	processors.ScaleUpStatusProcessor.Process(&autoscalingCtx, scaleUpStatus)
+	scaleUpStatus, scaleUpErr := orchestrator.ScaleUp(context.TODO(), extraPods, nodes, []*appsv1.DaemonSet{}, nodeInfos, testConfig.AllOrNothing)
+	processors.ScaleUpStatusProcessor.Process(context.TODO(), &autoscalingCtx, scaleUpStatus)
 
 	// aggregate group size changes
 	close(groupSizeChangesChannel)
@@ -1337,10 +1338,10 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	assert.NoError(t, err)
 	err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, pods, nil, nil)
 	assert.NoError(t, err)
-	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
-	clusterState.UpdateNodes(nodes, time.Now())
+	clusterState.UpdateNodes(context.TODO(), nodes, time.Now())
 	p3 := BuildTestPod("p-new", 550, 0)
 
 	quotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
@@ -1350,7 +1351,7 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	})
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{p3}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+	scaleUpStatus, err := suOrchestrator.ScaleUp(context.TODO(), []*apiv1.Pod{p3}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
 
 	assert.NoError(t, err)
 	// Node group is unhealthy.
@@ -1386,12 +1387,12 @@ func TestBinpackingLimiter(t *testing.T) {
 	assert.NoError(t, err)
 	err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, nil, nil, nil)
 	assert.NoError(t, err)
-	err = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+	err = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 	assert.NoError(t, err)
 	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 
 	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
-	clusterState.UpdateNodes(nodes, time.Now())
+	clusterState.UpdateNodes(context.TODO(), nodes, time.Now())
 
 	extraPod := BuildTestPod("p-new", 500, 0)
 
@@ -1409,8 +1410,8 @@ func TestBinpackingLimiter(t *testing.T) {
 	expander := NewMockReportingStrategy(t, nil, nil)
 	autoscalingCtx.ExpanderStrategy = expander
 
-	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{extraPod}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
-	processors.ScaleUpStatusProcessor.Process(&autoscalingCtx, scaleUpStatus)
+	scaleUpStatus, err := suOrchestrator.ScaleUp(context.TODO(), []*apiv1.Pod{extraPod}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+	processors.ScaleUpStatusProcessor.Process(context.TODO(), &autoscalingCtx, scaleUpStatus)
 	assert.NoError(t, err)
 	assert.True(t, scaleUpStatus.WasSuccessful())
 
@@ -1451,10 +1452,10 @@ func TestScaleUpNoHelp(t *testing.T) {
 	assert.NoError(t, err)
 	err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, pods, nil, nil)
 	assert.NoError(t, err)
-	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
-	clusterState.UpdateNodes(nodes, time.Now())
+	clusterState.UpdateNodes(context.TODO(), nodes, time.Now())
 	p3 := BuildTestPod("p-new", 500, 0)
 
 	quotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
@@ -1464,8 +1465,8 @@ func TestScaleUpNoHelp(t *testing.T) {
 	})
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{p3}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
-	processors.ScaleUpStatusProcessor.Process(&autoscalingCtx, scaleUpStatus)
+	scaleUpStatus, err := suOrchestrator.ScaleUp(context.TODO(), []*apiv1.Pod{p3}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+	processors.ScaleUpStatusProcessor.Process(context.TODO(), &autoscalingCtx, scaleUpStatus)
 
 	assert.NoError(t, err)
 	assert.False(t, scaleUpStatus.WasSuccessful())
@@ -1482,11 +1483,11 @@ type constNodeGroupSetProcessor struct {
 	similarNodeGroups []cloudprovider.NodeGroup
 }
 
-func (p *constNodeGroupSetProcessor) FindSimilarNodeGroups(_ *ca_context.AutoscalingContext, _ cloudprovider.NodeGroup, _ map[string]*framework.NodeInfo) ([]cloudprovider.NodeGroup, errors.AutoscalerError) {
+func (p *constNodeGroupSetProcessor) FindSimilarNodeGroups(ctx context.Context, _ *ca_context.AutoscalingContext, _ cloudprovider.NodeGroup, _ map[string]*framework.NodeInfo) ([]cloudprovider.NodeGroup, errors.AutoscalerError) {
 	return p.similarNodeGroups, nil
 }
 
-func (p *constNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(_ *ca_context.AutoscalingContext, _ []cloudprovider.NodeGroup, _ int) ([]nodegroupset.ScaleUpInfo, errors.AutoscalerError) {
+func (p *constNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(ctx context.Context, _ *ca_context.AutoscalingContext, _ []cloudprovider.NodeGroup, _ int) ([]nodegroupset.ScaleUpInfo, errors.AutoscalerError) {
 	return nil, nil
 }
 
@@ -1612,14 +1613,14 @@ func TestComputeSimilarNodeGroups(t *testing.T) {
 			assert.NoError(t, err)
 			err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, nil, nil, nil)
 			assert.NoError(t, err)
-			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 			nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 			clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(nodegroupchange.NewNodeGroupChangeObserversList()))
-			assert.NoError(t, clusterState.UpdateNodes(nodes, time.Now()))
+			assert.NoError(t, clusterState.UpdateNodes(context.TODO(), nodes, time.Now()))
 
 			suOrchestrator := &ScaleUpOrchestrator{}
 			suOrchestrator.Initialize(&autoscalingCtx, &processors.AutoscalingProcessors{NodeGroupSetProcessor: nodeGroupSetProcessor}, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, nil)
-			similarNodeGroups := suOrchestrator.ComputeSimilarNodeGroups(provider.GetNodeGroup(tc.nodeGroup), nodeInfos, tc.schedulablePodGroups, now)
+			similarNodeGroups := suOrchestrator.ComputeSimilarNodeGroups(context.TODO(), provider.GetNodeGroup(tc.nodeGroup), nodeInfos, tc.schedulablePodGroups, now)
 
 			var gotSimilarNodeGroups []string
 			for _, ng := range similarNodeGroups {
@@ -1699,10 +1700,10 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 			assert.NoError(t, err)
 			err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, podList, nil, nil)
 			assert.NoError(t, err)
-			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 			nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 			clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
-			clusterState.UpdateNodes(nodes, time.Now())
+			clusterState.UpdateNodes(context.TODO(), nodes, time.Now())
 
 			pods := make([]*apiv1.Pod, 0)
 			for i := 0; i < 2; i++ {
@@ -1719,7 +1720,7 @@ func TestScaleUpBalanceGroups(t *testing.T) {
 			})
 			suOrchestrator := New()
 			suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-			scaleUpStatus, typedErr := suOrchestrator.ScaleUp(pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+			scaleUpStatus, typedErr := suOrchestrator.ScaleUp(context.TODO(), pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
 
 			assert.NoError(t, typedErr)
 			assert.True(t, scaleUpStatus.WasSuccessful())
@@ -1862,10 +1863,10 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 			assert.NoError(t, err)
 			err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, podList, nil, nil)
 			assert.NoError(t, err)
-			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 			nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 			clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
-			clusterState.UpdateNodes(nodes, time.Now())
+			clusterState.UpdateNodes(context.TODO(), nodes, time.Now())
 
 			pods := make([]*apiv1.Pod, 0)
 			for i := 0; i < 6; i++ {
@@ -1882,7 +1883,7 @@ func TestScaleUpBalanceGroupsRespectsQuota(t *testing.T) {
 			})
 			suOrchestrator := New()
 			suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-			scaleUpStatus, typedErr := suOrchestrator.ScaleUp(pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+			scaleUpStatus, typedErr := suOrchestrator.ScaleUp(context.TODO(), pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
 
 			assert.NoError(t, typedErr)
 			assert.True(t, scaleUpStatus.WasSuccessful())
@@ -1935,7 +1936,7 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	processors.NodeGroupManager = &MockAutoprovisioningNodeGroupManager{T: t, ExtraGroups: 0}
 
 	nodes := []*apiv1.Node{}
-	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
+	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 
 	quotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
@@ -1945,7 +1946,7 @@ func TestScaleUpAutoprovisionedNodeGroup(t *testing.T) {
 	})
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{p1, p2}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+	scaleUpStatus, err := suOrchestrator.ScaleUp(context.TODO(), []*apiv1.Pod{p1, p2}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
 	assert.NoError(t, err)
 	assert.True(t, scaleUpStatus.WasSuccessful())
 	assert.Equal(t, "autoprovisioned-T1", utils.GetStringFromChan(createdGroups))
@@ -2005,7 +2006,7 @@ func TestScaleUpBalanceAutoprovisionedNodeGroups(t *testing.T) {
 	processors.NodeGroupManager = &MockAutoprovisioningNodeGroupManager{T: t, ExtraGroups: 2}
 
 	nodes := []*apiv1.Node{}
-	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
+	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 
 	quotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
@@ -2015,7 +2016,7 @@ func TestScaleUpBalanceAutoprovisionedNodeGroups(t *testing.T) {
 	})
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-	scaleUpStatus, err := suOrchestrator.ScaleUp([]*apiv1.Pod{p1, p2, p3, p4}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+	scaleUpStatus, err := suOrchestrator.ScaleUp(context.TODO(), []*apiv1.Pod{p1, p2, p3, p4}, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
 	assert.NoError(t, err)
 	assert.True(t, scaleUpStatus.WasSuccessful())
 	assert.Equal(t, "autoprovisioned-T1", utils.GetStringFromChan(createdGroups))
@@ -2078,10 +2079,10 @@ func TestScaleUpToMeetNodeGroupMinSize(t *testing.T) {
 	nodes := []*apiv1.Node{n1, n2}
 	err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, nil, nil, nil)
 	assert.NoError(t, err)
-	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
+	_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
-	clusterState.UpdateNodes(nodes, time.Now())
+	clusterState.UpdateNodes(context.TODO(), nodes, time.Now())
 
 	quotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
 	trackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
@@ -2090,7 +2091,7 @@ func TestScaleUpToMeetNodeGroupMinSize(t *testing.T) {
 	})
 	suOrchestrator := New()
 	suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-	scaleUpStatus, err := suOrchestrator.ScaleUpToNodeGroupMinSize(nodes, nodeInfos)
+	scaleUpStatus, err := suOrchestrator.ScaleUpToNodeGroupMinSize(context.TODO(), nodes, nodeInfos)
 	assert.NoError(t, err)
 	assert.True(t, scaleUpStatus.WasSuccessful())
 	assert.Equal(t, 1, len(scaleUpStatus.ScaleUpInfos))
@@ -2179,7 +2180,7 @@ func TestScaleupAsyncNodeGroupsEnabled(t *testing.T) {
 		processors.AsyncNodeGroupStateChecker = &asyncnodegroups.MockAsyncNodeGroupStateChecker{IsUpcomingNodeGroup: tc.isUpcomingMockMap}
 
 		nodes := []*apiv1.Node{}
-		nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
+		nodeInfos, _ := nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil, false).Process(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 
 		quotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
 		trackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
@@ -2188,7 +2189,7 @@ func TestScaleupAsyncNodeGroupsEnabled(t *testing.T) {
 		})
 		suOrchestrator := New()
 		suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
-		scaleUpStatus, err := suOrchestrator.ScaleUp(tc.podsToAdd, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+		scaleUpStatus, err := suOrchestrator.ScaleUp(context.TODO(), tc.podsToAdd, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
 		assert.NoError(t, err)
 		assert.True(t, scaleUpStatus.WasSuccessful())
 
@@ -2382,11 +2383,11 @@ func TestScaleUpSimulationForSkippedNodeGroups(t *testing.T) {
 			nodes := []*apiv1.Node{node1, node2, node3}
 			err = autoscalingCtx.ClusterSnapshot.SetClusterState(nodes, nil, nil, nil)
 			assert.NoError(t, err)
-			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
+			_ = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, time.Now())
 			nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 
 			clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
-			clusterState.UpdateNodes(nodes, time.Now())
+			clusterState.UpdateNodes(context.TODO(), nodes, time.Now())
 
 			quotasProvider := resourcequotas.NewCloudQuotasProvider(provider)
 			trackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
@@ -2397,7 +2398,7 @@ func TestScaleUpSimulationForSkippedNodeGroups(t *testing.T) {
 			suOrchestrator := New()
 			suOrchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
 
-			scaleUpStatus, err := suOrchestrator.ScaleUp(tc.pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
+			scaleUpStatus, err := suOrchestrator.ScaleUp(context.TODO(), tc.pods, nodes, []*appsv1.DaemonSet{}, nodeInfos, false)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedResult, scaleUpStatus.Result)
 

--- a/cluster-autoscaler/core/scaleup/scaleup.go
+++ b/cluster-autoscaler/core/scaleup/scaleup.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaleup
 
 import (
+	"context"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
@@ -46,7 +47,7 @@ type Orchestrator interface {
 	// an unexpected error occurred. Assumes that all nodes in the cluster are ready
 	// and in sync with instance groups.
 	ScaleUp(
-		unschedulablePods []*apiv1.Pod,
+		ctx context.Context, unschedulablePods []*apiv1.Pod,
 		nodes []*apiv1.Node,
 		daemonSets []*appsv1.DaemonSet,
 		nodeInfos map[string]*framework.NodeInfo,
@@ -57,7 +58,7 @@ type Orchestrator interface {
 	// size is the TargetSize queried directly from cloud providers. Returns
 	// appropriate status or error if an unexpected error occurred.
 	ScaleUpToNodeGroupMinSize(
-		nodes []*apiv1.Node,
+		ctx context.Context, nodes []*apiv1.Node,
 		nodeInfos map[string]*framework.NodeInfo,
 	) (*status.ScaleUpStatus, errors.AutoscalerError)
 }

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -110,8 +110,8 @@ type staticAutoscalerProcessorCallbacks struct {
 	scaleDownPlanner        scaledown.Planner
 }
 
-func (callbacks *staticAutoscalerProcessorCallbacks) ResetUnneededNodes() {
-	callbacks.scaleDownPlanner.CleanUpUnneededNodes()
+func (callbacks *staticAutoscalerProcessorCallbacks) ResetUnneededNodes(ctx context.Context) {
+	callbacks.scaleDownPlanner.CleanUpUnneededNodes(ctx)
 }
 
 func newStaticAutoscalerProcessorCallbacks() *staticAutoscalerProcessorCallbacks {
@@ -255,7 +255,7 @@ func (a *StaticAutoscaler) Start() error {
 
 // cleanUpIfRequired removes ToBeDeleted taints added by a previous run of CA
 // the taints are removed only once per runtime
-func (a *StaticAutoscaler) cleanUpIfRequired() {
+func (a *StaticAutoscaler) cleanUpIfRequired(ctx context.Context) {
 	if a.initialized {
 		return
 	}
@@ -265,19 +265,19 @@ func (a *StaticAutoscaler) cleanUpIfRequired() {
 		klog.Errorf("Failed to list ready nodes, not cleaning up taints: %v", err)
 	} else {
 		// Make sure we are only cleaning taints from selected node groups.
-		selectedNodes := filterNodesFromSelectedGroups(a.CloudProvider, allNodes...)
-		taints.CleanAllToBeDeleted(selectedNodes,
+		selectedNodes := filterNodesFromSelectedGroups(ctx, a.CloudProvider, allNodes...)
+		taints.CleanAllToBeDeleted(ctx, selectedNodes,
 			a.AutoscalingContext.ClientSet, a.Recorder, a.CordonNodeBeforeTerminate)
 		if a.AutoscalingContext.AutoscalingOptions.MaxBulkSoftTaintCount == 0 {
 			// Clean old taints if soft taints handling is disabled
-			taints.CleanStaleDeletionCandidates(allNodes,
+			taints.CleanStaleDeletionCandidates(ctx, allNodes,
 				a.AutoscalingContext.ClientSet, a.Recorder, a.NodeDeletionCandidateTTL)
 		}
 	}
 	a.initialized = true
 }
 
-func (a *StaticAutoscaler) initializeRemainingPdbTracker() caerrors.AutoscalerError {
+func (a *StaticAutoscaler) initializeRemainingPdbTracker(ctx context.Context) caerrors.AutoscalerError {
 	a.RemainingPdbTracker.Clear()
 
 	pdbs, err := a.PodDisruptionBudgetLister().List()
@@ -294,10 +294,11 @@ func (a *StaticAutoscaler) initializeRemainingPdbTracker() caerrors.AutoscalerEr
 
 // RunOnce iterates over node groups and scales them up/down if necessary
 func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerError {
-	a.cleanUpIfRequired()
+	ctx := context.Background()
+	a.cleanUpIfRequired(ctx)
 	a.processorCallbacks.reset()
-	a.DebuggingSnapshotter.StartDataCollection()
-	defer a.DebuggingSnapshotter.Flush()
+	a.DebuggingSnapshotter.StartDataCollection(ctx)
+	defer a.DebuggingSnapshotter.Flush(ctx)
 	if a.capacityBufferPodsRegistry != nil {
 		a.capacityBufferPodsRegistry.Clear()
 	}
@@ -328,18 +329,17 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 
 	// Get nodes and pods currently living on cluster
-	allNodes, readyNodes, typedErr := a.obtainNodeLists(draSnapshot, csiSnapshot)
+	allNodes, readyNodes, typedErr := a.obtainNodeLists(ctx, draSnapshot, csiSnapshot)
 	if typedErr != nil {
 		klog.Errorf("Failed to get node list: %v", typedErr)
 		return typedErr
 	}
 
-	if abortLoop, err := a.processors.ActionableClusterProcessor.ShouldAbort(
-		a.AutoscalingContext, allNodes, readyNodes, currentTime); abortLoop {
+	if abortLoop, err := a.processors.ActionableClusterProcessor.ShouldAbort(ctx, a.AutoscalingContext, allNodes, readyNodes, currentTime); abortLoop {
 		return err
 	}
 
-	podsBySchedulability, err := listPods(podLister, a.BypassedSchedulers, a.AllowedSchedulers)
+	podsBySchedulability, err := listPods(ctx, podLister, a.BypassedSchedulers, a.AllowedSchedulers)
 	if err != nil {
 		return caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
 	}
@@ -361,14 +361,14 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	err = a.AutoscalingContext.CloudProvider.Refresh()
 	if a.AutoscalingOptions.AsyncNodeGroupsEnabled {
 		// Some node groups might have been created asynchronously, without registering in CSR.
-		a.clusterStateRegistry.Recalculate()
+		a.clusterStateRegistry.Recalculate(ctx)
 	}
-	metrics.UpdateDurationFromStart(metrics.CloudProviderRefresh, refreshStart)
+	metrics.UpdateDurationFromStart(ctx, metrics.CloudProviderRefresh, refreshStart)
 	if err != nil {
 		klog.Errorf("Failed to refresh cloud provider config: %v", err)
 		return caerrors.ToAutoscalerError(caerrors.CloudProviderError, err)
 	}
-	a.loopStartNotifier.Refresh()
+	a.loopStartNotifier.Refresh(ctx)
 
 	// Update node groups min/max and maximum number of nodes being set for all node groups after cloud provider refresh
 	maxNodesCount := 0
@@ -392,39 +392,40 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		return caerrors.ToAutoscalerError(caerrors.InternalError, err).AddPrefix("failed to initialize ClusterSnapshot: ")
 	}
 	// Initialize Pod Disruption Budget tracking
-	if typedErr := a.initializeRemainingPdbTracker(); typedErr != nil {
+	if typedErr := a.initializeRemainingPdbTracker(ctx); typedErr != nil {
 		return typedErr.AddPrefix("failed to initialize RemainingPdbTracker: ")
 	}
 
-	if autoscalerError := a.AutoscalingContext.TemplateNodeInfoRegistry.Recompute(a.AutoscalingContext, allNodes, daemonsets, a.taintConfig, currentTime); autoscalerError != nil {
+	if autoscalerError := a.AutoscalingContext.TemplateNodeInfoRegistry.Recompute(ctx, a.AutoscalingContext, allNodes, daemonsets, a.taintConfig, currentTime); autoscalerError != nil {
 		klog.Errorf("Failed to recompute template node infos: %v", autoscalerError)
 		return autoscalerError.AddPrefix("failed to recompute template node infos: ")
 	}
 
-	a.DebuggingSnapshotter.SetTemplateNodes(autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos())
+	a.DebuggingSnapshotter.SetTemplateNodes(ctx, autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos())
 
-	if typedErr := a.updateClusterState(allNodes, currentTime); typedErr != nil {
+	if typedErr := a.updateClusterState(ctx, allNodes, currentTime); typedErr != nil {
 		klog.Errorf("Failed to update cluster state: %v", typedErr)
 		return typedErr
 	}
-	metrics.UpdateDurationFromStart(metrics.UpdateState, stateUpdateStart)
+	metrics.UpdateDurationFromStart(ctx, metrics.UpdateState, stateUpdateStart)
 
 	scaleUpStatus := &status.ScaleUpStatus{Result: status.ScaleUpNotTried}
 	scaleUpTriggered := false
 	scaleDownStatus := &scaledownstatus.ScaleDownStatus{Result: scaledownstatus.ScaleDownNotTried}
 
 	defer func() {
+		loggingContext := context.WithoutCancel(ctx)
 		// Update status information when the loop is done (regardless of reason)
 		if autoscalingCtx.WriteStatusConfigMap {
-			status := a.clusterStateRegistry.GetStatus(currentTime)
-			utils.WriteStatusConfigMap(autoscalingCtx.ClientSet, autoscalingCtx.ConfigNamespace,
+			status := a.clusterStateRegistry.GetStatus(loggingContext, currentTime)
+			utils.WriteStatusConfigMap(loggingContext, autoscalingCtx.ClientSet, autoscalingCtx.ConfigNamespace,
 				*status, a.AutoscalingContext.LogRecorder, a.AutoscalingContext.StatusConfigMapName, currentTime)
 		}
 
 		// This deferred processor execution allows the processors to handle a situation when a scale-(up|down)
 		// wasn't even attempted because e.g. the iteration exited earlier.
 		if !scaleUpTriggered && a.processors.ScaleUpStatusProcessor != nil {
-			a.processors.ScaleUpStatusProcessor.Process(a.AutoscalingContext, scaleUpStatus)
+			a.processors.ScaleUpStatusProcessor.Process(loggingContext, a.AutoscalingContext, scaleUpStatus)
 		}
 		if a.processors.ScaleDownStatusProcessor != nil {
 			// Gather status before scaledown status processor invocation
@@ -432,13 +433,13 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 			scaleDownStatus.NodeDeleteResults = nodeDeletionResults
 			scaleDownStatus.NodeDeleteResultsAsOf = nodeDeletionResultsAsOf
 			a.scaleDownActuator.ClearResultsNotNewerThan(scaleDownStatus.NodeDeleteResultsAsOf)
-			scaleDownStatus.SetUnremovableNodesInfo(a.scaleDownPlanner.UnremovableNodes(), a.scaleDownPlanner.NodeUtilizationMap(), a.CloudProvider)
+			scaleDownStatus.SetUnremovableNodesInfo(loggingContext, a.scaleDownPlanner.UnremovableNodes(), a.scaleDownPlanner.NodeUtilizationMap(), a.CloudProvider)
 
-			a.processors.ScaleDownStatusProcessor.Process(a.AutoscalingContext, scaleDownStatus)
+			a.processors.ScaleDownStatusProcessor.Process(loggingContext, a.AutoscalingContext, scaleDownStatus)
 		}
 
 		if a.processors.AutoscalingStatusProcessor != nil {
-			err := a.processors.AutoscalingStatusProcessor.Process(a.AutoscalingContext, a.clusterStateRegistry, currentTime)
+			err := a.processors.AutoscalingStatusProcessor.Process(loggingContext, a.AutoscalingContext, a.clusterStateRegistry, currentTime)
 			if err != nil {
 				klog.Errorf("AutoscalingStatusProcessor error: %v.", err)
 			}
@@ -450,7 +451,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	unregisteredNodes := a.clusterStateRegistry.GetUnregisteredNodes()
 	if len(unregisteredNodes) > 0 {
 		klog.V(1).Infof("%d unregistered nodes present", len(unregisteredNodes))
-		removedAny, err := a.removeOldUnregisteredNodes(unregisteredNodes,
+		removedAny, err := a.removeOldUnregisteredNodes(ctx, unregisteredNodes,
 			a.clusterStateRegistry, currentTime, autoscalingCtx.LogRecorder)
 		// There was a problem with removing unregistered nodes. Retry in the next loop.
 		if err != nil {
@@ -463,17 +464,17 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 
 	if !a.clusterStateRegistry.IsClusterHealthy() {
 		klog.Warning("Cluster is not ready for autoscaling")
-		a.scaleDownPlanner.CleanUpUnneededNodes()
+		a.scaleDownPlanner.CleanUpUnneededNodes(ctx)
 		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", "Cluster is unhealthy")
 		return nil
 	}
 
-	a.deleteCreatedNodesWithErrors()
+	a.deleteCreatedNodesWithErrors(ctx)
 
 	// Check if there has been a constant difference between the number of nodes in k8s and
 	// the number of nodes on the cloud provider side.
 	// TODO: andrewskim - add protection for ready AWS nodes.
-	fixedSomething, err := fixNodeGroupSize(autoscalingCtx, a.clusterStateRegistry, currentTime)
+	fixedSomething, err := fixNodeGroupSize(ctx, autoscalingCtx, a.clusterStateRegistry, currentTime)
 	if err != nil {
 		klog.Errorf("Failed to fix node group sizes: %v", err)
 		return caerrors.ToAutoscalerError(caerrors.CloudProviderError, err)
@@ -490,13 +491,13 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	// Treat unknown pods as unschedulable, pod list processor will remove schedulable pods
 	podsBySchedulability.Unschedulable = append(podsBySchedulability.Unschedulable, podsBySchedulability.Unprocessed...)
 	// Upcoming nodes are recently created nodes that haven't registered in the cluster yet, or haven't become ready yet.
-	upcomingCounts, registeredUpcoming := a.clusterStateRegistry.GetUpcomingNodes()
+	upcomingCounts, registeredUpcoming := a.clusterStateRegistry.GetUpcomingNodes(ctx)
 	// For each upcoming node we inject a placeholder node faked to appear ready into the cluster snapshot, so that we can pack unschedulable pods on
 	// them and not trigger another scale-up.
 	// The fake nodes are intentionally not added to the all nodes list, so that they are not considered as candidates for scale-down (which
 	// doesn't make sense as they're not real).
 	templateNodeInfos := a.AutoscalingContext.TemplateNodeInfoRegistry.GetNodeInfos()
-	if _, err := a.addUpcomingNodesToClusterSnapshot(upcomingCounts, templateNodeInfos, "upcoming-%d"); err != nil {
+	if _, err := a.addUpcomingNodesToClusterSnapshot(ctx, upcomingCounts, templateNodeInfos, "upcoming-%d"); err != nil {
 		klog.Errorf("Failed adding upcoming nodes to cluster snapshot: %v", err)
 		return caerrors.ToAutoscalerError(caerrors.InternalError, err)
 	}
@@ -510,7 +511,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	allNodes = subtractNodesByName(allNodes, allRegisteredUpcoming)
 	// Remove the nodes from the snapshot as well so that the state is consistent.
 	for _, notStartedNodeName := range allRegisteredUpcoming {
-		err := a.ClusterSnapshot.RemoveNodeInfo(notStartedNodeName)
+		err := a.ClusterSnapshot.RemoveNodeInfo(ctx, notStartedNodeName)
 		if err != nil {
 			klog.Errorf("Failed to remove NotStarted node %s from cluster snapshot: %v", notStartedNodeName, err)
 			// ErrNodeNotFound shouldn't happen (so it needs to be logged above if it does), but what we care about here is that the
@@ -524,17 +525,17 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	if err != nil {
 		klog.Errorf("Unable to fetch ClusterNode List for Debugging Snapshot, %v", err)
 	} else {
-		a.AutoscalingContext.DebuggingSnapshotter.SetClusterNodes(allNodeInfos)
+		a.AutoscalingContext.DebuggingSnapshotter.SetClusterNodes(ctx, allNodeInfos)
 	}
 
-	unschedulablePodsToHelp, err := a.processors.PodListProcessor.Process(a.AutoscalingContext, podsBySchedulability.Unschedulable)
+	unschedulablePodsToHelp, err := a.processors.PodListProcessor.Process(ctx, a.AutoscalingContext, podsBySchedulability.Unschedulable)
 
 	if err != nil {
 		klog.Warningf("Failed to process unschedulable pods: %v", err)
 	}
 
 	// finally, filter out pods that are too "young" to safely be considered for a scale-up (delay is configurable)
-	unschedulablePodsToHelp = a.filterOutYoungPods(unschedulablePodsToHelp, currentTime)
+	unschedulablePodsToHelp = a.filterOutYoungPods(ctx, unschedulablePodsToHelp, currentTime)
 
 	shouldScaleUp := true
 
@@ -578,16 +579,14 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		}
 
 		if a.AutoscalingContext.AutoscalingOptions.SalvoScaleUp {
-			scaleUpStatus, typedErr = a.runScaleUpSalvo(
-				currentTime,
+			scaleUpStatus, typedErr = a.runScaleUpSalvo(ctx, currentTime,
 				unschedulablePodsToHelp,
 				daemonsets,
 				nodes,
 				templateNodeInfos,
 			)
 		} else {
-			_, scaleUpStatus, typedErr = a.runSingleScaleUp(
-				currentTime,
+			_, scaleUpStatus, typedErr = a.runSingleScaleUp(ctx, currentTime,
 				unschedulablePodsToHelp,
 				daemonsets,
 				nodes,
@@ -602,7 +601,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 
 	if a.ScaleDownEnabled {
-		if typedErr = a.scaleDown(currentTime, allNodes, scaleDownActuationStatus, scaleDownStatus); typedErr != nil {
+		if typedErr = a.scaleDown(ctx, currentTime, allNodes, scaleDownActuationStatus, scaleDownStatus); typedErr != nil {
 			return typedErr
 		}
 	}
@@ -615,9 +614,9 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		}
 
 		scaleUpFn := func() (*status.ScaleUpStatus, caerrors.AutoscalerError) {
-			return a.scaleUpOrchestrator.ScaleUpToNodeGroupMinSize(nodes, templateNodeInfos)
+			return a.scaleUpOrchestrator.ScaleUpToNodeGroupMinSize(ctx, nodes, templateNodeInfos)
 		}
-		_, scaleUpStatus, typedErr = a.instrumentedScaleUp(currentTime, scaleUpFn)
+		_, scaleUpStatus, typedErr = a.instrumentedScaleUp(ctx, currentTime, scaleUpFn)
 	}
 
 	return nil
@@ -626,7 +625,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 // instrumentedScaleUp handles a single ScaleUp orchestrator call with metrics and status reporting.
 // It accepts a generic scaleUpFn closure, allowing it to handle regular scale-ups or scaling up to node group min size.
 func (a *StaticAutoscaler) instrumentedScaleUp(
-	currentTime time.Time,
+	ctx context.Context, currentTime time.Time,
 	scaleUpFn func() (*status.ScaleUpStatus, caerrors.AutoscalerError),
 ) ([]*apiv1.Pod, *status.ScaleUpStatus, caerrors.AutoscalerError) {
 	scaleUpStart := time.Now()
@@ -636,10 +635,10 @@ func (a *StaticAutoscaler) instrumentedScaleUp(
 	// Reference copy is sufficient since processors are not expected to modify the slice elements.
 	unfilteredPodsTriggeredScaleUp := scaleUpStatus.PodsTriggeredScaleUp
 
-	metrics.UpdateDurationFromStart(metrics.ScaleUp, scaleUpStart)
+	metrics.UpdateDurationFromStart(ctx, metrics.ScaleUp, scaleUpStart)
 
 	if a.processors.ScaleUpStatusProcessor != nil {
-		a.processors.ScaleUpStatusProcessor.Process(a.AutoscalingContext, scaleUpStatus)
+		a.processors.ScaleUpStatusProcessor.Process(ctx, a.AutoscalingContext, scaleUpStatus)
 	}
 
 	if typedErr != nil {
@@ -654,20 +653,20 @@ func (a *StaticAutoscaler) instrumentedScaleUp(
 }
 
 func (a *StaticAutoscaler) runSingleScaleUp(
-	currentTime time.Time,
+	ctx context.Context, currentTime time.Time,
 	unschedulablePodsToHelp []*apiv1.Pod,
 	daemonsets []*v1.DaemonSet,
 	nodes []*apiv1.Node,
 	templateNodeInfos map[string]*framework.NodeInfo,
 ) ([]*apiv1.Pod, *status.ScaleUpStatus, caerrors.AutoscalerError) {
 	scaleUpFn := func() (*status.ScaleUpStatus, caerrors.AutoscalerError) {
-		return a.scaleUpOrchestrator.ScaleUp(unschedulablePodsToHelp, nodes, daemonsets, templateNodeInfos, false)
+		return a.scaleUpOrchestrator.ScaleUp(ctx, unschedulablePodsToHelp, nodes, daemonsets, templateNodeInfos, false)
 	}
-	return a.instrumentedScaleUp(currentTime, scaleUpFn)
+	return a.instrumentedScaleUp(ctx, currentTime, scaleUpFn)
 }
 
 func (a *StaticAutoscaler) runScaleUpSalvo(
-	currentTime time.Time,
+	ctx context.Context, currentTime time.Time,
 	unschedulablePodsToHelp []*apiv1.Pod,
 	daemonsets []*v1.DaemonSet,
 	nodes []*apiv1.Node,
@@ -692,7 +691,7 @@ func (a *StaticAutoscaler) runScaleUpSalvo(
 		klog.V(4).Infof("Scale up salvo: iteration %d, pods left: %d", i, len(podsMap))
 		unschedulablePods := slices.Collect(maps.Values(podsMap))
 
-		handledPods, scaleUpStatus, typedErr = a.runSingleScaleUp(currentTime, unschedulablePods, daemonsets, nodes, templateNodeInfos)
+		handledPods, scaleUpStatus, typedErr = a.runSingleScaleUp(ctx, currentTime, unschedulablePods, daemonsets, nodes, templateNodeInfos)
 		if typedErr != nil {
 			klog.Infof("Scale up failed, finishing the scale up salvo: %v", typedErr)
 			break
@@ -720,7 +719,7 @@ func (a *StaticAutoscaler) runScaleUpSalvo(
 			break
 		}
 
-		newNodes, err := a.addLatestScaleUpResultsToClusterSnapshot(i, scaleUpStatus, handledPods, templateNodeInfos)
+		newNodes, err := a.addLatestScaleUpResultsToClusterSnapshot(ctx, i, scaleUpStatus, handledPods, templateNodeInfos)
 		if err != nil {
 			klog.Warningf("Failed to update cluster snapshot after scale up, finishing the scale up salvo: %v", err)
 			break
@@ -731,22 +730,22 @@ func (a *StaticAutoscaler) runScaleUpSalvo(
 	return scaleUpStatus, typedErr
 }
 
-func (a *StaticAutoscaler) updateSoftDeletionTaints(allNodes []*apiv1.Node) {
+func (a *StaticAutoscaler) updateSoftDeletionTaints(ctx context.Context, allNodes []*apiv1.Node) {
 	if a.AutoscalingContext.AutoscalingOptions.MaxBulkSoftTaintCount != 0 {
 		taintableNodes := retrieveNodes(a.scaleDownPlanner.UnneededNodes())
 
 		// Make sure we are only cleaning taints from selected node groups.
-		selectedNodes := filterNodesFromSelectedGroups(a.CloudProvider, allNodes...)
+		selectedNodes := filterNodesFromSelectedGroups(ctx, a.CloudProvider, allNodes...)
 
 		// This is a sanity check to make sure `taintableNodes` only includes
 		// nodes from selected nodes.
 		taintableNodes = intersectNodes(selectedNodes, taintableNodes)
 		untaintableNodes := subtractNodes(selectedNodes, taintableNodes)
-		actuation.UpdateSoftDeletionTaints(a.AutoscalingContext, taintableNodes, untaintableNodes)
+		actuation.UpdateSoftDeletionTaints(ctx, a.AutoscalingContext, taintableNodes, untaintableNodes)
 	}
 }
 
-func (a *StaticAutoscaler) scaleDown(currentTime time.Time, allNodes []*apiv1.Node, scaleDownActuationStatus scaledown.ActuationStatus, scaleDownStatus *scaledownstatus.ScaleDownStatus) caerrors.AutoscalerError {
+func (a *StaticAutoscaler) scaleDown(ctx context.Context, currentTime time.Time, allNodes []*apiv1.Node, scaleDownActuationStatus scaledown.ActuationStatus, scaleDownStatus *scaledownstatus.ScaleDownStatus) caerrors.AutoscalerError {
 	unneededStart := time.Now()
 
 	klog.V(4).Infof("Calculating unneeded nodes")
@@ -778,10 +777,10 @@ func (a *StaticAutoscaler) scaleDown(currentTime time.Time, allNodes []*apiv1.No
 		}
 	}
 
-	typedErr := a.scaleDownPlanner.UpdateClusterState(podDestinations, scaleDownCandidates, scaleDownActuationStatus, currentTime)
+	typedErr := a.scaleDownPlanner.UpdateClusterState(ctx, podDestinations, scaleDownCandidates, scaleDownActuationStatus, currentTime)
 	// Update clusterStateRegistry and metrics regardless of whether ScaleDown was successful or not.
 	unneededNodes := a.scaleDownPlanner.UnneededNodes()
-	a.processors.ScaleDownCandidatesNotifier.Update(unneededNodes, currentTime)
+	a.processors.ScaleDownCandidatesNotifier.Update(ctx, unneededNodes, currentTime)
 	metrics.UpdateUnneededNodesCount(len(unneededNodes))
 	if typedErr != nil {
 		scaleDownStatus.Result = scaledownstatus.ScaleDownError
@@ -789,7 +788,7 @@ func (a *StaticAutoscaler) scaleDown(currentTime time.Time, allNodes []*apiv1.No
 		return typedErr
 	}
 
-	metrics.UpdateDurationFromStart(metrics.FindUnneeded, unneededStart)
+	metrics.UpdateDurationFromStart(ctx, metrics.FindUnneeded, unneededStart)
 
 	scaleDownInCooldown := a.isScaleDownInCooldown(currentTime)
 	klog.V(4).Infof("Scale down status: lastScaleUpTime=%s lastScaleDownDeleteTime=%v "+
@@ -812,31 +811,31 @@ func (a *StaticAutoscaler) scaleDown(currentTime time.Time, allNodes []*apiv1.No
 
 	if scaleDownInCooldown {
 		scaleDownStatus.Result = scaledownstatus.ScaleDownInCooldown
-		a.updateSoftDeletionTaints(allNodes)
+		a.updateSoftDeletionTaints(ctx, allNodes)
 	} else if len(scaleDownCandidates) == 0 {
 		klog.V(4).Infof("Starting scale down: no scale down candidates. skipping...")
 		scaleDownStatus.Result = scaledownstatus.ScaleDownNoCandidates
 		metrics.UpdateLastTime(metrics.ScaleDown, time.Now())
-		a.updateSoftDeletionTaints(allNodes)
+		a.updateSoftDeletionTaints(ctx, allNodes)
 	} else {
 		klog.V(4).Infof("Starting scale down")
 
 		scaleDownStart := time.Now()
 		metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
-		empty, needDrain := a.scaleDownPlanner.NodesToDelete(currentTime)
-		scaleDownResult, scaledDownNodes, typedErr := a.scaleDownActuator.StartDeletion(empty, needDrain)
+		empty, needDrain := a.scaleDownPlanner.NodesToDelete(ctx, currentTime)
+		scaleDownResult, scaledDownNodes, typedErr := a.scaleDownActuator.StartDeletion(ctx, empty, needDrain)
 		scaleDownStatus.Result = scaleDownResult
 		scaleDownStatus.ScaledDownNodes = scaledDownNodes
-		metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
+		metrics.UpdateDurationFromStart(ctx, metrics.ScaleDown, scaleDownStart)
 		metrics.UpdateUnremovableNodesCount(countsByReason(a.scaleDownPlanner.UnremovableNodes()))
 
 		scaleDownStatus.RemovedNodeGroups = removedNodeGroups
 
 		if scaleDownStatus.Result == scaledownstatus.ScaleDownNodeDeleteStarted {
 			a.lastScaleDownDeleteTime = currentTime
-			a.clusterStateRegistry.Recalculate()
+			a.clusterStateRegistry.Recalculate(ctx)
 		}
-		a.updateSoftDeletionTaints(allNodes)
+		a.updateSoftDeletionTaints(ctx, allNodes)
 		if typedErr != nil {
 			klog.Errorf("Failed to scale down: %v", typedErr)
 			a.lastScaleDownFailTime = currentTime
@@ -848,11 +847,11 @@ func (a *StaticAutoscaler) scaleDown(currentTime time.Time, allNodes []*apiv1.No
 
 // addUpcomingNodesToClusterSnapshot generates upcoming node infos based on upcomingCounts and adds them to the ClusterSnapshot.
 func (a *StaticAutoscaler) addUpcomingNodesToClusterSnapshot(
-	upcomingCounts map[string]int,
+	ctx context.Context, upcomingCounts map[string]int,
 	templateNodeInfos map[string]*framework.NodeInfo,
 	suffixFmt string,
 ) ([]*apiv1.Node, error) {
-	upcomingNodeInfosPerNg, err := getUpcomingNodeInfos(upcomingCounts, templateNodeInfos, suffixFmt)
+	upcomingNodeInfosPerNg, err := getUpcomingNodeInfos(ctx, upcomingCounts, templateNodeInfos, suffixFmt)
 	if err != nil {
 		return nil, err
 	}
@@ -888,7 +887,7 @@ func (a *StaticAutoscaler) addUpcomingNodesToClusterSnapshot(
 //   - adds upcoming nodeInfos from the latest scale up to ClusterSnapshot
 //   - schedules the Pods that triggered the scale up on the latest nodeInfos
 //   - returns the new nodes
-func (a *StaticAutoscaler) addLatestScaleUpResultsToClusterSnapshot(idx int, scaleUpStatus *status.ScaleUpStatus, handledPods []*apiv1.Pod, templateNodeInfos map[string]*framework.NodeInfo) ([]*apiv1.Node, error) {
+func (a *StaticAutoscaler) addLatestScaleUpResultsToClusterSnapshot(ctx context.Context, idx int, scaleUpStatus *status.ScaleUpStatus, handledPods []*apiv1.Pod, templateNodeInfos map[string]*framework.NodeInfo) ([]*apiv1.Node, error) {
 	salvoSuffix := fmt.Sprintf("salvo-%d", idx)
 	upcomingCounts := make(map[string]int)
 
@@ -904,13 +903,13 @@ func (a *StaticAutoscaler) addLatestScaleUpResultsToClusterSnapshot(idx int, sca
 		upcomingCounts[suInfo.Group.Id()] += nodesToInject
 	}
 
-	newNodes, err := a.addUpcomingNodesToClusterSnapshot(upcomingCounts, templateNodeInfos, "%d-"+salvoSuffix)
+	newNodes, err := a.addUpcomingNodesToClusterSnapshot(ctx, upcomingCounts, templateNodeInfos, "%d-"+salvoSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get upcoming node infos for salvo %d: %v", idx, err)
 	}
 
 	for _, pod := range handledPods {
-		nodeName, err := a.ClusterSnapshot.SchedulePodOnAnyNodeMatching(pod, clustersnapshot.SchedulingOptions{
+		nodeName, err := a.ClusterSnapshot.SchedulePodOnAnyNodeMatching(ctx, pod, clustersnapshot.SchedulingOptions{
 			IsNodeAcceptable: func(nodeInfo *framework.NodeInfo) bool {
 				return strings.HasSuffix(nodeInfo.Node().Name, salvoSuffix)
 			},
@@ -943,7 +942,7 @@ func (a *StaticAutoscaler) isScaleDownInCooldown(currentTime time.Time) bool {
 // Sets the target size of node groups to the current number of nodes in them
 // if the difference was constant for a prolonged time. Returns true if managed
 // to fix something.
-func fixNodeGroupSize(autoscalingCtx *ca_context.AutoscalingContext, clusterStateRegistry *clusterstate.ClusterStateRegistry, currentTime time.Time) (bool, error) {
+func fixNodeGroupSize(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, clusterStateRegistry *clusterstate.ClusterStateRegistry, currentTime time.Time) (bool, error) {
 	fixed := false
 	for _, nodeGroup := range autoscalingCtx.CloudProvider.NodeGroups() {
 		incorrectSize := clusterStateRegistry.GetIncorrectNodeGroupSize(nodeGroup.Id())
@@ -973,10 +972,10 @@ func fixNodeGroupSize(autoscalingCtx *ca_context.AutoscalingContext, clusterStat
 
 // removeOldUnregisteredNodes removes unregistered nodes if needed. Returns true
 // if anything was removed and error if such occurred.
-func (a *StaticAutoscaler) removeOldUnregisteredNodes(allUnregisteredNodes []clusterstate.UnregisteredNode,
+func (a *StaticAutoscaler) removeOldUnregisteredNodes(ctx context.Context, allUnregisteredNodes []clusterstate.UnregisteredNode,
 	csr *clusterstate.ClusterStateRegistry, currentTime time.Time, logRecorder *utils.LogEventRecorder) (bool, error) {
 
-	unregisteredNodesToRemove, err := a.oldUnregisteredNodes(allUnregisteredNodes, csr, currentTime)
+	unregisteredNodesToRemove, err := a.oldUnregisteredNodes(ctx, allUnregisteredNodes, csr, currentTime)
 	if err != nil {
 		return false, err
 	}
@@ -1023,7 +1022,7 @@ func (a *StaticAutoscaler) removeOldUnregisteredNodes(allUnregisteredNodes []clu
 		} else {
 			err = nodeGroup.DeleteNodes(nodesToDelete)
 		}
-		csr.InvalidateNodeInstancesCacheEntry(nodeGroup)
+		csr.InvalidateNodeInstancesCacheEntry(ctx, nodeGroup)
 		if err != nil {
 			klog.Warningf("Failed to remove %v unregistered nodes from node group %s: %v", len(nodesToDelete), nodeGroupId, err)
 			for _, node := range nodesToDelete {
@@ -1043,7 +1042,7 @@ func (a *StaticAutoscaler) removeOldUnregisteredNodes(allUnregisteredNodes []clu
 }
 
 // oldUnregisteredNodes returns old unregistered nodes grouped by their node group id.
-func (a *StaticAutoscaler) oldUnregisteredNodes(allUnregisteredNodes []clusterstate.UnregisteredNode, csr *clusterstate.ClusterStateRegistry, currentTime time.Time) (map[string][]clusterstate.UnregisteredNode, error) {
+func (a *StaticAutoscaler) oldUnregisteredNodes(ctx context.Context, allUnregisteredNodes []clusterstate.UnregisteredNode, csr *clusterstate.ClusterStateRegistry, currentTime time.Time) (map[string][]clusterstate.UnregisteredNode, error) {
 	nodesByNodeGroupId := make(map[string][]clusterstate.UnregisteredNode)
 	for _, unregisteredNode := range allUnregisteredNodes {
 		nodeGroup, err := a.CloudProvider.NodeGroupForNode(unregisteredNode.Node)
@@ -1078,7 +1077,7 @@ func toNodes(unregisteredNodes []clusterstate.UnregisteredNode) []*apiv1.Node {
 	return nodes
 }
 
-func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() {
+func (a *StaticAutoscaler) deleteCreatedNodesWithErrors(ctx context.Context) {
 	// We always schedule deleting of incoming errornous nodes
 	// TODO[lukaszos] Consider adding logic to not retry delete every loop iteration
 	nodeGroups := a.nodeGroupsById()
@@ -1108,13 +1107,13 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() {
 			klog.Warningf("Error while trying to delete nodes from %v: %v", nodeGroupId, err)
 		} else if len(nodesToDelete) > 0 {
 			deletedAny = true
-			a.clusterStateRegistry.InvalidateNodeInstancesCacheEntry(nodeGroup)
+			a.clusterStateRegistry.InvalidateNodeInstancesCacheEntry(ctx, nodeGroup)
 		}
 	}
 
 	if deletedAny {
 		klog.V(0).Infof("Some nodes that failed to create were removed, recalculating cluster state.")
-		a.clusterStateRegistry.Recalculate()
+		a.clusterStateRegistry.Recalculate(ctx)
 	}
 }
 
@@ -1167,7 +1166,7 @@ func (a *StaticAutoscaler) nodeGroupsById() map[string]cloudprovider.NodeGroup {
 
 // Don't consider pods newer than newPodScaleUpDelay or annotated podScaleUpDelay
 // seconds old as unschedulable.
-func (a *StaticAutoscaler) filterOutYoungPods(allUnschedulablePods []*apiv1.Pod, currentTime time.Time) []*apiv1.Pod {
+func (a *StaticAutoscaler) filterOutYoungPods(ctx context.Context, allUnschedulablePods []*apiv1.Pod, currentTime time.Time) []*apiv1.Pod {
 	var oldUnschedulablePods []*apiv1.Pod
 	newPodScaleUpDelay := a.AutoscalingOptions.NewPodScaleUpDelay
 	for _, pod := range allUnschedulablePods {
@@ -1204,14 +1203,16 @@ func (a *StaticAutoscaler) ExitCleanUp() {
 	if !a.AutoscalingContext.WriteStatusConfigMap {
 		return
 	}
-	utils.DeleteStatusConfigMap(a.AutoscalingContext.ClientSet, a.AutoscalingContext.ConfigNamespace, a.AutoscalingContext.StatusConfigMapName)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	utils.DeleteStatusConfigMap(ctx, a.AutoscalingContext.ClientSet, a.AutoscalingContext.ConfigNamespace, a.AutoscalingContext.StatusConfigMapName)
 
 	a.CloudProvider.Cleanup()
 
 	a.clusterStateRegistry.Stop()
 }
 
-func (a *StaticAutoscaler) obtainNodeLists(draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node, caerrors.AutoscalerError) {
+func (a *StaticAutoscaler) obtainNodeLists(ctx context.Context, draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node, caerrors.AutoscalerError) {
 	allNodes, err := a.AllNodeLister().List()
 	if err != nil {
 		klog.Errorf("Failed to list all nodes: %v", err)
@@ -1229,12 +1230,12 @@ func (a *StaticAutoscaler) obtainNodeLists(draSnapshot *drasnapshot.Snapshot, cs
 	// Treat those nodes as unready until GPU actually becomes available and let
 	// our normal handling for booting up nodes deal with this.
 	// TODO: Remove this call when we handle dynamically provisioned resources.
-	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes, draSnapshot, csiSnapshot)
-	allNodes, readyNodes = taints.FilterOutNodesWithStartupTaints(a.taintConfig, allNodes, readyNodes)
+	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(ctx, a.AutoscalingContext, allNodes, readyNodes, draSnapshot, csiSnapshot)
+	allNodes, readyNodes = taints.FilterOutNodesWithStartupTaints(ctx, a.taintConfig, allNodes, readyNodes)
 	return allNodes, readyNodes, nil
 }
 
-func filterNodesFromSelectedGroups(cp cloudprovider.CloudProvider, nodes ...*apiv1.Node) []*apiv1.Node {
+func filterNodesFromSelectedGroups(ctx context.Context, cp cloudprovider.CloudProvider, nodes ...*apiv1.Node) []*apiv1.Node {
 	filtered := make([]*apiv1.Node, 0, len(nodes))
 	for _, n := range nodes {
 		if ng, err := cp.NodeGroupForNode(n); err != nil {
@@ -1246,11 +1247,11 @@ func filterNodesFromSelectedGroups(cp cloudprovider.CloudProvider, nodes ...*api
 	return filtered
 }
 
-func (a *StaticAutoscaler) updateClusterState(allNodes []*apiv1.Node, currentTime time.Time) caerrors.AutoscalerError {
-	err := a.clusterStateRegistry.UpdateNodes(allNodes, currentTime)
+func (a *StaticAutoscaler) updateClusterState(ctx context.Context, allNodes []*apiv1.Node, currentTime time.Time) caerrors.AutoscalerError {
+	err := a.clusterStateRegistry.UpdateNodes(ctx, allNodes, currentTime)
 	if err != nil {
 		klog.Errorf("Failed to update node registry: %v", err)
-		a.scaleDownPlanner.CleanUpUnneededNodes()
+		a.scaleDownPlanner.CleanUpUnneededNodes(ctx)
 		return caerrors.ToAutoscalerError(caerrors.CloudProviderError, err)
 	}
 	core_utils.UpdateClusterStateMetrics(a.clusterStateRegistry)
@@ -1273,7 +1274,7 @@ func allPodsAreNew(pods []*apiv1.Pod, currentTime time.Time) bool {
 	return found && oldest.Add(unschedulablePodWithGpuTimeBuffer).After(currentTime)
 }
 
-func getUpcomingNodeInfos(upcomingCounts map[string]int, nodeInfos map[string]*framework.NodeInfo, suffixFmt string) (map[string][]*framework.NodeInfo, error) {
+func getUpcomingNodeInfos(ctx context.Context, upcomingCounts map[string]int, nodeInfos map[string]*framework.NodeInfo, suffixFmt string) (map[string][]*framework.NodeInfo, error) {
 	upcomingNodes := make(map[string][]*framework.NodeInfo)
 	for nodeGroup, numberOfNodes := range upcomingCounts {
 		nodeTemplate, found := nodeInfos[nodeGroup]
@@ -1287,7 +1288,7 @@ func getUpcomingNodeInfos(upcomingCounts map[string]int, nodeInfos map[string]*f
 			// Ensure new nodes have different names because nodeName
 			// will be used as a map key. Also deep copy pods (daemonsets &
 			// any pods added by cloud provider on template).
-			freshNodeInfo, err := simulator.SanitizedNodeInfo(nodeTemplate, fmt.Sprintf(suffixFmt, i))
+			freshNodeInfo, err := simulator.SanitizedNodeInfo(ctx, nodeTemplate, fmt.Sprintf(suffixFmt, i))
 			if err != nil {
 				return nil, err
 			}
@@ -1385,7 +1386,7 @@ func retrieveNodes(candidates []*scaledown.UnneededNode) []*apiv1.Node {
 	return nodes
 }
 
-func listPods(podLister kube_util.PodLister, bypassedSchedulers, allowedSchedulers map[string]bool) (podsBySchedulability kube_util.PodsBySchedulability, err error) {
+func listPods(ctx context.Context, podLister kube_util.PodLister, bypassedSchedulers, allowedSchedulers map[string]bool) (podsBySchedulability kube_util.PodsBySchedulability, err error) {
 	pods, err := podLister.List()
 	if err != nil {
 		klog.Errorf("Failed to list pods: %v", err)

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -256,13 +256,14 @@ func (a *StaticAutoscaler) Start() error {
 // cleanUpIfRequired removes ToBeDeleted taints added by a previous run of CA
 // the taints are removed only once per runtime
 func (a *StaticAutoscaler) cleanUpIfRequired(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	if a.initialized {
 		return
 	}
 
 	// CA can die at any time. Removing taints that might have been left from the previous run.
 	if allNodes, err := a.AllNodeLister().List(); err != nil {
-		klog.Errorf("Failed to list ready nodes, not cleaning up taints: %v", err)
+		logger.Error(err, "Failed to list ready nodes, not cleaning up taints")
 	} else {
 		// Make sure we are only cleaning taints from selected node groups.
 		selectedNodes := filterNodesFromSelectedGroups(ctx, a.CloudProvider, allNodes...)
@@ -278,11 +279,12 @@ func (a *StaticAutoscaler) cleanUpIfRequired(ctx context.Context) {
 }
 
 func (a *StaticAutoscaler) initializeRemainingPdbTracker(ctx context.Context) caerrors.AutoscalerError {
+	logger := klog.FromContext(ctx)
 	a.RemainingPdbTracker.Clear()
 
 	pdbs, err := a.PodDisruptionBudgetLister().List()
 	if err != nil {
-		klog.Errorf("Failed to list pod disruption budgets: %v", err)
+		logger.Error(err, "Failed to list pod disruption budgets")
 		return caerrors.NewAutoscalerError(caerrors.ApiCallError, err.Error())
 	}
 	err = a.RemainingPdbTracker.SetPdbs(pdbs)
@@ -295,6 +297,7 @@ func (a *StaticAutoscaler) initializeRemainingPdbTracker(ctx context.Context) ca
 // RunOnce iterates over node groups and scales them up/down if necessary
 func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerError {
 	ctx := context.Background()
+	logger := klog.FromContext(ctx)
 	a.cleanUpIfRequired(ctx)
 	a.processorCallbacks.reset()
 	a.DebuggingSnapshotter.StartDataCollection(ctx)
@@ -305,8 +308,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 
 	podLister := a.AllPodLister()
 	autoscalingCtx := a.AutoscalingContext
-
-	klog.V(4).Info("Starting main loop")
+	logger.V(4).Info("Starting main loop")
 
 	stateUpdateStart := time.Now()
 
@@ -331,7 +333,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	// Get nodes and pods currently living on cluster
 	allNodes, readyNodes, typedErr := a.obtainNodeLists(ctx, draSnapshot, csiSnapshot)
 	if typedErr != nil {
-		klog.Errorf("Failed to get node list: %v", typedErr)
+		logger.Error(typedErr, "Failed to get node list")
 		return typedErr
 	}
 
@@ -350,7 +352,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 
 	daemonsets, err := a.ListerRegistry.DaemonSetLister().List(labels.Everything())
 	if err != nil {
-		klog.Errorf("Failed to get daemonset list: %v", err)
+		logger.Error(err, "Failed to get daemonset list")
 		return caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
 	}
 
@@ -365,7 +367,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 	metrics.UpdateDurationFromStart(ctx, metrics.CloudProviderRefresh, refreshStart)
 	if err != nil {
-		klog.Errorf("Failed to refresh cloud provider config: %v", err)
+		logger.Error(err, "Failed to refresh cloud provider config")
 		return caerrors.ToAutoscalerError(caerrors.CloudProviderError, err)
 	}
 	a.loopStartNotifier.Refresh(ctx)
@@ -397,14 +399,14 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 
 	if autoscalerError := a.AutoscalingContext.TemplateNodeInfoRegistry.Recompute(ctx, a.AutoscalingContext, allNodes, daemonsets, a.taintConfig, currentTime); autoscalerError != nil {
-		klog.Errorf("Failed to recompute template node infos: %v", autoscalerError)
+		logger.Error(autoscalerError, "Failed to recompute template node infos")
 		return autoscalerError.AddPrefix("failed to recompute template node infos: ")
 	}
 
 	a.DebuggingSnapshotter.SetTemplateNodes(ctx, autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos())
 
 	if typedErr := a.updateClusterState(ctx, allNodes, currentTime); typedErr != nil {
-		klog.Errorf("Failed to update cluster state: %v", typedErr)
+		logger.Error(typedErr, "Failed to update cluster state")
 		return typedErr
 	}
 	metrics.UpdateDurationFromStart(ctx, metrics.UpdateState, stateUpdateStart)
@@ -441,7 +443,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		if a.processors.AutoscalingStatusProcessor != nil {
 			err := a.processors.AutoscalingStatusProcessor.Process(loggingContext, a.AutoscalingContext, a.clusterStateRegistry, currentTime)
 			if err != nil {
-				klog.Errorf("AutoscalingStatusProcessor error: %v.", err)
+				logger.Error(err, "AutoscalingStatusProcessor.")
 			}
 		}
 	}()
@@ -450,20 +452,20 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	// master.
 	unregisteredNodes := a.clusterStateRegistry.GetUnregisteredNodes()
 	if len(unregisteredNodes) > 0 {
-		klog.V(1).Infof("%d unregistered nodes present", len(unregisteredNodes))
+		logger.V(1).Info("unregistered nodes present", "unregisteredNodesCount", len(unregisteredNodes))
 		removedAny, err := a.removeOldUnregisteredNodes(ctx, unregisteredNodes,
 			a.clusterStateRegistry, currentTime, autoscalingCtx.LogRecorder)
 		// There was a problem with removing unregistered nodes. Retry in the next loop.
 		if err != nil {
-			klog.Warningf("Failed to remove unregistered nodes: %v", err)
+			logger.Info("Failed to remove unregistered nodes", "err", err)
 		}
 		if removedAny {
-			klog.V(0).Infof("Some unregistered nodes were removed")
+			logger.V(0).Info("Some unregistered nodes were removed")
 		}
 	}
 
 	if !a.clusterStateRegistry.IsClusterHealthy() {
-		klog.Warning("Cluster is not ready for autoscaling")
+		logger.Info("Cluster is not ready for autoscaling")
 		a.scaleDownPlanner.CleanUpUnneededNodes(ctx)
 		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", "Cluster is unhealthy")
 		return nil
@@ -476,11 +478,11 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	// TODO: andrewskim - add protection for ready AWS nodes.
 	fixedSomething, err := fixNodeGroupSize(ctx, autoscalingCtx, a.clusterStateRegistry, currentTime)
 	if err != nil {
-		klog.Errorf("Failed to fix node group sizes: %v", err)
+		logger.Error(err, "Failed to fix node group sizes")
 		return caerrors.ToAutoscalerError(caerrors.CloudProviderError, err)
 	}
 	if fixedSomething {
-		klog.V(0).Infof("Some node group target size was fixed, skipping the iteration")
+		logger.V(0).Info("Some node group target size was fixed, skipping the iteration")
 		return nil
 	}
 
@@ -498,7 +500,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	// doesn't make sense as they're not real).
 	templateNodeInfos := a.AutoscalingContext.TemplateNodeInfoRegistry.GetNodeInfos()
 	if _, err := a.addUpcomingNodesToClusterSnapshot(ctx, upcomingCounts, templateNodeInfos, "upcoming-%d"); err != nil {
-		klog.Errorf("Failed adding upcoming nodes to cluster snapshot: %v", err)
+		logger.Error(err, "Failed adding upcoming nodes to cluster snapshot")
 		return caerrors.ToAutoscalerError(caerrors.InternalError, err)
 	}
 	// Some upcoming nodes can already be registered in the cluster, but not yet ready - we still inject replacements for them above. The actual registered nodes
@@ -513,7 +515,8 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	for _, notStartedNodeName := range allRegisteredUpcoming {
 		err := a.ClusterSnapshot.RemoveNodeInfo(ctx, notStartedNodeName)
 		if err != nil {
-			klog.Errorf("Failed to remove NotStarted node %s from cluster snapshot: %v", notStartedNodeName, err)
+			logger.Error(err, "Failed to remove NotStarted node from cluster snapshot", "notStartedNode", notStartedNodeName)
+
 			// ErrNodeNotFound shouldn't happen (so it needs to be logged above if it does), but what we care about here is that the
 			// node is not in the snapshot - so we don't have to error out in that case.
 			if !errors.Is(err, clustersnapshot.ErrNodeNotFound) {
@@ -523,7 +526,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	}
 	allNodeInfos, err := a.ClusterSnapshot.ListNodeInfos()
 	if err != nil {
-		klog.Errorf("Unable to fetch ClusterNode List for Debugging Snapshot, %v", err)
+		logger.Error(err, "Unable to fetch ClusterNode List for Debugging Snapshot")
 	} else {
 		a.AutoscalingContext.DebuggingSnapshotter.SetClusterNodes(ctx, allNodeInfos)
 	}
@@ -531,7 +534,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 	unschedulablePodsToHelp, err := a.processors.PodListProcessor.Process(ctx, a.AutoscalingContext, podsBySchedulability.Unschedulable)
 
 	if err != nil {
-		klog.Warningf("Failed to process unschedulable pods: %v", err)
+		logger.Info("Failed to process unschedulable pods", "err", err)
 	}
 
 	// finally, filter out pods that are too "young" to safely be considered for a scale-up (delay is configurable)
@@ -541,11 +544,11 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 
 	if len(unschedulablePodsToHelp) == 0 {
 		scaleUpStatus.Result = status.ScaleUpNotNeeded
-		klog.V(1).Info("No unschedulable pods")
+		logger.V(1).Info("No unschedulable pods")
 		shouldScaleUp = false
 	} else if a.MaxNodesTotal > 0 && len(readyNodes) >= a.MaxNodesTotal {
 		scaleUpStatus.Result = status.ScaleUpLimitedByMaxNodesTotal
-		klog.Warningf("Max total nodes in cluster reached: %v. Current number of ready nodes: %v", a.MaxNodesTotal, len(readyNodes))
+		logger.Info("Max total nodes in cluster reached. Current number of ready nodes", "maxNodesTotal", a.MaxNodesTotal, "readyNodesCount", len(readyNodes))
 		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "MaxNodesTotalReached",
 			"Max total nodes in cluster reached: %v", autoscalingCtx.MaxNodesTotal)
 		shouldScaleUp = false
@@ -567,7 +570,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) caerrors.AutoscalerErr
 		// by bypassing scheduler marking pods as unschedulable.
 		a.processorCallbacks.DisableScaleDownForLoop()
 		scaleUpStatus.Result = status.ScaleUpInCooldown
-		klog.V(1).Info("Unschedulable pods are very new, waiting one iteration for more")
+		logger.V(1).Info("Unschedulable pods are very new, waiting one iteration for more")
 		shouldScaleUp = false
 	}
 
@@ -628,6 +631,7 @@ func (a *StaticAutoscaler) instrumentedScaleUp(
 	ctx context.Context, currentTime time.Time,
 	scaleUpFn func() (*status.ScaleUpStatus, caerrors.AutoscalerError),
 ) ([]*apiv1.Pod, *status.ScaleUpStatus, caerrors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	scaleUpStart := time.Now()
 	metrics.UpdateLastTime(metrics.ScaleUp, scaleUpStart)
 
@@ -642,7 +646,7 @@ func (a *StaticAutoscaler) instrumentedScaleUp(
 	}
 
 	if typedErr != nil {
-		klog.Errorf("Failed to scale up: %v", typedErr)
+		logger.Error(typedErr, "Failed to scale up")
 		return unfilteredPodsTriggeredScaleUp, scaleUpStatus, typedErr
 	}
 	if scaleUpStatus.Result == status.ScaleUpSuccessful {
@@ -672,6 +676,7 @@ func (a *StaticAutoscaler) runScaleUpSalvo(
 	nodes []*apiv1.Node,
 	templateNodeInfos map[string]*framework.NodeInfo,
 ) (*status.ScaleUpStatus, caerrors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	var scaleUpStatus *status.ScaleUpStatus
 	var typedErr caerrors.AutoscalerError
 	var handledPods []*apiv1.Pod
@@ -684,24 +689,24 @@ func (a *StaticAutoscaler) runScaleUpSalvo(
 	budget := a.AutoscalingContext.AutoscalingOptions.SalvoScaleUpBudget
 	salvoCtx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
-
-	klog.Infof("Starting scale up salvo: %d pods to help, budget: %v", len(podsMap), budget)
+	logger.Info("Starting scale up salvo: pods to help, budget", "podsMapCount", len(podsMap), "budget", budget)
 	i := 0
 	for ; ; i++ {
-		klog.V(4).Infof("Scale up salvo: iteration %d, pods left: %d", i, len(podsMap))
+		logger.V(4).Info("Scale up salvo: iteration, pods left", "i", i, "podsMapCount", len(podsMap))
 		unschedulablePods := slices.Collect(maps.Values(podsMap))
 
 		handledPods, scaleUpStatus, typedErr = a.runSingleScaleUp(ctx, currentTime, unschedulablePods, daemonsets, nodes, templateNodeInfos)
 		if typedErr != nil {
-			klog.Infof("Scale up failed, finishing the scale up salvo: %v", typedErr)
+			logger.Info("Scale up failed, finishing the scale up salvo", "err", typedErr)
 			break
 		}
 		if !scaleUpStatus.WasSuccessful() {
-			klog.Infof("Scale up not successful: %v, finishing the scale up salvo", scaleUpStatus.Result)
+			logger.Info("Scale up not successful, finishing the scale up salvo", "result", scaleUpStatus.Result)
 			break
 		}
 		if len(handledPods) == 0 {
-			klog.Infof("Empty unfilteredPodsTriggeredScaleUp list - cannot update cluster snapshot, finishing the scale up salvo")
+			logger.Info("Empty unfilteredPodsTriggeredScaleUp list - cannot update cluster snapshot, finishing the scale up salvo")
+
 			break
 		}
 
@@ -710,23 +715,25 @@ func (a *StaticAutoscaler) runScaleUpSalvo(
 		}
 
 		if len(podsMap) == 0 {
-			klog.Infof("All unschedulable pods have been helped, finishing the scale up salvo")
+			logger.Info("All unschedulable pods have been helped, finishing the scale up salvo")
+
 			break
 		}
 
 		if err := salvoCtx.Err(); err != nil {
-			klog.Infof("Scale up budget of %v exhausted, finishing the scale up salvo", budget)
+			logger.Info("Scale up budget exhausted, finishing the scale up salvo", "budget", budget, "err", err)
+
 			break
 		}
 
 		newNodes, err := a.addLatestScaleUpResultsToClusterSnapshot(ctx, i, scaleUpStatus, handledPods, templateNodeInfos)
 		if err != nil {
-			klog.Warningf("Failed to update cluster snapshot after scale up, finishing the scale up salvo: %v", err)
+			logger.Info("Failed to update cluster snapshot after scale up, finishing the scale up salvo", "err", err)
 			break
 		}
 		nodes = append(nodes, newNodes...)
 	}
-	klog.Infof("Finished scale up salvo after %d iterations, unschedulable pods left: %d", i, len(podsMap))
+	logger.Info("Finished scale up salvo after iterations, unschedulable pods left", "i", i, "podsMapCount", len(podsMap))
 	return scaleUpStatus, typedErr
 }
 
@@ -746,9 +753,9 @@ func (a *StaticAutoscaler) updateSoftDeletionTaints(ctx context.Context, allNode
 }
 
 func (a *StaticAutoscaler) scaleDown(ctx context.Context, currentTime time.Time, allNodes []*apiv1.Node, scaleDownActuationStatus scaledown.ActuationStatus, scaleDownStatus *scaledownstatus.ScaleDownStatus) caerrors.AutoscalerError {
+	logger := klog.FromContext(ctx)
 	unneededStart := time.Now()
-
-	klog.V(4).Infof("Calculating unneeded nodes")
+	logger.V(4).Info("Calculating unneeded nodes")
 
 	var scaleDownCandidates []*apiv1.Node
 	var podDestinations []*apiv1.Node
@@ -767,12 +774,12 @@ func (a *StaticAutoscaler) scaleDown(ctx context.Context, currentTime time.Time,
 		scaleDownCandidates, err = a.processors.ScaleDownNodeProcessor.GetScaleDownCandidates(
 			a.AutoscalingContext, allNodes)
 		if err != nil {
-			klog.Error(err)
+			logger.Error(err, "")
 			return err
 		}
 		podDestinations, err = a.processors.ScaleDownNodeProcessor.GetPodDestinationCandidates(a.AutoscalingContext, allNodes)
 		if err != nil {
-			klog.Error(err)
+			logger.Error(err, "")
 			return err
 		}
 	}
@@ -784,17 +791,14 @@ func (a *StaticAutoscaler) scaleDown(ctx context.Context, currentTime time.Time,
 	metrics.UpdateUnneededNodesCount(len(unneededNodes))
 	if typedErr != nil {
 		scaleDownStatus.Result = scaledownstatus.ScaleDownError
-		klog.Errorf("Failed to scale down: %v", typedErr)
+		logger.Error(typedErr, "Failed to scale down")
 		return typedErr
 	}
 
 	metrics.UpdateDurationFromStart(ctx, metrics.FindUnneeded, unneededStart)
 
 	scaleDownInCooldown := a.isScaleDownInCooldown(currentTime)
-	klog.V(4).Infof("Scale down status: lastScaleUpTime=%s lastScaleDownDeleteTime=%v "+
-		"lastScaleDownFailTime=%s scaleDownForbidden=%v scaleDownInCooldown=%v",
-		a.lastScaleUpTime, a.lastScaleDownDeleteTime, a.lastScaleDownFailTime,
-		a.processorCallbacks.disableScaleDownForLoop, scaleDownInCooldown)
+	logger.V(4).Info("Scale down status", "lastScaleUpTime", a.lastScaleUpTime, "lastScaleDownDeleteTime", a.lastScaleDownDeleteTime, "lastScaleDownFailTime", a.lastScaleDownFailTime, "disableScaleDownForLoop", a.processorCallbacks.disableScaleDownForLoop, "scaleDownInCooldown", scaleDownInCooldown)
 	metrics.UpdateScaleDownInCooldown(scaleDownInCooldown)
 	// We want to delete unneeded Node Groups only if here is no current delete
 	// in progress.
@@ -804,7 +808,7 @@ func (a *StaticAutoscaler) scaleDown(ctx context.Context, currentTime time.Time,
 		var err error
 		removedNodeGroups, err = a.processors.NodeGroupManager.RemoveUnneededNodeGroups(a.AutoscalingContext)
 		if err != nil {
-			klog.Errorf("Error while removing unneeded node groups: %v", err)
+			logger.Error(err, "Error while removing unneeded node groups")
 		}
 		scaleDownStatus.RemovedNodeGroups = removedNodeGroups
 	}
@@ -813,12 +817,12 @@ func (a *StaticAutoscaler) scaleDown(ctx context.Context, currentTime time.Time,
 		scaleDownStatus.Result = scaledownstatus.ScaleDownInCooldown
 		a.updateSoftDeletionTaints(ctx, allNodes)
 	} else if len(scaleDownCandidates) == 0 {
-		klog.V(4).Infof("Starting scale down: no scale down candidates. skipping...")
+		logger.V(4).Info("Starting scale down: no scale down candidates. skipping...")
 		scaleDownStatus.Result = scaledownstatus.ScaleDownNoCandidates
 		metrics.UpdateLastTime(metrics.ScaleDown, time.Now())
 		a.updateSoftDeletionTaints(ctx, allNodes)
 	} else {
-		klog.V(4).Infof("Starting scale down")
+		logger.V(4).Info("Starting scale down")
 
 		scaleDownStart := time.Now()
 		metrics.UpdateLastTime(metrics.ScaleDown, scaleDownStart)
@@ -837,7 +841,7 @@ func (a *StaticAutoscaler) scaleDown(ctx context.Context, currentTime time.Time,
 		}
 		a.updateSoftDeletionTaints(ctx, allNodes)
 		if typedErr != nil {
-			klog.Errorf("Failed to scale down: %v", typedErr)
+			logger.Error(typedErr, "Failed to scale down")
 			a.lastScaleDownFailTime = currentTime
 			return typedErr
 		}
@@ -851,6 +855,7 @@ func (a *StaticAutoscaler) addUpcomingNodesToClusterSnapshot(
 	templateNodeInfos map[string]*framework.NodeInfo,
 	suffixFmt string,
 ) ([]*apiv1.Node, error) {
+	logger := klog.FromContext(ctx)
 	upcomingNodeInfosPerNg, err := getUpcomingNodeInfos(ctx, upcomingCounts, templateNodeInfos, suffixFmt)
 	if err != nil {
 		return nil, err
@@ -878,7 +883,7 @@ func (a *StaticAutoscaler) addUpcomingNodesToClusterSnapshot(
 		}
 	}
 	if len(upcomingNodeGroups) > 0 {
-		klog.Infof("Injecting %d upcoming node groups with %d upcoming nodes: %v", len(upcomingNodeGroups), upcomingNodesFromUpcomingNodeGroups, upcomingNodeGroups)
+		logger.Info("Injecting upcoming node groups upcoming nodes", "upcomingNodeGroupsCount", len(upcomingNodeGroups), "upcomingNodesFromUpcomingNodeGroups", upcomingNodesFromUpcomingNodeGroups, "upcomingNodeGroups", upcomingNodeGroups)
 	}
 	return newNodes, nil
 }
@@ -888,6 +893,7 @@ func (a *StaticAutoscaler) addUpcomingNodesToClusterSnapshot(
 //   - schedules the Pods that triggered the scale up on the latest nodeInfos
 //   - returns the new nodes
 func (a *StaticAutoscaler) addLatestScaleUpResultsToClusterSnapshot(ctx context.Context, idx int, scaleUpStatus *status.ScaleUpStatus, handledPods []*apiv1.Pod, templateNodeInfos map[string]*framework.NodeInfo) ([]*apiv1.Node, error) {
+	logger := klog.FromContext(ctx)
 	salvoSuffix := fmt.Sprintf("salvo-%d", idx)
 	upcomingCounts := make(map[string]int)
 
@@ -921,7 +927,7 @@ func (a *StaticAutoscaler) addLatestScaleUpResultsToClusterSnapshot(ctx context.
 			}
 			return nil, fmt.Errorf("Failed cluster snapshot update: couldn't schedule triggering pod %s on any of the nodes from scaled up node group(s) %v: %v", pod.Name, nodeGroupIds, err)
 		}
-		klog.V(5).Infof("Updated cluster snapshot: scheduled pod %s on node %s", pod.Name, nodeName)
+		logger.V(5).Info("Updated cluster snapshot: scheduled pod on node", "pod", pod.Name, "node", nodeName)
 	}
 
 	return newNodes, nil
@@ -943,6 +949,7 @@ func (a *StaticAutoscaler) isScaleDownInCooldown(currentTime time.Time) bool {
 // if the difference was constant for a prolonged time. Returns true if managed
 // to fix something.
 func fixNodeGroupSize(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, clusterStateRegistry *clusterstate.ClusterStateRegistry, currentTime time.Time) (bool, error) {
+	logger := klog.FromContext(ctx)
 	fixed := false
 	for _, nodeGroup := range autoscalingCtx.CloudProvider.NodeGroups() {
 		incorrectSize := clusterStateRegistry.GetIncorrectNodeGroupSize(nodeGroup.Id())
@@ -956,10 +963,7 @@ func fixNodeGroupSize(ctx context.Context, autoscalingCtx *ca_context.Autoscalin
 		if incorrectSize.FirstObserved.Add(maxNodeProvisionTime).Before(currentTime) {
 			delta := incorrectSize.CurrentSize - incorrectSize.ExpectedSize
 			if delta < 0 {
-				klog.V(0).Infof("Decreasing size of %s, expected=%d current=%d delta=%d", nodeGroup.Id(),
-					incorrectSize.ExpectedSize,
-					incorrectSize.CurrentSize,
-					delta)
+				logger.V(0).Info("Decreasing size", "nodeGroupId", nodeGroup.Id(), "expectedSize", incorrectSize.ExpectedSize, "currentSize", incorrectSize.CurrentSize, "delta", delta)
 				if err := nodeGroup.DecreaseTargetSize(delta); err != nil {
 					return fixed, fmt.Errorf("failed to decrease %s: %v", nodeGroup.Id(), err)
 				}
@@ -975,6 +979,7 @@ func fixNodeGroupSize(ctx context.Context, autoscalingCtx *ca_context.Autoscalin
 func (a *StaticAutoscaler) removeOldUnregisteredNodes(ctx context.Context, allUnregisteredNodes []clusterstate.UnregisteredNode,
 	csr *clusterstate.ClusterStateRegistry, currentTime time.Time, logRecorder *utils.LogEventRecorder) (bool, error) {
 
+	logger := klog.FromContext(ctx)
 	unregisteredNodesToRemove, err := a.oldUnregisteredNodes(ctx, allUnregisteredNodes, csr, currentTime)
 	if err != nil {
 		return false, err
@@ -984,21 +989,20 @@ func (a *StaticAutoscaler) removeOldUnregisteredNodes(ctx context.Context, allUn
 	removedAny := false
 	for nodeGroupId, unregisteredNodesToDelete := range unregisteredNodesToRemove {
 		nodeGroup := nodeGroups[nodeGroupId]
-
-		klog.V(0).Infof("Removing %v unregistered nodes for node group %v", len(unregisteredNodesToDelete), nodeGroupId)
+		logger.V(0).Info("Removing unregistered nodes for node group", "unregisteredNodesToDeleteCount", len(unregisteredNodesToDelete), "nodeGroupId", nodeGroupId)
 		if !a.ForceDeleteLongUnregisteredNodes {
 			size, err := nodeGroup.TargetSize()
 			if err != nil {
-				klog.Warningf("Failed to get node group size; nodeGroup=%v; err=%v", nodeGroup.Id(), err)
+				logger.Info("Failed to get node group size", "nodeGroupId", nodeGroup.Id(), "err", err)
 				continue
 			}
 			possibleToDelete := size - nodeGroup.MinSize()
 			if possibleToDelete <= 0 {
-				klog.Warningf("Node group %s min size reached, skipping removal of %v unregistered nodes", nodeGroupId, len(unregisteredNodesToDelete))
+				logger.Info("Node group min size reached, skipping removal unregistered nodes", "nodeGroupId", nodeGroupId, "unregisteredNodesToDeleteCount", len(unregisteredNodesToDelete))
 				continue
 			}
 			if len(unregisteredNodesToDelete) > possibleToDelete {
-				klog.Warningf("Capping node group %s unregistered node removal to %d nodes, removing all %d would exceed min size constaint", nodeGroupId, possibleToDelete, len(unregisteredNodesToDelete))
+				logger.Info("Capping node group unregistered node removal nodes, removing all would exceed min size constaint", "nodeGroupId", nodeGroupId, "possibleToDelete", possibleToDelete, "unregisteredNodesToDeleteCount", len(unregisteredNodesToDelete))
 				unregisteredNodesToDelete = unregisteredNodesToDelete[:possibleToDelete]
 			}
 		}
@@ -1006,7 +1010,7 @@ func (a *StaticAutoscaler) removeOldUnregisteredNodes(ctx context.Context, allUn
 		nodesToDelete := toNodes(unregisteredNodesToDelete)
 		nodesToDelete, err := overrideNodesToDeleteForZeroOrMax(a.NodeGroupDefaults, nodeGroup, nodesToDelete)
 		if err != nil {
-			klog.Warningf("Failed to remove unregistered nodes from node group %s: %v", nodeGroupId, err)
+			logger.Info("Failed to remove unregistered nodes from node group", "nodeGroupId", nodeGroupId, "err", err)
 			continue
 		}
 
@@ -1024,7 +1028,7 @@ func (a *StaticAutoscaler) removeOldUnregisteredNodes(ctx context.Context, allUn
 		}
 		csr.InvalidateNodeInstancesCacheEntry(ctx, nodeGroup)
 		if err != nil {
-			klog.Warningf("Failed to remove %v unregistered nodes from node group %s: %v", len(nodesToDelete), nodeGroupId, err)
+			logger.Info("Failed to remove unregistered nodes from node group", "nodesToDeleteCount", len(nodesToDelete), "nodeGroupId", nodeGroupId, "err", err)
 			for _, node := range nodesToDelete {
 				logRecorder.Eventf(apiv1.EventTypeWarning, "DeleteUnregisteredFailed",
 					"Failed to remove node %s: %v", node.Name, err)
@@ -1043,15 +1047,16 @@ func (a *StaticAutoscaler) removeOldUnregisteredNodes(ctx context.Context, allUn
 
 // oldUnregisteredNodes returns old unregistered nodes grouped by their node group id.
 func (a *StaticAutoscaler) oldUnregisteredNodes(ctx context.Context, allUnregisteredNodes []clusterstate.UnregisteredNode, csr *clusterstate.ClusterStateRegistry, currentTime time.Time) (map[string][]clusterstate.UnregisteredNode, error) {
+	logger := klog.FromContext(ctx)
 	nodesByNodeGroupId := make(map[string][]clusterstate.UnregisteredNode)
 	for _, unregisteredNode := range allUnregisteredNodes {
 		nodeGroup, err := a.CloudProvider.NodeGroupForNode(unregisteredNode.Node)
 		if err != nil {
-			klog.Warningf("Failed to get node group for %s: %v", unregisteredNode.Node.Name, err)
+			logger.Info("Failed to get node group", "node", unregisteredNode.Node.Name, "err", err)
 			continue
 		}
 		if nodeGroup == nil {
-			klog.Warningf("No node group for node %s, skipping", unregisteredNode.Node.Name)
+			logger.Info("No node group for node, skipping", "node", unregisteredNode.Node.Name)
 			continue
 		}
 
@@ -1061,7 +1066,7 @@ func (a *StaticAutoscaler) oldUnregisteredNodes(ctx context.Context, allUnregist
 		}
 
 		if unregisteredNode.UnregisteredSince.Add(maxNodeProvisionTime).Before(currentTime) {
-			klog.V(0).Infof("Marking unregistered node %v for removal", unregisteredNode.Node.Name)
+			logger.V(0).Info("Marking unregistered node for removal", "node", unregisteredNode.Node.Name)
 			nodesByNodeGroupId[nodeGroup.Id()] = append(nodesByNodeGroupId[nodeGroup.Id()], unregisteredNode)
 		}
 	}
@@ -1080,6 +1085,7 @@ func toNodes(unregisteredNodes []clusterstate.UnregisteredNode) []*apiv1.Node {
 func (a *StaticAutoscaler) deleteCreatedNodesWithErrors(ctx context.Context) {
 	// We always schedule deleting of incoming errornous nodes
 	// TODO[lukaszos] Consider adding logic to not retry delete every loop iteration
+	logger := klog.FromContext(ctx)
 	nodeGroups := a.nodeGroupsById()
 	nodesToDeleteByNodeGroupId := a.clusterStateRegistry.GetCreatedNodesWithErrors()
 
@@ -1087,7 +1093,7 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors(ctx context.Context) {
 
 	for nodeGroupId, nodesToDelete := range nodesToDeleteByNodeGroupId {
 		var err error
-		klog.V(1).Infof("Deleting %v from %v node group because of create errors", len(nodesToDelete), nodeGroupId)
+		logger.V(1).Info("Deleting node group because of create errors", "nodesToDeleteCount", len(nodesToDelete), "nodeGroupId", nodeGroupId)
 
 		nodeGroup := nodeGroups[nodeGroupId]
 		if nodeGroup == nil {
@@ -1104,7 +1110,7 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors(ctx context.Context) {
 		}
 
 		if err != nil {
-			klog.Warningf("Error while trying to delete nodes from %v: %v", nodeGroupId, err)
+			logger.Info("Error while trying to delete nodes", "nodeGroupId", nodeGroupId, "err", err)
 		} else if len(nodesToDelete) > 0 {
 			deletedAny = true
 			a.clusterStateRegistry.InvalidateNodeInstancesCacheEntry(ctx, nodeGroup)
@@ -1112,7 +1118,7 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors(ctx context.Context) {
 	}
 
 	if deletedAny {
-		klog.V(0).Infof("Some nodes that failed to create were removed, recalculating cluster state.")
+		logger.V(0).Info("Some nodes that failed to create were removed, recalculating cluster state.")
 		a.clusterStateRegistry.Recalculate(ctx)
 	}
 }
@@ -1167,6 +1173,7 @@ func (a *StaticAutoscaler) nodeGroupsById() map[string]cloudprovider.NodeGroup {
 // Don't consider pods newer than newPodScaleUpDelay or annotated podScaleUpDelay
 // seconds old as unschedulable.
 func (a *StaticAutoscaler) filterOutYoungPods(ctx context.Context, allUnschedulablePods []*apiv1.Pod, currentTime time.Time) []*apiv1.Pod {
+	logger := klog.FromContext(ctx)
 	var oldUnschedulablePods []*apiv1.Pod
 	newPodScaleUpDelay := a.AutoscalingOptions.NewPodScaleUpDelay
 	for _, pod := range allUnschedulablePods {
@@ -1176,10 +1183,10 @@ func (a *StaticAutoscaler) filterOutYoungPods(ctx context.Context, allUnschedula
 		if podScaleUpDelayAnnotationStr, ok := pod.Annotations[annotations.PodScaleUpDelayAnnotationKey]; ok {
 			podScaleUpDelayAnnotation, err := time.ParseDuration(podScaleUpDelayAnnotationStr)
 			if err != nil {
-				klog.Errorf("Failed to parse pod %q annotation %s: %v", pod.Name, annotations.PodScaleUpDelayAnnotationKey, err)
+				logger.Error(err, "Failed to parse pod annotation", "pod", pod.Name, "podScaleUpDelayAnnotationKey", annotations.PodScaleUpDelayAnnotationKey)
 			} else {
 				if podScaleUpDelayAnnotation < podScaleUpDelay {
-					klog.Errorf("Failed to set pod scale up delay for %q through annotation %s: %d is less then %d", pod.Name, annotations.PodScaleUpDelayAnnotationKey, podScaleUpDelayAnnotation, newPodScaleUpDelay)
+					logger.Error(nil, "Failed to set pod scale up delay through annotation: is less then", "pod", pod.Name, "podScaleUpDelayAnnotationKey", annotations.PodScaleUpDelayAnnotationKey, "podScaleUpDelayAnnotation", podScaleUpDelayAnnotation, "newPodScaleUpDelay", newPodScaleUpDelay)
 				} else {
 					podScaleUpDelay = podScaleUpDelayAnnotation
 				}
@@ -1189,7 +1196,7 @@ func (a *StaticAutoscaler) filterOutYoungPods(ctx context.Context, allUnschedula
 		if podAge > podScaleUpDelay {
 			oldUnschedulablePods = append(oldUnschedulablePods, pod)
 		} else {
-			klog.V(3).Infof("Pod %s is %.3f seconds old, too new to consider unschedulable", pod.Name, podAge.Seconds())
+			logger.V(3).Info("Pod is seconds old, too new to consider unschedulable", "pod", pod.Name, "seconds", podAge.Seconds())
 		}
 	}
 	return oldUnschedulablePods
@@ -1213,14 +1220,15 @@ func (a *StaticAutoscaler) ExitCleanUp() {
 }
 
 func (a *StaticAutoscaler) obtainNodeLists(ctx context.Context, draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node, caerrors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	allNodes, err := a.AllNodeLister().List()
 	if err != nil {
-		klog.Errorf("Failed to list all nodes: %v", err)
+		logger.Error(err, "Failed to list all nodes")
 		return nil, nil, caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
 	}
 	readyNodes, err := a.ReadyNodeLister().List()
 	if err != nil {
-		klog.Errorf("Failed to list ready nodes: %v", err)
+		logger.Error(err, "Failed to list ready nodes")
 		return nil, nil, caerrors.ToAutoscalerError(caerrors.ApiCallError, err)
 	}
 	a.reportTaintsCount(allNodes)
@@ -1236,10 +1244,11 @@ func (a *StaticAutoscaler) obtainNodeLists(ctx context.Context, draSnapshot *dra
 }
 
 func filterNodesFromSelectedGroups(ctx context.Context, cp cloudprovider.CloudProvider, nodes ...*apiv1.Node) []*apiv1.Node {
+	logger := klog.FromContext(ctx)
 	filtered := make([]*apiv1.Node, 0, len(nodes))
 	for _, n := range nodes {
 		if ng, err := cp.NodeGroupForNode(n); err != nil {
-			klog.Errorf("Failed to get a nodegroup for node %q: %v", n.Name, err)
+			logger.Error(err, "Failed to get a nodegroup for node", "node", n.Name)
 		} else if ng != nil {
 			filtered = append(filtered, n)
 		}
@@ -1248,9 +1257,10 @@ func filterNodesFromSelectedGroups(ctx context.Context, cp cloudprovider.CloudPr
 }
 
 func (a *StaticAutoscaler) updateClusterState(ctx context.Context, allNodes []*apiv1.Node, currentTime time.Time) caerrors.AutoscalerError {
+	logger := klog.FromContext(ctx)
 	err := a.clusterStateRegistry.UpdateNodes(ctx, allNodes, currentTime)
 	if err != nil {
-		klog.Errorf("Failed to update node registry: %v", err)
+		logger.Error(err, "Failed to update node registry")
 		a.scaleDownPlanner.CleanUpUnneededNodes(ctx)
 		return caerrors.ToAutoscalerError(caerrors.CloudProviderError, err)
 	}
@@ -1275,11 +1285,12 @@ func allPodsAreNew(pods []*apiv1.Pod, currentTime time.Time) bool {
 }
 
 func getUpcomingNodeInfos(ctx context.Context, upcomingCounts map[string]int, nodeInfos map[string]*framework.NodeInfo, suffixFmt string) (map[string][]*framework.NodeInfo, error) {
+	logger := klog.FromContext(ctx)
 	upcomingNodes := make(map[string][]*framework.NodeInfo)
 	for nodeGroup, numberOfNodes := range upcomingCounts {
 		nodeTemplate, found := nodeInfos[nodeGroup]
 		if !found {
-			klog.Warningf("Couldn't find template for node group %s", nodeGroup)
+			logger.Info("Couldn't find template for node group", "nodeGroup", nodeGroup)
 			continue
 		}
 
@@ -1387,9 +1398,10 @@ func retrieveNodes(candidates []*scaledown.UnneededNode) []*apiv1.Node {
 }
 
 func listPods(ctx context.Context, podLister kube_util.PodLister, bypassedSchedulers, allowedSchedulers map[string]bool) (podsBySchedulability kube_util.PodsBySchedulability, err error) {
+	logger := klog.FromContext(ctx)
 	pods, err := podLister.List()
 	if err != nil {
-		klog.Errorf("Failed to list pods: %v", err)
+		logger.Error(err, "Failed to list pods")
 		return podsBySchedulability, err
 	}
 	initialPodCount := len(pods)
@@ -1401,8 +1413,7 @@ func listPods(ctx context.Context, podLister kube_util.PodLister, bypassedSchedu
 	if len(pods) != len(podsBySchedulability.Scheduled) {
 		ignoredDueToDisallowed := initialPodCount - len(pods)
 		ignored := len(pods) - len(podsBySchedulability.Scheduled) - len(podsBySchedulability.NominatedNode) - len(podsBySchedulability.Unschedulable) - len(podsBySchedulability.Unprocessed)
-		klog.Infof("Found %d pods in the cluster: %d scheduled, %d with nominated node, %d unschedulable, %d unprocessed by scheduler, %d ignored by allowed schedulers (most likely using custom scheduler), %d ignored due to dissallowed schedulers",
-			initialPodCount, len(podsBySchedulability.Scheduled), len(podsBySchedulability.NominatedNode), len(podsBySchedulability.Unschedulable), len(podsBySchedulability.Unprocessed), ignored, ignoredDueToDisallowed)
+		logger.Info("Found pods in the cluster: scheduled, with nominated node, unschedulable, unprocessed by scheduler, ignored by allowed schedulers (most likely using custom scheduler), ignored due to dissallowed schedulers", "initialPodCount", initialPodCount, "scheduledCount", len(podsBySchedulability.Scheduled), "nominatedNodeCount", len(podsBySchedulability.NominatedNode), "unschedulableCount", len(podsBySchedulability.Unschedulable), "unprocessedCount", len(podsBySchedulability.Unprocessed), "ignored", ignored, "ignoredDueToDisallowed", ignoredDueToDisallowed)
 	}
 	return
 }

--- a/cluster-autoscaler/core/static_autoscaler_dra_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_dra_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package core
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"slices"
@@ -82,7 +83,7 @@ type fakeScaleUpStatusProcessor struct {
 	lastStatus *status.ScaleUpStatus
 }
 
-func (f *fakeScaleUpStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleUpStatus) {
+func (f *fakeScaleUpStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleUpStatus) {
 	f.lastStatus = status
 }
 
@@ -93,7 +94,7 @@ type fakeScaleDownStatusProcessor struct {
 	lastStatus *scaledownstatus.ScaleDownStatus
 }
 
-func (f *fakeScaleDownStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, status *scaledownstatus.ScaleDownStatus) {
+func (f *fakeScaleDownStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *scaledownstatus.ScaleDownStatus) {
 	f.lastStatus = status
 }
 

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -196,7 +196,7 @@ type scaleDownStatusProcessorMock struct {
 	scaleDownStatus *status.ScaleDownStatus
 }
 
-func (p *scaleDownStatusProcessorMock) Process(_ *ca_context.AutoscalingContext, st *status.ScaleDownStatus) {
+func (p *scaleDownStatusProcessorMock) Process(ctx context.Context, _ *ca_context.AutoscalingContext, st *status.ScaleDownStatus) {
 	p.called += 1
 	p.scaleDownStatus = st
 }
@@ -322,7 +322,7 @@ func setupAutoscaler(config *autoscalerSetupConfig) (*StaticAutoscaler, error) {
 	}
 
 	clusterState := clusterstate.NewNotifiedClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), processors.NodeGroupConfigProcessor, templateNodeInfoRegistry, clusterstate.WithAsyncNodeGroupStateChecker(processors.AsyncNodeGroupStateChecker), clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier), clusterstate.WithConfig(config.clusterStateConfig))
-	clusterState.UpdateNodes(allNodes, config.nodeStateUpdateTime)
+	clusterState.UpdateNodes(context.TODO(), allNodes, config.nodeStateUpdateTime)
 	quotasTrackerFactory := newQuotasTrackerFactory(&autoscalingCtx, processors)
 
 	suOrchestrator := orchestrator.New()
@@ -602,7 +602,7 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 			description: "ng1 scaled up recently - both ng1 and ng2 have under-utilized nodes",
 			beforeTest: func(processors *ca_processors.AutoscalingProcessors) {
 				// make CA think ng1 scaled up recently
-				processors.ScaleStateNotifier.RegisterScaleUp(ng1, 1, time.Now().Add(-3*time.Minute))
+				processors.ScaleStateNotifier.RegisterScaleUp(context.TODO(), ng1, 1, time.Now().Add(-3*time.Minute))
 			},
 			expectedScaleDownNG:   "ng2",
 			expectedScaleDownNode: "n2",
@@ -610,7 +610,7 @@ func TestStaticAutoscalerRunOnceWithScaleDownDelayPerNG(t *testing.T) {
 				// reset scale up in ng1 so that it doesn't block scale down in the next test
 				// scale down is always recorded relative to time.Now(), no matter
 				// what currentTime time is passed to RunOnce()
-				processors.ScaleStateNotifier.RegisterScaleUp(ng1, 1, time.Time{})
+				processors.ScaleStateNotifier.RegisterScaleUp(context.TODO(), ng1, 1, time.Time{})
 			},
 		},
 
@@ -1001,10 +1001,10 @@ func TestStaticAutoscalerRunOnceWithALongUnregisteredNode(t *testing.T) {
 
 			nodes := []*apiv1.Node{n1}
 			// nodeInfos, _ := getNodeInfosForGroups(nodes, provider, listerRegistry, []*appsv1.DaemonSet{}, autoscalingCtx.PredicateChecker)
-			clusterState.UpdateNodes(nodes, now)
+			clusterState.UpdateNodes(context.TODO(), nodes, now)
 
 			// broken node failed to register in time
-			clusterState.UpdateNodes(nodes, later)
+			clusterState.UpdateNodes(context.TODO(), nodes, later)
 
 			sdPlanner, sdActuator := newScaleDownPlannerAndActuator(&autoscalingCtx, processors, clusterState, nil)
 			quotasTrackerFactory := newQuotasTrackerFactory(&autoscalingCtx, processors)
@@ -1960,10 +1960,10 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 
 			clusterState.RefreshCloudProviderNodeInstancesCache()
 			// propagate nodes info in cluster state
-			clusterState.UpdateNodes([]*apiv1.Node{}, now)
+			clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 
 			// delete nodes with create errors
-			autoscaler.deleteCreatedNodesWithErrors()
+			autoscaler.deleteCreatedNodesWithErrors(context.TODO())
 
 			// nodes should be deleted
 			expectedDeleteCalls := 1
@@ -1995,10 +1995,10 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 
 			// propagate nodes info in cluster state again
 			// no changes in what provider returns
-			clusterState.UpdateNodes([]*apiv1.Node{}, now)
+			clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 
 			// delete nodes with create errors
-			autoscaler.deleteCreatedNodesWithErrors()
+			autoscaler.deleteCreatedNodesWithErrors(context.TODO())
 
 			// nodes should be deleted again
 			expectedDeleteCalls += 1
@@ -2068,10 +2068,10 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 			clusterState.RefreshCloudProviderNodeInstancesCache()
 
 			// update cluster state
-			clusterState.UpdateNodes([]*apiv1.Node{}, now)
+			clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 
 			// delete nodes with create errors
-			autoscaler.deleteCreatedNodesWithErrors()
+			autoscaler.deleteCreatedNodesWithErrors(context.TODO())
 
 			// we expect no more Delete Nodes, don't increase expectedDeleteCalls
 			if tc.forceDeleteEnabled {
@@ -2116,10 +2116,10 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 			autoscaler.clusterStateRegistry = clusterState
 
 			// update cluster state
-			clusterState.UpdateNodes([]*apiv1.Node{}, time.Now())
+			clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{}, time.Now())
 
 			// No nodes are deleted when failed nodes don't have matching node groups
-			autoscaler.deleteCreatedNodesWithErrors()
+			autoscaler.deleteCreatedNodesWithErrors(context.TODO())
 			nodeGroupC.AssertNumberOfCalls(t, deleteMethod, 0)
 
 			// Node group with getOptions error gets no deletes.
@@ -2165,10 +2165,10 @@ func TestStaticAutoscalerInstanceCreationErrors(t *testing.T) {
 			autoscaler.CloudProvider = provider
 			autoscaler.clusterStateRegistry = clusterState
 			// propagate nodes info in cluster state
-			clusterState.UpdateNodes([]*apiv1.Node{}, now)
+			clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{}, now)
 
 			// delete nodes with create errors
-			autoscaler.deleteCreatedNodesWithErrors()
+			autoscaler.deleteCreatedNodesWithErrors(context.TODO())
 
 			nodeGroupError.AssertNumberOfCalls(t, deleteMethod, 0)
 		})
@@ -2256,7 +2256,7 @@ func setupTestStaticAutoscalerInstanceCreationErrorsForZeroOrMaxScaling(t *testi
 	autoscaler.CloudProvider = provider
 	autoscaler.clusterStateRegistry = clusterState
 	// propagate nodes info in cluster state
-	clusterState.UpdateNodes([]*apiv1.Node{}, time.Now())
+	clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{}, time.Now())
 
 	return autoscaler, nodeGroupAtomic
 }
@@ -2288,7 +2288,7 @@ func TestStaticAutoscalerInstanceCreationErrorsForZeroOrMaxScaling(t *testing.T)
 		},
 	}, false)
 
-	autoscaler.deleteCreatedNodesWithErrors()
+	autoscaler.deleteCreatedNodesWithErrors(context.TODO())
 
 	nodeGroupAtomic.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
 		func(nodes []*apiv1.Node) bool {
@@ -2328,7 +2328,7 @@ func TestStaticAutoscalerInstanceCreationErrorsForZeroOrMaxScaling(t *testing.T)
 		},
 	}, true)
 
-	autoscaler.deleteCreatedNodesWithErrors()
+	autoscaler.deleteCreatedNodesWithErrors(context.TODO())
 
 	nodeGroupAtomic.AssertNumberOfCalls(t, "DeleteNodes", 0)
 
@@ -2366,7 +2366,7 @@ func TestStaticAutoscalerInstanceCreationErrorsForZeroOrMaxScaling(t *testing.T)
 		},
 	}, true)
 
-	autoscaler.deleteCreatedNodesWithErrors()
+	autoscaler.deleteCreatedNodesWithErrors(context.TODO())
 
 	nodeGroupAtomic.AssertCalled(t, "DeleteNodes", mock.MatchedBy(
 		func(nodes []*apiv1.Node) bool {
@@ -2385,7 +2385,7 @@ type candidateTrackingFakePlanner struct {
 	lastCandidateNodes map[string]bool
 }
 
-func (f *candidateTrackingFakePlanner) UpdateClusterState(podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, currentTime time.Time) errors.AutoscalerError {
+func (f *candidateTrackingFakePlanner) UpdateClusterState(ctx context.Context, podDestinations, scaleDownCandidates []*apiv1.Node, as scaledown.ActuationStatus, currentTime time.Time) errors.AutoscalerError {
 	f.lastCandidateNodes = map[string]bool{}
 	for _, node := range scaleDownCandidates {
 		f.lastCandidateNodes[node.Name] = true
@@ -2393,10 +2393,10 @@ func (f *candidateTrackingFakePlanner) UpdateClusterState(podDestinations, scale
 	return nil
 }
 
-func (f *candidateTrackingFakePlanner) CleanUpUnneededNodes() {
+func (f *candidateTrackingFakePlanner) CleanUpUnneededNodes(ctx context.Context) {
 }
 
-func (f *candidateTrackingFakePlanner) NodesToDelete(currentTime time.Time) (empty, needDrain []*apiv1.Node) {
+func (f *candidateTrackingFakePlanner) NodesToDelete(ctx context.Context, currentTime time.Time) (empty, needDrain []*apiv1.Node) {
 	return nil, nil
 }
 
@@ -2502,7 +2502,7 @@ func TestStaticAutoscalerUpcomingScaleDownCandidates(t *testing.T) {
 	csrConfig := clusterstate.ClusterStateRegistryConfig{OkTotalUnreadyCount: nodeGroupCount * unreadyNodesCount}
 	csr := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute, MaxNodeStartupTime: 15 * time.Minute}), templateNodeInfoRegistry, clusterstate.WithConfig(csrConfig))
 	for ngNum := 0; ngNum < nodeGroupCount; ngNum++ {
-		csr.RegisterScaleUp(provider.GetNodeGroup(fmt.Sprintf("ng-%d", ngNum)), unreadyNodesCount, startTime)
+		csr.RegisterScaleUp(context.TODO(), provider.GetNodeGroup(fmt.Sprintf("ng-%d", ngNum)), unreadyNodesCount, startTime)
 	}
 
 	// Setting the Actuator is necessary for testing any scale-down logic, it shouldn't have anything to do in this test.
@@ -2587,7 +2587,7 @@ func TestRemoveFixNodeTargetSize(t *testing.T) {
 	provider.AddNode("ng1", ng1_1)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := clusterstate_utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := clusterstate_utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 
 	autoscalingCtx := &ca_context.AutoscalingContext{
 		AutoscalingOptions: config.AutoscalingOptions{
@@ -2602,16 +2602,16 @@ func TestRemoveFixNodeTargetSize(t *testing.T) {
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
-	err := clusterState.UpdateNodes([]*apiv1.Node{ng1_1}, now.Add(-time.Hour))
+	err := clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, now.Add(-time.Hour))
 	assert.NoError(t, err)
 
 	// Nothing should be fixed. The incorrect size state is not old enough.
-	removed, err := fixNodeGroupSize(autoscalingCtx, clusterState, now.Add(-50*time.Minute))
+	removed, err := fixNodeGroupSize(context.TODO(), autoscalingCtx, clusterState, now.Add(-50*time.Minute))
 	assert.NoError(t, err)
 	assert.False(t, removed)
 
 	// Node group should be decreased.
-	removed, err = fixNodeGroupSize(autoscalingCtx, clusterState, now)
+	removed, err = fixNodeGroupSize(context.TODO(), autoscalingCtx, clusterState, now)
 	assert.NoError(t, err)
 	assert.True(t, removed)
 	change := core_utils.GetStringFromChan(sizeChanges)
@@ -2636,7 +2636,7 @@ func TestRemoveOldUnregisteredNodes(t *testing.T) {
 	provider.AddNode("ng1", ng1_2)
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := clusterstate_utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := clusterstate_utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 
 	autoscalingCtx := &ca_context.AutoscalingContext{
 		AutoscalingOptions: config.AutoscalingOptions{
@@ -2650,7 +2650,7 @@ func TestRemoveOldUnregisteredNodes(t *testing.T) {
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
-	err := clusterState.UpdateNodes([]*apiv1.Node{ng1_1}, now.Add(-time.Hour))
+	err := clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{ng1_1}, now.Add(-time.Hour))
 	assert.NoError(t, err)
 
 	unregisteredNodes := clusterState.GetUnregisteredNodes()
@@ -2662,12 +2662,12 @@ func TestRemoveOldUnregisteredNodes(t *testing.T) {
 	}
 
 	// Nothing should be removed. The unregistered node is not old enough.
-	removed, err := autoscaler.removeOldUnregisteredNodes(unregisteredNodes, clusterState, now.Add(-50*time.Minute), fakeLogRecorder)
+	removed, err := autoscaler.removeOldUnregisteredNodes(context.TODO(), unregisteredNodes, clusterState, now.Add(-50*time.Minute), fakeLogRecorder)
 	assert.NoError(t, err)
 	assert.False(t, removed)
 
 	// ng1_2 should be removed.
-	removed, err = autoscaler.removeOldUnregisteredNodes(unregisteredNodes, clusterState, now, fakeLogRecorder)
+	removed, err = autoscaler.removeOldUnregisteredNodes(context.TODO(), unregisteredNodes, clusterState, now, fakeLogRecorder)
 	assert.NoError(t, err)
 	assert.True(t, removed)
 	deletedNode := core_utils.GetStringFromChan(deletedNodes)
@@ -2696,7 +2696,7 @@ func setupTestRemoveOldUnregisteredNodesAtomic(t *testing.T, now time.Time, allo
 	}
 
 	fakeClient := &fake.Clientset{}
-	fakeLogRecorder, _ := clusterstate_utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+	fakeLogRecorder, _ := clusterstate_utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
 
 	autoscalingCtx := &ca_context.AutoscalingContext{
 		AutoscalingOptions: config.AutoscalingOptions{
@@ -2710,7 +2710,7 @@ func setupTestRemoveOldUnregisteredNodesAtomic(t *testing.T, now time.Time, allo
 		MaxTotalUnreadyPercentage: 10,
 		OkTotalUnreadyCount:       1,
 	}))
-	err := clusterState.UpdateNodes([]*apiv1.Node{regNode}, now.Add(-time.Hour))
+	err := clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{regNode}, now.Add(-time.Hour))
 	assert.NoError(t, err)
 
 	return clusterState, autoscalingCtx, fakeLogRecorder, deletedNodes
@@ -2730,12 +2730,12 @@ func TestRemoveOldUnregisteredNodesAtomic(t *testing.T) {
 	}
 
 	// Nothing should be removed. The unregistered node is not old enough.
-	removed, err := autoscaler.removeOldUnregisteredNodes(unregisteredNodes, clusterState, now.Add(-50*time.Minute), fakeLogRecorder)
+	removed, err := autoscaler.removeOldUnregisteredNodes(context.TODO(), unregisteredNodes, clusterState, now.Add(-50*time.Minute), fakeLogRecorder)
 	assert.NoError(t, err)
 	assert.False(t, removed)
 
 	// unregNode is long unregistered, so all of the nodes should be removed due to ZeroOrMaxNodeScaling option
-	removed, err = autoscaler.removeOldUnregisteredNodes(unregisteredNodes, clusterState, now, fakeLogRecorder)
+	removed, err = autoscaler.removeOldUnregisteredNodes(context.TODO(), unregisteredNodes, clusterState, now, fakeLogRecorder)
 
 	assert.NoError(t, err)
 	assert.True(t, removed)
@@ -2761,18 +2761,18 @@ func TestRemoveOldUnregisteredNodesAtomic(t *testing.T) {
 	}
 
 	// nodes are long unregistered, but not all of them, so all should be kept for ZeroOrMaxNodeScaling
-	removed, err = autoscaler.removeOldUnregisteredNodes(unregisteredNodes, autoscaler.clusterStateRegistry, now, fakeLogRecorder)
+	removed, err = autoscaler.removeOldUnregisteredNodes(context.TODO(), unregisteredNodes, autoscaler.clusterStateRegistry, now, fakeLogRecorder)
 	assert.NoError(t, err)
 	assert.False(t, removed)
 
-	err = clusterState.UpdateNodes([]*apiv1.Node{}, now.Add(-time.Hour))
+	err = clusterState.UpdateNodes(context.TODO(), []*apiv1.Node{}, now.Add(-time.Hour))
 	assert.NoError(t, err)
 
 	unregisteredNodes = clusterState.GetUnregisteredNodes()
 	assert.Equal(t, 10, len(unregisteredNodes))
 
 	// all nodes are long unregistered, so all should be removed for ZeroOrMaxNodeScaling
-	removed, err = autoscaler.removeOldUnregisteredNodes(unregisteredNodes, autoscaler.clusterStateRegistry, now, fakeLogRecorder)
+	removed, err = autoscaler.removeOldUnregisteredNodes(context.TODO(), unregisteredNodes, autoscaler.clusterStateRegistry, now, fakeLogRecorder)
 	assert.NoError(t, err)
 	assert.True(t, removed)
 
@@ -2917,7 +2917,7 @@ func TestFilterOutYoungPods(t *testing.T) {
 				klog.SetOutput(os.Stderr)
 			}()
 
-			actual := autoscaler.filterOutYoungPods(tt.pods, tt.runTime)
+			actual := autoscaler.filterOutYoungPods(context.TODO(), tt.pods, tt.runTime)
 
 			assert.Equal(t, tt.expectedPods, actual)
 			if tt.expectedError != "" {
@@ -3039,7 +3039,7 @@ func TestStaticAutoscalerRunOnceInvokesScaleDownStatusProcessor(t *testing.T) {
 				tracker := deletiontracker.NewNodeDeletionTracker(time.Second * 0)
 				for node, result := range test.fakeDeletionResults {
 					tracker.StartDeletion(test.fakeDeletionResultsNodeGroup, node)
-					tracker.EndDeletion(test.fakeDeletionResultsNodeGroup, node, result)
+					tracker.EndDeletion(context.TODO(), test.fakeDeletionResultsNodeGroup, node, result)
 				}
 
 				mocks.nodeDeletionTracker = tracker
@@ -3151,7 +3151,7 @@ func TestFilterNodesFromSelectedGroups(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filteredNodes := filterNodesFromSelectedGroups(provider, tt.nodes...)
+			filteredNodes := filterNodesFromSelectedGroups(context.TODO(), provider, tt.nodes...)
 			assert.Equal(t, tt.wantNodes, filteredNodes)
 		})
 	}
@@ -3617,7 +3617,7 @@ func TestStaticAutoscalerWithNodeDeclaredFeatures(t *testing.T) {
 			}
 
 			// Update ClusterStateRegistry with initial nodes
-			err = clusterState.UpdateNodes(tc.initialNodes, time.Now())
+			err = clusterState.UpdateNodes(context.TODO(), tc.initialNodes, time.Now())
 			assert.NoError(t, err)
 
 			allPodListerMock.On("List").Return(tc.pods, nil).Once()
@@ -3807,7 +3807,7 @@ type customQuotaProvider struct {
 	quotas []resourcequotas.Quota
 }
 
-func (p *customQuotaProvider) Quotas() ([]resourcequotas.Quota, error) {
+func (p *customQuotaProvider) Quotas(ctx context.Context) ([]resourcequotas.Quota, error) {
 	return p.quotas, nil
 }
 

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -2888,7 +2888,7 @@ func TestFilterOutYoungPods(t *testing.T) {
 			runTime:            now.Add(2 * time.Minute),
 			pods:               []*apiv1.Pod{p1, p3},
 			expectedPods:       []*apiv1.Pod(nil),
-			expectedError:      "Failed to set pod scale up delay for",
+			expectedError:      "Failed to set pod scale up delay through annotation",
 		},
 		{
 			name:               "annotation delay with error",

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"slices"
@@ -176,7 +177,7 @@ func NewScaleTestAutoscalingContext(
 	// Not enough buffer space causes the test to hang without printing any logs.
 	// This is not useful.
 	fakeRecorder := kube_record.NewFakeRecorder(100)
-	fakeLogRecorder, err := utils.NewStatusMapRecorder(fakeClient, "kube-system", fakeRecorder, false, "my-cool-configmap")
+	fakeLogRecorder, err := utils.NewStatusMapRecorder(context.TODO(), fakeClient, "kube-system", fakeRecorder, false, "my-cool-configmap")
 	if err != nil {
 		return ca_context.AutoscalingContext{}, err
 	}
@@ -323,7 +324,7 @@ func (p *MockBinpackingLimiter) MarkProcessed(autoscalingCtx *ca_context.Autosca
 }
 
 // StopBinpacking stops the binpacking early, if we already have requiredExpansionOptions i.e. 1.
-func (p *MockBinpackingLimiter) StopBinpacking(autoscalingCtx *ca_context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
+func (p *MockBinpackingLimiter) StopBinpacking(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
 	return len(evaluatedOptions) == p.requiredExpansionOptions
 }
 
@@ -372,10 +373,10 @@ func (r *MockReportingStrategy) LastInputOptions() []GroupSizeChange {
 // BestOption satisfies the Strategy interface. Picks the best option from those passed as an argument.
 // When parameter optionToChoose is defined, it's picked as the best one.
 // Otherwise, random option is used.
-func (r *MockReportingStrategy) BestOption(options []expander.Option, nodeInfo map[string]*framework.NodeInfo) *expander.Option {
+func (r *MockReportingStrategy) BestOption(ctx context.Context, options []expander.Option, nodeInfo map[string]*framework.NodeInfo) *expander.Option {
 	r.results.inputOptions = expanderOptionsToGroupSizeChanges(options)
 	if r.optionToChoose == nil {
-		return r.defaultStrategy.BestOption(options, nodeInfo)
+		return r.defaultStrategy.BestOption(ctx, options, nodeInfo)
 	}
 	for _, option := range options {
 		groupSizeChange := expanderOptionToGroupSizeChange(option)

--- a/cluster-autoscaler/debuggingsnapshot/debugging_snapshotter.go
+++ b/cluster-autoscaler/debuggingsnapshot/debugging_snapshotter.go
@@ -186,11 +186,13 @@ func (d *DebuggingSnapshotterImpl) IsDataCollectionAllowedNoLock() bool {
 // to start data collection. To be done at the start of the runLoop to allow for consistency
 // as the trigger can be called mid-loop leading to partial data collection
 func (d *DebuggingSnapshotterImpl) StartDataCollection(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 	if *d.State == TRIGGER_ENABLED {
 		*d.State = START_DATA_COLLECTION
-		klog.Infof("Trigger Enabled for Debugging Snapshot, starting data collection")
+		logger.Info("Trigger Enabled for Debugging Snapshot, starting data collection")
+
 		d.DebuggingSnapshot.SetStartTimestamp(time.Now().In(time.UTC))
 	}
 }
@@ -198,13 +200,15 @@ func (d *DebuggingSnapshotterImpl) StartDataCollection(ctx context.Context) {
 // Flush is the impl for DebuggingSnapshotter.Flush
 // It checks if any data has been collected or data collection failed
 func (d *DebuggingSnapshotterImpl) Flush(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 
 	// Case where Data Collection was started but no data was collected, needs to
 	// be stated as an error and reset to pre-trigger State
 	if *d.State == START_DATA_COLLECTION {
-		klog.Errorf("No data was collected for the snapshot in this loop. So no snapshot can be generated.")
+		logger.Error(nil, "No data was collected for the snapshot in this loop. So no snapshot can be generated.")
+
 		d.DebuggingSnapshot.SetErrorMessage("Unable to collect any data")
 		d.Trigger <- struct{}{}
 		return
@@ -218,36 +222,39 @@ func (d *DebuggingSnapshotterImpl) Flush(ctx context.Context) {
 // SetClusterNodes is the setter for Node Group Info
 // All filtering/prettifying of data should be done here.
 func (d *DebuggingSnapshotterImpl) SetClusterNodes(ctx context.Context, nodeInfos []*framework.NodeInfo) {
+	logger := klog.FromContext(ctx)
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 	if !d.IsDataCollectionAllowedNoLock() {
 		return
 	}
-	klog.V(4).Infof("NodeGroupInfo is being set for the debugging snapshot")
+	logger.V(4).Info("NodeGroupInfo is being set for the debugging snapshot")
 	d.DebuggingSnapshot.SetClusterNodes(nodeInfos)
 	*d.State = DATA_COLLECTED
 }
 
 // SetUnscheduledPodsCanBeScheduled is the setter for UnscheduledPodsCanBeScheduled
 func (d *DebuggingSnapshotterImpl) SetUnscheduledPodsCanBeScheduled(ctx context.Context, podList []*v1.Pod) {
+	logger := klog.FromContext(ctx)
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 	if !d.IsDataCollectionAllowedNoLock() {
 		return
 	}
-	klog.V(4).Infof("UnscheduledPodsCanBeScheduled is being set for the debugging snapshot")
+	logger.V(4).Info("UnscheduledPodsCanBeScheduled is being set for the debugging snapshot")
 	d.DebuggingSnapshot.SetUnscheduledPodsCanBeScheduled(podList)
 	*d.State = DATA_COLLECTED
 }
 
 // SetTemplateNodes is the setter for TemplateNodes
 func (d *DebuggingSnapshotterImpl) SetTemplateNodes(ctx context.Context, templates map[string]*framework.NodeInfo) {
+	logger := klog.FromContext(ctx)
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 	if !d.IsDataCollectionAllowedNoLock() {
 		return
 	}
-	klog.V(4).Infof("TemplateNodes is being set for the debugging snapshot")
+	logger.V(4).Info("TemplateNodes is being set for the debugging snapshot")
 	d.DebuggingSnapshot.SetTemplateNodes(templates)
 }
 

--- a/cluster-autoscaler/debuggingsnapshot/debugging_snapshotter.go
+++ b/cluster-autoscaler/debuggingsnapshot/debugging_snapshotter.go
@@ -73,15 +73,15 @@ type DebuggingSnapshotter interface {
 
 	// StartDataCollection will check the State(s) and enable data
 	// collection for the loop if applicable
-	StartDataCollection()
+	StartDataCollection(context.Context)
 	// SetClusterNodes is a setter to capture all the ClusterNode
-	SetClusterNodes([]*framework.NodeInfo)
+	SetClusterNodes(context.Context, []*framework.NodeInfo)
 	// SetUnscheduledPodsCanBeScheduled is a setter for all pods which are unscheduled
 	// but they can be scheduled. i.e. pods which aren't triggering scale-up
-	SetUnscheduledPodsCanBeScheduled([]*v1.Pod)
+	SetUnscheduledPodsCanBeScheduled(context.Context, []*v1.Pod)
 	// SetTemplateNodes is a setter for all the TemplateNodes present in the cluster
 	// incl. templates for which there are no nodes
-	SetTemplateNodes(map[string]*framework.NodeInfo)
+	SetTemplateNodes(context.Context, map[string]*framework.NodeInfo)
 	// ResponseHandler is the http response handler to manage incoming requests
 	ResponseHandler(http.ResponseWriter, *http.Request)
 	// IsDataCollectionAllowed checks the internal State of the snapshotter
@@ -89,7 +89,7 @@ type DebuggingSnapshotter interface {
 	// for the snapshot
 	IsDataCollectionAllowed() bool
 	// Flush triggers the flushing of the snapshot
-	Flush()
+	Flush(context.Context)
 	// Cleanup clears the internal data beans of the snapshot, readying for next request
 	Cleanup()
 }
@@ -185,7 +185,7 @@ func (d *DebuggingSnapshotterImpl) IsDataCollectionAllowedNoLock() bool {
 // StartDataCollection changes the State when the trigger has been enabled
 // to start data collection. To be done at the start of the runLoop to allow for consistency
 // as the trigger can be called mid-loop leading to partial data collection
-func (d *DebuggingSnapshotterImpl) StartDataCollection() {
+func (d *DebuggingSnapshotterImpl) StartDataCollection(ctx context.Context) {
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 	if *d.State == TRIGGER_ENABLED {
@@ -197,7 +197,7 @@ func (d *DebuggingSnapshotterImpl) StartDataCollection() {
 
 // Flush is the impl for DebuggingSnapshotter.Flush
 // It checks if any data has been collected or data collection failed
-func (d *DebuggingSnapshotterImpl) Flush() {
+func (d *DebuggingSnapshotterImpl) Flush(ctx context.Context) {
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 
@@ -217,7 +217,7 @@ func (d *DebuggingSnapshotterImpl) Flush() {
 
 // SetClusterNodes is the setter for Node Group Info
 // All filtering/prettifying of data should be done here.
-func (d *DebuggingSnapshotterImpl) SetClusterNodes(nodeInfos []*framework.NodeInfo) {
+func (d *DebuggingSnapshotterImpl) SetClusterNodes(ctx context.Context, nodeInfos []*framework.NodeInfo) {
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 	if !d.IsDataCollectionAllowedNoLock() {
@@ -229,7 +229,7 @@ func (d *DebuggingSnapshotterImpl) SetClusterNodes(nodeInfos []*framework.NodeIn
 }
 
 // SetUnscheduledPodsCanBeScheduled is the setter for UnscheduledPodsCanBeScheduled
-func (d *DebuggingSnapshotterImpl) SetUnscheduledPodsCanBeScheduled(podList []*v1.Pod) {
+func (d *DebuggingSnapshotterImpl) SetUnscheduledPodsCanBeScheduled(ctx context.Context, podList []*v1.Pod) {
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 	if !d.IsDataCollectionAllowedNoLock() {
@@ -241,7 +241,7 @@ func (d *DebuggingSnapshotterImpl) SetUnscheduledPodsCanBeScheduled(podList []*v
 }
 
 // SetTemplateNodes is the setter for TemplateNodes
-func (d *DebuggingSnapshotterImpl) SetTemplateNodes(templates map[string]*framework.NodeInfo) {
+func (d *DebuggingSnapshotterImpl) SetTemplateNodes(ctx context.Context, templates map[string]*framework.NodeInfo) {
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 	if !d.IsDataCollectionAllowedNoLock() {

--- a/cluster-autoscaler/debuggingsnapshot/debugging_snapshotter_test.go
+++ b/cluster-autoscaler/debuggingsnapshot/debugging_snapshotter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package debuggingsnapshot
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -60,10 +61,10 @@ func TestBasicSnapshotRequest(t *testing.T) {
 	}()
 
 	for !snapshotter.IsDataCollectionAllowed() {
-		snapshotter.StartDataCollection()
+		snapshotter.StartDataCollection(context.TODO())
 	}
-	snapshotter.SetClusterNodes(nodeGroups)
-	snapshotter.Flush()
+	snapshotter.SetClusterNodes(context.TODO(), nodeGroups)
+	snapshotter.Flush(context.TODO())
 
 	wg.Wait()
 	resp := w.Result()
@@ -85,9 +86,9 @@ func TestFlushWithoutData(t *testing.T) {
 	}()
 
 	for !snapshotter.IsDataCollectionAllowed() {
-		snapshotter.StartDataCollection()
+		snapshotter.StartDataCollection(context.TODO())
 	}
-	snapshotter.Flush()
+	snapshotter.Flush(context.TODO())
 
 	wg.Wait()
 	resp := w.Result()
@@ -109,7 +110,7 @@ func TestRequestTerminationOnShutdown(t *testing.T) {
 	}()
 
 	for !snapshotter.IsDataCollectionAllowed() {
-		snapshotter.StartDataCollection()
+		snapshotter.StartDataCollection(context.TODO())
 	}
 
 	go snapshotter.Cleanup()
@@ -132,7 +133,7 @@ func TestRejectParallelRequest(t *testing.T) {
 	}()
 
 	for !snapshotter.IsDataCollectionAllowed() {
-		snapshotter.StartDataCollection()
+		snapshotter.StartDataCollection(context.TODO())
 	}
 
 	w1 := httptest.NewRecorder()
@@ -140,8 +141,8 @@ func TestRejectParallelRequest(t *testing.T) {
 	snapshotter.ResponseHandler(w1, req1)
 	assert.Equal(t, http.StatusTooManyRequests, w1.Code)
 
-	snapshotter.SetClusterNodes(nil)
-	snapshotter.Flush()
+	snapshotter.SetClusterNodes(context.TODO(), nil)
+	snapshotter.Flush(context.TODO())
 	wg.Wait()
 
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	gocontext "context"
 	"fmt"
 	"math"
 	"strconv"
@@ -100,13 +101,13 @@ func newEstimationState() *estimationState {
 // It is assumed that all pods from the given list can fit to nodeTemplate.
 // Returns the number of nodes needed to accommodate all pods from the list.
 func (e *BinpackingNodeEstimator) Estimate(
-	podsEquivalenceGroups []PodEquivalenceGroup,
+	ctx gocontext.Context, podsEquivalenceGroups []PodEquivalenceGroup,
 	nodeTemplate *framework.NodeInfo,
 	nodeGroup cloudprovider.NodeGroup,
 ) (int, []*apiv1.Pod) {
 	observeBinpackingHeterogeneity(podsEquivalenceGroups, nodeTemplate)
 
-	e.limiter.StartEstimation(podsEquivalenceGroups, nodeGroup, e.context)
+	e.limiter.StartEstimation(ctx, podsEquivalenceGroups, nodeGroup, e.context)
 	defer e.limiter.EndEstimation()
 
 	podsEquivalenceGroups = e.podOrderer.Order(podsEquivalenceGroups, nodeTemplate, nodeGroup)
@@ -134,7 +135,7 @@ func (e *BinpackingNodeEstimator) Estimate(
 		var err error
 		var remainingPods []*apiv1.Pod
 
-		remainingPods, err = e.tryToScheduleOnExistingNodes(estimationState, podsEquivalenceGroup.Pods)
+		remainingPods, err = e.tryToScheduleOnExistingNodes(ctx, estimationState, podsEquivalenceGroup.Pods)
 		if err != nil {
 			klog.Error(err.Error())
 			return 0, nil
@@ -143,9 +144,9 @@ func (e *BinpackingNodeEstimator) Estimate(
 		if newNodesAvailable {
 			// Since fastpath binpacking adds just one node to the snapshot, it will cause inaccurate simulations on subsequent loops, therefore we only use it on the last group
 			if i == len(podsEquivalenceGroups)-1 && useFastpathOnLastPEG {
-				newNodesAvailable, err = e.tryFastPath(estimationState, nodeTemplate, remainingPods)
+				newNodesAvailable, err = e.tryFastPath(ctx, estimationState, nodeTemplate, remainingPods)
 			} else {
-				newNodesAvailable, err = e.tryToScheduleOnNewNodes(estimationState, nodeTemplate, remainingPods)
+				newNodesAvailable, err = e.tryToScheduleOnNewNodes(ctx, estimationState, nodeTemplate, remainingPods)
 			}
 			if err != nil {
 				klog.Error(err.Error())
@@ -161,6 +162,7 @@ func (e *BinpackingNodeEstimator) Estimate(
 }
 
 func (e *BinpackingNodeEstimator) tryToScheduleOnExistingNodes(
+	ctx gocontext.Context,
 	estimationState *estimationState,
 	pods []*apiv1.Pod,
 ) ([]*apiv1.Pod, error) {
@@ -169,7 +171,7 @@ func (e *BinpackingNodeEstimator) tryToScheduleOnExistingNodes(
 		pod := pods[index]
 
 		// Try to schedule the pod on all nodes created during simulation
-		nodeName, err := e.clusterSnapshot.SchedulePodOnAnyNodeMatching(pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(nodeInfo *framework.NodeInfo) bool {
+		nodeName, err := e.clusterSnapshot.SchedulePodOnAnyNodeMatching(ctx, pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(nodeInfo *framework.NodeInfo) bool {
 			return estimationState.newNodeNames[nodeInfo.Node().Name]
 		}})
 		if err != nil && err.Type() == clustersnapshot.SchedulingInternalError {
@@ -188,7 +190,7 @@ func (e *BinpackingNodeEstimator) tryToScheduleOnExistingNodes(
 // Returns whether it is worth retrying adding new nodes and error in unexpected
 // situations where whole estimation should be stopped.
 func (e *BinpackingNodeEstimator) tryToScheduleOnNewNodes(
-	estimationState *estimationState,
+	ctx gocontext.Context, estimationState *estimationState,
 	nodeTemplate *framework.NodeInfo,
 	pods []*apiv1.Pod,
 ) (bool, error) {
@@ -197,7 +199,7 @@ func (e *BinpackingNodeEstimator) tryToScheduleOnNewNodes(
 
 		if estimationState.lastNodeName != "" {
 			// Try to schedule the pod on only newly created node.
-			err := e.clusterSnapshot.SchedulePod(pod, estimationState.lastNodeName)
+			err := e.clusterSnapshot.SchedulePod(ctx, pod, estimationState.lastNodeName)
 			if err == nil {
 				// The pod was scheduled on the newly created node.
 				found = true
@@ -212,7 +214,7 @@ func (e *BinpackingNodeEstimator) tryToScheduleOnNewNodes(
 			if isPodUsingHostNameTopologyKey(pod) && hasTopologyConstraintError(err) {
 				// If the pod can't be scheduled on the last node because of topology constraints, we can stop binpacking.
 				// The pod can't be scheduled on any new node either, because it has the same topology constraints.
-				nodeName, err := e.clusterSnapshot.SchedulePodOnAnyNodeMatching(pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(nodeInfo *framework.NodeInfo) bool {
+				nodeName, err := e.clusterSnapshot.SchedulePodOnAnyNodeMatching(ctx, pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(nodeInfo *framework.NodeInfo) bool {
 					return nodeInfo.Node().Name != estimationState.lastNodeName // only skip the last node that failed scheduling
 				}})
 				if err != nil && err.Type() == clustersnapshot.SchedulingInternalError {
@@ -241,12 +243,12 @@ func (e *BinpackingNodeEstimator) tryToScheduleOnNewNodes(
 			// The thresholdBasedEstimationLimiter implementation assumes that for
 			// each call that returns true, one node gets added. Therefore this
 			// must be the last check right before really adding a node.
-			if !e.limiter.PermissionToAddNode() {
+			if !e.limiter.PermissionToAddNode(ctx) {
 				return false, nil
 			}
 
 			// Add new node
-			if err := e.addNewNodeToSnapshot(estimationState, nodeTemplate); err != nil {
+			if err := e.addNewNodeToSnapshot(ctx, estimationState, nodeTemplate); err != nil {
 				return false, fmt.Errorf("Error while adding new node for template to ClusterSnapshot; %w", err)
 			}
 
@@ -254,7 +256,7 @@ func (e *BinpackingNodeEstimator) tryToScheduleOnNewNodes(
 			// Note that this may still fail (ex. if topology spreading with zonal topologyKey is used);
 			// in this case we can't help the pending pod. We keep the node in clusterSnapshot to avoid
 			// adding and removing node to snapshot for each such pod.
-			if err := e.clusterSnapshot.SchedulePod(pod, estimationState.lastNodeName); err != nil && err.Type() == clustersnapshot.SchedulingInternalError {
+			if err := e.clusterSnapshot.SchedulePod(ctx, pod, estimationState.lastNodeName); err != nil && err.Type() == clustersnapshot.SchedulingInternalError {
 				// Unexpected error.
 				return false, err
 			} else if err != nil {
@@ -272,24 +274,24 @@ func (e *BinpackingNodeEstimator) tryToScheduleOnNewNodes(
 // It attempts to pack as much pods as possible on a single node, and then estimates the total
 // amount of nodes by simple arithmetic: EstimatedNodes = ceil(TotalPods / PodsFittingOnASingleNode)
 func (e *BinpackingNodeEstimator) tryFastPath(
-	estimationState *estimationState,
+	ctx gocontext.Context, estimationState *estimationState,
 	nodeTemplate *framework.NodeInfo,
 	pods []*apiv1.Pod,
 ) (bool, error) {
 	if len(pods) == 0 {
 		return true, nil
 	}
-	if !e.limiter.PermissionToAddNode() {
+	if !e.limiter.PermissionToAddNode(ctx) {
 		return false, nil
 	}
 	// Add test node to snapshot.
-	if err := e.addNewNodeToSnapshot(estimationState, nodeTemplate); err != nil {
+	if err := e.addNewNodeToSnapshot(ctx, estimationState, nodeTemplate); err != nil {
 		return false, fmt.Errorf("Error while adding new node for template to ClusterSnapshot; %w", err)
 	}
 
 	i := 0
 	for ; i < len(pods); i++ {
-		if err := e.clusterSnapshot.SchedulePod(pods[i], estimationState.lastNodeName); err != nil && err.Type() == clustersnapshot.SchedulingInternalError {
+		if err := e.clusterSnapshot.SchedulePod(ctx, pods[i], estimationState.lastNodeName); err != nil && err.Type() == clustersnapshot.SchedulingInternalError {
 			// Unexpected error.
 			return false, err
 		} else if err != nil {
@@ -309,7 +311,7 @@ func (e *BinpackingNodeEstimator) tryFastPath(
 
 	// We already added 1 node and scheduled on it, now the rest we can only mark without the simulation
 	for j := 1; j < scaleUpSize; j++ {
-		if !e.limiter.PermissionToAddNode() {
+		if !e.limiter.PermissionToAddNode(ctx) {
 			return false, nil
 		}
 		fakeNodeName := fmt.Sprintf("%s-fake-%d", estimationState.lastNodeName, j)
@@ -324,10 +326,10 @@ func (e *BinpackingNodeEstimator) tryFastPath(
 }
 
 func (e *BinpackingNodeEstimator) addNewNodeToSnapshot(
-	estimationState *estimationState,
+	ctx gocontext.Context, estimationState *estimationState,
 	template *framework.NodeInfo,
 ) error {
-	newNodeInfo, err := core_utils.SanitizedNodeInfo(template, fmt.Sprintf("e-%d", estimationState.newNodeNameIndex))
+	newNodeInfo, err := core_utils.SanitizedNodeInfo(ctx, template, fmt.Sprintf("e-%d", estimationState.newNodeNameIndex))
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/estimator/binpacking_estimator.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator.go
@@ -105,6 +105,7 @@ func (e *BinpackingNodeEstimator) Estimate(
 	nodeTemplate *framework.NodeInfo,
 	nodeGroup cloudprovider.NodeGroup,
 ) (int, []*apiv1.Pod) {
+	logger := klog.FromContext(ctx)
 	observeBinpackingHeterogeneity(podsEquivalenceGroups, nodeTemplate)
 
 	e.limiter.StartEstimation(ctx, podsEquivalenceGroups, nodeGroup, e.context)
@@ -137,7 +138,7 @@ func (e *BinpackingNodeEstimator) Estimate(
 
 		remainingPods, err = e.tryToScheduleOnExistingNodes(ctx, estimationState, podsEquivalenceGroup.Pods)
 		if err != nil {
-			klog.Error(err.Error())
+			logger.Error(err, "")
 			return 0, nil
 		}
 
@@ -149,7 +150,7 @@ func (e *BinpackingNodeEstimator) Estimate(
 				newNodesAvailable, err = e.tryToScheduleOnNewNodes(ctx, estimationState, nodeTemplate, remainingPods)
 			}
 			if err != nil {
-				klog.Error(err.Error())
+				logger.Error(err, "")
 				return 0, nil
 			}
 		}

--- a/cluster-autoscaler/estimator/binpacking_estimator_test.go
+++ b/cluster-autoscaler/estimator/binpacking_estimator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -236,7 +237,7 @@ func TestBinpackingEstimate(t *testing.T) {
 			node := makeNode(tc.millicores, tc.memory, 10, "template", "zone-mars")
 			nodeInfo := framework.NewTestNodeInfo(node)
 
-			estimatedNodes, estimatedPods := estimator.Estimate(tc.podsEquivalenceGroup, nodeInfo, nil)
+			estimatedNodes, estimatedPods := estimator.Estimate(context.TODO(), tc.podsEquivalenceGroup, nodeInfo, nil)
 			assert.Equal(t, tc.expectNodeCount, estimatedNodes)
 			assert.Equal(t, tc.expectPodCount, len(estimatedPods))
 			if tc.expectProcessedPods != nil {
@@ -245,7 +246,7 @@ func TestBinpackingEstimate(t *testing.T) {
 			// For single pod group estimations, the result should be consistent with fastpath and non-fastpath
 			if len(tc.podsEquivalenceGroup) == 1 {
 				fastpathEstimator := NewBinpackingNodeEstimator(clusterSnapshot, limiter, processor, nil /* EstimationContext */, nil /* EstimationAnalyserFunc */, true)
-				fastpathEstimatedNodes, fastpathEstimatedPods := fastpathEstimator.Estimate(tc.podsEquivalenceGroup, nodeInfo, nil)
+				fastpathEstimatedNodes, fastpathEstimatedPods := fastpathEstimator.Estimate(context.TODO(), tc.podsEquivalenceGroup, nodeInfo, nil)
 				assert.Equal(t, fastpathEstimatedNodes, estimatedNodes)
 				assert.Equal(t, fastpathEstimatedPods, estimatedPods)
 			}
@@ -296,7 +297,7 @@ func BenchmarkBinpackingEstimate(b *testing.B) {
 		node := makeNode(millicores, memory, podsPerNode, "template", "zone-mars")
 		nodeInfo := framework.NewTestNodeInfo(node)
 
-		estimatedNodes, estimatedPods := estimator.Estimate(podsEquivalenceGroup, nodeInfo, nil)
+		estimatedNodes, estimatedPods := estimator.Estimate(context.TODO(), podsEquivalenceGroup, nodeInfo, nil)
 		assert.Equal(b, expectNodeCount, estimatedNodes)
 		assert.Equal(b, expectPodCount, len(estimatedPods))
 	}

--- a/cluster-autoscaler/estimator/cluster_capacity_threshold.go
+++ b/cluster-autoscaler/estimator/cluster_capacity_threshold.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	"context"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 
@@ -28,7 +29,7 @@ type clusterCapacityThreshold struct {
 //   - -1 when cluster has no available capacity
 //   - 0 when estimationContext or cluster-wide node limit is not set. Return value of 0 means that there is no limit.
 //   - Any positive number representing maximum possible number of new nodes
-func (l *clusterCapacityThreshold) NodeLimit(_ cloudprovider.NodeGroup, estimationContext EstimationContext) NodeLimitResult {
+func (l *clusterCapacityThreshold) NodeLimit(ctx context.Context, _ cloudprovider.NodeGroup, estimationContext EstimationContext) NodeLimitResult {
 	if estimationContext == nil || estimationContext.ClusterMaxNodeLimit() == 0 {
 		return NodeLimitResult{Limit: 0}
 	}

--- a/cluster-autoscaler/estimator/cluster_capacity_threshold_test.go
+++ b/cluster-autoscaler/estimator/cluster_capacity_threshold_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	gocontext "context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,7 +62,7 @@ func TestNewClusterCapacityThreshold(t *testing.T) {
 				currentNodeCount:    tt.contextCurrentNodes,
 				clusterMaxNodeLimit: tt.contextMaxNodes,
 			}
-			assert.Equal(t, tt.wantThreshold, NewClusterCapacityThreshold().NodeLimit(nil, context).Limit)
+			assert.Equal(t, tt.wantThreshold, NewClusterCapacityThreshold().NodeLimit(gocontext.TODO(), nil, context).Limit)
 			assert.True(t, NewClusterCapacityThreshold().DurationLimit(nil, nil).Duration == 0)
 		})
 	}

--- a/cluster-autoscaler/estimator/estimator.go
+++ b/cluster-autoscaler/estimator/estimator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	gocontext "context"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -52,7 +53,7 @@ func (p *PodEquivalenceGroup) Exemplar() *apiv1.Pod {
 // to schedule on those nodes.
 type Estimator interface {
 	// Estimate estimates how many nodes are needed to provision pods coming from the given equivalence groups.
-	Estimate([]PodEquivalenceGroup, *framework.NodeInfo, cloudprovider.NodeGroup) (int, []*apiv1.Pod)
+	Estimate(gocontext.Context, []PodEquivalenceGroup, *framework.NodeInfo, cloudprovider.NodeGroup) (int, []*apiv1.Pod)
 }
 
 // EstimatorBuilder creates a new estimator object.
@@ -79,7 +80,7 @@ func NewEstimatorBuilder(name string, limiter EstimationLimiter, orderer Estimat
 // scale-up is limited by external factors.
 type EstimationLimiter interface {
 	// StartEstimation is called at the start of estimation.
-	StartEstimation([]PodEquivalenceGroup, cloudprovider.NodeGroup, EstimationContext)
+	StartEstimation(gocontext.Context, []PodEquivalenceGroup, cloudprovider.NodeGroup, EstimationContext)
 	// EndEstimation is called at the end of estimation.
 	EndEstimation()
 	// PermissionToAddNode is called by an estimator when it wants to add additional
@@ -87,7 +88,7 @@ type EstimationLimiter interface {
 	// not to add any more nodes in this simulation.
 	// There is no requirement for the Estimator to stop calculations, it's
 	// just not expected to add any more nodes.
-	PermissionToAddNode() bool
+	PermissionToAddNode(gocontext.Context) bool
 }
 
 // EstimationPodOrderer is an interface used to determine the order of the pods

--- a/cluster-autoscaler/estimator/sng_capacity_threshold.go
+++ b/cluster-autoscaler/estimator/sng_capacity_threshold.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	"context"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/klog/v2"
 )
@@ -29,13 +30,13 @@ type sngCapacityThreshold struct {
 //   - -1 when this node group AND similar node groups have no available capacity
 //   - 0 when estimationContext is not set. Return value of 0 means that there is no limit.
 //   - Any positive number representing maximum possible number of new nodes
-func (t *sngCapacityThreshold) NodeLimit(nodeGroup cloudprovider.NodeGroup, estimationContext EstimationContext) NodeLimitResult {
+func (t *sngCapacityThreshold) NodeLimit(ctx context.Context, nodeGroup cloudprovider.NodeGroup, estimationContext EstimationContext) NodeLimitResult {
 	if estimationContext == nil {
 		return NodeLimitResult{Limit: 0}
 	}
-	totalAvailableCapacity := t.computeNodeGroupCapacity(nodeGroup)
+	totalAvailableCapacity := t.computeNodeGroupCapacity(ctx, nodeGroup)
 	for _, sng := range estimationContext.SimilarNodeGroups() {
-		totalAvailableCapacity += t.computeNodeGroupCapacity(sng)
+		totalAvailableCapacity += t.computeNodeGroupCapacity(ctx, sng)
 	}
 	if totalAvailableCapacity <= 0 {
 		return NodeLimitResult{Limit: -1}
@@ -43,7 +44,7 @@ func (t *sngCapacityThreshold) NodeLimit(nodeGroup cloudprovider.NodeGroup, esti
 	return NodeLimitResult{Limit: totalAvailableCapacity}
 }
 
-func (t *sngCapacityThreshold) computeNodeGroupCapacity(nodeGroup cloudprovider.NodeGroup) int {
+func (t *sngCapacityThreshold) computeNodeGroupCapacity(ctx context.Context, nodeGroup cloudprovider.NodeGroup) int {
 	nodeGroupTargetSize, err := nodeGroup.TargetSize()
 	// Should not ever happen as only valid node groups are passed to estimator
 	if err != nil {

--- a/cluster-autoscaler/estimator/sng_capacity_threshold.go
+++ b/cluster-autoscaler/estimator/sng_capacity_threshold.go
@@ -45,10 +45,11 @@ func (t *sngCapacityThreshold) NodeLimit(ctx context.Context, nodeGroup cloudpro
 }
 
 func (t *sngCapacityThreshold) computeNodeGroupCapacity(ctx context.Context, nodeGroup cloudprovider.NodeGroup) int {
+	logger := klog.FromContext(ctx)
 	nodeGroupTargetSize, err := nodeGroup.TargetSize()
 	// Should not ever happen as only valid node groups are passed to estimator
 	if err != nil {
-		klog.Errorf("Error while computing available capacity of a node group %v: can't get target size of the group: %v", nodeGroup.Id(), err)
+		logger.Error(err, "Error while computing available capacity of a node group: can't get target size of the group", "nodeGroupId", nodeGroup.Id())
 		return 0
 	}
 	groupCapacity := nodeGroup.MaxSize() - nodeGroupTargetSize

--- a/cluster-autoscaler/estimator/sng_capacity_threshold_test.go
+++ b/cluster-autoscaler/estimator/sng_capacity_threshold_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	gocontext "context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,7 +86,7 @@ func TestSngCapacityThreshold(t *testing.T) {
 			context := estimationContext{similarNodeGroups: provider.NodeGroups()}
 			provider.AddNodeGroup(tt.currentNodeGroup.name, 0, tt.currentNodeGroup.maxNodes, tt.currentNodeGroup.nodesCount)
 			currentNodeGroup := provider.GetNodeGroup(tt.currentNodeGroup.name)
-			assert.Equalf(t, tt.wantThreshold, NewSngCapacityThreshold().NodeLimit(currentNodeGroup, &context).Limit, "NewSngCapacityThreshold()")
+			assert.Equalf(t, tt.wantThreshold, NewSngCapacityThreshold().NodeLimit(gocontext.TODO(), currentNodeGroup, &context).Limit, "NewSngCapacityThreshold()")
 			assert.True(t, NewClusterCapacityThreshold().DurationLimit(currentNodeGroup, &context).Duration == 0)
 		})
 	}

--- a/cluster-autoscaler/estimator/static_threshold.go
+++ b/cluster-autoscaler/estimator/static_threshold.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -27,7 +28,7 @@ type staticThreshold struct {
 	maxDuration time.Duration
 }
 
-func (l *staticThreshold) NodeLimit(cloudprovider.NodeGroup, EstimationContext) NodeLimitResult {
+func (l *staticThreshold) NodeLimit(ctx context.Context, _ cloudprovider.NodeGroup, _ EstimationContext) NodeLimitResult {
 	return NodeLimitResult{Limit: l.maxNodes}
 }
 

--- a/cluster-autoscaler/estimator/threshold.go
+++ b/cluster-autoscaler/estimator/threshold.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -25,7 +26,7 @@ import (
 // Threshold provides resources configuration for threshold based estimation limiter.
 // Return value of 0 means that no limit is set.
 type Threshold interface {
-	NodeLimit(cloudprovider.NodeGroup, EstimationContext) NodeLimitResult
+	NodeLimit(context.Context, cloudprovider.NodeGroup, EstimationContext) NodeLimitResult
 	DurationLimit(cloudprovider.NodeGroup, EstimationContext) DurationLimitResult
 }
 

--- a/cluster-autoscaler/estimator/threshold_based_limiter.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	gocontext "context"
 	"fmt"
 	"strings"
 	"time"
@@ -34,14 +35,14 @@ type thresholdBasedEstimationLimiter struct {
 	debugStrings []string
 }
 
-func (tbel *thresholdBasedEstimationLimiter) StartEstimation(_ []PodEquivalenceGroup, nodeGroup cloudprovider.NodeGroup, context EstimationContext) {
+func (tbel *thresholdBasedEstimationLimiter) StartEstimation(ctx gocontext.Context, _ []PodEquivalenceGroup, nodeGroup cloudprovider.NodeGroup, context EstimationContext) {
 	tbel.start = time.Now()
 	tbel.nodes = 0
 	tbel.maxNodes = 0
 	tbel.maxDuration = time.Duration(0)
 	tbel.debugStrings = make([]string, 0)
 	for _, threshold := range tbel.thresholds {
-		nodeLimitResult := threshold.NodeLimit(nodeGroup, context)
+		nodeLimitResult := threshold.NodeLimit(ctx, nodeGroup, context)
 		tbel.maxNodes = getMinLimit(tbel.maxNodes, nodeLimitResult.Limit)
 		if nodeLimitResult.Reason != "" {
 			tbel.debugStrings = append(tbel.debugStrings, fmt.Sprintf("%T(Node Limit): %s", threshold, nodeLimitResult.Reason))
@@ -66,7 +67,7 @@ func getMinLimit[V int | time.Duration](baseLimit V, targetLimit V) V {
 
 func (*thresholdBasedEstimationLimiter) EndEstimation() {}
 
-func (tbel *thresholdBasedEstimationLimiter) PermissionToAddNode() bool {
+func (tbel *thresholdBasedEstimationLimiter) PermissionToAddNode(ctx gocontext.Context) bool {
 	if tbel.maxNodes < 0 || (tbel.maxNodes > 0 && tbel.nodes >= tbel.maxNodes) {
 		klog.V(4).Infof("Capping binpacking after exceeding threshold of %d nodes. Debug: %s", tbel.maxNodes, strings.Join(tbel.debugStrings, ","))
 		return false

--- a/cluster-autoscaler/estimator/threshold_based_limiter.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter.go
@@ -68,13 +68,14 @@ func getMinLimit[V int | time.Duration](baseLimit V, targetLimit V) V {
 func (*thresholdBasedEstimationLimiter) EndEstimation() {}
 
 func (tbel *thresholdBasedEstimationLimiter) PermissionToAddNode(ctx gocontext.Context) bool {
+	logger := klog.FromContext(ctx)
 	if tbel.maxNodes < 0 || (tbel.maxNodes > 0 && tbel.nodes >= tbel.maxNodes) {
-		klog.V(4).Infof("Capping binpacking after exceeding threshold of %d nodes. Debug: %s", tbel.maxNodes, strings.Join(tbel.debugStrings, ","))
+		logger.V(4).Info("Capping binpacking after exceeding threshold nodes. Debug", "maxNodes", tbel.maxNodes, "debugStrings", strings.Join(tbel.debugStrings, ","))
 		return false
 	}
 	timeDefined := tbel.maxDuration > 0 && tbel.start != time.Time{}
 	if tbel.maxDuration < 0 || (timeDefined && time.Now().After(tbel.start.Add(tbel.maxDuration))) {
-		klog.V(4).Infof("Capping binpacking after exceeding max duration of %v. Debug: %s", tbel.maxDuration, strings.Join(tbel.debugStrings, ","))
+		logger.V(4).Info("Capping binpacking after exceeding max duration. Debug", "maxDuration", tbel.maxDuration, "debugStrings", strings.Join(tbel.debugStrings, ","))
 		return false
 	}
 	tbel.nodes++

--- a/cluster-autoscaler/estimator/threshold_based_limiter_test.go
+++ b/cluster-autoscaler/estimator/threshold_based_limiter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package estimator
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,16 +28,16 @@ import (
 type limiterOperation func(*testing.T, EstimationLimiter)
 
 func expectDeny(t *testing.T, l EstimationLimiter) {
-	assert.Equal(t, false, l.PermissionToAddNode())
+	assert.Equal(t, false, l.PermissionToAddNode(context.TODO()))
 }
 
 func expectAllow(t *testing.T, l EstimationLimiter) {
-	assert.Equal(t, true, l.PermissionToAddNode())
+	assert.Equal(t, true, l.PermissionToAddNode(context.TODO()))
 }
 
 func resetLimiter(_ *testing.T, l EstimationLimiter) {
 	l.EndEstimation()
-	l.StartEstimation([]PodEquivalenceGroup{}, nil, nil)
+	l.StartEstimation(context.TODO(), []PodEquivalenceGroup{}, nil, nil)
 }
 
 type dynamicThreshold struct {
@@ -47,7 +48,7 @@ func (d *dynamicThreshold) DurationLimit(cloudprovider.NodeGroup, EstimationCont
 	return DurationLimitResult{Duration: 0}
 }
 
-func (d *dynamicThreshold) NodeLimit(cloudprovider.NodeGroup, EstimationContext) NodeLimitResult {
+func (d *dynamicThreshold) NodeLimit(ctx context.Context, _ cloudprovider.NodeGroup, _ EstimationContext) NodeLimitResult {
 	d.nodeLimit += 1
 	return NodeLimitResult{Limit: d.nodeLimit}
 }
@@ -172,7 +173,7 @@ func TestThresholdBasedLimiter(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			limiter := NewThresholdBasedEstimationLimiter(tc.thresholds).(*thresholdBasedEstimationLimiter)
-			limiter.StartEstimation([]PodEquivalenceGroup{}, nil, nil)
+			limiter.StartEstimation(context.TODO(), []PodEquivalenceGroup{}, nil, nil)
 
 			if tc.startDelta != time.Duration(0) {
 				limiter.start = limiter.start.Add(tc.startDelta)

--- a/cluster-autoscaler/expander/expander.go
+++ b/cluster-autoscaler/expander/expander.go
@@ -17,6 +17,7 @@ limitations under the License.
 package expander
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
@@ -53,10 +54,10 @@ type Option struct {
 
 // Strategy describes an interface for selecting the best option when scaling up
 type Strategy interface {
-	BestOption(options []Option, nodeInfo map[string]*framework.NodeInfo) *Option
+	BestOption(ctx context.Context, options []Option, nodeInfo map[string]*framework.NodeInfo) *Option
 }
 
 // Filter describes an interface for filtering to equally good options according to some criteria
 type Filter interface {
-	BestOptions(options []Option, nodeInfo map[string]*framework.NodeInfo) []Option
+	BestOptions(ctx context.Context, options []Option, nodeInfo map[string]*framework.NodeInfo) []Option
 }

--- a/cluster-autoscaler/expander/factory/chain.go
+++ b/cluster-autoscaler/expander/factory/chain.go
@@ -17,6 +17,7 @@ limitations under the License.
 package factory
 
 import (
+	"context"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 )
@@ -33,13 +34,13 @@ func newChainStrategy(filters []expander.Filter, fallback expander.Strategy) exp
 	}
 }
 
-func (c *chainStrategy) BestOption(options []expander.Option, nodeInfo map[string]*framework.NodeInfo) *expander.Option {
+func (c *chainStrategy) BestOption(ctx context.Context, options []expander.Option, nodeInfo map[string]*framework.NodeInfo) *expander.Option {
 	filteredOptions := options
 	for _, filter := range c.filters {
-		filteredOptions = filter.BestOptions(filteredOptions, nodeInfo)
+		filteredOptions = filter.BestOptions(ctx, filteredOptions, nodeInfo)
 		if len(filteredOptions) == 1 {
 			return &filteredOptions[0]
 		}
 	}
-	return c.fallback.BestOption(filteredOptions, nodeInfo)
+	return c.fallback.BestOption(ctx, filteredOptions, nodeInfo)
 }

--- a/cluster-autoscaler/expander/factory/chain_test.go
+++ b/cluster-autoscaler/expander/factory/chain_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package factory
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -35,7 +36,7 @@ func newSubstringTestFilterStrategy(substring string) *substringTestFilterStrate
 	}
 }
 
-func (s *substringTestFilterStrategy) BestOptions(expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+func (s *substringTestFilterStrategy) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
 	var ret []expander.Option
 	for _, option := range expansionOptions {
 		if strings.Contains(option.Debug, s.substring) {
@@ -46,8 +47,8 @@ func (s *substringTestFilterStrategy) BestOptions(expansionOptions []expander.Op
 
 }
 
-func (s *substringTestFilterStrategy) BestOption(expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) *expander.Option {
-	ret := s.BestOptions(expansionOptions, nodeInfo)
+func (s *substringTestFilterStrategy) BestOption(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) *expander.Option {
+	ret := s.BestOptions(ctx, expansionOptions, nodeInfo)
 	if len(ret) == 0 {
 		return nil
 	}
@@ -120,7 +121,7 @@ func TestChainStrategy_BestOption(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			subject := newChainStrategy(tc.filters, tc.fallback)
-			actual := subject.BestOption(tc.options, nil)
+			actual := subject.BestOption(context.TODO(), tc.options, nil)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}

--- a/cluster-autoscaler/expander/grpcplugin/grpc_client.go
+++ b/cluster-autoscaler/expander/grpcplugin/grpc_client.go
@@ -73,8 +73,10 @@ func createGRPCClient(expanderCert string, expanderUrl string) protos.ExpanderCl
 }
 
 func (g *grpcclientstrategy) BestOptions(logging_ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+	logger := klog.FromContext(logging_ctx)
 	if g.grpcClient == nil {
-		klog.Errorf("Incorrect gRPC client config, filtering no options")
+		logger.Error(nil, "Incorrect gRPC client config, filtering no options")
+
 		return expansionOptions
 	}
 
@@ -83,23 +85,23 @@ func (g *grpcclientstrategy) BestOptions(logging_ctx context.Context, expansionO
 	grpcNodeBytesMap := populateNodeInfoForGRPC(nodeInfo)
 
 	// call gRPC server to get BestOption
-	klog.V(2).Infof("GPRC call of best options to server with %v options", len(nodeGroupIDOptionMap))
+	logger.V(2).Info("Calling gRPC server for best options", "nodeGroupIDOptionMapCount", len(nodeGroupIDOptionMap))
 	ctx, cancel := context.WithTimeout(context.Background(), gRPCTimeout)
 	defer cancel()
 	bestOptionsResponse, err := g.grpcClient.BestOptions(ctx, &protos.BestOptionsRequest{Options: grpcOptionsSlice, NodeBytesMap: grpcNodeBytesMap})
 	if err != nil {
-		klog.V(4).Infof("GRPC call failed, no options filtered: %v", err)
+		logger.V(4).Info("GRPC call failed, no options filtered", "err", err)
 		return expansionOptions
 	}
 
 	if bestOptionsResponse == nil || len(bestOptionsResponse.Options) == 0 {
-		klog.V(4).Info("GRPC returned nil bestOptions")
+		logger.V(4).Info("GRPC returned nil bestOptions")
 		return nil
 	}
 	// Transform back options slice
 	options := transformAndSanitizeOptionsFromGRPC(logging_ctx, bestOptionsResponse.Options, nodeGroupIDOptionMap)
 	if options == nil {
-		klog.V(4).Info("Unable to sanitize GPRC returned bestOptions, no options filtered")
+		logger.V(4).Info("Unable to sanitize GPRC returned bestOptions, no options filtered")
 		return expansionOptions
 	}
 	return options
@@ -138,16 +140,17 @@ func populateNodeInfoForGRPC(nodeInfos map[string]*framework.NodeInfo) map[strin
 }
 
 func transformAndSanitizeOptionsFromGRPC(ctx context.Context, bestOptionsResponseOptions []*protos.Option, nodeGroupIDOptionMap map[string]expander.Option) []expander.Option {
+	logger := klog.FromContext(ctx)
 	var options []expander.Option
 	for _, option := range bestOptionsResponseOptions {
 		if option == nil {
-			klog.Error("GRPC server returned nil Option")
+			logger.Error(nil, "GRPC server returned nil Option")
 			continue
 		}
 		if _, ok := nodeGroupIDOptionMap[option.NodeGroupId]; ok {
 			options = append(options, nodeGroupIDOptionMap[option.NodeGroupId])
 		} else {
-			klog.Errorf("GRPC server returned invalid nodeGroup ID: %s", option.NodeGroupId)
+			logger.Error(nil, "GRPC server returned invalid nodeGroup ID", "nodeGroupId", option.NodeGroupId)
 			continue
 		}
 	}

--- a/cluster-autoscaler/expander/grpcplugin/grpc_client.go
+++ b/cluster-autoscaler/expander/grpcplugin/grpc_client.go
@@ -72,8 +72,8 @@ func createGRPCClient(expanderCert string, expanderUrl string) protos.ExpanderCl
 	return protos.NewExpanderClient(conn)
 }
 
-func (g *grpcclientstrategy) BestOptions(logging_ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
-	logger := klog.FromContext(logging_ctx)
+func (g *grpcclientstrategy) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+	logger := klog.FromContext(ctx)
 	if g.grpcClient == nil {
 		logger.Error(nil, "Incorrect gRPC client config, filtering no options")
 
@@ -86,9 +86,9 @@ func (g *grpcclientstrategy) BestOptions(logging_ctx context.Context, expansionO
 
 	// call gRPC server to get BestOption
 	logger.V(2).Info("Calling gRPC server for best options", "nodeGroupIDOptionMapCount", len(nodeGroupIDOptionMap))
-	ctx, cancel := context.WithTimeout(context.Background(), gRPCTimeout)
+	callCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gRPCTimeout)
 	defer cancel()
-	bestOptionsResponse, err := g.grpcClient.BestOptions(ctx, &protos.BestOptionsRequest{Options: grpcOptionsSlice, NodeBytesMap: grpcNodeBytesMap})
+	bestOptionsResponse, err := g.grpcClient.BestOptions(callCtx, &protos.BestOptionsRequest{Options: grpcOptionsSlice, NodeBytesMap: grpcNodeBytesMap})
 	if err != nil {
 		logger.V(4).Info("GRPC call failed, no options filtered", "err", err)
 		return expansionOptions
@@ -99,7 +99,7 @@ func (g *grpcclientstrategy) BestOptions(logging_ctx context.Context, expansionO
 		return nil
 	}
 	// Transform back options slice
-	options := transformAndSanitizeOptionsFromGRPC(logging_ctx, bestOptionsResponse.Options, nodeGroupIDOptionMap)
+	options := transformAndSanitizeOptionsFromGRPC(ctx, bestOptionsResponse.Options, nodeGroupIDOptionMap)
 	if options == nil {
 		logger.V(4).Info("Unable to sanitize GPRC returned bestOptions, no options filtered")
 		return expansionOptions

--- a/cluster-autoscaler/expander/grpcplugin/grpc_client.go
+++ b/cluster-autoscaler/expander/grpcplugin/grpc_client.go
@@ -72,7 +72,7 @@ func createGRPCClient(expanderCert string, expanderUrl string) protos.ExpanderCl
 	return protos.NewExpanderClient(conn)
 }
 
-func (g *grpcclientstrategy) BestOptions(expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+func (g *grpcclientstrategy) BestOptions(logging_ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
 	if g.grpcClient == nil {
 		klog.Errorf("Incorrect gRPC client config, filtering no options")
 		return expansionOptions
@@ -97,7 +97,7 @@ func (g *grpcclientstrategy) BestOptions(expansionOptions []expander.Option, nod
 		return nil
 	}
 	// Transform back options slice
-	options := transformAndSanitizeOptionsFromGRPC(bestOptionsResponse.Options, nodeGroupIDOptionMap)
+	options := transformAndSanitizeOptionsFromGRPC(logging_ctx, bestOptionsResponse.Options, nodeGroupIDOptionMap)
 	if options == nil {
 		klog.V(4).Info("Unable to sanitize GPRC returned bestOptions, no options filtered")
 		return expansionOptions
@@ -137,7 +137,7 @@ func populateNodeInfoForGRPC(nodeInfos map[string]*framework.NodeInfo) map[strin
 	return grpcNodeBytesMap
 }
 
-func transformAndSanitizeOptionsFromGRPC(bestOptionsResponseOptions []*protos.Option, nodeGroupIDOptionMap map[string]expander.Option) []expander.Option {
+func transformAndSanitizeOptionsFromGRPC(ctx context.Context, bestOptionsResponseOptions []*protos.Option, nodeGroupIDOptionMap map[string]expander.Option) []expander.Option {
 	var options []expander.Option
 	for _, option := range bestOptionsResponseOptions {
 		if option == nil {

--- a/cluster-autoscaler/expander/grpcplugin/grpc_client_test.go
+++ b/cluster-autoscaler/expander/grpcplugin/grpc_client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package grpcplugin
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -153,7 +154,7 @@ func TestValidTransformAndSanitizeOptionsFromGRPC(t *testing.T) {
 
 	expectedOptions := []expander.Option{eoT2Micro, eoT3Large, eoM44XLarge}
 
-	ret := transformAndSanitizeOptionsFromGRPC(responseOptionsSlice, nodeGroupIDOptionMap)
+	ret := transformAndSanitizeOptionsFromGRPC(context.TODO(), responseOptionsSlice, nodeGroupIDOptionMap)
 	assert.Equal(t, expectedOptions, ret)
 }
 
@@ -165,7 +166,7 @@ func TestAnInvalidTransformAndSanitizeOptionsFromGRPC(t *testing.T) {
 		eoT3Large.NodeGroup.Id(): eoT3Large,
 	}
 
-	ret := transformAndSanitizeOptionsFromGRPC(responseOptionsSlice, nodeGroupIDOptionMap)
+	ret := transformAndSanitizeOptionsFromGRPC(context.TODO(), responseOptionsSlice, nodeGroupIDOptionMap)
 	assert.Equal(t, []expander.Option{eoT2Micro, eoT3Large}, ret)
 }
 
@@ -189,7 +190,7 @@ func TestBestOptionsValid(t *testing.T) {
 		gomock.Any(), gomock.Eq(expectedBestOptionsReq),
 	).Return(&protos.BestOptionsResponse{Options: []*protos.Option{&grpcEoT3Large}}, nil)
 
-	resp := g.BestOptions(options, nodeInfos)
+	resp := g.BestOptions(context.TODO(), options, nodeInfos)
 
 	assert.Equal(t, resp, []expander.Option{eoT3Large})
 }
@@ -226,7 +227,7 @@ func TestBestOptionsEmpty(t *testing.T) {
 					Options:      []*protos.Option{&grpcEoT2Micro, &grpcEoT2Large, &grpcEoT3Large, &grpcEoM44XLarge},
 					NodeBytesMap: grpcNodeBytesMap,
 				})).Return(&tc.mockResponse, nil)
-		resp := g.BestOptions(options, makeFakeNodeInfos())
+		resp := g.BestOptions(context.TODO(), options, makeFakeNodeInfos())
 
 		assert.Nil(t, resp)
 	}
@@ -292,7 +293,7 @@ func TestBestOptionsErrors(t *testing.T) {
 						NodeBytesMap: grpcNodeBytesMap,
 					})).Return(&tc.mockResponse, tc.errResponse)
 		}
-		resp := tc.client.BestOptions(options, tc.nodeInfo)
+		resp := tc.client.BestOptions(context.TODO(), options, tc.nodeInfo)
 
 		assert.Equal(t, resp, options)
 	}

--- a/cluster-autoscaler/expander/leastnodes/leastnodes.go
+++ b/cluster-autoscaler/expander/leastnodes/leastnodes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package leastnodes
 
 import (
+	"context"
 	"math"
 
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -32,7 +33,7 @@ func NewFilter() expander.Filter {
 }
 
 // BestOptions selects the expansion option that uses the least number of nodes
-func (m *leastnodes) BestOptions(expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+func (m *leastnodes) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
 	leastNodes := math.MaxInt
 	var leastOptions []expander.Option
 

--- a/cluster-autoscaler/expander/leastnodes/leastnodes_test.go
+++ b/cluster-autoscaler/expander/leastnodes/leastnodes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package leastnodes
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,7 +107,7 @@ func TestLeastNodes(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			e := NewFilter()
-			ret := e.BestOptions(tc.expansionOptions, nil)
+			ret := e.BestOptions(context.TODO(), tc.expansionOptions, nil)
 			assert.Equal(t, ret, tc.expectedExpansionOptions)
 		})
 	}

--- a/cluster-autoscaler/expander/mostpods/mostpods.go
+++ b/cluster-autoscaler/expander/mostpods/mostpods.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mostpods
 
 import (
+	"context"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 )
@@ -30,7 +31,7 @@ func NewFilter() expander.Filter {
 }
 
 // BestOptions selects the expansion option that schedules the most pods
-func (m *mostpods) BestOptions(expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+func (m *mostpods) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
 	var maxPods int
 	var maxOptions []expander.Option
 

--- a/cluster-autoscaler/expander/mostpods/mostpods_test.go
+++ b/cluster-autoscaler/expander/mostpods/mostpods_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mostpods
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,15 +30,15 @@ func TestMostPods(t *testing.T) {
 	e := NewFilter()
 
 	eo0 := expander.Option{Debug: "EO0"}
-	ret := e.BestOptions([]expander.Option{eo0}, nil)
+	ret := e.BestOptions(context.TODO(), []expander.Option{eo0}, nil)
 	assert.Equal(t, ret, []expander.Option{eo0})
 
 	eo1 := expander.Option{Debug: "EO1", Pods: []*apiv1.Pod{nil}}
-	ret = e.BestOptions([]expander.Option{eo0, eo1}, nil)
+	ret = e.BestOptions(context.TODO(), []expander.Option{eo0, eo1}, nil)
 	assert.Equal(t, ret, []expander.Option{eo1})
 
 	eo1b := expander.Option{Debug: "EO1b", Pods: []*apiv1.Pod{nil}}
-	ret = e.BestOptions([]expander.Option{eo0, eo1, eo1b}, nil)
+	ret = e.BestOptions(context.TODO(), []expander.Option{eo0, eo1, eo1b}, nil)
 	assert.NotEqual(t, ret, []expander.Option{eo0})
 	assert.ObjectsAreEqual(ret, []expander.Option{eo1, eo1b})
 }

--- a/cluster-autoscaler/expander/price/price.go
+++ b/cluster-autoscaler/expander/price/price.go
@@ -89,6 +89,7 @@ func NewFilter(cloudProvider cloudprovider.CloudProvider,
 
 // BestOption selects option based on cost and preferred node type.
 func (p *priceBased) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfos map[string]*framework.NodeInfo) []expander.Option {
+	logger := klog.FromContext(ctx)
 	var bestOptions []expander.Option
 	bestOptionScore := 0.0
 	now := time.Now()
@@ -96,18 +97,18 @@ func (p *priceBased) BestOptions(ctx context.Context, expansionOptions []expande
 
 	preferredNode, err := p.preferredNodeProvider.Node()
 	if err != nil {
-		klog.Errorf("Failed to get preferred node, switching to default: %v", err)
+		logger.Error(err, "Failed to get preferred node, switching to default")
 		preferredNode = defaultPreferredNode
 	}
 
 	pricingModel, err := p.cloudProvider.Pricing()
 	if err != nil {
-		klog.Errorf("Failed to get pricing model from cloud provider: %v", err)
+		logger.Error(err, "Failed to get pricing model from cloud provider")
 	}
 
 	stabilizationPrice, err := pricingModel.PodPrice(priceStabilizationPod, now, then)
 	if err != nil {
-		klog.Errorf("Failed to get price for stabilization pod: %v", err)
+		logger.Error(err, "Failed to get price for stabilization pod")
 		// continuing without stabilization.
 	}
 
@@ -115,12 +116,12 @@ nextoption:
 	for _, option := range expansionOptions {
 		nodeInfo, found := nodeInfos[option.NodeGroup.Id()]
 		if !found {
-			klog.Warningf("No node info for %s", option.NodeGroup.Id())
+			logger.Info("No node info", "nodeGroupId", option.NodeGroup.Id())
 			continue
 		}
 		nodePrice, err := pricingModel.NodePrice(nodeInfo.Node(), now, then)
 		if err != nil {
-			klog.Warningf("Failed to calculate node price for %s: %v", option.NodeGroup.Id(), err)
+			logger.Info("Failed to calculate node price", "nodeGroupId", option.NodeGroup.Id(), "err", err)
 			continue
 		}
 		totalNodePrice := nodePrice * float64(option.NodeCount)
@@ -128,7 +129,7 @@ nextoption:
 		for _, pod := range option.Pods {
 			podPrice, err := pricingModel.PodPrice(pod, now, then)
 			if err != nil {
-				klog.Warningf("Failed to calculate pod price for %s/%s: %v", pod.Namespace, pod.Name, err)
+				logger.Info("Failed to calculate pod price", "namespace", pod.Namespace, "pod", pod.Name, "err", err)
 				continue nextoption
 			}
 			totalPodPrice += podPrice
@@ -149,7 +150,7 @@ nextoption:
 		// Set constant, very high unfitness to make them unattractive for pods that doesn't need GPU and
 		// avoid optimizing them for CPU utilization.
 		if gpu.NodeHasGpu(p.cloudProvider.GPULabel(), nodeInfo.Node()) {
-			klog.V(4).Infof("Price expander overriding unfitness for node group with GPU %s", option.NodeGroup.Id())
+			logger.V(4).Info("Price expander overriding unfitness for node group with GPU", "nodeGroupId", option.NodeGroup.Id())
 			supressedUnfitness = gpuUnfitnessOverride
 		}
 
@@ -167,8 +168,7 @@ nextoption:
 			supressedUnfitness,
 			optionScore,
 		)
-
-		klog.V(5).Infof("Price expander for %s: %s", option.NodeGroup.Id(), debug)
+		logger.V(5).Info("Price expander", "nodeGroupId", option.NodeGroup.Id(), "debug", debug)
 
 		maybeBestOption := expander.Option{
 			NodeGroup: option.NodeGroup,

--- a/cluster-autoscaler/expander/price/price.go
+++ b/cluster-autoscaler/expander/price/price.go
@@ -17,6 +17,7 @@ limitations under the License.
 package price
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"time"
@@ -87,7 +88,7 @@ func NewFilter(cloudProvider cloudprovider.CloudProvider,
 }
 
 // BestOption selects option based on cost and preferred node type.
-func (p *priceBased) BestOptions(expansionOptions []expander.Option, nodeInfos map[string]*framework.NodeInfo) []expander.Option {
+func (p *priceBased) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfos map[string]*framework.NodeInfo) []expander.Option {
 	var bestOptions []expander.Option
 	bestOptionScore := 0.0
 	now := time.Now()

--- a/cluster-autoscaler/expander/price/price_test.go
+++ b/cluster-autoscaler/expander/price/price_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package price
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -133,7 +134,7 @@ func TestPriceExpander(t *testing.T) {
 			preferred: buildNode(2000, units.GiB),
 		},
 		SimpleNodeUnfitness,
-	).BestOptions(options, nodeInfosForGroups)), []string{"ng1"})
+	).BestOptions(context.TODO(), options, nodeInfosForGroups)), []string{"ng1"})
 
 	// First node group is cheaper, however, the second one is preferred.
 	pricingModel = &testPricingModel{
@@ -154,7 +155,7 @@ func TestPriceExpander(t *testing.T) {
 			preferred: buildNode(4000, units.GiB),
 		},
 		SimpleNodeUnfitness,
-	).BestOptions(options, nodeInfosForGroups)), []string{"ng2"})
+	).BestOptions(context.TODO(), options, nodeInfosForGroups)), []string{"ng2"})
 
 	// All node groups accept the same set of pods. Lots of nodes.
 	options1b := []expander.Option{
@@ -192,7 +193,7 @@ func TestPriceExpander(t *testing.T) {
 			preferred: buildNode(4000, units.GiB),
 		},
 		SimpleNodeUnfitness,
-	).BestOptions(options1b, nodeInfosForGroups)), []string{"ng1"})
+	).BestOptions(context.TODO(), options1b, nodeInfosForGroups)), []string{"ng1"})
 
 	// Second node group is cheaper
 	pricingModel = &testPricingModel{
@@ -213,7 +214,7 @@ func TestPriceExpander(t *testing.T) {
 			preferred: buildNode(2000, units.GiB),
 		},
 		SimpleNodeUnfitness,
-	).BestOptions(options, nodeInfosForGroups)), []string{"ng2"})
+	).BestOptions(context.TODO(), options, nodeInfosForGroups)), []string{"ng2"})
 
 	// First group accept 1 pod and second accepts 2.
 	options2 := []expander.Option{
@@ -250,7 +251,7 @@ func TestPriceExpander(t *testing.T) {
 			preferred: buildNode(2000, units.GiB),
 		},
 		SimpleNodeUnfitness,
-	).BestOptions(options2, nodeInfosForGroups)), []string{"ng2"})
+	).BestOptions(context.TODO(), options2, nodeInfosForGroups)), []string{"ng2"})
 
 	// Errors are expected
 	pricingModel = &testPricingModel{
@@ -264,7 +265,7 @@ func TestPriceExpander(t *testing.T) {
 			preferred: buildNode(2000, units.GiB),
 		},
 		SimpleNodeUnfitness,
-	).BestOptions(options2, nodeInfosForGroups))
+	).BestOptions(context.TODO(), options2, nodeInfosForGroups))
 
 	// Add node info for autoprovisioned group.
 	nodeInfosForGroups["autoprovisioned-MT1"] = ni3
@@ -309,7 +310,7 @@ func TestPriceExpander(t *testing.T) {
 			preferred: buildNode(2000, units.GiB),
 		},
 		SimpleNodeUnfitness,
-	).BestOptions(options3, nodeInfosForGroups)), []string{"ng2"})
+	).BestOptions(context.TODO(), options3, nodeInfosForGroups)), []string{"ng2"})
 
 	// Choose non-existing group when non-existing is cheaper.
 	pricingModel = &testPricingModel{
@@ -331,5 +332,5 @@ func TestPriceExpander(t *testing.T) {
 			preferred: buildNode(2000, units.GiB),
 		},
 		SimpleNodeUnfitness,
-	).BestOptions(options3, nodeInfosForGroups)), []string{"ng3"})
+	).BestOptions(context.TODO(), options3, nodeInfosForGroups)), []string{"ng3"})
 }

--- a/cluster-autoscaler/expander/priority/priority.go
+++ b/cluster-autoscaler/expander/priority/priority.go
@@ -84,12 +84,14 @@ func (p *priority) reloadConfigMap(ctx context.Context) (priorities, *apiv1.Conf
 }
 
 func (p *priority) logConfigWarning(ctx context.Context, cm *apiv1.ConfigMap, reason, msg string) {
+	logger := klog.FromContext(ctx)
 	p.logRecorder.Event(cm, apiv1.EventTypeWarning, reason, msg)
-	klog.Warning(msg)
+	logger.Info(msg)
 	p.badConfigUpdates++
 }
 
 func (p *priority) parsePrioritiesYAMLString(ctx context.Context, prioritiesYAML string) (priorities, error) {
+	logger := klog.FromContext(ctx)
 	if prioritiesYAML == "" {
 		return nil, fmt.Errorf("priority configuration in %s configmap is empty; please provide valid configuration",
 			PriorityConfigMapName)
@@ -112,12 +114,13 @@ func (p *priority) parsePrioritiesYAMLString(ctx context.Context, prioritiesYAML
 
 	p.okConfigUpdates++
 	msg := "Successfully loaded priority configuration from configmap."
-	klog.V(4).Info(msg)
+	logger.V(4).Info(msg)
 
 	return newPriorities, nil
 }
 
 func (p *priority) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+	logger := klog.FromContext(ctx)
 	if len(expansionOptions) <= 0 {
 		return nil
 	}
@@ -161,7 +164,7 @@ func (p *priority) BestOptions(ctx context.Context, expansionOptions []expander.
 	}
 
 	for _, opt := range best {
-		klog.V(2).Infof("priority expander: %s chosen as the highest available", opt.NodeGroup.Id())
+		logger.V(2).Info("priority expander: chosen as the highest available", "nodeGroupId", opt.NodeGroup.Id())
 	}
 	return best
 }

--- a/cluster-autoscaler/expander/priority/priority.go
+++ b/cluster-autoscaler/expander/priority/priority.go
@@ -17,6 +17,7 @@ limitations under the License.
 package priority
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -58,7 +59,7 @@ func NewFilter(configMapLister v1lister.ConfigMapNamespaceLister,
 	return res
 }
 
-func (p *priority) reloadConfigMap() (priorities, *apiv1.ConfigMap, error) {
+func (p *priority) reloadConfigMap(ctx context.Context) (priorities, *apiv1.ConfigMap, error) {
 	cm, err := p.configMapLister.Get(PriorityConfigMapName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Priority expander config map %s not found: %v", PriorityConfigMapName, err)
@@ -68,27 +69,27 @@ func (p *priority) reloadConfigMap() (priorities, *apiv1.ConfigMap, error) {
 	if !found {
 		msg := fmt.Sprintf("Wrong configmap for priority expander, doesn't contain %s key. Ignoring update.",
 			ConfigMapKey)
-		p.logConfigWarning(cm, "PriorityConfigMapInvalid", msg)
+		p.logConfigWarning(ctx, cm, "PriorityConfigMapInvalid", msg)
 		return nil, cm, errors.New(msg)
 	}
 
-	newPriorities, err := p.parsePrioritiesYAMLString(prioString)
+	newPriorities, err := p.parsePrioritiesYAMLString(ctx, prioString)
 	if err != nil {
 		msg := fmt.Sprintf("Wrong configuration for priority expander: %v. Ignoring update.", err)
-		p.logConfigWarning(cm, "PriorityConfigMapInvalid", msg)
+		p.logConfigWarning(ctx, cm, "PriorityConfigMapInvalid", msg)
 		return nil, cm, err
 	}
 
 	return newPriorities, cm, nil
 }
 
-func (p *priority) logConfigWarning(cm *apiv1.ConfigMap, reason, msg string) {
+func (p *priority) logConfigWarning(ctx context.Context, cm *apiv1.ConfigMap, reason, msg string) {
 	p.logRecorder.Event(cm, apiv1.EventTypeWarning, reason, msg)
 	klog.Warning(msg)
 	p.badConfigUpdates++
 }
 
-func (p *priority) parsePrioritiesYAMLString(prioritiesYAML string) (priorities, error) {
+func (p *priority) parsePrioritiesYAMLString(ctx context.Context, prioritiesYAML string) (priorities, error) {
 	if prioritiesYAML == "" {
 		return nil, fmt.Errorf("priority configuration in %s configmap is empty; please provide valid configuration",
 			PriorityConfigMapName)
@@ -116,12 +117,12 @@ func (p *priority) parsePrioritiesYAMLString(prioritiesYAML string) (priorities,
 	return newPriorities, nil
 }
 
-func (p *priority) BestOptions(expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+func (p *priority) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
 	if len(expansionOptions) <= 0 {
 		return nil
 	}
 
-	priorities, cm, err := p.reloadConfigMap()
+	priorities, cm, err := p.reloadConfigMap(ctx)
 	if err != nil {
 		return expansionOptions
 	}
@@ -149,13 +150,13 @@ func (p *priority) BestOptions(expansionOptions []expander.Option, nodeInfo map[
 		if !found {
 			msg := fmt.Sprintf("Priority expander: node group %s not found in priority expander configuration. "+
 				"The group won't be used.", id)
-			p.logConfigWarning(cm, "PriorityConfigMapNotMatchedGroup", msg)
+			p.logConfigWarning(ctx, cm, "PriorityConfigMapNotMatchedGroup", msg)
 		}
 	}
 
 	if len(best) == 0 {
 		msg := "Priority expander: no priorities info found for any of the expansion options. No options filtered."
-		p.logConfigWarning(cm, "PriorityConfigMapNoGroupMatched", msg)
+		p.logConfigWarning(ctx, cm, "PriorityConfigMapNoGroupMatched", msg)
 		return expansionOptions
 	}
 

--- a/cluster-autoscaler/expander/priority/priority_test.go
+++ b/cluster-autoscaler/expander/priority/priority_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package priority
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -106,37 +107,37 @@ func getFilterInstance(t *testing.T, config string) (expander.Filter, *record.Fa
 
 func TestPriorityExpanderCorrecltyFiltersSingleMatchingOptionOutOfOne(t *testing.T) {
 	s, _, _ := getFilterInstance(t, config)
-	ret := s.BestOptions([]expander.Option{eoT2Large}, nil)
+	ret := s.BestOptions(context.TODO(), []expander.Option{eoT2Large}, nil)
 	assert.Equal(t, ret, []expander.Option{eoT2Large})
 }
 
 func TestPriorityExpanderCorrecltyFiltersSingleMatchingOptionOutOfMany(t *testing.T) {
 	s, _, _ := getFilterInstance(t, config)
-	ret := s.BestOptions([]expander.Option{eoT2Large, eoM44XLarge}, nil)
+	ret := s.BestOptions(context.TODO(), []expander.Option{eoT2Large, eoM44XLarge}, nil)
 	assert.Equal(t, ret, []expander.Option{eoM44XLarge})
 }
 
 func TestPriorityExpanderFiltersToHigherPriorityMatch(t *testing.T) {
 	s, _, _ := getFilterInstance(t, wildcardMatchConfig)
-	ret := s.BestOptions([]expander.Option{eoT2Large, eoT2Micro}, nil)
+	ret := s.BestOptions(context.TODO(), []expander.Option{eoT2Large, eoT2Micro}, nil)
 	assert.Equal(t, ret, []expander.Option{eoT2Large})
 }
 
 func TestPriorityExpanderCorrecltyFiltersTwoMatchingOptionsOutOfMany(t *testing.T) {
 	s, _, _ := getFilterInstance(t, config)
-	ret := s.BestOptions([]expander.Option{eoT2Large, eoT3Large, eoT2Micro}, nil)
+	ret := s.BestOptions(context.TODO(), []expander.Option{eoT2Large, eoT3Large, eoT2Micro}, nil)
 	assert.Equal(t, ret, []expander.Option{eoT2Large, eoT3Large})
 }
 
 func TestPriorityExpanderCorrecltyFallsBackToAllWhenNoMatches(t *testing.T) {
 	s, _, _ := getFilterInstance(t, config)
-	ret := s.BestOptions([]expander.Option{eoT2Large, eoT3Large}, nil)
+	ret := s.BestOptions(context.TODO(), []expander.Option{eoT2Large, eoT3Large}, nil)
 	assert.Equal(t, ret, []expander.Option{eoT2Large, eoT3Large})
 }
 
 func TestPriorityExpanderCorrecltyHandlesConfigUpdate(t *testing.T) {
 	s, r, cm := getFilterInstance(t, oneEntryConfig)
-	ret := s.BestOptions([]expander.Option{eoT2Large, eoT3Large, eoM44XLarge}, nil)
+	ret := s.BestOptions(context.TODO(), []expander.Option{eoT2Large, eoT3Large, eoM44XLarge}, nil)
 	assert.Equal(t, ret, []expander.Option{eoT2Large})
 
 	var event string
@@ -146,7 +147,7 @@ func TestPriorityExpanderCorrecltyHandlesConfigUpdate(t *testing.T) {
 	}
 
 	cm.Data[ConfigMapKey] = config
-	ret = s.BestOptions([]expander.Option{eoT2Large, eoT3Large, eoM44XLarge}, nil)
+	ret = s.BestOptions(context.TODO(), []expander.Option{eoT2Large, eoT3Large, eoM44XLarge}, nil)
 
 	priority := s.(*priority)
 	assert.Equal(t, 2, priority.okConfigUpdates)
@@ -159,7 +160,7 @@ func TestPriorityExpanderCorrecltySkipsBadChangeConfig(t *testing.T) {
 	assert.Equal(t, 0, priority.okConfigUpdates)
 
 	cm.Data[ConfigMapKey] = ""
-	ret := s.BestOptions([]expander.Option{eoT2Large, eoT3Large, eoM44XLarge}, nil)
+	ret := s.BestOptions(context.TODO(), []expander.Option{eoT2Large, eoT3Large, eoM44XLarge}, nil)
 
 	assert.Equal(t, 1, priority.badConfigUpdates)
 

--- a/cluster-autoscaler/expander/random/random.go
+++ b/cluster-autoscaler/expander/random/random.go
@@ -17,6 +17,7 @@ limitations under the License.
 package random
 
 import (
+	"context"
 	"math/rand"
 
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -37,8 +38,8 @@ func NewStrategy() expander.Strategy {
 }
 
 // BestOptions selects from the expansion options at random
-func (r *random) BestOptions(expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
-	best := r.BestOption(expansionOptions, nodeInfo)
+func (r *random) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+	best := r.BestOption(ctx, expansionOptions, nodeInfo)
 	if best == nil {
 		return nil
 	}
@@ -46,7 +47,7 @@ func (r *random) BestOptions(expansionOptions []expander.Option, nodeInfo map[st
 }
 
 // BestOption selects from the expansion options at random
-func (r *random) BestOption(expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) *expander.Option {
+func (r *random) BestOption(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) *expander.Option {
 	if len(expansionOptions) <= 0 {
 		return nil
 	}

--- a/cluster-autoscaler/expander/random/random_test.go
+++ b/cluster-autoscaler/expander/random/random_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package random
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,13 +29,13 @@ func TestRandomExpander(t *testing.T) {
 	e := NewStrategy()
 
 	eo1a := expander.Option{Debug: "EO1a"}
-	ret := e.BestOption([]expander.Option{eo1a}, nil)
+	ret := e.BestOption(context.TODO(), []expander.Option{eo1a}, nil)
 	assert.Equal(t, *ret, eo1a)
 
 	eo1b := expander.Option{Debug: "EO1b"}
-	ret = e.BestOption([]expander.Option{eo1a, eo1b}, nil)
+	ret = e.BestOption(context.TODO(), []expander.Option{eo1a, eo1b}, nil)
 	assert.True(t, assert.ObjectsAreEqual(*ret, eo1a) || assert.ObjectsAreEqual(*ret, eo1b))
 
-	ret = e.BestOption([]expander.Option{}, nil)
+	ret = e.BestOption(context.TODO(), []expander.Option{}, nil)
 	assert.Nil(t, ret)
 }

--- a/cluster-autoscaler/expander/waste/waste.go
+++ b/cluster-autoscaler/expander/waste/waste.go
@@ -36,6 +36,7 @@ func NewFilter() expander.Filter {
 
 // BestOption Finds the option that wastes the least fraction of CPU and Memory
 func (l *leastwaste) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+	logger := klog.FromContext(ctx)
 	var leastWastedScore float64
 	var leastWastedOptions []expander.Option
 
@@ -43,7 +44,7 @@ func (l *leastwaste) BestOptions(ctx context.Context, expansionOptions []expande
 		requestedCPU, requestedMemory := resourcesForPods(option.Pods)
 		node, found := nodeInfo[option.NodeGroup.Id()]
 		if !found {
-			klog.Errorf("No node info for: %s", option.NodeGroup.Id())
+			logger.Error(nil, "No node info for", "nodeGroupId", option.NodeGroup.Id())
 			continue
 		}
 
@@ -53,8 +54,7 @@ func (l *leastwaste) BestOptions(ctx context.Context, expansionOptions []expande
 		wastedCPU := float64(availCPU-requestedCPU.MilliValue()) / float64(availCPU)
 		wastedMemory := float64(availMemory-requestedMemory.Value()) / float64(availMemory)
 		wastedScore := wastedCPU + wastedMemory
-
-		klog.V(1).Infof("Expanding Node Group %s would waste %0.2f%% CPU, %0.2f%% Memory, %0.2f%% Blended\n", option.NodeGroup.Id(), wastedCPU*100.0, wastedMemory*100.0, wastedScore*50.0)
+		logger.V(1).Info("Expanding Node Group would waste % CPU, % Memory, % Blended", "nodeGroupId", option.NodeGroup.Id(), "wastedCPU", wastedCPU*100.0, "wastedMemory", wastedMemory*100.0, "wastedScore", wastedScore*50.0)
 
 		if wastedScore == leastWastedScore {
 			leastWastedOptions = append(leastWastedOptions, option)

--- a/cluster-autoscaler/expander/waste/waste.go
+++ b/cluster-autoscaler/expander/waste/waste.go
@@ -17,6 +17,7 @@ limitations under the License.
 package waste
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -34,7 +35,7 @@ func NewFilter() expander.Filter {
 }
 
 // BestOption Finds the option that wastes the least fraction of CPU and Memory
-func (l *leastwaste) BestOptions(expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
+func (l *leastwaste) BestOptions(ctx context.Context, expansionOptions []expander.Option, nodeInfo map[string]*framework.NodeInfo) []expander.Option {
 	var leastWastedScore float64
 	var leastWastedOptions []expander.Option
 

--- a/cluster-autoscaler/expander/waste/waste_test.go
+++ b/cluster-autoscaler/expander/waste/waste_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package waste
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -89,7 +90,7 @@ func TestLeastWaste(t *testing.T) {
 	balancedOption := expander.Option{NodeGroup: &FakeNodeGroup{"balanced"}, NodeCount: 1}
 
 	// Test without any pods, one node info
-	ret := e.BestOptions([]expander.Option{balancedOption}, nodeMap)
+	ret := e.BestOptions(context.TODO(), []expander.Option{balancedOption}, nodeMap)
 	assert.Equal(t, ret, []expander.Option{balancedOption})
 
 	pod := &apiv1.Pod{
@@ -109,20 +110,20 @@ func TestLeastWaste(t *testing.T) {
 
 	// Test with one pod, one node info
 	balancedOption.Pods = []*apiv1.Pod{pod}
-	ret = e.BestOptions([]expander.Option{balancedOption}, nodeMap)
+	ret = e.BestOptions(context.TODO(), []expander.Option{balancedOption}, nodeMap)
 	assert.Equal(t, ret, []expander.Option{balancedOption})
 
 	// Test with one pod, two node infos, one that has lots of RAM one that has less
 	highmemNodeInfo := makeNodeInfo(16*cpuPerPod, 32*memoryPerPod, 100)
 	nodeMap["highmem"] = highmemNodeInfo
 	highmemOption := expander.Option{NodeGroup: &FakeNodeGroup{"highmem"}, NodeCount: 1, Pods: []*apiv1.Pod{pod}}
-	ret = e.BestOptions([]expander.Option{balancedOption, highmemOption}, nodeMap)
+	ret = e.BestOptions(context.TODO(), []expander.Option{balancedOption, highmemOption}, nodeMap)
 	assert.Equal(t, ret, []expander.Option{balancedOption})
 
 	// Test with one pod, three node infos, one that has lots of RAM one that has less, and one that has less CPU
 	lowcpuNodeInfo := makeNodeInfo(8*cpuPerPod, 16*memoryPerPod, 100)
 	nodeMap["lowcpu"] = lowcpuNodeInfo
 	lowcpuOption := expander.Option{NodeGroup: &FakeNodeGroup{"lowcpu"}, NodeCount: 1, Pods: []*apiv1.Pod{pod}}
-	ret = e.BestOptions([]expander.Option{balancedOption, highmemOption, lowcpuOption}, nodeMap)
+	ret = e.BestOptions(context.TODO(), []expander.Option{balancedOption, highmemOption, lowcpuOption}, nodeMap)
 	assert.Equal(t, ret, []expander.Option{lowcpuOption})
 }

--- a/cluster-autoscaler/loop/run.go
+++ b/cluster-autoscaler/loop/run.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loop
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
@@ -42,5 +43,5 @@ func RunAutoscalerOnce(autoscaler autoscaler, healthCheck *metrics.HealthCheck, 
 		metrics.UpdateLastTime(metrics.MainSuccessful, successTime)
 	}
 
-	metrics.UpdateDurationFromStart(metrics.Main, loopStart)
+	metrics.UpdateDurationFromStart(context.TODO(), metrics.Main, loopStart)
 }

--- a/cluster-autoscaler/loop/trigger.go
+++ b/cluster-autoscaler/loop/trigger.go
@@ -73,7 +73,7 @@ func NewLoopTrigger(scalingTimesGetter scalingTimesGetter, provisioningRequestPr
 // Wait waits for the next autoscaling iteration
 func (t *LoopTrigger) Wait(lastRun time.Time) {
 	sleepStart := time.Now()
-	defer metrics.UpdateDurationFromStart(metrics.LoopWait, sleepStart)
+	defer metrics.UpdateDurationFromStart(context.TODO(), metrics.LoopWait, sleepStart)
 
 	// To improve scale-up throughput, Cluster Autoscaler starts new iteration
 	// immediately if the previous one was productive.

--- a/cluster-autoscaler/metrics/legacy_functions.go
+++ b/cluster-autoscaler/metrics/legacy_functions.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
@@ -40,13 +41,13 @@ func RegisterAll(emitPerNodeGroupMetrics bool) {
 
 // UpdateDurationFromStart records the duration of the step identified by the
 // label using start time
-func UpdateDurationFromStart(label FunctionLabel, start time.Time) {
-	DefaultMetrics.UpdateDurationFromStart(label, start)
+func UpdateDurationFromStart(ctx context.Context, label FunctionLabel, start time.Time) {
+	DefaultMetrics.UpdateDurationFromStart(ctx, label, start)
 }
 
 // UpdateDuration records the duration of the step identified by the label
-func UpdateDuration(label FunctionLabel, duration time.Duration) {
-	DefaultMetrics.UpdateDuration(label, duration)
+func UpdateDuration(ctx context.Context, label FunctionLabel, duration time.Duration) {
+	DefaultMetrics.UpdateDuration(ctx, label, duration)
 }
 
 // UpdateLastTime records the time the step identified by the label was started

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -632,8 +632,9 @@ func (m *caMetrics) UpdateDurationFromStart(ctx context.Context, label FunctionL
 
 // UpdateDuration records the duration of the step identified by the label
 func (m *caMetrics) UpdateDuration(ctx context.Context, label FunctionLabel, duration time.Duration) {
+	logger := klog.FromContext(ctx)
 	if duration > LogLongDurationThreshold {
-		klog.V(4).Infof("Function %s took %v to complete", label, duration)
+		logger.V(4).Info("Function took to complete", "label", label, "duration", duration)
 	}
 	m.functionDuration.WithLabelValues(string(label)).Observe(duration.Seconds())
 	m.functionDurationSummary.WithLabelValues(string(label)).Observe(duration.Seconds())

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -624,13 +625,13 @@ func (m *caMetrics) InitMetrics() {
 
 // UpdateDurationFromStart records the duration of the step identified by the
 // label using start time
-func (m *caMetrics) UpdateDurationFromStart(label FunctionLabel, start time.Time) {
+func (m *caMetrics) UpdateDurationFromStart(ctx context.Context, label FunctionLabel, start time.Time) {
 	duration := time.Now().Sub(start)
-	m.UpdateDuration(label, duration)
+	m.UpdateDuration(ctx, label, duration)
 }
 
 // UpdateDuration records the duration of the step identified by the label
-func (m *caMetrics) UpdateDuration(label FunctionLabel, duration time.Duration) {
+func (m *caMetrics) UpdateDuration(ctx context.Context, label FunctionLabel, duration time.Duration) {
 	if duration > LogLongDurationThreshold {
 		klog.V(4).Infof("Function %s took %v to complete", label, duration)
 	}

--- a/cluster-autoscaler/observers/loopstart/loopstart.go
+++ b/cluster-autoscaler/observers/loopstart/loopstart.go
@@ -16,10 +16,15 @@ limitations under the License.
 
 package loopstart
 
+import (
+	"context"
+)
+
+
 // Observer interface is used to store object that needed to be refreshed in each CA loop.
 // It returns error and a bool value whether the loop should be skipped.
 type Observer interface {
-	Refresh()
+	Refresh(ctx context.Context)
 }
 
 // ObserversList interface is used to store objects that needed to be refreshed in each CA loop.
@@ -28,9 +33,9 @@ type ObserversList struct {
 }
 
 // Refresh refresh observers each CA loop.
-func (l *ObserversList) Refresh() {
+func (l *ObserversList) Refresh(ctx context.Context) {
 	for _, observer := range l.observers {
-		observer.Refresh()
+		observer.Refresh(ctx)
 	}
 }
 

--- a/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
+++ b/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
@@ -126,13 +126,14 @@ func (p *NodeGroupChangeMetricsProducer) RegisterScaleDown(nodeGroup cloudprovid
 
 // RegisterFailedScaleUp emits the failed scale up metric.
 func (p *NodeGroupChangeMetricsProducer) RegisterFailedScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
+	logger := klog.FromContext(ctx)
 	availableGPUTypes := p.cloudProvider.GetAvailableGPUTypes()
 	gpuResourceName, gpuType, draDriverNames := "", "", ""
 	nodeInfo, err := nodeGroup.TemplateNodeInfo()
 	if err != nil {
-		klog.Warningf("Failed to get template node info for a node group: %s", err)
+		logger.Info("Failed to get template node info for a node group", "err", err)
 	} else if nodeInfo == nil {
-		klog.Warningf("Template node info is nil for node group: %s", nodeGroup.Id())
+		logger.Info("Template node info is nil for node group", "nodeGroupId", nodeGroup.Id())
 	} else {
 		gpuResourceName, gpuType = gpu.GetGpuInfoForMetrics(ctx, p.cloudProvider.GetNodeGpuConfig(nodeInfo.Node()), availableGPUTypes, nodeInfo.Node(), nodeGroup)
 		draDriverNames = dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)

--- a/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
+++ b/cluster-autoscaler/observers/nodegroupchange/scale_state_observer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodegroupchange
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -34,12 +35,12 @@ import (
 // * scale-down failure(s) for a nodegroup
 type NodeGroupChangeObserver interface {
 	// RegisterScaleUp records scale up for a nodegroup.
-	RegisterScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time)
+	RegisterScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, currentTime time.Time)
 	// RegisterScaleDowns records scale down for a nodegroup.
 	RegisterScaleDown(nodeGroup cloudprovider.NodeGroup, nodeName string, currentTime time.Time, expectedDeleteTime time.Time)
 	// RegisterFailedScaleUp records failed scale-up for a nodegroup.
 	// errorInfo is a wrapper containing the reason for failed scale-up and the actual error message
-	RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time)
+	RegisterFailedScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time)
 	// RegisterFailedScaleDown records failed scale-down for a nodegroup.
 	RegisterFailedScaleDown(nodeGroup cloudprovider.NodeGroup, reason string, currentTime time.Time)
 }
@@ -58,12 +59,12 @@ func (l *NodeGroupChangeObserversList) Register(o NodeGroupChangeObserver) {
 }
 
 // RegisterScaleUp calls RegisterScaleUp for each observer.
-func (l *NodeGroupChangeObserversList) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup,
+func (l *NodeGroupChangeObserversList) RegisterScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup,
 	delta int, currentTime time.Time) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	for _, observer := range l.observers {
-		observer.RegisterScaleUp(nodeGroup, delta, currentTime)
+		observer.RegisterScaleUp(ctx, nodeGroup, delta, currentTime)
 	}
 }
 
@@ -78,11 +79,11 @@ func (l *NodeGroupChangeObserversList) RegisterScaleDown(nodeGroup cloudprovider
 }
 
 // RegisterFailedScaleUp calls RegisterFailedScaleUp for each observer.
-func (l *NodeGroupChangeObserversList) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
+func (l *NodeGroupChangeObserversList) RegisterFailedScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	for _, observer := range l.observers {
-		observer.RegisterFailedScaleUp(nodeGroup, delta, errorInfo, currentTime)
+		observer.RegisterFailedScaleUp(ctx, nodeGroup, delta, errorInfo, currentTime)
 	}
 }
 
@@ -114,7 +115,7 @@ type NodeGroupChangeMetricsProducer struct {
 }
 
 // RegisterScaleUp calls RegisterScaleUp for each observer.
-func (p *NodeGroupChangeMetricsProducer) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup,
+func (p *NodeGroupChangeMetricsProducer) RegisterScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup,
 	delta int, currentTime time.Time) {
 }
 
@@ -124,7 +125,7 @@ func (p *NodeGroupChangeMetricsProducer) RegisterScaleDown(nodeGroup cloudprovid
 }
 
 // RegisterFailedScaleUp emits the failed scale up metric.
-func (p *NodeGroupChangeMetricsProducer) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
+func (p *NodeGroupChangeMetricsProducer) RegisterFailedScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
 	availableGPUTypes := p.cloudProvider.GetAvailableGPUTypes()
 	gpuResourceName, gpuType, draDriverNames := "", "", ""
 	nodeInfo, err := nodeGroup.TemplateNodeInfo()
@@ -133,7 +134,7 @@ func (p *NodeGroupChangeMetricsProducer) RegisterFailedScaleUp(nodeGroup cloudpr
 	} else if nodeInfo == nil {
 		klog.Warningf("Template node info is nil for node group: %s", nodeGroup.Id())
 	} else {
-		gpuResourceName, gpuType = gpu.GetGpuInfoForMetrics(p.cloudProvider.GetNodeGpuConfig(nodeInfo.Node()), availableGPUTypes, nodeInfo.Node(), nodeGroup)
+		gpuResourceName, gpuType = gpu.GetGpuInfoForMetrics(ctx, p.cloudProvider.GetNodeGpuConfig(nodeInfo.Node()), availableGPUTypes, nodeInfo.Node(), nodeGroup)
 		draDriverNames = dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
 	}
 	reason := metrics.FailedScaleUpReason(errorInfo.ErrorCode)

--- a/cluster-autoscaler/observers/nodegroupchange/scale_state_observer_test.go
+++ b/cluster-autoscaler/observers/nodegroupchange/scale_state_observer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodegroupchange
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -79,7 +80,7 @@ func TestRegisterFailedScaleUpDirectCall(t *testing.T) {
 	errorInfo := cloudprovider.InstanceErrorInfo{
 		ErrorCode: "OUT_OF_RESOURCES",
 	}
-	producer.RegisterFailedScaleUp(nodeGroup, 3, errorInfo, now)
+	producer.RegisterFailedScaleUp(context.TODO(), nodeGroup, 3, errorInfo, now)
 
 	mockMetricsObj.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("OUT_OF_RESOURCES"), "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net")
 	mockMetricsObj.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("OUT_OF_RESOURCES"), 3)
@@ -109,7 +110,7 @@ func TestRegisterFailedScaleUpCallViaObserversList(t *testing.T) {
 	errorInfo := cloudprovider.InstanceErrorInfo{
 		ErrorCode: "TIMEOUT",
 	}
-	list.RegisterFailedScaleUp(nodeGroup, 5, errorInfo, now)
+	list.RegisterFailedScaleUp(context.TODO(), nodeGroup, 5, errorInfo, now)
 
 	// Assertions
 	mockMetricsObj.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("TIMEOUT"), "", "", "")

--- a/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
+++ b/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
@@ -67,7 +67,8 @@ func (e *EmptyClusterProcessor) ShouldAbort(ctx context.Context, autoscalingCtx 
 
 // OnEmptyCluster runs actions if the cluster is empty
 func OnEmptyCluster(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status string, emitEvent bool) {
-	klog.Warning(status)
+	logger := klog.FromContext(ctx)
+	logger.Info(status)
 	autoscalingCtx.ProcessorCallbacks.ResetUnneededNodes(ctx)
 	// updates metrics related to empty cluster's state.
 	metrics.UpdateClusterSafeToAutoscale(false)

--- a/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
+++ b/cluster-autoscaler/processors/actionablecluster/actionable_cluster_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actionablecluster
 
 import (
+	"context"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -34,7 +35,7 @@ const NodesNotReadyAfterStartTimeout = 10 * time.Minute
 // ActionableClusterProcessor defines interface for whether action can be taken on the cluster or not
 type ActionableClusterProcessor interface {
 	// ShouldAbort is the func that will return where the cluster is in an actionable state or not
-	ShouldAbort(autoscalingCtx *ca_context.AutoscalingContext, allNodes []*apiv1.Node, readyNodes []*apiv1.Node, currentTime time.Time) (abortLoop bool, err errors.AutoscalerError)
+	ShouldAbort(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes []*apiv1.Node, readyNodes []*apiv1.Node, currentTime time.Time) (abortLoop bool, err errors.AutoscalerError)
 	CleanUp()
 }
 
@@ -46,18 +47,18 @@ type EmptyClusterProcessor struct {
 }
 
 // ShouldAbort give the decision on whether CA can act on the cluster
-func (e *EmptyClusterProcessor) ShouldAbort(autoscalingCtx *ca_context.AutoscalingContext, allNodes []*apiv1.Node, readyNodes []*apiv1.Node, currentTime time.Time) (bool, errors.AutoscalerError) {
+func (e *EmptyClusterProcessor) ShouldAbort(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes []*apiv1.Node, readyNodes []*apiv1.Node, currentTime time.Time) (bool, errors.AutoscalerError) {
 	if autoscalingCtx.AutoscalingOptions.ScaleUpFromZero {
 		return false, nil
 	}
 	if len(allNodes) == 0 {
-		OnEmptyCluster(autoscalingCtx, "Cluster has no nodes.", true)
+		OnEmptyCluster(ctx, autoscalingCtx, "Cluster has no nodes.", true)
 		return true, nil
 	}
 	if len(readyNodes) == 0 {
 		// Cluster Autoscaler may start running before nodes are ready.
 		// Timeout ensures no ClusterUnhealthy events are published immediately in this case.
-		OnEmptyCluster(autoscalingCtx, "Cluster has no ready nodes.", currentTime.After(e.startTime.Add(e.nodesNotReadyAfterStartTimeout)))
+		OnEmptyCluster(ctx, autoscalingCtx, "Cluster has no ready nodes.", currentTime.After(e.startTime.Add(e.nodesNotReadyAfterStartTimeout)))
 		return true, nil
 	}
 	// the cluster is not empty
@@ -65,14 +66,14 @@ func (e *EmptyClusterProcessor) ShouldAbort(autoscalingCtx *ca_context.Autoscali
 }
 
 // OnEmptyCluster runs actions if the cluster is empty
-func OnEmptyCluster(autoscalingCtx *ca_context.AutoscalingContext, status string, emitEvent bool) {
+func OnEmptyCluster(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status string, emitEvent bool) {
 	klog.Warning(status)
-	autoscalingCtx.ProcessorCallbacks.ResetUnneededNodes()
+	autoscalingCtx.ProcessorCallbacks.ResetUnneededNodes(ctx)
 	// updates metrics related to empty cluster's state.
 	metrics.UpdateClusterSafeToAutoscale(false)
 	metrics.UpdateNodesCount(0, 0, 0, 0, 0, 0)
 	if autoscalingCtx.WriteStatusConfigMap {
-		utils.WriteStatusConfigMap(autoscalingCtx.ClientSet, autoscalingCtx.ConfigNamespace, api.ClusterAutoscalerStatus{AutoscalerStatus: api.ClusterAutoscalerInitializing, Message: status}, autoscalingCtx.LogRecorder, autoscalingCtx.StatusConfigMapName, time.Now())
+		utils.WriteStatusConfigMap(ctx, autoscalingCtx.ClientSet, autoscalingCtx.ConfigNamespace, api.ClusterAutoscalerStatus{AutoscalerStatus: api.ClusterAutoscalerInitializing, Message: status}, autoscalingCtx.LogRecorder, autoscalingCtx.StatusConfigMapName, time.Now())
 	}
 	if emitEvent {
 		autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeWarning, "ClusterUnhealthy", status)

--- a/cluster-autoscaler/processors/binpacking/binpacking_limiter.go
+++ b/cluster-autoscaler/processors/binpacking/binpacking_limiter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package binpacking
 
 import (
+	"context"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -26,6 +27,6 @@ import (
 type BinpackingLimiter interface {
 	InitBinpacking(autoscalingCtx *ca_context.AutoscalingContext, nodeGroups []cloudprovider.NodeGroup)
 	MarkProcessed(autoscalingCtx *ca_context.AutoscalingContext, nodegroupId string)
-	StopBinpacking(autoscalingCtx *ca_context.AutoscalingContext, evaluatedOptions []expander.Option) bool
+	StopBinpacking(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, evaluatedOptions []expander.Option) bool
 	FinalizeBinpacking(autoscalingCtx *ca_context.AutoscalingContext, finalOptions []expander.Option)
 }

--- a/cluster-autoscaler/processors/binpacking/combined_limiter.go
+++ b/cluster-autoscaler/processors/binpacking/combined_limiter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package binpacking
 
 import (
+	"context"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
@@ -50,10 +51,10 @@ func (l *CombinedLimiter) MarkProcessed(autoscalingCtx *ca_context.AutoscalingCo
 }
 
 // StopBinpacking returns true if at least one of the underline limiter met the stop condition.
-func (l *CombinedLimiter) StopBinpacking(autoscalingCtx *ca_context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
+func (l *CombinedLimiter) StopBinpacking(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
 	stopCondition := false
 	for _, limiter := range l.limiters {
-		stopCondition = limiter.StopBinpacking(autoscalingCtx, evaluatedOptions) || stopCondition
+		stopCondition = limiter.StopBinpacking(ctx, autoscalingCtx, evaluatedOptions) || stopCondition
 	}
 	return stopCondition
 }

--- a/cluster-autoscaler/processors/binpacking/time_limiter.go
+++ b/cluster-autoscaler/processors/binpacking/time_limiter.go
@@ -59,9 +59,10 @@ func (b *TimeLimiter) MarkProcessed(autoscalingCtx *ca_context.AutoscalingContex
 
 // StopBinpacking returns true if the binpacking time exceeds maxBinpackingDuration.
 func (b *TimeLimiter) StopBinpacking(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
+	logger := klog.FromContext(ctx)
 	now := b.now()
 	if now.After(b.startTime.Add(b.maxBinpackingDuration)) {
-		klog.Infof("Binpacking is cut short after %v seconds due to exceeding maxBinpackingDuration", now.Sub(b.startTime).Seconds())
+		logger.Info("Binpacking is cut short after seconds due to exceeding maxBinpackingDuration", "seconds", now.Sub(b.startTime).Seconds())
 		return true
 	}
 	return false

--- a/cluster-autoscaler/processors/binpacking/time_limiter.go
+++ b/cluster-autoscaler/processors/binpacking/time_limiter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package binpacking
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -57,7 +58,7 @@ func (b *TimeLimiter) MarkProcessed(autoscalingCtx *ca_context.AutoscalingContex
 }
 
 // StopBinpacking returns true if the binpacking time exceeds maxBinpackingDuration.
-func (b *TimeLimiter) StopBinpacking(autoscalingCtx *ca_context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
+func (b *TimeLimiter) StopBinpacking(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, evaluatedOptions []expander.Option) bool {
 	now := b.now()
 	if now.After(b.startTime.Add(b.maxBinpackingDuration)) {
 		klog.Infof("Binpacking is cut short after %v seconds due to exceeding maxBinpackingDuration", now.Sub(b.startTime).Seconds())

--- a/cluster-autoscaler/processors/binpacking/time_limiter_test.go
+++ b/cluster-autoscaler/processors/binpacking/time_limiter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package binpacking
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -65,7 +66,7 @@ func TestTimeLimiter(t *testing.T) {
 			limiter.InitBinpacking(nil, nil)
 			fakeClock.Step(tc.timeAdvanced)
 
-			assert.Equal(t, tc.expectStop, limiter.StopBinpacking(nil, nil))
+			assert.Equal(t, tc.expectStop, limiter.StopBinpacking(context.TODO(), nil, nil))
 		})
 	}
 }

--- a/cluster-autoscaler/processors/callbacks/processor_callbacks.go
+++ b/cluster-autoscaler/processors/callbacks/processor_callbacks.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package callbacks
 
+import "context"
+
 // ProcessorCallbacks is interface defining extra callback methods which can be called by processors used in extension points.
 type ProcessorCallbacks interface {
 	// DisableScaleDownForLoop disables scale down for current loop iteration
@@ -24,7 +26,7 @@ type ProcessorCallbacks interface {
 	// ResetUnneededNodes resets information about any nodes that were previously considered unneeded by scale-down logic.
 	// CA will only delete a node if it's unneeded (meets criteria for scale-down) for time specified
 	// via --scale-down-unneeded-time. This call resets the timer for all the nodes in the cluster.
-	ResetUnneededNodes()
+	ResetUnneededNodes(context.Context)
 
 	// SetExtraValue sets arbitrary value for given key. Value storage will be reset at the beginning of each loop iteration.
 	// Arbitrary value storage is used to pass information between processors used in extension points.

--- a/cluster-autoscaler/processors/callbacks/test_utils.go
+++ b/cluster-autoscaler/processors/callbacks/test_utils.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package callbacks
 
+import "context"
+
 // TestProcessorCallbacks is test implementation of ProcessorCallbacks
 type TestProcessorCallbacks struct {
 	// ScaleDownDisabledForLoop marks if scaledown should be disabled for loop
@@ -25,7 +27,7 @@ type TestProcessorCallbacks struct {
 }
 
 // ResetUnneededNodes is test implementation, which takes no action
-func (callbacks *TestProcessorCallbacks) ResetUnneededNodes() {
+func (callbacks *TestProcessorCallbacks) ResetUnneededNodes(ctx context.Context) {
 	return
 }
 

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package capacitybufferpodlister
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -84,19 +85,19 @@ func NewCapacityBufferPodListProcessor(client *client.CapacityBufferClient, prov
 }
 
 // Process updates unschedulablePods by injecting fake pods to match replicas defined in buffers status
-func (p *CapacityBufferPodListProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+func (p *CapacityBufferPodListProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	buffers, err := p.client.ListCapacityBuffers("")
 	if err != nil {
 		klog.Errorf("CapacityBufferPodListProcessor failed to list buffers with error: %v", err.Error())
 		return unschedulablePods, nil
 	}
 	buffers = p.filterBuffersProvStrategy(buffers)
-	_, buffers = p.statusFilter.Filter(buffers)
-	_, buffers = p.podTemplateGenFilter.Filter(buffers)
+	_, buffers = p.statusFilter.Filter(ctx, buffers)
+	_, buffers = p.podTemplateGenFilter.Filter(ctx, buffers)
 
 	totalFakePods := []*apiv1.Pod{}
 	for _, buffer := range buffers {
-		fakePods := p.provision(buffer)
+		fakePods := p.provision(ctx, buffer)
 		p.updateCapacityBufferRegistry(fakePods, buffer)
 		totalFakePods = append(totalFakePods, fakePods...)
 	}
@@ -125,18 +126,18 @@ func (p *CapacityBufferPodListProcessor) clearCapacityBufferRegistry() {
 	p.buffersRegistry.Clear()
 }
 
-func (p *CapacityBufferPodListProcessor) provision(buffer *v1beta1.CapacityBuffer) []*apiv1.Pod {
+func (p *CapacityBufferPodListProcessor) provision(ctx context.Context, buffer *v1beta1.CapacityBuffer) []*apiv1.Pod {
 	if buffer.Status.PodTemplateRef == nil || buffer.Status.Replicas == nil || meta.IsStatusConditionFalse(buffer.Status.Conditions, capacitybuffer.ReadyForProvisioningCondition) {
 		changed := common.UpdateBufferStatusToFailedProvisioning(buffer, NotReadyForProvisioningReason, "CapacityBuffer is not ready for provisioning")
 		if changed {
-			p.updateBufferStatus(buffer)
+			p.updateBufferStatus(ctx, buffer)
 		}
 		return []*apiv1.Pod{}
 	}
 	if *buffer.Status.Replicas == 0 {
 		changed := common.UpdateBufferStatusToFailedProvisioning(buffer, BufferIsEmptyReason, "CapacityBuffer has zero replicas")
 		if changed {
-			p.updateBufferStatus(buffer)
+			p.updateBufferStatus(ctx, buffer)
 		}
 		return []*apiv1.Pod{}
 	}
@@ -146,7 +147,7 @@ func (p *CapacityBufferPodListProcessor) provision(buffer *v1beta1.CapacityBuffe
 	if err != nil {
 		changed := common.UpdateBufferStatusToFailedProvisioning(buffer, FailedToGetPodTemplateReason, fmt.Sprintf("failed to get pod template with error: %v", err.Error()))
 		if changed {
-			p.updateBufferStatus(buffer)
+			p.updateBufferStatus(ctx, buffer)
 		}
 		return []*apiv1.Pod{}
 	}
@@ -154,12 +155,12 @@ func (p *CapacityBufferPodListProcessor) provision(buffer *v1beta1.CapacityBuffe
 	if err != nil {
 		changed := common.UpdateBufferStatusToFailedProvisioning(buffer, FailedToMakeFakePodsReason, fmt.Sprintf("failed to create fake pods with error: %v", err.Error()))
 		if changed {
-			p.updateBufferStatus(buffer)
+			p.updateBufferStatus(ctx, buffer)
 		}
 		return []*apiv1.Pod{}
 	}
 	common.UpdateBufferStatusToSuccessfullyProvisioning(buffer, FakePodsInjectedReason)
-	p.updateBufferStatus(buffer)
+	p.updateBufferStatus(ctx, buffer)
 	return fakePods
 }
 
@@ -173,7 +174,7 @@ func (p *CapacityBufferPodListProcessor) filterBuffersProvStrategy(buffers []*v1
 	return filteredBuffers
 }
 
-func (p *CapacityBufferPodListProcessor) updateBufferStatus(buffer *v1beta1.CapacityBuffer) {
+func (p *CapacityBufferPodListProcessor) updateBufferStatus(ctx context.Context, buffer *v1beta1.CapacityBuffer) {
 	_, err := p.client.UpdateCapacityBuffer(buffer)
 	if err != nil {
 		klog.Errorf("Failed to update buffer status for buffer %v, error: %v", buffer.Name, err.Error())

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -86,9 +86,10 @@ func NewCapacityBufferPodListProcessor(client *client.CapacityBufferClient, prov
 
 // Process updates unschedulablePods by injecting fake pods to match replicas defined in buffers status
 func (p *CapacityBufferPodListProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	logger := klog.FromContext(ctx)
 	buffers, err := p.client.ListCapacityBuffers("")
 	if err != nil {
-		klog.Errorf("CapacityBufferPodListProcessor failed to list buffers with error: %v", err.Error())
+		logger.Error(err, "CapacityBufferPodListProcessor failed to list buffers with")
 		return unschedulablePods, nil
 	}
 	buffers = p.filterBuffersProvStrategy(buffers)
@@ -101,7 +102,7 @@ func (p *CapacityBufferPodListProcessor) Process(ctx context.Context, autoscalin
 		p.updateCapacityBufferRegistry(fakePods, buffer)
 		totalFakePods = append(totalFakePods, fakePods...)
 	}
-	klog.V(2).Infof("Capacity pod processor injecting %v fake pods provisioning %v capacity buffers", len(totalFakePods), len(buffers))
+	logger.V(2).Info("Capacity pod processor injecting fake pods provisioning capacity buffers", "totalFakePodsCount", len(totalFakePods), "buffersCount", len(buffers))
 	unschedulablePods = append(unschedulablePods, totalFakePods...)
 	return unschedulablePods, nil
 }
@@ -175,9 +176,10 @@ func (p *CapacityBufferPodListProcessor) filterBuffersProvStrategy(buffers []*v1
 }
 
 func (p *CapacityBufferPodListProcessor) updateBufferStatus(ctx context.Context, buffer *v1beta1.CapacityBuffer) {
+	logger := klog.FromContext(ctx)
 	_, err := p.client.UpdateCapacityBuffer(buffer)
 	if err != nil {
-		klog.Errorf("Failed to update buffer status for buffer %v, error: %v", buffer.Name, err.Error())
+		logger.Error(err, "Failed to update buffer status for buffer", "buffer", buffer.Name)
 	}
 }
 

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
@@ -194,7 +194,7 @@ func TestPodListProcessor(t *testing.T) {
 			capacityBuffersRegistry := fakepods.NewRegistry(nil)
 
 			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, capacityBuffersRegistry, test.forceSafeToEvict)
-			resUnschedulablePods, err := processor.Process(nil, test.unschedulablePods)
+			resUnschedulablePods, err := processor.Process(context.TODO(), nil, test.unschedulablePods)
 			assert.Equal(t, err != nil, test.expectError)
 
 			numberOfFakePods := 0
@@ -281,7 +281,7 @@ func TestCapacityBufferFakePodsRegistry(t *testing.T) {
 
 			registry := fakepods.NewRegistry(nil)
 			processor := NewCapacityBufferPodListProcessor(fakeCapacityBuffersClient, []string{testProvStrategyAllowed}, registry, false)
-			resUnschedulablePods, err := processor.Process(nil, test.unschedulablePods)
+			resUnschedulablePods, err := processor.Process(context.TODO(), nil, test.unschedulablePods)
 			assert.Equal(t, nil, err)
 			assert.Equal(t, test.expectedUnschedPodsCount, len(resUnschedulablePods))
 			for _, pod := range resUnschedulablePods {

--- a/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package capacitybufferpodlister
 
 import (
+	gocontext "context"
 	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -45,7 +46,7 @@ func NewFakePodsScaleUpStatusProcessor(buffersRegistry *fakepods.Registry) *Fake
 
 // Process updates scaleupStatus to remove all capacity buffer fake pods from
 // PodsRemainUnschedulable, PodsAwaitEvaluation & PodsTriggeredScaleup
-func (p *FakePodsScaleUpStatusProcessor) Process(context *ca_context.AutoscalingContext, scaleUpStatus *status.ScaleUpStatus) {
+func (p *FakePodsScaleUpStatusProcessor) Process(ctx gocontext.Context, context *ca_context.AutoscalingContext, scaleUpStatus *status.ScaleUpStatus) {
 	var fakePodsRemainUnschedulable []status.NoScaleUpInfo
 	var fakePodsTriggeredScaleUp []*apiv1.Pod
 

--- a/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/scale_up_status_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package capacitybufferpodlister
 
 import (
+	gocontext "context"
 	"strings"
 	"testing"
 
@@ -85,7 +86,7 @@ func TestProcess(t *testing.T) {
 			autoscalingCtx := &ca_context.AutoscalingContext{}
 
 			p := NewFakePodsScaleUpStatusProcessor(fakepods.NewRegistry(nil))
-			p.Process(autoscalingCtx, scaleUpStatus)
+			p.Process(gocontext.TODO(), autoscalingCtx, scaleUpStatus)
 
 			assert.ElementsMatch(t, tc.expectedPodsRemainUnschedulable, extractPodsFromNoScaleUpInfo(scaleUpStatus.PodsRemainUnschedulable))
 			assert.ElementsMatch(t, tc.expectedPodsAwaitEvaluation, scaleUpStatus.PodsAwaitEvaluation)
@@ -288,7 +289,7 @@ func TestBuffersEvent(t *testing.T) {
 				},
 			}
 			p := NewFakePodsScaleUpStatusProcessor(tc.buffersRegistry)
-			p.Process(ctx, tc.state)
+			p.Process(gocontext.TODO(), ctx, tc.state)
 
 			triggeredScaleUp := 0
 			notTriggerScaleUp := 0

--- a/cluster-autoscaler/processors/customresources/csi_processor.go
+++ b/cluster-autoscaler/processors/customresources/csi_processor.go
@@ -35,11 +35,13 @@ type CSICustomResourcesProcessor struct {
 
 // FilterOutNodesWithUnreadyResources filters out nodes with unready CSI resources.
 func (p *CSICustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+	logger := klog.FromContext(ctx)
 	newAllNodes := make([]*apiv1.Node, 0)
 	newReadyNodes := make([]*apiv1.Node, 0)
 	nodesWithUnreadyCSI := make(map[string]*apiv1.Node)
 	if csiSnapshot == nil {
-		klog.Warningf("Cannot filter out nodes with unready CSI resources. The CSI snapshot is nil. Processing will be skipped.")
+		logger.Info("Cannot filter out nodes with unready CSI resources. The CSI snapshot is nil. Processing will be skipped.")
+
 		return allNodes, readyNodes
 	}
 
@@ -47,7 +49,7 @@ func (p *CSICustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx con
 		ng, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)
 		if err != nil {
 			newReadyNodes = append(newReadyNodes, node)
-			klog.Warningf("Failed to get node group for node %s, Skipping CSI readiness check and keeping node in ready list. Error: %v", node.Name, err)
+			logger.Info("Failed to get node group for node, Skipping CSI readiness check and keeping node in ready list. Error", "node", node.Name, "err", err)
 			continue
 		}
 		if ng == nil {
@@ -59,21 +61,21 @@ func (p *CSICustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx con
 		templateNodeInfo, err := ng.TemplateNodeInfo()
 		if err != nil {
 			newReadyNodes = append(newReadyNodes, node)
-			klog.Warningf("Failed to get template node info for node group %s with error: %v", ng.Id(), err)
+			logger.Info("Failed to get template node info for node group with", "nodeGroupId", ng.Id(), "err", err)
 			continue
 		}
 
 		// if cloudprovider does not provide CSI related stuff, then we can skip the CSI readiness check
 		if templateNodeInfo.CSINode == nil {
 			newReadyNodes = append(newReadyNodes, node)
-			klog.V(5).Infof("No CSI node found for node %s, Skipping CSI readiness check and keeping node in ready list.", node.Name)
+			logger.V(5).Info("No CSI node found for node, Skipping CSI readiness check and keeping node in ready list.", "node", node.Name)
 			continue
 		}
 
 		csiNode, err := csiSnapshot.Get(node.Name)
 		if err != nil {
 			newReadyNodes = append(newReadyNodes, node)
-			klog.V(5).Infof("Failed to get CSI node for node %s, Skipping CSI readiness check and keeping node in ready list. Error: %v", node.Name, err)
+			logger.V(5).Info("Failed to get CSI node for node, Skipping CSI readiness check and keeping node in ready list. Error", "node", node.Name, "err", err)
 			continue
 		}
 

--- a/cluster-autoscaler/processors/customresources/csi_processor.go
+++ b/cluster-autoscaler/processors/customresources/csi_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package customresources
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -33,7 +34,7 @@ type CSICustomResourcesProcessor struct {
 }
 
 // FilterOutNodesWithUnreadyResources filters out nodes with unready CSI resources.
-func (p *CSICustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+func (p *CSICustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
 	newAllNodes := make([]*apiv1.Node, 0)
 	newReadyNodes := make([]*apiv1.Node, 0)
 	nodesWithUnreadyCSI := make(map[string]*apiv1.Node)
@@ -94,7 +95,7 @@ func (p *CSICustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autosca
 
 // GetNodeResourceTargets returns mapping of resource names to their targets.
 // CSI processor doesn't track resource targets, so it returns an empty list.
-func (p *CSICustomResourcesProcessor) GetNodeResourceTargets(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
+func (p *CSICustomResourcesProcessor) GetNodeResourceTargets(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
 	return []CustomResourceTarget{}, nil
 }
 

--- a/cluster-autoscaler/processors/customresources/csi_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/csi_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package customresources
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -307,7 +308,7 @@ func TestFilterOutNodesWithUnreadyCSIResources(t *testing.T) {
 
 			autoscalingCtx := &ca_context.AutoscalingContext{CloudProvider: provider, ClusterSnapshot: clusterSnapshot}
 			processor := CSICustomResourcesProcessor{}
-			newAllNodes, newReadyNodes := processor.FilterOutNodesWithUnreadyResources(autoscalingCtx, initialAllNodes, initialReadyNodes, nil, csiSnapshot)
+			newAllNodes, newReadyNodes := processor.FilterOutNodesWithUnreadyResources(context.TODO(), autoscalingCtx, initialAllNodes, initialReadyNodes, nil, csiSnapshot)
 
 			readyNodes := make(map[string]bool)
 			for _, node := range newReadyNodes {

--- a/cluster-autoscaler/processors/customresources/custom_resources_processor.go
+++ b/cluster-autoscaler/processors/customresources/custom_resources_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package customresources
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
@@ -37,9 +38,9 @@ type CustomResourceTarget struct {
 type CustomResourcesProcessor interface {
 	// FilterOutNodesWithUnreadyResources removes nodes that should have a custom resource, but don't have
 	// it in allocatable from ready nodes list and updates their status to unready on all nodes list.
-	FilterOutNodesWithUnreadyResources(autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node)
+	FilterOutNodesWithUnreadyResources(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node)
 	// GetNodeResourceTargets returns mapping of resource names to their targets.
-	GetNodeResourceTargets(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError)
+	GetNodeResourceTargets(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError)
 	// CleanUp cleans up processor's internal structures.
 	CleanUp()
 }

--- a/cluster-autoscaler/processors/customresources/default_custom_processor.go
+++ b/cluster-autoscaler/processors/customresources/default_custom_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package customresources
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
@@ -44,20 +45,20 @@ func NewDefaultCustomResourcesProcessor(draEnabled bool, csiEnabled bool) Custom
 }
 
 // FilterOutNodesWithUnreadyResources calls the corresponding method for internal custom resources processors in order.
-func (p *DefaultCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+func (p *DefaultCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
 	newAllNodes := allNodes
 	newReadyNodes := readyNodes
 	for _, processor := range p.customResourcesProcessors {
-		newAllNodes, newReadyNodes = processor.FilterOutNodesWithUnreadyResources(autoscalingCtx, newAllNodes, newReadyNodes, draSnapshot, csiSnapshot)
+		newAllNodes, newReadyNodes = processor.FilterOutNodesWithUnreadyResources(ctx, autoscalingCtx, newAllNodes, newReadyNodes, draSnapshot, csiSnapshot)
 	}
 	return newAllNodes, newReadyNodes
 }
 
 // GetNodeResourceTargets calls the corresponding method for internal custom resources processors in order.
-func (p *DefaultCustomResourcesProcessor) GetNodeResourceTargets(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
+func (p *DefaultCustomResourcesProcessor) GetNodeResourceTargets(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
 	customResourcesTargets := []CustomResourceTarget{}
 	for _, processor := range p.customResourcesProcessors {
-		targets, err := processor.GetNodeResourceTargets(autoscalingCtx, node, nodeGroup)
+		targets, err := processor.GetNodeResourceTargets(ctx, autoscalingCtx, node, nodeGroup)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/processors/customresources/default_custom_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/default_custom_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package customresources
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -113,7 +114,7 @@ func TestDefaultProcessorFilterOut(t *testing.T) {
 					readyNodes = append(readyNodes, node)
 				}
 			}
-			resultedAllNodes, resultedReadyNodes := processor.FilterOutNodesWithUnreadyResources(nil, tc.allNodes, readyNodes, nil, nil)
+			resultedAllNodes, resultedReadyNodes := processor.FilterOutNodesWithUnreadyResources(context.TODO(), nil, tc.allNodes, readyNodes, nil, nil)
 			assert.ElementsMatch(t, tc.allNodes, resultedAllNodes)
 			assert.True(t, len(resultedReadyNodes) == len(tc.expectedReadyNodes))
 			for _, node := range resultedReadyNodes {
@@ -163,7 +164,7 @@ func TestDefaultProcessorGetNodeResourceTargets(t *testing.T) {
 	}
 	for tcName, tc := range testCases {
 		t.Run(tcName, func(t *testing.T) {
-			customResourceTarget, _ := processor.GetNodeResourceTargets(nil, tc.node, nil)
+			customResourceTarget, _ := processor.GetNodeResourceTargets(context.TODO(), nil, tc.node, nil)
 			assert.ElementsMatch(t, customResourceTarget, tc.expectedResources)
 		})
 	}
@@ -175,7 +176,7 @@ type mockCustomResourcesProcessor struct {
 	customResourceTargetsQuantity int64
 }
 
-func (m *mockCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(_ *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+func (m *mockCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx context.Context, _ *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
 	filteredReadyNodes := []*apiv1.Node{}
 	for _, node := range readyNodes {
 		if !strings.Contains(node.Name, m.nodeMark) {
@@ -185,7 +186,7 @@ func (m *mockCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(_ *ca_
 	return allNodes, filteredReadyNodes
 }
 
-func (m *mockCustomResourcesProcessor) GetNodeResourceTargets(_ *ca_context.AutoscalingContext, node *apiv1.Node, _ cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
+func (m *mockCustomResourcesProcessor) GetNodeResourceTargets(ctx context.Context, _ *ca_context.AutoscalingContext, node *apiv1.Node, _ cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
 	result := []CustomResourceTarget{}
 	if strings.Contains(node.Name, m.nodeMark) {
 		for _, rt := range m.customResourceTargetsToAdd {

--- a/cluster-autoscaler/processors/customresources/dra_processor.go
+++ b/cluster-autoscaler/processors/customresources/dra_processor.go
@@ -54,11 +54,13 @@ func NewDraCustomResourcesProcessor() *DraCustomResourcesProcessor {
 // FilterOutNodesWithUnreadyResources removes nodes that should have DRA resource, but don't have
 // it in allocatable from ready nodes list and updates their status to unready on all nodes list.
 func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, draSnapshot *snapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+	logger := klog.FromContext(ctx)
 	newAllNodes := make([]*apiv1.Node, 0)
 	newReadyNodes := make([]*apiv1.Node, 0)
 	nodesWithUnreadyDraResources := make(map[string]*apiv1.Node)
 	if draSnapshot == nil {
-		klog.Warningf("Cannot filter out nodes with unready DRA resources. The DRA snapshot is nil. Processing will be skipped.")
+		logger.Info("Cannot filter out nodes with unready DRA resources. The DRA snapshot is nil. Processing will be skipped.")
+
 		return allNodes, readyNodes
 	}
 
@@ -70,7 +72,7 @@ func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx con
 		ng, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)
 		if err != nil {
 			newReadyNodes = append(newReadyNodes, node)
-			klog.Warningf("Failed to get node group for node %s, Skipping DRA readiness check and keeping node in ready list. Error: %v", node.Name, err)
+			logger.Info("Failed to get node group for node, Skipping DRA readiness check and keeping node in ready list. Error", "node", node.Name, "err", err)
 			continue
 		}
 		if ng == nil {
@@ -81,7 +83,7 @@ func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx con
 		templateNodeInfo, err := getNodeInfo(autoscalingCtx, ng)
 		if err != nil {
 			newReadyNodes = append(newReadyNodes, node)
-			klog.Warningf("Failed to get template node info for node group %s with error: %v", ng.Id(), err)
+			logger.Info("Failed to get template node info for node group with", "nodeGroupId", ng.Id(), "err", err)
 			continue
 		}
 

--- a/cluster-autoscaler/processors/customresources/dra_processor.go
+++ b/cluster-autoscaler/processors/customresources/dra_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package customresources
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
@@ -34,7 +35,7 @@ import (
 
 // resourceDiscrepancyReporter defines the interface for reporting DRA discrepancies.
 type resourceDiscrepancyReporter interface {
-	ReportResourceDiscrepancies(nodeNames []string, templateSlices [][]*resourceapi.ResourceSlice, nodeSlices [][]*resourceapi.ResourceSlice)
+	ReportResourceDiscrepancies(ctx context.Context, nodeNames []string, templateSlices [][]*resourceapi.ResourceSlice, nodeSlices [][]*resourceapi.ResourceSlice)
 }
 
 // DraCustomResourcesProcessor handles DRA custom resource. It assumes,
@@ -52,7 +53,7 @@ func NewDraCustomResourcesProcessor() *DraCustomResourcesProcessor {
 
 // FilterOutNodesWithUnreadyResources removes nodes that should have DRA resource, but don't have
 // it in allocatable from ready nodes list and updates their status to unready on all nodes list.
-func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, draSnapshot *snapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, draSnapshot *snapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
 	newAllNodes := make([]*apiv1.Node, 0)
 	newReadyNodes := make([]*apiv1.Node, 0)
 	nodesWithUnreadyDraResources := make(map[string]*apiv1.Node)
@@ -95,7 +96,7 @@ func (p *DraCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autosca
 		}
 	}
 
-	p.resourcesComparator.ReportResourceDiscrepancies(readyNodeNames, readyTemplateSlices, readyNodeSlices)
+	p.resourcesComparator.ReportResourceDiscrepancies(ctx, readyNodeNames, readyTemplateSlices, readyNodeSlices)
 
 	// Override any node with unready DRA resources with its "unready" copy
 	for _, node := range allNodes {
@@ -118,7 +119,7 @@ func getNodeInfo(autoscalingCtx *ca_context.AutoscalingContext, ng cloudprovider
 }
 
 // GetNodeResourceTargets returns the resource targets for DRA resource slices, not implemented.
-func (p *DraCustomResourcesProcessor) GetNodeResourceTargets(_ *ca_context.AutoscalingContext, _ *apiv1.Node, _ cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
+func (p *DraCustomResourcesProcessor) GetNodeResourceTargets(ctx context.Context, _ *ca_context.AutoscalingContext, _ *apiv1.Node, _ cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
 	// TODO(DRA): Figure out resource limits for DRA here.
 	return []CustomResourceTarget{}, nil
 }

--- a/cluster-autoscaler/processors/customresources/dra_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/dra_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package customresources
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"testing"
@@ -67,7 +68,7 @@ func (m *mockTemplateNodeInfoRegistry) GetNodeInfos() map[string]*framework.Node
 	return m.nodeInfos
 }
 
-func (m *mockTemplateNodeInfoRegistry) Recompute(_ *ca_context.AutoscalingContext, _ []*apiv1.Node, _ []*appsv1.DaemonSet, _ taints.TaintConfig, _ time.Time) errors.AutoscalerError {
+func (m *mockTemplateNodeInfoRegistry) Recompute(ctx context.Context, _ *ca_context.AutoscalingContext, _ []*apiv1.Node, _ []*appsv1.DaemonSet, _ taints.TaintConfig, _ time.Time) errors.AutoscalerError {
 	return nil
 }
 
@@ -572,7 +573,7 @@ func TestFilterOutNodesWithUnreadyDRAResources(t *testing.T) {
 				TemplateNodeInfoRegistry: newMockTemplateNodeInfoRegistry(tc.registryNodeInfos),
 			}
 			processor := DraCustomResourcesProcessor{resourcesComparator: comparator.NewNodeResourcesComparator(noOpMetricsEmitter{})}
-			newAllNodes, newReadyNodes := processor.FilterOutNodesWithUnreadyResources(autoscalingCtx, initialAllNodes, initialReadyNodes, draSnapshot, nil)
+			newAllNodes, newReadyNodes := processor.FilterOutNodesWithUnreadyResources(context.TODO(), autoscalingCtx, initialAllNodes, initialReadyNodes, draSnapshot, nil)
 
 			readyNodes := make(map[string]bool)
 			for _, node := range newReadyNodes {
@@ -1131,7 +1132,7 @@ type fakeResourceDiscrepancyReporter struct {
 	reportedNodeSlices     [][]*resourceapi.ResourceSlice
 }
 
-func (m *fakeResourceDiscrepancyReporter) ReportResourceDiscrepancies(nodeNames []string, templateSlices [][]*resourceapi.ResourceSlice, nodeSlices [][]*resourceapi.ResourceSlice) {
+func (m *fakeResourceDiscrepancyReporter) ReportResourceDiscrepancies(ctx context.Context, nodeNames []string, templateSlices [][]*resourceapi.ResourceSlice, nodeSlices [][]*resourceapi.ResourceSlice) {
 	m.reportedNodeNames = nodeNames
 	m.reportedTemplateSlices = templateSlices
 	m.reportedNodeSlices = nodeSlices
@@ -1189,7 +1190,7 @@ func TestDraProcessorResourceComparator(t *testing.T) {
 			mockComparator := &fakeResourceDiscrepancyReporter{}
 			processor := DraCustomResourcesProcessor{resourcesComparator: mockComparator}
 
-			processor.FilterOutNodesWithUnreadyResources(autoscalingCtx, []*apiv1.Node{node}, []*apiv1.Node{node}, draSnapshot, nil)
+			processor.FilterOutNodesWithUnreadyResources(context.TODO(), autoscalingCtx, []*apiv1.Node{node}, []*apiv1.Node{node}, draSnapshot, nil)
 
 			if tc.expectReported {
 				assert.Equal(t, []string{node.Name}, mockComparator.reportedNodeNames)

--- a/cluster-autoscaler/processors/customresources/gpu_processor.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor.go
@@ -40,6 +40,7 @@ type GpuCustomResourcesProcessor struct {
 // This is a hack/workaround for nodes with GPU coming up without installed drivers, resulting
 // in GPU missing from their allocatable and capacity.
 func (p *GpuCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+	logger := klog.FromContext(ctx)
 	newAllNodes := make([]*apiv1.Node, 0)
 	newReadyNodes := make([]*apiv1.Node, 0)
 	nodesWithUnreadyGpu := make(map[string]*apiv1.Node)
@@ -52,8 +53,7 @@ func (p *GpuCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx con
 		_, hasGpuLabel := node.Labels[autoscalingCtx.CloudProvider.GPULabel()]
 		_, hasAnyGpuAllocatable := gpu.NodeHasGpuAllocatable(node)
 		if hasGpuLabel && !hasAnyGpuAllocatable {
-			klog.V(3).Infof("Overriding status of node %v, which seems to have unready GPU",
-				node.Name)
+			logger.V(3).Info("Overriding status of node, which seems to have unready GPU", "node", node.Name)
 			nodesWithUnreadyGpu[node.Name] = kubernetes.GetUnreadyNodeCopy(node, kubernetes.ResourceUnready)
 		} else {
 			newReadyNodes = append(newReadyNodes, node)
@@ -80,6 +80,7 @@ func (p *GpuCustomResourcesProcessor) GetNodeResourceTargets(ctx context.Context
 // GetNodeGpuTarget returns the gpu target of a given node. This includes gpus
 // that are not ready to use and visible in kubernetes.
 func (p *GpuCustomResourcesProcessor) GetNodeGpuTarget(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (CustomResourceTarget, errors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	gpuLabel, found := node.Labels[autoscalingCtx.CloudProvider.GPULabel()]
 	if !found {
 		return CustomResourceTarget{}, nil
@@ -112,7 +113,7 @@ func (p *GpuCustomResourcesProcessor) GetNodeGpuTarget(ctx context.Context, auto
 
 	template, err := nodeGroup.TemplateNodeInfo()
 	if err != nil {
-		klog.Errorf("Failed to build template for getting GPU estimation for node %v: %v", node.Name, err)
+		logger.Error(err, "Failed to build template for getting GPU estimation for node", "node", node.Name)
 		return CustomResourceTarget{}, errors.ToAutoscalerError(errors.CloudProviderError, err)
 	}
 	for _, gpuVendorResourceName := range gpu.GPUVendorResourceNames {
@@ -122,7 +123,7 @@ func (p *GpuCustomResourcesProcessor) GetNodeGpuTarget(ctx context.Context, auto
 	}
 
 	// if template does not define gpus we assume node will not have any even if ith has gpu label
-	klog.Warningf("Template does not define gpus even though node from its node group does; node=%v", node.Name)
+	logger.Info("Template does not define gpus even though node from its node group does", "node", node.Name)
 	return CustomResourceTarget{}, nil
 }
 

--- a/cluster-autoscaler/processors/customresources/gpu_processor.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package customresources
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
@@ -38,7 +39,7 @@ type GpuCustomResourcesProcessor struct {
 // it in allocatable from ready nodes list and updates their status to unready on all nodes list.
 // This is a hack/workaround for nodes with GPU coming up without installed drivers, resulting
 // in GPU missing from their allocatable and capacity.
-func (p *GpuCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+func (p *GpuCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
 	newAllNodes := make([]*apiv1.Node, 0)
 	newReadyNodes := make([]*apiv1.Node, 0)
 	nodesWithUnreadyGpu := make(map[string]*apiv1.Node)
@@ -71,14 +72,14 @@ func (p *GpuCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(autosca
 
 // GetNodeResourceTargets returns mapping of resource names to their targets.
 // This includes resources which are not yet ready to use and visible in kubernetes.
-func (p *GpuCustomResourcesProcessor) GetNodeResourceTargets(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
-	gpuTarget, err := p.GetNodeGpuTarget(autoscalingCtx, node, nodeGroup)
+func (p *GpuCustomResourcesProcessor) GetNodeResourceTargets(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
+	gpuTarget, err := p.GetNodeGpuTarget(ctx, autoscalingCtx, node, nodeGroup)
 	return []CustomResourceTarget{gpuTarget}, err
 }
 
 // GetNodeGpuTarget returns the gpu target of a given node. This includes gpus
 // that are not ready to use and visible in kubernetes.
-func (p *GpuCustomResourcesProcessor) GetNodeGpuTarget(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (CustomResourceTarget, errors.AutoscalerError) {
+func (p *GpuCustomResourcesProcessor) GetNodeGpuTarget(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (CustomResourceTarget, errors.AutoscalerError) {
 	gpuLabel, found := node.Labels[autoscalingCtx.CloudProvider.GPULabel()]
 	if !found {
 		return CustomResourceTarget{}, nil

--- a/cluster-autoscaler/processors/customresources/gpu_processor_test.go
+++ b/cluster-autoscaler/processors/customresources/gpu_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package customresources
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -189,7 +190,7 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 	processor := GpuCustomResourcesProcessor{}
 	provider := testprovider.NewTestCloudProviderBuilder().Build()
 	autoscalingCtx := &ca_context.AutoscalingContext{CloudProvider: provider}
-	newAllNodes, newReadyNodes := processor.FilterOutNodesWithUnreadyResources(autoscalingCtx, initialAllNodes, initialReadyNodes, nil, nil)
+	newAllNodes, newReadyNodes := processor.FilterOutNodesWithUnreadyResources(context.TODO(), autoscalingCtx, initialAllNodes, initialReadyNodes, nil, nil)
 
 	foundInReady := make(map[string]bool)
 	for _, node := range newReadyNodes {

--- a/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/azure_nodegroups_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodegroupset
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -122,7 +123,7 @@ func TestFindSimilarNodeGroupsAzureByLabel(t *testing.T) {
 	autoscalingCtx.CloudProvider = provider
 
 	// Groups with different cpu and mem are not similar.
-	similar, err := processor.FindSimilarNodeGroups(autoscalingCtx, ng1, nodeInfosForGroups)
+	similar, err := processor.FindSimilarNodeGroups(context.TODO(), autoscalingCtx, ng1, nodeInfosForGroups)
 	assert.NoError(t, err)
 	assert.Equal(t, similar, []cloudprovider.NodeGroup{})
 
@@ -131,7 +132,7 @@ func TestFindSimilarNodeGroupsAzureByLabel(t *testing.T) {
 	n2.ObjectMeta.Labels["agentpool"] = "foobar"
 	n1.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foobar"
 	n2.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foobar"
-	similar, err = processor.FindSimilarNodeGroups(autoscalingCtx, ng1, nodeInfosForGroups)
+	similar, err = processor.FindSimilarNodeGroups(context.TODO(), autoscalingCtx, ng1, nodeInfosForGroups)
 	assert.NoError(t, err)
 	assert.Equal(t, similar, []cloudprovider.NodeGroup{ng2})
 
@@ -150,7 +151,7 @@ func TestFindSimilarNodeGroupsAzureByLabel(t *testing.T) {
 	n2.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foobar2"
 	n3.ObjectMeta.Labels["kubernetes.azure.com/agentpool"] = "foobar3"
 
-	similar, err = processor.FindSimilarNodeGroups(autoscalingCtx, ng1, nodeInfosForGroups)
+	similar, err = processor.FindSimilarNodeGroups(context.TODO(), autoscalingCtx, ng1, nodeInfosForGroups)
 	assert.NoError(t, err)
 	assert.Equal(t, similar, []cloudprovider.NodeGroup{ng3})
 }

--- a/cluster-autoscaler/processors/nodegroupset/balancing_processor.go
+++ b/cluster-autoscaler/processors/nodegroupset/balancing_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodegroupset
 
 import (
+	"context"
 	"sort"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -34,7 +35,7 @@ type BalancingNodeGroupSetProcessor struct {
 
 // FindSimilarNodeGroups returns a list of NodeGroups similar to the given one using the
 // BalancingNodeGroupSetProcessor's comparator function.
-func (b *BalancingNodeGroupSetProcessor) FindSimilarNodeGroups(autoscalingCtx *ca_context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup,
+func (b *BalancingNodeGroupSetProcessor) FindSimilarNodeGroups(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup,
 	nodeInfosForGroups map[string]*framework.NodeInfo) ([]cloudprovider.NodeGroup, errors.AutoscalerError) {
 
 	result := []cloudprovider.NodeGroup{}
@@ -76,7 +77,7 @@ func (b *BalancingNodeGroupSetProcessor) FindSimilarNodeGroups(autoscalingCtx *c
 // MaxSize of each group will be respected. If newNodes > total free capacity
 // of all NodeGroups it will be capped to total capacity. In particular if all
 // group already have MaxSize, empty list will be returned.
-func (b *BalancingNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError) {
+func (b *BalancingNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError) {
 	if len(groups) == 0 {
 		return []ScaleUpInfo{}, errors.NewAutoscalerError(
 			errors.InternalError, "Can't balance scale up between 0 groups")

--- a/cluster-autoscaler/processors/nodegroupset/balancing_processor.go
+++ b/cluster-autoscaler/processors/nodegroupset/balancing_processor.go
@@ -38,6 +38,7 @@ type BalancingNodeGroupSetProcessor struct {
 func (b *BalancingNodeGroupSetProcessor) FindSimilarNodeGroups(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup,
 	nodeInfosForGroups map[string]*framework.NodeInfo) ([]cloudprovider.NodeGroup, errors.AutoscalerError) {
 
+	logger := klog.FromContext(ctx)
 	result := []cloudprovider.NodeGroup{}
 	nodeGroupId := nodeGroup.Id()
 	nodeInfo, found := nodeInfosForGroups[nodeGroupId]
@@ -54,7 +55,7 @@ func (b *BalancingNodeGroupSetProcessor) FindSimilarNodeGroups(ctx context.Conte
 		}
 		ngNodeInfo, found := nodeInfosForGroups[ngId]
 		if !found {
-			klog.Warningf("Failed to find nodeInfo for group %v", ngId)
+			logger.Info("Failed to find nodeInfo for group", "ngId", ngId)
 			continue
 		}
 		comparator := b.Comparator
@@ -78,6 +79,7 @@ func (b *BalancingNodeGroupSetProcessor) FindSimilarNodeGroups(ctx context.Conte
 // of all NodeGroups it will be capped to total capacity. In particular if all
 // group already have MaxSize, empty list will be returned.
 func (b *BalancingNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	if len(groups) == 0 {
 		return []ScaleUpInfo{}, errors.NewAutoscalerError(
 			errors.InternalError, "Can't balance scale up between 0 groups")
@@ -110,7 +112,7 @@ func (b *BalancingNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(ctx context
 		})
 	}
 	if totalCapacity < newNodes {
-		klog.V(2).Infof("Requested scale-up (%v) exceeds node group set capacity, capping to %v", newNodes, totalCapacity)
+		logger.V(2).Info("Requested scale-up exceeds node group set capacity, capping", "newNodes", newNodes, "totalCapacity", totalCapacity)
 		newNodes = totalCapacity
 	}
 

--- a/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/balancing_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodegroupset
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -65,15 +66,15 @@ func basicSimilarNodeGroupsTest(
 	ng2, _ := autoscalingCtx.CloudProvider.NodeGroupForNode(ni2.Node())
 	ng3, _ := autoscalingCtx.CloudProvider.NodeGroupForNode(ni3.Node())
 
-	similar, err := processor.FindSimilarNodeGroups(autoscalingCtx, ng1, nodeInfosForGroups)
+	similar, err := processor.FindSimilarNodeGroups(context.TODO(), autoscalingCtx, ng1, nodeInfosForGroups)
 	assert.NoError(t, err)
 	assert.Equal(t, []cloudprovider.NodeGroup{ng2}, similar)
 
-	similar, err = processor.FindSimilarNodeGroups(autoscalingCtx, ng2, nodeInfosForGroups)
+	similar, err = processor.FindSimilarNodeGroups(context.TODO(), autoscalingCtx, ng2, nodeInfosForGroups)
 	assert.NoError(t, err)
 	assert.Equal(t, []cloudprovider.NodeGroup{ng1}, similar)
 
-	similar, err = processor.FindSimilarNodeGroups(autoscalingCtx, ng3, nodeInfosForGroups)
+	similar, err = processor.FindSimilarNodeGroups(context.TODO(), autoscalingCtx, ng3, nodeInfosForGroups)
 	assert.NoError(t, err)
 	assert.Equal(t, []cloudprovider.NodeGroup{}, similar)
 }
@@ -116,13 +117,13 @@ func TestBalanceSingleGroup(t *testing.T) {
 	provider.AddNodeGroup("ng1", 1, 10, 1)
 
 	// just one node
-	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 1)
+	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, provider.NodeGroups(), 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, 2, scaleUpInfo[0].NewSize)
 
 	// multiple nodes
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 4)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, provider.NodeGroups(), 4)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, 5, scaleUpInfo[0].NewSize)
@@ -139,19 +140,19 @@ func TestBalanceUnderMaxSize(t *testing.T) {
 	provider.AddNodeGroup("ng4", 1, 10, 5)
 
 	// add a single node
-	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 1)
+	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, provider.NodeGroups(), 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, 2, scaleUpInfo[0].NewSize)
 
 	// add multiple nodes to single group
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 2)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, provider.NodeGroups(), 2)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, 3, scaleUpInfo[0].NewSize)
 
 	// add nodes to groups of different sizes, divisible
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 4)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, provider.NodeGroups(), 4)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(scaleUpInfo))
 	assert.Equal(t, 4, scaleUpInfo[0].NewSize)
@@ -161,7 +162,7 @@ func TestBalanceUnderMaxSize(t *testing.T) {
 
 	// add nodes to groups of different sizes, non-divisible
 	// we expect new sizes to be 4 and 5, doesn't matter which group gets how many
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 5)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, provider.NodeGroups(), 5)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(scaleUpInfo))
 	assert.Equal(t, 9, scaleUpInfo[0].NewSize+scaleUpInfo[1].NewSize)
@@ -170,7 +171,7 @@ func TestBalanceUnderMaxSize(t *testing.T) {
 	assert.True(t, scaleUpInfo[0].Group.Id() == "ng2" || scaleUpInfo[1].Group.Id() == "ng2")
 
 	// add nodes to all groups, divisible
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, provider.NodeGroups(), 10)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, provider.NodeGroups(), 10)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(scaleUpInfo))
 	for _, info := range scaleUpInfo {
@@ -210,33 +211,33 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	}
 
 	// Just one maxed out group
-	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng1"), 1)
+	scaleUpInfo, err := processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, getGroups("ng1"), 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(scaleUpInfo))
 
 	// Smallest group already maxed out, add one node
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng1", "ng2"), 1)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, getGroups("ng1", "ng2"), 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, "ng2", scaleUpInfo[0].Group.Id())
 	assert.Equal(t, 2, scaleUpInfo[0].NewSize)
 
 	// Smallest group already maxed out, too many nodes (should cap to max capacity)
-	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng1", "ng2"), 5)
+	scaleUpInfo, err = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, getGroups("ng1", "ng2"), 5)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	assert.Equal(t, "ng2", scaleUpInfo[0].Group.Id())
 	assert.Equal(t, 3, scaleUpInfo[0].NewSize)
 
 	// First group maxes out before proceeding to next one
-	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng3"), 4)
+	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, getGroups("ng2", "ng3"), 4)
 	assert.Equal(t, 2, len(scaleUpInfo))
 	scaleUpMap := toMap(scaleUpInfo)
 	assert.Equal(t, 3, scaleUpMap["ng2"].NewSize)
 	assert.Equal(t, 5, scaleUpMap["ng3"].NewSize)
 
 	// Last group maxes out before previous one
-	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng3", "ng4"), 9)
+	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, getGroups("ng2", "ng3", "ng4"), 9)
 	assert.Equal(t, 3, len(scaleUpInfo))
 	scaleUpMap = toMap(scaleUpInfo)
 	assert.Equal(t, 3, scaleUpMap["ng2"].NewSize)
@@ -244,7 +245,7 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	assert.Equal(t, 7, scaleUpMap["ng4"].NewSize)
 
 	// Use all capacity, cap to max
-	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng3", "ng4"), 900)
+	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, getGroups("ng2", "ng3", "ng4"), 900)
 	assert.Equal(t, 3, len(scaleUpInfo))
 	scaleUpMap = toMap(scaleUpInfo)
 	assert.Equal(t, 3, scaleUpMap["ng2"].NewSize)
@@ -252,7 +253,7 @@ func TestBalanceHittingMaxSize(t *testing.T) {
 	assert.Equal(t, 7, scaleUpMap["ng4"].NewSize)
 
 	// One node group exceeds max.
-	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(autoscalingCtx, getGroups("ng2", "ng5"), 1)
+	scaleUpInfo, _ = processor.BalanceScaleUpBetweenGroups(context.TODO(), autoscalingCtx, getGroups("ng2", "ng5"), 1)
 	assert.Equal(t, 1, len(scaleUpInfo))
 	scaleUpMap = toMap(scaleUpInfo)
 	assert.Equal(t, 2, scaleUpMap["ng2"].NewSize)

--- a/cluster-autoscaler/processors/nodegroupset/nodegroup_set_processor.go
+++ b/cluster-autoscaler/processors/nodegroupset/nodegroup_set_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodegroupset
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -45,10 +46,10 @@ func (s ScaleUpInfo) String() string {
 
 // NodeGroupSetProcessor finds nodegroups that are similar and allows balancing scale-up between them.
 type NodeGroupSetProcessor interface {
-	FindSimilarNodeGroups(autoscalingCtx *ca_context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup,
+	FindSimilarNodeGroups(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup,
 		nodeInfosForGroups map[string]*framework.NodeInfo) ([]cloudprovider.NodeGroup, errors.AutoscalerError)
 
-	BalanceScaleUpBetweenGroups(autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError)
+	BalanceScaleUpBetweenGroups(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError)
 	CleanUp()
 }
 
@@ -57,13 +58,13 @@ type NoOpNodeGroupSetProcessor struct {
 }
 
 // FindSimilarNodeGroups returns a list of NodeGroups similar to the one provided in parameter.
-func (n *NoOpNodeGroupSetProcessor) FindSimilarNodeGroups(autoscalingCtx *ca_context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup,
+func (n *NoOpNodeGroupSetProcessor) FindSimilarNodeGroups(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup,
 	nodeInfosForGroups map[string]*framework.NodeInfo) ([]cloudprovider.NodeGroup, errors.AutoscalerError) {
 	return []cloudprovider.NodeGroup{}, nil
 }
 
 // BalanceScaleUpBetweenGroups splits a scale-up between provided NodeGroups.
-func (n *NoOpNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError) {
+func (n *NoOpNodeGroupSetProcessor) BalanceScaleUpBetweenGroups(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, groups []cloudprovider.NodeGroup, newNodes int) ([]ScaleUpInfo, errors.AutoscalerError) {
 	return []ScaleUpInfo{}, nil
 }
 

--- a/cluster-autoscaler/processors/nodeinfosprovider/annotation_node_info_provider.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/annotation_node_info_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeinfosprovider
 
 import (
+	"context"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -47,8 +48,8 @@ func NewCustomAnnotationNodeInfoProvider(templateNodeInfoProvider TemplateNodeIn
 }
 
 // Process returns the nodeInfos set for this cluster.
-func (p *AnnotationNodeInfoProvider) Process(autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) (map[string]*framework.NodeInfo, errors.AutoscalerError) {
-	nodeInfos, err := p.templateNodeInfoProvider.Process(autoscalingCtx, nodes, daemonsets, taintConfig, currentTime)
+func (p *AnnotationNodeInfoProvider) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) (map[string]*framework.NodeInfo, errors.AutoscalerError) {
+	nodeInfos, err := p.templateNodeInfoProvider.Process(ctx, autoscalingCtx, nodes, daemonsets, taintConfig, currentTime)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/processors/nodeinfosprovider/asg_tag_resource_node_info_provider.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/asg_tag_resource_node_info_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeinfosprovider
 
 import (
+	"context"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -40,8 +41,8 @@ func NewAsgTagResourceNodeInfoProvider(t *time.Duration, forceDaemonSets bool) *
 }
 
 // Process returns the nodeInfos set for this cluster.
-func (p *AsgTagResourceNodeInfoProvider) Process(autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) (map[string]*framework.NodeInfo, errors.AutoscalerError) {
-	nodeInfos, err := p.mixedTemplateNodeInfoProvider.Process(autoscalingCtx, nodes, daemonsets, taintConfig, currentTime)
+func (p *AsgTagResourceNodeInfoProvider) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) (map[string]*framework.NodeInfo, errors.AutoscalerError) {
+	nodeInfos, err := p.mixedTemplateNodeInfoProvider.Process(ctx, autoscalingCtx, nodes, daemonsets, taintConfig, currentTime)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeinfosprovider
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -71,7 +72,7 @@ func (p *MixedTemplateNodeInfoProvider) CleanUp() {
 }
 
 // Process returns the nodeInfos set for this cluster
-func (p *MixedTemplateNodeInfoProvider) Process(autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, now time.Time) (map[string]*framework.NodeInfo, caerror.AutoscalerError) {
+func (p *MixedTemplateNodeInfoProvider) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, now time.Time) (map[string]*framework.NodeInfo, caerror.AutoscalerError) {
 	// TODO(mwielgus): This returns map keyed by url, while most code (including scheduler) uses node.Name for a key.
 	// TODO(mwielgus): Review error policy - sometimes we may continue with partial errors.
 	result := make(map[string]*framework.NodeInfo)
@@ -105,7 +106,7 @@ func (p *MixedTemplateNodeInfoProvider) Process(autoscalingCtx *ca_context.Autos
 			if err != nil {
 				return false, "", caerror.NewAutoscalerErrorf(caerror.InternalError, "error while retrieving node %s from cluster snapshot - this shouldn't happen: %v", node.Name, err)
 			}
-			templateNodeInfo, caErr := simulator.SanitizedTemplateNodeInfoFromNodeInfo(nodeInfo, id, daemonsets, p.forceDaemonSets, taintConfig)
+			templateNodeInfo, caErr := simulator.SanitizedTemplateNodeInfoFromNodeInfo(ctx, nodeInfo, id, daemonsets, p.forceDaemonSets, taintConfig)
 			if caErr != nil {
 				return false, "", caErr
 			}
@@ -146,7 +147,7 @@ func (p *MixedTemplateNodeInfoProvider) Process(autoscalingCtx *ca_context.Autos
 
 		// No good template, trying to generate one. This is called only if there are no
 		// working nodes in the node groups. By default CA tries to use a real-world example.
-		nodeInfo, err := simulator.SanitizedTemplateNodeInfoFromNodeGroup(nodeGroup, daemonsets, taintConfig)
+		nodeInfo, err := simulator.SanitizedTemplateNodeInfoFromNodeGroup(ctx, nodeGroup, daemonsets, taintConfig)
 		if err != nil {
 			if !errors.Is(err, cloudprovider.ErrNotImplemented) {
 				klog.Errorf("Unable to build proper template node for %s: %v", id, err)

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
@@ -75,6 +75,7 @@ func (p *MixedTemplateNodeInfoProvider) CleanUp() {
 func (p *MixedTemplateNodeInfoProvider) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, now time.Time) (map[string]*framework.NodeInfo, caerror.AutoscalerError) {
 	// TODO(mwielgus): This returns map keyed by url, while most code (including scheduler) uses node.Name for a key.
 	// TODO(mwielgus): Review error policy - sometimes we may continue with partial errors.
+	logger := klog.FromContext(ctx)
 	result := make(map[string]*framework.NodeInfo)
 	seenGroups := make(map[string]bool)
 
@@ -94,7 +95,7 @@ func (p *MixedTemplateNodeInfoProvider) Process(ctx context.Context, autoscaling
 	processNode := func(node *apiv1.Node) (bool, string, caerror.AutoscalerError) {
 		nodeGroup, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)
 		if err != nil {
-			klog.Warningf("Failed to find node group for %s: %v", node.Name, err)
+			logger.Info("Failed to find node group", "node", node.Name, "err", err)
 			return false, "", nil
 		}
 		if nodeGroup == nil {
@@ -150,7 +151,7 @@ func (p *MixedTemplateNodeInfoProvider) Process(ctx context.Context, autoscaling
 		nodeInfo, err := simulator.SanitizedTemplateNodeInfoFromNodeGroup(ctx, nodeGroup, daemonsets, taintConfig)
 		if err != nil {
 			if !errors.Is(err, cloudprovider.ErrNotImplemented) {
-				klog.Errorf("Unable to build proper template node for %s: %v", id, err)
+				logger.Error(err, "Unable to build proper template node", "id", id)
 			}
 			continue
 		}
@@ -173,10 +174,10 @@ func (p *MixedTemplateNodeInfoProvider) Process(ctx context.Context, autoscaling
 		if added {
 			nodeGroup, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)
 			if nodeGroup == nil || err != nil {
-				klog.Warningf("Failed to find node group for %s: %v", node.Name, err)
+				logger.Info("Failed to find node group", "node", node.Name, "err", err)
 				continue
 			}
-			klog.Warningf("Built template for %s based on unready/unschedulable node %s", nodeGroup.Id(), node.Name)
+			logger.Info("Built template based on unready unschedulable node", "nodeGroupId", nodeGroup.Id(), "node", node.Name)
 		}
 	}
 

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeinfosprovider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -344,7 +345,7 @@ func TestMixedNodeInfosProvider(t *testing.T) {
 			if tc.withCache != nil {
 				processor.nodeInfoCache = tc.withCache
 			}
-			nodeInfos, err := processor.Process(ctx, allNodes, nil, taints.TaintConfig{}, now)
+			nodeInfos, err := processor.Process(context.TODO(), ctx, allNodes, nil, taints.TaintConfig{}, now)
 
 			assert.Equal(t, tc.wantError, err)
 			if tc.wantError == nil {

--- a/cluster-autoscaler/processors/nodeinfosprovider/node_info_provider_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/node_info_provider_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeinfosprovider
 
 import (
+	"context"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,7 +32,7 @@ import (
 // TemplateNodeInfoProvider is provides the initial nodeInfos set.
 type TemplateNodeInfoProvider interface {
 	// Process returns a map of nodeInfos for node groups.
-	Process(autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) (map[string]*framework.NodeInfo, errors.AutoscalerError)
+	Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) (map[string]*framework.NodeInfo, errors.AutoscalerError)
 	// CleanUp cleans up processor's internal structures.
 	CleanUp()
 }

--- a/cluster-autoscaler/processors/nodeinfosprovider/template_node_info_registry.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/template_node_info_registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeinfosprovider
 
 import (
+	"context"
 	"maps"
 	"sync"
 	"time"
@@ -48,8 +49,8 @@ func NewTemplateNodeInfoRegistry(provider TemplateNodeInfoProvider) *TemplateNod
 }
 
 // Recompute calls the embedded provider to update the cached node infos.
-func (r *TemplateNodeInfoRegistry) Recompute(autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) errors.AutoscalerError {
-	nodeInfos, err := r.provider.Process(autoscalingCtx, nodes, daemonsets, taintConfig, currentTime)
+func (r *TemplateNodeInfoRegistry) Recompute(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig, currentTime time.Time) errors.AutoscalerError {
+	nodeInfos, err := r.provider.Process(ctx, autoscalingCtx, nodes, daemonsets, taintConfig, currentTime)
 	if err != nil {
 		return err
 	}

--- a/cluster-autoscaler/processors/nodeinfosprovider/template_node_info_registry_test.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/template_node_info_registry_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeinfosprovider
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -36,7 +37,7 @@ type mockTemplateNodeInfoProvider struct {
 	nodeInfos map[string]*framework.NodeInfo
 }
 
-func (p *mockTemplateNodeInfoProvider) Process(_ *ca_context.AutoscalingContext, _ []*apiv1.Node, _ []*appsv1.DaemonSet, _ taints.TaintConfig, _ time.Time) (map[string]*framework.NodeInfo, errors.AutoscalerError) {
+func (p *mockTemplateNodeInfoProvider) Process(ctx context.Context, _ *ca_context.AutoscalingContext, _ []*apiv1.Node, _ []*appsv1.DaemonSet, _ taints.TaintConfig, _ time.Time) (map[string]*framework.NodeInfo, errors.AutoscalerError) {
 	return p.nodeInfos, nil
 }
 
@@ -51,7 +52,7 @@ func TestTemplateNodeInfoRegistry(t *testing.T) {
 	registry := NewTemplateNodeInfoRegistry(mockProvider)
 
 	// Test Recompute
-	err := registry.Recompute(nil, nil, nil, taints.TaintConfig{}, time.Now())
+	err := registry.Recompute(context.TODO(), nil, nil, nil, taints.TaintConfig{}, time.Now())
 	assert.NoError(t, err)
 
 	// Test GetNodeInfo
@@ -75,7 +76,7 @@ func TestTemplateNodeInfoRegistry(t *testing.T) {
 		"ng1": framework.NewTestNodeInfo(BuildTestNode("node1", 1000, 1000)),
 		"ng2": framework.NewTestNodeInfo(BuildTestNode("node2", 1000, 1000)),
 	}
-	err = registry.Recompute(nil, nil, nil, taints.TaintConfig{}, time.Now())
+	err = registry.Recompute(context.TODO(), nil, nil, nil, taints.TaintConfig{}, time.Now())
 	assert.NoError(t, err)
 
 	info, found = registry.GetNodeInfo("ng2")
@@ -98,7 +99,7 @@ func TestTemplateNodeInfoRegistry_Concurrent(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 100; i++ {
-			err := registry.Recompute(nil, nil, nil, taints.TaintConfig{}, time.Now())
+			err := registry.Recompute(context.TODO(), nil, nil, nil, taints.TaintConfig{}, time.Now())
 			assert.NoError(t, err)
 		}
 	}()

--- a/cluster-autoscaler/processors/nodes/pre_filtering_processor.go
+++ b/cluster-autoscaler/processors/nodes/pre_filtering_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodes
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
 
@@ -43,7 +44,7 @@ func (n *PreFilteringScaleDownNodeProcessor) GetScaleDownCandidates(autoscalingC
 	nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
 	result := make([]*apiv1.Node, 0, len(nodes))
 
-	nodeGroupSize := utils.GetNodeGroupSizeMap(autoscalingCtx.CloudProvider)
+	nodeGroupSize := utils.GetNodeGroupSizeMap(context.TODO(), autoscalingCtx.CloudProvider)
 
 	for _, node := range nodes {
 		nodeGroup, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)

--- a/cluster-autoscaler/processors/nodes/scale_down_set_processor.go
+++ b/cluster-autoscaler/processors/nodes/scale_down_set_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodes
 
 import (
+	"context"
 	"slices"
 	"strconv"
 
@@ -44,13 +45,13 @@ func NewCompositeScaleDownSetProcessor(orderedProcessorList []ScaleDownSetProces
 }
 
 // FilterUnremovableNodes filters the passed removable candidates from unremovable nodes by calling orderedProcessorList in order
-func (p *CompositeScaleDownSetProcessor) FilterUnremovableNodes(autoscalingCtx *ca_context.AutoscalingContext, scaleDownCtx *ScaleDownContext, candidates []simulator.NodeToBeRemoved) ([]simulator.NodeToBeRemoved, []simulator.UnremovableNode) {
+func (p *CompositeScaleDownSetProcessor) FilterUnremovableNodes(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownCtx *ScaleDownContext, candidates []simulator.NodeToBeRemoved) ([]simulator.NodeToBeRemoved, []simulator.UnremovableNode) {
 	unremovableNodes := []simulator.UnremovableNode{}
 	nodesToBeRemoved := []simulator.NodeToBeRemoved{}
 	nodesToBeRemoved = append(nodesToBeRemoved, candidates...)
 
 	for indx, p := range p.orderedProcessorList {
-		processorRemovableNodes, processorUnremovableNodes := p.FilterUnremovableNodes(autoscalingCtx, scaleDownCtx, nodesToBeRemoved)
+		processorRemovableNodes, processorUnremovableNodes := p.FilterUnremovableNodes(ctx, autoscalingCtx, scaleDownCtx, nodesToBeRemoved)
 
 		if len(processorRemovableNodes)+len(processorUnremovableNodes) != len(candidates) {
 			klog.Errorf("Scale down set composite processor failed with processor at index %d: removable nodes (%d) + unremovable nodes (%d) != candidates nodes (%d)",
@@ -79,7 +80,7 @@ type AtomicResizeFilteringProcessor struct {
 }
 
 // FilterUnremovableNodes marks all candidate nodes as unremovable if ZeroOrMaxNodeScaling is enabled and number of nodes to remove are not equal to target or current size
-func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(autoscalingCtx *ca_context.AutoscalingContext, scaleDownCtx *ScaleDownContext, candidates []simulator.NodeToBeRemoved) ([]simulator.NodeToBeRemoved, []simulator.UnremovableNode) {
+func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownCtx *ScaleDownContext, candidates []simulator.NodeToBeRemoved) ([]simulator.NodeToBeRemoved, []simulator.UnremovableNode) {
 	nodesToBeRemoved := []simulator.NodeToBeRemoved{}
 	unremovableNodes := []simulator.UnremovableNode{}
 
@@ -135,19 +136,19 @@ func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(autoscalingCtx *
 			registeredNodes, err := p.getAllRegisteredNodesForNodeGroup(nodeGroup, allNodes)
 			if err != nil {
 				klog.Errorf("Failed to get registered nodes for group %s: %v", nodeGroup.Id(), err)
-				unremovableNodes = p.atomicScaleDownFailed(consideredNodes, ngSize, unremovableNodes, nodeGroup)
+				unremovableNodes = p.atomicScaleDownFailed(ctx, consideredNodes, ngSize, unremovableNodes, nodeGroup)
 			} else if len(registeredNodes) == len(consideredNodes) {
 				klog.V(2).Infof("Scheduling atomic scale down for all %v registered nodes from node group %s", len(consideredNodes), nodeGroup.Id())
 				nodesToBeRemoved = append(nodesToBeRemoved, consideredNodes...)
 			} else {
-				unremovableNodes = p.atomicScaleDownFailed(consideredNodes, len(registeredNodes), unremovableNodes, nodeGroup)
+				unremovableNodes = p.atomicScaleDownFailed(ctx, consideredNodes, len(registeredNodes), unremovableNodes, nodeGroup)
 			}
 		}
 	}
 	return nodesToBeRemoved, unremovableNodes
 }
 
-func (p *AtomicResizeFilteringProcessor) atomicScaleDownFailed(nodes []simulator.NodeToBeRemoved, ngSize int, unremovableNodes []simulator.UnremovableNode, nodeGroup cloudprovider.NodeGroup) []simulator.UnremovableNode {
+func (p *AtomicResizeFilteringProcessor) atomicScaleDownFailed(ctx context.Context, nodes []simulator.NodeToBeRemoved, ngSize int, unremovableNodes []simulator.UnremovableNode, nodeGroup cloudprovider.NodeGroup) []simulator.UnremovableNode {
 	klog.V(2).Infof("Skipping scale down for %v nodes from node group %s, all %v nodes have to be scaled down atomically", len(nodes), nodeGroup.Id(), ngSize)
 	unremovableNodes = slices.Grow(unremovableNodes, len(nodes))
 	for _, node := range nodes {

--- a/cluster-autoscaler/processors/nodes/scale_down_set_processor.go
+++ b/cluster-autoscaler/processors/nodes/scale_down_set_processor.go
@@ -46,6 +46,7 @@ func NewCompositeScaleDownSetProcessor(orderedProcessorList []ScaleDownSetProces
 
 // FilterUnremovableNodes filters the passed removable candidates from unremovable nodes by calling orderedProcessorList in order
 func (p *CompositeScaleDownSetProcessor) FilterUnremovableNodes(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownCtx *ScaleDownContext, candidates []simulator.NodeToBeRemoved) ([]simulator.NodeToBeRemoved, []simulator.UnremovableNode) {
+	logger := klog.FromContext(ctx)
 	unremovableNodes := []simulator.UnremovableNode{}
 	nodesToBeRemoved := []simulator.NodeToBeRemoved{}
 	nodesToBeRemoved = append(nodesToBeRemoved, candidates...)
@@ -54,8 +55,7 @@ func (p *CompositeScaleDownSetProcessor) FilterUnremovableNodes(ctx context.Cont
 		processorRemovableNodes, processorUnremovableNodes := p.FilterUnremovableNodes(ctx, autoscalingCtx, scaleDownCtx, nodesToBeRemoved)
 
 		if len(processorRemovableNodes)+len(processorUnremovableNodes) != len(candidates) {
-			klog.Errorf("Scale down set composite processor failed with processor at index %d: removable nodes (%d) + unremovable nodes (%d) != candidates nodes (%d)",
-				indx, len(processorRemovableNodes), len(processorUnremovableNodes), len(candidates))
+			logger.Error(nil, "Scale down set composite processor failed with processor at index: removable nodes + unremovable nodes != candidates nodes", "indx", indx, "processorRemovableNodesCount", len(processorRemovableNodes), "processorUnremovableNodesCount", len(processorUnremovableNodes), "candidatesCount", len(candidates))
 		}
 
 		nodesToBeRemoved = processorRemovableNodes
@@ -81,6 +81,7 @@ type AtomicResizeFilteringProcessor struct {
 
 // FilterUnremovableNodes marks all candidate nodes as unremovable if ZeroOrMaxNodeScaling is enabled and number of nodes to remove are not equal to target or current size
 func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownCtx *ScaleDownContext, candidates []simulator.NodeToBeRemoved) ([]simulator.NodeToBeRemoved, []simulator.UnremovableNode) {
+	logger := klog.FromContext(ctx)
 	nodesToBeRemoved := []simulator.NodeToBeRemoved{}
 	unremovableNodes := []simulator.UnremovableNode{}
 
@@ -89,24 +90,24 @@ func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(ctx context.Cont
 	nodesByGroup := map[cloudprovider.NodeGroup][]simulator.NodeToBeRemoved{}
 	allNodes, err := allNodes(autoscalingCtx.ClusterSnapshot)
 	if err != nil {
-		klog.Errorf("failed to read all nodes from the cluster snapshot for filtering unremovable nodes, err: %s", err)
+		logger.Error(err, "failed to read all nodes from the cluster snapshot for filtering unremovable nodes")
 	}
 
 	for _, node := range candidates {
 		nodeGroup, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node.Node)
 		if err != nil {
-			klog.Errorf("Node %v will not scale down, failed to get node info: %s", node.Node.Name, err)
+			logger.Error(err, "Node will not scale down, failed to get node info", "node", node.Node.Name)
 			unremovableNodes = append(unremovableNodes, simulator.UnremovableNode{Node: node.Node, Reason: simulator.UnexpectedError})
 			continue
 		}
 		if nodeGroup == nil {
-			klog.V(4).Infof("Node %v will not scale down, has no node group config.", node.Node.Name)
+			logger.V(4).Info("Node will not scale down, has no node group config.", "node", node.Node.Name)
 			unremovableNodes = append(unremovableNodes, simulator.UnremovableNode{Node: node.Node, Reason: simulator.NotAutoscaled})
 			continue
 		}
 		autoscalingOptions, err := nodeGroup.GetOptions(autoscalingCtx.NodeGroupDefaults)
 		if err != nil && err != cloudprovider.ErrNotImplemented {
-			klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
+			logger.Error(err, "Failed to get autoscaling options for node group", "nodeGroupId", nodeGroup.Id())
 			unremovableNodes = append(unremovableNodes, simulator.UnremovableNode{Node: node.Node, Reason: simulator.UnexpectedError})
 			continue
 		}
@@ -123,22 +124,22 @@ func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(ctx context.Cont
 	for nodeGroup, consideredNodes := range nodesByGroup {
 		ngSize, err := nodeGroup.TargetSize()
 		if err != nil {
-			klog.Errorf("Nodes from group %s will not scale down, failed to get target size: %s", nodeGroup.Id(), err)
+			logger.Error(err, "Nodes from group will not scale down, failed to get target size", "nodeGroupId", nodeGroup.Id())
 			for _, node := range consideredNodes {
 				unremovableNodes = append(unremovableNodes, simulator.UnremovableNode{Node: node.Node, Reason: simulator.UnexpectedError})
 			}
 			continue
 		}
 		if ngSize == len(consideredNodes) {
-			klog.V(2).Infof("Scheduling atomic scale down for all %v nodes from node group %s", len(consideredNodes), nodeGroup.Id())
+			logger.V(2).Info("Scheduling atomic scale down for all nodes from node group", "consideredNodesCount", len(consideredNodes), "nodeGroupId", nodeGroup.Id())
 			nodesToBeRemoved = append(nodesToBeRemoved, consideredNodes...)
 		} else {
 			registeredNodes, err := p.getAllRegisteredNodesForNodeGroup(nodeGroup, allNodes)
 			if err != nil {
-				klog.Errorf("Failed to get registered nodes for group %s: %v", nodeGroup.Id(), err)
+				logger.Error(err, "Failed to get registered nodes for group", "nodeGroupId", nodeGroup.Id())
 				unremovableNodes = p.atomicScaleDownFailed(ctx, consideredNodes, ngSize, unremovableNodes, nodeGroup)
 			} else if len(registeredNodes) == len(consideredNodes) {
-				klog.V(2).Infof("Scheduling atomic scale down for all %v registered nodes from node group %s", len(consideredNodes), nodeGroup.Id())
+				logger.V(2).Info("Scheduling atomic scale down for all registered nodes from node group", "consideredNodesCount", len(consideredNodes), "nodeGroupId", nodeGroup.Id())
 				nodesToBeRemoved = append(nodesToBeRemoved, consideredNodes...)
 			} else {
 				unremovableNodes = p.atomicScaleDownFailed(ctx, consideredNodes, len(registeredNodes), unremovableNodes, nodeGroup)
@@ -149,7 +150,8 @@ func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(ctx context.Cont
 }
 
 func (p *AtomicResizeFilteringProcessor) atomicScaleDownFailed(ctx context.Context, nodes []simulator.NodeToBeRemoved, ngSize int, unremovableNodes []simulator.UnremovableNode, nodeGroup cloudprovider.NodeGroup) []simulator.UnremovableNode {
-	klog.V(2).Infof("Skipping scale down for %v nodes from node group %s, all %v nodes have to be scaled down atomically", len(nodes), nodeGroup.Id(), ngSize)
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Skipping scale down nodes from node group, all nodes have to be scaled down atomically", "nodesCount", len(nodes), "nodeGroupId", nodeGroup.Id(), "ngSize", ngSize)
 	unremovableNodes = slices.Grow(unremovableNodes, len(nodes))
 	for _, node := range nodes {
 		unremovableNodes = append(unremovableNodes, simulator.UnremovableNode{Node: node.Node, Reason: simulator.AtomicScaleDownFailed})

--- a/cluster-autoscaler/processors/nodes/scale_down_set_processor_test.go
+++ b/cluster-autoscaler/processors/nodes/scale_down_set_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodes
 
 import (
+	gocontext "context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -365,7 +366,7 @@ func TestAtomicResizeFilterUnremovableNodes(t *testing.T) {
 			}, &fake.Clientset{}, nil, provider, nil, nil, nil)
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, context.ClusterSnapshot, nodes, nil)
 
-			toBeRemoved, unRemovable := processor.FilterUnremovableNodes(&context, tc.scaleDownContext, candidates)
+			toBeRemoved, unRemovable := processor.FilterUnremovableNodes(gocontext.TODO(), &context, tc.scaleDownContext, candidates)
 
 			assert.ElementsMatch(t, tc.expectedToBeRemoved, toBeRemoved)
 			assert.ElementsMatch(t, tc.expectedUnremovable, unRemovable)

--- a/cluster-autoscaler/processors/nodes/types.go
+++ b/cluster-autoscaler/processors/nodes/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodes
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
@@ -39,7 +40,7 @@ type ScaleDownSetProcessor interface {
 	// FilterUnremovableNodes divides all candidates into removable nodes and unremovable nodes with reason
 	// Note that len(removableNodes) + len(unremovableNode) should equal len(candidates)
 	// in other words, each candidate should end up in one and only one of the resulting node lists.
-	FilterUnremovableNodes(autoscalingCtx *ca_context.AutoscalingContext, scaleDownCtx *ScaleDownContext, candidates []simulator.NodeToBeRemoved) ([]simulator.NodeToBeRemoved, []simulator.UnremovableNode)
+	FilterUnremovableNodes(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, scaleDownCtx *ScaleDownContext, candidates []simulator.NodeToBeRemoved) ([]simulator.NodeToBeRemoved, []simulator.UnremovableNode)
 	// CleanUp is called at CA termination
 	CleanUp()
 }

--- a/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor.go
+++ b/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podinjection
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
@@ -43,7 +44,7 @@ func NewEnforceInjectedPodsLimitProcessor(podLimit int) *EnforceInjectedPodsLimi
 }
 
 // Process filters unschedulablePods and enforces the limit of the number of injected pods
-func (p *EnforceInjectedPodsLimitProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+func (p *EnforceInjectedPodsLimitProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 
 	numberOfFakePodsToRemove := len(unschedulablePods) - p.podLimit
 	removedFakePodsCount := 0

--- a/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor_test.go
+++ b/cluster-autoscaler/processors/podinjection/enforce_injected_pods_limit_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podinjection
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,7 +100,7 @@ func TestEnforceInjectedPodsLimitProcessor(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			p := NewEnforceInjectedPodsLimitProcessor(tc.podLimit)
-			pods, _ := p.Process(nil, tc.unschedulablePods)
+			pods, _ := p.Process(context.TODO(), nil, tc.unschedulablePods)
 			assert.EqualValues(t, tc.expectedNumberOfResultedUnschedulablePods, len(pods))
 			numberOfFakePods := numberOfFakePods(pods)
 			assert.EqualValues(t, tc.expectedNumberOfResultedUnschedulableFakePods, numberOfFakePods)

--- a/cluster-autoscaler/processors/podinjection/job_controller.go
+++ b/cluster-autoscaler/processors/podinjection/job_controller.go
@@ -25,10 +25,11 @@ import (
 )
 
 func createJobControllers(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) []controller {
+	logger := klog.FromContext(ctx)
 	var controllers []controller
 	jobs, err := autoscalingCtx.ListerRegistry.JobLister().List(labels.Everything())
 	if err != nil {
-		klog.Errorf("Failed to list jobs: %v", err)
+		logger.Error(err, "Failed to list jobs")
 	}
 	for _, job := range jobs {
 		controllers = append(controllers, controller{uid: job.UID, desiredReplicas: desiredReplicasFromJob(job)})

--- a/cluster-autoscaler/processors/podinjection/job_controller.go
+++ b/cluster-autoscaler/processors/podinjection/job_controller.go
@@ -17,13 +17,14 @@ limitations under the License.
 package podinjection
 
 import (
+	"context"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/klog/v2"
 )
 
-func createJobControllers(autoscalingCtx *ca_context.AutoscalingContext) []controller {
+func createJobControllers(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) []controller {
 	var controllers []controller
 	jobs, err := autoscalingCtx.ListerRegistry.JobLister().List(labels.Everything())
 	if err != nil {

--- a/cluster-autoscaler/processors/podinjection/pod_injection_processor.go
+++ b/cluster-autoscaler/processors/podinjection/pod_injection_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podinjection
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -50,10 +51,10 @@ func NewPodInjectionPodListProcessor(fakePodRegistry *podinjectionbackoff.Contro
 }
 
 // Process updates unschedulablePods by injecting fake pods to match target replica count
-func (p *PodInjectionPodListProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+func (p *PodInjectionPodListProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 
-	controllers := listControllers(autoscalingCtx)
-	controllers = p.skipBackedoffControllers(controllers)
+	controllers := listControllers(ctx, autoscalingCtx)
+	controllers = p.skipBackedoffControllers(ctx, controllers)
 
 	nodeInfos, err := autoscalingCtx.ClusterSnapshot.ListNodeInfos()
 	if err != nil {
@@ -124,15 +125,15 @@ func podsFromNodeInfos(nodeInfos []*framework.NodeInfo) []*apiv1.Pod {
 }
 
 // listControllers returns the list of controllers that can be used to inject fake pods
-func listControllers(autoscalingCtx *ca_context.AutoscalingContext) []controller {
+func listControllers(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) []controller {
 	var controllers []controller
-	controllers = append(controllers, createReplicaSetControllers(autoscalingCtx)...)
-	controllers = append(controllers, createJobControllers(autoscalingCtx)...)
-	controllers = append(controllers, createStatefulSetControllers(autoscalingCtx)...)
+	controllers = append(controllers, createReplicaSetControllers(ctx, autoscalingCtx)...)
+	controllers = append(controllers, createJobControllers(ctx, autoscalingCtx)...)
+	controllers = append(controllers, createStatefulSetControllers(ctx, autoscalingCtx)...)
 	return controllers
 }
 
-func (p *PodInjectionPodListProcessor) skipBackedoffControllers(controllers []controller) []controller {
+func (p *PodInjectionPodListProcessor) skipBackedoffControllers(ctx context.Context, controllers []controller) []controller {
 	var filteredControllers []controller
 	backoffRegistry := p.fakePodControllerBackoffRegistry
 	now := time.Now()

--- a/cluster-autoscaler/processors/podinjection/pod_injection_processor.go
+++ b/cluster-autoscaler/processors/podinjection/pod_injection_processor.go
@@ -134,12 +134,13 @@ func listControllers(ctx context.Context, autoscalingCtx *ca_context.Autoscaling
 }
 
 func (p *PodInjectionPodListProcessor) skipBackedoffControllers(ctx context.Context, controllers []controller) []controller {
+	logger := klog.FromContext(ctx)
 	var filteredControllers []controller
 	backoffRegistry := p.fakePodControllerBackoffRegistry
 	now := time.Now()
 	for _, controller := range controllers {
 		if backoffUntil := backoffRegistry.BackOffUntil(controller.uid, now); backoffUntil.After(now) {
-			klog.Warningf("Skipping generating fake pods for controller in backoff until (%s): %v", backoffUntil.Format(time.TimeOnly), controller.uid)
+			logger.Info("Skipping generating fake pods for controller in backoff until", "timeOnly", backoffUntil.Format(time.TimeOnly), "uid", controller.uid)
 			continue
 		}
 		filteredControllers = append(filteredControllers, controller)

--- a/cluster-autoscaler/processors/podinjection/pod_injection_processor_test.go
+++ b/cluster-autoscaler/processors/podinjection/pod_injection_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podinjection
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -145,7 +146,7 @@ func TestTargetCountInjectionPodListProcessor(t *testing.T) {
 				},
 				ClusterSnapshot: clusterSnapshot,
 			}
-			pods, err := p.Process(&autoscalingCtx, tc.unschedulablePods)
+			pods, err := p.Process(context.TODO(), &autoscalingCtx, tc.unschedulablePods)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.wantPods, pods)
 		})
@@ -308,7 +309,7 @@ func TestGroupPods(t *testing.T) {
 					ListerRegistry: kubernetes.NewListerRegistry(nil, nil, nil, nil, nil, nil, jobLister, replicaSetLister, statefulsetLister),
 				},
 			}
-			controllers := listControllers(&autoscalingCtx)
+			controllers := listControllers(context.TODO(), &autoscalingCtx)
 			groupedPods := groupPods(append(tc.scheduledPods, tc.unscheduledPods...), controllers)
 			assert.Equal(t, tc.wantGroupedPods, groupedPods)
 		})

--- a/cluster-autoscaler/processors/podinjection/replicaset_controller.go
+++ b/cluster-autoscaler/processors/podinjection/replicaset_controller.go
@@ -25,10 +25,11 @@ import (
 )
 
 func createReplicaSetControllers(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) []controller {
+	logger := klog.FromContext(ctx)
 	var controllers []controller
 	replicaSets, err := autoscalingCtx.ListerRegistry.ReplicaSetLister().List(labels.Everything())
 	if err != nil {
-		klog.Errorf("Failed to list replicaSets: %v", err)
+		logger.Error(err, "Failed to list replicaSets")
 		return controllers
 	}
 	for _, replicaSet := range replicaSets {

--- a/cluster-autoscaler/processors/podinjection/replicaset_controller.go
+++ b/cluster-autoscaler/processors/podinjection/replicaset_controller.go
@@ -17,13 +17,14 @@ limitations under the License.
 package podinjection
 
 import (
+	"context"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/klog/v2"
 )
 
-func createReplicaSetControllers(autoscalingCtx *ca_context.AutoscalingContext) []controller {
+func createReplicaSetControllers(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) []controller {
 	var controllers []controller
 	replicaSets, err := autoscalingCtx.ListerRegistry.ReplicaSetLister().List(labels.Everything())
 	if err != nil {

--- a/cluster-autoscaler/processors/podinjection/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/podinjection/scale_up_status_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podinjection
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -44,21 +45,21 @@ func NewFakePodsScaleUpStatusProcessor(fakePodRegistry *podinjectionbackoff.Cont
 
 // Process updates scaleupStatus to remove all fake pods from
 // PodsRemainUnschedulable, PodsAwaitEvaluation & PodsTriggeredScaleup
-func (a *FakePodsScaleUpStatusProcessor) Process(_ *ca_context.AutoscalingContext, scaleUpStatus *status.ScaleUpStatus) {
+func (a *FakePodsScaleUpStatusProcessor) Process(ctx context.Context, _ *ca_context.AutoscalingContext, scaleUpStatus *status.ScaleUpStatus) {
 	controllersToBackoff := extractFakePodsControllersUIDs(scaleUpStatus.PodsRemainUnschedulable)
 	for uid := range controllersToBackoff {
 		a.fakePodControllerBackoffRegistry.BackoffController(uid, time.Now())
 	}
 
-	scaleUpStatus.PodsRemainUnschedulable = filterFakePods(scaleUpStatus.PodsRemainUnschedulable, func(noScaleUpInfo status.NoScaleUpInfo) *apiv1.Pod { return noScaleUpInfo.Pod }, "PodsRemainUnschedulable")
-	scaleUpStatus.PodsAwaitEvaluation = filterFakePods(scaleUpStatus.PodsAwaitEvaluation, func(pod *apiv1.Pod) *apiv1.Pod { return pod }, "PodsAwaitEvaluation")
-	scaleUpStatus.PodsTriggeredScaleUp = filterFakePods(scaleUpStatus.PodsTriggeredScaleUp, func(pod *apiv1.Pod) *apiv1.Pod { return pod }, "PodsTriggeredScaleUp")
+	scaleUpStatus.PodsRemainUnschedulable = filterFakePods(ctx, scaleUpStatus.PodsRemainUnschedulable, func(noScaleUpInfo status.NoScaleUpInfo) *apiv1.Pod { return noScaleUpInfo.Pod }, "PodsRemainUnschedulable")
+	scaleUpStatus.PodsAwaitEvaluation = filterFakePods(ctx, scaleUpStatus.PodsAwaitEvaluation, func(pod *apiv1.Pod) *apiv1.Pod { return pod }, "PodsAwaitEvaluation")
+	scaleUpStatus.PodsTriggeredScaleUp = filterFakePods(ctx, scaleUpStatus.PodsTriggeredScaleUp, func(pod *apiv1.Pod) *apiv1.Pod { return pod }, "PodsTriggeredScaleUp")
 }
 
 // filterFakePods removes fake pods from the input list of T using passed getPod(T)
 // Uses `resourceName` to log which resource it has modified
 // Returns a list containing only non-fake pods
-func filterFakePods[T any](podsWrappers []T, getPod func(T) *apiv1.Pod, resourceName string) []T {
+func filterFakePods[T any](ctx context.Context, podsWrappers []T, getPod func(T) *apiv1.Pod, resourceName string) []T {
 	filteredPodsSouces := make([]T, 0)
 	removedPods := make([]*apiv1.Pod, 0)
 
@@ -79,7 +80,7 @@ func filterFakePods[T any](podsWrappers []T, getPod func(T) *apiv1.Pod, resource
 		klog.V(5).Infof("Filtering out pod %s from %v with controller reference %s", currentPod.Name, resourceName, controllerRef.Name)
 	}
 
-	logRemovedPods(removedPods, resourceName)
+	logRemovedPods(ctx, removedPods, resourceName)
 	return filteredPodsSouces
 }
 
@@ -95,7 +96,7 @@ func extractFakePodsControllersUIDs(NoScaleUpInfos []status.NoScaleUpInfo) map[t
 }
 
 // logRemovedPods logs the removed pods from resourceName
-func logRemovedPods(removedPods []*apiv1.Pod, resourceName string) {
+func logRemovedPods(ctx context.Context, removedPods []*apiv1.Pod, resourceName string) {
 	if len(removedPods) == 0 {
 		return
 	}

--- a/cluster-autoscaler/processors/podinjection/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/podinjection/scale_up_status_processor.go
@@ -60,6 +60,7 @@ func (a *FakePodsScaleUpStatusProcessor) Process(ctx context.Context, _ *ca_cont
 // Uses `resourceName` to log which resource it has modified
 // Returns a list containing only non-fake pods
 func filterFakePods[T any](ctx context.Context, podsWrappers []T, getPod func(T) *apiv1.Pod, resourceName string) []T {
+	logger := klog.FromContext(ctx)
 	filteredPodsSouces := make([]T, 0)
 	removedPods := make([]*apiv1.Pod, 0)
 
@@ -72,12 +73,12 @@ func filterFakePods[T any](ctx context.Context, podsWrappers []T, getPod func(T)
 
 		controllerRef := v1.GetControllerOf(currentPod)
 		if controllerRef == nil {
-			klog.Infof("Failed to find controller for pod %s, ignoring.", currentPod.Name)
+			logger.Info("Failed to find controller for pod, ignoring.", "currentPod", currentPod.Name)
 			continue
 		}
 
 		removedPods = append(removedPods, currentPod)
-		klog.V(5).Infof("Filtering out pod %s from %v with controller reference %s", currentPod.Name, resourceName, controllerRef.Name)
+		logger.V(5).Info("Filtering out pod with controller reference", "currentPod", currentPod.Name, "resource", resourceName, "controllerRef", controllerRef.Name)
 	}
 
 	logRemovedPods(ctx, removedPods, resourceName)
@@ -97,6 +98,7 @@ func extractFakePodsControllersUIDs(NoScaleUpInfos []status.NoScaleUpInfo) map[t
 
 // logRemovedPods logs the removed pods from resourceName
 func logRemovedPods(ctx context.Context, removedPods []*apiv1.Pod, resourceName string) {
+	logger := klog.FromContext(ctx)
 	if len(removedPods) == 0 {
 		return
 	}
@@ -104,7 +106,7 @@ func logRemovedPods(ctx context.Context, removedPods []*apiv1.Pod, resourceName 
 	for idx, pod := range removedPods {
 		controllerRefNames[idx] = v1.GetControllerOf(pod).Name
 	}
-	klog.Infof("Filtered out %d pods from %s for controllers %s", len(removedPods), resourceName, strings.Join(controllerRefNames, ", "))
+	logger.Info("Filtered out pods for controllers", "removedPodsCount", len(removedPods), "resource", resourceName, "controllerRefNames", strings.Join(controllerRefNames, ", "))
 }
 
 // CleanUp is called at CA termination

--- a/cluster-autoscaler/processors/podinjection/scale_up_status_processor_test.go
+++ b/cluster-autoscaler/processors/podinjection/scale_up_status_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podinjection
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,7 +70,7 @@ func TestProcess(t *testing.T) {
 			autoscalingCtx := &ca_context.AutoscalingContext{}
 
 			p := NewFakePodsScaleUpStatusProcessor(podinjectionbackoff.NewFakePodControllerRegistry())
-			p.Process(autoscalingCtx, scaleUpStatus)
+			p.Process(context.TODO(), autoscalingCtx, scaleUpStatus)
 
 			assert.ElementsMatch(t, tc.expectedPodsRemainUnschedulable, extractPodsFromNoScaleUpInfo(scaleUpStatus.PodsRemainUnschedulable))
 			assert.ElementsMatch(t, tc.expectedPodsAwaitEvaluation, scaleUpStatus.PodsAwaitEvaluation)

--- a/cluster-autoscaler/processors/podinjection/statefulset_controller.go
+++ b/cluster-autoscaler/processors/podinjection/statefulset_controller.go
@@ -17,13 +17,14 @@ limitations under the License.
 package podinjection
 
 import (
+	"context"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/klog/v2"
 )
 
-func createStatefulSetControllers(autoscalingCtx *ca_context.AutoscalingContext) []controller {
+func createStatefulSetControllers(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) []controller {
 	var controllers []controller
 	statefulSets, err := autoscalingCtx.ListerRegistry.StatefulSetLister().List(labels.Everything())
 	if err != nil {

--- a/cluster-autoscaler/processors/podinjection/statefulset_controller.go
+++ b/cluster-autoscaler/processors/podinjection/statefulset_controller.go
@@ -25,10 +25,11 @@ import (
 )
 
 func createStatefulSetControllers(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) []controller {
+	logger := klog.FromContext(ctx)
 	var controllers []controller
 	statefulSets, err := autoscalingCtx.ListerRegistry.StatefulSetLister().List(labels.Everything())
 	if err != nil {
-		klog.Errorf("Failed to list statefulsets: %v", err)
+		logger.Error(err, "Failed to list statefulsets")
 		return controllers
 	}
 	for _, statefulSet := range statefulSets {

--- a/cluster-autoscaler/processors/pods/pod_list_processor.go
+++ b/cluster-autoscaler/processors/pods/pod_list_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pods
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 )
@@ -24,7 +25,7 @@ import (
 // PodListProcessor processes lists of unschedulable pods.
 type PodListProcessor interface {
 	Process(
-		autoscalingCtx *ca_context.AutoscalingContext,
+		ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext,
 		unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error)
 	CleanUp()
 }
@@ -40,7 +41,7 @@ func NewDefaultPodListProcessor() PodListProcessor {
 
 // Process processes lists of unschedulable and scheduled pods before scaling of the cluster.
 func (p *NoOpPodListProcessor) Process(
-	autoscalingCtx *ca_context.AutoscalingContext,
+	ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext,
 	unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	return unschedulablePods, nil
 }
@@ -65,10 +66,10 @@ func (p *CombinedPodListProcessor) AddProcessor(processor PodListProcessor) {
 }
 
 // Process runs sub-processors sequentially
-func (p *CombinedPodListProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+func (p *CombinedPodListProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	var err error
 	for _, processor := range p.processors {
-		unschedulablePods, err = processor.Process(autoscalingCtx, unschedulablePods)
+		unschedulablePods, err = processor.Process(ctx, autoscalingCtx, unschedulablePods)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/processors/pods/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/pods/pod_list_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pods
 
 import (
+	"context"
 	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -30,7 +31,7 @@ func TestDefaultUnschedulablePodListProcessor(t *testing.T) {
 	p1 := BuildTestPod("p1", 40, 0)
 	unschedulablePods := []*apiv1.Pod{p1}
 	podListProcessor := NewDefaultPodListProcessor()
-	gotUnschedulablePods, err := podListProcessor.Process(autoscalingCtx, unschedulablePods)
+	gotUnschedulablePods, err := podListProcessor.Process(context.TODO(), autoscalingCtx, unschedulablePods)
 	if len(gotUnschedulablePods) != 1 || err != nil {
 		t.Errorf("Error podListProcessor.Process() = %v,%v want %v, nil ",
 			gotUnschedulablePods, err, unschedulablePods)

--- a/cluster-autoscaler/processors/provreq/injector.go
+++ b/cluster-autoscaler/processors/provreq/injector.go
@@ -76,9 +76,10 @@ func (p *ProvisioningRequestPodsInjector) IsAvailableForProvisioning(pr *provreq
 
 // MarkAsAccepted marks the ProvisioningRequest as accepted.
 func (p *ProvisioningRequestPodsInjector) MarkAsAccepted(ctx context.Context, pr *provreqwrapper.ProvisioningRequest) error {
+	logger := klog.FromContext(ctx)
 	provreqconditions.AddOrUpdateCondition(ctx, pr, v1.Accepted, metav1.ConditionTrue, provreqconditions.AcceptedReason, provreqconditions.AcceptedMsg, metav1.NewTime(p.clock.Now()))
 	if _, err := p.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); err != nil {
-		klog.Errorf("failed add Accepted condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, err)
+		logger.Error(err, "failed add Accepted condition to ProvReq", "namespace", pr.Namespace, "pr", pr.Name)
 		return err
 	}
 	p.UpdateLastProcessTime()
@@ -87,9 +88,10 @@ func (p *ProvisioningRequestPodsInjector) MarkAsAccepted(ctx context.Context, pr
 
 // MarkAsFailed marks the ProvisioningRequest as failed.
 func (p *ProvisioningRequestPodsInjector) MarkAsFailed(ctx context.Context, pr *provreqwrapper.ProvisioningRequest, reason string, message string) {
+	logger := klog.FromContext(ctx)
 	provreqconditions.AddOrUpdateCondition(ctx, pr, v1.Failed, metav1.ConditionTrue, reason, message, metav1.NewTime(p.clock.Now()))
 	if _, err := p.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); err != nil {
-		klog.Errorf("failed add Failed condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, err)
+		logger.Error(err, "failed add Failed condition to ProvReq", "namespace", pr.Namespace, "pr", pr.Name)
 	}
 	p.UpdateLastProcessTime()
 }
@@ -110,6 +112,7 @@ func (p *ProvisioningRequestPodsInjector) shouldMarkAsAccepted(ctx context.Conte
 
 // GetPodsFromNextRequest picks one ProvisioningRequest meeting the condition passed using isSupportedClass function, marks it as accepted and returns pods from it.
 func (p *ProvisioningRequestPodsInjector) GetPodsFromNextRequest(ctx context.Context) ([]*apiv1.Pod, error) {
+	logger := klog.FromContext(ctx)
 	provReqs, err := p.client.ProvisioningRequests(ctx)
 	if err != nil {
 		return nil, err
@@ -126,7 +129,7 @@ func (p *ProvisioningRequestPodsInjector) GetPodsFromNextRequest(ctx context.Con
 
 		podsFromProvReq, err := provreqpods.PodsForProvisioningRequest(pr)
 		if err != nil {
-			klog.Errorf("Failed to get pods for ProvisioningRequest %v", pr.Name)
+			logger.Error(err, "Failed to get pods for ProvisioningRequest", "pr", pr.Name)
 			p.MarkAsFailed(ctx, pr, provreqconditions.FailedToCreatePodsReason, err.Error())
 			continue
 		}
@@ -153,6 +156,7 @@ type ProvisioningRequestWithPods struct {
 // We do not mark the PRs as accepted here.
 // If we fail to get the pods for a PR, we mark the PR as failed and issue an update.
 func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(ctx context.Context, maxPrs int) ([]ProvisioningRequestWithPods, error) {
+	logger := klog.FromContext(ctx)
 	provReqs, err := p.client.ProvisioningRequests(ctx)
 	if err != nil {
 		return nil, err
@@ -171,7 +175,7 @@ func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(ctx context.Cont
 
 		pods, err := provreqpods.PodsForProvisioningRequest(pr)
 		if err != nil {
-			klog.Errorf("Failed to get pods for ProvisioningRequest %v", pr.Name)
+			logger.Error(err, "Failed to get pods for ProvisioningRequest", "pr", pr.Name)
 			p.MarkAsFailed(ctx, pr, provreqconditions.FailedToCreatePodsReason, err.Error())
 			continue
 		}

--- a/cluster-autoscaler/processors/provreq/injector.go
+++ b/cluster-autoscaler/processors/provreq/injector.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provreq
 
 import (
+	"context"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -74,9 +75,9 @@ func (p *ProvisioningRequestPodsInjector) IsAvailableForProvisioning(pr *provreq
 }
 
 // MarkAsAccepted marks the ProvisioningRequest as accepted.
-func (p *ProvisioningRequestPodsInjector) MarkAsAccepted(pr *provreqwrapper.ProvisioningRequest) error {
-	provreqconditions.AddOrUpdateCondition(pr, v1.Accepted, metav1.ConditionTrue, provreqconditions.AcceptedReason, provreqconditions.AcceptedMsg, metav1.NewTime(p.clock.Now()))
-	if _, err := p.client.UpdateProvisioningRequest(pr.ProvisioningRequest); err != nil {
+func (p *ProvisioningRequestPodsInjector) MarkAsAccepted(ctx context.Context, pr *provreqwrapper.ProvisioningRequest) error {
+	provreqconditions.AddOrUpdateCondition(ctx, pr, v1.Accepted, metav1.ConditionTrue, provreqconditions.AcceptedReason, provreqconditions.AcceptedMsg, metav1.NewTime(p.clock.Now()))
+	if _, err := p.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); err != nil {
 		klog.Errorf("failed add Accepted condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, err)
 		return err
 	}
@@ -85,36 +86,36 @@ func (p *ProvisioningRequestPodsInjector) MarkAsAccepted(pr *provreqwrapper.Prov
 }
 
 // MarkAsFailed marks the ProvisioningRequest as failed.
-func (p *ProvisioningRequestPodsInjector) MarkAsFailed(pr *provreqwrapper.ProvisioningRequest, reason string, message string) {
-	provreqconditions.AddOrUpdateCondition(pr, v1.Failed, metav1.ConditionTrue, reason, message, metav1.NewTime(p.clock.Now()))
-	if _, err := p.client.UpdateProvisioningRequest(pr.ProvisioningRequest); err != nil {
+func (p *ProvisioningRequestPodsInjector) MarkAsFailed(ctx context.Context, pr *provreqwrapper.ProvisioningRequest, reason string, message string) {
+	provreqconditions.AddOrUpdateCondition(ctx, pr, v1.Failed, metav1.ConditionTrue, reason, message, metav1.NewTime(p.clock.Now()))
+	if _, err := p.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); err != nil {
 		klog.Errorf("failed add Failed condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, err)
 	}
 	p.UpdateLastProcessTime()
 }
 
-func (p *ProvisioningRequestPodsInjector) isSupportedClass(pr *provreqwrapper.ProvisioningRequest) bool {
-	return provisioningrequest.SupportedProvisioningClass(pr.ProvisioningRequest, p.checkCapacityProcessorInstance)
+func (p *ProvisioningRequestPodsInjector) isSupportedClass(ctx context.Context, pr *provreqwrapper.ProvisioningRequest) bool {
+	return provisioningrequest.SupportedProvisioningClass(ctx, pr.ProvisioningRequest, p.checkCapacityProcessorInstance)
 }
 
-func (p *ProvisioningRequestPodsInjector) isSupportedCheckCapacityClass(pr *provreqwrapper.ProvisioningRequest) bool {
-	return provisioningrequest.SupportedCheckCapacityClass(pr.ProvisioningRequest, p.checkCapacityProcessorInstance)
+func (p *ProvisioningRequestPodsInjector) isSupportedCheckCapacityClass(ctx context.Context, pr *provreqwrapper.ProvisioningRequest) bool {
+	return provisioningrequest.SupportedCheckCapacityClass(ctx, pr.ProvisioningRequest, p.checkCapacityProcessorInstance)
 }
 
-func (p *ProvisioningRequestPodsInjector) shouldMarkAsAccepted(pr *provreqwrapper.ProvisioningRequest) bool {
+func (p *ProvisioningRequestPodsInjector) shouldMarkAsAccepted(ctx context.Context, pr *provreqwrapper.ProvisioningRequest) bool {
 	// Don't mark as accepted the check capacity ProvReq when batch processing is enabled.
 	// It will be marked later, in parallel, during processing the requests.
-	return !p.checkCapacityBatchProcessing || !p.isSupportedCheckCapacityClass(pr)
+	return !p.checkCapacityBatchProcessing || !p.isSupportedCheckCapacityClass(ctx, pr)
 }
 
 // GetPodsFromNextRequest picks one ProvisioningRequest meeting the condition passed using isSupportedClass function, marks it as accepted and returns pods from it.
-func (p *ProvisioningRequestPodsInjector) GetPodsFromNextRequest() ([]*apiv1.Pod, error) {
-	provReqs, err := p.client.ProvisioningRequests()
+func (p *ProvisioningRequestPodsInjector) GetPodsFromNextRequest(ctx context.Context) ([]*apiv1.Pod, error) {
+	provReqs, err := p.client.ProvisioningRequests(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for _, pr := range provReqs {
-		if !p.isSupportedClass(pr) {
+		if !p.isSupportedClass(ctx, pr) {
 			continue
 		}
 
@@ -126,11 +127,11 @@ func (p *ProvisioningRequestPodsInjector) GetPodsFromNextRequest() ([]*apiv1.Pod
 		podsFromProvReq, err := provreqpods.PodsForProvisioningRequest(pr)
 		if err != nil {
 			klog.Errorf("Failed to get pods for ProvisioningRequest %v", pr.Name)
-			p.MarkAsFailed(pr, provreqconditions.FailedToCreatePodsReason, err.Error())
+			p.MarkAsFailed(ctx, pr, provreqconditions.FailedToCreatePodsReason, err.Error())
 			continue
 		}
-		if p.shouldMarkAsAccepted(pr) {
-			if err := p.MarkAsAccepted(pr); err != nil {
+		if p.shouldMarkAsAccepted(ctx, pr) {
+			if err := p.MarkAsAccepted(ctx, pr); err != nil {
 				continue
 			}
 			return podsFromProvReq, nil
@@ -151,8 +152,8 @@ type ProvisioningRequestWithPods struct {
 // GetCheckCapacityBatch returns up to the requested number of ProvisioningRequestWithPods.
 // We do not mark the PRs as accepted here.
 // If we fail to get the pods for a PR, we mark the PR as failed and issue an update.
-func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(maxPrs int) ([]ProvisioningRequestWithPods, error) {
-	provReqs, err := p.client.ProvisioningRequests()
+func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(ctx context.Context, maxPrs int) ([]ProvisioningRequestWithPods, error) {
+	provReqs, err := p.client.ProvisioningRequests(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(maxPrs int) ([]P
 		if len(prsWithPods) >= maxPrs {
 			break
 		}
-		if !p.isSupportedCheckCapacityClass(pr) {
+		if !p.isSupportedCheckCapacityClass(ctx, pr) {
 			continue
 		}
 		if !p.IsAvailableForProvisioning(pr) {
@@ -171,7 +172,7 @@ func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(maxPrs int) ([]P
 		pods, err := provreqpods.PodsForProvisioningRequest(pr)
 		if err != nil {
 			klog.Errorf("Failed to get pods for ProvisioningRequest %v", pr.Name)
-			p.MarkAsFailed(pr, provreqconditions.FailedToCreatePodsReason, err.Error())
+			p.MarkAsFailed(ctx, pr, provreqconditions.FailedToCreatePodsReason, err.Error())
 			continue
 		}
 		prsWithPods = append(prsWithPods, ProvisioningRequestWithPods{pr, pods})
@@ -181,10 +182,10 @@ func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(maxPrs int) ([]P
 
 // Process pick one ProvisioningRequest, update Accepted condition and inject pods to unscheduled pods list.
 func (p *ProvisioningRequestPodsInjector) Process(
-	_ *ca_context.AutoscalingContext,
+	ctx context.Context, _ *ca_context.AutoscalingContext,
 	unschedulablePods []*apiv1.Pod,
 ) ([]*apiv1.Pod, error) {
-	podsFromProvReq, err := p.GetPodsFromNextRequest()
+	podsFromProvReq, err := p.GetPodsFromNextRequest(ctx)
 	if err != nil {
 		return unschedulablePods, err
 	}

--- a/cluster-autoscaler/processors/provreq/injector_test.go
+++ b/cluster-autoscaler/processors/provreq/injector_test.go
@@ -175,7 +175,7 @@ func TestProvisioningRequestPodsInjector(t *testing.T) {
 		backoffTime := lru.New(100)
 		backoffTime.Add(key(notProvisionedRecentlyProvReqB), 2*time.Minute)
 		injector := ProvisioningRequestPodsInjector{1 * time.Minute, 10 * time.Minute, backoffTime, clock.NewFakePassiveClock(now), client, now, tc.checkCapacityBatchProcessing, tc.checkCapacityProcessorInstance}
-		getUnscheduledPods, err := injector.Process(nil, provreqwrapper.BuildTestPods("ns", "pod", tc.existingUnsUnschedulablePodCount))
+		getUnscheduledPods, err := injector.Process(context.TODO(), nil, provreqwrapper.BuildTestPods("ns", "pod", tc.existingUnsUnschedulablePodCount))
 		if err != nil {
 			t.Errorf("%s failed: injector.Process return error %v", tc.name, err)
 		}

--- a/cluster-autoscaler/processors/provreq/pods_filter.go
+++ b/cluster-autoscaler/processors/provreq/pods_filter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provreq
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -68,7 +69,7 @@ type ProvisioningRequestPodsFilter struct {
 
 // Process filters out all pods that are consuming a Provisioning Request from unschedulable pods list.
 func (p *ProvisioningRequestPodsFilter) Process(
-	autoscalingCtx *ca_context.AutoscalingContext,
+	ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext,
 	unschedulablePods []*apiv1.Pod,
 ) ([]*apiv1.Pod, error) {
 	now := time.Now()

--- a/cluster-autoscaler/processors/provreq/pods_filter_test.go
+++ b/cluster-autoscaler/processors/provreq/pods_filter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provreq
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -70,7 +71,7 @@ func TestProvisioningRequestPodsFilter(t *testing.T) {
 		eventRecorder := record.NewFakeRecorder(10)
 		autoscalingCtx := &ca_context.AutoscalingContext{AutoscalingKubeClients: ca_context.AutoscalingKubeClients{Recorder: eventRecorder}}
 		filter := NewProvisioningRequestPodsFilter(NewDefautlEventManager())
-		got, _ := filter.Process(autoscalingCtx, test.unschedulableCandidates)
+		got, _ := filter.Process(context.TODO(), autoscalingCtx, test.unschedulableCandidates)
 		assert.ElementsMatch(t, got, test.expectedUnscheduledPods)
 		if len(test.expectedUnscheduledPods) < len(test.expectedUnscheduledPods) {
 			select {
@@ -96,7 +97,7 @@ func TestEventManager(t *testing.T) {
 		prPod.Annotations[v1.ProvisioningRequestPodAnnotationKey] = "pr-class"
 		unscheduledPods = append(unscheduledPods, prPod)
 	}
-	got, err := prFilter.Process(autoscalingCtx, unscheduledPods)
+	got, err := prFilter.Process(context.TODO(), autoscalingCtx, unscheduledPods)
 	assert.NoError(t, err)
 	if len(got) != 1 {
 		t.Errorf("Want 1 unschedulable pod, got: %v", got)

--- a/cluster-autoscaler/processors/provreq/processor.go
+++ b/cluster-autoscaler/processors/provreq/processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provreq
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -45,7 +46,7 @@ const (
 )
 
 type injector interface {
-	TrySchedulePods(clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) ([]scheduling.Status, int, error)
+	TrySchedulePods(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) ([]scheduling.Status, int, error)
 }
 
 type provReqProcessor struct {
@@ -64,27 +65,27 @@ func NewProvReqProcessor(client *provreqclient.ProvisioningRequestClient, checkC
 // Refresh implements loop.Observer interface and will be run at the start
 // of every iteration of the main loop. It tries to fetch current
 // ProvisioningRequests and processes up to p.maxUpdated of them.
-func (p *provReqProcessor) Refresh() {
-	provReqs, err := p.client.ProvisioningRequests()
+func (p *provReqProcessor) Refresh(ctx context.Context) {
+	provReqs, err := p.client.ProvisioningRequests(ctx)
 	if err != nil {
 		klog.Errorf("Failed to get ProvisioningRequests list, err: %v", err)
 		return
 	}
-	p.refresh(provReqs)
+	p.refresh(ctx, provReqs)
 }
 
 // refresh iterates over ProvisioningRequests and apply:
 // -BookingExpired condition for Provisioned ProvisioningRequest if capacity reservation time is expired.
 // -Failed condition for ProvisioningRequest that were not provisioned during defaultExpirationTime.
 // TODO(yaroslava): fetch reservation and expiration time from ProvisioningRequest
-func (p *provReqProcessor) refresh(provReqs []*provreqwrapper.ProvisioningRequest) {
+func (p *provReqProcessor) refresh(ctx context.Context, provReqs []*provreqwrapper.ProvisioningRequest) {
 	expiredProvReq := []*provreqwrapper.ProvisioningRequest{}
 	failedProvReq := []*provreqwrapper.ProvisioningRequest{}
 	for _, provReq := range provReqs {
 		if len(expiredProvReq) >= p.maxUpdated {
 			break
 		}
-		if !provisioningrequest.SupportedProvisioningClass(provReq.ProvisioningRequest, p.checkCapacityProcessorInstance) {
+		if !provisioningrequest.SupportedProvisioningClass(ctx, provReq.ProvisioningRequest, p.checkCapacityProcessorInstance) {
 			continue
 		}
 		conditions := provReq.Status.Conditions
@@ -104,22 +105,22 @@ func (p *provReqProcessor) refresh(provReqs []*provreqwrapper.ProvisioningReques
 		}
 	}
 	for _, provReq := range expiredProvReq {
-		conditions.AddOrUpdateCondition(provReq, v1.BookingExpired, metav1.ConditionTrue, conditions.CapacityReservationTimeExpiredReason, conditions.CapacityReservationTimeExpiredMsg, metav1.NewTime(p.now()))
-		_, updErr := p.client.UpdateProvisioningRequest(provReq.ProvisioningRequest)
+		conditions.AddOrUpdateCondition(ctx, provReq, v1.BookingExpired, metav1.ConditionTrue, conditions.CapacityReservationTimeExpiredReason, conditions.CapacityReservationTimeExpiredMsg, metav1.NewTime(p.now()))
+		_, updErr := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest)
 		if updErr != nil {
 			klog.Errorf("failed to add BookingExpired condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, updErr)
 			continue
 		}
 	}
 	for _, provReq := range failedProvReq {
-		conditions.AddOrUpdateCondition(provReq, v1.Failed, metav1.ConditionTrue, conditions.ExpiredReason, conditions.ExpiredMsg, metav1.NewTime(p.now()))
-		_, updErr := p.client.UpdateProvisioningRequest(provReq.ProvisioningRequest)
+		conditions.AddOrUpdateCondition(ctx, provReq, v1.Failed, metav1.ConditionTrue, conditions.ExpiredReason, conditions.ExpiredMsg, metav1.NewTime(p.now()))
+		_, updErr := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest)
 		if updErr != nil {
 			klog.Errorf("failed to add Failed condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, updErr)
 			continue
 		}
 	}
-	p.DeleteOldProvReqs(provReqs)
+	p.DeleteOldProvReqs(ctx, provReqs)
 }
 
 // CleanUp cleans up internal state
@@ -127,8 +128,8 @@ func (p *provReqProcessor) CleanUp() {}
 
 // Process implements PodListProcessor.Process() and inject fake pods to the cluster snapshoot for Provisioned ProvReqs in order to
 // reserve capacity from ScaleDown.
-func (p *provReqProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
-	err := p.bookCapacity(autoscalingCtx)
+func (p *provReqProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	err := p.bookCapacity(ctx, autoscalingCtx)
 	if err != nil {
 		klog.Warningf("Failed to book capacity for ProvisioningRequests: %s", err)
 	}
@@ -137,8 +138,8 @@ func (p *provReqProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext
 
 // bookCapacity schedule fake pods for ProvisioningRequest that should have reserved capacity
 // in the cluster.
-func (p *provReqProcessor) bookCapacity(autoscalingCtx *ca_context.AutoscalingContext) error {
-	provReqs, err := p.client.ProvisioningRequests()
+func (p *provReqProcessor) bookCapacity(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) error {
+	provReqs, err := p.client.ProvisioningRequests(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't fetch ProvisioningRequests in the cluster: %v", err)
 	}
@@ -157,13 +158,13 @@ func (p *provReqProcessor) bookCapacity(autoscalingCtx *ca_context.AutoscalingCo
 	}
 	podsToCreate := []*apiv1.Pod{}
 	for _, provReq := range provReqs {
-		if !conditions.ShouldCapacityBeBooked(provReq, p.checkCapacityProcessorInstance) {
+		if !conditions.ShouldCapacityBeBooked(ctx, provReq, p.checkCapacityProcessorInstance) {
 			continue
 		}
 		// All pods already scheduled
 		if scheduledPods[provReq.Namespace+"/"+provReq.Name] >= provReq.PodCount() {
-			conditions.AddOrUpdateCondition(provReq, v1.BookingExpired, metav1.ConditionTrue, conditions.CapacityBookingConsumedReason, conditions.CapacityBookingConsumedMsg, metav1.NewTime(p.now()))
-			if _, err := p.client.UpdateProvisioningRequest(provReq.ProvisioningRequest); err != nil {
+			conditions.AddOrUpdateCondition(ctx, provReq, v1.BookingExpired, metav1.ConditionTrue, conditions.CapacityBookingConsumedReason, conditions.CapacityBookingConsumedMsg, metav1.NewTime(p.now()))
+			if _, err := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest); err != nil {
 				klog.Errorf("failed to add BookingExpired condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, err)
 			}
 			continue
@@ -173,8 +174,8 @@ func (p *provReqProcessor) bookCapacity(autoscalingCtx *ca_context.AutoscalingCo
 			// ClusterAutoscaler was able to create pods before, so we shouldn't have error here.
 			// If there is an error, mark PR as invalid, because we won't be able to book capacity
 			// for it anyway.
-			conditions.AddOrUpdateCondition(provReq, v1.Failed, metav1.ConditionTrue, conditions.FailedToBookCapacityReason, fmt.Sprintf("Couldn't create pods, err: %v", err), metav1.Now())
-			if _, err := p.client.UpdateProvisioningRequest(provReq.ProvisioningRequest); err != nil {
+			conditions.AddOrUpdateCondition(ctx, provReq, v1.Failed, metav1.ConditionTrue, conditions.FailedToBookCapacityReason, fmt.Sprintf("Couldn't create pods, err: %v", err), metav1.Now())
+			if _, err := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest); err != nil {
 				klog.Errorf("failed to add Accepted condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, err)
 			}
 			continue
@@ -185,14 +186,14 @@ func (p *provReqProcessor) bookCapacity(autoscalingCtx *ca_context.AutoscalingCo
 		return nil
 	}
 	// Scheduling the pods to reserve capacity for provisioning request.
-	if _, _, err = p.injector.TrySchedulePods(autoscalingCtx.ClusterSnapshot, podsToCreate, false, clustersnapshot.SchedulingOptions{}); err != nil {
+	if _, _, err = p.injector.TrySchedulePods(ctx, autoscalingCtx.ClusterSnapshot, podsToCreate, false, clustersnapshot.SchedulingOptions{}); err != nil {
 		return err
 	}
 	return nil
 }
 
 // DeleteOldProvReqs delete ProvReq that have terminal state (Provisioned/Failed == True) more than a week.
-func (p *provReqProcessor) DeleteOldProvReqs(provReqs []*provreqwrapper.ProvisioningRequest) {
+func (p *provReqProcessor) DeleteOldProvReqs(ctx context.Context, provReqs []*provreqwrapper.ProvisioningRequest) {
 	provReqQuota := klogx.NewLoggingQuota(30)
 	for _, provReq := range provReqs {
 		conditions := provReq.Status.Conditions
@@ -201,7 +202,7 @@ func (p *provReqProcessor) DeleteOldProvReqs(provReqs []*provreqwrapper.Provisio
 		if provisioned != nil && provisioned.LastTransitionTime.Add(defaultTerminalProvReqTTL).Before(p.now()) ||
 			failed != nil && failed.LastTransitionTime.Add(defaultTerminalProvReqTTL).Before(p.now()) {
 			klogx.V(4).UpTo(provReqQuota).Infof("Delete old ProvisioningRequest %s/%s", provReq.Namespace, provReq.Name)
-			err := p.client.DeleteProvisioningRequest(provReq.ProvisioningRequest)
+			err := p.client.DeleteProvisioningRequest(ctx, provReq.ProvisioningRequest)
 			if err != nil {
 				klog.Warningf("Couldn't delete old %s/%s Provisioning Request, err: %v", provReq.Namespace, provReq.Name, err)
 			}

--- a/cluster-autoscaler/processors/provreq/processor.go
+++ b/cluster-autoscaler/processors/provreq/processor.go
@@ -66,9 +66,10 @@ func NewProvReqProcessor(client *provreqclient.ProvisioningRequestClient, checkC
 // of every iteration of the main loop. It tries to fetch current
 // ProvisioningRequests and processes up to p.maxUpdated of them.
 func (p *provReqProcessor) Refresh(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	provReqs, err := p.client.ProvisioningRequests(ctx)
 	if err != nil {
-		klog.Errorf("Failed to get ProvisioningRequests list, err: %v", err)
+		logger.Error(err, "Failed to get ProvisioningRequests list")
 		return
 	}
 	p.refresh(ctx, provReqs)
@@ -79,6 +80,7 @@ func (p *provReqProcessor) Refresh(ctx context.Context) {
 // -Failed condition for ProvisioningRequest that were not provisioned during defaultExpirationTime.
 // TODO(yaroslava): fetch reservation and expiration time from ProvisioningRequest
 func (p *provReqProcessor) refresh(ctx context.Context, provReqs []*provreqwrapper.ProvisioningRequest) {
+	logger := klog.FromContext(ctx)
 	expiredProvReq := []*provreqwrapper.ProvisioningRequest{}
 	failedProvReq := []*provreqwrapper.ProvisioningRequest{}
 	for _, provReq := range provReqs {
@@ -108,7 +110,7 @@ func (p *provReqProcessor) refresh(ctx context.Context, provReqs []*provreqwrapp
 		conditions.AddOrUpdateCondition(ctx, provReq, v1.BookingExpired, metav1.ConditionTrue, conditions.CapacityReservationTimeExpiredReason, conditions.CapacityReservationTimeExpiredMsg, metav1.NewTime(p.now()))
 		_, updErr := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest)
 		if updErr != nil {
-			klog.Errorf("failed to add BookingExpired condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, updErr)
+			logger.Error(updErr, "failed to add BookingExpired condition to ProvReq", "namespace", provReq.Namespace, "provReq", provReq.Name)
 			continue
 		}
 	}
@@ -116,7 +118,7 @@ func (p *provReqProcessor) refresh(ctx context.Context, provReqs []*provreqwrapp
 		conditions.AddOrUpdateCondition(ctx, provReq, v1.Failed, metav1.ConditionTrue, conditions.ExpiredReason, conditions.ExpiredMsg, metav1.NewTime(p.now()))
 		_, updErr := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest)
 		if updErr != nil {
-			klog.Errorf("failed to add Failed condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, updErr)
+			logger.Error(updErr, "failed to add Failed condition to ProvReq", "namespace", provReq.Namespace, "provReq", provReq.Name)
 			continue
 		}
 	}
@@ -129,9 +131,10 @@ func (p *provReqProcessor) CleanUp() {}
 // Process implements PodListProcessor.Process() and inject fake pods to the cluster snapshoot for Provisioned ProvReqs in order to
 // reserve capacity from ScaleDown.
 func (p *provReqProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	logger := klog.FromContext(ctx)
 	err := p.bookCapacity(ctx, autoscalingCtx)
 	if err != nil {
-		klog.Warningf("Failed to book capacity for ProvisioningRequests: %s", err)
+		logger.Info("Failed to book capacity for ProvisioningRequests", "err", err)
 	}
 	return unschedulablePods, nil
 }
@@ -139,6 +142,7 @@ func (p *provReqProcessor) Process(ctx context.Context, autoscalingCtx *ca_conte
 // bookCapacity schedule fake pods for ProvisioningRequest that should have reserved capacity
 // in the cluster.
 func (p *provReqProcessor) bookCapacity(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) error {
+	logger := klog.FromContext(ctx)
 	provReqs, err := p.client.ProvisioningRequests(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't fetch ProvisioningRequests in the cluster: %v", err)
@@ -165,7 +169,7 @@ func (p *provReqProcessor) bookCapacity(ctx context.Context, autoscalingCtx *ca_
 		if scheduledPods[provReq.Namespace+"/"+provReq.Name] >= provReq.PodCount() {
 			conditions.AddOrUpdateCondition(ctx, provReq, v1.BookingExpired, metav1.ConditionTrue, conditions.CapacityBookingConsumedReason, conditions.CapacityBookingConsumedMsg, metav1.NewTime(p.now()))
 			if _, err := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest); err != nil {
-				klog.Errorf("failed to add BookingExpired condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, err)
+				logger.Error(err, "failed to add BookingExpired condition to ProvReq", "namespace", provReq.Namespace, "provReq", provReq.Name)
 			}
 			continue
 		}
@@ -176,7 +180,7 @@ func (p *provReqProcessor) bookCapacity(ctx context.Context, autoscalingCtx *ca_
 			// for it anyway.
 			conditions.AddOrUpdateCondition(ctx, provReq, v1.Failed, metav1.ConditionTrue, conditions.FailedToBookCapacityReason, fmt.Sprintf("Couldn't create pods, err: %v", err), metav1.Now())
 			if _, err := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest); err != nil {
-				klog.Errorf("failed to add Accepted condition to ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, err)
+				logger.Error(err, "failed to add Accepted condition to ProvReq", "namespace", provReq.Namespace, "provReq", provReq.Name)
 			}
 			continue
 		}
@@ -194,6 +198,7 @@ func (p *provReqProcessor) bookCapacity(ctx context.Context, autoscalingCtx *ca_
 
 // DeleteOldProvReqs delete ProvReq that have terminal state (Provisioned/Failed == True) more than a week.
 func (p *provReqProcessor) DeleteOldProvReqs(ctx context.Context, provReqs []*provreqwrapper.ProvisioningRequest) {
+	logger := klog.FromContext(ctx)
 	provReqQuota := klogx.NewLoggingQuota(30)
 	for _, provReq := range provReqs {
 		conditions := provReq.Status.Conditions
@@ -204,7 +209,7 @@ func (p *provReqProcessor) DeleteOldProvReqs(ctx context.Context, provReqs []*pr
 			klogx.V(4).UpTo(provReqQuota).Infof("Delete old ProvisioningRequest %s/%s", provReq.Namespace, provReq.Name)
 			err := p.client.DeleteProvisioningRequest(ctx, provReq.ProvisioningRequest)
 			if err != nil {
-				klog.Warningf("Couldn't delete old %s/%s Provisioning Request, err: %v", provReq.Namespace, provReq.Name, err)
+				logger.Info("Couldn't delete old Provisioning Request", "namespace", provReq.Namespace, "provReq", provReq.Name, "err", err)
 			}
 		}
 	}

--- a/cluster-autoscaler/processors/provreq/processor_test.go
+++ b/cluster-autoscaler/processors/provreq/processor_test.go
@@ -158,7 +158,7 @@ func TestRefresh(t *testing.T) {
 		additionalPr.Spec.ProvisioningClassName = v1.ProvisioningClassCheckCapacity
 
 		processor := provReqProcessor{func() time.Time { return now }, 1, provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, pr, additionalPr), nil, ""}
-		processor.refresh([]*provreqwrapper.ProvisioningRequest{pr, additionalPr})
+		processor.refresh(context.Background(), []*provreqwrapper.ProvisioningRequest{pr, additionalPr})
 
 		assert.ElementsMatch(t, test.wantConditions, pr.Status.Conditions)
 		if len(test.conditions) == len(test.wantConditions) {
@@ -218,7 +218,7 @@ func TestDeleteOldProvReqs(t *testing.T) {
 	client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, pr, additionalPr, oldFailedPr, oldExpiredPr)
 
 	processor := provReqProcessor{func() time.Time { return now }, 1, client, nil, ""}
-	processor.refresh([]*provreqwrapper.ProvisioningRequest{pr, additionalPr, oldFailedPr, oldExpiredPr})
+	processor.refresh(context.Background(), []*provreqwrapper.ProvisioningRequest{pr, additionalPr, oldFailedPr, oldExpiredPr})
 
 	_, err := client.ProvisioningRequestNoCache(oldFailedPr.Namespace, oldFailedPr.Name)
 	assert.Error(t, err)
@@ -234,7 +234,7 @@ type fakeInjector struct {
 	pods []*apiv1.Pod
 }
 
-func (f *fakeInjector) TrySchedulePods(clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) ([]scheduling.Status, int, error) {
+func (f *fakeInjector) TrySchedulePods(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) ([]scheduling.Status, int, error) {
 	f.pods = pods
 	return nil, 0, nil
 }
@@ -287,7 +287,7 @@ func TestBookCapacity(t *testing.T) {
 			test := test
 			injector := &fakeInjector{pods: []*apiv1.Pod{}}
 			for _, condition := range test.conditions {
-				conditions.AddOrUpdateCondition(test.provReq, condition, metav1.ConditionTrue, "", "", metav1.Now())
+				conditions.AddOrUpdateCondition(context.TODO(), test.provReq, condition, metav1.ConditionTrue, "", "", metav1.Now())
 			}
 
 			processor := &provReqProcessor{
@@ -297,7 +297,7 @@ func TestBookCapacity(t *testing.T) {
 				injector:   injector,
 			}
 			autoscalingCtx, _ := NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, nil, nil, nil, nil, nil, nil)
-			processor.bookCapacity(&autoscalingCtx)
+			processor.bookCapacity(context.TODO(), &autoscalingCtx)
 			if (test.capacityIsBooked && len(injector.pods) == 0) || (!test.capacityIsBooked && len(injector.pods) > 0) {
 				t.Fail()
 			}
@@ -319,7 +319,7 @@ func TestBookCapacityConsumed(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			provReq := provreqwrapper.BuildTestProvisioningRequest("ns", "pr", "2", "100m", "", podCount, false, time.Now(), v1.ProvisioningClassBestEffortAtomicScaleUp)
-			conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, "", "", metav1.Now())
+			conditions.AddOrUpdateCondition(context.TODO(), provReq, v1.Provisioned, metav1.ConditionTrue, "", "", metav1.Now())
 
 			node := BuildTestNode("node", 10000, 10000)
 			scheduledPods := make([]*apiv1.Pod, test.scheduledPods)
@@ -337,12 +337,12 @@ func TestBookCapacityConsumed(t *testing.T) {
 				t.Fatalf("failed to set cluster state: %v", err)
 			}
 
-			processor.bookCapacity(&autoscalingCtx)
+			processor.bookCapacity(context.TODO(), &autoscalingCtx)
 
 			if booked := len(injector.pods) > 0; booked != test.booked {
 				t.Errorf("booked: got %v, want %v", booked, test.booked)
 			}
-			updated, err := client.ProvisioningRequest("ns", "pr")
+			updated, err := client.ProvisioningRequest(context.TODO(), "ns", "pr")
 			if err != nil {
 				t.Fatalf("failed to get ProvisioningRequest: %v", err)
 			}

--- a/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/emptycandidates/empty_candidates_sorting.go
@@ -17,6 +17,7 @@ limitations under the License.
 package emptycandidates
 
 import (
+	"context"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -97,7 +98,7 @@ func (p *EmptySorting) isNodeEmptyNoCache(node *apiv1.Node) emptyInfo {
 	if err != nil {
 		return emptyInfo{IsEmpty: false}
 	}
-	podMoveInfo, err := simulator.GetPodsToMove(nodeInfo, p.deleteOptions, p.drainabilityRules, nil, nil, time.Now())
+	podMoveInfo, err := simulator.GetPodsToMove(context.TODO(), nodeInfo, p.deleteOptions, p.drainabilityRules, nil, nil, time.Now())
 	if err == nil && len(podMoveInfo.Pods) == 0 {
 		return emptyInfo{
 			IsEmpty:             true,

--- a/cluster-autoscaler/processors/scaledowncandidates/previouscandidates/previous_candidates_sorting.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/previouscandidates/previous_candidates_sorting.go
@@ -17,6 +17,7 @@ limitations under the License.
 package previouscandidates
 
 import (
+	"context"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -34,7 +35,7 @@ func NewPreviousCandidates() *PreviousCandidates {
 }
 
 // UpdateScaleDownCandidates updates scale down candidates.
-func (p *PreviousCandidates) UpdateScaleDownCandidates(nodes []*scaledown.UnneededNode, now time.Time) {
+func (p *PreviousCandidates) UpdateScaleDownCandidates(ctx context.Context, nodes []*scaledown.UnneededNode, now time.Time) {
 	result := make(map[string]bool)
 	for _, node := range nodes {
 		result[node.Node.Name] = true

--- a/cluster-autoscaler/processors/scaledowncandidates/previouscandidates/previous_candidates_sorting_test.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/previouscandidates/previous_candidates_sorting_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package previouscandidates
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ func TestScaleDownEarlierThan(t *testing.T) {
 	nonCandidate2 := BuildTestNode("non-candidate2", 100, 0)
 
 	p := NewPreviousCandidates()
-	p.UpdateScaleDownCandidates([]*scaledown.UnneededNode{{Node: candidate1}, {Node: candidate2}}, time.Now())
+	p.UpdateScaleDownCandidates(context.TODO(), []*scaledown.UnneededNode{{Node: candidate1}, {Node: candidate2}}, time.Now())
 	testCases := []struct {
 		name  string
 		node1 *apiv1.Node

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaledowncandidates
 
 import (
+	"context"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -95,7 +96,7 @@ func (p *ScaleDownCandidatesDelayProcessor) CleanUp() {
 }
 
 // RegisterScaleUp records when the last scale up happened for a nodegroup.
-func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup,
+func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup,
 	_ int, currentTime time.Time) {
 	p.scaleUps[nodeGroup.Id()] = currentTime
 }
@@ -107,7 +108,7 @@ func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleDown(nodeGroup cloudpro
 }
 
 // RegisterFailedScaleUp records when the last scale up failed for a nodegroup.
-func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleUp(_ cloudprovider.NodeGroup, _ int, _ cloudprovider.InstanceErrorInfo, currentTime time.Time) {
+func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleUp(ctx context.Context, _ cloudprovider.NodeGroup, _ int, _ cloudprovider.InstanceErrorInfo, currentTime time.Time) {
 }
 
 // RegisterFailedScaleDown records failed scale-down for a nodegroup.

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor_test.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_delay_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaledowncandidates
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -98,9 +99,9 @@ func TestGetScaleDownCandidates(t *testing.T) {
 				ng3 := test.NewTestNodeGroup("ng-3", 0, 0, 0, false, false, "", nil, nil)
 
 				// in cool down
-				p.RegisterScaleUp(ng2, 0, time.Now().Add(-time.Minute*5))
+				p.RegisterScaleUp(context.TODO(), ng2, 0, time.Now().Add(-time.Minute*5))
 				// not in cool down anymore
-				p.RegisterScaleUp(ng3, 0, time.Now().Add(-time.Minute*11))
+				p.RegisterScaleUp(context.TODO(), ng3, 0, time.Now().Add(-time.Minute*11))
 				return p
 			},
 		},

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_observer.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_observer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaledowncandidates
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown"
@@ -25,7 +26,7 @@ import (
 // Observer is an observer of scale down candidates
 type Observer interface {
 	// UpdateScaleDownCandidates updates scale down candidates.
-	UpdateScaleDownCandidates([]*scaledown.UnneededNode, time.Time)
+	UpdateScaleDownCandidates(context.Context, []*scaledown.UnneededNode, time.Time)
 }
 
 // ObserversList is a slice of observers of scale down candidates
@@ -39,9 +40,9 @@ func (l *ObserversList) Register(o Observer) {
 }
 
 // Update updates scale down candidates for each observer.
-func (l *ObserversList) Update(nodes []*scaledown.UnneededNode, now time.Time) {
+func (l *ObserversList) Update(ctx context.Context, nodes []*scaledown.UnneededNode, now time.Time) {
 	for _, observer := range l.observers {
-		observer.UpdateScaleDownCandidates(nodes, now)
+		observer.UpdateScaleDownCandidates(ctx, nodes, now)
 	}
 }
 

--- a/cluster-autoscaler/processors/status/autoscaling_status_processor.go
+++ b/cluster-autoscaler/processors/status/autoscaling_status_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
@@ -26,7 +27,7 @@ import (
 // AutoscalingStatusProcessor processes the status of the cluster after each autoscaling iteration.
 // It's triggered at the end of Autoscaler's RunOnce method.
 type AutoscalingStatusProcessor interface {
-	Process(autoscalingCtx *ca_context.AutoscalingContext, csr *clusterstate.ClusterStateRegistry, now time.Time) error
+	Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, csr *clusterstate.ClusterStateRegistry, now time.Time) error
 	CleanUp()
 }
 
@@ -41,7 +42,7 @@ func NewDefaultAutoscalingStatusProcessor() AutoscalingStatusProcessor {
 type NoOpAutoscalingStatusProcessor struct{}
 
 // Process processes the status of the cluster after an autoscaling iteration.
-func (p *NoOpAutoscalingStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, csr *clusterstate.ClusterStateRegistry, now time.Time) error {
+func (p *NoOpAutoscalingStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, csr *clusterstate.ClusterStateRegistry, now time.Time) error {
 	return nil
 }
 

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
@@ -37,6 +37,7 @@ type EventingScaleUpStatusProcessor struct{}
 // Process processes the state of the cluster after a scale-up by emitting
 // relevant events for pods depending on their post scale-up status.
 func (p *EventingScaleUpStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus) {
+	logger := klog.FromContext(ctx)
 	consideredNodeGroupsMap := cloudprovider.NodeGroupListToMapById(status.ConsideredNodeGroups)
 	if status.Result != ScaleUpSuccessful && status.Result != ScaleUpError {
 		for _, noScaleUpInfo := range status.PodsRemainUnschedulable {
@@ -45,8 +46,8 @@ func (p *EventingScaleUpStatusProcessor) Process(ctx context.Context, autoscalin
 					ReasonsMessage(status.Result, noScaleUpInfo, consideredNodeGroupsMap)))
 		}
 	} else {
-		klog.V(4).Infof("Skipping event processing for unschedulable pods since there is a" +
-			" ScaleUp attempt this loop")
+		logger.V(4).Info("Skipping event processing for unschedulable pods since there is a ScaleUp attempt this loop")
+
 	}
 	if len(status.ScaleUpInfos) > 0 {
 		for _, pod := range status.PodsTriggeredScaleUp {

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -35,7 +36,7 @@ type EventingScaleUpStatusProcessor struct{}
 
 // Process processes the state of the cluster after a scale-up by emitting
 // relevant events for pods depending on their post scale-up status.
-func (p *EventingScaleUpStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus) {
+func (p *EventingScaleUpStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus) {
 	consideredNodeGroupsMap := cloudprovider.NodeGroupListToMapById(status.ConsideredNodeGroups)
 	if status.Result != ScaleUpSuccessful && status.Result != ScaleUpError {
 		for _, noScaleUpInfo := range status.PodsRemainUnschedulable {

--- a/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
+++ b/cluster-autoscaler/processors/status/eventing_scale_up_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -125,7 +126,7 @@ func TestEventingScaleUpStatusProcessor(t *testing.T) {
 				Recorder: fakeRecorder,
 			},
 		}
-		p.Process(autoscalingCtx, tc.state)
+		p.Process(context.TODO(), autoscalingCtx, tc.state)
 		triggered := 0
 		noTriggered := 0
 		for eventsLeft := true; eventsLeft; {

--- a/cluster-autoscaler/processors/status/metrics_autoscaling_status_processor.go
+++ b/cluster-autoscaler/processors/status/metrics_autoscaling_status_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/clusterstate"
@@ -39,13 +40,13 @@ type MetricsAutoscalingStatusProcessor struct {
 }
 
 // Process queries the health status and backoff situation of all node groups and updates metrics after each autoscaling iteration.
-func (p *MetricsAutoscalingStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, csr *clusterstate.ClusterStateRegistry, now time.Time) error {
+func (p *MetricsAutoscalingStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, csr *clusterstate.ClusterStateRegistry, now time.Time) error {
 	for _, nodeGroup := range autoscalingCtx.CloudProvider.NodeGroups() {
 		if !nodeGroup.Exist() {
 			continue
 		}
-		metrics.UpdateNodeGroupHealthStatus(nodeGroup.Id(), csr.IsNodeGroupHealthy(nodeGroup.Id()))
-		backoffStatus := csr.BackoffStatusForNodeGroup(nodeGroup, now)
+		metrics.UpdateNodeGroupHealthStatus(nodeGroup.Id(), csr.IsNodeGroupHealthy(ctx, nodeGroup.Id()))
+		backoffStatus := csr.BackoffStatusForNodeGroup(ctx, nodeGroup, now)
 		p.updateNodeGroupBackoffStatusMetrics(nodeGroup.Id(), backoffStatus)
 	}
 	return nil

--- a/cluster-autoscaler/processors/status/scale_down_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_down_status_processor.go
@@ -17,13 +17,14 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/status"
 )
 
 // ScaleDownStatusProcessor processes the status of the cluster after a scale-down.
 type ScaleDownStatusProcessor interface {
-	Process(autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus)
+	Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus)
 	CleanUp()
 }
 
@@ -36,7 +37,7 @@ func NewDefaultScaleDownStatusProcessor() ScaleDownStatusProcessor {
 type NoOpScaleDownStatusProcessor struct{}
 
 // Process processes the status of the cluster after a scale-down.
-func (p *NoOpScaleDownStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus) {
+func (p *NoOpScaleDownStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *status.ScaleDownStatus) {
 }
 
 // CleanUp cleans up the processor's internal structures.

--- a/cluster-autoscaler/processors/status/scale_up_status_processor.go
+++ b/cluster-autoscaler/processors/status/scale_up_status_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -106,7 +107,7 @@ type Reasons interface {
 
 // ScaleUpStatusProcessor processes the status of the cluster after a scale-up.
 type ScaleUpStatusProcessor interface {
-	Process(autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus)
+	Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus)
 	CleanUp()
 }
 
@@ -119,7 +120,7 @@ func NewDefaultScaleUpStatusProcessor() ScaleUpStatusProcessor {
 type NoOpScaleUpStatusProcessor struct{}
 
 // Process processes the status of the cluster after a scale-up.
-func (p *NoOpScaleUpStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus) {
+func (p *NoOpScaleUpStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus) {
 }
 
 // CleanUp cleans up the processor's internal structures.
@@ -150,9 +151,9 @@ func (p *CombinedScaleUpStatusProcessor) AddProcessor(processor ScaleUpStatusPro
 }
 
 // Process runs sub-processors sequentially in the same order of addition
-func (p *CombinedScaleUpStatusProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus) {
+func (p *CombinedScaleUpStatusProcessor) Process(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, status *ScaleUpStatus) {
 	for _, processor := range p.processors {
-		processor.Process(autoscalingCtx, status)
+		processor.Process(ctx, autoscalingCtx, status)
 	}
 }
 

--- a/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
+++ b/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
@@ -82,6 +82,7 @@ func (o *bestEffortAtomicProvClass) Provision(
 	daemonSets []*appsv1.DaemonSet,
 	nodeInfos map[string]*framework.NodeInfo,
 ) (*status.ScaleUpStatus, errors.AutoscalerError) {
+	logger := klog.FromContext(ctx)
 	if len(unschedulablePods) == 0 {
 		return &status.ScaleUpStatus{Result: status.ScaleUpNotTried}, nil
 	}
@@ -101,7 +102,7 @@ func (o *bestEffortAtomicProvClass) Provision(
 	if err != nil {
 		conditions.AddOrUpdateCondition(ctx, pr, v1.Provisioned, metav1.ConditionFalse, conditions.FailedToCheckCapacityReason, conditions.FailedToCheckCapacityMsg, metav1.Now())
 		if _, updateErr := o.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); updateErr != nil {
-			klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+			logger.Error(updateErr, "failed to add Provisioned=false condition to ProvReq", "namespace", pr.Namespace, "pr", pr.Name)
 		}
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "error during ScaleUp: %s", err.Error()))
 	}
@@ -110,7 +111,7 @@ func (o *bestEffortAtomicProvClass) Provision(
 		// Nothing to do here - everything fits without scale-up.
 		conditions.AddOrUpdateCondition(ctx, pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
 		if _, updateErr := o.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); updateErr != nil {
-			klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+			logger.Error(updateErr, "failed to add Provisioned=true condition to ProvReq", "namespace", pr.Namespace, "pr", pr.Name)
 			return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "capacity available, but failed to admit workload: %s", updateErr.Error()))
 		}
 		return &status.ScaleUpStatus{Result: status.ScaleUpNotNeeded}, nil
@@ -121,7 +122,7 @@ func (o *bestEffortAtomicProvClass) Provision(
 		// Happy path - all is well.
 		conditions.AddOrUpdateCondition(ctx, pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsProvisionedReason, conditions.CapacityIsProvisionedMsg, metav1.Now())
 		if _, updateErr := o.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); updateErr != nil {
-			klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+			logger.Error(updateErr, "failed to add Provisioned=true condition to ProvReq", "namespace", pr.Namespace, "pr", pr.Name)
 			return st, errors.NewAutoscalerErrorf(errors.InternalError, "scale up requested, but failed to admit workload: %s", updateErr.Error())
 		}
 		return st, nil
@@ -130,7 +131,7 @@ func (o *bestEffortAtomicProvClass) Provision(
 	// We are not happy with the results.
 	conditions.AddOrUpdateCondition(ctx, pr, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
 	if _, updateErr := o.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); updateErr != nil {
-		klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
+		logger.Error(updateErr, "failed to add Provisioned=false condition to ProvReq", "namespace", pr.Namespace, "pr", pr.Name)
 	}
 	if err != nil {
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "error during ScaleUp: %s", err.Error()))

--- a/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
+++ b/cluster-autoscaler/provisioningrequest/besteffortatomic/provisioning_class.go
@@ -17,6 +17,7 @@ limitations under the License.
 package besteffortatomic
 
 import (
+	"context"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,7 +77,7 @@ func (o *bestEffortAtomicProvClass) Initialize(
 
 // Provision returns success if there is, or has just been requested, sufficient capacity in the cluster for pods from ProvisioningRequest.
 func (o *bestEffortAtomicProvClass) Provision(
-	unschedulablePods []*apiv1.Pod,
+	ctx context.Context, unschedulablePods []*apiv1.Pod,
 	nodes []*apiv1.Node,
 	daemonSets []*appsv1.DaemonSet,
 	nodeInfos map[string]*framework.NodeInfo,
@@ -84,8 +85,8 @@ func (o *bestEffortAtomicProvClass) Provision(
 	if len(unschedulablePods) == 0 {
 		return &status.ScaleUpStatus{Result: status.ScaleUpNotTried}, nil
 	}
-	prs := provreqclient.ProvisioningRequestsForPods(o.client, unschedulablePods)
-	prs = provreqclient.FilterOutProvisioningClass(prs, v1.ProvisioningClassBestEffortAtomicScaleUp, "")
+	prs := provreqclient.ProvisioningRequestsForPods(ctx, o.client, unschedulablePods)
+	prs = provreqclient.FilterOutProvisioningClass(ctx, prs, v1.ProvisioningClassBestEffortAtomicScaleUp, "")
 	if len(prs) == 0 {
 		return &status.ScaleUpStatus{Result: status.ScaleUpNotTried}, nil
 	}
@@ -96,10 +97,10 @@ func (o *bestEffortAtomicProvClass) Provision(
 	defer o.autoscalingCtx.ClusterSnapshot.Revert()
 
 	// For provisioning requests, unschedulablePods are actually all injected pods. Some may even be schedulable!
-	actuallyUnschedulablePods, err := o.filterOutSchedulable(unschedulablePods)
+	actuallyUnschedulablePods, err := o.filterOutSchedulable(ctx, unschedulablePods)
 	if err != nil {
-		conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.FailedToCheckCapacityReason, conditions.FailedToCheckCapacityMsg, metav1.Now())
-		if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+		conditions.AddOrUpdateCondition(ctx, pr, v1.Provisioned, metav1.ConditionFalse, conditions.FailedToCheckCapacityReason, conditions.FailedToCheckCapacityMsg, metav1.Now())
+		if _, updateErr := o.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); updateErr != nil {
 			klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
 		}
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "error during ScaleUp: %s", err.Error()))
@@ -107,19 +108,19 @@ func (o *bestEffortAtomicProvClass) Provision(
 
 	if len(actuallyUnschedulablePods) == 0 {
 		// Nothing to do here - everything fits without scale-up.
-		conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
-		if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+		conditions.AddOrUpdateCondition(ctx, pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+		if _, updateErr := o.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); updateErr != nil {
 			klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
 			return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "capacity available, but failed to admit workload: %s", updateErr.Error()))
 		}
 		return &status.ScaleUpStatus{Result: status.ScaleUpNotNeeded}, nil
 	}
 
-	st, err := o.scaleUpOrchestrator.ScaleUp(actuallyUnschedulablePods, nodes, daemonSets, nodeInfos, true)
+	st, err := o.scaleUpOrchestrator.ScaleUp(ctx, actuallyUnschedulablePods, nodes, daemonSets, nodeInfos, true)
 	if err == nil && st.Result == status.ScaleUpSuccessful {
 		// Happy path - all is well.
-		conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsProvisionedReason, conditions.CapacityIsProvisionedMsg, metav1.Now())
-		if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+		conditions.AddOrUpdateCondition(ctx, pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsProvisionedReason, conditions.CapacityIsProvisionedMsg, metav1.Now())
+		if _, updateErr := o.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); updateErr != nil {
 			klog.Errorf("failed to add Provisioned=true condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
 			return st, errors.NewAutoscalerErrorf(errors.InternalError, "scale up requested, but failed to admit workload: %s", updateErr.Error())
 		}
@@ -127,8 +128,8 @@ func (o *bestEffortAtomicProvClass) Provision(
 	}
 
 	// We are not happy with the results.
-	conditions.AddOrUpdateCondition(pr, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
-	if _, updateErr := o.client.UpdateProvisioningRequest(pr.ProvisioningRequest); updateErr != nil {
+	conditions.AddOrUpdateCondition(ctx, pr, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
+	if _, updateErr := o.client.UpdateProvisioningRequest(ctx, pr.ProvisioningRequest); updateErr != nil {
 		klog.Errorf("failed to add Provisioned=false condition to ProvReq %s/%s, err: %v", pr.Namespace, pr.Name, updateErr)
 	}
 	if err != nil {
@@ -137,8 +138,8 @@ func (o *bestEffortAtomicProvClass) Provision(
 	return st, nil
 }
 
-func (o *bestEffortAtomicProvClass) filterOutSchedulable(pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
-	statuses, _, err := o.injector.TrySchedulePods(o.autoscalingCtx.ClusterSnapshot, pods, false, clustersnapshot.SchedulingOptions{})
+func (o *bestEffortAtomicProvClass) filterOutSchedulable(ctx context.Context, pods []*apiv1.Pod) ([]*apiv1.Pod, error) {
+	statuses, _, err := o.injector.TrySchedulePods(ctx, o.autoscalingCtx.ClusterSnapshot, pods, false, clustersnapshot.SchedulingOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -17,6 +17,7 @@ limitations under the License.
 package checkcapacity
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -92,7 +93,7 @@ func (o *checkCapacityProvClass) Initialize(
 
 // Provision return if there is capacity in the cluster for pods from ProvisioningRequest.
 func (o *checkCapacityProvClass) Provision(
-	unschedulablePods []*apiv1.Pod,
+	ctx context.Context, unschedulablePods []*apiv1.Pod,
 	nodes []*apiv1.Node,
 	daemonSets []*appsv1.DaemonSet,
 	nodeInfos map[string]*framework.NodeInfo,
@@ -104,7 +105,7 @@ func (o *checkCapacityProvClass) Provision(
 	defer o.autoscalingCtx.ClusterSnapshot.Revert()
 
 	// Gather ProvisioningRequests.
-	prs, err := o.getProvisioningRequestsAndPods(unschedulablePods)
+	prs, err := o.getProvisioningRequestsAndPods(ctx, unschedulablePods)
 	if err != nil {
 		return status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "Error fetching provisioning requests and associated pods: %s", err.Error()))
 	} else if len(prs) == 0 {
@@ -119,30 +120,30 @@ func (o *checkCapacityProvClass) Provision(
 
 	// Add accepted condition to ProvisioningRequests.
 	for _, pr := range prs {
-		conditions.AddOrUpdateCondition(pr.PrWrapper, v1.Accepted, metav1.ConditionTrue, conditions.AcceptedReason, conditions.AcceptedMsg, metav1.Now())
+		conditions.AddOrUpdateCondition(ctx, pr.PrWrapper, v1.Accepted, metav1.ConditionTrue, conditions.AcceptedReason, conditions.AcceptedMsg, metav1.Now())
 	}
 
 	// Check Capacity. Add Provisioned or Failed conditions.
-	processedPrs := o.checkCapacityBatch(prs, &combinedStatus, startTime)
+	processedPrs := o.checkCapacityBatch(ctx, prs, &combinedStatus, startTime)
 
 	// Use client to update ProvisioningRequests conditions.
-	updateRequests(o.client, processedPrs, &combinedStatus)
+	updateRequests(ctx, o.client, processedPrs, &combinedStatus)
 
 	return combinedStatus.Export()
 }
 
-func (o *checkCapacityProvClass) getProvisioningRequestsAndPods(unschedulablePods []*apiv1.Pod) ([]provreq.ProvisioningRequestWithPods, error) {
+func (o *checkCapacityProvClass) getProvisioningRequestsAndPods(ctx context.Context, unschedulablePods []*apiv1.Pod) ([]provreq.ProvisioningRequestWithPods, error) {
 	if !o.isBatchEnabled() {
 		klog.Info("Processing single provisioning request (non-batch)")
-		prs := provreqclient.ProvisioningRequestsForPods(o.client, unschedulablePods)
-		prs = provreqclient.FilterOutProvisioningClass(prs, v1.ProvisioningClassCheckCapacity, o.autoscalingCtx.CheckCapacityProcessorInstance)
+		prs := provreqclient.ProvisioningRequestsForPods(ctx, o.client, unschedulablePods)
+		prs = provreqclient.FilterOutProvisioningClass(ctx, prs, v1.ProvisioningClassCheckCapacity, o.autoscalingCtx.CheckCapacityProcessorInstance)
 		if len(prs) == 0 {
 			return nil, nil
 		}
 		return []provreq.ProvisioningRequestWithPods{{PrWrapper: prs[0], Pods: unschedulablePods}}, nil
 	}
 
-	batch, err := o.provreqInjector.GetCheckCapacityBatch(o.checkCapacityProvisioningRequestMaxBatchSize)
+	batch, err := o.provreqInjector.GetCheckCapacityBatch(ctx, o.checkCapacityProvisioningRequestMaxBatchSize)
 	if err != nil {
 		return nil, err
 	}
@@ -154,10 +155,10 @@ func (o *checkCapacityProvClass) isBatchEnabled() bool {
 	return o.provreqInjector != nil && o.checkCapacityProvisioningRequestMaxBatchSize > 1
 }
 
-func (o *checkCapacityProvClass) checkCapacityBatch(reqs []provreq.ProvisioningRequestWithPods, combinedStatus *combinedStatusSet, startTime time.Time) []*provreqwrapper.ProvisioningRequest {
+func (o *checkCapacityProvClass) checkCapacityBatch(ctx context.Context, reqs []provreq.ProvisioningRequestWithPods, combinedStatus *combinedStatusSet, startTime time.Time) []*provreqwrapper.ProvisioningRequest {
 	updates := make([]*provreqwrapper.ProvisioningRequest, 0, len(reqs))
 	for _, req := range reqs {
-		if err := o.checkCapacity(req.Pods, req.PrWrapper, combinedStatus); err != nil {
+		if err := o.checkCapacity(ctx, req.Pods, req.PrWrapper, combinedStatus); err != nil {
 			klog.Errorf("error checking capacity %v", err)
 			continue
 		}
@@ -174,11 +175,11 @@ func (o *checkCapacityProvClass) checkCapacityBatch(reqs []provreq.ProvisioningR
 }
 
 // checkCapacity checks if there is capacity, updates combinedStatus and Conditions. If capacity is found, it commits to the clusterSnapshot.
-func (o *checkCapacityProvClass) checkCapacity(unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) error {
+func (o *checkCapacityProvClass) checkCapacity(ctx context.Context, unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) error {
 	o.autoscalingCtx.ClusterSnapshot.Fork()
 
 	// Case 1: Capacity fits.
-	scheduled, _, err := o.schedulingSimulator.TrySchedulePods(o.autoscalingCtx.ClusterSnapshot, unschedulablePods, true, clustersnapshot.SchedulingOptions{})
+	scheduled, _, err := o.schedulingSimulator.TrySchedulePods(ctx, o.autoscalingCtx.ClusterSnapshot, unschedulablePods, true, clustersnapshot.SchedulingOptions{})
 	if err == nil && len(scheduled) == len(unschedulablePods) {
 		commitError := o.autoscalingCtx.ClusterSnapshot.Commit()
 		if commitError != nil {
@@ -186,7 +187,7 @@ func (o *checkCapacityProvClass) checkCapacity(unschedulablePods []*apiv1.Pod, p
 			return commitError
 		}
 		combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
-		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+		conditions.AddOrUpdateCondition(ctx, provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
 		return nil
 	}
 	// Case 2: Capacity doesn't fit.
@@ -195,25 +196,25 @@ func (o *checkCapacityProvClass) checkCapacity(unschedulablePods []*apiv1.Pod, p
 	if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry == "true" {
 		// Failed=true condition triggers retry in Kueue. Otherwise ProvisioningRequest with Provisioned=Failed
 		// condition block capacity in Kueue even if it's in the middle of backoff waiting time.
-		conditions.AddOrUpdateCondition(provReq, v1.Failed, metav1.ConditionTrue, conditions.CapacityIsNotFoundReason, "CA could not find requested capacity", metav1.Now())
+		conditions.AddOrUpdateCondition(ctx, provReq, v1.Failed, metav1.ConditionTrue, conditions.CapacityIsNotFoundReason, "CA could not find requested capacity", metav1.Now())
 	} else {
 		if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry != "false" {
 			klog.Errorf("Ignoring Parameter %v with invalid value: %v in ProvisioningRequest: %v. Supported values are: \"true\", \"false\"", NoRetryParameterKey, noRetry, provReq.Name)
 		}
-		conditions.AddOrUpdateCondition(provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
+		conditions.AddOrUpdateCondition(ctx, provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
 	}
 	return err
 }
 
 // updateRequests calls the client to update ProvisioningRequests, in parallel.
-func updateRequests(client *provreqclient.ProvisioningRequestClient, prWrappers []*provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) {
+func updateRequests(ctx context.Context, client *provreqclient.ProvisioningRequestClient, prWrappers []*provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(prWrappers))
 	lock := sync.Mutex{}
 	for _, wrapper := range prWrappers {
 		go func() {
 			provReq := wrapper.ProvisioningRequest
-			_, updErr := client.UpdateProvisioningRequest(provReq)
+			_, updErr := client.UpdateProvisioningRequest(ctx, provReq)
 			if updErr != nil {
 				err := fmt.Errorf("failed to update ProvReq %s/%s, err: %v", provReq.Namespace, provReq.Name, updErr)
 				scaleUpStatus, _ := status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "error during ScaleUp: %s", err.Error()))

--- a/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/cluster-autoscaler/provisioningrequest/checkcapacity/provisioningclass.go
@@ -133,8 +133,9 @@ func (o *checkCapacityProvClass) Provision(
 }
 
 func (o *checkCapacityProvClass) getProvisioningRequestsAndPods(ctx context.Context, unschedulablePods []*apiv1.Pod) ([]provreq.ProvisioningRequestWithPods, error) {
+	logger := klog.FromContext(ctx)
 	if !o.isBatchEnabled() {
-		klog.Info("Processing single provisioning request (non-batch)")
+		logger.Info("Processing single provisioning request (non-batch)")
 		prs := provreqclient.ProvisioningRequestsForPods(ctx, o.client, unschedulablePods)
 		prs = provreqclient.FilterOutProvisioningClass(ctx, prs, v1.ProvisioningClassCheckCapacity, o.autoscalingCtx.CheckCapacityProcessorInstance)
 		if len(prs) == 0 {
@@ -147,7 +148,7 @@ func (o *checkCapacityProvClass) getProvisioningRequestsAndPods(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	klog.Infof("Processing provisioning requests as batch of size %d", len(batch))
+	logger.Info("Processing provisioning requests as batch of size", "batchCount", len(batch))
 	return batch, nil
 }
 
@@ -156,10 +157,11 @@ func (o *checkCapacityProvClass) isBatchEnabled() bool {
 }
 
 func (o *checkCapacityProvClass) checkCapacityBatch(ctx context.Context, reqs []provreq.ProvisioningRequestWithPods, combinedStatus *combinedStatusSet, startTime time.Time) []*provreqwrapper.ProvisioningRequest {
+	logger := klog.FromContext(ctx)
 	updates := make([]*provreqwrapper.ProvisioningRequest, 0, len(reqs))
 	for _, req := range reqs {
 		if err := o.checkCapacity(ctx, req.Pods, req.PrWrapper, combinedStatus); err != nil {
-			klog.Errorf("error checking capacity %v", err)
+			logger.Error(err, "error checking capacity")
 			continue
 		}
 
@@ -167,7 +169,7 @@ func (o *checkCapacityProvClass) checkCapacityBatch(ctx context.Context, reqs []
 
 		// timebox checkCapacity when batch processing.
 		if o.isBatchEnabled() && time.Since(startTime) > o.checkCapacityProvisioningRequestBatchTimebox {
-			klog.Infof("Batch timebox exceeded, processed %d check capacity provisioning requests this iteration", len(updates))
+			logger.Info("Batch timebox exceeded, processed check capacity provisioning requests this iteration", "updatesCount", len(updates))
 			break
 		}
 	}
@@ -176,6 +178,7 @@ func (o *checkCapacityProvClass) checkCapacityBatch(ctx context.Context, reqs []
 
 // checkCapacity checks if there is capacity, updates combinedStatus and Conditions. If capacity is found, it commits to the clusterSnapshot.
 func (o *checkCapacityProvClass) checkCapacity(ctx context.Context, unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) error {
+	logger := klog.FromContext(ctx)
 	o.autoscalingCtx.ClusterSnapshot.Fork()
 
 	// Case 1: Capacity fits.
@@ -199,7 +202,7 @@ func (o *checkCapacityProvClass) checkCapacity(ctx context.Context, unschedulabl
 		conditions.AddOrUpdateCondition(ctx, provReq, v1.Failed, metav1.ConditionTrue, conditions.CapacityIsNotFoundReason, "CA could not find requested capacity", metav1.Now())
 	} else {
 		if noRetry, ok := provReq.Spec.Parameters[NoRetryParameterKey]; ok && noRetry != "false" {
-			klog.Errorf("Ignoring Parameter %v with invalid value: %v in ProvisioningRequest: %v. Supported values are: \"true\", \"false\"", NoRetryParameterKey, noRetry, provReq.Name)
+			logger.Error(nil, "Ignoring Parameter with invalid value in ProvisioningRequest. Supported values are: \"true\", \"false\"", "NoRetryParameterKey", NoRetryParameterKey, "noRetry", noRetry, "provReq", provReq.Name)
 		}
 		conditions.AddOrUpdateCondition(ctx, provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
 	}

--- a/cluster-autoscaler/provisioningrequest/conditions/condition_test.go
+++ b/cluster-autoscaler/provisioningrequest/conditions/condition_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package conditions
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -199,7 +200,7 @@ func TestBookCapacity(t *testing.T) {
 						Conditions: test.prConditions,
 					},
 				}, nil)
-			got := ShouldCapacityBeBooked(pr, test.checkCapacityProcessorInstance)
+			got := ShouldCapacityBeBooked(context.TODO(), pr, test.checkCapacityProcessorInstance)
 			if got != test.want {
 				t.Errorf("Want: %v, got: %v", test.want, got)
 			}
@@ -354,7 +355,7 @@ func TestSetCondition(t *testing.T) {
 						Conditions: test.oldConditions,
 					},
 				}, nil)
-			AddOrUpdateCondition(pr, test.newType, test.newStatus, "", "", metav1.Now())
+			AddOrUpdateCondition(context.TODO(), pr, test.newType, test.newStatus, "", "", metav1.Now())
 			got := pr.Status.Conditions
 			if len(got) > 2 || len(got) != len(test.want) || got[0].Type != test.want[0].Type || got[0].Status != test.want[0].Status {
 				t.Errorf("want %v, got: %v", test.want, got)

--- a/cluster-autoscaler/provisioningrequest/conditions/conditions.go
+++ b/cluster-autoscaler/provisioningrequest/conditions/conditions.go
@@ -17,6 +17,7 @@ limitations under the License.
 package conditions
 
 import (
+	"context"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
@@ -63,8 +64,8 @@ const (
 )
 
 // ShouldCapacityBeBooked returns whether capacity should be booked.
-func ShouldCapacityBeBooked(pr *provreqwrapper.ProvisioningRequest, checkCapacityProcessorInstance string) bool {
-	if !provisioningrequest.SupportedProvisioningClass(pr.ProvisioningRequest, checkCapacityProcessorInstance) {
+func ShouldCapacityBeBooked(ctx context.Context, pr *provreqwrapper.ProvisioningRequest, checkCapacityProcessorInstance string) bool {
+	if !provisioningrequest.SupportedProvisioningClass(ctx, pr.ProvisioningRequest, checkCapacityProcessorInstance) {
 		return false
 	}
 	conditions := pr.Status.Conditions
@@ -77,7 +78,7 @@ func ShouldCapacityBeBooked(pr *provreqwrapper.ProvisioningRequest, checkCapacit
 }
 
 // AddOrUpdateCondition adds a Condition if the condition is not present amond ProvisioningRequest conditions or updte it otherwise.
-func AddOrUpdateCondition(pr *provreqwrapper.ProvisioningRequest, conditionType string, conditionStatus metav1.ConditionStatus, reason, message string, now metav1.Time) {
+func AddOrUpdateCondition(ctx context.Context, pr *provreqwrapper.ProvisioningRequest, conditionType string, conditionStatus metav1.ConditionStatus, reason, message string, now metav1.Time) {
 	var newConditions []metav1.Condition
 	newCondition := metav1.Condition{
 		Type:               conditionType,

--- a/cluster-autoscaler/provisioningrequest/conditions/conditions.go
+++ b/cluster-autoscaler/provisioningrequest/conditions/conditions.go
@@ -79,6 +79,7 @@ func ShouldCapacityBeBooked(ctx context.Context, pr *provreqwrapper.Provisioning
 
 // AddOrUpdateCondition adds a Condition if the condition is not present amond ProvisioningRequest conditions or updte it otherwise.
 func AddOrUpdateCondition(ctx context.Context, pr *provreqwrapper.ProvisioningRequest, conditionType string, conditionStatus metav1.ConditionStatus, reason, message string, now metav1.Time) {
+	logger := klog.FromContext(ctx)
 	var newConditions []metav1.Condition
 	newCondition := metav1.Condition{
 		Type:               conditionType,
@@ -104,7 +105,7 @@ func AddOrUpdateCondition(ctx context.Context, pr *provreqwrapper.ProvisioningRe
 			newConditions = append(prevConditions, newCondition)
 		}
 	default:
-		klog.Errorf("Unknown (conditionType; conditionStatus) pair: (%s; %s) ", conditionType, conditionStatus)
+		logger.Error(nil, "Unknown (conditionType; conditionStatus) pair", "conditionType", conditionType, "conditionStatus", conditionStatus)
 		newConditions = prevConditions
 	}
 	pr.SetConditions(newConditions)

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,7 +38,7 @@ import (
 
 // ProvisioningClass is an interface for ProvisioningRequests.
 type ProvisioningClass interface {
-	Provision([]*apiv1.Pod, []*apiv1.Node, []*appsv1.DaemonSet,
+	Provision(context.Context, []*apiv1.Pod, []*apiv1.Node, []*appsv1.DaemonSet,
 		map[string]*framework.NodeInfo) (*status.ScaleUpStatus, ca_errors.AutoscalerError)
 	Initialize(*ca_context.AutoscalingContext, *ca_processors.AutoscalingProcessors, *clusterstate.ClusterStateRegistry,
 		estimator.EstimatorBuilder, taints.TaintConfig, *scheduling.HintingSimulator, *resourcequotas.TrackerFactory)
@@ -81,7 +82,7 @@ func (o *provReqOrchestrator) Initialize(
 // so only one ProvisioningClass return non empty scaleUp result.
 // In case we implement multiple ProvisioningRequest ScaleUp, the function should return combined status
 func (o *provReqOrchestrator) ScaleUp(
-	unschedulablePods []*apiv1.Pod,
+	ctx context.Context, unschedulablePods []*apiv1.Pod,
 	nodes []*apiv1.Node,
 	daemonSets []*appsv1.DaemonSet,
 	nodeInfos map[string]*framework.NodeInfo,
@@ -96,7 +97,7 @@ func (o *provReqOrchestrator) ScaleUp(
 
 	// unschedulablePods pods should belong to one ProvisioningClass, so only one provClass should try to ScaleUp.
 	for _, provClass := range o.provisioningClasses {
-		st, err := provClass.Provision(unschedulablePods, nodes, daemonSets, nodeInfos)
+		st, err := provClass.Provision(ctx, unschedulablePods, nodes, daemonSets, nodeInfos)
 		if err != nil || st != nil && st.Result != status.ScaleUpNotTried {
 			return st, err
 		}
@@ -106,7 +107,7 @@ func (o *provReqOrchestrator) ScaleUp(
 
 // ScaleUpToNodeGroupMinSize doesn't have implementation for ProvisioningRequest Orchestrator.
 func (o *provReqOrchestrator) ScaleUpToNodeGroupMinSize(
-	nodes []*apiv1.Node,
+	ctx context.Context, nodes []*apiv1.Node,
 	nodeInfos map[string]*framework.NodeInfo,
 ) (*status.ScaleUpStatus, ca_errors.AutoscalerError) {
 	return nil, nil

--- a/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/orchestrator_test.go
@@ -431,7 +431,7 @@ func TestScaleUp(t *testing.T) {
 			client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, testProvReqs...)
 			orchestrator, nodeInfos := setupTest(t, client, nodes, onScaleUpFunc, tc.autoprovisioning, tc.batchProcessing, tc.maxBatchSize, tc.batchTimebox)
 
-			st, err := orchestrator.ScaleUp(prPods, []*apiv1.Node{}, []*appsv1.DaemonSet{}, nodeInfos, false)
+			st, err := orchestrator.ScaleUp(context.TODO(), prPods, []*apiv1.Node{}, []*appsv1.DaemonSet{}, nodeInfos, false)
 			if !tc.err {
 				assert.NoError(t, err)
 				if tc.scaleUpResult != st.Result && len(st.PodsRemainUnschedulable) > 0 {
@@ -500,7 +500,7 @@ func setupTest(t *testing.T, client *provreqclient.ProvisioningRequestClient, no
 		processors.NodeGroupListProcessor = &MockAutoprovisioningNodeGroupListProcessor{T: t}
 		processors.NodeGroupManager = &MockAutoprovisioningNodeGroupManager{T: t, ExtraGroups: 2}
 	}
-	err = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(&autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
+	err = autoscalingCtx.TemplateNodeInfoRegistry.Recompute(context.TODO(), &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now)
 	assert.NoError(t, err)
 	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 
@@ -513,7 +513,7 @@ func setupTest(t *testing.T, client *provreqclient.ProvisioningRequestClient, no
 	)
 
 	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(autoscalingCtx.NodeGroupDefaults), templateNodeInfoRegistry)
-	clusterState.UpdateNodes(nodes, now)
+	clusterState.UpdateNodes(context.TODO(), nodes, now)
 
 	var injector *provreq.ProvisioningRequestPodsInjector
 	if batchProcessing {

--- a/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
@@ -59,7 +60,7 @@ func (o *WrapperOrchestrator) Initialize(autoscalingCtx *ca_context.AutoscalingC
 
 // ScaleUp run scaleUp function for regular pods of pods from ProvisioningRequest.
 func (o *WrapperOrchestrator) ScaleUp(
-	unschedulablePods []*apiv1.Pod,
+	ctx context.Context, unschedulablePods []*apiv1.Pod,
 	nodes []*apiv1.Node,
 	daemonSets []*appsv1.DaemonSet,
 	nodeInfos map[string]*framework.NodeInfo,
@@ -77,9 +78,9 @@ func (o *WrapperOrchestrator) ScaleUp(
 	}
 
 	if o.autoscalingCtx.ProvisioningRequestScaleUpMode {
-		return o.provReqOrchestrator.ScaleUp(provReqPods, nodes, daemonSets, nodeInfos, allOrNothing)
+		return o.provReqOrchestrator.ScaleUp(ctx, provReqPods, nodes, daemonSets, nodeInfos, allOrNothing)
 	}
-	return o.podsOrchestrator.ScaleUp(regularPods, nodes, daemonSets, nodeInfos, allOrNothing)
+	return o.podsOrchestrator.ScaleUp(ctx, regularPods, nodes, daemonSets, nodeInfos, allOrNothing)
 }
 
 func splitOut(unschedulablePods []*apiv1.Pod) (provReqPods, regularPods []*apiv1.Pod) {
@@ -98,8 +99,8 @@ func splitOut(unschedulablePods []*apiv1.Pod) (provReqPods, regularPods []*apiv1
 // size is the TargetSize queried directly from cloud providers. Returns
 // appropriate status or error if an unexpected error occurred.
 func (o *WrapperOrchestrator) ScaleUpToNodeGroupMinSize(
-	nodes []*apiv1.Node,
+	ctx context.Context, nodes []*apiv1.Node,
 	nodeInfos map[string]*framework.NodeInfo,
 ) (*status.ScaleUpStatus, errors.AutoscalerError) {
-	return o.podsOrchestrator.ScaleUpToNodeGroupMinSize(nodes, nodeInfos)
+	return o.podsOrchestrator.ScaleUpToNodeGroupMinSize(ctx, nodes, nodeInfos)
 }

--- a/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator_test.go
+++ b/cluster-autoscaler/provisioningrequest/orchestrator/wrapper_orchestrator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,9 +59,9 @@ func TestWrapperScaleUp(t *testing.T) {
 		pod.Annotations[v1.ProvisioningRequestPodAnnotationKey] = "true"
 	}
 	unschedulablePods := append(regularPods, provReqPods...)
-	_, err := o.ScaleUp(unschedulablePods, nil, nil, nil, false)
+	_, err := o.ScaleUp(context.TODO(), unschedulablePods, nil, nil, nil, false)
 	assert.Equal(t, err.Error(), provisioningRequestErrorMsg)
-	_, err = o.ScaleUp(unschedulablePods, nil, nil, nil, false)
+	_, err = o.ScaleUp(context.TODO(), unschedulablePods, nil, nil, nil, false)
 	assert.Equal(t, err.Error(), regularPodsErrorMsg)
 }
 
@@ -69,7 +70,7 @@ type fakeScaleUp struct {
 }
 
 func (f *fakeScaleUp) ScaleUp(
-	unschedulablePods []*apiv1.Pod,
+	ctx context.Context, unschedulablePods []*apiv1.Pod,
 	nodes []*apiv1.Node,
 	daemonSets []*appsv1.DaemonSet,
 	nodeInfos map[string]*framework.NodeInfo,
@@ -82,7 +83,7 @@ func (f *fakeScaleUp) Initialize(autoscalingCtx *ca_context.AutoscalingContext, 
 }
 
 func (f *fakeScaleUp) ScaleUpToNodeGroupMinSize(
-	nodes []*apiv1.Node,
+	ctx context.Context, nodes []*apiv1.Node,
 	nodeInfos map[string]*framework.NodeInfo,
 ) (*status.ScaleUpStatus, errors.AutoscalerError) {
 	return nil, nil

--- a/cluster-autoscaler/provisioningrequest/provreqclient/client.go
+++ b/cluster-autoscaler/provisioningrequest/provreqclient/client.go
@@ -93,11 +93,12 @@ func (c *ProvisioningRequestClient) ProvisioningRequests(ctx context.Context) ([
 
 // FetchPodTemplates fetches PodTemplates referenced by the Provisioning Request.
 func (c *ProvisioningRequestClient) FetchPodTemplates(ctx context.Context, pr *v1.ProvisioningRequest) ([]*apiv1.PodTemplate, error) {
+	logger := klog.FromContext(ctx)
 	podTemplates := make([]*apiv1.PodTemplate, 0, len(pr.Spec.PodSets))
 	for _, podSpec := range pr.Spec.PodSets {
 		podTemplate, err := c.podTemplLister.PodTemplates(pr.Namespace).Get(podSpec.PodTemplateRef.Name)
 		if errors.IsNotFound(err) {
-			klog.Infof("While fetching Pod Template for Provisioning Request %s/%s received not found error", pr.Namespace, pr.Name)
+			logger.Info("While fetching Pod Template for Provisioning Request received not found error", "namespace", pr.Namespace, "pr", pr.Name)
 			continue
 		} else if err != nil {
 			return nil, err
@@ -109,6 +110,7 @@ func (c *ProvisioningRequestClient) FetchPodTemplates(ctx context.Context, pr *v
 
 // UpdateProvisioningRequest updates the given ProvisioningRequest CR by propagating the changes using the ProvisioningRequestInterface and returns the updated instance or the original one in case of an error.
 func (c *ProvisioningRequestClient) UpdateProvisioningRequest(logging_ctx context.Context, pr *v1.ProvisioningRequest) (*v1.ProvisioningRequest, error) {
+	logger := klog.FromContext(logging_ctx)
 	ctx, cancel := context.WithTimeout(logging_ctx, provisioningRequestClientCallTimeout)
 	defer cancel()
 
@@ -116,12 +118,13 @@ func (c *ProvisioningRequestClient) UpdateProvisioningRequest(logging_ctx contex
 	if err != nil {
 		return pr, err
 	}
-	klog.V(4).Infof("Updated ProvisioningRequest %s/%s,  status: %q,", updatedPr.Namespace, updatedPr.Name, updatedPr.Status)
+	logger.V(4).Info("Updated ProvisioningRequest, status", "namespace", updatedPr.Namespace, "updatedPr", updatedPr.Name, "status", updatedPr.Status)
 	return updatedPr, nil
 }
 
 // ProvisioningRequestsForPods check that all pods belong to one ProvisioningRequest and return it.
 func ProvisioningRequestsForPods(ctx context.Context, client *ProvisioningRequestClient, unschedulablePods []*apiv1.Pod) []*provreqwrapper.ProvisioningRequest {
+	logger := klog.FromContext(ctx)
 	prMap := make(map[string]*provreqwrapper.ProvisioningRequest)
 	prList := []*provreqwrapper.ProvisioningRequest{}
 	if len(unschedulablePods) == 0 {
@@ -129,12 +132,12 @@ func ProvisioningRequestsForPods(ctx context.Context, client *ProvisioningReques
 	}
 	for _, pod := range unschedulablePods {
 		if len(pod.OwnerReferences) == 0 {
-			klog.Errorf("pod %s has no OwnerReference", pod.Name)
+			logger.Error(nil, "pod has no OwnerReference", "pod", pod.Name)
 			continue
 		}
 		provReq, err := client.ProvisioningRequest(ctx, pod.Namespace, pod.OwnerReferences[0].Name)
 		if err != nil {
-			klog.Errorf("failed to retrieve ProvisioningRequest from unschedulable pod, err: %v", err)
+			logger.Error(err, "failed to retrieve ProvisioningRequest from unschedulable pod")
 			continue
 		}
 		if _, found := prMap[provReq.Name]; !found {
@@ -150,13 +153,14 @@ func ProvisioningRequestsForPods(ctx context.Context, client *ProvisioningReques
 // DeleteProvisioningRequest deletes the given ProvisioningRequest CR using the ProvisioningRequestInterface and returns an error in case of failure.
 func (c *ProvisioningRequestClient) DeleteProvisioningRequest(ctx context.Context, pr *v1.ProvisioningRequest) error {
 	ctx, cancel := context.WithTimeout(ctx, provisioningRequestClientCallTimeout)
+	logger := klog.FromContext(ctx)
 	defer cancel()
 
 	err := c.client.AutoscalingV1().ProvisioningRequests(pr.Namespace).Delete(ctx, pr.Name, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("error deleting ProvisioningRequest %s/%s: %w", pr.Namespace, pr.Name, err)
 	}
-	klog.V(4).Infof("Deleted ProvisioningRequest %s/%s", pr.Namespace, pr.Name)
+	logger.V(4).Info("Deleted ProvisioningRequest", "namespace", pr.Namespace, "pr", pr.Name)
 	return nil
 }
 

--- a/cluster-autoscaler/provisioningrequest/provreqclient/client.go
+++ b/cluster-autoscaler/provisioningrequest/provreqclient/client.go
@@ -62,12 +62,12 @@ func NewProvisioningRequestClient(
 }
 
 // ProvisioningRequest gets a specific ProvisioningRequest CR.
-func (c *ProvisioningRequestClient) ProvisioningRequest(namespace, name string) (*provreqwrapper.ProvisioningRequest, error) {
+func (c *ProvisioningRequestClient) ProvisioningRequest(ctx context.Context, namespace, name string) (*provreqwrapper.ProvisioningRequest, error) {
 	v1PR, err := c.provReqLister.ProvisioningRequests(namespace).Get(name)
 	if err != nil {
 		return nil, err
 	}
-	podTemplates, err := c.FetchPodTemplates(v1PR)
+	podTemplates, err := c.FetchPodTemplates(ctx, v1PR)
 	if err != nil {
 		return nil, fmt.Errorf("while fetching pod templates for Get Provisioning Request %s/%s got error: %v", namespace, name, err)
 	}
@@ -75,14 +75,14 @@ func (c *ProvisioningRequestClient) ProvisioningRequest(namespace, name string) 
 }
 
 // ProvisioningRequests gets all ProvisioningRequest CRs.
-func (c *ProvisioningRequestClient) ProvisioningRequests() ([]*provreqwrapper.ProvisioningRequest, error) {
+func (c *ProvisioningRequestClient) ProvisioningRequests(ctx context.Context) ([]*provreqwrapper.ProvisioningRequest, error) {
 	v1PRs, err := c.provReqLister.List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("error fetching provisioningRequests: %w", err)
 	}
 	prs := make([]*provreqwrapper.ProvisioningRequest, 0, len(v1PRs))
 	for _, v1PR := range v1PRs {
-		podTemplates, errPodTemplates := c.FetchPodTemplates(v1PR)
+		podTemplates, errPodTemplates := c.FetchPodTemplates(ctx, v1PR)
 		if errPodTemplates != nil {
 			return nil, fmt.Errorf("while fetching pod templates for List Provisioning Request %s/%s got error: %v", v1PR.Namespace, v1PR.Name, errPodTemplates)
 		}
@@ -92,7 +92,7 @@ func (c *ProvisioningRequestClient) ProvisioningRequests() ([]*provreqwrapper.Pr
 }
 
 // FetchPodTemplates fetches PodTemplates referenced by the Provisioning Request.
-func (c *ProvisioningRequestClient) FetchPodTemplates(pr *v1.ProvisioningRequest) ([]*apiv1.PodTemplate, error) {
+func (c *ProvisioningRequestClient) FetchPodTemplates(ctx context.Context, pr *v1.ProvisioningRequest) ([]*apiv1.PodTemplate, error) {
 	podTemplates := make([]*apiv1.PodTemplate, 0, len(pr.Spec.PodSets))
 	for _, podSpec := range pr.Spec.PodSets {
 		podTemplate, err := c.podTemplLister.PodTemplates(pr.Namespace).Get(podSpec.PodTemplateRef.Name)
@@ -108,8 +108,8 @@ func (c *ProvisioningRequestClient) FetchPodTemplates(pr *v1.ProvisioningRequest
 }
 
 // UpdateProvisioningRequest updates the given ProvisioningRequest CR by propagating the changes using the ProvisioningRequestInterface and returns the updated instance or the original one in case of an error.
-func (c *ProvisioningRequestClient) UpdateProvisioningRequest(pr *v1.ProvisioningRequest) (*v1.ProvisioningRequest, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), provisioningRequestClientCallTimeout)
+func (c *ProvisioningRequestClient) UpdateProvisioningRequest(logging_ctx context.Context, pr *v1.ProvisioningRequest) (*v1.ProvisioningRequest, error) {
+	ctx, cancel := context.WithTimeout(logging_ctx, provisioningRequestClientCallTimeout)
 	defer cancel()
 
 	updatedPr, err := c.client.AutoscalingV1().ProvisioningRequests(pr.Namespace).UpdateStatus(ctx, pr, metav1.UpdateOptions{})
@@ -121,7 +121,7 @@ func (c *ProvisioningRequestClient) UpdateProvisioningRequest(pr *v1.Provisionin
 }
 
 // ProvisioningRequestsForPods check that all pods belong to one ProvisioningRequest and return it.
-func ProvisioningRequestsForPods(client *ProvisioningRequestClient, unschedulablePods []*apiv1.Pod) []*provreqwrapper.ProvisioningRequest {
+func ProvisioningRequestsForPods(ctx context.Context, client *ProvisioningRequestClient, unschedulablePods []*apiv1.Pod) []*provreqwrapper.ProvisioningRequest {
 	prMap := make(map[string]*provreqwrapper.ProvisioningRequest)
 	prList := []*provreqwrapper.ProvisioningRequest{}
 	if len(unschedulablePods) == 0 {
@@ -132,7 +132,7 @@ func ProvisioningRequestsForPods(client *ProvisioningRequestClient, unschedulabl
 			klog.Errorf("pod %s has no OwnerReference", pod.Name)
 			continue
 		}
-		provReq, err := client.ProvisioningRequest(pod.Namespace, pod.OwnerReferences[0].Name)
+		provReq, err := client.ProvisioningRequest(ctx, pod.Namespace, pod.OwnerReferences[0].Name)
 		if err != nil {
 			klog.Errorf("failed to retrieve ProvisioningRequest from unschedulable pod, err: %v", err)
 			continue
@@ -148,8 +148,8 @@ func ProvisioningRequestsForPods(client *ProvisioningRequestClient, unschedulabl
 }
 
 // DeleteProvisioningRequest deletes the given ProvisioningRequest CR using the ProvisioningRequestInterface and returns an error in case of failure.
-func (c *ProvisioningRequestClient) DeleteProvisioningRequest(pr *v1.ProvisioningRequest) error {
-	ctx, cancel := context.WithTimeout(context.Background(), provisioningRequestClientCallTimeout)
+func (c *ProvisioningRequestClient) DeleteProvisioningRequest(ctx context.Context, pr *v1.ProvisioningRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, provisioningRequestClientCallTimeout)
 	defer cancel()
 
 	err := c.client.AutoscalingV1().ProvisioningRequests(pr.Namespace).Delete(ctx, pr.Name, metav1.DeleteOptions{})
@@ -161,20 +161,20 @@ func (c *ProvisioningRequestClient) DeleteProvisioningRequest(pr *v1.Provisionin
 }
 
 // FilterOutProvisioningClass filters out ProvReqs that belongs to certain Provisioning Class
-func FilterOutProvisioningClass(prList []*provreqwrapper.ProvisioningRequest, class string, checkCapacityProcessorInstance string) []*provreqwrapper.ProvisioningRequest {
+func FilterOutProvisioningClass(ctx context.Context, prList []*provreqwrapper.ProvisioningRequest, class string, checkCapacityProcessorInstance string) []*provreqwrapper.ProvisioningRequest {
 	newPrList := []*provreqwrapper.ProvisioningRequest{}
 	for _, pr := range prList {
-		if matchesProvisioningClass(pr, class, checkCapacityProcessorInstance) {
+		if matchesProvisioningClass(ctx, pr, class, checkCapacityProcessorInstance) {
 			newPrList = append(newPrList, pr)
 		}
 	}
 	return newPrList
 }
 
-func matchesProvisioningClass(pr *provreqwrapper.ProvisioningRequest, class string, checkCapacityProcessorInstance string) bool {
+func matchesProvisioningClass(ctx context.Context, pr *provreqwrapper.ProvisioningRequest, class string, checkCapacityProcessorInstance string) bool {
 	switch class {
 	case v1.ProvisioningClassCheckCapacity:
-		return provisioningrequest.SupportedCheckCapacityClass(pr.ProvisioningRequest, checkCapacityProcessorInstance)
+		return provisioningrequest.SupportedCheckCapacityClass(ctx, pr.ProvisioningRequest, checkCapacityProcessorInstance)
 	case v1.ProvisioningClassBestEffortAtomicScaleUp:
 		return pr.Spec.ProvisioningClassName == v1.ProvisioningClassBestEffortAtomicScaleUp
 	default:

--- a/cluster-autoscaler/provisioningrequest/provreqclient/client_test.go
+++ b/cluster-autoscaler/provisioningrequest/provreqclient/client_test.go
@@ -37,7 +37,7 @@ func TestFetchPodTemplates(t *testing.T) {
 
 	ctx := context.Background()
 	c := NewFakeProvisioningRequestClient(ctx, t, mockProvisioningRequests...)
-	got, err := c.FetchPodTemplates(pr1.ProvisioningRequest)
+	got, err := c.FetchPodTemplates(context.TODO(), pr1.ProvisioningRequest)
 	if err != nil {
 		t.Errorf("provisioningRequestClient.ProvisioningRequests() error: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestProvisioningRequestsForPods(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := ProvisioningRequestsForPods(client, tc.pods)
+			got := ProvisioningRequestsForPods(context.TODO(), client, tc.pods)
 			assert.ElementsMatch(t, got, tc.prs)
 		})
 	}

--- a/cluster-autoscaler/provisioningrequest/provreqclient/testutils.go
+++ b/cluster-autoscaler/provisioningrequest/provreqclient/testutils.go
@@ -139,7 +139,7 @@ func (c *ProvisioningRequestClient) ProvisioningRequestNoCache(namespace, name s
 	if err != nil {
 		return nil, err
 	}
-	podTemplates, err := c.FetchPodTemplates(v1)
+	podTemplates, err := c.FetchPodTemplates(context.TODO(), v1)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (c *ProvisioningRequestClient) ProvisioningRequestsNoCache() ([]*provreqwra
 	}
 	prs := make([]*provreqwrapper.ProvisioningRequest, 0, len(v1s.Items))
 	for _, v1 := range v1s.Items {
-		podTemplates, err := c.FetchPodTemplates(&v1)
+		podTemplates, err := c.FetchPodTemplates(context.TODO(), &v1)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/provisioningrequest/supported_class_test.go
+++ b/cluster-autoscaler/provisioningrequest/supported_class_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provisioningrequest
 
 import (
+	"context"
 	"testing"
 
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
@@ -88,7 +89,7 @@ func TestSupportedProvisioningClass(t *testing.T) {
 					},
 				},
 			}
-			got := SupportedProvisioningClass(pr, test.checkCapacityProcessorInstance)
+			got := SupportedProvisioningClass(context.TODO(), pr, test.checkCapacityProcessorInstance)
 			if test.want != got {
 				t.Errorf("Expected SupportedProvisioningClass result: %v, got: %v", test.want, got)
 			}

--- a/cluster-autoscaler/provisioningrequest/supported_classes.go
+++ b/cluster-autoscaler/provisioningrequest/supported_classes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provisioningrequest
 
 import (
+	"context"
 	"strings"
 
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
@@ -32,7 +33,7 @@ const (
 )
 
 // SupportedProvisioningClass verifies if the ProvisioningRequest with the given checkCapacityProcessorInstance is supported.
-func SupportedProvisioningClass(pr *v1.ProvisioningRequest, checkCapacityProcessorInstance string) bool {
+func SupportedProvisioningClass(ctx context.Context, pr *v1.ProvisioningRequest, checkCapacityProcessorInstance string) bool {
 	if pr.Spec.ProvisioningClassName == v1.ProvisioningClassBestEffortAtomicScaleUp {
 		if checkCapacityProcessorInstance != "" {
 			// If processor instance is set, BestEffortAtomicScaleUp should not be processed.
@@ -41,11 +42,11 @@ func SupportedProvisioningClass(pr *v1.ProvisioningRequest, checkCapacityProcess
 		return true
 	}
 
-	return SupportedCheckCapacityClass(pr, checkCapacityProcessorInstance)
+	return SupportedCheckCapacityClass(ctx, pr, checkCapacityProcessorInstance)
 }
 
 // SupportedCheckCapacityClass verifies if the check capacity ProvisioningRequest with the given checkCapacityProcessorInstance is supported.
-func SupportedCheckCapacityClass(pr *v1.ProvisioningRequest, checkCapacityProcessorInstance string) bool {
+func SupportedCheckCapacityClass(ctx context.Context, pr *v1.ProvisioningRequest, checkCapacityProcessorInstance string) bool {
 	provisioningClassName := pr.Spec.ProvisioningClassName
 	processorInstance := string(pr.Spec.Parameters[CheckCapacityProcessorInstanceKey])
 

--- a/cluster-autoscaler/provisioningrequest/supported_classes.go
+++ b/cluster-autoscaler/provisioningrequest/supported_classes.go
@@ -47,6 +47,7 @@ func SupportedProvisioningClass(ctx context.Context, pr *v1.ProvisioningRequest,
 
 // SupportedCheckCapacityClass verifies if the check capacity ProvisioningRequest with the given checkCapacityProcessorInstance is supported.
 func SupportedCheckCapacityClass(ctx context.Context, pr *v1.ProvisioningRequest, checkCapacityProcessorInstance string) bool {
+	logger := klog.FromContext(ctx)
 	provisioningClassName := pr.Spec.ProvisioningClassName
 	processorInstance := string(pr.Spec.Parameters[CheckCapacityProcessorInstanceKey])
 
@@ -68,7 +69,7 @@ func SupportedCheckCapacityClass(ctx context.Context, pr *v1.ProvisioningRequest
 	if !strings.HasPrefix(provisioningClassName, checkCapacityProcessorInstance) {
 		return false
 	}
-	klog.Warningf("ProvReq %s/%s has prefixed provisioningClassName %q that is not recommended and will be removed in CA 1.35. Parameters should be used instead", pr.Namespace, pr.Name, provisioningClassName)
+	logger.Info("ProvReq has prefixed provisioningClassName that is not recommended and will be removed in CA 1.35. Parameters should be used instead", "namespace", pr.Namespace, "pr", pr.Name, "provisioningClass", provisioningClassName)
 
 	return provisioningClassName[len(checkCapacityProcessorInstance):] == v1.ProvisioningClassCheckCapacity
 }

--- a/cluster-autoscaler/resourcequotas/cache.go
+++ b/cluster-autoscaler/resourcequotas/cache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,14 +45,14 @@ func newNodeResourcesCache(crp customresources.CustomResourcesProcessor) *nodeRe
 // the resources will be calculated. If the node belongs to any node group,
 // the resources will be cached for the entire node group.
 func (nc *nodeResourcesCache) totalNodeResources(
-	autoscalingCtx *cacontext.AutoscalingContext, node *corev1.Node, nodeGroup cloudprovider.NodeGroup,
+	ctx context.Context, autoscalingCtx *cacontext.AutoscalingContext, node *corev1.Node, nodeGroup cloudprovider.NodeGroup,
 ) (resourceList, error) {
 	if nodeGroup != nil {
 		if resources, ok := nc.resources[nodeGroup.Id()]; ok {
 			return resources, nil
 		}
 	}
-	resources, err := totalNodeResources(autoscalingCtx, nc.crp, node, nodeGroup)
+	resources, err := totalNodeResources(ctx, autoscalingCtx, nc.crp, node, nodeGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +63,7 @@ func (nc *nodeResourcesCache) totalNodeResources(
 }
 
 // totalNodeResources calculates the amount of resources that a node contains.
-func totalNodeResources(autoscalingCtx *cacontext.AutoscalingContext, crp customresources.CustomResourcesProcessor, node *corev1.Node, nodeGroup cloudprovider.NodeGroup) (resourceList, error) {
+func totalNodeResources(ctx context.Context, autoscalingCtx *cacontext.AutoscalingContext, crp customresources.CustomResourcesProcessor, node *corev1.Node, nodeGroup cloudprovider.NodeGroup) (resourceList, error) {
 	// TODO: storage?
 	nodeCPU, nodeMemory := utils.GetNodeCoresAndMemory(node)
 	nodeResources := resourceList{
@@ -71,7 +72,7 @@ func totalNodeResources(autoscalingCtx *cacontext.AutoscalingContext, crp custom
 		ResourceNodes:                 1,
 	}
 
-	resourceTargets, err := crp.GetNodeResourceTargets(autoscalingCtx, node, nodeGroup)
+	resourceTargets, err := crp.GetNodeResourceTargets(ctx, autoscalingCtx, node, nodeGroup)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get custom resources: %w", err)
 	}

--- a/cluster-autoscaler/resourcequotas/cache_test.go
+++ b/cluster-autoscaler/resourcequotas/cache_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	gocontext "context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,11 +40,11 @@ type mockCustomResourcesProcessor struct {
 // Verify that mockCustomResourcesProcessor implements the CustomResourcesProcessor interface.
 var _ customresources.CustomResourcesProcessor = &mockCustomResourcesProcessor{}
 
-func (m *mockCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(_ *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+func (m *mockCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx gocontext.Context, _ *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
 	return allNodes, readyNodes
 }
 
-func (m *mockCustomResourcesProcessor) GetNodeResourceTargets(autoscalingCtx *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]customresources.CustomResourceTarget, errors.AutoscalerError) {
+func (m *mockCustomResourcesProcessor) GetNodeResourceTargets(ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]customresources.CustomResourceTarget, errors.AutoscalerError) {
 	args := m.Called(autoscalingCtx, node, nodeGroup)
 	return args.Get(0).([]customresources.CustomResourceTarget), nil
 }
@@ -110,7 +111,7 @@ func TestNodeResourcesCache(t *testing.T) {
 			tc.setupCRPExpectations(&mockCRP.Mock)
 			nc := newNodeResourcesCache(mockCRP)
 			for _, call := range tc.calls {
-				resources, err := nc.totalNodeResources(autoscalingCtx, call.node, call.nodeGroup)
+				resources, err := nc.totalNodeResources(gocontext.TODO(), autoscalingCtx, call.node, call.nodeGroup)
 				if err != nil {
 					t.Fatalf("totalNodeResources unexpected error: %v", err)
 				}
@@ -173,7 +174,7 @@ func TestNodeResources(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &context.AutoscalingContext{}
-			delta, err := totalNodeResources(ctx, tc.crp, tc.node, nil)
+			delta, err := totalNodeResources(gocontext.TODO(), ctx, tc.crp, tc.node, nil)
 			if err != nil {
 				t.Errorf("totalNodeResources: unexpected error: %v", err)
 			}

--- a/cluster-autoscaler/resourcequotas/capacityquota/provider.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/provider.go
@@ -42,6 +42,7 @@ func NewCapacityQuotasProvider(kubeClient client.Client) *Provider {
 
 // Quotas returns quotas built from CapacityQuota resources in the cluster.
 func (p *Provider) Quotas(ctx context.Context) ([]resourcequotas.Quota, error) {
+	logger := klog.FromContext(ctx)
 	capacityQuotas := &cqv1beta1.CapacityQuotaList{}
 	err := p.kubeClient.List(context.TODO(), capacityQuotas)
 	if err != nil {
@@ -50,12 +51,12 @@ func (p *Provider) Quotas(ctx context.Context) ([]resourcequotas.Quota, error) {
 	var quotas []resourcequotas.Quota
 	for _, cq := range capacityQuotas.Items {
 		if !meta.IsStatusConditionTrue(cq.Status.Conditions, ValidCondition) {
-			klog.V(5).Infof("CapacityQuota %q is not valid, skipping", cq.Name)
+			logger.V(5).Info("CapacityQuota is not valid, skipping", "cq", cq.Name)
 			continue
 		}
 		quota, err := newFromCapacityQuota(cq)
 		if err != nil {
-			klog.Errorf("Skipping CapacityQuota %q, err: %v", cq.Name, err)
+			logger.Error(err, "Skipping CapacityQuota", "cq", cq.Name)
 			continue
 		}
 		quotas = append(quotas, quota)

--- a/cluster-autoscaler/resourcequotas/capacityquota/provider.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/provider.go
@@ -41,7 +41,7 @@ func NewCapacityQuotasProvider(kubeClient client.Client) *Provider {
 }
 
 // Quotas returns quotas built from CapacityQuota resources in the cluster.
-func (p *Provider) Quotas() ([]resourcequotas.Quota, error) {
+func (p *Provider) Quotas(ctx context.Context) ([]resourcequotas.Quota, error) {
 	capacityQuotas := &cqv1beta1.CapacityQuotaList{}
 	err := p.kubeClient.List(context.TODO(), capacityQuotas)
 	if err != nil {

--- a/cluster-autoscaler/resourcequotas/capacityquota/provider_test.go
+++ b/cluster-autoscaler/resourcequotas/capacityquota/provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package capacityquota
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -136,7 +137,7 @@ func TestProvider_Quotas(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.existingCQs...).Build()
 			p := &Provider{kubeClient: fakeClient}
 
-			gotQuotas, err := p.Quotas()
+			gotQuotas, err := p.Quotas(context.TODO())
 			if err != nil {
 				t.Fatalf("Provider.Quotas() unexpected error: %v", err)
 			}

--- a/cluster-autoscaler/resourcequotas/factory.go
+++ b/cluster-autoscaler/resourcequotas/factory.go
@@ -76,6 +76,7 @@ func (f *TrackerFactory) NewMinQuotasTracker(ctx gocontext.Context, autoscalingC
 // If isMinEnforcement is true, it calculates headroom to the minimum limit (for scale-down).
 // Otherwise, it calculates headroom to the maximum limit (for scale-up).
 func (f *TrackerFactory) newQuotasTracker(ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node, isMinEnforcement bool) (*Tracker, error) {
+	logger := klog.FromContext(ctx)
 	quotas, err := f.quotasProvider.Quotas(ctx)
 	if err != nil {
 		return nil, err
@@ -88,7 +89,7 @@ func (f *TrackerFactory) newQuotasTracker(ctx gocontext.Context, autoscalingCtx 
 	}
 	var quotaStatuses []*quotaStatus
 	for _, rq := range quotas {
-		klog.V(5).Infof("Quota %q status: limits: %v, usages: %v", rq.ID(), rq.Limits(), usages[rq.ID()])
+		logger.V(5).Info("Quota status: limits, usages", "rqId", rq.ID(), "limits", rq.Limits(), "usages", usages[rq.ID()])
 		limitsLeft := make(resourceList)
 		limits := rq.Limits()
 		for resourceType, limit := range limits {

--- a/cluster-autoscaler/resourcequotas/factory.go
+++ b/cluster-autoscaler/resourcequotas/factory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	gocontext "context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
@@ -51,15 +52,15 @@ func NewTrackerFactory(opts TrackerOptions) *TrackerFactory {
 // NewMaxQuotasTracker calculates resources used by the nodes for every
 // quota returned by the Provider. Then, based on usages and limits it calculates
 // how many resources can be still added to the cluster. Returns a Tracker object.
-func (f *TrackerFactory) NewMaxQuotasTracker(autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node) (*Tracker, error) {
-	return f.newQuotasTracker(autoscalingCtx, nodes, false /* isMinEnforcement */)
+func (f *TrackerFactory) NewMaxQuotasTracker(ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node) (*Tracker, error) {
+	return f.newQuotasTracker(ctx, autoscalingCtx, nodes, false /* isMinEnforcement */)
 }
 
 // NewQuotasTracker builds a new Tracker for maximum limits enforcement.
 //
 // Deprecated: Use NewMaxQuotasTracker instead.
-func (f *TrackerFactory) NewQuotasTracker(autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node) (*Tracker, error) {
-	return f.NewMaxQuotasTracker(autoscalingCtx, nodes)
+func (f *TrackerFactory) NewQuotasTracker(ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node) (*Tracker, error) {
+	return f.NewMaxQuotasTracker(ctx, autoscalingCtx, nodes)
 }
 
 // NewMinQuotasTracker builds a new Tracker for minimum limits enforcement.
@@ -67,21 +68,21 @@ func (f *TrackerFactory) NewQuotasTracker(autoscalingCtx *context.AutoscalingCon
 // NewMinQuotasTracker calculates resources used by the nodes for every
 // quota returned by the Provider. Then, based on usages and limits it calculates
 // how many resources can be still removed from the cluster. Returns a Tracker object.
-func (f *TrackerFactory) NewMinQuotasTracker(autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node) (*Tracker, error) {
-	return f.newQuotasTracker(autoscalingCtx, nodes, true /* isMinEnforcement */)
+func (f *TrackerFactory) NewMinQuotasTracker(ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node) (*Tracker, error) {
+	return f.newQuotasTracker(ctx, autoscalingCtx, nodes, true /* isMinEnforcement */)
 }
 
 // newQuotasTracker builds a new Tracker for either minimum or maximum limits enforcement.
 // If isMinEnforcement is true, it calculates headroom to the minimum limit (for scale-down).
 // Otherwise, it calculates headroom to the maximum limit (for scale-up).
-func (f *TrackerFactory) newQuotasTracker(autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node, isMinEnforcement bool) (*Tracker, error) {
-	quotas, err := f.quotasProvider.Quotas()
+func (f *TrackerFactory) newQuotasTracker(ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node, isMinEnforcement bool) (*Tracker, error) {
+	quotas, err := f.quotasProvider.Quotas(ctx)
 	if err != nil {
 		return nil, err
 	}
 	nc := newNodeResourcesCache(f.crp)
 	uc := newUsageCalculator(f.nodeFilter, nc)
-	usages, err := uc.calculateUsages(autoscalingCtx, nodes, quotas)
+	usages, err := uc.calculateUsages(ctx, autoscalingCtx, nodes, quotas)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/resourcequotas/factory_test.go
+++ b/cluster-autoscaler/resourcequotas/factory_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	gocontext "context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -228,12 +229,12 @@ func TestNewMaxQuotasTracker(t *testing.T) {
 				QuotaProvider:            NewCloudQuotasProvider(cloudProvider),
 				NodeFilter:               tc.nodeFilter,
 			})
-			tracker, err := factory.NewMaxQuotasTracker(ctx, tc.nodes)
+			tracker, err := factory.NewMaxQuotasTracker(gocontext.TODO(), ctx, tc.nodes)
 			if err != nil {
 				t.Errorf("failed to create tracker: %v", err)
 			}
 			var ng cloudprovider.NodeGroup
-			result, err := tracker.CheckQuota(ctx, ng, tc.newNode, tc.nodeDelta)
+			result, err := tracker.CheckQuota(gocontext.TODO(), ctx, ng, tc.newNode, tc.nodeDelta)
 			if err != nil {
 				t.Errorf("failed to check delta: %v", err)
 			}
@@ -429,12 +430,12 @@ func TestNewMinQuotasTracker(t *testing.T) {
 				QuotaProvider:            NewFakeProvider([]Quota{tc.quota}),
 				NodeFilter:               tc.nodeFilter,
 			})
-			tracker, err := factory.NewMinQuotasTracker(ctx, tc.nodes)
+			tracker, err := factory.NewMinQuotasTracker(gocontext.TODO(), ctx, tc.nodes)
 			if err != nil {
 				t.Errorf("failed to create tracker: %v", err)
 			}
 			var ng cloudprovider.NodeGroup
-			result, err := tracker.CheckQuota(ctx, ng, tc.newNode, tc.nodeDelta)
+			result, err := tracker.CheckQuota(gocontext.TODO(), ctx, ng, tc.newNode, tc.nodeDelta)
 			if err != nil {
 				t.Errorf("failed to check quota: %v", err)
 			}

--- a/cluster-autoscaler/resourcequotas/provider.go
+++ b/cluster-autoscaler/resourcequotas/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	"context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
@@ -24,7 +25,7 @@ import (
 // Provider provides Quotas. Each Provider implementation acts as a different
 // source of Quotas.
 type Provider interface {
-	Quotas() ([]Quota, error)
+	Quotas(context.Context) ([]Quota, error)
 }
 
 // CloudQuotasProvider is an adapter for cloudprovider.ResourceLimiter.
@@ -35,7 +36,7 @@ type CloudQuotasProvider struct {
 // Quotas returns the cloud provider's ResourceLimiter, which implements Quota interface.
 //
 // This acts as a compatibility layer with the legacy resource LimitsVal system.
-func (p *CloudQuotasProvider) Quotas() ([]Quota, error) {
+func (p *CloudQuotasProvider) Quotas(ctx context.Context) ([]Quota, error) {
 	rl, err := p.cloudProvider.GetResourceLimiter()
 	if err != nil {
 		return nil, err
@@ -63,10 +64,10 @@ func NewCombinedQuotasProvider(providers []Provider) *CombinedQuotasProvider {
 }
 
 // Quotas returns a union of quotas from all wrapped providers.
-func (p *CombinedQuotasProvider) Quotas() ([]Quota, error) {
+func (p *CombinedQuotasProvider) Quotas(ctx context.Context) ([]Quota, error) {
 	var allQuotas []Quota
 	for _, provider := range p.providers {
-		quotas, err := provider.Quotas()
+		quotas, err := provider.Quotas(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -111,7 +112,7 @@ type CloudMinProvider struct {
 }
 
 // Quotas returns the minimum quotas from the cloud provider.
-func (p *CloudMinProvider) Quotas() ([]Quota, error) {
+func (p *CloudMinProvider) Quotas(ctx context.Context) ([]Quota, error) {
 	rl, err := p.cloudProvider.GetResourceLimiter()
 	if err != nil {
 		return nil, err
@@ -130,7 +131,7 @@ type CloudMaxProvider struct {
 }
 
 // Quotas returns the maximum quotas from the cloud provider.
-func (p *CloudMaxProvider) Quotas() ([]Quota, error) {
+func (p *CloudMaxProvider) Quotas(ctx context.Context) ([]Quota, error) {
 	rl, err := p.cloudProvider.GetResourceLimiter()
 	if err != nil {
 		return nil, err

--- a/cluster-autoscaler/resourcequotas/provider_test.go
+++ b/cluster-autoscaler/resourcequotas/provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -33,7 +34,7 @@ func TestCloudLimitersProvider(t *testing.T) {
 	cloudProvider.SetResourceLimiter(resourceLimiter)
 
 	quotasProvider := NewCloudQuotasProvider(cloudProvider)
-	quotas, err := quotasProvider.Quotas()
+	quotas, err := quotasProvider.Quotas(context.TODO())
 	if err != nil {
 		t.Errorf("failed to get quotas: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestCombinedQuotasProvider(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			provider := NewCombinedQuotasProvider(tc.providers)
-			quotas, err := provider.Quotas()
+			quotas, err := provider.Quotas(context.TODO())
 
 			if !errors.Is(err, tc.wantErr) {
 				t.Errorf("Quotas() err mismatch: got %v, want %v", err, tc.wantErr)
@@ -147,7 +148,7 @@ func TestCloudMinProvider(t *testing.T) {
 	cloudProvider.SetResourceLimiter(resourceLimiter)
 
 	quotasProvider := NewCloudMinProvider(cloudProvider)
-	quotas, err := quotasProvider.Quotas()
+	quotas, err := quotasProvider.Quotas(context.TODO())
 	if err != nil {
 		t.Errorf("failed to get quotas: %v", err)
 	}
@@ -167,7 +168,7 @@ func TestCloudMaxProvider(t *testing.T) {
 	cloudProvider.SetResourceLimiter(resourceLimiter)
 
 	quotasProvider := NewCloudMaxProvider(cloudProvider)
-	quotas, err := quotasProvider.Quotas()
+	quotas, err := quotasProvider.Quotas(context.TODO())
 	if err != nil {
 		t.Errorf("failed to get quotas: %v", err)
 	}

--- a/cluster-autoscaler/resourcequotas/testutils.go
+++ b/cluster-autoscaler/resourcequotas/testutils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	gocontext "context"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
@@ -44,11 +45,11 @@ type fakeCustomResourcesProcessor struct {
 // Verify that fakeCustomResourcesProcessor implements the CustomResourcesProcessor interface.
 var _ customresources.CustomResourcesProcessor = &fakeCustomResourcesProcessor{}
 
-func (f *fakeCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+func (f *fakeCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(ctx gocontext.Context, context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, draSnapshot *drasnapshot.Snapshot, csiSnapshot *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
 	return allNodes, readyNodes
 }
 
-func (f *fakeCustomResourcesProcessor) GetNodeResourceTargets(context *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]customresources.CustomResourceTarget, errors.AutoscalerError) {
+func (f *fakeCustomResourcesProcessor) GetNodeResourceTargets(ctx gocontext.Context, context *context.AutoscalingContext, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]customresources.CustomResourceTarget, errors.AutoscalerError) {
 	if f.NodeResourceTargets == nil {
 		return nil, nil
 	}
@@ -92,7 +93,7 @@ type FakeProvider struct {
 }
 
 // Quotas returns quotas or error explicitly passed to the fake provider.
-func (f *FakeProvider) Quotas() ([]Quota, error) {
+func (f *FakeProvider) Quotas(ctx gocontext.Context) ([]Quota, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/cluster-autoscaler/resourcequotas/tracker.go
+++ b/cluster-autoscaler/resourcequotas/tracker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	gocontext "context"
 	"errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -70,12 +71,12 @@ func newTracker(quotaStatuses []*quotaStatus, nodeCache *nodeResourcesCache) *Tr
 //
 // WARNING: nodeDelta must be non-negative. It is a magnitude/absolute value, so when removing a node, nodeDelta would be 1, not -1.
 func (t *Tracker) ConsumeQuota(
-	autoscalingCtx *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup, node *corev1.Node, nodeDelta int,
+	ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup, node *corev1.Node, nodeDelta int,
 ) (*CheckDeltaResult, error) {
 	if nodeDelta < 0 {
 		return nil, ErrNegativeDelta
 	}
-	delta, err := t.nodeCache.totalNodeResources(autoscalingCtx, node, nodeGroup)
+	delta, err := t.nodeCache.totalNodeResources(ctx, autoscalingCtx, node, nodeGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (t *Tracker) ConsumeQuota(
 func (t *Tracker) ApplyDelta(
 	autoscalingCtx *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup, node *corev1.Node, nodeDelta int,
 ) (*CheckDeltaResult, error) {
-	return t.ConsumeQuota(autoscalingCtx, nodeGroup, node, nodeDelta)
+	return t.ConsumeQuota(gocontext.TODO(), autoscalingCtx, nodeGroup, node, nodeDelta)
 }
 
 // CheckQuota checks if a delta is within limits and returns a struct containing information
@@ -119,12 +120,12 @@ func (t *Tracker) ApplyDelta(
 // are taken from the template node passed via the node parameter. nodeGroup is required to fetch
 // the custom resources, such as GPU.
 func (t *Tracker) CheckQuota(
-	autoscalingCtx *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup, node *corev1.Node, nodeDelta int,
+	ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup, node *corev1.Node, nodeDelta int,
 ) (*CheckDeltaResult, error) {
 	if nodeDelta < 0 {
 		return nil, ErrNegativeDelta
 	}
-	delta, err := t.nodeCache.totalNodeResources(autoscalingCtx, node, nodeGroup)
+	delta, err := t.nodeCache.totalNodeResources(ctx, autoscalingCtx, node, nodeGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func (t *Tracker) CheckQuota(
 func (t *Tracker) CheckDelta(
 	autoscalingCtx *context.AutoscalingContext, nodeGroup cloudprovider.NodeGroup, node *corev1.Node, nodeDelta int,
 ) (*CheckDeltaResult, error) {
-	return t.CheckQuota(autoscalingCtx, nodeGroup, node, nodeDelta)
+	return t.CheckQuota(gocontext.TODO(), autoscalingCtx, nodeGroup, node, nodeDelta)
 }
 
 func (t *Tracker) checkQuota(delta resourceList, matchingQuotas []*quotaStatus, nodeDelta int) *CheckDeltaResult {

--- a/cluster-autoscaler/resourcequotas/tracker_test.go
+++ b/cluster-autoscaler/resourcequotas/tracker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	gocontext "context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -228,7 +229,7 @@ func TestCheckQuota(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			provider := cptest.NewTestCloudProviderBuilder().Build()
 			ctx := &context.AutoscalingContext{CloudProvider: provider}
-			gotResult, err := tc.tracker.CheckQuota(ctx, nil, tc.node, tc.nodeDelta)
+			gotResult, err := tc.tracker.CheckQuota(gocontext.TODO(), ctx, nil, tc.node, tc.nodeDelta)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("CheckQuota() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -360,7 +361,7 @@ func TestConsumeQuota(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			provider := cptest.NewTestCloudProviderBuilder().Build()
 			ctx := &context.AutoscalingContext{CloudProvider: provider}
-			gotResult, err := tc.tracker.ConsumeQuota(ctx, nil, tc.node, tc.nodeDelta)
+			gotResult, err := tc.tracker.ConsumeQuota(gocontext.TODO(), ctx, nil, tc.node, tc.nodeDelta)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("ConsumeQuota() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/cluster-autoscaler/resourcequotas/usage.go
+++ b/cluster-autoscaler/resourcequotas/usage.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	gocontext "context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -64,7 +65,7 @@ func newUsageCalculator(nodeFilter NodeFilter, nodeCache *nodeResourcesCache) *u
 
 // calculateUsages calculates resources used by nodes for every quota.
 // Returns a map with quota ID as a key and resources used in the corresponding quota as a value.
-func (u *usageCalculator) calculateUsages(autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node, quotas []Quota) (map[string]resourceList, error) {
+func (u *usageCalculator) calculateUsages(ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node, quotas []Quota) (map[string]resourceList, error) {
 	usages := make(map[string]resourceList)
 	for _, rl := range quotas {
 		usages[rl.ID()] = make(resourceList)
@@ -79,7 +80,7 @@ func (u *usageCalculator) calculateUsages(autoscalingCtx *context.AutoscalingCon
 		if err != nil {
 			return nil, fmt.Errorf("failed to get node group for node %q: %w", node.Name, err)
 		}
-		delta, err := u.nodeCache.totalNodeResources(autoscalingCtx, node, ng)
+		delta, err := u.nodeCache.totalNodeResources(ctx, autoscalingCtx, node, ng)
 		if err != nil {
 			return nil, err
 		}

--- a/cluster-autoscaler/resourcequotas/usage_test.go
+++ b/cluster-autoscaler/resourcequotas/usage_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcequotas
 
 import (
+	gocontext "context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -199,7 +200,7 @@ func TestCalculateUsages(t *testing.T) {
 				nf = &fakeNodeFilter{NodeFilterFn: tc.nodeFilter}
 			}
 			calculator := newUsageCalculator(nf, newNodeResourcesCache(crp))
-			usages, err := calculator.calculateUsages(ctx, tc.nodes, tc.quotas)
+			usages, err := calculator.calculateUsages(gocontext.TODO(), ctx, tc.nodes, tc.quotas)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -175,7 +176,7 @@ func NewRemovalSimulator(listers kube_util.ListerRegistry, clusterSnapshot clust
 // the outcome, exactly one of (NodeToBeRemoved, UnremovableNode) will be
 // populated in the return value, the other will be nil.
 func (r *RemovalSimulator) SimulateNodeRemoval(
-	nodeName string,
+	ctx context.Context, nodeName string,
 	destinationMap map[string]bool,
 	timestamp time.Time,
 	remainingPdbTracker pdb.RemainingPdbTracker,
@@ -192,7 +193,7 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 	}
 	klog.V(2).Infof("Simulating node %s removal", nodeName)
 
-	podMoveInfo, err := GetPodsToMove(nodeInfo, r.deleteOptions, r.drainabilityRules, r.listers, remainingPdbTracker, timestamp)
+	podMoveInfo, err := GetPodsToMove(ctx, nodeInfo, r.deleteOptions, r.drainabilityRules, r.listers, remainingPdbTracker, timestamp)
 	if err != nil {
 		klog.V(2).Infof("Node %s cannot be removed: %v", nodeName, err)
 		if podMoveInfo.BlockingPod != nil {
@@ -201,8 +202,8 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 		return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: UnexpectedError}
 	}
 
-	err = r.withForkedSnapshot(func() error {
-		return r.findPlaceFor(nodeName, podMoveInfo.Pods, destinationMap, timestamp)
+	err = r.withForkedSnapshot(ctx, func() error {
+		return r.findPlaceFor(ctx, nodeName, podMoveInfo.Pods, destinationMap, timestamp)
 	})
 	if err != nil {
 		klog.V(2).Infof("Node %s is not suitable for removal: %v", nodeName, err)
@@ -217,7 +218,7 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 	}, nil
 }
 
-func (r *RemovalSimulator) withForkedSnapshot(f func() error) (err error) {
+func (r *RemovalSimulator) withForkedSnapshot(ctx context.Context, f func() error) (err error) {
 	r.clusterSnapshot.Fork()
 	defer func() {
 		if err == nil && r.canPersist {
@@ -233,7 +234,7 @@ func (r *RemovalSimulator) withForkedSnapshot(f func() error) (err error) {
 	return err
 }
 
-func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, nodes map[string]bool, timestamp time.Time) error {
+func (r *RemovalSimulator) findPlaceFor(ctx context.Context, removedNode string, pods []*apiv1.Pod, nodes map[string]bool, timestamp time.Time) error {
 	isCandidateNode := func(nodeInfo *framework.NodeInfo) bool {
 		return nodeInfo.Node().Name != removedNode && nodes[nodeInfo.Node().Name]
 	}
@@ -248,7 +249,7 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
 		}
 	}
 
-	if err := r.replaceWithTaintedGhostNode(removedNode, timestamp); err != nil {
+	if err := r.replaceWithTaintedGhostNode(ctx, removedNode, timestamp); err != nil {
 		return err
 	}
 
@@ -259,7 +260,7 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
 		newpods = append(newpods, &newpod)
 	}
 
-	statuses, _, err := r.schedulingSimulator.TrySchedulePods(r.clusterSnapshot, newpods, true, clustersnapshot.SchedulingOptions{IsNodeAcceptable: isCandidateNode})
+	statuses, _, err := r.schedulingSimulator.TrySchedulePods(ctx, r.clusterSnapshot, newpods, true, clustersnapshot.SchedulingOptions{IsNodeAcceptable: isCandidateNode})
 	if err != nil {
 		return err
 	}
@@ -270,7 +271,7 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
 	// After successful scheduling simulation, remove the tainted ghost node so that
 	// persisted snapshot state (used by subsequent simulations when canPersist=true)
 	// correctly reflects the node being gone.
-	return r.clusterSnapshot.RemoveNodeInfo(removedNode)
+	return r.clusterSnapshot.RemoveNodeInfo(ctx, removedNode)
 }
 
 // replaceWithTaintedGhostNode replaces the given node in the snapshot with a
@@ -282,12 +283,12 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
 // though pods can't schedule on them. Removing the node entirely would
 // eliminate its domain from topology calculations, making the simulation
 // overly optimistic and causing scale-down/scale-up oscillation.
-func (r *RemovalSimulator) replaceWithTaintedGhostNode(nodeName string, timestamp time.Time) error {
+func (r *RemovalSimulator) replaceWithTaintedGhostNode(ctx context.Context, nodeName string, timestamp time.Time) error {
 	nodeInfo, err := r.clusterSnapshot.GetNodeInfo(nodeName)
 	if err != nil {
 		return fmt.Errorf("couldn't get NodeInfo for removed node %s: %v", nodeName, err)
 	}
-	if err = r.clusterSnapshot.RemoveNodeInfo(nodeName); err != nil {
+	if err = r.clusterSnapshot.RemoveNodeInfo(ctx, nodeName); err != nil {
 		return fmt.Errorf("couldn't remove NodeInfo for %s: %v", nodeName, err)
 	}
 	taintedNode := nodeInfo.Node().DeepCopy()

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -181,9 +181,10 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 	timestamp time.Time,
 	remainingPdbTracker pdb.RemainingPdbTracker,
 ) (*NodeToBeRemoved, *UnremovableNode) {
+	logger := klog.FromContext(ctx)
 	nodeInfo, err := r.clusterSnapshot.GetNodeInfo(nodeName)
 	if err != nil {
-		klog.Errorf("Can't retrieve node %s from snapshot, err: %v", nodeName, err)
+		logger.Error(err, "Can't retrieve node from snapshot", "node", nodeName)
 		unremovableReason := UnexpectedError
 		if errors.Is(err, clustersnapshot.ErrNodeNotFound) {
 			unremovableReason = NoNodeInfo
@@ -191,11 +192,11 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 		unremovableNode := &UnremovableNode{Node: &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}, Reason: unremovableReason}
 		return nil, unremovableNode
 	}
-	klog.V(2).Infof("Simulating node %s removal", nodeName)
+	logger.V(2).Info("Simulating node removal", "node", nodeName)
 
 	podMoveInfo, err := GetPodsToMove(ctx, nodeInfo, r.deleteOptions, r.drainabilityRules, r.listers, remainingPdbTracker, timestamp)
 	if err != nil {
-		klog.V(2).Infof("Node %s cannot be removed: %v", nodeName, err)
+		logger.V(2).Info("Node cannot be removed", "node", nodeName, "err", err)
 		if podMoveInfo.BlockingPod != nil {
 			return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: BlockedByPod, BlockingPod: podMoveInfo.BlockingPod}
 		}
@@ -206,10 +207,10 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 		return r.findPlaceFor(ctx, nodeName, podMoveInfo.Pods, destinationMap, timestamp)
 	})
 	if err != nil {
-		klog.V(2).Infof("Node %s is not suitable for removal: %v", nodeName, err)
+		logger.V(2).Info("Node is not suitable for removal", "node", nodeName, "err", err)
 		return nil, &UnremovableNode{Node: nodeInfo.Node(), Reason: NoPlaceToMovePods}
 	}
-	klog.V(2).Infof("Node %s may be removed", nodeName)
+	logger.V(2).Info("Node may be removed", "node", nodeName)
 	return &NodeToBeRemoved{
 		Node:             nodeInfo.Node(),
 		PodsToReschedule: podMoveInfo.Pods,
@@ -235,6 +236,7 @@ func (r *RemovalSimulator) withForkedSnapshot(ctx context.Context, f func() erro
 }
 
 func (r *RemovalSimulator) findPlaceFor(ctx context.Context, removedNode string, pods []*apiv1.Pod, nodes map[string]bool, timestamp time.Time) error {
+	logger := klog.FromContext(ctx)
 	isCandidateNode := func(nodeInfo *framework.NodeInfo) bool {
 		return nodeInfo.Node().Name != removedNode && nodes[nodeInfo.Node().Name]
 	}
@@ -245,7 +247,7 @@ func (r *RemovalSimulator) findPlaceFor(ctx context.Context, removedNode string,
 	for _, pod := range pods {
 		if err := r.clusterSnapshot.UnschedulePod(pod.Namespace, pod.Name, removedNode); err != nil {
 			// just log error
-			klog.Errorf("Simulating removal of %s/%s return error; %v", pod.Namespace, pod.Name, err)
+			logger.Error(err, "Simulating removal return error", "namespace", pod.Namespace, "pod", pod.Name)
 		}
 	}
 

--- a/cluster-autoscaler/simulator/cluster_scheduling_test.go
+++ b/cluster-autoscaler/simulator/cluster_scheduling_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -127,7 +128,7 @@ func TestTopologySpreadTaintScheduling(t *testing.T) {
 			replacementPod.Labels = map[string]string{"app": "topo-app"}
 			replacementPod.Spec.TopologySpreadConstraints = []apiv1.TopologySpreadConstraint{tc.tsc}
 
-			nodeName, schedErr := snapshot.SchedulePodOnAnyNodeMatching(replacementPod, clustersnapshot.SchedulingOptions{
+			nodeName, schedErr := snapshot.SchedulePodOnAnyNodeMatching(context.TODO(), replacementPod, clustersnapshot.SchedulingOptions{
 				IsNodeAcceptable: func(ni *framework.NodeInfo) bool {
 					return true
 				},

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -229,7 +230,7 @@ func TestSimulateNodeRemoval(t *testing.T) {
 			}
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, clusterSnapshot, test.allNodes, test.pods)
 			r := NewRemovalSimulator(registry, clusterSnapshot, testDeleteOptions(), nil, false)
-			toRemove, unremovable := r.SimulateNodeRemoval(test.nodeName, destinations, time.Now(), nil)
+			toRemove, unremovable := r.SimulateNodeRemoval(context.TODO(), test.nodeName, destinations, time.Now(), nil)
 			assert.Equal(t, test.toRemove, toRemove)
 			assert.Equal(t, test.unremovable, unremovable)
 		})

--- a/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/clustersnapshot.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clustersnapshot
 
 import (
+	"context"
 	"errors"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -56,7 +57,7 @@ type ClusterSnapshot interface {
 	AddNodeInfo(nodeInfo *framework.NodeInfo) error
 	// RemoveNodeInfo removes the given NodeInfo from the snapshot.
 	// The Node and the Pods are removed, as well as any DRA and CSI objects owned by them.
-	RemoveNodeInfo(nodeName string) error
+	RemoveNodeInfo(ctx context.Context, nodeName string) error
 	// GetNodeInfo returns an internal NodeInfo for a given Node - all information about the Node tracked in the snapshot.
 	// The returned framework.NodeInfo is fully populated with DRA and CSI data.
 	// The internal NodeInfos obtained via this method should always be used in CA code instead of directly using *schedulerframework.NodeInfo.
@@ -78,14 +79,14 @@ type ClusterSnapshot interface {
 	// all relevant DRA objects are modified to reflect that. Returns nil if the pod got scheduled, and a non-nil
 	// error explaining why not otherwise. The error Type() can be checked against SchedulingInternalError to distinguish
 	// failing predicates from unexpected errors.
-	SchedulePod(pod *apiv1.Pod, nodeName string) SchedulingError
+	SchedulePod(ctx context.Context, pod *apiv1.Pod, nodeName string) SchedulingError
 	// SchedulePodOnAnyNodeMatching tries to schedule the given Pod on any Node for which opts.IsNodeAcceptable returns
 	// true. Scheduling predicates are checked, and the pod is scheduled only if there is a matching Node with passing
 	// predicates. If the pod is scheduled, all relevant DRA objects are modified to reflect that, and the name of the
 	// Node its scheduled on and nil are returned. If the pod can't be scheduled on any Node, an empty string and a non-nil
 	// error explaining why are returned. The error Type() can be checked against SchedulingInternalError to distinguish
 	// failing predicates from unexpected errors.
-	SchedulePodOnAnyNodeMatching(pod *apiv1.Pod, opts SchedulingOptions) (matchingNode string, err SchedulingError)
+	SchedulePodOnAnyNodeMatching(ctx context.Context, pod *apiv1.Pod, opts SchedulingOptions) (matchingNode string, err SchedulingError)
 	// UnschedulePod removes the given Pod from the given Node inside the snapshot, and modifies all relevant DRA objects
 	// to reflect the removal. The pod can then be scheduled on another Node in the snapshot using the Schedule methods.
 	UnschedulePod(namespace string, podName string, nodeName string) error
@@ -93,7 +94,7 @@ type ClusterSnapshot interface {
 	// CheckPredicates runs scheduler predicates to check if the given Pod would be able to schedule on the Node with the given
 	// name. Returns nil if predicates pass, or a non-nil error specifying why they didn't otherwise. The error Type() can be
 	// checked against SchedulingInternalError to distinguish failing predicates from unexpected errors. Doesn't mutate the snapshot.
-	CheckPredicates(pod *apiv1.Pod, nodeName string) SchedulingError
+	CheckPredicates(ctx context.Context, pod *apiv1.Pod, nodeName string) SchedulingError
 
 	// DraSnapshot returns an interface that allows accessing and modifying the DRA objects in the snapshot.
 	DraSnapshot() *drasnapshot.Snapshot
@@ -121,7 +122,7 @@ type ClusterSnapshotStore interface {
 	StoreNodeInfo(nodeInfo *framework.NodeInfo) error
 	// RemoveNodeInfo removes the given *framework.NodeInfo from the snapshot.
 	// This shouldn't be used outside the clustersnapshot pkg, use ClusterSnapshot.RemoveNodeInfo() instead.
-	RemoveNodeInfo(nodeName string) error
+	RemoveNodeInfo(ctx context.Context, nodeName string) error
 
 	// Clear resets the snapshot to an empty, unforked state.
 	Clear()

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner.go
@@ -51,7 +51,7 @@ func NewSchedulerPluginRunner(fwHandle *framework.Handle, snapshot clustersnapsh
 
 // RunFiltersUntilPassingNode runs the scheduler framework PreFilter phase once, and then keeps running the Filter phase for all nodes in the cluster that match the
 // opts.IsNodeAcceptable function - until a Node where the Filters pass is found. Filters are only run for matching Nodes. If no matching Node with passing Filters is found, an error is returned.
-func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts clustersnapshot.SchedulingOptions) (*apiv1.Node, *schedulerimpl.CycleState, clustersnapshot.SchedulingError) {
+func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(ctx context.Context, pod *apiv1.Pod, opts clustersnapshot.SchedulingOptions) (*apiv1.Node, *schedulerimpl.CycleState, clustersnapshot.SchedulingError) {
 	nodeInfosList, err := p.snapshot.ListNodeInfos()
 	if err != nil {
 		return nil, nil, clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("error listing NodeInfos: %v", err))
@@ -61,10 +61,11 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 	defer p.fwHandle.DelegatingLister.ResetDelegate()
 
 	state := schedulerimpl.NewCycleState()
+	ctx = context.WithoutCancel(ctx)
 	// Run the PreFilter phase of the framework for the Pod. This allows plugins to precompute some things (for all Nodes in the cluster at once) and
 	// save them in the CycleState. During the Filter phase, plugins can retrieve the precomputes from the CycleState and use them for answering the Filter
 	// for a given Node.
-	preFilterResult, preFilterStatus, _ := p.fwHandle.Framework.RunPreFilterPlugins(context.TODO(), state, pod)
+	preFilterResult, preFilterStatus, _ := p.fwHandle.Framework.RunPreFilterPlugins(ctx, state, pod)
 	if !preFilterStatus.IsSuccess() {
 		// If any of the plugin PreFilter methods isn't successful, the corresponding Filter method can't be run, so the whole scheduling cycle is aborted.
 		// Match that behavior here.
@@ -84,7 +85,7 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 
 	nodeOrdering.Reset(nodeInfosList)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	cancellableCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	earliestMatch := len(nodeInfosList)
 
@@ -117,7 +118,7 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 
 		// Run the Filter phase of the framework. Plugins retrieve the state they saved during PreFilter from CycleState, and answer whether the
 		// given Pod can be scheduled on the given Node.
-		filterStatus := p.fwHandle.Framework.RunFilterPlugins(context.TODO(), state, pod, nodeInfo)
+		filterStatus := p.fwHandle.Framework.RunFilterPlugins(ctx, state, pod, nodeInfo)
 		if filterStatus.IsSuccess() {
 			// Filter passed for all plugins, so this pod can be scheduled on this Node.
 			mu.Lock()
@@ -132,7 +133,7 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 		// Filter didn't pass for some plugin, so this Node won't work - move on to the next one.
 	}
 
-	workqueue.ParallelizeUntil(ctx, p.parallelism, len(nodeInfosList), checkNode, workqueue.WithChunkSize(chunkSizeFor(len(nodeInfosList), p.parallelism)))
+	workqueue.ParallelizeUntil(cancellableCtx, p.parallelism, len(nodeInfosList), checkNode, workqueue.WithChunkSize(chunkSizeFor(len(nodeInfosList), p.parallelism)))
 
 	if foundNode != nil {
 		nodeOrdering.MarkMatch(foundIndex)
@@ -143,7 +144,7 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 }
 
 // RunFiltersOnNode runs the scheduler framework PreFilter and Filter phases to check if the given pod can be scheduled on the given node.
-func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string) (*apiv1.Node, *schedulerimpl.CycleState, clustersnapshot.SchedulingError) {
+func (p *SchedulerPluginRunner) RunFiltersOnNode(ctx context.Context, pod *apiv1.Pod, nodeName string) (*apiv1.Node, *schedulerimpl.CycleState, clustersnapshot.SchedulingError) {
 	nodeInfo, err := p.snapshot.GetNodeInfo(nodeName)
 	if err != nil {
 		return nil, nil, clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("error obtaining NodeInfo for name %q: %v", nodeName, err))
@@ -153,8 +154,9 @@ func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string
 	defer p.fwHandle.DelegatingLister.ResetDelegate()
 
 	state := schedulerimpl.NewCycleState()
+	ctx = context.WithoutCancel(ctx)
 	// Run the PreFilter phase of the framework for the Pod and check the results. See the corresponding comments in RunFiltersUntilPassingNode() for more info.
-	preFilterResult, preFilterStatus, nodeFilteringPlugins := p.fwHandle.Framework.RunPreFilterPlugins(context.TODO(), state, pod)
+	preFilterResult, preFilterStatus, nodeFilteringPlugins := p.fwHandle.Framework.RunPreFilterPlugins(ctx, state, pod)
 	if !preFilterStatus.IsSuccess() {
 		// nil check on preFilterStatus not required, as IsSuccess returns true for nil
 		return nil, nil, clustersnapshot.NewFailingPredicateError(pod, preFilterStatus.Plugin(), preFilterStatus.Reasons(), "PreFilter failed", "")
@@ -165,7 +167,7 @@ func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string
 	}
 
 	// Run the Filter phase of the framework for the Pod and the Node and check the results. See the corresponding comments in RunFiltersUntilPassingNode() for more info.
-	filterStatus := p.fwHandle.Framework.RunFilterPlugins(context.TODO(), state, pod, nodeInfo)
+	filterStatus := p.fwHandle.Framework.RunFilterPlugins(ctx, state, pod, nodeInfo)
 	if !filterStatus.IsSuccess() {
 		filterName := filterStatus.Plugin()
 		filterReasons := filterStatus.Reasons()

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/plugin_runner_test.go
@@ -175,7 +175,7 @@ func TestRunFiltersOnNode(t *testing.T) {
 			err = snapshot.AddNodeInfo(framework.NewTestNodeInfo(tt.node, tt.scheduledPods...))
 			assert.NoError(t, err)
 
-			node, state, predicateError := pluginRunner.RunFiltersOnNode(tt.testPod, tt.node.Name)
+			node, state, predicateError := pluginRunner.RunFiltersOnNode(context.TODO(), tt.testPod, tt.node.Name)
 			if tt.expectError {
 				assert.Nil(t, node)
 				assert.Nil(t, state)
@@ -279,7 +279,7 @@ func TestRunFilterUntilPassingNode(t *testing.T) {
 			err = snapshot.AddNodeInfo(framework.NewTestNodeInfo(n2000))
 			assert.NoError(t, err)
 
-			node, state, err := pluginRunner.RunFiltersUntilPassingNode(tc.pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(info *framework.NodeInfo) bool { return true }})
+			node, state, err := pluginRunner.RunFiltersUntilPassingNode(context.TODO(), tc.pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(info *framework.NodeInfo) bool { return true }})
 			if tc.expectError {
 				assert.Nil(t, node)
 				assert.Nil(t, state)
@@ -315,7 +315,7 @@ func TestRunFilterUntilPassingNode_NodeOrdering(t *testing.T) {
 
 	var visitOrder []string
 
-	_, _, err = pluginRunner.RunFiltersUntilPassingNode(p100, clustersnapshot.SchedulingOptions{
+	_, _, err = pluginRunner.RunFiltersUntilPassingNode(context.TODO(), p100, clustersnapshot.SchedulingOptions{
 		NodeOrdering: reverseOrderedIterator,
 		IsNodeAcceptable: func(info *framework.NodeInfo) bool {
 			visitOrder = append(visitOrder, info.Node().Name)
@@ -371,7 +371,7 @@ func TestRunFilterUntilPassingNode_ExitEarlyWhenOrderingReturnNegativeOne(t *tes
 	iter := newEarlyExitNodeOrderMapping(1) // Only allow visiting index 0 (node n1).
 	var nodesVisited []string
 
-	_, _, err = pluginRunner.RunFiltersUntilPassingNode(p100, clustersnapshot.SchedulingOptions{
+	_, _, err = pluginRunner.RunFiltersUntilPassingNode(context.TODO(), p100, clustersnapshot.SchedulingOptions{
 		NodeOrdering: iter,
 		IsNodeAcceptable: func(info *framework.NodeInfo) bool {
 			nodesVisited = append(nodesVisited, info.Node().Name)
@@ -414,7 +414,7 @@ func TestRunFilterUntilPassingNode_PreferSmallestSteps(t *testing.T) {
 	chosenNodeName := ""
 
 	go func() {
-		node, _, err := pluginRunner.RunFiltersUntilPassingNode(p100, clustersnapshot.SchedulingOptions{
+		node, _, err := pluginRunner.RunFiltersUntilPassingNode(context.TODO(), p100, clustersnapshot.SchedulingOptions{
 			NodeOrdering: orderedIterator, // Needed to make the test deterministic.
 			IsNodeAcceptable: func(info *framework.NodeInfo) bool {
 				if info.Node().Name == "n1" {
@@ -469,7 +469,7 @@ func TestDebugInfo(t *testing.T) {
 	err = clusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node1))
 	assert.NoError(t, err)
 
-	_, _, predicateErr := defaultPluginRunner.RunFiltersOnNode(p1, "n1")
+	_, _, predicateErr := defaultPluginRunner.RunFiltersOnNode(context.TODO(), p1, "n1")
 	assert.NotNil(t, predicateErr)
 	assert.Contains(t, predicateErr.FailingPredicateReasons(), "node(s) had untolerated taint(s)")
 	assert.Contains(t, predicateErr.Error(), "node(s) had untolerated taint(s)")
@@ -500,7 +500,7 @@ func TestDebugInfo(t *testing.T) {
 	err = clusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node1))
 	assert.NoError(t, err)
 
-	_, _, predicateErr = customPluginRunner.RunFiltersOnNode(p1, "n1")
+	_, _, predicateErr = customPluginRunner.RunFiltersOnNode(context.TODO(), p1, "n1")
 	assert.Nil(t, predicateErr)
 }
 
@@ -565,7 +565,7 @@ func BenchmarkRunFiltersUntilPassingNode(b *testing.B) {
 			pluginRunner.parallelism = tc.parallelism
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, _, err := pluginRunner.RunFiltersUntilPassingNode(pod, clustersnapshot.SchedulingOptions{
+				_, _, err := pluginRunner.RunFiltersUntilPassingNode(context.TODO(), pod, clustersnapshot.SchedulingOptions{
 					NodeOrdering: clustersnapshot.NewLastIndexOrderMapping(1),
 				})
 				assert.NoError(b, err)

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot.go
@@ -233,13 +233,13 @@ func (s *PredicateSnapshot) AddNodeInfo(nodeInfo *framework.NodeInfo) error {
 
 // RemoveNodeInfo removes a NodeInfo matching the provided nodeName from the snapshot.
 // The DRA slices and CSI data are removed from the underlying draSnapshot and csiSnapshot.
-func (s *PredicateSnapshot) RemoveNodeInfo(nodeName string) error {
+func (s *PredicateSnapshot) RemoveNodeInfo(ctx context.Context, nodeName string) error {
 	nodeInfo, err := s.GetNodeInfo(nodeName)
 	if err != nil {
 		return err
 	}
 
-	if err := s.ClusterSnapshotStore.RemoveNodeInfo(nodeName); err != nil {
+	if err := s.ClusterSnapshotStore.RemoveNodeInfo(ctx, nodeName); err != nil {
 		return err
 	}
 
@@ -247,7 +247,7 @@ func (s *PredicateSnapshot) RemoveNodeInfo(nodeName string) error {
 		s.draSnapshot.RemoveNodeResourceSlices(nodeName)
 
 		for _, pod := range nodeInfo.Pods() {
-			s.draSnapshot.RemovePodOwnedClaims(pod.Pod)
+			s.draSnapshot.RemovePodOwnedClaims(ctx, pod.Pod)
 		}
 	}
 	if s.enableCSINodeAwareScheduling {
@@ -262,8 +262,8 @@ func (s *PredicateSnapshot) RemoveNodeInfo(nodeName string) error {
 // SchedulePod adds pod to the snapshot and schedules it to given node.
 // The scheduler's Reserve phase computes DRA claim allocations, which are pushed to the draSnapshot.
 // The updated claims are then pulled to construct the final PodInfo.
-func (s *PredicateSnapshot) SchedulePod(pod *apiv1.Pod, nodeName string) clustersnapshot.SchedulingError {
-	node, cycleState, schedErr := s.pluginRunner.RunFiltersOnNode(pod, nodeName)
+func (s *PredicateSnapshot) SchedulePod(ctx context.Context, pod *apiv1.Pod, nodeName string) clustersnapshot.SchedulingError {
+	node, cycleState, schedErr := s.pluginRunner.RunFiltersOnNode(ctx, pod, nodeName)
 	if schedErr != nil {
 		return schedErr
 	}
@@ -290,8 +290,8 @@ func (s *PredicateSnapshot) SchedulePod(pod *apiv1.Pod, nodeName string) cluster
 
 // SchedulePodOnAnyNodeMatching adds pod to the snapshot and schedules it to any node matching the provided function.
 // Data flow is the same as SchedulePod.
-func (s *PredicateSnapshot) SchedulePodOnAnyNodeMatching(pod *apiv1.Pod, opts clustersnapshot.SchedulingOptions) (string, clustersnapshot.SchedulingError) {
-	node, cycleState, schedErr := s.pluginRunner.RunFiltersUntilPassingNode(pod, opts)
+func (s *PredicateSnapshot) SchedulePodOnAnyNodeMatching(ctx context.Context, pod *apiv1.Pod, opts clustersnapshot.SchedulingOptions) (string, clustersnapshot.SchedulingError) {
+	node, cycleState, schedErr := s.pluginRunner.RunFiltersUntilPassingNode(ctx, pod, opts)
 	if schedErr != nil {
 		return "", schedErr
 	}
@@ -364,8 +364,8 @@ func (s *PredicateSnapshot) ForceRemovePod(namespace string, podName string, nod
 }
 
 // CheckPredicates checks whether scheduler predicates pass for the given pod on the given node.
-func (s *PredicateSnapshot) CheckPredicates(pod *apiv1.Pod, nodeName string) clustersnapshot.SchedulingError {
-	_, _, err := s.pluginRunner.RunFiltersOnNode(pod, nodeName)
+func (s *PredicateSnapshot) CheckPredicates(ctx context.Context, pod *apiv1.Pod, nodeName string) clustersnapshot.SchedulingError {
+	_, _, err := s.pluginRunner.RunFiltersOnNode(ctx, pod, nodeName)
 	return err
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package predicate
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -358,7 +359,7 @@ func BenchmarkScheduleRevert(b *testing.B) {
 									WithResourceClaim(sharedClaim.Name, sharedClaim.Name, ""),
 								)
 
-								err := snapshot.SchedulePod(pod, nodeInfo.Node().Name)
+								err := snapshot.SchedulePod(context.TODO(), pod, nodeInfo.Node().Name)
 								if err != nil {
 									b.Errorf(
 										"Failed to schedule a pod %s to node %s: %v",
@@ -371,7 +372,7 @@ func BenchmarkScheduleRevert(b *testing.B) {
 
 							for podIndex := 0; podIndex < cfg.ownedClaimPods; podIndex++ {
 								owningPod := owningPods[nodeIndex][podIndex]
-								err := snapshot.SchedulePod(owningPod, nodeInfo.Node().Name)
+								err := snapshot.SchedulePod(context.TODO(), owningPod, nodeInfo.Node().Name)
 								if err != nil {
 									b.Errorf(
 										"Failed to schedule a pod %s to node %s: %v",

--- a/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package predicate
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"math/rand"
@@ -364,7 +365,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				csiSnapshot: createCSISnapshot(csiNode),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				return snapshot.RemoveNodeInfo(node.Name)
+				return snapshot.RemoveNodeInfo(context.TODO(), node.Name)
 			},
 		},
 		{
@@ -374,7 +375,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				csiSnapshot: createCSISnapshot(csiNode),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				if err := snapshot.RemoveNodeInfo(node.Name); err != nil {
+				if err := snapshot.RemoveNodeInfo(context.TODO(), node.Name); err != nil {
 					return err
 				}
 				return snapshot.AddNodeInfo(framework.NewTestNodeInfoWithCSI(node, csiNode))
@@ -394,7 +395,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				if schedErr := snapshot.ForceAddPod(pod, node.Name); schedErr != nil {
 					return schedErr
 				}
-				return snapshot.RemoveNodeInfo(node.Name)
+				return snapshot.RemoveNodeInfo(context.TODO(), node.Name)
 			},
 		},
 		{
@@ -404,7 +405,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				csiSnapshot: createCSISnapshot(csiNode),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				return snapshot.SchedulePod(pod, node.Name)
+				return snapshot.SchedulePod(context.TODO(), pod, node.Name)
 			},
 			modifiedState: snapshotState{
 				nodes:       []*apiv1.Node{node},
@@ -419,7 +420,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				csiSnapshot: createCSISnapshot(csiNode, largeCSINode),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(largePod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
+				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(context.TODO(), largePod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
 				if diff := cmp.Diff(largeNode.Name, foundNodeName); diff != "" {
 					t.Errorf("SchedulePodOnAnyNodeMatching(): unexpected output (-want +got): %s", diff)
 				}
@@ -438,7 +439,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				csiSnapshot: createCSISnapshot(csiNode, largeCSINode),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(info *framework.NodeInfo) bool { return info.Node().Name == node.Name }})
+				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(context.TODO(), pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(info *framework.NodeInfo) bool { return info.Node().Name == node.Name }})
 				if diff := cmp.Diff(node.Name, foundNodeName); diff != "" {
 					t.Errorf("SchedulePodOnAnyNodeMatching(): unexpected output (-want +got): %s", diff)
 				}
@@ -457,7 +458,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				csiSnapshot: createCSISnapshot(csiNode),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				return snapshot.SchedulePod(largePod, node.Name)
+				return snapshot.SchedulePod(context.TODO(), largePod, node.Name)
 			},
 			// SchedulePod should fail on scheduling predicates because the pod is too big for the node.
 			wantErr: clustersnapshot.NewFailingPredicateError(nil, "", nil, "", ""), // Only the type of the error is asserted (via cmp.EquateErrors() and errors.Is()), so the parameters don't matter here.
@@ -474,7 +475,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				csiSnapshot: createCSISnapshot(csiNode, otherCSINode),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(largePod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
+				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(context.TODO(), largePod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
 				if foundNodeName != "" {
 					t.Errorf("SchedulePodOnAnyNodeMatching(): unexpected output: want empty string, got %q", foundNodeName)
 				}
@@ -495,7 +496,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				csiSnapshot: createCSISnapshot(csiNode, otherCSINode),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return false }})
+				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(context.TODO(), pod, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return false }})
 				if foundNodeName != "" {
 					t.Errorf("SchedulePodOnAnyNodeMatching(): unexpected output: want empty string, got %q", foundNodeName)
 				}
@@ -744,7 +745,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 					nil, deviceClasses),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				return snapshot.RemoveNodeInfo(node.Name)
+				return snapshot.RemoveNodeInfo(context.TODO(), node.Name)
 			},
 			// LocalResourceSlices for the removed Node should get removed from the DRA snapshot.
 			// The pod-owned claim referenced by a pod from the removed Node should get removed from the DRA snapshot.
@@ -773,7 +774,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 			},
 			// Remove the NodeInfo and then add it back to the snapshot.
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				if err := snapshot.RemoveNodeInfo(node.Name); err != nil {
+				if err := snapshot.RemoveNodeInfo(context.TODO(), node.Name); err != nil {
 					return err
 				}
 				podInfo := framework.NewPodInfo(podWithClaims, []*resourceapi.ResourceClaim{
@@ -803,7 +804,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				draSnapshot: drasnapshot.NewSnapshot(nil, map[string][]*resourceapi.ResourceSlice{node.Name: resourceSlices}, nil, deviceClasses),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				return snapshot.RemoveNodeInfo("wrong-name")
+				return snapshot.RemoveNodeInfo(context.TODO(), "wrong-name")
 			},
 			// The removed Node isn't in the snapshot, so this should be an error.
 			wantErr: cmpopts.AnyError,
@@ -828,7 +829,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 			},
 			// Run SchedulePod, which should allocate the claims in the DRA snapshot via the DRA scheduler plugin.
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				return snapshot.SchedulePod(podWithClaims, node.Name)
+				return snapshot.SchedulePod(context.TODO(), podWithClaims, node.Name)
 			},
 			// The pod should get added to the Node.
 			// The claims referenced by the Pod should get allocated and reserved for the Pod.
@@ -860,7 +861,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 			},
 			// Run SchedulePod, which should allocate the pod-owned claim in the DRA snapshot via the DRA scheduler plugin.
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				return snapshot.SchedulePod(podWithClaims, node.Name)
+				return snapshot.SchedulePod(context.TODO(), podWithClaims, node.Name)
 			},
 			// The pod should get added to the Node.
 			// The pod-owned claim referenced by the Pod should get allocated. Both claims referenced by the Pod should get reserved for the Pod.
@@ -890,7 +891,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 					map[string][]*resourceapi.ResourceSlice{node.Name: resourceSlices}, nil, deviceClasses),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				return snapshot.SchedulePod(podWithClaims, node.Name)
+				return snapshot.SchedulePod(context.TODO(), podWithClaims, node.Name)
 			},
 			// SchedulePod should fail at checking scheduling predicates, because the DRA plugin can't find one of the claims.
 			wantErr: clustersnapshot.NewFailingPredicateError(nil, "", nil, "", ""), // Only the type of the error is asserted (via cmp.EquateErrors() and errors.Is()), so the parameters don't matter here.
@@ -920,7 +921,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 					map[string][]*resourceapi.ResourceSlice{node.Name: resourceSlices}, nil, deviceClasses),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				return snapshot.SchedulePod(podWithClaims, node.Name)
+				return snapshot.SchedulePod(context.TODO(), podWithClaims, node.Name)
 			},
 			// The shared claim referenced by the pod is already at the max reservation count, and no more reservations can be added - this should be an error to match scheduler behavior.
 			wantErr: clustersnapshot.NewSchedulingInternalError(nil, ""), // Only the type of the error is asserted (via cmp.EquateErrors() and errors.Is()), so the parameters don't matter here.
@@ -953,7 +954,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 			},
 			// Run SchedulePod, which should allocate the claims in the DRA snapshot via the DRA scheduler plugin.
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(podWithClaims, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
+				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(context.TODO(), podWithClaims, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
 				if diff := cmp.Diff(node.Name, foundNodeName); diff != "" {
 					t.Errorf("SchedulePodOnAnyNodeMatching(): unexpected output (-want +got): %s", diff)
 				}
@@ -987,7 +988,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 					map[string][]*resourceapi.ResourceSlice{node.Name: resourceSlices}, nil, deviceClasses),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(podWithClaims, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
+				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(context.TODO(), podWithClaims, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
 				if foundNodeName != "" {
 					t.Errorf("SchedulePodOnAnyNodeMatching(): unexpected output: want empty string, got %q", foundNodeName)
 				}
@@ -1021,7 +1022,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 					map[string][]*resourceapi.ResourceSlice{node.Name: resourceSlices}, nil, deviceClasses),
 			},
 			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
-				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(podWithClaims, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
+				foundNodeName, err := snapshot.SchedulePodOnAnyNodeMatching(context.TODO(), podWithClaims, clustersnapshot.SchedulingOptions{IsNodeAcceptable: func(_ *framework.NodeInfo) bool { return true }})
 				if foundNodeName != "" {
 					t.Errorf("SchedulePodOnAnyNodeMatching(): unexpected output: want empty string, got %q", foundNodeName)
 				}
@@ -1091,7 +1092,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				if err := snapshot.UnschedulePod(podWithClaims.Namespace, podWithClaims.Name, node.Name); err != nil {
 					return err
 				}
-				return snapshot.SchedulePod(withNodeName(podWithClaims, node.Name), node.Name)
+				return snapshot.SchedulePod(context.TODO(), withNodeName(podWithClaims, node.Name), node.Name)
 			},
 			// The state shouldn't change.
 			modifiedState: snapshotState{
@@ -1156,7 +1157,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				if err := snapshot.UnschedulePod(podWithClaims.Namespace, podWithClaims.Name, node.Name); err != nil {
 					return err
 				}
-				return snapshot.SchedulePod(withNodeName(podWithClaims, node.Name), node.Name)
+				return snapshot.SchedulePod(context.TODO(), withNodeName(podWithClaims, node.Name), node.Name)
 			},
 			// The state shouldn't change.
 			modifiedState: snapshotState{
@@ -1565,7 +1566,7 @@ func TestNode404(t *testing.T) {
 			return snapshot.ForceRemovePod("default", "p1", "node")
 		}},
 		{"schedule pod", func(snapshot clustersnapshot.ClusterSnapshot) error {
-			return snapshot.SchedulePod(BuildTestPod("p1", 0, 0), "node")
+			return snapshot.SchedulePod(context.TODO(), BuildTestPod("p1", 0, 0), "node")
 		}},
 		{"unschedule pod", func(snapshot clustersnapshot.ClusterSnapshot) error {
 			return snapshot.UnschedulePod("default", "p1", "node")
@@ -1579,7 +1580,7 @@ func TestNode404(t *testing.T) {
 			return err
 		}},
 		{"remove NodeInfo", func(snapshot clustersnapshot.ClusterSnapshot) error {
-			return snapshot.RemoveNodeInfo("node")
+			return snapshot.RemoveNodeInfo(context.TODO(), "node")
 		}},
 	}
 
@@ -1608,7 +1609,7 @@ func TestNode404(t *testing.T) {
 					snapshot.Fork()
 					assert.NoError(t, err)
 
-					err = snapshot.RemoveNodeInfo("node")
+					err = snapshot.RemoveNodeInfo(context.TODO(), "node")
 					assert.NoError(t, err)
 
 					// Node deleted after fork - shouldn't be able to operate on it.
@@ -1633,7 +1634,7 @@ func TestNode404(t *testing.T) {
 					err = snapshot.AddNodeInfo(framework.NewTestNodeInfoWithCSI(node, csiNode))
 					assert.NoError(t, err)
 
-					err = snapshot.RemoveNodeInfo("node")
+					err = snapshot.RemoveNodeInfo(context.TODO(), "node")
 					assert.NoError(t, err)
 
 					// Node deleted from base - shouldn't be able to operate on it.

--- a/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/basic.go
@@ -17,6 +17,7 @@ limitations under the License.
 package store
 
 import (
+	"context"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -209,7 +210,7 @@ func (snapshot *BasicSnapshotStore) getInternalData() *internalBasicSnapshotData
 }
 
 // RemoveNodeInfo removes nodes (and pods scheduled to it) from the snapshot.
-func (snapshot *BasicSnapshotStore) RemoveNodeInfo(nodeName string) error {
+func (snapshot *BasicSnapshotStore) RemoveNodeInfo(ctx context.Context, nodeName string) error {
 	return snapshot.getInternalData().removeNodeInfo(nodeName)
 }
 

--- a/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
+++ b/cluster-autoscaler/simulator/clustersnapshot/store/delta.go
@@ -17,6 +17,7 @@ limitations under the License.
 package store
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -413,7 +414,7 @@ func NewDeltaSnapshotStore() *DeltaSnapshotStore {
 }
 
 // RemoveNodeInfo removes nodes (and pods scheduled to it) from the snapshot.
-func (snapshot *DeltaSnapshotStore) RemoveNodeInfo(nodeName string) error {
+func (snapshot *DeltaSnapshotStore) RemoveNodeInfo(ctx context.Context, nodeName string) error {
 	return snapshot.data.removeNodeInfo(nodeName)
 }
 

--- a/cluster-autoscaler/simulator/drain.go
+++ b/cluster-autoscaler/simulator/drain.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"context"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -46,7 +47,7 @@ type PodMoveInfo struct {
 // with dangling created-by annotation).
 // If listers is not nil it checks whether RC, DS, Jobs and RS that created
 // these pods still exist.
-func GetPodsToMove(nodeInfo *framework.NodeInfo, deleteOptions options.NodeDeleteOptions, drainabilityRules rules.Rules, listers kube_util.ListerRegistry, remainingPdbTracker pdb.RemainingPdbTracker, timestamp time.Time) (PodMoveInfo, error) {
+func GetPodsToMove(ctx context.Context, nodeInfo *framework.NodeInfo, deleteOptions options.NodeDeleteOptions, drainabilityRules rules.Rules, listers kube_util.ListerRegistry, remainingPdbTracker pdb.RemainingPdbTracker, timestamp time.Time) (PodMoveInfo, error) {
 	if drainabilityRules == nil {
 		drainabilityRules = rules.Default(deleteOptions)
 	}
@@ -64,7 +65,7 @@ func GetPodsToMove(nodeInfo *framework.NodeInfo, deleteOptions options.NodeDelet
 	for _, podInfo := range nodeInfo.Pods() {
 		pod := podInfo.Pod
 
-		status := drainabilityRules.Drainable(drainCtx, pod, nodeInfo)
+		status := drainabilityRules.Drainable(ctx, drainCtx, pod, nodeInfo)
 		switch status.Outcome {
 		case drainability.UndefinedOutcome, drainability.DrainOk:
 			if pod_util.IsDaemonSetPod(pod) {

--- a/cluster-autoscaler/simulator/drain_test.go
+++ b/cluster-autoscaler/simulator/drain_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -838,7 +839,7 @@ func TestGetPodsToMove(t *testing.T) {
 			tracker := pdb.NewBasicRemainingPdbTracker()
 			tracker.SetPdbs(tc.pdbs)
 			ni := framework.NewTestNodeInfo(nil, tc.pods...)
-			podMoveInfo, err := GetPodsToMove(ni, deleteOptions, rules, registry, tracker, testTime)
+			podMoveInfo, err := GetPodsToMove(context.TODO(), ni, deleteOptions, rules, registry, tracker, testTime)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/cluster-autoscaler/simulator/drainability/rules/rules.go
+++ b/cluster-autoscaler/simulator/drainability/rules/rules.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rules
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability"
@@ -84,7 +85,7 @@ type Rules []Rule
 
 // Drainable determines whether a given pod is drainable according to the
 // specified set of rules.
-func (rs Rules) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod, nodeInfo *framework.NodeInfo) drainability.Status {
+func (rs Rules) Drainable(ctx context.Context, drainCtx *drainability.DrainContext, pod *apiv1.Pod, nodeInfo *framework.NodeInfo) drainability.Status {
 	if drainCtx == nil {
 		drainCtx = &drainability.DrainContext{}
 	}

--- a/cluster-autoscaler/simulator/drainability/rules/rules.go
+++ b/cluster-autoscaler/simulator/drainability/rules/rules.go
@@ -86,6 +86,7 @@ type Rules []Rule
 // Drainable determines whether a given pod is drainable according to the
 // specified set of rules.
 func (rs Rules) Drainable(ctx context.Context, drainCtx *drainability.DrainContext, pod *apiv1.Pod, nodeInfo *framework.NodeInfo) drainability.Status {
+	logger := klog.FromContext(ctx)
 	if drainCtx == nil {
 		drainCtx = &drainability.DrainContext{}
 	}
@@ -104,7 +105,7 @@ func (rs Rules) Drainable(ctx context.Context, drainCtx *drainability.DrainConte
 		for _, candidate := range candidates {
 			for _, override := range candidate.status.Overrides {
 				if status.Outcome == override {
-					klog.V(5).Infof("Overriding pod %s/%s drainability rule %s with rule %s, outcome %v", pod.GetNamespace(), pod.GetName(), r.Name(), candidate.name, candidate.status.Outcome)
+					logger.V(5).Info("Overriding pod drainability rule with rule, outcome", "getNamespace", pod.GetNamespace(), "pod", pod.GetName(), "r", r.Name(), "candidate", candidate.name, "outcome", candidate.status.Outcome)
 					return candidate.status
 				}
 			}

--- a/cluster-autoscaler/simulator/drainability/rules/rules_test.go
+++ b/cluster-autoscaler/simulator/drainability/rules/rules_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rules
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -112,7 +113,7 @@ func TestDrainable(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			got := tc.rules.Drainable(nil, &apiv1.Pod{}, nil)
+			got := tc.rules.Drainable(context.TODO(), nil, &apiv1.Pod{}, nil)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Drainable(): got status diff (-want +got):\n%s", diff)
 			}

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
@@ -113,10 +113,12 @@ func (c *NodeResourcesComparator) ReportResourceDiscrepancies(
 	templateSlices [][]*resourceapi.ResourceSlice,
 	nodeSlices [][]*resourceapi.ResourceSlice,
 ) {
+	logger := klog.FromContext(ctx)
 	c.reset()
 
 	if len(nodeNames) != len(templateSlices) || len(nodeNames) != len(nodeSlices) {
-		klog.Errorf("NodeResourcesComparator: nodeNames, templateSlices, and nodeSlices must have the same length")
+		logger.Error(nil, "NodeResourcesComparator: nodeNames, templateSlices, and nodeSlices must have the same length")
+
 		return
 	}
 

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/node.go
@@ -17,6 +17,7 @@ limitations under the License.
 package comparator
 
 import (
+	"context"
 	"slices"
 
 	resourceapi "k8s.io/api/resource/v1"
@@ -108,7 +109,7 @@ func (c *NodeResourcesComparator) reset() {
 // Function assumes that nodeNames, templateSlices, and nodeSlices have the same length,
 // and aborts execution if they don't.
 func (c *NodeResourcesComparator) ReportResourceDiscrepancies(
-	nodeNames []string,
+	ctx context.Context, nodeNames []string,
 	templateSlices [][]*resourceapi.ResourceSlice,
 	nodeSlices [][]*resourceapi.ResourceSlice,
 ) {

--- a/cluster-autoscaler/simulator/dynamicresources/comparator/node_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/comparator/node_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package comparator
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -364,7 +365,7 @@ func TestReportResourceDiscrepancies(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fake := &fakeMetricsEmitter{}
 			c := NewNodeResourcesComparator(fake)
-			c.ReportResourceDiscrepancies(nodeNamesArray(tc.data), templateSlicesArray(tc.data), nodeSlicesArray(tc.data))
+			c.ReportResourceDiscrepancies(context.TODO(), nodeNamesArray(tc.data), templateSlicesArray(tc.data), nodeSlicesArray(tc.data))
 			if diff := cmp.Diff(tc.wantMetrics, fake.metrics); diff != "" {
 				t.Errorf("ReportResourceDiscrepancies() metrics diff (-want +got):\n%s", diff)
 			}
@@ -427,19 +428,19 @@ func TestMissingNodesGaugesAreReset(t *testing.T) {
 
 	fake := &fakeMetricsEmitter{}
 	c := NewNodeResourcesComparator(fake)
-	c.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
+	c.ReportResourceDiscrepancies(context.TODO(), nodeNames, templateSlices, nodeSlices)
 	if diff := cmp.Diff(wantMetricsBeforeScaleDown, fake.metrics); diff != "" {
 		t.Errorf("ReportResourceDiscrepancies() metrics diff (-want +got):\n%s", diff)
 	}
 
 	fake.Reset()
-	c.ReportResourceDiscrepancies([]string{}, [][]*resourceapi.ResourceSlice{}, [][]*resourceapi.ResourceSlice{})
+	c.ReportResourceDiscrepancies(context.TODO(), []string{}, [][]*resourceapi.ResourceSlice{}, [][]*resourceapi.ResourceSlice{})
 	if diff := cmp.Diff(wantMetricsAfterScaleDown, fake.metrics); diff != "" {
 		t.Errorf("ReportResourceDiscrepancies() metrics diff (-want +got):\n%s", diff)
 	}
 
 	fake.Reset()
-	c.ReportResourceDiscrepancies([]string{}, [][]*resourceapi.ResourceSlice{}, [][]*resourceapi.ResourceSlice{})
+	c.ReportResourceDiscrepancies(context.TODO(), []string{}, [][]*resourceapi.ResourceSlice{}, [][]*resourceapi.ResourceSlice{})
 	if len(fake.metrics) != 0 {
 		t.Errorf("Expected no metrics after second reset, while reported: %v", fake.metrics)
 	}
@@ -456,7 +457,7 @@ func BenchmarkReportResourceDiscrepancies_1Node_0Discrepancies(b *testing.B) {
 	}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
+		comparator.ReportResourceDiscrepancies(context.TODO(), nodeNames, templateSlices, nodeSlices)
 	}
 }
 
@@ -467,7 +468,7 @@ func BenchmarkReportResourceDiscrepancies_1Node_NoDRA(b *testing.B) {
 	nodeSlices := [][]*resourceapi.ResourceSlice{nil}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
+		comparator.ReportResourceDiscrepancies(context.TODO(), nodeNames, templateSlices, nodeSlices)
 	}
 }
 
@@ -483,7 +484,7 @@ func BenchmarkReportResourceDiscrepancies_1Node_10Discrepancies(b *testing.B) {
 	nodeSlices := [][]*resourceapi.ResourceSlice{{}}
 	templateSlices := [][]*resourceapi.ResourceSlice{templateSlice}
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
+		comparator.ReportResourceDiscrepancies(context.TODO(), nodeNames, templateSlices, nodeSlices)
 	}
 }
 
@@ -505,7 +506,7 @@ func BenchmarkReportResourceDiscrepancies_10Nodes_10DiscrepanciesEach(b *testing
 	}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
+		comparator.ReportResourceDiscrepancies(context.TODO(), nodeNames, templateSlices, nodeSlices)
 	}
 }
 
@@ -522,7 +523,7 @@ func BenchmarkReportResourceDiscrepancies_10Nodes_NoDRA(b *testing.B) {
 	}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(nodeNames, templateSlices, nodeSlices)
+		comparator.ReportResourceDiscrepancies(context.TODO(), nodeNames, templateSlices, nodeSlices)
 	}
 }
 
@@ -540,7 +541,7 @@ func BenchmarkReportResourceDiscrepancies_10Nodes_0Discrepancies(b *testing.B) {
 	}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(names, tpl, nodes)
+		comparator.ReportResourceDiscrepancies(context.TODO(), names, tpl, nodes)
 	}
 }
 func BenchmarkReportResourceDiscrepancies_1Node_10Drivers_10Discrepancies(b *testing.B) {
@@ -555,7 +556,7 @@ func BenchmarkReportResourceDiscrepancies_1Node_10Drivers_10Discrepancies(b *tes
 	nodes := [][]*resourceapi.ResourceSlice{nil}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(names, tpl, nodes)
+		comparator.ReportResourceDiscrepancies(context.TODO(), names, tpl, nodes)
 	}
 }
 
@@ -576,6 +577,6 @@ func BenchmarkReportResourceDiscrepancies_10Nodes_10Drivers_10DiscrepanciesEach(
 	}
 
 	for b.Loop() {
-		comparator.ReportResourceDiscrepancies(names, tpl, nodes)
+		comparator.ReportResourceDiscrepancies(context.TODO(), names, tpl, nodes)
 	}
 }

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
@@ -139,9 +139,10 @@ func (s *Snapshot) PodClaims(pod *apiv1.Pod) ([]*resourceapi.ResourceClaim, erro
 // Claims referenced by the Pod but not owned by it are not removed, but the Pod's reservation is removed from them.
 // This method removes all relevant claims that are in the snapshot, and doesn't error out if any of the claims are missing.
 func (s *Snapshot) RemovePodOwnedClaims(ctx context.Context, pod *apiv1.Pod) {
+	logger := klog.FromContext(ctx)
 	claims, err := s.findPodClaims(pod, true)
 	if err != nil {
-		klog.Errorf("Snapshot.RemovePodOwnedClaims ignored an error: %s", err)
+		logger.Error(err, "Snapshot.RemovePodOwnedClaims ignored an")
 	}
 
 	for _, claim := range claims {

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot.go
@@ -17,6 +17,7 @@ limitations under the License.
 package snapshot
 
 import (
+	"context"
 	"fmt"
 	"maps"
 
@@ -137,7 +138,7 @@ func (s *Snapshot) PodClaims(pod *apiv1.Pod) ([]*resourceapi.ResourceClaim, erro
 // RemovePodOwnedClaims iterates over all the claims referenced by the Pod, and removes the ones owned by the Pod from the Snapshot.
 // Claims referenced by the Pod but not owned by it are not removed, but the Pod's reservation is removed from them.
 // This method removes all relevant claims that are in the snapshot, and doesn't error out if any of the claims are missing.
-func (s *Snapshot) RemovePodOwnedClaims(pod *apiv1.Pod) {
+func (s *Snapshot) RemovePodOwnedClaims(ctx context.Context, pod *apiv1.Pod) {
 	claims, err := s.findPodClaims(pod, true)
 	if err != nil {
 		klog.Errorf("Snapshot.RemovePodOwnedClaims ignored an error: %s", err)

--- a/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_test.go
+++ b/cluster-autoscaler/simulator/dynamicresources/snapshot/snapshot_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package snapshot
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -177,7 +178,7 @@ func TestSnapshotResourceClaims(t *testing.T) {
 				GetClaimId(pod1OwnClaim2): pod1OwnClaim2.DeepCopy(),
 			},
 			claimsModFun: func(snapshot *Snapshot) error {
-				snapshot.RemovePodOwnedClaims(pod1)
+				snapshot.RemovePodOwnedClaims(context.TODO(), pod1)
 				return nil
 			},
 			pod:              pod1,
@@ -195,7 +196,7 @@ func TestSnapshotResourceClaims(t *testing.T) {
 				GetClaimId(pod1OwnClaim2): pod1OwnClaim2.DeepCopy(),
 			},
 			claimsModFun: func(snapshot *Snapshot) error {
-				snapshot.RemovePodOwnedClaims(pod1)
+				snapshot.RemovePodOwnedClaims(context.TODO(), pod1)
 				return nil
 			},
 			pod:              pod1,

--- a/cluster-autoscaler/simulator/node_info_utils.go
+++ b/cluster-autoscaler/simulator/node_info_utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 
@@ -42,7 +43,7 @@ type nodeGroupTemplateNodeInfoGetter interface {
 
 // SanitizedTemplateNodeInfoFromNodeGroup returns a template NodeInfo object based on NodeGroup.TemplateNodeInfo(). The template is sanitized, and only
 // contains the pods that should appear on a new Node from the same node group (e.g. DaemonSet pods).
-func SanitizedTemplateNodeInfoFromNodeGroup(nodeGroup nodeGroupTemplateNodeInfoGetter, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig) (*framework.NodeInfo, errors.AutoscalerError) {
+func SanitizedTemplateNodeInfoFromNodeGroup(ctx context.Context, nodeGroup nodeGroupTemplateNodeInfoGetter, daemonsets []*appsv1.DaemonSet, taintConfig taints.TaintConfig) (*framework.NodeInfo, errors.AutoscalerError) {
 	// TODO(DRA): Figure out how to handle TemplateNodeInfo() returning DaemonSet Pods using DRA. Currently, things only work correctly if such pods are
 	// already allocated by TemplateNodeInfo(). It might be better for TemplateNodeInfo() to return unallocated claims, and to run scheduler predicates and
 	// compute the allocations here.
@@ -50,7 +51,7 @@ func SanitizedTemplateNodeInfoFromNodeGroup(nodeGroup nodeGroupTemplateNodeInfoG
 	if err != nil {
 		return nil, errors.ToAutoscalerError(errors.CloudProviderError, err).AddPrefix("failed to obtain template NodeInfo from node group %q: ", nodeGroup.Id())
 	}
-	sanitizedNodeInfo, aErr := SanitizedTemplateNodeInfoFromNodeInfo(baseNodeInfo, nodeGroup.Id(), daemonsets, true, taintConfig)
+	sanitizedNodeInfo, aErr := SanitizedTemplateNodeInfoFromNodeInfo(ctx, baseNodeInfo, nodeGroup.Id(), daemonsets, true, taintConfig)
 	if aErr != nil {
 		return nil, aErr
 	}
@@ -60,13 +61,13 @@ func SanitizedTemplateNodeInfoFromNodeGroup(nodeGroup nodeGroupTemplateNodeInfoG
 
 // SanitizedTemplateNodeInfoFromNodeInfo returns a template NodeInfo object based on a real example NodeInfo from the cluster. The template is sanitized, and only
 // contains the pods that should appear on a new Node from the same node group (e.g. DaemonSet pods).
-func SanitizedTemplateNodeInfoFromNodeInfo(example *framework.NodeInfo, nodeGroupId string, daemonsets []*appsv1.DaemonSet, forceDaemonSets bool, taintConfig taints.TaintConfig) (*framework.NodeInfo, errors.AutoscalerError) {
+func SanitizedTemplateNodeInfoFromNodeInfo(ctx context.Context, example *framework.NodeInfo, nodeGroupId string, daemonsets []*appsv1.DaemonSet, forceDaemonSets bool, taintConfig taints.TaintConfig) (*framework.NodeInfo, errors.AutoscalerError) {
 	randSuffix := fmt.Sprintf("%d", rand.Int63())
 	newNodeNameBase := fmt.Sprintf("template-node-for-%s", nodeGroupId)
 
 	// We need to sanitize the example before determining the DS pods, since taints are checked there, and
 	// we might need to filter some out during sanitization.
-	sanitizedExample, err := createSanitizedNodeInfo(example, newNodeNameBase, randSuffix, &taintConfig)
+	sanitizedExample, err := createSanitizedNodeInfo(ctx, example, newNodeNameBase, randSuffix, &taintConfig)
 	if err != nil {
 		return nil, errors.ToAutoscalerError(errors.InternalError, err)
 	}
@@ -90,14 +91,14 @@ func SanitizedTemplateNodeInfoFromNodeInfo(example *framework.NodeInfo, nodeGrou
 
 // SanitizedNodeInfo duplicates the provided template NodeInfo, returning a fresh NodeInfo that can be injected into the cluster snapshot.
 // The NodeInfo is sanitized (names, UIDs are changed, etc.), so that it can be injected along other copies created from the same template.
-func SanitizedNodeInfo(template *framework.NodeInfo, suffix string) (*framework.NodeInfo, error) {
+func SanitizedNodeInfo(ctx context.Context, template *framework.NodeInfo, suffix string) (*framework.NodeInfo, error) {
 	// Template node infos should already have taints and pods filtered, so not setting these parameters.
-	return createSanitizedNodeInfo(template, template.Node().Name, suffix, nil)
+	return createSanitizedNodeInfo(ctx, template, template.Node().Name, suffix, nil)
 }
 
-func createSanitizedNodeInfo(nodeInfo *framework.NodeInfo, newNodeNameBase string, namesSuffix string, taintConfig *taints.TaintConfig) (*framework.NodeInfo, error) {
+func createSanitizedNodeInfo(ctx context.Context, nodeInfo *framework.NodeInfo, newNodeNameBase string, namesSuffix string, taintConfig *taints.TaintConfig) (*framework.NodeInfo, error) {
 	freshNodeName := fmt.Sprintf("%s-%s", newNodeNameBase, namesSuffix)
-	freshNode := createSanitizedNode(nodeInfo.Node(), freshNodeName, taintConfig)
+	freshNode := createSanitizedNode(ctx, nodeInfo.Node(), freshNodeName, taintConfig)
 	freshResourceSlices, oldPoolNames, err := drautils.SanitizedNodeResourceSlices(nodeInfo.LocalResourceSlices, freshNode.Name, namesSuffix)
 	if err != nil {
 		return nil, err
@@ -119,7 +120,7 @@ func createSanitizedNodeInfo(nodeInfo *framework.NodeInfo, newNodeNameBase strin
 	return result, nil
 }
 
-func createSanitizedNode(node *apiv1.Node, newName string, taintConfig *taints.TaintConfig) *apiv1.Node {
+func createSanitizedNode(ctx context.Context, node *apiv1.Node, newName string, taintConfig *taints.TaintConfig) *apiv1.Node {
 	newNode := node.DeepCopy()
 	newNode.UID = uuid.NewUUID()
 
@@ -136,7 +137,7 @@ func createSanitizedNode(node *apiv1.Node, newName string, taintConfig *taints.T
 	}
 
 	if taintConfig != nil {
-		newNode.Spec.Taints = taints.SanitizeTaints(newNode.Spec.Taints, *taintConfig)
+		newNode.Spec.Taints = taints.SanitizeTaints(ctx, newNode.Spec.Taints, *taintConfig)
 	}
 	return newNode
 }

--- a/cluster-autoscaler/simulator/node_info_utils_test.go
+++ b/cluster-autoscaler/simulator/node_info_utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -149,7 +150,7 @@ func TestSanitizedTemplateNodeInfoFromNodeGroup(t *testing.T) {
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
-			templateNodeInfo, err := SanitizedTemplateNodeInfoFromNodeGroup(tc.nodeGroup, testDaemonSets, taints.TaintConfig{})
+			templateNodeInfo, err := SanitizedTemplateNodeInfoFromNodeGroup(context.TODO(), tc.nodeGroup, testDaemonSets, taints.TaintConfig{})
 			if tc.wantCpError {
 				if err == nil || err.Type() != errors.CloudProviderError {
 					t.Fatalf("TemplateNodeInfoFromNodeGroupTemplate(): want CloudProviderError, but got: %v (%T)", err, err)
@@ -368,7 +369,7 @@ func TestSanitizedTemplateNodeInfoFromNodeInfo(t *testing.T) {
 				exampleNodeInfo.SetCSINode(tc.csiNode)
 			}
 
-			templateNodeInfo, err := SanitizedTemplateNodeInfoFromNodeInfo(exampleNodeInfo, nodeGroupId, tc.daemonSets, tc.forceDS, taints.TaintConfig{})
+			templateNodeInfo, err := SanitizedTemplateNodeInfoFromNodeInfo(context.TODO(), exampleNodeInfo, nodeGroupId, tc.daemonSets, tc.forceDS, taints.TaintConfig{})
 			if tc.wantError {
 				if err == nil {
 					t.Fatal("TemplateNodeInfoFromExampleNodeInfo(): want error, but got nil")
@@ -413,7 +414,7 @@ func TestSanitizedNodeInfo(t *testing.T) {
 	templateNodeInfo := framework.NewNodeInfo(templateNode, nil, pods...)
 
 	suffix := "abc"
-	freshNodeInfo, err := SanitizedNodeInfo(templateNodeInfo, suffix)
+	freshNodeInfo, err := SanitizedNodeInfo(context.TODO(), templateNodeInfo, suffix)
 	if err != nil {
 		t.Fatalf("FreshNodeInfoFromTemplateNodeInfo(): want nil error, got %v", err)
 	}
@@ -578,7 +579,7 @@ func TestCreateSanitizedNodeInfo(t *testing.T) {
 
 			newNameBase := "node"
 			suffix := "abc"
-			nodeInfo, err := createSanitizedNodeInfo(tc.nodeInfo, newNameBase, suffix, tc.taintConfig)
+			nodeInfo, err := createSanitizedNodeInfo(context.TODO(), tc.nodeInfo, newNameBase, suffix, tc.taintConfig)
 			if err != nil {
 				t.Fatalf("sanitizeNodeInfo(): want nil error, got %v", err)
 			}

--- a/cluster-autoscaler/simulator/scheduling/hinting_simulator.go
+++ b/cluster-autoscaler/simulator/scheduling/hinting_simulator.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scheduling
 
 import (
+	"context"
+
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/klogx"
@@ -50,20 +52,20 @@ func NewHintingSimulator() *HintingSimulator {
 // after the first scheduling attempt that fails. This is useful if all provided
 // pods need to be scheduled.
 // Note: this function does not fork clusterSnapshot: this has to be done by the caller.
-func (s *HintingSimulator) TrySchedulePods(clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) ([]Status, int, error) {
+func (s *HintingSimulator) TrySchedulePods(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pods []*apiv1.Pod, breakOnFailure bool, opts clustersnapshot.SchedulingOptions) ([]Status, int, error) {
 	similarPods := NewSimilarPodsScheduling()
 
 	var statuses []Status
 	loggingQuota := klogx.PodsLoggingQuota()
 	for _, pod := range pods {
 		klogx.V(5).UpTo(loggingQuota).Infof("Looking for place for %s/%s", pod.Namespace, pod.Name)
-		nodeName, err := s.tryScheduleUsingHints(clusterSnapshot, pod, opts.IsNodeAcceptable)
+		nodeName, err := s.tryScheduleUsingHints(ctx, clusterSnapshot, pod, opts.IsNodeAcceptable)
 		if err != nil {
 			return nil, 0, err
 		}
 
 		if nodeName == "" {
-			nodeName, err = s.trySchedule(similarPods, clusterSnapshot, pod, loggingQuota, opts)
+			nodeName, err = s.trySchedule(ctx, similarPods, clusterSnapshot, pod, loggingQuota, opts)
 			if err != nil {
 				return nil, 0, err
 			}
@@ -82,7 +84,7 @@ func (s *HintingSimulator) TrySchedulePods(clusterSnapshot clustersnapshot.Clust
 
 // tryScheduleUsingHints tries to schedule the provided Pod in the provided clusterSnapshot using hints. If the pod is scheduled, the name of its Node is returned. If the
 // pod couldn't be scheduled using hints, an empty string and nil error is returned. Error is only returned for unexpected errors.
-func (s *HintingSimulator) tryScheduleUsingHints(clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, isNodeAcceptable func(*framework.NodeInfo) bool) (string, error) {
+func (s *HintingSimulator) tryScheduleUsingHints(ctx context.Context, clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, isNodeAcceptable func(*framework.NodeInfo) bool) (string, error) {
 	hk := HintKeyFromPod(pod)
 	hintedNode, hasHint := s.hints.Get(hk)
 	if !hasHint {
@@ -98,7 +100,7 @@ func (s *HintingSimulator) tryScheduleUsingHints(clusterSnapshot clustersnapshot
 		return "", nil
 	}
 
-	if err := clusterSnapshot.SchedulePod(pod, hintedNode); err != nil && err.Type() == clustersnapshot.SchedulingInternalError {
+	if err := clusterSnapshot.SchedulePod(ctx, pod, hintedNode); err != nil && err.Type() == clustersnapshot.SchedulingInternalError {
 		// Unexpected error.
 		return "", err
 	} else if err != nil {
@@ -112,13 +114,13 @@ func (s *HintingSimulator) tryScheduleUsingHints(clusterSnapshot clustersnapshot
 
 // trySchedule tries to schedule the provided Pod in the provided clusterSnapshot on any Node passing isNodeAcceptable. If the pod is scheduled, the name of its Node is returned. If no Node
 // with passing scheduling predicates could be found, an empty string and nil error is returned. Error is only returned for unexpected errors.
-func (s *HintingSimulator) trySchedule(similarPods *SimilarPodsScheduling, clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, loggingQuota *klogx.Quota, opts clustersnapshot.SchedulingOptions) (string, error) {
+func (s *HintingSimulator) trySchedule(ctx context.Context, similarPods *SimilarPodsScheduling, clusterSnapshot clustersnapshot.ClusterSnapshot, pod *apiv1.Pod, loggingQuota *klogx.Quota, opts clustersnapshot.SchedulingOptions) (string, error) {
 	if similarPods.IsSimilarUnschedulable(pod) {
 		klogx.V(4).UpTo(loggingQuota).Infof("failed to find place for %s/%s based on similar pods scheduling", pod.Namespace, pod.Name)
 		return "", nil
 	}
 
-	newNodeName, err := clusterSnapshot.SchedulePodOnAnyNodeMatching(pod, opts)
+	newNodeName, err := clusterSnapshot.SchedulePodOnAnyNodeMatching(ctx, pod, opts)
 	if err != nil && err.Type() == clustersnapshot.SchedulingInternalError {
 		// Unexpected error.
 		return "", err

--- a/cluster-autoscaler/simulator/scheduling/hinting_simulator_test.go
+++ b/cluster-autoscaler/simulator/scheduling/hinting_simulator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduling
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -163,7 +164,7 @@ func TestTrySchedulePods(t *testing.T) {
 				s.hints.Set(HintKeyFromPod(pod), nodeName)
 			}
 
-			statuses, _, err := s.TrySchedulePods(clusterSnapshot, tc.newPods, false, clustersnapshot.SchedulingOptions{IsNodeAcceptable: tc.acceptableNodes})
+			statuses, _, err := s.TrySchedulePods(context.TODO(), clusterSnapshot, tc.newPods, false, clustersnapshot.SchedulingOptions{IsNodeAcceptable: tc.acceptableNodes})
 			if tc.wantErr {
 				assert.Error(t, err)
 				return
@@ -250,7 +251,7 @@ func TestPodSchedulesOnHintedNode(t *testing.T) {
 				s.hints.Set(HintKeyFromPod(pod), n)
 				expectedStatuses = append(expectedStatuses, Status{Pod: pod, NodeName: n})
 			}
-			statuses, _, err := s.TrySchedulePods(clusterSnapshot, pods, false, clustersnapshot.SchedulingOptions{})
+			statuses, _, err := s.TrySchedulePods(context.TODO(), clusterSnapshot, pods, false, clustersnapshot.SchedulingOptions{})
 			assert.NoError(t, err)
 			assert.Equal(t, expectedStatuses, statuses)
 

--- a/cluster-autoscaler/simulator/utilization/info.go
+++ b/cluster-autoscaler/simulator/utilization/info.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utilization
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -47,7 +48,7 @@ type Info struct {
 // memory) or gpu utilization based on if the node has GPU or not. Per resource
 // utilization is the sum of requests for it divided by allocatable. It also
 // returns the individual cpu, memory and gpu utilization.
-func Calculate(nodeInfo *framework.NodeInfo, skipDaemonSetPods, skipMirrorPods, draEnabled bool, gpuConfig *cloudprovider.GpuConfig, currentTime time.Time) (utilInfo Info, err error) {
+func Calculate(ctx context.Context, nodeInfo *framework.NodeInfo, skipDaemonSetPods, skipMirrorPods, draEnabled bool, gpuConfig *cloudprovider.GpuConfig, currentTime time.Time) (utilInfo Info, err error) {
 	if gpuConfig != nil && !gpuConfig.ExposedViaDra() {
 		gpuUtil, err := CalculateUtilizationOfResource(nodeInfo, gpuConfig.ExtendedResourceName, skipDaemonSetPods, skipMirrorPods, currentTime)
 		if err != nil {

--- a/cluster-autoscaler/simulator/utilization/info.go
+++ b/cluster-autoscaler/simulator/utilization/info.go
@@ -49,10 +49,12 @@ type Info struct {
 // utilization is the sum of requests for it divided by allocatable. It also
 // returns the individual cpu, memory and gpu utilization.
 func Calculate(ctx context.Context, nodeInfo *framework.NodeInfo, skipDaemonSetPods, skipMirrorPods, draEnabled bool, gpuConfig *cloudprovider.GpuConfig, currentTime time.Time) (utilInfo Info, err error) {
+	logger := klog.FromContext(ctx)
 	if gpuConfig != nil && !gpuConfig.ExposedViaDra() {
 		gpuUtil, err := CalculateUtilizationOfResource(nodeInfo, gpuConfig.ExtendedResourceName, skipDaemonSetPods, skipMirrorPods, currentTime)
 		if err != nil {
-			klog.V(3).Infof("node %s has unready GPU resource: %s", nodeInfo.Node().Name, gpuConfig.ExtendedResourceName)
+			logger.V(3).Info("node has unready GPU resource", "node", nodeInfo.Node().Name, "extendedResourceName", gpuConfig.ExtendedResourceName, "err", err)
+
 			// Return 0 if GPU is unready. This will guarantee we can still scale down a node with unready GPU.
 			return Info{GpuUtil: 0, ResourceName: gpuConfig.ExtendedResourceName, Utilization: 0}, nil
 		}

--- a/cluster-autoscaler/simulator/utilization/info_test.go
+++ b/cluster-autoscaler/simulator/utilization/info_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utilization
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -83,7 +84,7 @@ func TestCalculate(t *testing.T) {
 	nodeInfo := framework.NewTestNodeInfo(node, pod, pod, pod2)
 
 	gpuConfig := getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err := Calculate(nodeInfo, false, false, false, gpuConfig, testTime)
+	utilInfo, err := Calculate(context.TODO(), nodeInfo, false, false, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 	assert.Equal(t, 0.1, utilInfo.CpuUtil)
@@ -92,7 +93,7 @@ func TestCalculate(t *testing.T) {
 	nodeInfo = framework.NewTestNodeInfo(node2, pod, pod, pod2)
 
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	_, err = Calculate(nodeInfo, false, false, false, gpuConfig, testTime)
+	_, err = Calculate(context.TODO(), nodeInfo, false, false, false, gpuConfig, testTime)
 	assert.Error(t, err)
 
 	node3 := BuildTestNode("node3", 2000, 2000000)
@@ -100,7 +101,7 @@ func TestCalculate(t *testing.T) {
 	nodeInfo = framework.NewTestNodeInfo(node3, pod, podWithInitContainers, podWithLargeNonRestartableInitContainers)
 
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err = Calculate(nodeInfo, false, false, false, gpuConfig, testTime)
+	utilInfo, err = Calculate(context.TODO(), nodeInfo, false, false, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 50.25, utilInfo.Utilization, 0.01)
 	assert.InEpsilon(t, 25.125, utilInfo.CpuUtil, 0.005)
@@ -114,13 +115,13 @@ func TestCalculate(t *testing.T) {
 
 	nodeInfo = framework.NewTestNodeInfo(node, pod, pod, pod2, daemonSetPod3, daemonSetPod4)
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err = Calculate(nodeInfo, true, false, false, gpuConfig, testTime)
+	utilInfo, err = Calculate(context.TODO(), nodeInfo, true, false, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.5/10, utilInfo.Utilization, 0.01)
 
 	nodeInfo = framework.NewTestNodeInfo(node, pod, pod2, daemonSetPod3)
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err = Calculate(nodeInfo, false, false, false, gpuConfig, testTime)
+	utilInfo, err = Calculate(context.TODO(), nodeInfo, false, false, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 
@@ -128,7 +129,7 @@ func TestCalculate(t *testing.T) {
 	terminatedPod.DeletionTimestamp = &metav1.Time{Time: testTime.Add(-10 * time.Minute)}
 	nodeInfo = framework.NewTestNodeInfo(node, pod, pod, pod2, terminatedPod)
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err = Calculate(nodeInfo, false, false, false, gpuConfig, testTime)
+	utilInfo, err = Calculate(context.TODO(), nodeInfo, false, false, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 
@@ -139,19 +140,19 @@ func TestCalculate(t *testing.T) {
 
 	nodeInfo = framework.NewTestNodeInfo(node, pod, pod, pod2, mirrorPod)
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err = Calculate(nodeInfo, false, true, false, gpuConfig, testTime)
+	utilInfo, err = Calculate(context.TODO(), nodeInfo, false, true, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/9.0, utilInfo.Utilization, 0.01)
 
 	nodeInfo = framework.NewTestNodeInfo(node, pod, pod2, mirrorPod)
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err = Calculate(nodeInfo, false, false, false, gpuConfig, testTime)
+	utilInfo, err = Calculate(context.TODO(), nodeInfo, false, false, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 2.0/10, utilInfo.Utilization, 0.01)
 
 	nodeInfo = framework.NewTestNodeInfo(node, pod, mirrorPod, daemonSetPod3)
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err = Calculate(nodeInfo, true, true, false, gpuConfig, testTime)
+	utilInfo, err = Calculate(context.TODO(), nodeInfo, true, true, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 1.0/8.0, utilInfo.Utilization, 0.01)
 
@@ -162,7 +163,7 @@ func TestCalculate(t *testing.T) {
 	TolerateGpuForPod(gpuPod)
 	nodeInfo = framework.NewTestNodeInfo(gpuNode, pod, pod, gpuPod)
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err = Calculate(nodeInfo, false, false, false, gpuConfig, testTime)
+	utilInfo, err = Calculate(context.TODO(), nodeInfo, false, false, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.InEpsilon(t, 1/1, utilInfo.Utilization, 0.01)
 
@@ -171,7 +172,7 @@ func TestCalculate(t *testing.T) {
 	AddGpuLabelToNode(gpuNode)
 	nodeInfo = framework.NewTestNodeInfo(gpuNode, pod, pod)
 	gpuConfig = getGpuConfigFromNode(nodeInfo.Node(), false)
-	utilInfo, err = Calculate(nodeInfo, false, false, false, gpuConfig, testTime)
+	utilInfo, err = Calculate(context.TODO(), nodeInfo, false, false, false, gpuConfig, testTime)
 	assert.NoError(t, err)
 	assert.Zero(t, utilInfo.Utilization)
 }
@@ -362,7 +363,7 @@ func TestCalculateWithDynamicResources(t *testing.T) {
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
-			utilInfo, err := Calculate(tc.nodeInfo, false, false, tc.draEnabled, tc.gpuConfig, now)
+			utilInfo, err := Calculate(context.TODO(), tc.nodeInfo, false, false, tc.draEnabled, tc.gpuConfig, now)
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Calculate(): unexpected error (-want +got): %s", diff)
 			}

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gpu
 
 import (
+	"context"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -69,7 +70,7 @@ const (
 // GetGpuInfoForMetrics returns the name of the custom resource and the GPU used on the node or empty string if there's no GPU
 // if the GPU type is unknown, "generic" is returned
 // NOTE: current implementation is GKE/GCE-specific
-func GetGpuInfoForMetrics(gpuConfig *cloudprovider.GpuConfig, availableGPUTypes map[string]struct{}, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (gpuResource string, gpuType string) {
+func GetGpuInfoForMetrics(ctx context.Context, gpuConfig *cloudprovider.GpuConfig, availableGPUTypes map[string]struct{}, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (gpuResource string, gpuType string) {
 	// There is no sign of GPU
 	if gpuConfig == nil {
 		return "", MetricsNoGPU

--- a/cluster-autoscaler/utils/gpu/gpu.go
+++ b/cluster-autoscaler/utils/gpu/gpu.go
@@ -72,6 +72,7 @@ const (
 // NOTE: current implementation is GKE/GCE-specific
 func GetGpuInfoForMetrics(ctx context.Context, gpuConfig *cloudprovider.GpuConfig, availableGPUTypes map[string]struct{}, node *apiv1.Node, nodeGroup cloudprovider.NodeGroup) (gpuResource string, gpuType string) {
 	// There is no sign of GPU
+	logger := klog.FromContext(ctx)
 	if gpuConfig == nil {
 		return "", MetricsNoGPU
 	}
@@ -98,7 +99,7 @@ func GetGpuInfoForMetrics(ctx context.Context, gpuConfig *cloudprovider.GpuConfi
 	if nodeGroup != nil {
 		template, err := nodeGroup.TemplateNodeInfo()
 		if err != nil {
-			klog.Warningf("Failed to build template for getting GPU metrics for node %v: %v", node.Name, err)
+			logger.Info("Failed to build template for getting GPU metrics for node", "node", node.Name, "err", err)
 			return resourceName.String(), MetricsErrorGPU
 		}
 
@@ -107,7 +108,7 @@ func GetGpuInfoForMetrics(ctx context.Context, gpuConfig *cloudprovider.GpuConfi
 		}
 
 		// if template does not define GPUs we assume node will not have any even if it has gpu label
-		klog.Warningf("Template does not define GPUs even though node from its node group does; node=%v", node.Name)
+		logger.Info("Template does not define GPUs even though node from its node group does", "node", node.Name)
 		return resourceName.String(), MetricsUnexpectedLabelGPU
 	}
 

--- a/cluster-autoscaler/utils/gpu/gpu_test.go
+++ b/cluster-autoscaler/utils/gpu/gpu_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gpu_test
 
 import (
+	"context"
 	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -230,7 +231,7 @@ func TestGetGpuInfoForMetrics(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gpuResource, gpuType := gpu.GetGpuInfoForMetrics(tc.gpuConfig, availableGPUTypes, tc.node, tc.nodeGroup)
+			gpuResource, gpuType := gpu.GetGpuInfoForMetrics(context.TODO(), tc.gpuConfig, availableGPUTypes, tc.node, tc.nodeGroup)
 			assert.Equal(t, tc.expectedGpuResource, gpuResource)
 			assert.Equal(t, tc.expectedGpuType, gpuType)
 		})

--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -179,13 +179,13 @@ func taintKeys(taints []apiv1.Taint) []string {
 }
 
 // MarkToBeDeleted sets a taint that makes the node unschedulable.
-func MarkToBeDeleted(node *apiv1.Node, client kube_client.Interface, cordonNode bool) (*apiv1.Node, error) {
+func MarkToBeDeleted(ctx context.Context, node *apiv1.Node, client kube_client.Interface, cordonNode bool) (*apiv1.Node, error) {
 	taint := apiv1.Taint{
 		Key:    ToBeDeletedTaint,
 		Value:  fmt.Sprint(time.Now().Unix()),
 		Effect: apiv1.TaintEffectNoSchedule,
 	}
-	return AddTaints(node, client, []apiv1.Taint{taint}, cordonNode)
+	return AddTaints(ctx, node, client, []apiv1.Taint{taint}, cordonNode)
 }
 
 // DeletionCandidateTaint returns a taint that marks the node as a DeletionCandidate for Cluster Autoscaler.
@@ -198,13 +198,13 @@ func DeletionCandidateTaint() apiv1.Taint {
 }
 
 // MarkDeletionCandidate sets a soft taint that makes the node preferably unschedulable.
-func MarkDeletionCandidate(node *apiv1.Node, client kube_client.Interface) (*apiv1.Node, error) {
+func MarkDeletionCandidate(ctx context.Context, node *apiv1.Node, client kube_client.Interface) (*apiv1.Node, error) {
 	taint := DeletionCandidateTaint()
-	return AddTaints(node, client, []apiv1.Taint{taint}, false)
+	return AddTaints(ctx, node, client, []apiv1.Taint{taint}, false)
 }
 
 // AddTaints sets the specified taints on the node and returns an updated copy of the node.
-func AddTaints(node *apiv1.Node, client kube_client.Interface, taints []apiv1.Taint, cordonNode bool) (*apiv1.Node, error) {
+func AddTaints(ctx context.Context, node *apiv1.Node, client kube_client.Interface, taints []apiv1.Taint, cordonNode bool) (*apiv1.Node, error) {
 	retryDeadline := time.Now().Add(maxRetryDeadline)
 	freshNode := node.DeepCopy()
 	var err error
@@ -212,14 +212,14 @@ func AddTaints(node *apiv1.Node, client kube_client.Interface, taints []apiv1.Ta
 	for {
 		if refresh {
 			// Get the newest version of the node.
-			freshNode, err = client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+			freshNode, err = client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 			if err != nil || freshNode == nil {
 				klog.Warningf("Error while adding %v taints on node %v: %v", strings.Join(taintKeys(taints), ","), node.Name, err)
 				return nil, fmt.Errorf("failed to get node %v: %v", node.Name, err)
 			}
 		}
 
-		if !addTaintsToSpec(freshNode, taints, cordonNode) {
+		if !addTaintsToSpec(ctx, freshNode, taints, cordonNode) {
 			if !refresh {
 				// Make sure we have the latest version before skipping update.
 				refresh = true
@@ -227,7 +227,7 @@ func AddTaints(node *apiv1.Node, client kube_client.Interface, taints []apiv1.Ta
 			}
 			return freshNode, nil
 		}
-		_, err = client.CoreV1().Nodes().Update(context.TODO(), freshNode, metav1.UpdateOptions{})
+		_, err = client.CoreV1().Nodes().Update(ctx, freshNode, metav1.UpdateOptions{})
 		if err != nil && errors.IsConflict(err) && time.Now().Before(retryDeadline) {
 			refresh = true
 			time.Sleep(conflictRetryInterval)
@@ -243,7 +243,7 @@ func AddTaints(node *apiv1.Node, client kube_client.Interface, taints []apiv1.Ta
 	}
 }
 
-func addTaintsToSpec(node *apiv1.Node, taints []apiv1.Taint, cordonNode bool) bool {
+func addTaintsToSpec(ctx context.Context, node *apiv1.Node, taints []apiv1.Taint, cordonNode bool) bool {
 	taintsAdded := false
 	for _, taint := range taints {
 		if HasTaint(node, taint.Key) {
@@ -309,17 +309,17 @@ func GetTaintTime(node *apiv1.Node, taintKey string) (*time.Time, error) {
 }
 
 // CleanToBeDeleted cleans CA's NoSchedule taint from a node.
-func CleanToBeDeleted(node *apiv1.Node, client kube_client.Interface, cordonNode bool) (*apiv1.Node, error) {
-	return CleanTaints(node, client, []string{ToBeDeletedTaint}, cordonNode)
+func CleanToBeDeleted(ctx context.Context, node *apiv1.Node, client kube_client.Interface, cordonNode bool) (*apiv1.Node, error) {
+	return CleanTaints(ctx, node, client, []string{ToBeDeletedTaint}, cordonNode)
 }
 
 // CleanDeletionCandidate cleans CA's soft NoSchedule taint from a node.
-func CleanDeletionCandidate(node *apiv1.Node, client kube_client.Interface) (*apiv1.Node, error) {
-	return CleanTaints(node, client, []string{DeletionCandidateTaintKey}, false)
+func CleanDeletionCandidate(ctx context.Context, node *apiv1.Node, client kube_client.Interface) (*apiv1.Node, error) {
+	return CleanTaints(ctx, node, client, []string{DeletionCandidateTaintKey}, false)
 }
 
 // CleanTaints cleans the specified taints from a node and returns an updated copy of the node.
-func CleanTaints(node *apiv1.Node, client kube_client.Interface, taintKeys []string, cordonNode bool) (*apiv1.Node, error) {
+func CleanTaints(ctx context.Context, node *apiv1.Node, client kube_client.Interface, taintKeys []string, cordonNode bool) (*apiv1.Node, error) {
 	retryDeadline := time.Now().Add(maxRetryDeadline)
 	freshNode := node.DeepCopy()
 	var err error
@@ -327,7 +327,7 @@ func CleanTaints(node *apiv1.Node, client kube_client.Interface, taintKeys []str
 	for {
 		if refresh {
 			// Get the newest version of the node.
-			freshNode, err = client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+			freshNode, err = client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 			if err != nil || freshNode == nil {
 				klog.Warningf("Error while removing %v taints from node %v: %v", strings.Join(taintKeys, ","), node.Name, err)
 				return nil, fmt.Errorf("failed to get node %v: %v", node.Name, err)
@@ -361,7 +361,7 @@ func CleanTaints(node *apiv1.Node, client kube_client.Interface, taintKeys []str
 			klog.V(1).Infof("Marking node %v to be uncordoned by Cluster Autoscaler", freshNode.Name)
 			freshNode.Spec.Unschedulable = false
 		}
-		_, err = client.CoreV1().Nodes().Update(context.TODO(), freshNode, metav1.UpdateOptions{})
+		_, err = client.CoreV1().Nodes().Update(ctx, freshNode, metav1.UpdateOptions{})
 
 		if err != nil && errors.IsConflict(err) && time.Now().Before(retryDeadline) {
 			refresh = true
@@ -379,7 +379,7 @@ func CleanTaints(node *apiv1.Node, client kube_client.Interface, taintKeys []str
 }
 
 // getDeletionCandidateTTLCondition returns a function that checks if a node's deletion candidate time has reached the specified TTL.
-func getDeletionCandidateTTLCondition(deletionCandidateTTL time.Duration) func(*apiv1.Node) bool {
+func getDeletionCandidateTTLCondition(ctx context.Context, deletionCandidateTTL time.Duration) func(*apiv1.Node) bool {
 	return func(node *apiv1.Node) bool {
 		if deletionCandidateTTL == 0 {
 			return true
@@ -401,17 +401,17 @@ func getDeletionCandidateTTLCondition(deletionCandidateTTL time.Duration) func(*
 }
 
 // CleanAllToBeDeleted cleans ToBeDeleted taints from given nodes.
-func CleanAllToBeDeleted(nodes []*apiv1.Node, client kube_client.Interface, recorder kube_record.EventRecorder, cordonNode bool) {
-	CleanAllTaints(nodes, client, recorder, ToBeDeletedTaint, cordonNode)
+func CleanAllToBeDeleted(ctx context.Context, nodes []*apiv1.Node, client kube_client.Interface, recorder kube_record.EventRecorder, cordonNode bool) {
+	CleanAllTaints(ctx, nodes, client, recorder, ToBeDeletedTaint, cordonNode)
 }
 
 // CleanStaleDeletionCandidates cleans DeletionCandidate taints from given nodes.
-func CleanStaleDeletionCandidates(nodes []*apiv1.Node, client kube_client.Interface, recorder kube_record.EventRecorder, deletionCandidateTTL time.Duration) {
-	CleanAllTaints(nodes, client, recorder, DeletionCandidateTaintKey, false, getDeletionCandidateTTLCondition(deletionCandidateTTL))
+func CleanStaleDeletionCandidates(ctx context.Context, nodes []*apiv1.Node, client kube_client.Interface, recorder kube_record.EventRecorder, deletionCandidateTTL time.Duration) {
+	CleanAllTaints(ctx, nodes, client, recorder, DeletionCandidateTaintKey, false, getDeletionCandidateTTLCondition(ctx, deletionCandidateTTL))
 }
 
 // CleanAllTaints cleans all specified taints from given nodes.
-func CleanAllTaints(nodes []*apiv1.Node, client kube_client.Interface, recorder kube_record.EventRecorder, taintKey string, cordonNode bool, conditions ...func(*apiv1.Node) bool) {
+func CleanAllTaints(ctx context.Context, nodes []*apiv1.Node, client kube_client.Interface, recorder kube_record.EventRecorder, taintKey string, cordonNode bool, conditions ...func(*apiv1.Node) bool) {
 	for _, node := range nodes {
 		skip := false
 		if !HasTaint(node, taintKey) {
@@ -425,7 +425,7 @@ func CleanAllTaints(nodes []*apiv1.Node, client kube_client.Interface, recorder 
 		if skip {
 			continue
 		}
-		updatedNode, err := CleanTaints(node, client, []string{taintKey}, cordonNode)
+		updatedNode, err := CleanTaints(ctx, node, client, []string{taintKey}, cordonNode)
 		if err != nil {
 			recorder.Eventf(node, apiv1.EventTypeWarning, "ClusterAutoscalerCleanup",
 				"failed to clean %v on node %v: %v", taintKey, node.Name, err)
@@ -446,7 +446,7 @@ func matchesAnyPrefix(prefixes []string, key string) bool {
 }
 
 // SanitizeTaints returns filtered taints
-func SanitizeTaints(taints []apiv1.Taint, taintConfig TaintConfig) []apiv1.Taint {
+func SanitizeTaints(ctx context.Context, taints []apiv1.Taint, taintConfig TaintConfig) []apiv1.Taint {
 	var newTaints []apiv1.Taint
 	for _, taint := range taints {
 		switch taint.Key {
@@ -476,7 +476,7 @@ func SanitizeTaints(taints []apiv1.Taint, taintConfig TaintConfig) []apiv1.Taint
 
 // FilterOutNodesWithStartupTaints override the condition status of the given nodes to mark them as NotReady when they have
 // filtered taints.
-func FilterOutNodesWithStartupTaints(taintConfig TaintConfig, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
+func FilterOutNodesWithStartupTaints(ctx context.Context, taintConfig TaintConfig, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
 	newAllNodes := make([]*apiv1.Node, 0)
 	newReadyNodes := make([]*apiv1.Node, 0)
 	nodesWithStartupTaints := make(map[string]*apiv1.Node)

--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -205,6 +205,7 @@ func MarkDeletionCandidate(ctx context.Context, node *apiv1.Node, client kube_cl
 
 // AddTaints sets the specified taints on the node and returns an updated copy of the node.
 func AddTaints(ctx context.Context, node *apiv1.Node, client kube_client.Interface, taints []apiv1.Taint, cordonNode bool) (*apiv1.Node, error) {
+	ctx = context.WithoutCancel(ctx)
 	logger := klog.FromContext(ctx)
 	retryDeadline := time.Now().Add(maxRetryDeadline)
 	freshNode := node.DeepCopy()
@@ -322,6 +323,7 @@ func CleanDeletionCandidate(ctx context.Context, node *apiv1.Node, client kube_c
 
 // CleanTaints cleans the specified taints from a node and returns an updated copy of the node.
 func CleanTaints(ctx context.Context, node *apiv1.Node, client kube_client.Interface, taintKeys []string, cordonNode bool) (*apiv1.Node, error) {
+	ctx = context.WithoutCancel(ctx)
 	logger := klog.FromContext(ctx)
 	retryDeadline := time.Now().Add(maxRetryDeadline)
 	freshNode := node.DeepCopy()

--- a/cluster-autoscaler/utils/taints/taints.go
+++ b/cluster-autoscaler/utils/taints/taints.go
@@ -205,6 +205,7 @@ func MarkDeletionCandidate(ctx context.Context, node *apiv1.Node, client kube_cl
 
 // AddTaints sets the specified taints on the node and returns an updated copy of the node.
 func AddTaints(ctx context.Context, node *apiv1.Node, client kube_client.Interface, taints []apiv1.Taint, cordonNode bool) (*apiv1.Node, error) {
+	logger := klog.FromContext(ctx)
 	retryDeadline := time.Now().Add(maxRetryDeadline)
 	freshNode := node.DeepCopy()
 	var err error
@@ -214,7 +215,7 @@ func AddTaints(ctx context.Context, node *apiv1.Node, client kube_client.Interfa
 			// Get the newest version of the node.
 			freshNode, err = client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 			if err != nil || freshNode == nil {
-				klog.Warningf("Error while adding %v taints on node %v: %v", strings.Join(taintKeys(taints), ","), node.Name, err)
+				logger.Info("Error while adding taints on node", "taintKeys", strings.Join(taintKeys(taints), ","), "node", node.Name, "err", err)
 				return nil, fmt.Errorf("failed to get node %v: %v", node.Name, err)
 			}
 		}
@@ -235,19 +236,20 @@ func AddTaints(ctx context.Context, node *apiv1.Node, client kube_client.Interfa
 		}
 
 		if err != nil {
-			klog.Warningf("Error while adding %v taints on node %v: %v", strings.Join(taintKeys(taints), ","), node.Name, err)
+			logger.Info("Error while adding taints on node", "taintKeys", strings.Join(taintKeys(taints), ","), "node", node.Name, "err", err)
 			return nil, err
 		}
-		klog.V(1).Infof("Successfully added %v on node %v", strings.Join(taintKeys(taints), ","), node.Name)
+		logger.V(1).Info("Successfully added on node", "taintKeys", strings.Join(taintKeys(taints), ","), "node", node.Name)
 		return freshNode, nil
 	}
 }
 
 func addTaintsToSpec(ctx context.Context, node *apiv1.Node, taints []apiv1.Taint, cordonNode bool) bool {
+	logger := klog.FromContext(ctx)
 	taintsAdded := false
 	for _, taint := range taints {
 		if HasTaint(node, taint.Key) {
-			klog.V(2).Infof("%v already present on node %v", taint.Key, node.Name)
+			logger.V(2).Info("already present on node", "key", taint.Key, "node", node.Name)
 			continue
 		}
 		taintsAdded = true
@@ -257,7 +259,7 @@ func addTaintsToSpec(ctx context.Context, node *apiv1.Node, taints []apiv1.Taint
 		return false
 	}
 	if cordonNode {
-		klog.V(1).Infof("Marking node %v to be cordoned by Cluster Autoscaler", node.Name)
+		logger.V(1).Info("Marking node to be cordoned by Cluster Autoscaler", "node", node.Name)
 		node.Spec.Unschedulable = true
 	}
 	return true
@@ -320,6 +322,7 @@ func CleanDeletionCandidate(ctx context.Context, node *apiv1.Node, client kube_c
 
 // CleanTaints cleans the specified taints from a node and returns an updated copy of the node.
 func CleanTaints(ctx context.Context, node *apiv1.Node, client kube_client.Interface, taintKeys []string, cordonNode bool) (*apiv1.Node, error) {
+	logger := klog.FromContext(ctx)
 	retryDeadline := time.Now().Add(maxRetryDeadline)
 	freshNode := node.DeepCopy()
 	var err error
@@ -329,7 +332,7 @@ func CleanTaints(ctx context.Context, node *apiv1.Node, client kube_client.Inter
 			// Get the newest version of the node.
 			freshNode, err = client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 			if err != nil || freshNode == nil {
-				klog.Warningf("Error while removing %v taints from node %v: %v", strings.Join(taintKeys, ","), node.Name, err)
+				logger.Info("Error while removing taints from node", "taintKeys", strings.Join(taintKeys, ","), "node", node.Name, "err", err)
 				return nil, fmt.Errorf("failed to get node %v: %v", node.Name, err)
 			}
 		}
@@ -338,7 +341,7 @@ func CleanTaints(ctx context.Context, node *apiv1.Node, client kube_client.Inter
 			keepTaint := true
 			for _, taintKey := range taintKeys {
 				if taint.Key == taintKey {
-					klog.V(1).Infof("Releasing taint %+v on node %v", taint, node.Name)
+					logger.V(1).Info("Releasing taint on node", "taint", taint, "node", node.Name)
 					keepTaint = false
 					break
 				}
@@ -358,7 +361,7 @@ func CleanTaints(ctx context.Context, node *apiv1.Node, client kube_client.Inter
 
 		freshNode.Spec.Taints = newTaints
 		if cordonNode {
-			klog.V(1).Infof("Marking node %v to be uncordoned by Cluster Autoscaler", freshNode.Name)
+			logger.V(1).Info("Marking node to be uncordoned by Cluster Autoscaler", "freshNode", freshNode.Name)
 			freshNode.Spec.Unschedulable = false
 		}
 		_, err = client.CoreV1().Nodes().Update(ctx, freshNode, metav1.UpdateOptions{})
@@ -370,30 +373,31 @@ func CleanTaints(ctx context.Context, node *apiv1.Node, client kube_client.Inter
 		}
 
 		if err != nil {
-			klog.Warningf("Error while releasing %v taints on node %v: %v", strings.Join(taintKeys, ","), node.Name, err)
+			logger.Info("Error while releasing taints on node", "taintKeys", strings.Join(taintKeys, ","), "node", node.Name, "err", err)
 			return nil, err
 		}
-		klog.V(1).Infof("Successfully released %v on node %v", strings.Join(taintKeys, ","), node.Name)
+		logger.V(1).Info("Successfully released on node", "taintKeys", strings.Join(taintKeys, ","), "node", node.Name)
 		return freshNode, nil
 	}
 }
 
 // getDeletionCandidateTTLCondition returns a function that checks if a node's deletion candidate time has reached the specified TTL.
 func getDeletionCandidateTTLCondition(ctx context.Context, deletionCandidateTTL time.Duration) func(*apiv1.Node) bool {
+	logger := klog.FromContext(ctx)
 	return func(node *apiv1.Node) bool {
 		if deletionCandidateTTL == 0 {
 			return true
 		}
 		markedForDeletionTime, err := GetDeletionCandidateTime(node)
 		if err != nil {
-			klog.Warningf("Error while getting DeletionCandidate time for node %v: %v", node.Name, err)
+			logger.Info("Error while getting DeletionCandidate time for node", "node", node.Name, "err", err)
 			return true
 		}
 		if markedForDeletionTime == nil {
 			return true
 		}
 		if time.Since(*markedForDeletionTime) < deletionCandidateTTL {
-			klog.V(4).Infof("Node %v has stale %v taint: the time is %v (%v ago)", node.Name, DeletionCandidateTaintKey, markedForDeletionTime, time.Since(*markedForDeletionTime))
+			logger.V(4).Info("Node has stale taint: the time is (ago)", "node", node.Name, "DeletionCandidateTaintKey", DeletionCandidateTaintKey, "markedForDeletionTime", markedForDeletionTime, "since", time.Since(*markedForDeletionTime))
 			return false
 		}
 		return true
@@ -447,25 +451,26 @@ func matchesAnyPrefix(prefixes []string, key string) bool {
 
 // SanitizeTaints returns filtered taints
 func SanitizeTaints(ctx context.Context, taints []apiv1.Taint, taintConfig TaintConfig) []apiv1.Taint {
+	logger := klog.FromContext(ctx)
 	var newTaints []apiv1.Taint
 	for _, taint := range taints {
 		switch taint.Key {
 		case ToBeDeletedTaint:
-			klog.V(4).Infof("Removing autoscaler taint when creating template from node")
+			logger.V(4).Info("Removing autoscaler taint when creating template from node")
 			continue
 		case DeletionCandidateTaintKey:
-			klog.V(4).Infof("Removing autoscaler soft taint when creating template from node")
+			logger.V(4).Info("Removing autoscaler soft taint when creating template from node")
 			continue
 		}
 
 		// ignore conditional taints as they represent a transient node state.
 		if exists := NodeConditionTaints[taint.Key]; exists {
-			klog.V(4).Infof("Removing node condition taint %s, when creating template from node", taint.Key)
+			logger.V(4).Info("Removing node condition taint, when creating template from node", "key", taint.Key)
 			continue
 		}
 
 		if taintConfig.IsStartupTaint(taint.Key) || taintConfig.IsStatusTaint(taint.Key) {
-			klog.V(4).Infof("Removing taint %s, when creating template from node", taint.Key)
+			logger.V(4).Info("Removing taint, when creating template from node", "key", taint.Key)
 			continue
 		}
 
@@ -477,6 +482,7 @@ func SanitizeTaints(ctx context.Context, taints []apiv1.Taint, taintConfig Taint
 // FilterOutNodesWithStartupTaints override the condition status of the given nodes to mark them as NotReady when they have
 // filtered taints.
 func FilterOutNodesWithStartupTaints(ctx context.Context, taintConfig TaintConfig, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
+	logger := klog.FromContext(ctx)
 	newAllNodes := make([]*apiv1.Node, 0)
 	newReadyNodes := make([]*apiv1.Node, 0)
 	nodesWithStartupTaints := make(map[string]*apiv1.Node)
@@ -490,7 +496,7 @@ func FilterOutNodesWithStartupTaints(ctx context.Context, taintConfig TaintConfi
 			if taintConfig.IsStartupTaint(t.Key) {
 				ready = false
 				nodesWithStartupTaints[node.Name] = kubernetes.GetUnreadyNodeCopy(node, kubernetes.StartupNodes)
-				klog.V(3).Infof("Overriding status of node %v, which seems to have startup taint %q", node.Name, t.Key)
+				logger.V(3).Info("Overriding status of node, which seems to have startup taint", "node", node.Name, "key", t.Key)
 				break
 			}
 		}

--- a/cluster-autoscaler/utils/taints/taints_test.go
+++ b/cluster-autoscaler/utils/taints/taints_test.go
@@ -45,7 +45,7 @@ func TestMarkNodes(t *testing.T) {
 	defer setConflictRetryInterval(setConflictRetryInterval(time.Millisecond))
 	node := BuildTestNode("node", 1000, 1000)
 	fakeClient := buildFakeClientWithConflicts(t, node)
-	_, err := MarkToBeDeleted(node, fakeClient, false)
+	_, err := MarkToBeDeleted(context.TODO(), node, fakeClient, false)
 	assert.NoError(t, err)
 
 	updatedNode := getNode(t, fakeClient, "node")
@@ -57,7 +57,7 @@ func TestSoftMarkNodes(t *testing.T) {
 	defer setConflictRetryInterval(setConflictRetryInterval(time.Millisecond))
 	node := BuildTestNode("node", 1000, 1000)
 	fakeClient := buildFakeClientWithConflicts(t, node)
-	_, err := MarkDeletionCandidate(node, fakeClient)
+	_, err := MarkDeletionCandidate(context.TODO(), node, fakeClient)
 	assert.NoError(t, err)
 
 	updatedNode := getNode(t, fakeClient, "node")
@@ -80,7 +80,7 @@ func TestCheckNodes(t *testing.T) {
 			Effect: apiv1.TaintEffectNoSchedule,
 		},
 	}
-	addTaintsToSpec(node, taints, false)
+	addTaintsToSpec(context.TODO(), node, taints, false)
 	fakeClient := buildFakeClientWithConflicts(t, node)
 
 	updatedNode := getNode(t, fakeClient, "node")
@@ -104,7 +104,7 @@ func TestSoftCheckNodes(t *testing.T) {
 			Effect: apiv1.TaintEffectPreferNoSchedule,
 		},
 	}
-	addTaintsToSpec(node, taints, false)
+	addTaintsToSpec(context.TODO(), node, taints, false)
 	fakeClient := buildFakeClientWithConflicts(t, node)
 
 	updatedNode := getNode(t, fakeClient, "node")
@@ -116,7 +116,7 @@ func TestQueryNodes(t *testing.T) {
 	defer setConflictRetryInterval(setConflictRetryInterval(time.Millisecond))
 	node := BuildTestNode("node", 1000, 1000)
 	fakeClient := buildFakeClientWithConflicts(t, node)
-	_, err := MarkToBeDeleted(node, fakeClient, false)
+	_, err := MarkToBeDeleted(context.TODO(), node, fakeClient, false)
 	assert.NoError(t, err)
 
 	updatedNode := getNode(t, fakeClient, "node")
@@ -132,7 +132,7 @@ func TestSoftQueryNodes(t *testing.T) {
 	defer setConflictRetryInterval(setConflictRetryInterval(time.Millisecond))
 	node := BuildTestNode("node", 1000, 1000)
 	fakeClient := buildFakeClientWithConflicts(t, node)
-	_, err := MarkDeletionCandidate(node, fakeClient)
+	_, err := MarkDeletionCandidate(context.TODO(), node, fakeClient)
 	assert.NoError(t, err)
 
 	updatedNode := getNode(t, fakeClient, "node")
@@ -159,7 +159,7 @@ func TestCleanNodes(t *testing.T) {
 			Effect: apiv1.TaintEffectNoSchedule,
 		},
 	}
-	addTaintsToSpec(node, taints, false)
+	addTaintsToSpec(context.TODO(), node, taints, false)
 	fakeClient := buildFakeClientWithConflicts(t, node)
 
 	apiNode := getNode(t, fakeClient, "node")
@@ -167,7 +167,7 @@ func TestCleanNodes(t *testing.T) {
 	assert.True(t, HasTaint(apiNode, "other-taint"))
 	assert.False(t, apiNode.Spec.Unschedulable)
 
-	updatedNode, err := CleanToBeDeleted(node, fakeClient, false)
+	updatedNode, err := CleanToBeDeleted(context.TODO(), node, fakeClient, false)
 	cleaned := !slices.Equal(updatedNode.Spec.Taints, node.Spec.Taints)
 	assert.True(t, cleaned)
 	assert.NoError(t, err)
@@ -194,7 +194,7 @@ func TestCleanNodesWithCordon(t *testing.T) {
 			Effect: apiv1.TaintEffectNoSchedule,
 		},
 	}
-	addTaintsToSpec(node, taints, true)
+	addTaintsToSpec(context.TODO(), node, taints, true)
 	fakeClient := buildFakeClientWithConflicts(t, node)
 
 	apiNode := getNode(t, fakeClient, "node")
@@ -202,7 +202,7 @@ func TestCleanNodesWithCordon(t *testing.T) {
 	assert.True(t, HasTaint(apiNode, "other-taint"))
 	assert.True(t, apiNode.Spec.Unschedulable)
 
-	updatedNode, err := CleanToBeDeleted(node, fakeClient, true)
+	updatedNode, err := CleanToBeDeleted(context.TODO(), node, fakeClient, true)
 	cleaned := !slices.Equal(updatedNode.Spec.Taints, node.Spec.Taints)
 	assert.True(t, cleaned)
 	assert.NoError(t, err)
@@ -229,7 +229,7 @@ func TestCleanNodesWithCordonOnOff(t *testing.T) {
 			Effect: apiv1.TaintEffectPreferNoSchedule,
 		},
 	}
-	addTaintsToSpec(node, taints, true)
+	addTaintsToSpec(context.TODO(), node, taints, true)
 	fakeClient := buildFakeClientWithConflicts(t, node)
 
 	apiNode := getNode(t, fakeClient, "node")
@@ -237,7 +237,7 @@ func TestCleanNodesWithCordonOnOff(t *testing.T) {
 	assert.True(t, HasTaint(apiNode, "other-taint"))
 	assert.True(t, apiNode.Spec.Unschedulable)
 
-	updatedNode, err := CleanToBeDeleted(node, fakeClient, false)
+	updatedNode, err := CleanToBeDeleted(context.TODO(), node, fakeClient, false)
 	cleaned := !slices.Equal(updatedNode.Spec.Taints, node.Spec.Taints)
 	assert.True(t, cleaned)
 	assert.NoError(t, err)
@@ -264,14 +264,14 @@ func TestSoftCleanNodes(t *testing.T) {
 			Effect: apiv1.TaintEffectPreferNoSchedule,
 		},
 	}
-	addTaintsToSpec(node, taints, false)
+	addTaintsToSpec(context.TODO(), node, taints, false)
 	fakeClient := buildFakeClientWithConflicts(t, node)
 
 	apiNode := getNode(t, fakeClient, "node")
 	assert.True(t, HasDeletionCandidateTaint(apiNode))
 	assert.True(t, HasTaint(apiNode, "other-taint"))
 
-	updatedNode, err := CleanDeletionCandidate(node, fakeClient)
+	updatedNode, err := CleanDeletionCandidate(context.TODO(), node, fakeClient)
 	cleaned := !slices.Equal(updatedNode.Spec.Taints, node.Spec.Taints)
 	assert.True(t, cleaned)
 	assert.NoError(t, err)
@@ -292,7 +292,7 @@ func TestCleanAllToBeDeleted(t *testing.T) {
 
 	assert.Equal(t, 1, len(getNode(t, fakeClient, "n2").Spec.Taints))
 
-	CleanAllToBeDeleted([]*apiv1.Node{n1, n2}, fakeClient, fakeRecorder, false)
+	CleanAllToBeDeleted(context.TODO(), []*apiv1.Node{n1, n2}, fakeClient, fakeRecorder, false)
 
 	assert.Equal(t, 0, len(getNode(t, fakeClient, "n1").Spec.Taints))
 	assert.Equal(t, 0, len(getNode(t, fakeClient, "n2").Spec.Taints))
@@ -308,7 +308,7 @@ func TestCleanAllDeletionCandidates(t *testing.T) {
 
 	assert.Equal(t, 1, len(getNode(t, fakeClient, "n2").Spec.Taints))
 
-	CleanStaleDeletionCandidates([]*apiv1.Node{n1, n2}, fakeClient, fakeRecorder, time.Duration(0))
+	CleanStaleDeletionCandidates(context.TODO(), []*apiv1.Node{n1, n2}, fakeClient, fakeRecorder, time.Duration(0))
 
 	assert.Equal(t, 0, len(getNode(t, fakeClient, "n1").Spec.Taints))
 	assert.Equal(t, 0, len(getNode(t, fakeClient, "n2").Spec.Taints))
@@ -532,7 +532,7 @@ func TestFilterOutNodesWithStartupTaints(t *testing.T) {
 				startupTaints:        tc.startupTaints,
 				startupTaintPrefixes: tc.startupTaintsPrefixes,
 			}
-			allNodes, readyNodes := FilterOutNodesWithStartupTaints(taintConfig, nodes, nodes)
+			allNodes, readyNodes := FilterOutNodesWithStartupTaints(context.TODO(), taintConfig, nodes, nodes)
 			assert.Equal(t, tc.allNodes, len(allNodes))
 			assert.Equal(t, tc.readyNodes, len(readyNodes))
 
@@ -624,7 +624,7 @@ func TestSanitizeTaints(t *testing.T) {
 		startupTaintPrefixes: []string{IgnoreTaintPrefix, StartupTaintPrefix},
 	}
 
-	newTaints := SanitizeTaints(node.Spec.Taints, taintConfig)
+	newTaints := SanitizeTaints(context.TODO(), node.Spec.Taints, taintConfig)
 	require.Equal(t, 2, len(newTaints))
 	assert.Equal(t, newTaints[0].Key, StatusTaintPrefix+"some-taint")
 	assert.Equal(t, newTaints[1].Key, "test-taint")
@@ -773,7 +773,7 @@ func TestAddTaints(t *testing.T) {
 					Effect: apiv1.TaintEffectNoSchedule,
 				}
 			}
-			updatedNode, err := AddTaints(n, fakeClient, newTaints, false)
+			updatedNode, err := AddTaints(context.TODO(), n, fakeClient, newTaints, false)
 			assert.NoError(t, err)
 			apiNode := getNode(t, fakeClient, "node")
 			for _, want := range tc.wantTaints {
@@ -834,7 +834,7 @@ func TestCleanTaints(t *testing.T) {
 			n.Spec.Taints = append([]apiv1.Taint{}, existingTaints...)
 			fakeClient := buildFakeClient(t, n)
 
-			updatedNode, err := CleanTaints(n, fakeClient, tc.taintsToRemove, false)
+			updatedNode, err := CleanTaints(context.TODO(), n, fakeClient, tc.taintsToRemove, false)
 			modified := !slices.Equal(updatedNode.Spec.Taints, n.Spec.Taints)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantModified, modified)
@@ -922,7 +922,7 @@ func TestCleanStaleDeletionCandidates(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeClient := buildFakeClient(t, tc.allNodes...)
-			CleanStaleDeletionCandidates(
+			CleanStaleDeletionCandidates(context.TODO(),
 				tc.allNodes,
 				fakeClient,
 				kube_util.CreateEventRecorder(context.TODO(), fakeClient, false),

--- a/cluster-autoscaler/utils/utils.go
+++ b/cluster-autoscaler/utils/utils.go
@@ -27,11 +27,12 @@ import (
 
 // GetNodeGroupSizeMap return a map of node group id and its target size
 func GetNodeGroupSizeMap(ctx context.Context, cloudProvider cloudprovider.CloudProvider) map[string]int {
+	logger := klog.FromContext(ctx)
 	nodeGroupSize := make(map[string]int)
 	for _, nodeGroup := range cloudProvider.NodeGroups() {
 		size, err := nodeGroup.TargetSize()
 		if err != nil {
-			klog.Errorf("Error while checking node group size %s: %v", nodeGroup.Id(), err)
+			logger.Error(err, "Error while checking node group size", "nodeGroupId", nodeGroup.Id())
 			continue
 		}
 		nodeGroupSize[nodeGroup.Id()] = size

--- a/cluster-autoscaler/utils/utils.go
+++ b/cluster-autoscaler/utils/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	apiv1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	klog "k8s.io/klog/v2"
@@ -25,7 +26,7 @@ import (
 )
 
 // GetNodeGroupSizeMap return a map of node group id and its target size
-func GetNodeGroupSizeMap(cloudProvider cloudprovider.CloudProvider) map[string]int {
+func GetNodeGroupSizeMap(ctx context.Context, cloudProvider cloudprovider.CloudProvider) map[string]int {
 	nodeGroupSize := make(map[string]int)
 	for _, nodeGroup := range cloudProvider.NodeGroups() {
 		size, err := nodeGroup.TargetSize()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR migrates all logs printed from CA's main loop to use contextual logging. This is done in phases.

Contextual logging enables us to augment the logs with additional, contextual information. For now this will be only used for `iteration_id` --  unique identifer for main loop iteration. All logs will be changed to use structured logging: instead of formatting values into log message, we will append them at the end of the log in form of key-value pairs.

##### Phase 1: Propagate context across CA.
This commit adds ctx as a parameter to methods across CA. If modified method is an implementation of an interface, we add ctx as a parameter to the interface method. If, as a result of modyfing an interface, there is a method called in the place where no context is present (e. g. in unit tests), we supply it with context.TODO().

##### Phase 2: Migrate the logs.
This commit migrates the logs to use the contextual logger instead of klog. This requires us to rewrite all logs to use structured logging. When migrating, we follow the guidelines described [here](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-instrumentation/migration-to-structured-logging.md).

##### Phase 3: Putting it all together. (NOT READY YET)
In this phase, we add feature flag that governs the contextual logging, and document all the changes.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Part of #9660

This PR is organized into commits to be reviewed sequentially. Some of the commits have huge diffs because they modify a lot of files. If Github is unable to display the diff - I'd recommend checking the PR out locally.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
