### PR TITLE
Use errors.Is for cloudprovider.ErrNotImplemented comparisons

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -1044,7 +1044,7 @@ func (a *StaticAutoscaler) removeOldUnregisteredNodes(allUnregisteredNodes []clu
 
 		if a.ForceDeleteLongUnregisteredNodes {
 			err = nodeGroup.ForceDeleteNodes(nodesToDelete)
-			if err == cloudprovider.ErrNotImplemented {
+			if errors.Is(err, cloudprovider.ErrNotImplemented) {
 				err = nodeGroup.DeleteNodes(nodesToDelete)
 			}
 		} else {
@@ -1150,7 +1150,7 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors() {
 // For a non-"ZeroOrMaxNodeScaling" node group it returns the unchanged list of nodes to delete.
 func overrideNodesToDeleteForZeroOrMax(defaults config.NodeGroupAutoscalingOptions, nodeGroup cloudprovider.NodeGroup, nodesToDelete []*apiv1.Node) ([]*apiv1.Node, error) {
 	opts, err := nodeGroup.GetOptions(defaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
+	if err != nil && !errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return []*apiv1.Node{}, fmt.Errorf("Failed to get node group options for %s: %s", nodeGroup.Id(), err)
 	}
 	// If a scale-up of "ZeroOrMaxNodeScaling" node group failed, the cleanup

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -2674,6 +2674,74 @@ func TestRemoveOldUnregisteredNodes(t *testing.T) {
 	assert.Equal(t, "ng1/ng1-2", deletedNode)
 }
 
+func TestRemoveOldUnregisteredNodesWithWrappedErrNotImplemented(t *testing.T) {
+	now := time.Now()
+
+	unregisteredNode := BuildTestNode("ng1-1", 1000, 1000)
+	unregisteredNode.Spec.ProviderID = "ng1-1"
+
+	options := config.AutoscalingOptions{
+		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+			MaxNodeProvisionTime: 45 * time.Minute,
+		},
+		ForceDeleteLongUnregisteredNodes: true,
+	}
+
+	nodeGroup := &mockprovider.NodeGroup{}
+	nodeGroup.On("Id").Return("ng1")
+	nodeGroup.On("GetOptions", options.NodeGroupDefaults).Return(&options.NodeGroupDefaults, nil)
+	// The node group doesn't support force deletion and reports it by wrapping
+	// the sentinel error with additional context.
+	nodeGroup.On("ForceDeleteNodes", mock.Anything).Return(fmt.Errorf("node group ng1: %w", cloudprovider.ErrNotImplemented))
+	nodeGroup.On("DeleteNodes", mock.Anything).Return(nil)
+
+	provider := &mockprovider.CloudProvider{}
+	provider.On("NodeGroups").Return([]cloudprovider.NodeGroup{nodeGroup})
+	provider.On("NodeGroupForNode", mock.Anything).Return(nodeGroup, nil)
+
+	fakeClient := &fake.Clientset{}
+	fakeLogRecorder, _ := clusterstate_utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+
+	autoscalingCtx := &ca_context.AutoscalingContext{
+		AutoscalingOptions: options,
+		CloudProvider:      provider,
+	}
+	clusterState := clusterstate.NewClusterStateRegistry(provider, fakeLogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults), nil, clusterstate.WithConfig(clusterstate.ClusterStateRegistryConfig{
+		MaxTotalUnreadyPercentage: 10,
+		OkTotalUnreadyCount:       1,
+	}))
+
+	autoscaler := &StaticAutoscaler{
+		AutoscalingContext:   autoscalingCtx,
+		clusterStateRegistry: clusterState,
+	}
+
+	unregisteredNodes := []clusterstate.UnregisteredNode{{Node: unregisteredNode, UnregisteredSince: now.Add(-time.Hour)}}
+
+	// The node should be removed via the DeleteNodes fallback.
+	removed, err := autoscaler.removeOldUnregisteredNodes(unregisteredNodes, clusterState, now, fakeLogRecorder)
+	assert.NoError(t, err)
+	assert.True(t, removed)
+	nodeGroup.AssertNumberOfCalls(t, "ForceDeleteNodes", 1)
+	nodeGroup.AssertNumberOfCalls(t, "DeleteNodes", 1)
+}
+
+func TestOverrideNodesToDeleteForZeroOrMaxWithWrappedErrNotImplemented(t *testing.T) {
+	defaults := config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 45 * time.Minute}
+
+	nodeGroup := &mockprovider.NodeGroup{}
+	nodeGroup.On("Id").Return("ng1")
+	// The node group doesn't support per-node-group options and reports it by
+	// wrapping the sentinel error with additional context.
+	nodeGroup.On("GetOptions", defaults).Return(nil, fmt.Errorf("node group ng1: %w", cloudprovider.ErrNotImplemented))
+
+	nodesToDelete := []*apiv1.Node{BuildTestNode("ng1-1", 1000, 1000)}
+
+	got, err := overrideNodesToDeleteForZeroOrMax(defaults, nodeGroup, nodesToDelete)
+	assert.NoError(t, err)
+	assert.Equal(t, nodesToDelete, got)
+}
+
 func setupTestRemoveOldUnregisteredNodesAtomic(t *testing.T, now time.Time, allowNonAtomicScaleUpToMax bool) (*clusterstate.ClusterStateRegistry, *ca_context.AutoscalingContext, *clusterstate_utils.LogEventRecorder, chan string) {
 	deletedNodes := make(chan string, 10)
 

--- a/cluster-autoscaler/processors/nodegroupconfig/node_group_config_processor.go
+++ b/cluster-autoscaler/processors/nodegroupconfig/node_group_config_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodegroupconfig
 
 import (
+	"errors"
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -53,10 +54,10 @@ type DelegatingNodeGroupConfigProcessor struct {
 // GetScaleDownUnneededTime returns ScaleDownUnneededTime value that should be used for a given NodeGroup.
 func (p *DelegatingNodeGroupConfigProcessor) GetScaleDownUnneededTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error) {
 	ngConfig, err := nodeGroup.GetOptions(p.nodeGroupDefaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
+	if err != nil && !errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return time.Duration(0), err
 	}
-	if ngConfig == nil || err == cloudprovider.ErrNotImplemented {
+	if ngConfig == nil || errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return p.nodeGroupDefaults.ScaleDownUnneededTime, nil
 	}
 	return ngConfig.ScaleDownUnneededTime, nil
@@ -65,10 +66,10 @@ func (p *DelegatingNodeGroupConfigProcessor) GetScaleDownUnneededTime(nodeGroup 
 // GetScaleDownUnreadyTime returns ScaleDownUnreadyTime value that should be used for a given NodeGroup.
 func (p *DelegatingNodeGroupConfigProcessor) GetScaleDownUnreadyTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error) {
 	ngConfig, err := nodeGroup.GetOptions(p.nodeGroupDefaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
+	if err != nil && !errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return time.Duration(0), err
 	}
-	if ngConfig == nil || err == cloudprovider.ErrNotImplemented {
+	if ngConfig == nil || errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return p.nodeGroupDefaults.ScaleDownUnreadyTime, nil
 	}
 	return ngConfig.ScaleDownUnreadyTime, nil
@@ -77,10 +78,10 @@ func (p *DelegatingNodeGroupConfigProcessor) GetScaleDownUnreadyTime(nodeGroup c
 // GetScaleDownUtilizationThreshold returns ScaleDownUtilizationThreshold value that should be used for a given NodeGroup.
 func (p *DelegatingNodeGroupConfigProcessor) GetScaleDownUtilizationThreshold(nodeGroup cloudprovider.NodeGroup) (float64, error) {
 	ngConfig, err := nodeGroup.GetOptions(p.nodeGroupDefaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
+	if err != nil && !errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return 0.0, err
 	}
-	if ngConfig == nil || err == cloudprovider.ErrNotImplemented {
+	if ngConfig == nil || errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return p.nodeGroupDefaults.ScaleDownUtilizationThreshold, nil
 	}
 	return ngConfig.ScaleDownUtilizationThreshold, nil
@@ -89,10 +90,10 @@ func (p *DelegatingNodeGroupConfigProcessor) GetScaleDownUtilizationThreshold(no
 // GetScaleDownGpuUtilizationThreshold returns ScaleDownGpuUtilizationThreshold value that should be used for a given NodeGroup.
 func (p *DelegatingNodeGroupConfigProcessor) GetScaleDownGpuUtilizationThreshold(nodeGroup cloudprovider.NodeGroup) (float64, error) {
 	ngConfig, err := nodeGroup.GetOptions(p.nodeGroupDefaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
+	if err != nil && !errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return 0.0, err
 	}
-	if ngConfig == nil || err == cloudprovider.ErrNotImplemented {
+	if ngConfig == nil || errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return p.nodeGroupDefaults.ScaleDownGpuUtilizationThreshold, nil
 	}
 	return ngConfig.ScaleDownGpuUtilizationThreshold, nil
@@ -101,10 +102,10 @@ func (p *DelegatingNodeGroupConfigProcessor) GetScaleDownGpuUtilizationThreshold
 // GetMaxNodeProvisionTime returns MaxNodeProvisionTime value that should be used for a given NodeGroup.
 func (p *DelegatingNodeGroupConfigProcessor) GetMaxNodeProvisionTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error) {
 	ngConfig, err := nodeGroup.GetOptions(p.nodeGroupDefaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
+	if err != nil && !errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return time.Duration(0), err
 	}
-	if ngConfig == nil || err == cloudprovider.ErrNotImplemented {
+	if ngConfig == nil || errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return p.nodeGroupDefaults.MaxNodeProvisionTime, nil
 	}
 	return ngConfig.MaxNodeProvisionTime, nil
@@ -113,10 +114,10 @@ func (p *DelegatingNodeGroupConfigProcessor) GetMaxNodeProvisionTime(nodeGroup c
 // GetMaxNodeStartupTime returns MaxNodeStartupTime value that should be used for a given NodeGroup.
 func (p *DelegatingNodeGroupConfigProcessor) GetMaxNodeStartupTime(nodeGroup cloudprovider.NodeGroup) (time.Duration, error) {
 	ngConfig, err := nodeGroup.GetOptions(p.nodeGroupDefaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
+	if err != nil && !errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return p.nodeGroupDefaults.MaxNodeStartupTime, err
 	}
-	if ngConfig == nil || err == cloudprovider.ErrNotImplemented {
+	if ngConfig == nil || errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return p.nodeGroupDefaults.MaxNodeStartupTime, nil
 	}
 	return ngConfig.MaxNodeStartupTime, nil
@@ -125,10 +126,10 @@ func (p *DelegatingNodeGroupConfigProcessor) GetMaxNodeStartupTime(nodeGroup clo
 // GetIgnoreDaemonSetsUtilization returns IgnoreDaemonSetsUtilization value that should be used for a given NodeGroup.
 func (p *DelegatingNodeGroupConfigProcessor) GetIgnoreDaemonSetsUtilization(nodeGroup cloudprovider.NodeGroup) (bool, error) {
 	ngConfig, err := nodeGroup.GetOptions(p.nodeGroupDefaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
+	if err != nil && !errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return false, err
 	}
-	if ngConfig == nil || err == cloudprovider.ErrNotImplemented {
+	if ngConfig == nil || errors.Is(err, cloudprovider.ErrNotImplemented) {
 		return p.nodeGroupDefaults.IgnoreDaemonSetsUtilization, nil
 	}
 	return ngConfig.IgnoreDaemonSetsUtilization, nil

--- a/cluster-autoscaler/processors/nodegroupconfig/node_group_config_processor_test.go
+++ b/cluster-autoscaler/processors/nodegroupconfig/node_group_config_processor_test.go
@@ -176,6 +176,11 @@ func TestDelegatingNodeGroupConfigProcessor(t *testing.T) {
 				ngError:       cloudprovider.ErrNotImplemented,
 				want:          GLOBAL,
 			},
+			"NodeGroup.GetOptions not implemented, error wrapped": {
+				globalOptions: globalOpts,
+				ngError:       fmt.Errorf("node group ng1: %w", cloudprovider.ErrNotImplemented),
+				want:          GLOBAL,
+			},
 			"NodeGroup returns error leads to error": {
 				globalOptions: globalOpts,
 				ngError:       errors.New("This sentence is false."),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Several places compare errors against `cloudprovider.ErrNotImplemented` with `==` / `!=` rather than `errors.Is`. Those comparisons break as soon as a cloud provider returns the sentinel wrapped with extra context, e.g.:

```go
return fmt.Errorf("node group %s: %w", id, cloudprovider.ErrNotImplemented)
```

Wrapping a sentinel error is idiomatic Go and something a provider can reasonably do, so the caller should not depend on the error being the bare sentinel value.

The consequences today:

- `removeOldUnregisteredNodes` — the `DeleteNodes` fallback is silently skipped and the wrapped error surfaces as a hard failure, so long-unregistered nodes are left in the cluster instead of being removed.
- `overrideNodesToDeleteForZeroOrMax` — a node group that does not implement `GetOptions` is treated as a hard error, so its nodes are skipped entirely.
- `DelegatingNodeGroupConfigProcessor` (all 7 `Get*` methods) — a node group that does not implement `GetOptions` cannot fall back to the global defaults, which makes the previous item unreachable in practice unless both are fixed together.

`deleteCreatedNodesWithErrors` already uses `errors.Is`; this makes the rest consistent with it.

No behaviour change for providers that return the bare sentinel — `errors.Is(err, target)` matches it, and `errors.Is(nil, target)` is `false`.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Split out of #10059 (ForceDeleteNodes for the ClusterAPI provider) to keep that change reviewable.

Tests added:

- `TestRemoveOldUnregisteredNodesWithWrappedErrNotImplemented` — a node group returns a wrapped `ErrNotImplemented` from `ForceDeleteNodes`; asserts the `DeleteNodes` fallback still runs. Uses `mockprovider.NodeGroup` because `testprovider.TestNodeGroup.ForceDeleteNodes` just delegates to `DeleteNodes` and cannot return a custom error.
- `TestOverrideNodesToDeleteForZeroOrMaxWithWrappedErrNotImplemented` — covers the `GetOptions` path directly.
- `node_group_config_processor_test.go` — extends the existing table with a wrapped-error case, which covers all 7 `Get*` methods.

Each test was confirmed to fail before the fix and pass after.

**Does this PR introduce a user-facing change?**

```release-note
Fixed handling of `cloudprovider.ErrNotImplemented` when a cloud provider returns it wrapped. Previously such errors were not recognized, which could skip the `DeleteNodes` fallback for long-unregistered nodes and prevent node groups from falling back to global autoscaling defaults.
```