### PR TITLE
VPA: lazily backfill checkpoints for VPAs newly tracked by a recommender

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -230,6 +230,11 @@ type clusterStateFeeder struct {
 	ignoredNamespaces   []string
 	vpaObjectNamespace  string
 	podsToDelete        []model.PodID
+	// checkpointsInitialized is set once InitFromCheckpoints has done its one-time bulk load of
+	// checkpoints. Afterwards, LoadVPAs lazily loads checkpoints for any VPA it newly starts
+	// tracking, so that a VPA reassigned to this recommender (e.g. via a spec.recommenders change)
+	// doesn't have its accumulated history wiped out by the next checkpoint write.
+	checkpointsInitialized bool
 }
 
 func (feeder *clusterStateFeeder) InitFromHistoryProvider(historyProvider history.HistoryProvider) {
@@ -304,6 +309,36 @@ func (feeder *clusterStateFeeder) InitFromCheckpoints(ctx context.Context) {
 			klog.V(3).InfoS("Loading checkpoint for VPA", "checkpoint", klog.KRef(checkpoint.Namespace, checkpoint.Spec.VPAObjectName), "container", checkpoint.Spec.ContainerName)
 			err = feeder.setVpaCheckpoint(checkpoint)
 			if err != nil {
+				klog.ErrorS(err, "Error while loading checkpoint")
+			}
+		}
+	}
+	feeder.checkpointsInitialized = true
+}
+
+// loadCheckpointsForNewVPAs loads persisted checkpoints for VPAs that have just started being
+// tracked by this recommender - either because they were newly assigned to it via
+// spec.recommenders, or because an existing VPA's pod selector changed and its in-memory state
+// was recreated from scratch. Without this, such a VPA would have its accumulated history
+// dropped the next time this recommender writes a checkpoint for it.
+func (feeder *clusterStateFeeder) loadCheckpointsForNewVPAs(newVpaIDs map[model.VpaID]bool) {
+	namespaces := make(map[string]bool)
+	for vpaID := range newVpaIDs {
+		namespaces[vpaID.Namespace] = true
+	}
+	for namespace := range namespaces {
+		checkpointList, err := feeder.vpaCheckpointLister.VerticalPodAutoscalerCheckpoints(namespace).List(labels.Everything())
+		if err != nil {
+			klog.ErrorS(err, "Cannot list VPA checkpoints", "namespace", namespace)
+			continue
+		}
+		for _, checkpoint := range checkpointList {
+			vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
+			if !newVpaIDs[vpaID] {
+				continue
+			}
+			klog.V(3).InfoS("Loading checkpoint for newly tracked VPA", "checkpoint", klog.KRef(checkpoint.Namespace, checkpoint.Spec.VPAObjectName), "container", checkpoint.Spec.ContainerName)
+			if err := feeder.setVpaCheckpoint(checkpoint); err != nil {
 				klog.ErrorS(err, "Error while loading checkpoint")
 			}
 		}
@@ -442,11 +477,13 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 	klog.V(3).InfoS("Fetching VPAs", "count", len(vpaCRDs))
 	// Add or update existing VPAs in the model.
 	vpaKeys := make(map[model.VpaID]bool)
+	newVpaIDs := make(map[model.VpaID]bool)
 	for _, vpaCRD := range vpaCRDs {
 		vpaID := model.VpaID{
 			Namespace: vpaCRD.Namespace,
 			VpaName:   vpaCRD.Name,
 		}
+		previousVpa := feeder.clusterState.VPAs()[vpaID]
 
 		selector, conditions := feeder.getSelector(ctx, vpaCRD)
 		klog.V(4).InfoS("Using selector", "selector", selector.String(), "vpa", klog.KObj(vpaCRD))
@@ -454,6 +491,12 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 		if feeder.clusterState.AddOrUpdateVpa(vpaCRD, selector) == nil {
 			// Successfully added VPA to the model.
 			vpaKeys[vpaID] = true
+			// AddOrUpdateVpa recreates the Vpa object, with an empty checkpoint baseline, both
+			// when it's newly tracked and when an already-tracked VPA's pod selector changed.
+			// Detect either case by comparing object identity rather than just key presence.
+			if feeder.clusterState.VPAs()[vpaID] != previousVpa {
+				newVpaIDs[vpaID] = true
+			}
 
 			for _, condition := range conditions {
 				if condition.delete {
@@ -474,6 +517,12 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 		}
 	}
 	feeder.clusterState.SetObservedVPAs(vpaCRDs)
+
+	// The initial bulk load already covers every VPA tracked at startup; only lazily backfill
+	// checkpoints for VPAs that started being tracked afterwards (e.g. reassigned recommenders).
+	if feeder.checkpointsInitialized && len(newVpaIDs) > 0 {
+		feeder.loadCheckpointsForNewVPAs(newVpaIDs)
+	}
 }
 
 // LoadPods loads pod into the cluster state.

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -1006,6 +1006,185 @@ func TestFilterVPAsIgnoreNamespaces(t *testing.T) {
 	assert.ElementsMatch(t, expectedResult, result)
 }
 
+// TestLoadVPAsBackfillsCheckpointForVpaReassignedToRecommender reproduces
+// https://github.com/kubernetes/autoscaler/issues/9241: a VPA whose spec.recommenders is
+// changed to point at an already-running recommender must have its checkpoint lazily loaded,
+// otherwise the recommender starts tracking it with empty state and the next checkpoint write
+// wipes out its accumulated history.
+func TestLoadVPAsBackfillsCheckpointForVpaReassignedToRecommender(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	targetSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
+	targetSelectorFetcher.EXPECT().Fetch(gomock.Any()).Return(parseLabelSelector("app = test"), nil).Times(1)
+
+	vpaBuilder := test.VerticalPodAutoscaler().WithName("testVpa").WithContainer("container").WithNamespace(namespace)
+	vpaForOtherRecommender := vpaBuilder.WithRecommender("other").Get()
+	vpaForThisRecommender := vpaBuilder.WithRecommender("frugal").Get()
+
+	vpaCheckpoint := &vpa_types.VerticalPodAutoscalerCheckpoint{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "testVpa-container"},
+		Spec: vpa_types.VerticalPodAutoscalerCheckpointSpec{
+			VPAObjectName: "testVpa",
+			ContainerName: "container",
+		},
+		Status: vpa_types.VerticalPodAutoscalerCheckpointStatus{
+			Version:           model.SupportedCheckpointVersion,
+			TotalSamplesCount: 42,
+		},
+	}
+	checkpointNamespaceLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointNamespaceLister.On("List").Return([]*vpa_types.VerticalPodAutoscalerCheckpoint{vpaCheckpoint}, nil)
+	checkpointLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointLister.On("VerticalPodAutoscalerCheckpoints", namespace).Return(checkpointNamespaceLister)
+
+	clusterState := model.NewClusterState(testGcPeriod)
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	feeder := clusterStateFeeder{
+		vpaLister:              vpaLister,
+		clusterState:           clusterState,
+		selectorFetcher:        targetSelectorFetcher,
+		vpaCheckpointLister:    checkpointLister,
+		recommenderName:        "frugal",
+		controllerFetcher:      &fakeControllerFetcher{},
+		checkpointsInitialized: true,
+	}
+
+	vpaID := model.VpaID{Namespace: namespace, VpaName: "testVpa"}
+
+	// Cycle 1: the VPA is still handled by a different recommender, so this recommender
+	// doesn't track it yet.
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaForOtherRecommender}, nil).Once()
+	feeder.LoadVPAs(context.Background())
+	assert.NotContains(t, clusterState.VPAs(), vpaID)
+
+	// Cycle 2: spec.recommenders now selects this recommender. The VPA is newly tracked, so
+	// its checkpoint must be lazily loaded rather than starting from empty state.
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaForThisRecommender}, nil).Once()
+	feeder.LoadVPAs(context.Background())
+
+	if assert.Contains(t, clusterState.VPAs(), vpaID) {
+		initialState, ok := clusterState.VPAs()[vpaID].ContainersInitialAggregateState["container"]
+		if assert.True(t, ok, "expected checkpoint to be backfilled into ContainersInitialAggregateState") {
+			assert.Equal(t, int(42), initialState.TotalSamplesCount)
+		}
+	}
+}
+
+// sequentialSelectorFetcher returns a different selector on each successive Fetch call, to
+// simulate a VPA's target's pod selector changing between reconcile cycles.
+type sequentialSelectorFetcher struct {
+	selectors []labels.Selector
+	calls     int
+}
+
+func (f *sequentialSelectorFetcher) Fetch(_ context.Context, _ *vpa_types.VerticalPodAutoscaler) (labels.Selector, error) {
+	selector := f.selectors[f.calls]
+	if f.calls < len(f.selectors)-1 {
+		f.calls++
+	}
+	return selector, nil
+}
+
+// TestLoadVPAsBackfillsCheckpointWhenSelectorChangeRecreatesVpa covers the other way a VPA's
+// in-memory state gets reset to empty: model.AddOrUpdateVpa recreates the Vpa object (with a
+// fresh, empty ContainersInitialAggregateState) whenever its target's pod selector changes, not
+// just when it's tracked for the first time. That recreation must also trigger a checkpoint
+// reload, or the next checkpoint write would wipe out the VPA's history just as in #9241.
+func TestLoadVPAsBackfillsCheckpointWhenSelectorChangeRecreatesVpa(t *testing.T) {
+	targetRef := &autoscalingv1.CrossVersionObjectReference{
+		Kind:       kind,
+		Name:       name1,
+		APIVersion: apiVersion,
+	}
+	topKey := &controllerfetcher.ControllerKeyWithAPIVersion{
+		ControllerKey: controllerfetcher.ControllerKey{
+			Kind:      kind,
+			Name:      name1,
+			Namespace: namespace,
+		},
+		ApiVersion: apiVersion,
+	}
+	vpa := test.VerticalPodAutoscaler().WithName("testVpa").WithContainer("container").WithNamespace(namespace).
+		WithTargetRef(targetRef).WithRecommender("frugal").Get()
+
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpa}, nil)
+
+	selectorFetcher := &sequentialSelectorFetcher{selectors: []labels.Selector{
+		parseLabelSelector("app = old"),
+		parseLabelSelector("app = new"),
+	}}
+
+	vpaCheckpoint := &vpa_types.VerticalPodAutoscalerCheckpoint{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "testVpa-container"},
+		Spec: vpa_types.VerticalPodAutoscalerCheckpointSpec{
+			VPAObjectName: "testVpa",
+			ContainerName: "container",
+		},
+		Status: vpa_types.VerticalPodAutoscalerCheckpointStatus{
+			Version:           model.SupportedCheckpointVersion,
+			TotalSamplesCount: 7,
+		},
+	}
+	checkpointNamespaceLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointNamespaceLister.On("List").Return([]*vpa_types.VerticalPodAutoscalerCheckpoint{vpaCheckpoint}, nil)
+	checkpointLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointLister.On("VerticalPodAutoscalerCheckpoints", namespace).Return(checkpointNamespaceLister)
+
+	clusterState := model.NewClusterState(testGcPeriod)
+	feeder := clusterStateFeeder{
+		vpaLister:              vpaLister,
+		clusterState:           clusterState,
+		selectorFetcher:        selectorFetcher,
+		vpaCheckpointLister:    checkpointLister,
+		recommenderName:        "frugal",
+		controllerFetcher:      &fakeControllerFetcher{key: topKey},
+		checkpointsInitialized: true,
+	}
+
+	vpaID := model.VpaID{Namespace: namespace, VpaName: "testVpa"}
+
+	// Cycle 1: VPA is tracked for the first time, with its initial pod selector.
+	feeder.LoadVPAs(context.Background())
+	if !assert.Contains(t, clusterState.VPAs(), vpaID) {
+		return
+	}
+	firstVpa := clusterState.VPAs()[vpaID]
+
+	// Cycle 2: the target's pod selector changed, so AddOrUpdateVpa recreates the Vpa object.
+	feeder.LoadVPAs(context.Background())
+	if !assert.Contains(t, clusterState.VPAs(), vpaID) {
+		return
+	}
+	recreatedVpa := clusterState.VPAs()[vpaID]
+	assert.NotSame(t, firstVpa, recreatedVpa, "expected the Vpa object to be recreated when its pod selector changes")
+
+	initialState, ok := recreatedVpa.ContainersInitialAggregateState["container"]
+	if assert.True(t, ok, "expected checkpoint to be backfilled after selector-driven recreation") {
+		assert.Equal(t, 7, initialState.TotalSamplesCount)
+	}
+}
+
+func TestInitFromCheckpointsSetsCheckpointsInitialized(t *testing.T) {
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{}, nil)
+
+	checkpointLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointLister.On("List").Return([]*vpa_types.VerticalPodAutoscalerCheckpoint{}, nil)
+
+	feeder := &clusterStateFeeder{
+		vpaLister:           vpaLister,
+		vpaCheckpointLister: checkpointLister,
+		clusterState:        model.NewClusterState(testGcPeriod),
+		recommenderName:     DefaultRecommenderName,
+	}
+
+	assert.False(t, feeder.checkpointsInitialized)
+	feeder.InitFromCheckpoints(context.Background())
+	assert.True(t, feeder.checkpointsInitialized, "InitFromCheckpoints must mark checkpoints as initialized so LoadVPAs starts lazily backfilling checkpoints for newly tracked VPAs")
+}
+
 func TestCanCleanupCheckpoints(t *testing.T) {
 	_, tctx := ktesting.NewTestContext(t)
 	client := fake.NewClientset()


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:

The VPA recommender only loads persisted VerticalPodAutoscalerCheckpoints
from storage once, at process startup (InitFromCheckpoints, called before
the RunOnce ticker loop starts). LoadVPAs, however, re-evaluates which
VPAs this recommender instance tracks on every RunOnce cycle, based on
spec.recommenders and the target's pod selector.

When a VPA starts being tracked by an already-running recommender for the
first time - either because spec.recommenders was changed to point at it,
or because the target's pod selector changed (which makes AddOrUpdateVpa
delete and recreate the in-memory Vpa object) - the new/recreated Vpa
object gets an empty ContainersInitialAggregateState, since its checkpoint
was never loaded into this process. The next periodic checkpoint write
then persists this near-empty state, silently overwriting the VPA's
previously accumulated histogram history. This matches the symptom
reported in #9241 (histogram buckets disappearing after changing a VPA's
recommenders), and is most visible with --memory-saver enabled, since
untracked pods aren't monitored at all, so there's no real-time-metric
data to fall back on in the meantime. User-visible behavior when a VPA is
never reassigned between recommenders and its selector never changes is
unaffected by this change.

