### PR TITLE
clusterapi: implement ForceDeleteNodes to bypass min size

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -103,6 +103,13 @@ func (ng *nodegroup) AtomicIncreaseSize(delta int) error {
 // group. This function should wait until node group size is updated.
 // Implementation required.
 func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
+	return ng.deleteNodes(nodes, false)
+}
+
+// deleteNodes deletes nodes from this node group. When force is true the
+// minimum size of the node group is not enforced, allowing it to be scaled
+// below its configured minimum.
+func (ng *nodegroup) deleteNodes(nodes []*corev1.Node, force bool) error {
 	ng.machineController.accessLock.Lock()
 	defer ng.machineController.accessLock.Unlock()
 
@@ -112,7 +119,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	}
 
 	// if we are at minSize already we fail early.
-	if replicas <= ng.MinSize() {
+	if !force && replicas <= ng.MinSize() {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 
@@ -138,7 +145,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	// Step 2: if deleting len(nodes) would make the replica count
 	// < minSize, then the request to delete that many nodes is bogus
 	// and we fail fast.
-	if replicas-len(nodes) < ng.MinSize() {
+	if !force && replicas-len(nodes) < ng.MinSize() {
 		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are %d, minSize is %d", len(nodes), ng.Id(), replicas, ng.MinSize())
 	}
 
@@ -187,7 +194,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 
 				klog.Warningf("No Machine found for node %q in MachinePool %q, falling back to replica decrement only", node.Spec.ProviderID, nodeGroup.Id())
 
-				if err := nodeGroup.scalableResource.SetSize(replicas - 1); err != nil {
+				if err := nodeGroup.scalableResource.setSize(replicas-1, force); err != nil {
 					return err
 				}
 
@@ -209,7 +216,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 			return err
 		}
 
-		if err := nodeGroup.scalableResource.SetSize(replicas - 1); err != nil {
+		if err := nodeGroup.scalableResource.setSize(replicas-1, force); err != nil {
 			_ = nodeGroup.scalableResource.UnmarkMachineForDeletion(machine)
 			return err
 		}
@@ -222,7 +229,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.
 func (ng *nodegroup) ForceDeleteNodes(nodes []*corev1.Node) error {
-	return cloudprovider.ErrNotImplemented
+	return ng.deleteNodes(nodes, true)
 }
 
 // DecreaseTargetSize decreases the target size of the node group.

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -951,6 +951,100 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 	})
 }
 
+func TestNodeGroupForceDeleteNodes(t *testing.T) {
+	// A node group sitting exactly at its minimum size. DeleteNodes must
+	// refuse to scale it down, while ForceDeleteNodes must be allowed to,
+	// so that nodes which no longer exist on the provider side can be
+	// removed and subsequently replaced.
+	test := func(t *testing.T, testConfig *TestConfig) {
+		controller := NewTestMachineController(t)
+		defer controller.Stop()
+		controller.AddTestConfigs(testConfig)
+
+		nodegroups, err := controller.nodeGroups()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if l := len(nodegroups); l != 1 {
+			t.Fatalf("expected 1 nodegroup, got %d", l)
+		}
+
+		ng := nodegroups[0].(*nodegroup)
+
+		if ng.MinSize() != 3 {
+			t.Fatalf("expected minSize=3, got %d", ng.MinSize())
+		}
+
+		nodesToDelete := testConfig.nodes[:1]
+
+		// Sanity check: the regular deletion path is blocked by the min size
+		// constraint, which is what leaves the node group unable to replace
+		// nodes that vanished on the provider side.
+		if err := ng.DeleteNodes(nodesToDelete); err == nil {
+			t.Fatal("expected DeleteNodes to fail at min size, got no error")
+		} else if !strings.Contains(err.Error(), "min size reached") {
+			t.Fatalf("expected %q, got %q", "min size reached", err.Error())
+		}
+
+		// ForceDeleteNodes must bypass the min size constraint.
+		if err := ng.ForceDeleteNodes(nodesToDelete); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		machine, err := controller.managementClient.Resource(controller.machineResource).
+			Namespace(testConfig.spec.namespace).
+			Get(context.TODO(), testConfig.machines[0].GetName(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, found := machine.GetAnnotations()[machineDeleteAnnotationKey]; !found {
+			t.Errorf("expected annotation %q on machine %s", machineDeleteAnnotationKey, machine.GetName())
+		}
+
+		gvr, err := ng.scalableResource.GroupVersionResource()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		scalableResource, err := ng.machineController.managementScaleClient.Scales(testConfig.spec.namespace).
+			Get(context.TODO(), gvr.GroupResource(), ng.scalableResource.Name(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Replicas are now below minSize; enforcing the minimum is left to the
+		// core autoscaler, which will scale the group back up and thereby
+		// replace the removed node.
+		if scalableResource.Spec.Replicas != 2 {
+			t.Errorf("expected 2, got %v", scalableResource.Spec.Replicas)
+		}
+	}
+
+	annotations := map[string]string{
+		nodeGroupMinSizeAnnotationKey: "3",
+		nodeGroupMaxSizeAnnotationKey: "10",
+	}
+
+	t.Run("MachineSet", func(t *testing.T) {
+		testConfig := NewTestConfigBuilder().
+			ForMachineSet().
+			WithNodeCount(3).
+			WithAnnotations(annotations).
+			Build()
+		test(t, testConfig)
+	})
+
+	t.Run("MachineDeployment", func(t *testing.T) {
+		testConfig := NewTestConfigBuilder().
+			ForMachineDeployment().
+			WithNodeCount(3).
+			WithAnnotations(annotations).
+			Build()
+		test(t, testConfig)
+	})
+}
+
 func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 	test := func(t *testing.T, expected int, testConfigs []*TestConfig) {
 		testConfig0, testConfig1 := testConfigs[0], testConfigs[1]

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -115,11 +115,24 @@ func (r *unstructuredScalableResource) Replicas() (int, error) {
 }
 
 func (r *unstructuredScalableResource) SetSize(nreplicas int) error {
+	return r.setSize(nreplicas, false)
+}
+
+// setSize updates the replica count of the scalable resource. When force is
+// true the configured minimum size is not enforced, allowing the resource to
+// be scaled below it; the replica count is still never allowed to go negative
+// or above the configured maximum.
+func (r *unstructuredScalableResource) setSize(nreplicas int, force bool) error {
+	minSize := r.minSize
+	if force {
+		minSize = 0
+	}
+
 	switch {
 	case nreplicas > r.maxSize:
 		return fmt.Errorf("size increase too large - desired:%d max:%d", nreplicas, r.maxSize)
-	case nreplicas < r.minSize:
-		return fmt.Errorf("size decrease too large - desired:%d min:%d", nreplicas, r.minSize)
+	case nreplicas < minSize:
+		return fmt.Errorf("size decrease too large - desired:%d min:%d", nreplicas, minSize)
 	}
 
 	gvr, err := r.GroupVersionResource()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a node group has reached its minimum size and a node disappears on the
provider side (deleted out-of-band, or otherwise left unregistered), the
ClusterAPI provider can never remove it, so it is never replaced. The node
group stays permanently below `minSize`, even with
`--enforce-node-group-min-size=true` and `--force-delete-unregistered-nodes=true`.

**Root cause**

The core autoscaler already has the whole path wired up. In
`removeOldUnregisteredNodes` (`core/static_autoscaler.go`), when
`--force-delete-unregistered-nodes` is set, core skips its own min-size capping
and calls `NodeGroup.ForceDeleteNodes`, falling back to `DeleteNodes` when the
provider returns `cloudprovider.ErrNotImplemented`.

The ClusterAPI provider never implemented `ForceDeleteNodes`:

```go
// ForceDeleteNodes deletes nodes from the group regardless of constraints.
func (ng *nodegroup) ForceDeleteNodes(nodes []*corev1.Node) error {
	return cloudprovider.ErrNotImplemented
}
```

So core always fell back to `DeleteNodes`, which enforces the minimum and
refuses the deletion:

```go
// if we are at minSize already we fail early.
if replicas <= ng.MinSize() {
	return fmt.Errorf("min size reached, nodes will not be deleted")
}
```

There are in fact three separate min-size gates on this path:
`DeleteNodes` fails early on `replicas <= MinSize()`, fails again on
`replicas-len(nodes) < MinSize()`, and finally
`unstructuredScalableResource.SetSize` rejects `nreplicas < r.minSize`. All three
have to be bypassed for a forced deletion to actually go through.

**The fix**

`DeleteNodes` and `ForceDeleteNodes` now share one implementation behind a
`force` flag that skips the two min-size checks, and the flag is plumbed into a
new `unstructuredScalableResource.setSize(nreplicas, force)` so the third gate is
bypassed too. A forced resize still refuses to drive the replica count negative
or above the configured maximum. `SetSize` keeps its existing signature and
behaviour.

Enforcing the minimum afterwards is deliberately left to core: once the stale
node is gone, the existing `--enforce-node-group-min-size` logic scales the group
back up, which is what replaces the node.

#### Scope

This PR only implements `ForceDeleteNodes` for the ClusterAPI provider, kept
deliberately narrow to keep the change reviewable.

Most other providers (AWS, and others touched by #7493) still return
`cloudprovider.ErrNotImplemented`, and are unaffected by this PR — core's
existing `ErrNotImplemented` fallback keeps their behaviour exactly as it is
today. They can follow the same pattern in separate PRs: share the delete
implementation behind a `force` flag and skip the provider's min-size
validation. GCP, Azure and OCI already implement `ForceDeleteNodes`.

Reported and analysed by @kincoy, who reproduced this locally with the ClusterAPI
provider and identified the unimplemented `ForceDeleteNodes` as the missing piece.

/cc @kincoy
/cc @elmiko

#### Which issue(s) this PR fixes:

Fixes #8046

#### Special notes for your reviewer:

New test `TestNodeGroupForceDeleteNodes` (MachineSet and MachineDeployment)
builds a node group sitting exactly at `minSize` (min=3, max=10, 3 nodes) and
asserts both halves of the behaviour:

- `DeleteNodes` still fails with `min size reached` — the blocking behaviour that
  causes the bug is intentionally preserved.
- `ForceDeleteNodes` succeeds, annotates the backing Machine for deletion, and
  brings replicas to 2, i.e. below `minSize`.

Before the fix the test fails with `unexpected error: Not implemented`; after it
passes. The existing `DeleteNodes` tests, including the MachinePool cases, are
unchanged and still pass.

Verified with:

- `go test ./cloudprovider/clusterapi/... -count=1` (also with `-race`)
- `go test ./core/... -count=1`
- `go build ./...`, `go vet ./cloudprovider/clusterapi/...`, `gofmt -l`

#### Does this PR introduce a user-facing change?

```release-note
Fixed the ClusterAPI provider never replacing nodes that were removed on the provider side while a node group was at its minimum size. `ForceDeleteNodes` is now implemented, so `--force-delete-unregistered-nodes` can remove such nodes and let `--enforce-node-group-min-size` scale the group back up.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
