### PR TITLE
Ensure that VPA checkpoint is loaded in the correct order

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -283,11 +283,11 @@ func (feeder *clusterStateFeeder) InitFromCheckpoints(ctx context.Context) {
 	klog.V(3).InfoS("Initializing VPA from checkpoints")
 	feeder.LoadVPAs(ctx)
 
-	klog.V(3).InfoS("Fetching VPA checkpoints")
 	checkpointList, err := feeder.vpaCheckpointLister.List(labels.Everything())
 	if err != nil {
 		klog.ErrorS(err, "Cannot list VPA checkpoints")
 	}
+	klog.V(3).InfoS("Fetching VPA checkpoints", "count", len(checkpointList))
 
 	namespaces := make(map[string]bool)
 	for _, v := range feeder.clusterState.VPAs() {

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
@@ -56,8 +56,8 @@ const (
 // It implements controllercontext.Controller.
 type RecommenderController struct {
 	recommender Recommender
-	interval    time.Duration
 	healthCheck *metrics.HealthCheck
+	config      *recommender_config.RecommenderConfig
 }
 
 // NewRecommenderController creates a RecommenderController
@@ -167,23 +167,23 @@ func NewRecommenderController(
 		UpdateWorkerCount:            config.UpdateWorkerCount,
 	}.Make()
 
-	if err := initHistoryProvider(ctx, recommender, config); err != nil {
-		return nil, err
-	}
-
 	return &RecommenderController{
 		recommender: recommender,
-		interval:    config.MetricsFetcherInterval,
 		healthCheck: healthCheck,
+		config:      config,
 	}, nil
 }
 
 // Run starts the recommender loop and blocks until ctx is cancelled.
 // It implements controllercontext.Controller.
 func (c *RecommenderController) Run(ctx context.Context) error {
+	if err := initHistoryProvider(ctx, c.recommender, c.config); err != nil {
+		return err
+	}
+
 	c.healthCheck.StartMonitoring()
 
-	ticker := time.NewTicker(c.interval)
+	ticker := time.NewTicker(c.config.MetricsFetcherInterval)
 	defer ticker.Stop()
 
 	for {

--- a/vertical-pod-autoscaler/test/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/recommender.go
@@ -281,6 +281,61 @@ var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {
 		}
 		gomega.Expect(changeDetected).To(gomega.Equal(true))
 	})
+
+	f.It("is loaded correctly on recommender restart", framework.WithSerial(), framework.WithSlow(), func() {
+		ns := f.Namespace.Name
+
+		ginkgo.By("Waiting for a populated checkpoint to be created")
+		var checkpoint *vpa_types.VerticalPodAutoscalerCheckpoint
+		err := wait.PollUntilContextTimeout(context.Background(), utils.PollInterval, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			list, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				klog.ErrorS(err, "Error listing VPA checkpoints")
+				return false, err
+			}
+			for i := range list.Items {
+				if list.Items[i].Spec.VPAObjectName == vpaCRD.Name && !list.Items[i].Status.FirstSampleStart.IsZero() {
+					checkpoint = &list.Items[i]
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		firstSampleStart := checkpoint.Status.FirstSampleStart
+		lastUpdateTime := checkpoint.Status.LastUpdateTime
+		totalSamplesCount := checkpoint.Status.TotalSamplesCount
+
+		ginkgo.By("Deleting recommender")
+		gomega.Expect(deleteRecommender(f.ClientSet)).To(gomega.BeNil())
+
+		ginkgo.By("Waiting for the checkpoint to be updated after restart")
+		var updatedCheckpoint *vpa_types.VerticalPodAutoscalerCheckpoint
+		err = wait.PollUntilContextTimeout(context.Background(), utils.PollInterval, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			c, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).Get(ctx, checkpoint.Name, metav1.GetOptions{})
+			if err != nil {
+				klog.ErrorS(err, "Error getting VPA checkpoint")
+				return false, nil
+			}
+			if !c.Status.LastUpdateTime.After(lastUpdateTime.Time) {
+				return false, nil
+			}
+			updatedCheckpoint = c
+			return true, nil
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking that firstSampleStart hasn't changed")
+		gomega.Expect(updatedCheckpoint.Status.FirstSampleStart.Equal(&firstSampleStart)).To(gomega.BeTrue(),
+			fmt.Sprintf("firstSampleStart changed after recommender restart: was %v, now %v",
+				firstSampleStart, updatedCheckpoint.Status.FirstSampleStart))
+
+		ginkgo.By("Checking that totalSamplesCount has increased")
+		gomega.Expect(updatedCheckpoint.Status.TotalSamplesCount).To(gomega.BeNumerically(">", totalSamplesCount),
+			fmt.Sprintf("totalSamplesCount should have increased after recommender restart: was %d, now %d",
+				totalSamplesCount, updatedCheckpoint.Status.TotalSamplesCount))
+	})
 })
 
 var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix regression that causes VPA checkpoints to not get loaded on startup

#### Which issue(s) this PR fixes:

Fixes #10035

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed VPA checkpoint loading to prevent recommendations from restarting from scratch
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