Approach:

In ClusterStateFeeder.LoadVPAs, detect VPAs whose in-memory Vpa object is
newly created this cycle (by comparing pointer identity before/after
AddOrUpdateVpa, which covers both the "never tracked before" and the
"selector changed" recreation cases) and, for just those VPAs, lazily
load their persisted checkpoint the same way InitFromCheckpoints does at
startup. A checkpointsInitialized flag ensures this lazy path only
engages after the one-time startup bulk load has already run, avoiding
redundant work at startup.

Validation:

cd vertical-pod-autoscaler && go build ./... && go vet ./pkg/recommender/...
cd vertical-pod-autoscaler && go test ./pkg/recommender/...
All packages pass, including two new regression tests added in
pkg/recommender/input/cluster_feeder_test.go:
- TestLoadVPAsBackfillsCheckpointForVpaReassignedToRecommender
- TestLoadVPAsBackfillsCheckpointWhenSelectorChangeRecreatesVpa
Both were confirmed to fail without the fix (verified by temporarily
disabling the new lazy-load call) and pass with it.

```release-note
Fixed a bug in the VPA recommender where a VPA's accumulated checkpoint
history (histogram data) could be silently overwritten with near-empty
data the first time it was tracked by an already-running recommender
instance - e.g. after changing spec.recommenders, or after its target's
pod selector changed.
```

Fixes #9241

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>