### PR TITLE
VPA: Add micro-benchmarks for recommender and admission-controller

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/logic/server_benchmark_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/logic/server_benchmark_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
+	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
+)
+
+// staticSelectorFetcher returns the same selector for every VPA, standing in
+// for the informer-backed target selector fetcher.
+type staticSelectorFetcher struct {
+	selector labels.Selector
+}
+
+func (f *staticSelectorFetcher) Fetch(_ context.Context, _ *vpa_types.VerticalPodAutoscaler) (labels.Selector, error) {
+	return f.selector, nil
+}
+
+// newBenchmarkAdmissionServer returns an AdmissionServer wired with the same
+// handler chain as production (see pkg/admission-controller/main.go), backed
+// by a lister with vpaCount VPA objects, together with a serialized
+// AdmissionReview request for a pod with containerCount containers that
+// matches exactly one of the VPAs.
+func newBenchmarkAdmissionServer(b *testing.B, containerCount, vpaCount int) (*AdmissionServer, []byte) {
+	b.Helper()
+
+	// A StatefulSet directly controls its pods, so the FakeControllerFetcher
+	// (which resolves a controller to itself) behaves like the real
+	// controller fetcher for this owner hierarchy.
+	sts := appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bench-sts",
+			Namespace: "default",
+		},
+	}
+	targetRef := &autoscalingv1.CrossVersionObjectReference{
+		Kind:       sts.Kind,
+		Name:       sts.Name,
+		APIVersion: sts.APIVersion,
+	}
+
+	podLabels := map[string]string{"app": "bench"}
+	podBuilder := test.Pod().WithName("bench-pod").WithLabels(podLabels).WithCreator(&sts.ObjectMeta, &sts.TypeMeta)
+	vpaBuilder := test.VerticalPodAutoscaler().WithName("bench-vpa").WithTargetRef(targetRef)
+	for i := range containerCount {
+		containerName := fmt.Sprintf("container-%d", i)
+		podBuilder = podBuilder.AddContainer(test.Container().WithName(containerName).
+			WithCPURequest(resource.MustParse("100m")).
+			WithMemRequest(resource.MustParse("100Mi")).
+			WithCPULimit(resource.MustParse("200m")).
+			WithMemLimit(resource.MustParse("200Mi")).
+			Get())
+		vpaBuilder = vpaBuilder.WithContainer(containerName).
+			AppendRecommendation(test.Recommendation().WithContainer(containerName).WithTarget("150m", "150Mi").GetContainerResources())
+	}
+
+	// One matching VPA plus vpaCount-1 VPAs targeting other controllers, all
+	// of which the matcher has to consider.
+	vpas := []*vpa_types.VerticalPodAutoscaler{vpaBuilder.Get()}
+	for i := 1; i < vpaCount; i++ {
+		vpas = append(vpas, test.VerticalPodAutoscaler().
+			WithName(fmt.Sprintf("other-vpa-%d", i)).
+			WithContainer("container-0").
+			WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
+				Kind:       "StatefulSet",
+				Name:       fmt.Sprintf("other-sts-%d", i),
+				APIVersion: "apps/v1",
+			}).
+			Get())
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, vpaObject := range vpas {
+		if err := indexer.Add(vpaObject); err != nil {
+			b.Fatalf("failed to add VPA to indexer: %v", err)
+		}
+	}
+	vpaLister := vpa_lister.NewVerticalPodAutoscalerLister(indexer)
+
+	vpaMatcher := vpa.NewMatcher(vpaLister, &staticSelectorFetcher{selector: labels.SelectorFromSet(podLabels)}, controllerfetcher.FakeControllerFetcher{})
+	limitRangeCalculator := limitrange.NewNoopLimitsCalculator()
+	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator))
+	calculators := []patch.Calculator{patch.NewResourceUpdatesCalculator(recommendationProvider, resource.QuantityValue{}), patch.NewObservedContainersCalculator()}
+	server := NewAdmissionServer(pod.NewDefaultPreProcessor(), vpa.NewDefaultPreProcessor(), limitRangeCalculator, vpaMatcher, calculators)
+
+	podJSON, err := json.Marshal(podBuilder.Get())
+	if err != nil {
+		b.Fatalf("failed to marshal pod: %v", err)
+	}
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
+		Request: &admissionv1.AdmissionRequest{
+			UID:         types.UID("bench-uid"),
+			Resource:    metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			RequestKind: &metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Namespace:   "default",
+			Operation:   admissionv1.Create,
+			Object:      runtime.RawExtension{Raw: podJSON},
+		},
+	}
+	body, err := json.Marshal(review)
+	if err != nil {
+		b.Fatalf("failed to marshal admission review: %v", err)
+	}
+	return server, body
+}
+
+func serveBenchmarkRequest(server *AdmissionServer, body []byte) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	server.Serve(recorder, request)
+	return recorder
+}
+
+// BenchmarkAdmissionServerServe measures the per-request cost of the pod
+// admission webhook: reading the request, unmarshalling the AdmissionReview,
+// matching the pod to a VPA, calculating resource patches and marshalling the
+// response.
+func BenchmarkAdmissionServerServe(b *testing.B) {
+	for _, tc := range []struct {
+		containerCount int
+		vpaCount       int
+	}{
+		{containerCount: 1, vpaCount: 1},
+		{containerCount: 1, vpaCount: 100},
+		{containerCount: 10, vpaCount: 1},
+		{containerCount: 10, vpaCount: 100},
+	} {
+		b.Run(fmt.Sprintf("containers=%d/vpas=%d", tc.containerCount, tc.vpaCount), func(b *testing.B) {
+			server, body := newBenchmarkAdmissionServer(b, tc.containerCount, tc.vpaCount)
+
+			// Sanity-check that the request produces patches, so the
+			// benchmark doesn't silently measure a no-op path.
+			recorder := serveBenchmarkRequest(server, body)
+			if recorder.Code != http.StatusOK {
+				b.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+			}
+			review := admissionv1.AdmissionReview{}
+			if err := json.Unmarshal(recorder.Body.Bytes(), &review); err != nil {
+				b.Fatalf("failed to unmarshal admission response: %v", err)
+			}
+			if review.Response == nil || len(review.Response.Patch) == 0 {
+				b.Fatalf("expected an admission response with patches, got %s", recorder.Body.String())
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				serveBenchmarkRequest(server, body)
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender_benchmark_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender_benchmark_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logic
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/config"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+)
+
+// newBenchmarkRecommender returns a PodResourceRecommender wired the same way
+// the production recommender is (see DefaultRecommenderConfig and
+// routines.RecommenderFactory).
+func newBenchmarkRecommender() PodResourceRecommender {
+	defaults := config.DefaultRecommenderConfig()
+	return CreatePodResourceRecommender(RecommendationConfig{
+		SafetyMarginFraction:       defaults.SafetyMarginFraction,
+		PodMinCPUMillicores:        defaults.PodMinCPUMillicores,
+		PodMinMemoryMb:             defaults.PodMinMemoryMb,
+		TargetCPUPercentile:        defaults.TargetCPUPercentile,
+		LowerBoundCPUPercentile:    defaults.LowerBoundCPUPercentile,
+		UpperBoundCPUPercentile:    defaults.UpperBoundCPUPercentile,
+		ConfidenceIntervalCPU:      defaults.ConfidenceIntervalCPU,
+		TargetMemoryPercentile:     defaults.TargetMemoryPercentile,
+		LowerBoundMemoryPercentile: defaults.LowerBoundMemoryPercentile,
+		UpperBoundMemoryPercentile: defaults.UpperBoundMemoryPercentile,
+		ConfidenceIntervalMemory:   defaults.ConfidenceIntervalMemory,
+	})
+}
+
+// newBenchmarkAggregateState returns an AggregateContainerState populated with
+// sampleCount CPU and memory usage samples, one pair per minute, with usage
+// varying deterministically so that the histograms have many non-empty buckets.
+func newBenchmarkAggregateState(sampleCount int) *model.AggregateContainerState {
+	state := model.NewAggregateContainerState()
+	timestamp := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range sampleCount {
+		state.AddSample(&model.ContainerUsageSample{
+			MeasureStart: timestamp,
+			Usage:        model.CPUAmountFromCores(0.1 + 0.005*float64(i%100)),
+			Resource:     model.ResourceCPU,
+		})
+		state.AddSample(&model.ContainerUsageSample{
+			MeasureStart: timestamp,
+			Usage:        model.MemoryAmountFromBytes(float64(100+i%100) * 1024 * 1024),
+			Resource:     model.ResourceMemory,
+		})
+		timestamp = timestamp.Add(time.Minute)
+	}
+	return state
+}
+
+// BenchmarkGetRecommendedPodResources measures the cost of computing a
+// recommendation for a single VPA from already-aggregated container usage
+// histograms. This is the per-VPA hot path of the recommender's main loop
+// (UpdateVPAs).
+func BenchmarkGetRecommendedPodResources(b *testing.B) {
+	// One day of per-minute usage samples per container.
+	const samplesPerContainer = 24 * 60
+	for _, containerCount := range []int{1, 2, 10} {
+		b.Run(fmt.Sprintf("containers=%d", containerCount), func(b *testing.B) {
+			recommender := newBenchmarkRecommender()
+			containerNameToAggregateStateMap := make(model.ContainerNameToAggregateStateMap, containerCount)
+			for i := range containerCount {
+				containerNameToAggregateStateMap[fmt.Sprintf("container-%d", i)] = newBenchmarkAggregateState(samplesPerContainer)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				recommendation := recommender.GetRecommendedPodResources(containerNameToAggregateStateMap)
+				if len(recommendation) != containerCount {
+					b.Fatalf("expected recommendations for %d containers, got %d", containerCount, len(recommendation))
+				}
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_benchmark_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_benchmark_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+const benchmarkNamespace = "bench-namespace"
+
+// newBenchmarkClusterState returns a clusterState tracking vpaCount VPAs, each
+// selecting pods with the label app=app-<i>.
+func newBenchmarkClusterState(b *testing.B, vpaCount int) *clusterState {
+	b.Helper()
+	cluster := NewClusterState(testGcPeriod)
+	for i := range vpaCount {
+		vpaObject := test.VerticalPodAutoscaler().
+			WithNamespace(benchmarkNamespace).
+			WithName(fmt.Sprintf("vpa-%d", i)).
+			WithContainer("container-1").
+			Get()
+		selector := labels.SelectorFromSet(labels.Set{"app": fmt.Sprintf("app-%d", i)})
+		if err := cluster.AddOrUpdateVpa(vpaObject, selector); err != nil {
+			b.Fatalf("failed to add VPA: %v", err)
+		}
+	}
+	return cluster
+}
+
+// BenchmarkClusterStateAddOrUpdatePod measures the cost of feeding pods into
+// the cluster state. The cluster state feeder calls AddOrUpdatePod for every
+// pod in the cluster on every recommender loop iteration:
+//   - existing-pod: re-adding an already tracked pod with unchanged labels
+//     (the steady-state resync path).
+//   - new-pod: adding a previously unknown pod and deleting it again (the pod
+//     churn path, e.g. after updater evictions). Its cost scales with the
+//     number of VPAs, because new pods are matched against every VPA.
+func BenchmarkClusterStateAddOrUpdatePod(b *testing.B) {
+	podID := PodID{Namespace: benchmarkNamespace, PodName: "pod-1"}
+	podLabels := labels.Set{"app": "app-0"}
+
+	b.Run("existing-pod", func(b *testing.B) {
+		cluster := newBenchmarkClusterState(b, 100)
+		cluster.AddOrUpdatePod(podID, podLabels, corev1.PodRunning)
+		b.ReportAllocs()
+		for b.Loop() {
+			cluster.AddOrUpdatePod(podID, podLabels, corev1.PodRunning)
+		}
+	})
+
+	for _, vpaCount := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("new-pod/vpas=%d", vpaCount), func(b *testing.B) {
+			cluster := newBenchmarkClusterState(b, vpaCount)
+			b.ReportAllocs()
+			for b.Loop() {
+				cluster.AddOrUpdatePod(podID, podLabels, corev1.PodRunning)
+				cluster.DeletePod(podID)
+			}
+		})
+	}
+}
+
+// BenchmarkClusterStateAddSample measures the cost of aggregating a single
+// container usage sample. The cluster state feeder calls AddSample for every
+// container in the cluster on every metrics resync.
+func BenchmarkClusterStateAddSample(b *testing.B) {
+	for _, resourceName := range []ResourceName{ResourceCPU, ResourceMemory} {
+		b.Run(string(resourceName), func(b *testing.B) {
+			cluster := newBenchmarkClusterState(b, 1)
+			podID := PodID{Namespace: benchmarkNamespace, PodName: "pod-1"}
+			containerID := ContainerID{PodID: podID, ContainerName: "container-1"}
+			cluster.AddOrUpdatePod(podID, labels.Set{"app": "app-0"}, corev1.PodRunning)
+			if err := cluster.AddOrUpdateContainer(containerID, testRequest); err != nil {
+				b.Fatalf("failed to add container: %v", err)
+			}
+			usage := CPUAmountFromCores(0.5)
+			if resourceName == ResourceMemory {
+				usage = MemoryAmountFromBytes(512 * 1024 * 1024)
+			}
+			timestamp := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			b.ReportAllocs()
+			for b.Loop() {
+				timestamp = timestamp.Add(time.Second)
+				err := cluster.AddSample(&ContainerUsageSampleWithKey{
+					ContainerUsageSample: ContainerUsageSample{
+						MeasureStart: timestamp,
+						Usage:        usage,
+						Resource:     resourceName,
+					},
+					Container: containerID,
+				})
+				if err != nil {
+					b.Fatalf("failed to add sample: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkVpaAggregateStateByContainerName measures the cost of merging the
+// aggregations contributing to a VPA into per-container-name state. The
+// recommender performs this merge for every VPA on every loop iteration,
+// before computing the recommendation. Pods with distinct label sets (e.g.
+// different pod-template-hash values across rolling updates) each contribute
+// a separate aggregation that must be merged.
+func BenchmarkVpaAggregateStateByContainerName(b *testing.B) {
+	// One hour of per-minute usage samples per aggregation.
+	const samplesPerAggregation = 60
+	for _, labelSetCount := range []int{1, 10, 50} {
+		b.Run(fmt.Sprintf("aggregations=%d", labelSetCount), func(b *testing.B) {
+			cluster := NewClusterState(testGcPeriod)
+			vpaObject := test.VerticalPodAutoscaler().
+				WithNamespace(benchmarkNamespace).
+				WithName("bench-vpa").
+				WithContainer("container-1").
+				Get()
+			selector := labels.SelectorFromSet(labels.Set{"app": "bench"})
+			if err := cluster.AddOrUpdateVpa(vpaObject, selector); err != nil {
+				b.Fatalf("failed to add VPA: %v", err)
+			}
+			for i := range labelSetCount {
+				podID := PodID{Namespace: benchmarkNamespace, PodName: fmt.Sprintf("pod-%d", i)}
+				podLabels := labels.Set{"app": "bench", "pod-template-hash": fmt.Sprintf("hash-%d", i)}
+				cluster.AddOrUpdatePod(podID, podLabels, corev1.PodRunning)
+				containerID := ContainerID{PodID: podID, ContainerName: "container-1"}
+				if err := cluster.AddOrUpdateContainer(containerID, testRequest); err != nil {
+					b.Fatalf("failed to add container: %v", err)
+				}
+				timestamp := testTimestamp
+				for j := range samplesPerAggregation {
+					timestamp = timestamp.Add(time.Minute)
+					err := cluster.AddSample(&ContainerUsageSampleWithKey{
+						ContainerUsageSample: ContainerUsageSample{
+							MeasureStart: timestamp,
+							Usage:        CPUAmountFromCores(0.1 + 0.01*float64(j%10)),
+							Resource:     ResourceCPU,
+						},
+						Container: containerID,
+					})
+					if err != nil {
+						b.Fatalf("failed to add sample: %v", err)
+					}
+				}
+			}
+			vpa := cluster.vpas[VpaID{Namespace: benchmarkNamespace, VpaName: "bench-vpa"}]
+			if got := len(vpa.aggregateContainerStates); got != labelSetCount {
+				b.Fatalf("expected %d aggregations, got %d", labelSetCount, got)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				merged := vpa.AggregateStateByContainerName()
+				if len(merged) != 1 {
+					b.Fatalf("expected aggregate state for 1 container name, got %d", len(merged))
+				}
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/test/benchmark/README.md
+++ b/vertical-pod-autoscaler/test/benchmark/README.md
@@ -2,7 +2,7 @@
 
 Measures VPA component latencies using KWOK (Kubernetes WithOut Kubelet) to simulate pods without real resource consumption.
 
-> **Note:** Currently only updater metrics are collected. Recommender metrics are planned for the future.
+> **Note:** The cluster benchmark currently only collects updater metrics. Recommender metrics are planned for the future. The hot paths of the recommender and the admission-controller are covered by [Go micro-benchmarks](#micro-benchmarks-no-cluster-required) that run without a cluster.
 
 <!-- toc -->
 - [Prerequisites](#prerequisites)
@@ -15,6 +15,7 @@ Measures VPA component latencies using KWOK (Kubernetes WithOut Kubelet) to simu
   - [Updater Metrics](#updater-metrics)
 - [Scripts](#scripts)
 - [Cleanup](#cleanup)
+- [Micro-benchmarks (No Cluster Required)](#micro-benchmarks-no-cluster-required)
 - [Notes](#notes)
   - [Performance Optimizations](#performance-optimizations)
   - [Caveats](#caveats)
@@ -154,6 +155,40 @@ Environment variables accepted by the scripts:
 
 ```bash
 kind delete cluster
+```
+
+## Micro-benchmarks (No Cluster Required)
+
+Standard Go benchmarks (`testing.B`) cover the recommender and
+admission-controller hot paths with synthetic VPA and pod fixtures. They run in
+seconds on a developer machine, need no cluster, and are the quickest way to
+check whether a code change regresses these code paths.
+
+| Package | Benchmark | What it measures |
+| ------- | --------- | ---------------- |
+| `pkg/recommender/model` | `BenchmarkClusterStateAddOrUpdatePod` | Feeding pods into the cluster state: steady-state resync of tracked pods and pod churn scaling with the number of VPAs |
+| `pkg/recommender/model` | `BenchmarkClusterStateAddSample` | Aggregating a single CPU/memory usage sample (runs for every container on every metrics resync) |
+| `pkg/recommender/model` | `BenchmarkVpaAggregateStateByContainerName` | Merging the aggregations contributing to a VPA (runs for every VPA on every recommender loop) |
+| `pkg/recommender/logic` | `BenchmarkGetRecommendedPodResources` | Computing the recommendation for one VPA from aggregated usage histograms, with the default production estimator chain |
+| `pkg/admission-controller/logic` | `BenchmarkAdmissionServerServe` | Full per-request cost of the pod admission webhook: request decoding, VPA matching, patch calculation and response encoding |
+
+Run all of them:
+
+```bash
+cd vertical-pod-autoscaler
+go test -run='^$' -bench=. -benchmem \
+  ./pkg/recommender/model/ ./pkg/recommender/logic/ ./pkg/admission-controller/logic/
+```
+
+To compare a change against `master`, collect repeated runs of the relevant
+benchmark on both branches and feed them to
+[benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat):
+
+```bash
+go test -run='^$' -bench=BenchmarkAdmissionServerServe -benchmem -count=10 \
+  ./pkg/admission-controller/logic/ | tee /tmp/new.txt
+# ... check out the baseline, repeat with | tee /tmp/old.txt ...
+benchstat /tmp/old.txt /tmp/new.txt
 ```
 
 ## Notes


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area vertical-pod-autoscaler

#### What this PR does / why we need it:

The VPA benchmark in `vertical-pod-autoscaler/test/benchmark` currently only collects step
latencies for the updater; there is no benchmarking coverage for the recommender or the
admission-controller (and no `testing.B` benchmarks anywhere in the VPA tree).

This PR adds standard Go micro-benchmarks for the recommender and admission-controller hot
paths, using synthetic VPA + pod fixtures and the production configuration/handler chains:

- `pkg/recommender/model`:
  - `BenchmarkClusterStateAddOrUpdatePod` — feeding pods into the cluster state: steady-state
    resync of tracked pods, and pod churn scaling with the number of VPAs (10/100/1000), i.e.
    the O(pods x VPAs) matching path.
  - `BenchmarkClusterStateAddSample` — aggregating a single CPU/memory usage sample (runs for
    every container on every metrics resync).
  - `BenchmarkVpaAggregateStateByContainerName` — merging the aggregations contributing to a
    VPA (1/10/50 distinct pod label sets), the pre-recommendation step of `UpdateVPAs`.
- `pkg/recommender/logic`:
  - `BenchmarkGetRecommendedPodResources` — computing the recommendation for one VPA from
    populated usage histograms (1/2/10 containers), with the estimator chain built from
    `config.DefaultRecommenderConfig()` exactly as `routines.RecommenderFactory` builds it.
- `pkg/admission-controller/logic`:
  - `BenchmarkAdmissionServerServe` — the full per-request cost of the pod admission webhook
    (request decoding, VPA matching, patch calculation, response encoding), wired with the
    same calculators/pre-processors as `pkg/admission-controller/main.go` and a real generated
    VPA lister; sub-benchmarks vary pod container count (1/10) and VPAs in the namespace
    (1/100). A pre-loop sanity check asserts the response contains patches, so the benchmark
    cannot silently measure a no-op path.

`test/benchmark/README.md` gains a "Micro-benchmarks (No Cluster Required)" section describing
what each benchmark measures, how to run them, and how to compare a change against `master`
with `benchstat`.

The benchmarks run in seconds on a developer machine, need no cluster, and add nothing to
plain `go test` runtime. Test-only files + docs; no production code is touched.

Example output (Apple M1 Pro, `go test -run='^$' -bench=. -benchmem`):

```
BenchmarkClusterStateAddOrUpdatePod/existing-pod-10            2609959      447.2 ns/op      56 B/op     3 allocs/op
BenchmarkClusterStateAddOrUpdatePod/new-pod/vpas=10-10          420786       2621 ns/op     200 B/op     5 allocs/op
BenchmarkClusterStateAddOrUpdatePod/new-pod/vpas=100-10          86766      15184 ns/op     200 B/op     5 allocs/op
BenchmarkClusterStateAddOrUpdatePod/new-pod/vpas=1000-10          8090     174931 ns/op     200 B/op     5 allocs/op
BenchmarkClusterStateAddSample/cpu-10                           617372       2638 ns/op     352 B/op     5 allocs/op
BenchmarkClusterStateAddSample/memory-10                        804904       2232 ns/op     288 B/op     4 allocs/op
BenchmarkVpaAggregateStateByContainerName/aggregations=1-10     363300      11769 ns/op    3600 B/op     9 allocs/op
BenchmarkVpaAggregateStateByContainerName/aggregations=10-10     34292      34673 ns/op    3600 B/op     9 allocs/op
BenchmarkVpaAggregateStateByContainerName/aggregations=50-10     24487      46554 ns/op    3600 B/op     9 allocs/op
BenchmarkGetRecommendedPodResources/containers=1-10             185139      12842 ns/op    1312 B/op    14 allocs/op
BenchmarkGetRecommendedPodResources/containers=2-10             122928      22820 ns/op    2080 B/op    20 allocs/op
BenchmarkGetRecommendedPodResources/containers=10-10             10000     106806 ns/op    8968 B/op    71 allocs/op
BenchmarkAdmissionServerServe/containers=1/vpas=1-10             10000     182934 ns/op   30580 B/op   218 allocs/op
BenchmarkAdmissionServerServe/containers=1/vpas=100-10            5505     220564 ns/op   34532 B/op   225 allocs/op
BenchmarkAdmissionServerServe/containers=10/vpas=1-10             1592    1146969 ns/op  195113 B/op  1212 allocs/op
BenchmarkAdmissionServerServe/containers=10/vpas=100-10           2137     685069 ns/op  199397 B/op  1220 allocs/op
```

#### Which issue(s) this PR fixes:

Part of #9443

#### Reviewer notes:

- #9443 was originally scoped around extending the KWOK cluster benchmark
  (test/benchmark) with recommender/admission metric scraping, which @maxcao13 started in
  #9449 before unassigning. This PR takes the complementary micro-benchmark route: it covers
  the same two components at the code-path level, runs without a cluster, and localizes
  regressions to a specific function. Extending the KWOK harness tables per #9449 can still
  follow as a separate PR — happy to adjust scope if you'd rather see that revived here
  instead.
- The admission benchmark substitutes only the informer-backed pieces that require an
  apiserver: the target selector fetcher returns a fixed selector and the controller fetcher
  is the existing `controllerfetcher.FakeControllerFetcher` with a StatefulSet owner (the same
  stand-in `matcher_test.go` uses). Everything else — matcher, lister, pre-processors,
  recommendation provider, capping processor, patch calculators, JSON (de)serialization — is
  the production chain.
- Verified with `go test`, `go vet` and `golangci-lint run` (repo config) on the three
  affected packages: all clean.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Usage]: vertical-pod-autoscaler/test/benchmark/README.md ("Micro-benchmarks (No Cluster Required)" section added in this PR)
```

As discussed in kubernetes/autoscaler#9443 (go-ahead from @adrianmoisey): part of #9443.

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
