### PR TITLE
Add VKE cloud provider for Cluster Autoscaler.

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -37,6 +37,7 @@ You should also take a look at the notes and "gotchas" for your specific cloud p
 * [Magnum](./cloudprovider/magnum/README.md)
 * [OracleCloud](./cloudprovider/oci/README.md)
 * [OVHcloud](./cloudprovider/ovhcloud/README.md)
+* [VKE](./cloudprovider/vke/README.md)
 * [Rancher](./cloudprovider/rancher/README.md)
 * [Scaleway](./cloudprovider/scaleway/README.md)
 * [TencentCloud](./cloudprovider/tencentcloud/README.md)
@@ -240,6 +241,7 @@ Supported cloud providers:
 * Magnum https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/magnum/README.md
 * OracleCloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/oci/README.md
 * OVHcloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/ovhcloud/README.md
+* VKE https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/vke/README.md
 * Rancher https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/rancher/README.md
 * Scaleway https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/scaleway/README.md
 * TencentCloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/tencentcloud/README.md

--- a/cluster-autoscaler/cloudprovider/router/router_all.go
+++ b/cluster-autoscaler/cloudprovider/router/router_all.go
@@ -1,5 +1,5 @@
-//go:build !gce && !aws && !azure && !kubemark && !alicloud && !magnum && !digitalocean && !clusterapi && !huaweicloud && !ionoscloud && !linode && !hetzner && !bizflycloud && !brightbox && !equinixmetal && !oci && !vultr && !tencentcloud && !scaleway && !externalgrpc && !civo && !rancher && !volcengine && !baiducloud && !cherry && !cloudstack && !exoscale && !kamatera && !ovhcloud && !kwok && !utho && !coreweave
-// +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum,!digitalocean,!clusterapi,!huaweicloud,!ionoscloud,!linode,!hetzner,!bizflycloud,!brightbox,!equinixmetal,!oci,!vultr,!tencentcloud,!scaleway,!externalgrpc,!civo,!rancher,!volcengine,!baiducloud,!cherry,!cloudstack,!exoscale,!kamatera,!ovhcloud,!kwok,!utho,!coreweave
+//go:build !gce && !aws && !azure && !kubemark && !alicloud && !magnum && !digitalocean && !clusterapi && !huaweicloud && !ionoscloud && !linode && !hetzner && !bizflycloud && !brightbox && !equinixmetal && !oci && !vultr && !tencentcloud && !scaleway && !externalgrpc && !civo && !rancher && !volcengine && !baiducloud && !cherry && !cloudstack && !exoscale && !kamatera && !ovhcloud && !kwok && !utho && !coreweave && !vke
+// +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum,!digitalocean,!clusterapi,!huaweicloud,!ionoscloud,!linode,!hetzner,!bizflycloud,!brightbox,!equinixmetal,!oci,!vultr,!tencentcloud,!scaleway,!externalgrpc,!civo,!rancher,!volcengine,!baiducloud,!cherry,!cloudstack,!exoscale,!kamatera,!ovhcloud,!kwok,!utho,!coreweave,!vke
 
 /*
 Copyright The Kubernetes Authors.
@@ -49,6 +49,7 @@ import (
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/scaleway"
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/tencentcloud"
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/utho"
+	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke"
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/volcengine"
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vultr"
 	_ "sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/clusterapi"

--- a/cluster-autoscaler/cloudprovider/router/router_vke.go
+++ b/cluster-autoscaler/cloudprovider/router/router_vke.go
@@ -1,0 +1,26 @@
+//go:build vke
+// +build vke
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	// Blank import to register a cloudprovider outside main or test package.
+	// This is by design.
+	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke"
+)

--- a/cluster-autoscaler/cloudprovider/vke/OWNERS
+++ b/cluster-autoscaler/cloudprovider/vke/OWNERS
@@ -1,0 +1,12 @@
+# See https://github.com/kubernetes/community/blob/master/community-membership.md
+# Handles may be temporarily commented per cloudprovider/POLICY.md until owners
+# join the Kubernetes GitHub organization.
+approvers:
+- kubilaykaptanoglu
+- mertongngl
+reviewers:
+- kubilaykaptanoglu
+- mertongngl
+
+labels:
+- area/provider/vke

--- a/cluster-autoscaler/cloudprovider/vke/README.md
+++ b/cluster-autoscaler/cloudprovider/vke/README.md
@@ -1,0 +1,78 @@
+# Cluster Autoscaler for VKE
+
+The cluster autoscaler for VKE scales worker nodes within a VKE Kubernetes
+cluster node group by calling the VKE control-plane API.
+
+Authentication uses OpenStack application credentials (Keystone). The API base
+URL is taken from the `VKE_URL` environment variable.
+
+## Configuration
+
+Pass a JSON cloud config with `--cloud-config`:
+
+```json
+{
+  "cluster_id": "<cluster-uuid>",
+  "tenant_id": "<openstack-project-id>",
+  "application_key": "<application-credential-id>",
+  "application_secret": "<application-credential-secret>",
+  "openstack_auth_url": "https://example.com:5000/v3"
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `cluster_id` | VKE cluster UUID |
+| `tenant_id` | OpenStack project / tenant ID |
+| `application_key` | OpenStack application credential ID |
+| `application_secret` | OpenStack application credential secret |
+| `openstack_auth_url` | Keystone auth URL |
+
+Also set:
+
+```bash
+export VKE_URL=https://vke-api.example.com
+```
+
+Example manifests live under [`examples/`](./examples).
+
+Apply order:
+
+```bash
+kubectl apply -f examples/cluster-autoscaler-secret.yaml
+kubectl apply -f examples/cluster-autoscaler-deployment.yaml
+```
+
+Replace placeholders in the secret before applying. Use your own Cluster Autoscaler image that includes the VKE provider (or build with `BUILD_TAGS=vke`).
+
+## Behavior
+
+- Node groups (node pools) are discovered from the VKE API on each `Refresh()`.
+- Scale-up adds nodes with the VKE nodegroup add API.
+- Scale-down deletes specific nodes with the VKE nodegroup node delete API.
+- Node `ProviderID` values are expected in `openstack:///<instance-id>` form.
+- Node group auto-provisioning is not supported yet.
+
+## Development
+
+From the `cluster-autoscaler` directory:
+
+```bash
+# Full binary (includes VKE among other providers)
+make build
+
+# VKE-only binary
+BUILD_TAGS=vke make build
+
+# Unit tests for this provider
+go test ./cloudprovider/vke/...
+```
+
+VKE is registered via `cloudprovider/router` blank imports and `builder.RegisterCloudProvider` in `init()`.
+
+Build an image:
+
+```bash
+make build-in-docker
+docker build -t <your-registry>/cluster-autoscaler:dev .
+```

--- a/cluster-autoscaler/cloudprovider/vke/examples/cluster-autoscaler-deployment.yaml
+++ b/cluster-autoscaler/cloudprovider/vke/examples/cluster-autoscaler-deployment.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources:
+      - "namespaces"
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes", "csistoragecapacities", "csidrivers"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resourceNames: ["cluster-autoscaler"]
+    resources: ["leases"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      serviceAccountName: cluster-autoscaler
+      containers:
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:latest
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --cloud-provider=vke
+            - --cloud-config=/config/cloud-config
+            - --stderrthreshold=info
+            - --skip-nodes-with-local-storage=false
+            - --skip-nodes-with-system-pods=false
+          env:
+            - name: VKE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cluster-autoscaler-cloud-config
+                  key: vke-url
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+            - name: cloud-config
+              mountPath: /config
+              readOnly: true
+          imagePullPolicy: Always
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs/ca-certificates.crt
+        - name: cloud-config
+          secret:
+            secretName: cluster-autoscaler-cloud-config

--- a/cluster-autoscaler/cloudprovider/vke/examples/cluster-autoscaler-secret.yaml
+++ b/cluster-autoscaler/cloudprovider/vke/examples/cluster-autoscaler-secret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-autoscaler-cloud-config
+  namespace: kube-system
+type: Opaque
+stringData:
+  cloud-config: |-
+    {
+      "cluster_id": "<cluster-uuid>",
+      "tenant_id": "<openstack-project-id>",
+      "application_key": "<application-credential-id>",
+      "application_secret": "<application-credential-secret>",
+      "openstack_auth_url": "https://example.com:5000/v3"
+    }
+  vke-url: "https://vke-api.example.com"

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/.gitignore
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/.gitignore
@@ -1,0 +1,3 @@
+**/*.swp
+.idea
+.vscode

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/.travis.yml
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/.travis.yml
@@ -1,0 +1,25 @@
+language: go
+sudo: false
+install:
+- GO111MODULE=off go get golang.org/x/crypto/ssh
+- GO111MODULE=off go get -v -tags 'fixtures acceptance' ./...
+- GO111MODULE=off go get github.com/wadey/gocovmerge
+- GO111MODULE=off go get github.com/mattn/goveralls
+- GO111MODULE=off go get golang.org/x/tools/cmd/goimports
+go:
+- "1.11"
+- "1.12"
+- "1.13"
+- "tip"
+env:
+  global:
+  - secure: "xSQsAG5wlL9emjbCdxzz/hYQsSpJ/bABO1kkbwMSISVcJ3Nk0u4ywF+LS4bgeOnwPfmFvNTOqVDu3RwEvMeWXSI76t1piCPcObutb2faKLVD/hLoAS76gYX+Z8yGWGHrSB7Do5vTPj1ERe2UljdrnsSeOXzoDwFxYRaZLX4bBOB4AyoGvRniil5QXPATiA1tsWX1VMicj8a4F8X+xeESzjt1Q5Iy31e7vkptu71bhvXCaoo5QhYwT+pLR9dN0S1b7Ro0KVvkRefmr1lUOSYd2e74h6Lc34tC1h3uYZCS4h47t7v5cOXvMNxinEj2C51RvbjvZI1RLVdkuAEJD1Iz4+Ote46nXbZ//6XRZMZz/YxQ13l7ux1PFjgEB6HAapmF5Xd8PRsgeTU9LRJxpiTJ3P5QJ3leS1va8qnziM5kYipj/Rn+V8g2ad/rgkRox9LSiR9VYZD2Pe45YCb1mTKSl2aIJnV7nkOqsShY5LNB4JZSg7xIffA+9YVDktw8dJlATjZqt7WvJJ49g6A61mIUV4C15q2JPGKTkZzDiG81NtmS7hFa7k0yaE2ELgYocbcuyUcAahhxntYTC0i23nJmEHVNiZmBO3u7EgpWe4KGVfumU+lt12tIn5b3dZRBBUk3QakKKozSK1QPHGpk/AZGrhu7H6l8to6IICKWtDcyMPQ="
+  - GO111MODULE=on
+before_script:
+- go vet ./...
+script:
+- ./script/coverage
+- ./script/unittest
+- ./script/format
+after_success:
+- $HOME/gopath/bin/goveralls -service=travis-ci -coverprofile=cover.out

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/.zuul.yaml
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/.zuul.yaml
@@ -1,0 +1,103 @@
+- job:
+    name: gophercloud-unittest
+    parent: golang-test
+    description: |
+      Run gophercloud unit test
+    run: .zuul/playbooks/gophercloud-unittest/run.yaml
+    nodeset: ubuntu-xenial-ut
+
+- job:
+    name: gophercloud-acceptance-test
+    parent: golang-test
+    description: |
+      Run gophercloud acceptance test on master branch
+    run: .zuul/playbooks/gophercloud-acceptance-test/run.yaml
+    nodeset: ubuntu-bionic
+
+- job:
+    name: gophercloud-acceptance-test-ironic
+    parent: golang-test
+    description: |
+      Run gophercloud ironic acceptance test on master branch
+    run: .zuul/playbooks/gophercloud-acceptance-test-ironic/run.yaml
+    nodeset: ubuntu-bionic
+
+- job:
+    name: gophercloud-acceptance-test-stein
+    parent: gophercloud-acceptance-test
+    description: |
+      Run gophercloud acceptance test on stein branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/stein
+
+- job:
+    name: gophercloud-acceptance-test-rocky
+    parent: gophercloud-acceptance-test
+    description: |
+      Run gophercloud acceptance test on rocky branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/rocky
+
+- job:
+    name: gophercloud-acceptance-test-queens
+    parent: gophercloud-acceptance-test
+    description: |
+      Run gophercloud acceptance test on queens branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/queens
+
+- job:
+    name: gophercloud-acceptance-test-pike
+    parent: gophercloud-acceptance-test
+    description: |
+      Run gophercloud acceptance test on pike branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/pike
+
+- job:
+    name: gophercloud-acceptance-test-ocata
+    parent: gophercloud-acceptance-test
+    description: |
+      Run gophercloud acceptance test on ocata branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/ocata
+
+- job:
+    name: gophercloud-acceptance-test-newton
+    parent: gophercloud-acceptance-test
+    description: |
+      Run gophercloud acceptance test on newton branch
+    vars:
+      global_env:
+        OS_BRANCH: stable/newton
+
+- project:
+    name: gophercloud/gophercloud
+    check:
+      jobs:
+        - gophercloud-unittest
+        - gophercloud-acceptance-test
+        - gophercloud-acceptance-test-ironic
+    recheck-newton:
+      jobs:
+        - gophercloud-acceptance-test-newton
+    recheck-ocata:
+      jobs:
+        - gophercloud-acceptance-test-ocata
+    recheck-pike:
+      jobs:
+        - gophercloud-acceptance-test-pike
+    recheck-queens:
+      jobs:
+        - gophercloud-acceptance-test-queens
+    recheck-rocky:
+      jobs:
+        - gophercloud-acceptance-test-rocky
+    recheck-stein:
+      jobs:
+        - gophercloud-acceptance-test-stein

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/CHANGELOG.md
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/CHANGELOG.md
@@ -1,0 +1,207 @@
+## 0.9.0 (Unreleased)
+
+## 0.8.0 (February 8, 2020)
+
+UPGRADE NOTES
+
+* The behavior of `keymanager/v1/acls.SetOpts` has changed. Instead of a struct, it is now `[]SetOpt`. See [GH-1816](https://github.com/gophercloud/gophercloud/pull/1816) for implementation details.
+
+IMPROVEMENTS
+
+* The result of `containerinfra/v1/clusters.Resize` now returns only the UUID when calling `Extract`. This is a backwards-breaking change from the previous struct that was returned [GH-1649](https://github.com/gophercloud/gophercloud/pull/1649)
+* Added `compute/v2/extensions/shelveunshelve.Shelve` [GH-1799](https://github.com/gophercloud/gophercloud/pull/1799)
+* Added `compute/v2/extensions/shelveunshelve.ShelveOffload` [GH-1799](https://github.com/gophercloud/gophercloud/pull/1799)
+* Added `compute/v2/extensions/shelveunshelve.Unshelve` [GH-1799](https://github.com/gophercloud/gophercloud/pull/1799)
+* Added `containerinfra/v1/nodegroups.Get` [GH-1774](https://github.com/gophercloud/gophercloud/pull/1774)
+* Added `containerinfra/v1/nodegroups.List` [GH-1774](https://github.com/gophercloud/gophercloud/pull/1774)
+* Added `orchestration/v1/resourcetypes.List` [GH-1806](https://github.com/gophercloud/gophercloud/pull/1806)
+* Added `orchestration/v1/resourcetypes.GetSchema` [GH-1806](https://github.com/gophercloud/gophercloud/pull/1806)
+* Added `orchestration/v1/resourcetypes.GenerateTemplate` [GH-1806](https://github.com/gophercloud/gophercloud/pull/1806)
+* Added `keymanager/v1/acls.SetOpt` and changed `keymanager/v1/acls.SetOpts` to `[]SetOpt` [GH-1816](https://github.com/gophercloud/gophercloud/pull/1816)
+* Added `blockstorage/apiversions.List` [GH-458](https://github.com/gophercloud/gophercloud/pull/458)
+* Added `blockstorage/apiversions.Get` [GH-458](https://github.com/gophercloud/gophercloud/pull/458)
+* Added `StatusCodeError` interface and `GetStatusCode` convenience method [GH-1820](https://github.com/gophercloud/gophercloud/pull/1820)
+* Added pagination support to `compute/v2/extensions/usage.SingleTenant` [GH-1819](https://github.com/gophercloud/gophercloud/pull/1819)
+* Added pagination support to `compute/v2/extensions/usage.AllTenants` [GH-1819](https://github.com/gophercloud/gophercloud/pull/1819)
+* Added `placement/v1/resourceproviders.List` [GH-1815](https://github.com/gophercloud/gophercloud/pull/1815)
+* Allow `CreateMemberOptsBuilder` to be passed in `loadbalancer/v2/pools.Create` [GH-1822](https://github.com/gophercloud/gophercloud/pull/1822)
+* Added `Backup` to `loadbalancer/v2/pools.CreateMemberOpts` [GH-1824](https://github.com/gophercloud/gophercloud/pull/1824)
+* Added `MonitorAddress` to `loadbalancer/v2/pools.CreateMemberOpts` [GH-1824](https://github.com/gophercloud/gophercloud/pull/1824)
+* Added `MonitorPort` to `loadbalancer/v2/pools.CreateMemberOpts` [GH-1824](https://github.com/gophercloud/gophercloud/pull/1824)
+* Changed `Impersonation` to a non-required field in `identity/v3/extensions/trusts.CreateOpts` [GH-1818](https://github.com/gophercloud/gophercloud/pull/1818)
+* Added `InsertHeaders` to `loadbalancer/v2/listeners.UpdateOpts` [GH-1835]
+* Added `NUMATopology` to `baremetalintrospection/v1/introspection.Data` [GH-1842](https://github.com/gophercloud/gophercloud/pull/1842)
+* Added `placement/v1/resourceproviders.Create` [GH-1841](https://github.com/gophercloud/gophercloud/pull/1841)
+
+BUG FIXES
+
+* Changed `sort_key` to `sort_keys` in ` workflow/v2/crontriggers.ListOpts` [GH-1809](https://github.com/gophercloud/gophercloud/pull/1809)
+* Allow `blockstorage/extensions/schedulerstats.Capabilities.MaxOverSubscriptionRatio` to accept both string and int/float responses [GH-1817](https://github.com/gophercloud/gophercloud/pull/1817)
+* Fixed bug in `NewLoadBalancerV2` for situations when the LBaaS service was advertised without a `/v2.0` endpoint [GH-1829](https://github.com/gophercloud/gophercloud/pull/1829)
+* Fixed JSON tags in `baremetal/v1/ports.UpdateOperation` [GH-1840](https://github.com/gophercloud/gophercloud/pull/1840)
+* Fixed JSON tags in `networking/v2/extensions/lbaas/vips.commonResult.Extract()` [GH-1840](https://github.com/gophercloud/gophercloud/pull/1840)
+
+## 0.7.0 (December 3, 2019)
+
+IMPROVEMENTS
+
+* Allow a token to be used directly for authentication instead of generating a new token based on a given token [GH-1752](https://github.com/gophercloud/gophercloud/pull/1752)
+* Moved `tags.ServerTagsExt` to servers.TagsExt` [GH-1760](https://github.com/gophercloud/gophercloud/pull/1760)
+* Added `tags`, `tags-any`, `not-tags`, and `not-tags-any` to `compute/v2/servers.ListOpts` [GH-1759](https://github.com/gophercloud/gophercloud/pull/1759)
+* Added `AccessRule` to `identity/v3/applicationcredentials` [GH-1758](https://github.com/gophercloud/gophercloud/pull/1758)
+* Gophercloud no longer returns an error when multiple endpoints are found. Instead, it will choose the first endpoint and discard the others [GH-1766](https://github.com/gophercloud/gophercloud/pull/1766)
+* Added `networking/v2/extensions/fwaas_v2/rules.Create` [GH-1768](https://github.com/gophercloud/gophercloud/pull/1768)
+* Added `networking/v2/extensions/fwaas_v2/rules.Delete` [GH-1771](https://github.com/gophercloud/gophercloud/pull/1771)
+* Added `loadbalancer/v2/providers.List` [GH-1765](https://github.com/gophercloud/gophercloud/pull/1765)
+* Added `networking/v2/extensions/fwaas_v2/rules.Get` [GH-1772](https://github.com/gophercloud/gophercloud/pull/1772)
+* Added `networking/v2/extensions/fwaas_v2/rules.Update` [GH-1776](https://github.com/gophercloud/gophercloud/pull/1776)
+* Added `networking/v2/extensions/fwaas_v2/rules.List` [GH-1783](https://github.com/gophercloud/gophercloud/pull/1783)
+* Added `MaxRetriesDown` into `loadbalancer/v2/monitors.CreateOpts` [GH-1785](https://github.com/gophercloud/gophercloud/pull/1785)
+* Added `MaxRetriesDown` into `loadbalancer/v2/monitors.UpdateOpts` [GH-1786](https://github.com/gophercloud/gophercloud/pull/1786)
+* Added `MaxRetriesDown` into `loadbalancer/v2/monitors.Monitor` [GH-1787](https://github.com/gophercloud/gophercloud/pull/1787)
+* Added `MaxRetriesDown` into `loadbalancer/v2/monitors.ListOpts` [GH-1788](https://github.com/gophercloud/gophercloud/pull/1788)
+* Updated `go.mod` dependencies, specifically to account for CVE-2019-11840 with `golang.org/x/crypto` [GH-1793](https://github.com/gophercloud/gophercloud/pull/1788)
+
+## 0.6.0 (October 17, 2019)
+
+UPGRADE NOTES
+
+* The way reauthentication works has been refactored. This should not cause a problem, but please report bugs if it does. See [GH-1746](https://github.com/gophercloud/gophercloud/pull/1746) for more information.
+
+IMPROVEMENTS
+
+* Added `networking/v2/extensions/quotas.Get` [GH-1742](https://github.com/gophercloud/gophercloud/pull/1742)
+* Added `networking/v2/extensions/quotas.Update` [GH-1747](https://github.com/gophercloud/gophercloud/pull/1747)
+* Refactored the reauthentication implementation to use goroutines and added a check to prevent an infinite loop in certain situations. [GH-1746](https://github.com/gophercloud/gophercloud/pull/1746)
+
+BUG FIXES
+
+* Changed `Flavor` to `FlavorID` in `loadbalancer/v2/loadbalancers` [GH-1744](https://github.com/gophercloud/gophercloud/pull/1744)
+* Changed `Flavor` to `FlavorID` in `networking/v2/extensions/lbaas_v2/loadbalancers` [GH-1744](https://github.com/gophercloud/gophercloud/pull/1744)
+* The `go-yaml` dependency was updated to `v2.2.4` to fix possible DDOS vulnerabilities [GH-1751](https://github.com/gophercloud/gophercloud/pull/1751)
+
+## 0.5.0 (October 13, 2019)
+
+IMPROVEMENTS
+
+* Added `VolumeType` to `compute/v2/extensions/bootfromvolume.BlockDevice`[GH-1690](https://github.com/gophercloud/gophercloud/pull/1690)
+* Added `networking/v2/extensions/layer3/portforwarding.List` [GH-1688](https://github.com/gophercloud/gophercloud/pull/1688)
+* Added `networking/v2/extensions/layer3/portforwarding.Get` [GH-1698](https://github.com/gophercloud/gophercloud/pull/1696)
+* Added `compute/v2/extensions/tags.ReplaceAll` [GH-1696](https://github.com/gophercloud/gophercloud/pull/1696)
+* Added `compute/v2/extensions/tags.Add` [GH-1696](https://github.com/gophercloud/gophercloud/pull/1696)
+* Added `networking/v2/extensions/layer3/portforwarding.Update` [GH-1703](https://github.com/gophercloud/gophercloud/pull/1703)
+* Added `ExtractDomain` method to token results in `identity/v3/tokens` [GH-1712](https://github.com/gophercloud/gophercloud/pull/1712)
+* Added `AllowedCIDRs` to `loadbalancer/v2/listeners.CreateOpts` [GH-1710](https://github.com/gophercloud/gophercloud/pull/1710)
+* Added `AllowedCIDRs` to `loadbalancer/v2/listeners.UpdateOpts` [GH-1710](https://github.com/gophercloud/gophercloud/pull/1710)
+* Added `AllowedCIDRs` to `loadbalancer/v2/listeners.Listener` [GH-1710](https://github.com/gophercloud/gophercloud/pull/1710)
+* Added `compute/v2/extensions/tags.Add` [GH-1695](https://github.com/gophercloud/gophercloud/pull/1695)
+* Added `compute/v2/extensions/tags.ReplaceAll` [GH-1694](https://github.com/gophercloud/gophercloud/pull/1694)
+* Added `compute/v2/extensions/tags.Delete` [GH-1699](https://github.com/gophercloud/gophercloud/pull/1699)
+* Added `compute/v2/extensions/tags.DeleteAll` [GH-1700](https://github.com/gophercloud/gophercloud/pull/1700)
+* Added `ImageStatusImporting` as an image status [GH-1725](https://github.com/gophercloud/gophercloud/pull/1725)
+* Added `ByPath` to `baremetalintrospection/v1/introspection.RootDiskType` [GH-1730](https://github.com/gophercloud/gophercloud/pull/1730)
+* Added `AttachedVolumes` to `compute/v2/servers.Server` [GH-1732](https://github.com/gophercloud/gophercloud/pull/1732)
+* Enable unmarshaling server tags to a `compute/v2/servers.Server` struct [GH-1734]
+* Allow setting an empty members list in `loadbalancer/v2/pools.BatchUpdateMembers` [GH-1736](https://github.com/gophercloud/gophercloud/pull/1736)
+* Allow unsetting members' subnet ID and name in `loadbalancer/v2/pools.BatchUpdateMemberOpts` [GH-1738](https://github.com/gophercloud/gophercloud/pull/1738)
+
+BUG FIXES
+
+* Changed struct type for options in `networking/v2/extensions/lbaas_v2/listeners` to `UpdateOptsBuilder` interface instead of specific UpdateOpts type [GH-1705](https://github.com/gophercloud/gophercloud/pull/1705)
+* Changed struct type for options in `networking/v2/extensions/lbaas_v2/loadbalancers` to `UpdateOptsBuilder` interface instead of specific UpdateOpts type [GH-1706](https://github.com/gophercloud/gophercloud/pull/1706)
+* Fixed issue with `blockstorage/v1/volumes.Create` where the response was expected to be 202 [GH-1720](https://github.com/gophercloud/gophercloud/pull/1720)
+* Changed `DefaultTlsContainerRef` from `string` to `*string` in `loadbalancer/v2/listeners.UpdateOpts` to allow the value to be removed during update. [GH-1723](https://github.com/gophercloud/gophercloud/pull/1723)
+* Changed `SniContainerRefs` from `[]string{}` to `*[]string{}` in `loadbalancer/v2/listeners.UpdateOpts` to allow the value to be removed during update. [GH-1723](https://github.com/gophercloud/gophercloud/pull/1723)
+* Changed `DefaultTlsContainerRef` from `string` to `*string` in `networking/v2/extensions/lbaas_v2/listeners.UpdateOpts` to allow the value to be removed during update. [GH-1723](https://github.com/gophercloud/gophercloud/pull/1723)
+* Changed `SniContainerRefs` from `[]string{}` to `*[]string{}` in `networking/v2/extensions/lbaas_v2/listeners.UpdateOpts` to allow the value to be removed during update. [GH-1723](https://github.com/gophercloud/gophercloud/pull/1723)
+
+
+## 0.4.0 (September 3, 2019)
+
+IMPROVEMENTS
+
+* Added `blockstorage/extensions/quotasets.results.QuotaSet.Groups` [GH-1668](https://github.com/gophercloud/gophercloud/pull/1668)
+* Added `blockstorage/extensions/quotasets.results.QuotaUsageSet.Groups` [GH-1668](https://github.com/gophercloud/gophercloud/pull/1668)
+* Added `containerinfra/v1/clusters.CreateOpts.FixedNetwork` [GH-1674](https://github.com/gophercloud/gophercloud/pull/1674)
+* Added `containerinfra/v1/clusters.CreateOpts.FixedSubnet` [GH-1676](https://github.com/gophercloud/gophercloud/pull/1676)
+* Added `containerinfra/v1/clusters.CreateOpts.FloatingIPEnabled` [GH-1677](https://github.com/gophercloud/gophercloud/pull/1677)
+* Added `CreatedAt` and `UpdatedAt` to `loadbalancers/v2/loadbalancers.LoadBalancer` [GH-1681](https://github.com/gophercloud/gophercloud/pull/1681)
+* Added `networking/v2/extensions/layer3/portforwarding.Create` [GH-1651](https://github.com/gophercloud/gophercloud/pull/1651)
+* Added `networking/v2/extensions/agents.ListDHCPNetworks` [GH-1686](https://github.com/gophercloud/gophercloud/pull/1686)
+* Added `networking/v2/extensions/layer3/portforwarding.Delete` [GH-1652](https://github.com/gophercloud/gophercloud/pull/1652)
+* Added `compute/v2/extensions/tags.List` [GH-1679](https://github.com/gophercloud/gophercloud/pull/1679)
+* Added `compute/v2/extensions/tags.Check` [GH-1679](https://github.com/gophercloud/gophercloud/pull/1679)
+
+BUG FIXES
+
+* Changed `identity/v3/endpoints.ListOpts.RegionID` from `int` to `string` [GH-1664](https://github.com/gophercloud/gophercloud/pull/1664)
+* Fixed issue where older time formats in some networking APIs/resources were unable to be parsed [GH-1671](https://github.com/gophercloud/gophercloud/pull/1664)
+* Changed `SATA`, `SCSI`, and `SAS` types to `InterfaceType` in `baremetal/v1/nodes` [GH-1683]
+
+## 0.3.0 (July 31, 2019)
+
+IMPROVEMENTS
+
+* Added `baremetal/apiversions.List` [GH-1577](https://github.com/gophercloud/gophercloud/pull/1577)
+* Added `baremetal/apiversions.Get` [GH-1577](https://github.com/gophercloud/gophercloud/pull/1577)
+* Added `compute/v2/extensions/servergroups.CreateOpts.Policy` [GH-1636](https://github.com/gophercloud/gophercloud/pull/1636)
+* Added `identity/v3/extensions/trusts.Create` [GH-1644](https://github.com/gophercloud/gophercloud/pull/1644)
+* Added `identity/v3/extensions/trusts.Delete` [GH-1644](https://github.com/gophercloud/gophercloud/pull/1644)
+* Added `CreatedAt` and `UpdatedAt` to `networking/v2/extensions/layer3/floatingips.FloatingIP` [GH-1647](https://github.com/gophercloud/gophercloud/issues/1646)
+* Added `CreatedAt` and `UpdatedAt` to `networking/v2/extensions/security/groups.SecGroup` [GH-1654](https://github.com/gophercloud/gophercloud/issues/1654)
+* Added `CreatedAt` and `UpdatedAt` to `networking/v2/networks.Network` [GH-1657](https://github.com/gophercloud/gophercloud/issues/1657)
+* Added `keymanager/v1/containers.CreateSecretRef` [GH-1659](https://github.com/gophercloud/gophercloud/issues/1659)
+* Added `keymanager/v1/containers.DeleteSecretRef` [GH-1659](https://github.com/gophercloud/gophercloud/issues/1659)
+* Added `sharedfilesystems/v2/shares.GetMetadata` [GH-1656](https://github.com/gophercloud/gophercloud/issues/1656)
+* Added `sharedfilesystems/v2/shares.GetMetadatum` [GH-1656](https://github.com/gophercloud/gophercloud/issues/1656)
+* Added `sharedfilesystems/v2/shares.SetMetadata` [GH-1656](https://github.com/gophercloud/gophercloud/issues/1656)
+* Added `sharedfilesystems/v2/shares.UpdateMetadata` [GH-1656](https://github.com/gophercloud/gophercloud/issues/1656)
+* Added `sharedfilesystems/v2/shares.DeleteMetadatum` [GH-1656](https://github.com/gophercloud/gophercloud/issues/1656)
+* Added `sharedfilesystems/v2/sharetypes.IDFromName` [GH-1662](https://github.com/gophercloud/gophercloud/issues/1662)
+
+
+
+BUG FIXES
+
+* Changed `baremetal/v1/nodes.CleanStep.Args` from `map[string]string` to `map[string]interface{}` [GH-1638](https://github.com/gophercloud/gophercloud/pull/1638)
+* Removed `URLPath` and `ExpectedCodes` from `loadbalancer/v2/monitors.ToMonitorCreateMap` since Octavia now provides default values when these fields are not specified [GH-1640](https://github.com/gophercloud/gophercloud/pull/1540)
+
+
+## 0.2.0 (June 17, 2019)
+
+IMPROVEMENTS
+
+* Added `networking/v2/extensions/qos/rules.ListBandwidthLimitRules` [GH-1584](https://github.com/gophercloud/gophercloud/pull/1584)
+* Added `networking/v2/extensions/qos/rules.GetBandwidthLimitRule` [GH-1584](https://github.com/gophercloud/gophercloud/pull/1584)
+* Added `networking/v2/extensions/qos/rules.CreateBandwidthLimitRule` [GH-1584](https://github.com/gophercloud/gophercloud/pull/1584)
+* Added `networking/v2/extensions/qos/rules.UpdateBandwidthLimitRule` [GH-1589](https://github.com/gophercloud/gophercloud/pull/1589)
+* Added `networking/v2/extensions/qos/rules.DeleteBandwidthLimitRule` [GH-1590](https://github.com/gophercloud/gophercloud/pull/1590)
+* Added `networking/v2/extensions/qos/policies.List` [GH-1591](https://github.com/gophercloud/gophercloud/pull/1591)
+* Added `networking/v2/extensions/qos/policies.Get` [GH-1593](https://github.com/gophercloud/gophercloud/pull/1593)
+* Added `networking/v2/extensions/qos/rules.ListDSCPMarkingRules` [GH-1594](https://github.com/gophercloud/gophercloud/pull/1594)
+* Added `networking/v2/extensions/qos/policies.Create` [GH-1595](https://github.com/gophercloud/gophercloud/pull/1595)
+* Added `compute/v2/extensions/diagnostics.Get` [GH-1592](https://github.com/gophercloud/gophercloud/pull/1592)
+* Added `networking/v2/extensions/qos/policies.Update` [GH-1603](https://github.com/gophercloud/gophercloud/pull/1603)
+* Added `networking/v2/extensions/qos/policies.Delete` [GH-1603](https://github.com/gophercloud/gophercloud/pull/1603)
+* Added `networking/v2/extensions/qos/rules.CreateDSCPMarkingRule` [GH-1605](https://github.com/gophercloud/gophercloud/pull/1605)
+* Added `networking/v2/extensions/qos/rules.UpdateDSCPMarkingRule` [GH-1605](https://github.com/gophercloud/gophercloud/pull/1605)
+* Added `networking/v2/extensions/qos/rules.GetDSCPMarkingRule` [GH-1609](https://github.com/gophercloud/gophercloud/pull/1609)
+* Added `networking/v2/extensions/qos/rules.DeleteDSCPMarkingRule` [GH-1609](https://github.com/gophercloud/gophercloud/pull/1609)
+* Added `networking/v2/extensions/qos/rules.ListMinimumBandwidthRules` [GH-1615](https://github.com/gophercloud/gophercloud/pull/1615)
+* Added `networking/v2/extensions/qos/rules.GetMinimumBandwidthRule` [GH-1615](https://github.com/gophercloud/gophercloud/pull/1615)
+* Added `networking/v2/extensions/qos/rules.CreateMinimumBandwidthRule` [GH-1615](https://github.com/gophercloud/gophercloud/pull/1615)
+* Added `Hostname` to `baremetalintrospection/v1/introspection.Data` [GH-1627](https://github.com/gophercloud/gophercloud/pull/1627)
+* Added `networking/v2/extensions/qos/rules.UpdateMinimumBandwidthRule` [GH-1624](https://github.com/gophercloud/gophercloud/pull/1624)
+* Added `networking/v2/extensions/qos/rules.DeleteMinimumBandwidthRule` [GH-1624](https://github.com/gophercloud/gophercloud/pull/1624)
+* Added `networking/v2/extensions/qos/ruletypes.GetRuleType` [GH-1625](https://github.com/gophercloud/gophercloud/pull/1625)
+* Added `Extra` to `baremetalintrospection/v1/introspection.Data` [GH-1611](https://github.com/gophercloud/gophercloud/pull/1611)
+* Added `blockstorage/extensions/volumeactions.SetImageMetadata` [GH-1621](https://github.com/gophercloud/gophercloud/pull/1621)
+
+BUG FIXES
+
+* Updated `networking/v2/extensions/qos/rules.UpdateBandwidthLimitRule` to use return code 200 [GH-1606](https://github.com/gophercloud/gophercloud/pull/1606)
+* Fixed bug in `compute/v2/extensions/schedulerhints.SchedulerHints.Query` where contents will now be marshalled to a string [GH-1620](https://github.com/gophercloud/gophercloud/pull/1620)
+
+## 0.1.0 (May 27, 2019)
+
+Initial tagged release. 

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/LICENSE
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/LICENSE
@@ -1,0 +1,191 @@
+Copyright 2012-2013 Rackspace, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.  You may obtain a copy of the
+License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations under the License.                                
+
+------
+ 
+				Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/README.md
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/README.md
@@ -1,0 +1,159 @@
+# Gophercloud: an OpenStack SDK for Go
+[![Build Status](https://travis-ci.org/gophercloud/gophercloud.svg?branch=master)](https://travis-ci.org/gophercloud/gophercloud)
+[![Coverage Status](https://coveralls.io/repos/github/gophercloud/gophercloud/badge.svg?branch=master)](https://coveralls.io/github/gophercloud/gophercloud?branch=master)
+
+Gophercloud is an OpenStack Go SDK.
+
+## Useful links
+
+* [Reference documentation](http://godoc.org/github.com/gophercloud/gophercloud)
+* [Effective Go](https://golang.org/doc/effective_go.html)
+
+## How to install
+
+Before installing, you need to ensure that your [GOPATH environment variable](https://golang.org/doc/code.html#GOPATH)
+is pointing to an appropriate directory where you want to install Gophercloud:
+
+```bash
+mkdir $HOME/go
+export GOPATH=$HOME/go
+```
+
+To protect yourself against changes in your dependencies, we highly recommend choosing a
+[dependency management solution](https://github.com/golang/go/wiki/PackageManagementTools) for
+your projects, such as [godep](https://github.com/tools/godep). Once this is set up, you can install
+Gophercloud as a dependency like so:
+
+```bash
+go get github.com/gophercloud/gophercloud
+
+# Edit your code to import relevant packages from "github.com/gophercloud/gophercloud"
+
+godep save ./...
+```
+
+This will install all the source files you need into a `Godeps/_workspace` directory, which is
+referenceable from your own source files when you use the `godep go` command.
+
+## Getting started
+
+### Credentials
+
+Because you'll be hitting an API, you will need to retrieve your OpenStack
+credentials and either store them as environment variables or in your local Go
+files. The first method is recommended because it decouples credential
+information from source code, allowing you to push the latter to your version
+control system without any security risk.
+
+You will need to retrieve the following:
+
+* username
+* password
+* a valid Keystone identity URL
+
+For users that have the OpenStack dashboard installed, there's a shortcut. If
+you visit the `project/access_and_security` path in Horizon and click on the
+"Download OpenStack RC File" button at the top right hand corner, you will
+download a bash file that exports all of your access details to environment
+variables. To execute the file, run `source admin-openrc.sh` and you will be
+prompted for your password.
+
+### Authentication
+
+Once you have access to your credentials, you can begin plugging them into
+Gophercloud. The next step is authentication, and this is handled by a base
+"Provider" struct. To get one, you can either pass in your credentials
+explicitly, or tell Gophercloud to use environment variables:
+
+```go
+import (
+  "github.com/gophercloud/gophercloud"
+  "github.com/gophercloud/gophercloud/openstack"
+  "github.com/gophercloud/gophercloud/openstack/utils"
+)
+
+// Option 1: Pass in the values yourself
+opts := gophercloud.AuthOptions{
+  IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
+  Username: "{username}",
+  Password: "{password}",
+}
+
+// Option 2: Use a utility function to retrieve all your environment variables
+opts, err := openstack.AuthOptionsFromEnv()
+```
+
+Once you have the `opts` variable, you can pass it in and get back a
+`ProviderClient` struct:
+
+```go
+provider, err := openstack.AuthenticatedClient(opts)
+```
+
+The `ProviderClient` is the top-level client that all of your OpenStack services
+derive from. The provider contains all of the authentication details that allow
+your Go code to access the API - such as the base URL and token ID.
+
+### Provision a server
+
+Once we have a base Provider, we inject it as a dependency into each OpenStack
+service. In order to work with the Compute API, we need a Compute service
+client; which can be created like so:
+
+```go
+client, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+  Region: os.Getenv("OS_REGION_NAME"),
+})
+```
+
+We then use this `client` for any Compute API operation we want. In our case,
+we want to provision a new server - so we invoke the `Create` method and pass
+in the flavor ID (hardware specification) and image ID (operating system) we're
+interested in:
+
+```go
+import "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+
+server, err := servers.Create(client, servers.CreateOpts{
+  Name:      "My new server!",
+  FlavorRef: "flavor_id",
+  ImageRef:  "image_id",
+}).Extract()
+```
+
+The above code sample creates a new server with the parameters, and embodies the
+new resource in the `server` variable (a
+[`servers.Server`](http://godoc.org/github.com/gophercloud/gophercloud) struct).
+
+## Advanced Usage
+
+Have a look at the [FAQ](./docs/FAQ.md) for some tips on customizing the way Gophercloud works.
+
+## Backwards-Compatibility Guarantees
+
+None. Vendor it and write tests covering the parts you use.
+
+## Contributing
+
+See the [contributing guide](./.github/CONTRIBUTING.md).
+
+## Help and feedback
+
+If you're struggling with something or have spotted a potential bug, feel free
+to submit an issue to our [bug tracker](https://github.com/gophercloud/gophercloud/issues).
+
+## Thank You
+
+We'd like to extend special thanks and appreciation to the following:
+
+### OpenLab
+
+<a href="http://openlabtesting.org/"><img src="./docs/assets/openlab.png" width="600px"></a>
+
+OpenLab is providing a full CI environment to test each PR and merge for a variety of OpenStack releases.
+
+### VEXXHOST
+
+<a href="https://vexxhost.com/"><img src="./docs/assets/vexxhost.png" width="600px"></a>
+
+VEXXHOST is providing their services to assist with the development and testing of Gophercloud.

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/auth_options.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/auth_options.go
@@ -1,0 +1,358 @@
+package gophercloud
+
+/*
+AuthOptions stores information needed to authenticate to an OpenStack Cloud.
+You can populate one manually, or use a provider's AuthOptionsFromEnv() function
+to read relevant information from the standard environment variables. Pass one
+to a provider's AuthenticatedClient function to authenticate and obtain a
+ProviderClient representing an active session on that provider.
+
+Its fields are the union of those recognized by each identity implementation and
+provider.
+
+An example of manually providing authentication information:
+
+	opts := gophercloud.AuthOptions{
+	  IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
+	  Username: "{username}",
+	  Password: "{password}",
+	  TenantID: "{tenant_id}",
+	}
+
+	provider, err := openstack.AuthenticatedClient(opts)
+
+An example of using AuthOptionsFromEnv(), where the environment variables can
+be read from a file, such as a standard openrc file:
+
+	opts, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(opts)
+*/
+type AuthOptions struct {
+	// IdentityEndpoint specifies the HTTP endpoint that is required to work with
+	// the Identity API of the appropriate version. While it's ultimately needed by
+	// all of the identity services, it will often be populated by a provider-level
+	// function.
+	//
+	// The IdentityEndpoint is typically referred to as the "auth_url" or
+	// "OS_AUTH_URL" in the information provided by the cloud operator.
+	IdentityEndpoint string `json:"-"`
+
+	// Username is required if using Identity V2 API. Consult with your provider's
+	// control panel to discover your account's username. In Identity V3, either
+	// UserID or a combination of Username and DomainID or DomainName are needed.
+	Username string `json:"username,omitempty"`
+	UserID   string `json:"-"`
+
+	Password string `json:"password,omitempty"`
+
+	// At most one of DomainID and DomainName must be provided if using Username
+	// with Identity V3. Otherwise, either are optional.
+	DomainID   string `json:"-"`
+	DomainName string `json:"name,omitempty"`
+
+	// The TenantID and TenantName fields are optional for the Identity V2 API.
+	// The same fields are known as project_id and project_name in the Identity
+	// V3 API, but are collected as TenantID and TenantName here in both cases.
+	// Some providers allow you to specify a TenantName instead of the TenantId.
+	// Some require both. Your provider's authentication policies will determine
+	// how these fields influence authentication.
+	// If DomainID or DomainName are provided, they will also apply to TenantName.
+	// It is not currently possible to authenticate with Username and a Domain
+	// and scope to a Project in a different Domain by using TenantName. To
+	// accomplish that, the ProjectID will need to be provided as the TenantID
+	// option.
+	TenantID   string `json:"tenantId,omitempty"`
+	TenantName string `json:"tenantName,omitempty"`
+
+	// AllowReauth should be set to true if you grant permission for Gophercloud to
+	// cache your credentials in memory, and to allow Gophercloud to attempt to
+	// re-authenticate automatically if/when your token expires.  If you set it to
+	// false, it will not cache these settings, but re-authentication will not be
+	// possible.  This setting defaults to false.
+	//
+	// NOTE: The reauth function will try to re-authenticate endlessly if left
+	// unchecked. The way to limit the number of attempts is to provide a custom
+	// HTTP client to the provider client and provide a transport that implements
+	// the RoundTripper interface and stores the number of failed retries. For an
+	// example of this, see here:
+	// https://github.com/rackspace/rack/blob/1.0.0/auth/clients.go#L311
+	AllowReauth bool `json:"-"`
+
+	// TokenID allows users to authenticate (possibly as another user) with an
+	// authentication token ID.
+	TokenID string `json:"-"`
+
+	// Scope determines the scoping of the authentication request.
+
+	// Authentication through Application Credentials requires supplying name, project and secret
+	// For project we can use TenantID
+	ApplicationCredentialID     string `json:"-"`
+	ApplicationCredentialName   string `json:"-"`
+	ApplicationCredentialSecret string `json:"-"`
+}
+
+// AuthScope allows a created token to be limited to a specific domain or project.
+type AuthScope struct {
+	ProjectID   string
+	ProjectName string
+	DomainID    string
+	DomainName  string
+}
+
+// ToTokenV2CreateMap allows AuthOptions to satisfy the AuthOptionsBuilder
+// interface in the v2 tokens package
+func (opts AuthOptions) ToTokenV2CreateMap() (map[string]interface{}, error) {
+	// Populate the request map.
+	authMap := make(map[string]interface{})
+
+	if opts.Username != "" {
+		if opts.Password != "" {
+			authMap["passwordCredentials"] = map[string]interface{}{
+				"username": opts.Username,
+				"password": opts.Password,
+			}
+		} else {
+			return nil, ErrMissingInput{Argument: "Password"}
+		}
+	} else if opts.TokenID != "" {
+		authMap["token"] = map[string]interface{}{
+			"id": opts.TokenID,
+		}
+	} else {
+		return nil, ErrMissingInput{Argument: "Username"}
+	}
+
+	if opts.TenantID != "" {
+		authMap["tenantId"] = opts.TenantID
+	}
+	if opts.TenantName != "" {
+		authMap["tenantName"] = opts.TenantName
+	}
+
+	return map[string]interface{}{"auth": authMap}, nil
+}
+
+func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[string]interface{}, error) {
+	type domainReq struct {
+		ID   *string `json:"id,omitempty"`
+		Name *string `json:"name,omitempty"`
+	}
+
+	type projectReq struct {
+		Domain *domainReq `json:"domain,omitempty"`
+		Name   *string    `json:"name,omitempty"`
+		ID     *string    `json:"id,omitempty"`
+	}
+
+	type userReq struct {
+		ID       *string    `json:"id,omitempty"`
+		Name     *string    `json:"name,omitempty"`
+		Password string     `json:"password,omitempty"`
+		Domain   *domainReq `json:"domain,omitempty"`
+	}
+
+	type passwordReq struct {
+		User userReq `json:"user"`
+	}
+
+	type tokenReq struct {
+		ID string `json:"id"`
+	}
+
+	type applicationCredentialReq struct {
+		ID     *string  `json:"id,omitempty"`
+		Name   *string  `json:"name,omitempty"`
+		User   *userReq `json:"user,omitempty"`
+		Secret *string  `json:"secret,omitempty"`
+	}
+
+	type identityReq struct {
+		Methods               []string                  `json:"methods"`
+		Password              *passwordReq              `json:"password,omitempty"`
+		Token                 *tokenReq                 `json:"token,omitempty"`
+		ApplicationCredential *applicationCredentialReq `json:"application_credential,omitempty"`
+	}
+
+	type authReq struct {
+		Identity identityReq `json:"identity"`
+	}
+
+	type request struct {
+		Auth authReq `json:"auth"`
+	}
+
+	// Populate the request structure based on the provided arguments. Create and return an error
+	// if insufficient or incompatible information is present.
+	var req request
+
+	if opts.Password == "" {
+		if opts.TokenID != "" {
+			// Because we aren't using password authentication, it's an error to also provide any of the user-based authentication
+			// parameters.
+			if opts.Username != "" {
+				return nil, ErrUsernameWithToken{}
+			}
+			if opts.UserID != "" {
+				return nil, ErrUserIDWithToken{}
+			}
+			if opts.DomainID != "" {
+				return nil, ErrDomainIDWithToken{}
+			}
+			if opts.DomainName != "" {
+				return nil, ErrDomainNameWithToken{}
+			}
+
+			// Configure the request for Token authentication.
+			req.Auth.Identity.Methods = []string{"token"}
+			req.Auth.Identity.Token = &tokenReq{
+				ID: opts.TokenID,
+			}
+
+		} else if opts.ApplicationCredentialID != "" {
+			// Configure the request for ApplicationCredentialID authentication.
+			// https://github.com/openstack/keystoneauth/blob/stable/rocky/keystoneauth1/identity/v3/application_credential.py#L48-L67
+			// There are three kinds of possible application_credential requests
+			// 1. application_credential id + secret
+			// 2. application_credential name + secret + user_id
+			// 3. application_credential name + secret + username + domain_id / domain_name
+			if opts.ApplicationCredentialSecret == "" {
+				return nil, ErrAppCredMissingSecret{}
+			}
+			req.Auth.Identity.Methods = []string{"application_credential"}
+			req.Auth.Identity.ApplicationCredential = &applicationCredentialReq{
+				ID:     &opts.ApplicationCredentialID,
+				Secret: &opts.ApplicationCredentialSecret,
+			}
+		} else if opts.ApplicationCredentialName != "" {
+			if opts.ApplicationCredentialSecret == "" {
+				return nil, ErrAppCredMissingSecret{}
+			}
+
+			var userRequest *userReq
+
+			if opts.UserID != "" {
+				// UserID could be used without the domain information
+				userRequest = &userReq{
+					ID: &opts.UserID,
+				}
+			}
+
+			if userRequest == nil && opts.Username == "" {
+				// Make sure that Username or UserID are provided
+				return nil, ErrUsernameOrUserID{}
+			}
+
+			if userRequest == nil && opts.DomainID != "" {
+				userRequest = &userReq{
+					Name:   &opts.Username,
+					Domain: &domainReq{ID: &opts.DomainID},
+				}
+			}
+
+			if userRequest == nil && opts.DomainName != "" {
+				userRequest = &userReq{
+					Name:   &opts.Username,
+					Domain: &domainReq{Name: &opts.DomainName},
+				}
+			}
+
+			// Make sure that DomainID or DomainName are provided among Username
+			if userRequest == nil {
+				return nil, ErrDomainIDOrDomainName{}
+			}
+
+			req.Auth.Identity.Methods = []string{"application_credential"}
+			req.Auth.Identity.ApplicationCredential = &applicationCredentialReq{
+				Name:   &opts.ApplicationCredentialName,
+				User:   userRequest,
+				Secret: &opts.ApplicationCredentialSecret,
+			}
+		} else {
+			// If no password or token ID or ApplicationCredential are available, authentication can't continue.
+			return nil, ErrMissingPassword{}
+		}
+	} else {
+		// Password authentication.
+		req.Auth.Identity.Methods = []string{"password"}
+
+		// At least one of Username and UserID must be specified.
+		if opts.Username == "" && opts.UserID == "" {
+			return nil, ErrUsernameOrUserID{}
+		}
+
+		if opts.Username != "" {
+			// If Username is provided, UserID may not be provided.
+			if opts.UserID != "" {
+				return nil, ErrUsernameOrUserID{}
+			}
+
+			// Either DomainID or DomainName must also be specified.
+			if opts.DomainID == "" && opts.DomainName == "" {
+				return nil, ErrDomainIDOrDomainName{}
+			}
+
+			if opts.DomainID != "" {
+				if opts.DomainName != "" {
+					return nil, ErrDomainIDOrDomainName{}
+				}
+
+				// Configure the request for Username and Password authentication with a DomainID.
+				req.Auth.Identity.Password = &passwordReq{
+					User: userReq{
+						Name:     &opts.Username,
+						Password: opts.Password,
+						Domain:   &domainReq{ID: &opts.DomainID},
+					},
+				}
+			}
+
+			if opts.DomainName != "" {
+				// Configure the request for Username and Password authentication with a DomainName.
+				req.Auth.Identity.Password = &passwordReq{
+					User: userReq{
+						Name:     &opts.Username,
+						Password: opts.Password,
+						Domain:   &domainReq{Name: &opts.DomainName},
+					},
+				}
+			}
+		}
+
+		if opts.UserID != "" {
+			// If UserID is specified, neither DomainID nor DomainName may be.
+			if opts.DomainID != "" {
+				return nil, ErrDomainIDWithUserID{}
+			}
+			if opts.DomainName != "" {
+				return nil, ErrDomainNameWithUserID{}
+			}
+
+			// Configure the request for UserID and Password authentication.
+			req.Auth.Identity.Password = &passwordReq{
+				User: userReq{ID: &opts.UserID, Password: opts.Password},
+			}
+		}
+	}
+
+	b, err := BuildRequestBody(req, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(scope) != 0 {
+		b["auth"].(map[string]interface{})["scope"] = scope
+	}
+
+	return b, nil
+}
+
+func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
+	// For backwards compatibility.
+	// If AuthOptions.Scope was not set, try to determine it.
+	// This works well for common scenarios.
+	return nil, nil
+}
+
+func (opts AuthOptions) CanReauth() bool {
+	return opts.AllowReauth
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/auth_result.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/auth_result.go
@@ -1,0 +1,52 @@
+package gophercloud
+
+/*
+AuthResult is the result from the request that was used to obtain a provider
+client's Keystone token. It is returned from ProviderClient.GetAuthResult().
+
+The following types satisfy this interface:
+
+	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens.CreateResult
+	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens.CreateResult
+
+Usage example:
+
+	import (
+		"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+		tokens2 "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens"
+		tokens3 "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens"
+	)
+
+	func GetAuthenticatedUserID(providerClient *gophercloud.ProviderClient) (string, error) {
+		r := providerClient.GetAuthResult()
+		if r == nil {
+			//ProviderClient did not use openstack.Authenticate(), e.g. because token
+			//was set manually with ProviderClient.SetToken()
+			return "", errors.New("no AuthResult available")
+		}
+		switch r := r.(type) {
+		case tokens2.CreateResult:
+			u, err := r.ExtractUser()
+			if err != nil {
+				return "", err
+			}
+			return u.ID, nil
+		case tokens3.CreateResult:
+			u, err := r.ExtractUser()
+			if err != nil {
+				return "", err
+			}
+			return u.ID, nil
+		default:
+			panic(fmt.Sprintf("got unexpected AuthResult type %t", r))
+		}
+	}
+
+Both implementing types share a lot of methods by name, like ExtractUser() in
+this example. But those methods cannot be part of the AuthResult interface
+because the return types are different (in this case, type tokens2.User vs.
+type tokens3.User).
+*/
+type AuthResult interface {
+	ExtractTokenID() (string, error)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/doc.go
@@ -1,0 +1,110 @@
+/*
+Package gophercloud provides a multi-vendor interface to OpenStack-compatible
+clouds. The library has a three-level hierarchy: providers, services, and
+resources.
+
+# Authenticating with Providers
+
+Provider structs represent the cloud providers that offer and manage a
+collection of services. You will generally want to create one Provider
+client per OpenStack cloud.
+
+	It is now recommended to use the `clientconfig` package found at
+	https://github.com/gophercloud/utils/tree/master/openstack/clientconfig
+	for all authentication purposes.
+
+	The below documentation is still relevant. clientconfig simply implements
+	the below and presents it in an easier and more flexible way.
+
+Use your OpenStack credentials to create a Provider client.  The
+IdentityEndpoint is typically refered to as "auth_url" or "OS_AUTH_URL" in
+information provided by the cloud operator. Additionally, the cloud may refer to
+TenantID or TenantName as project_id and project_name. Credentials are
+specified like so:
+
+	opts := gophercloud.AuthOptions{
+		IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
+		Username: "{username}",
+		Password: "{password}",
+		TenantID: "{tenant_id}",
+	}
+
+	provider, err := openstack.AuthenticatedClient(opts)
+
+You can authenticate with a token by doing:
+
+	opts := gophercloud.AuthOptions{
+		IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
+		TokenID:  "{token_id}",
+		TenantID: "{tenant_id}",
+	}
+
+	provider, err := openstack.AuthenticatedClient(opts)
+
+You may also use the openstack.AuthOptionsFromEnv() helper function. This
+function reads in standard environment variables frequently found in an
+OpenStack `openrc` file. Again note that Gophercloud currently uses "tenant"
+instead of "project".
+
+	opts, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(opts)
+
+# Service Clients
+
+Service structs are specific to a provider and handle all of the logic and
+operations for a particular OpenStack service. Examples of services include:
+Compute, Object Storage, Block Storage. In order to define one, you need to
+pass in the parent provider, like so:
+
+	opts := gophercloud.EndpointOpts{Region: "RegionOne"}
+
+	client, err := openstack.NewComputeV2(provider, opts)
+
+# Resources
+
+Resource structs are the domain models that services make use of in order
+to work with and represent the state of API resources:
+
+	server, err := servers.Get(client, "{serverId}").Extract()
+
+Intermediate Result structs are returned for API operations, which allow
+generic access to the HTTP headers, response body, and any errors associated
+with the network transaction. To turn a result into a usable resource struct,
+you must call the Extract method which is chained to the response, or an
+Extract function from an applicable extension:
+
+	result := servers.Get(client, "{serverId}")
+
+	// Attempt to extract the disk configuration from the OS-DCF disk config
+	// extension:
+	config, err := diskconfig.ExtractGet(result)
+
+All requests that enumerate a collection return a Pager struct that is used to
+iterate through the results one page at a time. Use the EachPage method on that
+Pager to handle each successive Page in a closure, then use the appropriate
+extraction method from that request's package to interpret that Page as a slice
+of results:
+
+	err := servers.List(client, nil).EachPage(func (page pagination.Page) (bool, error) {
+		s, err := servers.ExtractServers(page)
+		if err != nil {
+			return false, err
+		}
+
+		// Handle the []servers.Server slice.
+
+		// Return "false" or an error to prematurely stop fetching new pages.
+		return true, nil
+	})
+
+If you want to obtain the entire collection of pages without doing any
+intermediary processing on each page, you can use the AllPages method:
+
+	allPages, err := servers.List(client, nil).AllPages()
+	allServers, err := servers.ExtractServers(allPages)
+
+This top-level package contains utility functions and data types that are used
+throughout the provider and service packages. Of particular note for end users
+are the AuthOptions and EndpointOpts structs.
+*/
+package gophercloud

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/endpoint_search.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/endpoint_search.go
@@ -1,0 +1,76 @@
+package gophercloud
+
+// Availability indicates to whom a specific service endpoint is accessible:
+// the internet at large, internal networks only, or only to administrators.
+// Different identity services use different terminology for these. Identity v2
+// lists them as different kinds of URLs within the service catalog ("adminURL",
+// "internalURL", and "publicURL"), while v3 lists them as "Interfaces" in an
+// endpoint's response.
+type Availability string
+
+const (
+	// AvailabilityAdmin indicates that an endpoint is only available to
+	// administrators.
+	AvailabilityAdmin Availability = "admin"
+
+	// AvailabilityPublic indicates that an endpoint is available to everyone on
+	// the internet.
+	AvailabilityPublic Availability = "public"
+
+	// AvailabilityInternal indicates that an endpoint is only available within
+	// the cluster's internal network.
+	AvailabilityInternal Availability = "internal"
+)
+
+// EndpointOpts specifies search criteria used by queries against an
+// OpenStack service catalog. The options must contain enough information to
+// unambiguously identify one, and only one, endpoint within the catalog.
+//
+// Usually, these are passed to service client factory functions in a provider
+// package, like "openstack.NewComputeV2()".
+type EndpointOpts struct {
+	// Type [required] is the service type for the client (e.g., "compute",
+	// "object-store"). Generally, this will be supplied by the service client
+	// function, but a user-given value will be honored if provided.
+	Type string
+
+	// Name [optional] is the service name for the client (e.g., "nova") as it
+	// appears in the service catalog. Services can have the same Type but a
+	// different Name, which is why both Type and Name are sometimes needed.
+	Name string
+
+	// Region [required] is the geographic region in which the endpoint resides,
+	// generally specifying which datacenter should house your resources.
+	// Required only for services that span multiple regions.
+	Region string
+
+	// Availability [optional] is the visibility of the endpoint to be returned.
+	// Valid types include the constants AvailabilityPublic, AvailabilityInternal,
+	// or AvailabilityAdmin from this package.
+	//
+	// Availability is not required, and defaults to AvailabilityPublic. Not all
+	// providers or services offer all Availability options.
+	Availability Availability
+}
+
+/*
+EndpointLocator is an internal function to be used by provider implementations.
+
+It provides an implementation that locates a single endpoint from a service
+catalog for a specific ProviderClient based on user-provided EndpointOpts. The
+provider then uses it to discover related ServiceClients.
+*/
+type EndpointLocator func(EndpointOpts) (string, error)
+
+// ApplyDefaults is an internal method to be used by provider implementations.
+//
+// It sets EndpointOpts fields if not already set, including a default type.
+// Currently, EndpointOpts.Availability defaults to the public endpoint.
+func (eo *EndpointOpts) ApplyDefaults(t string) {
+	if eo.Type == "" {
+		eo.Type = t
+	}
+	if eo.Availability == "" {
+		eo.Availability = AvailabilityPublic
+	}
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/errors.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/errors.go
@@ -1,0 +1,488 @@
+package gophercloud
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BaseError is an error type that all other error types embed.
+type BaseError struct {
+	DefaultErrString string
+	Info             string
+}
+
+func (e BaseError) Error() string {
+	e.DefaultErrString = "An error occurred while executing a Gophercloud request."
+	return e.choseErrString()
+}
+
+func (e BaseError) choseErrString() string {
+	if e.Info != "" {
+		return e.Info
+	}
+	return e.DefaultErrString
+}
+
+// ErrMissingInput is the error when input is required in a particular
+// situation but not provided by the user
+type ErrMissingInput struct {
+	BaseError
+	Argument string
+}
+
+func (e ErrMissingInput) Error() string {
+	e.DefaultErrString = fmt.Sprintf("Missing input for argument [%s]", e.Argument)
+	return e.choseErrString()
+}
+
+// ErrInvalidInput is an error type used for most non-HTTP Gophercloud errors.
+type ErrInvalidInput struct {
+	ErrMissingInput
+	Value interface{}
+}
+
+func (e ErrInvalidInput) Error() string {
+	e.DefaultErrString = fmt.Sprintf("Invalid input provided for argument [%s]: [%+v]", e.Argument, e.Value)
+	return e.choseErrString()
+}
+
+// ErrMissingEnvironmentVariable is the error when environment variable is required
+// in a particular situation but not provided by the user
+type ErrMissingEnvironmentVariable struct {
+	BaseError
+	EnvironmentVariable string
+}
+
+func (e ErrMissingEnvironmentVariable) Error() string {
+	e.DefaultErrString = fmt.Sprintf("Missing environment variable [%s]", e.EnvironmentVariable)
+	return e.choseErrString()
+}
+
+// ErrMissingAnyoneOfEnvironmentVariables is the error when anyone of the environment variables
+// is required in a particular situation but not provided by the user
+type ErrMissingAnyoneOfEnvironmentVariables struct {
+	BaseError
+	EnvironmentVariables []string
+}
+
+func (e ErrMissingAnyoneOfEnvironmentVariables) Error() string {
+	e.DefaultErrString = fmt.Sprintf(
+		"Missing one of the following environment variables [%s]",
+		strings.Join(e.EnvironmentVariables, ", "),
+	)
+	return e.choseErrString()
+}
+
+// ErrUnexpectedResponseCode is returned by the Request method when a response code other than
+// those listed in OkCodes is encountered.
+type ErrUnexpectedResponseCode struct {
+	BaseError
+	URL      string
+	Method   string
+	Expected []int
+	Actual   int
+	Body     []byte
+}
+
+func (e ErrUnexpectedResponseCode) Error() string {
+	e.DefaultErrString = fmt.Sprintf(
+		"Expected HTTP response code %v when accessing [%s %s], but got %d instead\n%s",
+		e.Expected, e.Method, e.URL, e.Actual, e.Body,
+	)
+	return e.choseErrString()
+}
+
+// GetStatusCode returns the actual status code of the error.
+func (e ErrUnexpectedResponseCode) GetStatusCode() int {
+	return e.Actual
+}
+
+// StatusCodeError is a convenience interface to easily allow access to the
+// status code field of the various ErrDefault* types.
+//
+// By using this interface, you only have to make a single type cast of
+// the returned error to err.(StatusCodeError) and then call GetStatusCode()
+// instead of having a large switch statement checking for each of the
+// ErrDefault* types.
+type StatusCodeError interface {
+	Error() string
+	GetStatusCode() int
+}
+
+// ErrDefault400 is the default error type returned on a 400 HTTP response code.
+type ErrDefault400 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault401 is the default error type returned on a 401 HTTP response code.
+type ErrDefault401 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault403 is the default error type returned on a 403 HTTP response code.
+type ErrDefault403 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault404 is the default error type returned on a 404 HTTP response code.
+type ErrDefault404 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault405 is the default error type returned on a 405 HTTP response code.
+type ErrDefault405 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault408 is the default error type returned on a 408 HTTP response code.
+type ErrDefault408 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault409 is the default error type returned on a 409 HTTP response code.
+type ErrDefault409 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault429 is the default error type returned on a 429 HTTP response code.
+type ErrDefault429 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault500 is the default error type returned on a 500 HTTP response code.
+type ErrDefault500 struct {
+	ErrUnexpectedResponseCode
+}
+
+// ErrDefault503 is the default error type returned on a 503 HTTP response code.
+type ErrDefault503 struct {
+	ErrUnexpectedResponseCode
+}
+
+func (e ErrDefault400) Error() string {
+	e.DefaultErrString = fmt.Sprintf(
+		"Bad request with: [%s %s], error message: %s",
+		e.Method, e.URL, e.Body,
+	)
+	return e.choseErrString()
+}
+func (e ErrDefault401) Error() string {
+	return "Authentication failed"
+}
+func (e ErrDefault403) Error() string {
+	e.DefaultErrString = fmt.Sprintf(
+		"Request forbidden: [%s %s], error message: %s",
+		e.Method, e.URL, e.Body,
+	)
+	return e.choseErrString()
+}
+func (e ErrDefault404) Error() string {
+	return "Resource not found"
+}
+func (e ErrDefault405) Error() string {
+	return "Method not allowed"
+}
+func (e ErrDefault408) Error() string {
+	return "The server timed out waiting for the request"
+}
+func (e ErrDefault429) Error() string {
+	return "Too many requests have been sent in a given amount of time. Pause" +
+		" requests, wait up to one minute, and try again."
+}
+func (e ErrDefault500) Error() string {
+	return "Internal Server Error"
+}
+func (e ErrDefault503) Error() string {
+	return "The service is currently unable to handle the request due to a temporary" +
+		" overloading or maintenance. This is a temporary condition. Try again later."
+}
+
+// Err400er is the interface resource error types implement to override the error message
+// from a 400 error.
+type Err400er interface {
+	Error400(ErrUnexpectedResponseCode) error
+}
+
+// Err401er is the interface resource error types implement to override the error message
+// from a 401 error.
+type Err401er interface {
+	Error401(ErrUnexpectedResponseCode) error
+}
+
+// Err403er is the interface resource error types implement to override the error message
+// from a 403 error.
+type Err403er interface {
+	Error403(ErrUnexpectedResponseCode) error
+}
+
+// Err404er is the interface resource error types implement to override the error message
+// from a 404 error.
+type Err404er interface {
+	Error404(ErrUnexpectedResponseCode) error
+}
+
+// Err405er is the interface resource error types implement to override the error message
+// from a 405 error.
+type Err405er interface {
+	Error405(ErrUnexpectedResponseCode) error
+}
+
+// Err408er is the interface resource error types implement to override the error message
+// from a 408 error.
+type Err408er interface {
+	Error408(ErrUnexpectedResponseCode) error
+}
+
+// Err409er is the interface resource error types implement to override the error message
+// from a 409 error.
+type Err409er interface {
+	Error409(ErrUnexpectedResponseCode) error
+}
+
+// Err429er is the interface resource error types implement to override the error message
+// from a 429 error.
+type Err429er interface {
+	Error429(ErrUnexpectedResponseCode) error
+}
+
+// Err500er is the interface resource error types implement to override the error message
+// from a 500 error.
+type Err500er interface {
+	Error500(ErrUnexpectedResponseCode) error
+}
+
+// Err503er is the interface resource error types implement to override the error message
+// from a 503 error.
+type Err503er interface {
+	Error503(ErrUnexpectedResponseCode) error
+}
+
+// ErrTimeOut is the error type returned when an operations times out.
+type ErrTimeOut struct {
+	BaseError
+}
+
+func (e ErrTimeOut) Error() string {
+	e.DefaultErrString = "A time out occurred"
+	return e.choseErrString()
+}
+
+// ErrUnableToReauthenticate is the error type returned when reauthentication fails.
+type ErrUnableToReauthenticate struct {
+	BaseError
+	ErrOriginal error
+}
+
+func (e ErrUnableToReauthenticate) Error() string {
+	e.DefaultErrString = fmt.Sprintf("Unable to re-authenticate: %s", e.ErrOriginal)
+	return e.choseErrString()
+}
+
+// ErrErrorAfterReauthentication is the error type returned when reauthentication
+// succeeds, but an error occurs afterword (usually an HTTP error).
+type ErrErrorAfterReauthentication struct {
+	BaseError
+	ErrOriginal error
+}
+
+func (e ErrErrorAfterReauthentication) Error() string {
+	e.DefaultErrString = fmt.Sprintf("Successfully re-authenticated, but got error executing request: %s", e.ErrOriginal)
+	return e.choseErrString()
+}
+
+// ErrServiceNotFound is returned when no service in a service catalog matches
+// the provided EndpointOpts. This is generally returned by provider service
+// factory methods like "NewComputeV2()" and can mean that a service is not
+// enabled for your account.
+type ErrServiceNotFound struct {
+	BaseError
+}
+
+func (e ErrServiceNotFound) Error() string {
+	e.DefaultErrString = "No suitable service could be found in the service catalog."
+	return e.choseErrString()
+}
+
+// ErrEndpointNotFound is returned when no available endpoints match the
+// provided EndpointOpts. This is also generally returned by provider service
+// factory methods, and usually indicates that a region was specified
+// incorrectly.
+type ErrEndpointNotFound struct {
+	BaseError
+}
+
+func (e ErrEndpointNotFound) Error() string {
+	e.DefaultErrString = "No suitable endpoint could be found in the service catalog."
+	return e.choseErrString()
+}
+
+// ErrResourceNotFound is the error when trying to retrieve a resource's
+// ID by name and the resource doesn't exist.
+type ErrResourceNotFound struct {
+	BaseError
+	Name         string
+	ResourceType string
+}
+
+func (e ErrResourceNotFound) Error() string {
+	e.DefaultErrString = fmt.Sprintf("Unable to find %s with name %s", e.ResourceType, e.Name)
+	return e.choseErrString()
+}
+
+// ErrMultipleResourcesFound is the error when trying to retrieve a resource's
+// ID by name and multiple resources have the user-provided name.
+type ErrMultipleResourcesFound struct {
+	BaseError
+	Name         string
+	Count        int
+	ResourceType string
+}
+
+func (e ErrMultipleResourcesFound) Error() string {
+	e.DefaultErrString = fmt.Sprintf("Found %d %ss matching %s", e.Count, e.ResourceType, e.Name)
+	return e.choseErrString()
+}
+
+// ErrUnexpectedType is the error when an unexpected type is encountered
+type ErrUnexpectedType struct {
+	BaseError
+	Expected string
+	Actual   string
+}
+
+func (e ErrUnexpectedType) Error() string {
+	e.DefaultErrString = fmt.Sprintf("Expected %s but got %s", e.Expected, e.Actual)
+	return e.choseErrString()
+}
+
+func unacceptedAttributeErr(attribute string) string {
+	return fmt.Sprintf("The base Identity V3 API does not accept authentication by %s", attribute)
+}
+
+func redundantWithTokenErr(attribute string) string {
+	return fmt.Sprintf("%s may not be provided when authenticating with a TokenID", attribute)
+}
+
+func redundantWithUserID(attribute string) string {
+	return fmt.Sprintf("%s may not be provided when authenticating with a UserID", attribute)
+}
+
+// ErrAPIKeyProvided indicates that an APIKey was provided but can't be used.
+type ErrAPIKeyProvided struct{ BaseError }
+
+func (e ErrAPIKeyProvided) Error() string {
+	return unacceptedAttributeErr("APIKey")
+}
+
+// ErrTenantIDProvided indicates that a TenantID was provided but can't be used.
+type ErrTenantIDProvided struct{ BaseError }
+
+func (e ErrTenantIDProvided) Error() string {
+	return unacceptedAttributeErr("TenantID")
+}
+
+// ErrTenantNameProvided indicates that a TenantName was provided but can't be used.
+type ErrTenantNameProvided struct{ BaseError }
+
+func (e ErrTenantNameProvided) Error() string {
+	return unacceptedAttributeErr("TenantName")
+}
+
+// ErrUsernameWithToken indicates that a Username was provided, but token authentication is being used instead.
+type ErrUsernameWithToken struct{ BaseError }
+
+func (e ErrUsernameWithToken) Error() string {
+	return redundantWithTokenErr("Username")
+}
+
+// ErrUserIDWithToken indicates that a UserID was provided, but token authentication is being used instead.
+type ErrUserIDWithToken struct{ BaseError }
+
+func (e ErrUserIDWithToken) Error() string {
+	return redundantWithTokenErr("UserID")
+}
+
+// ErrDomainIDWithToken indicates that a DomainID was provided, but token authentication is being used instead.
+type ErrDomainIDWithToken struct{ BaseError }
+
+func (e ErrDomainIDWithToken) Error() string {
+	return redundantWithTokenErr("DomainID")
+}
+
+// ErrDomainNameWithToken indicates that a DomainName was provided, but token authentication is being used instead.s
+type ErrDomainNameWithToken struct{ BaseError }
+
+func (e ErrDomainNameWithToken) Error() string {
+	return redundantWithTokenErr("DomainName")
+}
+
+// ErrUsernameOrUserID indicates that neither username nor userID are specified, or both are at once.
+type ErrUsernameOrUserID struct{ BaseError }
+
+func (e ErrUsernameOrUserID) Error() string {
+	return "Exactly one of Username and UserID must be provided for password authentication"
+}
+
+// ErrDomainIDWithUserID indicates that a DomainID was provided, but unnecessary because a UserID is being used.
+type ErrDomainIDWithUserID struct{ BaseError }
+
+func (e ErrDomainIDWithUserID) Error() string {
+	return redundantWithUserID("DomainID")
+}
+
+// ErrDomainNameWithUserID indicates that a DomainName was provided, but unnecessary because a UserID is being used.
+type ErrDomainNameWithUserID struct{ BaseError }
+
+func (e ErrDomainNameWithUserID) Error() string {
+	return redundantWithUserID("DomainName")
+}
+
+// ErrDomainIDOrDomainName indicates that a username was provided, but no domain to scope it.
+// It may also indicate that both a DomainID and a DomainName were provided at once.
+type ErrDomainIDOrDomainName struct{ BaseError }
+
+func (e ErrDomainIDOrDomainName) Error() string {
+	return "You must provide exactly one of DomainID or DomainName to authenticate by Username"
+}
+
+// ErrMissingPassword indicates that no password was provided and no token is available.
+type ErrMissingPassword struct{ BaseError }
+
+func (e ErrMissingPassword) Error() string {
+	return "You must provide a password to authenticate"
+}
+
+// ErrScopeDomainIDOrDomainName indicates that a domain ID or Name was required in a Scope, but not present.
+type ErrScopeDomainIDOrDomainName struct{ BaseError }
+
+func (e ErrScopeDomainIDOrDomainName) Error() string {
+	return "You must provide exactly one of DomainID or DomainName in a Scope with ProjectName"
+}
+
+// ErrScopeProjectIDOrProjectName indicates that both a ProjectID and a ProjectName were provided in a Scope.
+type ErrScopeProjectIDOrProjectName struct{ BaseError }
+
+func (e ErrScopeProjectIDOrProjectName) Error() string {
+	return "You must provide at most one of ProjectID or ProjectName in a Scope"
+}
+
+// ErrScopeProjectIDAlone indicates that a ProjectID was provided with other constraints in a Scope.
+type ErrScopeProjectIDAlone struct{ BaseError }
+
+func (e ErrScopeProjectIDAlone) Error() string {
+	return "ProjectID must be supplied alone in a Scope"
+}
+
+// ErrScopeEmpty indicates that no credentials were provided in a Scope.
+type ErrScopeEmpty struct{ BaseError }
+
+func (e ErrScopeEmpty) Error() string {
+	return "You must provide either a Project or Domain in a Scope"
+}
+
+// ErrAppCredMissingSecret indicates that no Application Credential Secret was provided with Application Credential ID or Name
+type ErrAppCredMissingSecret struct{ BaseError }
+
+func (e ErrAppCredMissingSecret) Error() string {
+	return "You must provide an Application Credential Secret"
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/auth_env.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/auth_env.go
@@ -1,0 +1,125 @@
+package openstack
+
+import (
+	"os"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+var nilOptions = gophercloud.AuthOptions{}
+
+/*
+AuthOptionsFromEnv fills out an identity.AuthOptions structure with the
+settings found on the various OpenStack OS_* environment variables.
+
+The following variables provide sources of truth: OS_AUTH_URL, OS_USERNAME,
+OS_PASSWORD and OS_PROJECT_ID.
+
+Of these, OS_USERNAME, OS_PASSWORD, and OS_AUTH_URL must have settings,
+or an error will result.  OS_PROJECT_ID, is optional.
+
+OS_TENANT_ID and OS_TENANT_NAME are deprecated forms of OS_PROJECT_ID and
+OS_PROJECT_NAME and the latter are expected against a v3 auth api.
+
+If OS_PROJECT_ID and OS_PROJECT_NAME are set, they will still be referred
+as "tenant" in Gophercloud.
+
+If OS_PROJECT_NAME is set, it requires OS_PROJECT_ID to be set as well to
+handle projects not on the default domain.
+
+To use this function, first set the OS_* environment variables (for example,
+by sourcing an `openrc` file), then:
+
+	opts, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(opts)
+*/
+func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
+	authURL := os.Getenv("OS_AUTH_URL")
+	username := os.Getenv("OS_USERNAME")
+	userID := os.Getenv("OS_USERID")
+	password := os.Getenv("OS_PASSWORD")
+	tenantID := os.Getenv("OS_TENANT_ID")
+	tenantName := os.Getenv("OS_TENANT_NAME")
+	domainID := os.Getenv("OS_DOMAIN_ID")
+	domainName := os.Getenv("OS_DOMAIN_NAME")
+	applicationCredentialID := os.Getenv("OS_APPLICATION_CREDENTIAL_ID")
+	applicationCredentialName := os.Getenv("OS_APPLICATION_CREDENTIAL_NAME")
+	applicationCredentialSecret := os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")
+
+	// If OS_PROJECT_ID is set, overwrite tenantID with the value.
+	if v := os.Getenv("OS_PROJECT_ID"); v != "" {
+		tenantID = v
+	}
+
+	// If OS_PROJECT_NAME is set, overwrite tenantName with the value.
+	if v := os.Getenv("OS_PROJECT_NAME"); v != "" {
+		tenantName = v
+	}
+
+	if authURL == "" {
+		err := gophercloud.ErrMissingEnvironmentVariable{
+			EnvironmentVariable: "OS_AUTH_URL",
+		}
+		return nilOptions, err
+	}
+
+	if userID == "" && username == "" {
+		// Empty username and userID could be ignored, when applicationCredentialID and applicationCredentialSecret are set
+		if applicationCredentialID == "" && applicationCredentialSecret == "" {
+			err := gophercloud.ErrMissingAnyoneOfEnvironmentVariables{
+				EnvironmentVariables: []string{"OS_USERID", "OS_USERNAME"},
+			}
+			return nilOptions, err
+		}
+	}
+
+	if password == "" && applicationCredentialID == "" && applicationCredentialName == "" {
+		err := gophercloud.ErrMissingEnvironmentVariable{
+			EnvironmentVariable: "OS_PASSWORD",
+		}
+		return nilOptions, err
+	}
+
+	if (applicationCredentialID != "" || applicationCredentialName != "") && applicationCredentialSecret == "" {
+		err := gophercloud.ErrMissingEnvironmentVariable{
+			EnvironmentVariable: "OS_APPLICATION_CREDENTIAL_SECRET",
+		}
+		return nilOptions, err
+	}
+
+	if domainID == "" && domainName == "" && tenantID == "" && tenantName != "" {
+		err := gophercloud.ErrMissingEnvironmentVariable{
+			EnvironmentVariable: "OS_PROJECT_ID",
+		}
+		return nilOptions, err
+	}
+
+	if applicationCredentialID == "" && applicationCredentialName != "" && applicationCredentialSecret != "" {
+		if userID == "" && username == "" {
+			return nilOptions, gophercloud.ErrMissingAnyoneOfEnvironmentVariables{
+				EnvironmentVariables: []string{"OS_USERID", "OS_USERNAME"},
+			}
+		}
+		if username != "" && domainID == "" && domainName == "" {
+			return nilOptions, gophercloud.ErrMissingAnyoneOfEnvironmentVariables{
+				EnvironmentVariables: []string{"OS_DOMAIN_ID", "OS_DOMAIN_NAME"},
+			}
+		}
+	}
+
+	ao := gophercloud.AuthOptions{
+		IdentityEndpoint:            authURL,
+		UserID:                      userID,
+		Username:                    username,
+		Password:                    password,
+		TenantID:                    tenantID,
+		TenantName:                  tenantName,
+		DomainID:                    domainID,
+		DomainName:                  domainName,
+		ApplicationCredentialID:     applicationCredentialID,
+		ApplicationCredentialName:   applicationCredentialName,
+		ApplicationCredentialSecret: applicationCredentialSecret,
+	}
+
+	return ao, nil
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/client.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/client.go
@@ -1,0 +1,474 @@
+package openstack
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	tokens2 "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens"
+	tokens3 "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/utils"
+)
+
+const (
+	// v2 represents Keystone v2.
+	// It should never increase beyond 2.0.
+	v2 = "v2.0"
+
+	// v3 represents Keystone v3.
+	// The version can be anything from v3 to v3.x.
+	v3 = "v3"
+)
+
+/*
+NewClient prepares an unauthenticated ProviderClient instance.
+Most users will probably prefer using the AuthenticatedClient function
+instead.
+
+This is useful if you wish to explicitly control the version of the identity
+service that's used for authentication explicitly, for example.
+
+A basic example of using this would be:
+
+	ao, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.NewClient(ao.IdentityEndpoint)
+	client, err := openstack.NewIdentityV3(provider, gophercloud.EndpointOpts{})
+*/
+func NewClient(endpoint string) (*gophercloud.ProviderClient, error) {
+	base, err := utils.BaseEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint = gophercloud.NormalizeURL(endpoint)
+	base = gophercloud.NormalizeURL(base)
+
+	p := new(gophercloud.ProviderClient)
+	p.IdentityBase = base
+	p.IdentityEndpoint = endpoint
+	p.UseTokenLock()
+
+	return p, nil
+}
+
+/*
+AuthenticatedClient logs in to an OpenStack cloud found at the identity endpoint
+specified by the options, acquires a token, and returns a Provider Client
+instance that's ready to operate.
+
+If the full path to a versioned identity endpoint was specified  (example:
+http://example.com:5000/v3), that path will be used as the endpoint to query.
+
+If a versionless endpoint was specified (example: http://example.com:5000/),
+the endpoint will be queried to determine which versions of the identity service
+are available, then chooses the most recent or most supported version.
+
+Example:
+
+	ao, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(ao)
+	client, err := openstack.NewNetworkV2(client, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+*/
+func AuthenticatedClient(options gophercloud.AuthOptions) (*gophercloud.ProviderClient, error) {
+	client, err := NewClient(options.IdentityEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	err = Authenticate(client, options)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// Authenticate or re-authenticate against the most recent identity service
+// supported at the provided endpoint.
+func Authenticate(client *gophercloud.ProviderClient, options gophercloud.AuthOptions) error {
+	versions := []*utils.Version{
+		{ID: v2, Priority: 20, Suffix: "/v2.0/"},
+		{ID: v3, Priority: 30, Suffix: "/v3/"},
+	}
+
+	chosen, endpoint, err := utils.ChooseVersion(client, versions)
+	if err != nil {
+		return err
+	}
+
+	switch chosen.ID {
+	case v2:
+		return v2auth(client, endpoint, options, gophercloud.EndpointOpts{})
+	case v3:
+		return v3auth(client, endpoint, &options, gophercloud.EndpointOpts{})
+	default:
+		// The switch statement must be out of date from the versions list.
+		return fmt.Errorf("Unrecognized identity version: %s", chosen.ID)
+	}
+}
+
+// AuthenticateV2 explicitly authenticates against the identity v2 endpoint.
+func AuthenticateV2(client *gophercloud.ProviderClient, options gophercloud.AuthOptions, eo gophercloud.EndpointOpts) error {
+	return v2auth(client, "", options, eo)
+}
+
+func v2auth(client *gophercloud.ProviderClient, endpoint string, options gophercloud.AuthOptions, eo gophercloud.EndpointOpts) error {
+	v2Client, err := NewIdentityV2(client, eo)
+	if err != nil {
+		return err
+	}
+
+	if endpoint != "" {
+		v2Client.Endpoint = endpoint
+	}
+
+	v2Opts := tokens2.AuthOptions{
+		IdentityEndpoint: options.IdentityEndpoint,
+		Username:         options.Username,
+		Password:         options.Password,
+		TenantID:         options.TenantID,
+		TenantName:       options.TenantName,
+		AllowReauth:      options.AllowReauth,
+		TokenID:          options.TokenID,
+	}
+
+	result := tokens2.Create(v2Client, v2Opts)
+
+	err = client.SetTokenAndAuthResult(result)
+	if err != nil {
+		return err
+	}
+
+	if options.AllowReauth {
+		// here we're creating a throw-away client (tac). it's a copy of the user's provider client, but
+		// with the token and reauth func zeroed out. combined with setting `AllowReauth` to `false`,
+		// this should retry authentication only once
+		tac := *client
+		tac.SetThrowaway(true)
+		tac.ReauthFunc = nil
+		tac.SetTokenAndAuthResult(nil)
+		tao := options
+		tao.AllowReauth = false
+		client.ReauthFunc = func() error {
+			err := v2auth(&tac, endpoint, tao, eo)
+			if err != nil {
+				return err
+			}
+			client.CopyTokenFrom(&tac)
+			return nil
+		}
+	}
+	return nil
+}
+
+// AuthenticateV3 explicitly authenticates against the identity v3 service.
+func AuthenticateV3(client *gophercloud.ProviderClient, options tokens3.AuthOptionsBuilder, eo gophercloud.EndpointOpts) error {
+	return v3auth(client, "", options, eo)
+}
+
+func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.AuthOptionsBuilder, eo gophercloud.EndpointOpts) error {
+	// Override the generated service endpoint with the one returned by the version endpoint.
+	v3Client, err := NewIdentityV3(client, eo)
+	if err != nil {
+		return err
+	}
+
+	if endpoint != "" {
+		v3Client.Endpoint = endpoint
+	}
+
+	var catalog *tokens3.ServiceCatalog
+
+	var tokenID string
+	// passthroughToken allows to passthrough the token without a scope
+	var passthroughToken bool
+	switch v := opts.(type) {
+	case *gophercloud.AuthOptions:
+		tokenID = v.TokenID
+	case *tokens3.AuthOptions:
+		tokenID = v.TokenID
+	}
+
+	if tokenID != "" && passthroughToken {
+		// passing through the token ID without requesting a new scope
+		if opts.CanReauth() {
+			return fmt.Errorf("cannot use AllowReauth, when the token ID is defined and auth scope is not set")
+		}
+
+		v3Client.SetToken(tokenID)
+		result := tokens3.Get(v3Client, tokenID)
+		if result.Err != nil {
+			return result.Err
+		}
+
+		err = client.SetTokenAndAuthResult(result)
+		if err != nil {
+			return err
+		}
+
+		catalog, err = result.ExtractServiceCatalog()
+		if err != nil {
+			return err
+		}
+	} else {
+		result := tokens3.Create(v3Client, opts)
+
+		err = client.SetTokenAndAuthResult(result)
+		if err != nil {
+			return err
+		}
+
+		catalog, err = result.ExtractServiceCatalog()
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.CanReauth() {
+		// here we're creating a throw-away client (tac). it's a copy of the user's provider client, but
+		// with the token and reauth func zeroed out. combined with setting `AllowReauth` to `false`,
+		// this should retry authentication only once
+		tac := *client
+		tac.SetThrowaway(true)
+		tac.ReauthFunc = nil
+		tac.SetTokenAndAuthResult(nil)
+		var tao tokens3.AuthOptionsBuilder
+		switch ot := opts.(type) {
+		case *gophercloud.AuthOptions:
+			o := *ot
+			o.AllowReauth = false
+			tao = &o
+		case *tokens3.AuthOptions:
+			o := *ot
+			o.AllowReauth = false
+			tao = &o
+		default:
+			tao = opts
+		}
+		client.ReauthFunc = func() error {
+			err := v3auth(&tac, endpoint, tao, eo)
+			if err != nil {
+				return err
+			}
+			client.CopyTokenFrom(&tac)
+			return nil
+		}
+	}
+	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
+		return V3EndpointURL(catalog, opts)
+	}
+
+	return nil
+}
+
+// NewIdentityV2 creates a ServiceClient that may be used to interact with the
+// v2 identity service.
+func NewIdentityV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	endpoint := client.IdentityBase + "v2.0/"
+	clientType := "identity"
+	var err error
+	if !reflect.DeepEqual(eo, gophercloud.EndpointOpts{}) {
+		eo.ApplyDefaults(clientType)
+		endpoint, err = client.EndpointLocator(eo)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &gophercloud.ServiceClient{
+		ProviderClient: client,
+		Endpoint:       endpoint,
+		Type:           clientType,
+	}, nil
+}
+
+// NewIdentityV3 creates a ServiceClient that may be used to access the v3
+// identity service.
+func NewIdentityV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	endpoint := client.IdentityBase + "v3/"
+	clientType := "identity"
+	var err error
+	if !reflect.DeepEqual(eo, gophercloud.EndpointOpts{}) {
+		eo.ApplyDefaults(clientType)
+		endpoint, err = client.EndpointLocator(eo)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Ensure endpoint still has a suffix of v3.
+	// This is because EndpointLocator might have found a versionless
+	// endpoint or the published endpoint is still /v2.0. In both
+	// cases, we need to fix the endpoint to point to /v3.
+	base, err := utils.BaseEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	base = gophercloud.NormalizeURL(base)
+
+	endpoint = base + "v3/"
+
+	return &gophercloud.ServiceClient{
+		ProviderClient: client,
+		Endpoint:       endpoint,
+		Type:           clientType,
+	}, nil
+}
+
+func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clientType string) (*gophercloud.ServiceClient, error) {
+	sc := new(gophercloud.ServiceClient)
+	eo.ApplyDefaults(clientType)
+	url, err := client.EndpointLocator(eo)
+	if err != nil {
+		return sc, err
+	}
+	sc.ProviderClient = client
+	sc.Endpoint = url
+	sc.Type = clientType
+	return sc, nil
+}
+
+// NewBareMetalV1 creates a ServiceClient that may be used with the v1
+// bare metal package.
+func NewBareMetalV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "baremetal")
+}
+
+// NewBareMetalIntrospectionV1 creates a ServiceClient that may be used with the v1
+// bare metal introspection package.
+func NewBareMetalIntrospectionV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "baremetal-inspector")
+}
+
+// NewObjectStorageV1 creates a ServiceClient that may be used with the v1
+// object storage package.
+func NewObjectStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "object-store")
+}
+
+// NewComputeV2 creates a ServiceClient that may be used with the v2 compute
+// package.
+func NewComputeV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "compute")
+}
+
+// NewNetworkV2 creates a ServiceClient that may be used with the v2 network
+// package.
+func NewNetworkV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "network")
+	sc.ResourceBase = sc.Endpoint + "v2.0/"
+	return sc, err
+}
+
+// NewBlockStorageV1 creates a ServiceClient that may be used to access the v1
+// block storage service.
+func NewBlockStorageV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "volume")
+}
+
+// NewBlockStorageV2 creates a ServiceClient that may be used to access the v2
+// block storage service.
+func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "volumev2")
+}
+
+// NewBlockStorageV3 creates a ServiceClient that may be used to access the v3 block storage service.
+func NewBlockStorageV3(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "volumev3")
+}
+
+// NewSharedFileSystemV2 creates a ServiceClient that may be used to access the v2 shared file system service.
+func NewSharedFileSystemV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "sharev2")
+}
+
+// NewCDNV1 creates a ServiceClient that may be used to access the OpenStack v1
+// CDN service.
+func NewCDNV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "cdn")
+}
+
+// NewOrchestrationV1 creates a ServiceClient that may be used to access the v1
+// orchestration service.
+func NewOrchestrationV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "orchestration")
+}
+
+// NewDBV1 creates a ServiceClient that may be used to access the v1 DB service.
+func NewDBV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "database")
+}
+
+// NewDNSV2 creates a ServiceClient that may be used to access the v2 DNS
+// service.
+func NewDNSV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "dns")
+	sc.ResourceBase = sc.Endpoint + "v2/"
+	return sc, err
+}
+
+// NewImageServiceV2 creates a ServiceClient that may be used to access the v2
+// image service.
+func NewImageServiceV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "image")
+	sc.ResourceBase = sc.Endpoint + "v2/"
+	return sc, err
+}
+
+// NewLoadBalancerV2 creates a ServiceClient that may be used to access the v2
+// load balancer service.
+func NewLoadBalancerV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "load-balancer")
+
+	// Fixes edge case having an OpenStack lb endpoint with trailing version number.
+	endpoint := strings.Replace(sc.Endpoint, "v2.0/", "", -1)
+
+	sc.ResourceBase = endpoint + "v2.0/"
+	return sc, err
+}
+
+// NewClusteringV1 creates a ServiceClient that may be used with the v1 clustering
+// package.
+func NewClusteringV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "clustering")
+}
+
+// NewMessagingV2 creates a ServiceClient that may be used with the v2 messaging
+// service.
+func NewMessagingV2(client *gophercloud.ProviderClient, clientID string, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "messaging")
+	sc.MoreHeaders = map[string]string{"Client-ID": clientID}
+	return sc, err
+}
+
+// NewContainerV1 creates a ServiceClient that may be used with v1 container package
+func NewContainerV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "container")
+}
+
+// NewKeyManagerV1 creates a ServiceClient that may be used with the v1 key
+// manager service.
+func NewKeyManagerV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "key-manager")
+	sc.ResourceBase = sc.Endpoint + "v1/"
+	return sc, err
+}
+
+// NewContainerInfraV1 creates a ServiceClient that may be used with the v1 container infra management
+// package.
+func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "container-infra")
+}
+
+// NewWorkflowV2 creates a ServiceClient that may be used with the v2 workflow management package.
+func NewWorkflowV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "workflowv2")
+}
+
+// NewPlacementV1 creates a ServiceClient that may be used with the placement package.
+func NewPlacementV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "placement")
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/doc.go
@@ -1,0 +1,3 @@
+// Package apiversions provides information and interaction with the different
+// API versions for the Container Infra service, code-named Magnum.
+package apiversions

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/errors.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/errors.go
@@ -1,0 +1,23 @@
+package apiversions
+
+import (
+	"fmt"
+)
+
+// ErrVersionNotFound is the error when the requested API version
+// could not be found.
+type ErrVersionNotFound struct{}
+
+func (e ErrVersionNotFound) Error() string {
+	return fmt.Sprintf("Unable to find requested API version")
+}
+
+// ErrMultipleVersionsFound is the error when a request for an API
+// version returns multiple results.
+type ErrMultipleVersionsFound struct {
+	Count int
+}
+
+func (e ErrMultipleVersionsFound) Error() string {
+	return fmt.Sprintf("Found %d API versions", e.Count)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/requests.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/requests.go
@@ -1,0 +1,19 @@
+package apiversions
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// List lists all the API versions available to end-users.
+func List(c *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
+		return APIVersionPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get will get a specific API version, specified by major ID.
+func Get(client *gophercloud.ServiceClient, v string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, v), &r.Body, nil)
+	return
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/results.go
@@ -1,0 +1,68 @@
+package apiversions
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// APIVersion represents an API version for the Container Infra service.
+type APIVersion struct {
+	// ID is the unique identifier of the API version.
+	ID string `json:"id"`
+
+	// MinVersion is the minimum microversion supported.
+	MinVersion string `json:"min_version"`
+
+	// Status is the API versions status.
+	Status string `json:"status"`
+
+	// Version is the maximum microversion supported.
+	Version string `json:"max_version"`
+}
+
+// APIVersionPage is the page returned by a pager when traversing over a
+// collection of API versions.
+type APIVersionPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty checks whether an APIVersionPage struct is empty.
+func (r APIVersionPage) IsEmpty() (bool, error) {
+	is, err := ExtractAPIVersions(r)
+	return len(is) == 0, err
+}
+
+// ExtractAPIVersions takes a collection page, extracts all of the elements,
+// and returns them a slice of APIVersion structs. It is effectively a cast.
+func ExtractAPIVersions(r pagination.Page) ([]APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := (r.(APIVersionPage)).ExtractInto(&s)
+	return s.Versions, err
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts an API version resource.
+func (r GetResult) Extract() (*APIVersion, error) {
+	var s struct {
+		Versions []APIVersion `json:"versions"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(s.Versions) {
+	case 0:
+		return nil, ErrVersionNotFound{}
+	case 1:
+		return &s.Versions[0], nil
+	default:
+		return nil, ErrMultipleVersionsFound{Count: len(s.Versions)}
+	}
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/urls.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/apiversions/urls.go
@@ -1,0 +1,20 @@
+package apiversions
+
+import (
+	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/utils"
+)
+
+func getURL(c *gophercloud.ServiceClient, version string) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/" + strings.TrimRight(version, "/") + "/"
+	return endpoint
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	baseEndpoint, _ := utils.BaseEndpoint(c.Endpoint)
+	endpoint := strings.TrimRight(baseEndpoint, "/") + "/"
+	return endpoint
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/clusters/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/clusters/doc.go
@@ -1,0 +1,100 @@
+/*
+Package clusters contains functionality for working with Magnum Cluster resources.
+
+Example to Create a Cluster
+
+	masterCount := 1
+	nodeCount := 1
+	createTimeout := 30
+	opts := clusters.CreateOpts{
+		ClusterTemplateID: "0562d357-8641-4759-8fed-8173f02c9633",
+		CreateTimeout:     &createTimeout,
+		DiscoveryURL:      "",
+		FlavorID:          "m1.small",
+		KeyPair:           "my_keypair",
+		Labels:            map[string]string{},
+		MasterCount:       &masterCount,
+		MasterFlavorID:    "m1.small",
+		Name:              "k8s",
+		NodeCount:         &nodeCount,
+	}
+
+	cluster, err := clusters.Create(serviceClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Get a Cluster
+
+	clusterName := "cluster123"
+	cluster, err := clusters.Get(serviceClient, clusterName).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", cluster)
+
+Example to List Clusters
+
+	listOpts := clusters.ListOpts{
+		Limit: 20,
+	}
+
+	allPages, err := clusters.List(serviceClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allClusters, err := clusters.ExtractClusters(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, cluster := range allClusters {
+		fmt.Printf("%+v\n", cluster)
+	}
+
+Example to List Clusters with detailed information
+
+	allPagesDetail, err := clusters.ListDetail(serviceClient, clusters.ListOpts{}).AllPages()
+	if err != nil {
+	    panic(err)
+	}
+
+	allClustersDetail, err := clusters.ExtractClusters(allPagesDetail)
+	if err != nil {
+	    panic(err)
+	}
+
+	for _, clusterDetail := range allClustersDetail {
+	    fmt.Printf("%+v\n", clusterDetail)
+	}
+
+Example to Update a Cluster
+
+	updateOpts := []clusters.UpdateOptsBuilder{
+		clusters.UpdateOpts{
+			Op:    clusters.ReplaceOp,
+			Path:  "/master_lb_enabled",
+			Value: "True",
+		},
+		clusters.UpdateOpts{
+			Op:    clusters.ReplaceOp,
+			Path:  "/registry_enabled",
+			Value: "True",
+		},
+	}
+	clusterUUID, err := clusters.Update(serviceClient, clusterUUID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s\n", clusterUUID)
+
+Example to Delete a Cluster
+
+	clusterUUID := "dc6d336e3fc4c0a951b5698cd1236ee"
+	err := clusters.Delete(serviceClient, clusterUUID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package clusters

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/clusters/requests.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/clusters/requests.go
@@ -1,0 +1,217 @@
+package clusters
+
+import (
+	"net/http"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// CreateOptsBuilder Builder.
+type CreateOptsBuilder interface {
+	ToClusterCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts params
+type CreateOpts struct {
+	ClusterTemplateID string            `json:"cluster_template_id" required:"true"`
+	CreateTimeout     *int              `json:"create_timeout"`
+	DiscoveryURL      string            `json:"discovery_url,omitempty"`
+	DockerVolumeSize  *int              `json:"docker_volume_size,omitempty"`
+	FlavorID          string            `json:"flavor_id,omitempty"`
+	Keypair           string            `json:"keypair,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	MasterCount       *int              `json:"master_count,omitempty"`
+	MasterFlavorID    string            `json:"master_flavor_id,omitempty"`
+	Name              string            `json:"name"`
+	NodeCount         *int              `json:"node_count,omitempty"`
+	FloatingIPEnabled *bool             `json:"floating_ip_enabled,omitempty"`
+	FixedNetwork      string            `json:"fixed_network,omitempty"`
+	FixedSubnet       string            `json:"fixed_subnet,omitempty"`
+}
+
+// ToClusterCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToClusterCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Create requests the creation of a new cluster.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToClusterCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	var result *http.Response
+	result, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+
+	return
+}
+
+// Get retrieves a specific clusters based on its unique ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	var result *http.Response
+	result, r.Err = client.Get(getURL(client, id), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}
+
+// Delete deletes the specified cluster ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	var result *http.Response
+	result, r.Err = client.Delete(deleteURL(client, id), nil)
+	r.Header = result.Header
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToClustersListQuery() (string, error)
+}
+
+// ListOpts allows the sorting of paginated collections through
+// the API. SortKey allows you to sort by a particular cluster attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for pagination.
+type ListOpts struct {
+	Marker  string `q:"marker"`
+	Limit   int    `q:"limit"`
+	SortKey string `q:"sort_key"`
+	SortDir string `q:"sort_dir"`
+}
+
+// ToClustersListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToClustersListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// clusters. It accepts a ListOptsBuilder, which allows you to sort
+// the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToClustersListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return ClusterPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// ListDetail returns a Pager which allows you to iterate over a collection of
+// clusters with detailed information.
+// It accepts a ListOptsBuilder, which allows you to sort the returned
+// collection for greater efficiency.
+func ListDetail(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listDetailURL(c)
+	if opts != nil {
+		query, err := opts.ToClustersListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return ClusterPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type UpdateOp string
+
+const (
+	AddOp     UpdateOp = "add"
+	RemoveOp  UpdateOp = "remove"
+	ReplaceOp UpdateOp = "replace"
+)
+
+type UpdateOpts struct {
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToClustersUpdateMap() (map[string]interface{}, error)
+}
+
+// ToClusterUpdateMap assembles a request body based on the contents of
+// UpdateOpts.
+func (opts UpdateOpts) ToClustersUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update implements cluster updated request.
+func Update(client *gophercloud.ServiceClient, id string, opts []UpdateOptsBuilder) (r UpdateResult) {
+	var o []map[string]interface{}
+	for _, opt := range opts {
+		b, err := opt.ToClustersUpdateMap()
+		if err != nil {
+			r.Err = err
+			return r
+		}
+		o = append(o, b)
+	}
+
+	var result *http.Response
+	result, r.Err = client.Patch(updateURL(client, id), o, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}
+
+// ResizeOptsBuilder allows extensions to add additional parameters to the
+// Resize request.
+type ResizeOptsBuilder interface {
+	ToClusterResizeMap() (map[string]interface{}, error)
+}
+
+// ResizeOpts params
+type ResizeOpts struct {
+	NodeCount     *int     `json:"node_count" required:"true"`
+	NodesToRemove []string `json:"nodes_to_remove,omitempty"`
+	NodeGroup     string   `json:"nodegroup,omitempty"`
+}
+
+// ToClusterResizeMap constructs a request body from ResizeOpts.
+func (opts ResizeOpts) ToClusterResizeMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Resize an existing cluster node count.
+func Resize(client *gophercloud.ServiceClient, id string, opts ResizeOptsBuilder) (r ResizeResult) {
+	b, err := opts.ToClusterResizeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	var result *http.Response
+	result, r.Err = client.Post(resizeURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+	return
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/clusters/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/clusters/results.go
@@ -1,0 +1,130 @@
+package clusters
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// CreateResult is the response of a Create operations.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult is the result from a Delete operation. Call its Extract or ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	commonResult
+}
+
+// Extract is a function that accepts a result and extracts a cluster resource.
+func (r commonResult) Extract() (*Cluster, error) {
+	var s *Cluster
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// UpdateResult is the response of a Update operations.
+type UpdateResult struct {
+	commonResult
+}
+
+// ResizeResult is the response of a Resize operations.
+type ResizeResult struct {
+	commonResult
+}
+
+func (r CreateResult) Extract() (string, error) {
+	var s struct {
+		UUID string
+	}
+	err := r.ExtractInto(&s)
+	return s.UUID, err
+}
+
+func (r UpdateResult) Extract() (string, error) {
+	var s struct {
+		UUID string
+	}
+	err := r.ExtractInto(&s)
+	return s.UUID, err
+}
+
+func (r ResizeResult) Extract() (string, error) {
+	var s struct {
+		UUID string
+	}
+	err := r.ExtractInto(&s)
+	return s.UUID, err
+}
+
+type Cluster struct {
+	APIAddress        string             `json:"api_address"`
+	COEVersion        string             `json:"coe_version"`
+	ClusterTemplateID string             `json:"cluster_template_id"`
+	ContainerVersion  string             `json:"container_version"`
+	CreateTimeout     int                `json:"create_timeout"`
+	CreatedAt         time.Time          `json:"created_at"`
+	DiscoveryURL      string             `json:"discovery_url"`
+	DockerVolumeSize  int                `json:"docker_volume_size"`
+	Faults            map[string]string  `json:"faults"`
+	FlavorID          string             `json:"flavor_id"`
+	KeyPair           string             `json:"keypair"`
+	Labels            map[string]string  `json:"labels"`
+	Links             []gophercloud.Link `json:"links"`
+	MasterFlavorID    string             `json:"master_flavor_id"`
+	MasterAddresses   []string           `json:"master_addresses"`
+	MasterCount       int                `json:"master_count"`
+	Name              string             `json:"name"`
+	NodeAddresses     []string           `json:"node_addresses"`
+	NodeCount         int                `json:"node_count"`
+	ProjectID         string             `json:"project_id"`
+	StackID           string             `json:"stack_id"`
+	Status            string             `json:"status"`
+	StatusReason      string             `json:"status_reason"`
+	UUID              string             `json:"uuid"`
+	UpdatedAt         time.Time          `json:"updated_at"`
+	UserID            string             `json:"user_id"`
+	FloatingIPEnabled bool               `json:"floating_ip_enabled"`
+	FixedNetwork      string             `json:"fixed_network"`
+	FixedSubnet       string             `json:"fixed_subnet"`
+}
+
+type ClusterPage struct {
+	pagination.LinkedPageBase
+}
+
+func (r ClusterPage) NextPageURL() (string, error) {
+	var s struct {
+		Next string `json:"next"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Next, nil
+}
+
+// IsEmpty checks whether a ClusterPage struct is empty.
+func (r ClusterPage) IsEmpty() (bool, error) {
+	is, err := ExtractClusters(r)
+	return len(is) == 0, err
+}
+
+func ExtractClusters(r pagination.Page) ([]Cluster, error) {
+	var s struct {
+		Clusters []Cluster `json:"clusters"`
+	}
+	err := (r.(ClusterPage)).ExtractInto(&s)
+	return s.Clusters, err
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/clusters/urls.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/clusters/urls.go
@@ -1,0 +1,43 @@
+package clusters
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+var apiName = "clusters"
+
+func commonURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL(apiName)
+}
+
+func idURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL(apiName, id)
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return commonURL(client)
+}
+
+func deleteURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("clusters", id)
+}
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("clusters")
+}
+
+func listDetailURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("clusters", "detail")
+}
+
+func updateURL(client *gophercloud.ServiceClient, id string) string {
+	return idURL(client, id)
+}
+
+func resizeURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("clusters", id, "actions/resize")
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/nodegroups/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/nodegroups/doc.go
@@ -1,0 +1,112 @@
+/*
+Package nodegroups provides methods for interacting with the Magnum node group API.
+
+All node group actions must be performed on a specific cluster,
+so the cluster UUID/name is required as a parameter in each method.
+
+Create a client to use:
+
+	opts, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+	    panic(err)
+	}
+
+	provider, err := openstack.AuthenticatedClient(opts)
+	if err != nil {
+	    panic(err)
+	}
+
+	client, err := openstack.NewContainerInfraV1(provider, gophercloud.EndpointOpts{Region: os.Getenv("OS_REGION_NAME")})
+	if err != nil {
+	    panic(err)
+	}
+
+	client.Microversion = "1.9"
+
+Example of Getting a node group:
+
+	ng, err := nodegroups.Get(client, clusterUUID, nodeGroupUUID).Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Printf("%#v\n", ng)
+
+Example of Listing node groups:
+
+	listOpts := nodegroup.ListOpts{
+	    Role: "worker",
+	}
+
+	allPages, err := nodegroups.List(client, clusterUUID, listOpts).AllPages()
+	if err != nil {
+	    panic(err)
+	}
+
+	ngs, err := nodegroups.ExtractNodeGroups(allPages)
+	if err != nil {
+	    panic(err)
+	}
+
+	for _, ng := range ngs {
+	    fmt.Printf("%#v\n", ng)
+	}
+
+Example of Creating a node group:
+
+	// Labels, node image and node flavor will be inherited from the cluster value if not set.
+	// Role will default to "worker" if not set.
+
+	// To add a label to the new node group, need to know the cluster labels
+	cluster, err := clusters.Get(client, clusterUUID).Extract()
+	if err != nil {
+	    panic(err)
+	}
+
+	// Add the new label
+	labels := cluster.Labels
+	labels["availability_zone"] = "A"
+
+	maxNodes := 5
+	createOpts := nodegroups.CreateOpts{
+	    Name:         "new-nodegroup",
+	    MinNodeCount: 2,
+	    MaxNodeCount: &maxNodes,
+	    Labels: labels,
+	}
+
+	ng, err := nodegroups.Create(client, clusterUUID, createOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
+
+	fmt.Printf("%#v\n", ng)
+
+Example of Updating a node group:
+
+	// Valid paths are "/min_node_count" and "/max_node_count".
+	// Max node count can be unset with the "remove" op to have
+	// no enforced maximum node count.
+
+	updateOpts := []nodegroups.UpdateOptsBuilder{
+	    nodegroups.UpdateOpts{
+	        Op:    nodegroups.ReplaceOp,
+	        Path:  "/max_node_count",
+	        Value: 10,
+	    },
+	}
+
+	ng, err = nodegroups.Update(client, clusterUUID, nodeGroupUUID, updateOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
+
+	fmt.Printf("%#v\n", ng)
+
+Example of Deleting a node group:
+
+	err = nodegroups.Delete(client, clusterUUID, nodeGroupUUID).ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
+*/
+package nodegroups

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/nodegroups/requests.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/nodegroups/requests.go
@@ -1,0 +1,181 @@
+package nodegroups
+
+import (
+	"net/http"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// Get makes a request to the Magnum API to retrieve a node group
+// with the given ID/name belonging to the given cluster.
+// Use the Extract method of the returned GetResult to extract the
+// node group from the result.
+func Get(client *gophercloud.ServiceClient, clusterID, nodeGroupID string) (r GetResult) {
+	var response *http.Response
+	response, r.Err = client.Get(getURL(client, clusterID, nodeGroupID), &r.Body, &gophercloud.RequestOpts{OkCodes: []int{200}})
+	if r.Err == nil {
+		r.Header = response.Header
+	}
+	return
+}
+
+type ListOptsBuilder interface {
+	ToNodeGroupsListQuery() (string, error)
+}
+
+// ListOpts is used to filter and sort the node groups of a cluster
+// when using List.
+type ListOpts struct {
+	// Pagination marker for large data sets. (UUID field from node group).
+	Marker int `q:"marker"`
+	// Maximum number of resources to return in a single page.
+	Limit int `q:"limit"`
+	// Column to sort results by. Default: id.
+	SortKey string `q:"sort_key"`
+	// Direction to sort. "asc" or "desc". Default: asc.
+	SortDir string `q:"sort_dir"`
+	// List all nodegroups with the specified role.
+	Role string `q:"role"`
+}
+
+func (opts ListOpts) ToNodeGroupsListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request to the Magnum API to retrieve node groups
+// belonging to the given cluster. The request can be modified to
+// filter or sort the list using the options available in ListOpts.
+//
+// Use the AllPages method of the returned Pager to ensure that
+// all node groups are returned (for example when using the Limit
+// option to limit the number of node groups returned per page).
+//
+// Not all node group fields are returned in a list request.
+// Only the fields UUID, Name, FlavorID, ImageID,
+// NodeCount, Role, IsDefault, Status and StackID
+// are returned, all other fields are omitted
+// and will have their zero value when extracted.
+func List(client *gophercloud.ServiceClient, clusterID string, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client, clusterID)
+	if opts != nil {
+		query, err := opts.ToNodeGroupsListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return NodeGroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type CreateOptsBuilder interface {
+	ToNodeGroupCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is used to set available fields upon node group creation.
+//
+// If unset, some fields have defaults or will inherit from the cluster value.
+type CreateOpts struct {
+	Name             string `json:"name" required:"true"`
+	DockerVolumeSize *int   `json:"docker_volume_size,omitempty"`
+	// Labels will default to the cluster labels if unset.
+	Labels       map[string]string `json:"labels,omitempty"`
+	NodeCount    *int              `json:"node_count,omitempty"`
+	MinNodeCount int               `json:"min_node_count,omitempty"`
+	// MaxNodeCount can be left unset for no maximum node count.
+	MaxNodeCount *int `json:"max_node_count,omitempty"`
+	// Role defaults to "worker" if unset.
+	Role string `json:"role,omitempty"`
+	// Node image ID. Defaults to cluster template image if unset.
+	ImageID string `json:"image_id,omitempty"`
+	// Node machine flavor ID. Defaults to cluster minion flavor if unset.
+	FlavorID string `json:"flavor_id,omitempty"`
+}
+
+func (opts CreateOpts) ToNodeGroupCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Create makes a request to the Magnum API to create a node group
+// for the the given cluster.
+// Use the Extract method of the returned CreateResult to extract the
+// returned node group.
+func Create(client *gophercloud.ServiceClient, clusterID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToNodeGroupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	var result *http.Response
+	result, r.Err = client.Post(createURL(client, clusterID), b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{202}})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+
+	return
+}
+
+type UpdateOptsBuilder interface {
+	ToResourceUpdateMap() (map[string]interface{}, error)
+}
+
+type UpdateOp string
+
+const (
+	AddOp     UpdateOp = "add"
+	RemoveOp  UpdateOp = "remove"
+	ReplaceOp UpdateOp = "replace"
+)
+
+// UpdateOpts is used to define the action taken when updating a node group.
+//
+// Valid Ops are "add", "remove", "replace"
+// Valid Paths are "/min_node_count" and "/max_node_count"
+type UpdateOpts struct {
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+func (opts UpdateOpts) ToResourceUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// Update makes a request to the Magnum API to update a field of
+// the given node group belonging to the given cluster. More than
+// one UpdateOpts can be passed at a time.
+// Use the Extract method of the returned UpdateResult to extract the
+// updated node group from the result.
+func Update(client *gophercloud.ServiceClient, clusterID string, nodeGroupID string, opts []UpdateOptsBuilder) (r UpdateResult) {
+	var o []map[string]interface{}
+	for _, opt := range opts {
+		b, err := opt.ToResourceUpdateMap()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		o = append(o, b)
+	}
+
+	var result *http.Response
+	result, r.Err = client.Patch(updateURL(client, clusterID, nodeGroupID), o, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{202}})
+
+	if r.Err == nil {
+		r.Header = result.Header
+	}
+
+	return
+}
+
+// Delete makes a request to the Magnum API to delete a node group.
+func Delete(client *gophercloud.ServiceClient, clusterID, nodeGroupID string) (r DeleteResult) {
+	var result *http.Response
+	result, r.Err = client.Delete(deleteURL(client, clusterID, nodeGroupID), nil)
+	r.Header = result.Header
+	return
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/nodegroups/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/nodegroups/results.go
@@ -1,0 +1,98 @@
+package nodegroups
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+func (r commonResult) Extract() (*NodeGroup, error) {
+	var s NodeGroup
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// GetResult is the response from a Get request.
+// Use the Extract method to retrieve the NodeGroup itself.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult is the response from a Create request.
+// Use the Extract method to retrieve the created node group.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult is the response from an Update request.
+// Use the Extract method to retrieve the updated node group.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult is the response from a Delete request.
+// Use the ExtractErr method to extract the error from the result.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// NodeGroup is the API representation of a Magnum node group.
+type NodeGroup struct {
+	ID               int                `json:"id"`
+	UUID             string             `json:"uuid"`
+	Name             string             `json:"name"`
+	ClusterID        string             `json:"cluster_id"`
+	ProjectID        string             `json:"project_id"`
+	DockerVolumeSize *int               `json:"docker_volume_size"`
+	Labels           map[string]string  `json:"labels"`
+	Links            []gophercloud.Link `json:"links"`
+	FlavorID         string             `json:"flavor_id"`
+	ImageID          string             `json:"image_id"`
+	NodeAddresses    []string           `json:"node_addresses"`
+	NodeCount        int                `json:"node_count"`
+	Role             string             `json:"role"`
+	MinNodeCount     int                `json:"min_node_count"`
+	MaxNodeCount     *int               `json:"max_node_count"`
+	IsDefault        bool               `json:"is_default"`
+	StackID          string             `json:"stack_id"`
+	Status           string             `json:"status"`
+	StatusReason     string             `json:"status_reason"`
+	Version          string             `json:"version"`
+	CreatedAt        time.Time          `json:"created_at"`
+	UpdatedAt        time.Time          `json:"updated_at"`
+}
+
+type NodeGroupPage struct {
+	pagination.LinkedPageBase
+}
+
+func (r NodeGroupPage) NextPageURL() (string, error) {
+	var s struct {
+		Next string `json:"next"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Next, nil
+}
+
+func (r NodeGroupPage) IsEmpty() (bool, error) {
+	s, err := ExtractNodeGroups(r)
+	return len(s) == 0, err
+}
+
+// ExtractNodeGroups takes a Page of node groups as returned from List
+// or from AllPages and extracts it as a slice of NodeGroups.
+func ExtractNodeGroups(r pagination.Page) ([]NodeGroup, error) {
+	var s struct {
+		NodeGroups []NodeGroup `json:"nodegroups"`
+	}
+	err := (r.(NodeGroupPage)).ExtractInto(&s)
+	return s.NodeGroups, err
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/nodegroups/urls.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/containerinfra/v1/nodegroups/urls.go
@@ -1,0 +1,25 @@
+package nodegroups
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+func getURL(c *gophercloud.ServiceClient, clusterID, nodeGroupID string) string {
+	return c.ServiceURL("clusters", clusterID, "nodegroups", nodeGroupID)
+}
+
+func listURL(c *gophercloud.ServiceClient, clusterID string) string {
+	return c.ServiceURL("clusters", clusterID, "nodegroups")
+}
+
+func createURL(c *gophercloud.ServiceClient, clusterID string) string {
+	return c.ServiceURL("clusters", clusterID, "nodegroups")
+}
+
+func updateURL(c *gophercloud.ServiceClient, clusterID, nodeGroupID string) string {
+	return c.ServiceURL("clusters", clusterID, "nodegroups", nodeGroupID)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, clusterID, nodeGroupID string) string {
+	return c.ServiceURL("clusters", clusterID, "nodegroups", nodeGroupID)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/doc.go
@@ -1,0 +1,14 @@
+/*
+Package openstack contains resources for the individual OpenStack projects
+supported in Gophercloud. It also includes functions to authenticate to an
+OpenStack cloud and for provisioning various service-level clients.
+
+Example of Creating a Service Client
+
+	ao, err := openstack.AuthOptionsFromEnv()
+	provider, err := openstack.AuthenticatedClient(ao)
+	client, err := openstack.NewNetworkV2(client, gophercloud.EndpointOpts{
+		Region: os.Getenv("OS_REGION_NAME"),
+	})
+*/
+package openstack

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/endpoint_location.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/endpoint_location.go
@@ -1,0 +1,111 @@
+package openstack
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	tokens2 "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens"
+	tokens3 "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens"
+)
+
+/*
+V2EndpointURL discovers the endpoint URL for a specific service from a
+ServiceCatalog acquired during the v2 identity service.
+
+The specified EndpointOpts are used to identify a unique, unambiguous endpoint
+to return. It's an error both when multiple endpoints match the provided
+criteria and when none do. The minimum that can be specified is a Type, but you
+will also often need to specify a Name and/or a Region depending on what's
+available on your OpenStack deployment.
+*/
+func V2EndpointURL(catalog *tokens2.ServiceCatalog, opts gophercloud.EndpointOpts) (string, error) {
+	// Extract Endpoints from the catalog entries that match the requested Type, Name if provided, and Region if provided.
+	var endpoints = make([]tokens2.Endpoint, 0, 1)
+	for _, entry := range catalog.Entries {
+		if (entry.Type == opts.Type) && (opts.Name == "" || entry.Name == opts.Name) {
+			for _, endpoint := range entry.Endpoints {
+				if opts.Region == "" || endpoint.Region == opts.Region {
+					endpoints = append(endpoints, endpoint)
+				}
+			}
+		}
+	}
+
+	// If multiple endpoints were found, use the first result
+	// and disregard the other endpoints.
+	//
+	// This behavior matches the Python library. See GH-1764.
+	if len(endpoints) > 1 {
+		endpoints = endpoints[0:1]
+	}
+
+	// Extract the appropriate URL from the matching Endpoint.
+	for _, endpoint := range endpoints {
+		switch opts.Availability {
+		case gophercloud.AvailabilityPublic:
+			return gophercloud.NormalizeURL(endpoint.PublicURL), nil
+		case gophercloud.AvailabilityInternal:
+			return gophercloud.NormalizeURL(endpoint.InternalURL), nil
+		case gophercloud.AvailabilityAdmin:
+			return gophercloud.NormalizeURL(endpoint.AdminURL), nil
+		default:
+			err := &ErrInvalidAvailabilityProvided{}
+			err.Argument = "Availability"
+			err.Value = opts.Availability
+			return "", err
+		}
+	}
+
+	// Report an error if there were no matching endpoints.
+	err := &gophercloud.ErrEndpointNotFound{}
+	return "", err
+}
+
+/*
+V3EndpointURL discovers the endpoint URL for a specific service from a Catalog
+acquired during the v3 identity service.
+
+The specified EndpointOpts are used to identify a unique, unambiguous endpoint
+to return. It's an error both when multiple endpoints match the provided
+criteria and when none do. The minimum that can be specified is a Type, but you
+will also often need to specify a Name and/or a Region depending on what's
+available on your OpenStack deployment.
+*/
+func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpts) (string, error) {
+	// Extract Endpoints from the catalog entries that match the requested Type, Interface,
+	// Name if provided, and Region if provided.
+	var endpoints = make([]tokens3.Endpoint, 0, 1)
+	for _, entry := range catalog.Entries {
+		if (entry.Type == opts.Type) && (opts.Name == "" || entry.Name == opts.Name) {
+			for _, endpoint := range entry.Endpoints {
+				if opts.Availability != gophercloud.AvailabilityAdmin &&
+					opts.Availability != gophercloud.AvailabilityPublic &&
+					opts.Availability != gophercloud.AvailabilityInternal {
+					err := &ErrInvalidAvailabilityProvided{}
+					err.Argument = "Availability"
+					err.Value = opts.Availability
+					return "", err
+				}
+				if (opts.Availability == gophercloud.Availability(endpoint.Interface)) &&
+					(opts.Region == "" || endpoint.Region == opts.Region || endpoint.RegionID == opts.Region) {
+					endpoints = append(endpoints, endpoint)
+				}
+			}
+		}
+	}
+
+	// If multiple endpoints were found, use the first result
+	// and disregard the other endpoints.
+	//
+	// This behavior matches the Python library. See GH-1764.
+	if len(endpoints) > 1 {
+		endpoints = endpoints[0:1]
+	}
+
+	// Extract the URL from the matching Endpoint.
+	for _, endpoint := range endpoints {
+		return gophercloud.NormalizeURL(endpoint.URL), nil
+	}
+
+	// Report an error if there were no matching endpoints.
+	err := &gophercloud.ErrEndpointNotFound{}
+	return "", err
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/errors.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/errors.go
@@ -1,0 +1,47 @@
+package openstack
+
+import (
+	"fmt"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+// ErrEndpointNotFound is the error when no suitable endpoint can be found
+// in the user's catalog
+type ErrEndpointNotFound struct{ gophercloud.BaseError }
+
+func (e ErrEndpointNotFound) Error() string {
+	return "No suitable endpoint could be found in the service catalog."
+}
+
+// ErrInvalidAvailabilityProvided is the error when an invalid endpoint
+// availability is provided
+type ErrInvalidAvailabilityProvided struct{ gophercloud.ErrInvalidInput }
+
+func (e ErrInvalidAvailabilityProvided) Error() string {
+	return fmt.Sprintf("Unexpected availability in endpoint query: %s", e.Value)
+}
+
+// ErrNoAuthURL is the error when the OS_AUTH_URL environment variable is not
+// found
+type ErrNoAuthURL struct{ gophercloud.ErrInvalidInput }
+
+func (e ErrNoAuthURL) Error() string {
+	return "Environment variable OS_AUTH_URL needs to be set."
+}
+
+// ErrNoUsername is the error when the OS_USERNAME environment variable is not
+// found
+type ErrNoUsername struct{ gophercloud.ErrInvalidInput }
+
+func (e ErrNoUsername) Error() string {
+	return "Environment variable OS_USERNAME needs to be set."
+}
+
+// ErrNoPassword is the error when the OS_PASSWORD environment variable is not
+// found
+type ErrNoPassword struct{ gophercloud.ErrInvalidInput }
+
+func (e ErrNoPassword) Error() string {
+	return "Environment variable OS_PASSWORD needs to be set."
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tenants/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tenants/doc.go
@@ -1,0 +1,65 @@
+/*
+Package tenants provides information and interaction with the
+tenants API resource for the OpenStack Identity service.
+
+See http://developer.openstack.org/api-ref-identity-v2.html#identity-auth-v2
+and http://developer.openstack.org/api-ref-identity-v2.html#admin-tenants
+for more information.
+
+Example to List Tenants
+
+	listOpts := tenants.ListOpts{
+		Limit: 2,
+	}
+
+	allPages, err := tenants.List(identityClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allTenants, err := tenants.ExtractTenants(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, tenant := range allTenants {
+		fmt.Printf("%+v\n", tenant)
+	}
+
+Example to Create a Tenant
+
+	createOpts := tenants.CreateOpts{
+		Name:        "tenant_name",
+		Description: "this is a tenant",
+		Enabled:     gophercloud.Enabled,
+	}
+
+	tenant, err := tenants.Create(identityClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Tenant
+
+	tenantID := "e6db6ed6277c461a853458589063b295"
+
+	updateOpts := tenants.UpdateOpts{
+		Description: "this is a new description",
+		Enabled:     gophercloud.Disabled,
+	}
+
+	tenant, err := tenants.Update(identityClient, tenantID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Tenant
+
+	tenantID := "e6db6ed6277c461a853458589063b295"
+
+	err := tenants.Delete(identitYClient, tenantID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package tenants

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tenants/requests.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tenants/requests.go
@@ -1,0 +1,116 @@
+package tenants
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// ListOpts filters the Tenants that are returned by the List call.
+type ListOpts struct {
+	// Marker is the ID of the last Tenant on the previous page.
+	Marker string `q:"marker"`
+
+	// Limit specifies the page size.
+	Limit int `q:"limit"`
+}
+
+// List enumerates the Tenants to which the current token has access.
+func List(client *gophercloud.ServiceClient, opts *ListOpts) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		q, err := gophercloud.BuildQueryString(opts)
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += q.String()
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return TenantPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOpts represents the options needed when creating new tenant.
+type CreateOpts struct {
+	// Name is the name of the tenant.
+	Name string `json:"name" required:"true"`
+
+	// Description is the description of the tenant.
+	Description string `json:"description,omitempty"`
+
+	// Enabled sets the tenant status to enabled or disabled.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// CreateOptsBuilder enables extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToTenantCreateMap() (map[string]interface{}, error)
+}
+
+// ToTenantCreateMap assembles a request body based on the contents of
+// a CreateOpts.
+func (opts CreateOpts) ToTenantCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "tenant")
+}
+
+// Create is the operation responsible for creating new tenant.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToTenantCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+// Get requests details on a single tenant by ID.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToTenantUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts specifies the base attributes that may be updated on an existing
+// tenant.
+type UpdateOpts struct {
+	// Name is the name of the tenant.
+	Name string `json:"name,omitempty"`
+
+	// Description is the description of the tenant.
+	Description *string `json:"description,omitempty"`
+
+	// Enabled sets the tenant status to enabled or disabled.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// ToTenantUpdateMap formats an UpdateOpts structure into a request body.
+func (opts UpdateOpts) ToTenantUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "tenant")
+}
+
+// Update is the operation responsible for updating exist tenants by their TenantID.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToTenantUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete is the operation responsible for permanently deleting a tenant.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tenants/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tenants/results.go
@@ -1,0 +1,91 @@
+package tenants
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// Tenant is a grouping of users in the identity service.
+type Tenant struct {
+	// ID is a unique identifier for this tenant.
+	ID string `json:"id"`
+
+	// Name is a friendlier user-facing name for this tenant.
+	Name string `json:"name"`
+
+	// Description is a human-readable explanation of this Tenant's purpose.
+	Description string `json:"description"`
+
+	// Enabled indicates whether or not a tenant is active.
+	Enabled bool `json:"enabled"`
+}
+
+// TenantPage is a single page of Tenant results.
+type TenantPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Tenants contains any results.
+func (r TenantPage) IsEmpty() (bool, error) {
+	tenants, err := ExtractTenants(r)
+	return len(tenants) == 0, err
+}
+
+// NextPageURL extracts the "next" link from the tenants_links section of the result.
+func (r TenantPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"tenants_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractTenants returns a slice of Tenants contained in a single page of
+// results.
+func ExtractTenants(r pagination.Page) ([]Tenant, error) {
+	var s struct {
+		Tenants []Tenant `json:"tenants"`
+	}
+	err := (r.(TenantPage)).ExtractInto(&s)
+	return s.Tenants, err
+}
+
+type tenantResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any tenantResults as a Tenant.
+func (r tenantResult) Extract() (*Tenant, error) {
+	var s struct {
+		Tenant *Tenant `json:"tenant"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Tenant, err
+}
+
+// GetResult is the response from a Get request. Call its Extract method to
+// interpret it as a Tenant.
+type GetResult struct {
+	tenantResult
+}
+
+// CreateResult is the response from a Create request. Call its Extract method
+// to interpret it as a Tenant.
+type CreateResult struct {
+	tenantResult
+}
+
+// DeleteResult is the response from a Get request. Call its ExtractErr method
+// to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// UpdateResult is the response from a Update request. Call its Extract method
+// to interpret it as a Tenant.
+type UpdateResult struct {
+	tenantResult
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tenants/urls.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tenants/urls.go
@@ -1,0 +1,23 @@
+package tenants
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+
+func listURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("tenants")
+}
+
+func getURL(client *gophercloud.ServiceClient, tenantID string) string {
+	return client.ServiceURL("tenants", tenantID)
+}
+
+func createURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("tenants")
+}
+
+func deleteURL(client *gophercloud.ServiceClient, tenantID string) string {
+	return client.ServiceURL("tenants", tenantID)
+}
+
+func updateURL(client *gophercloud.ServiceClient, tenantID string) string {
+	return client.ServiceURL("tenants", tenantID)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens/doc.go
@@ -1,0 +1,46 @@
+/*
+Package tokens provides information and interaction with the token API
+resource for the OpenStack Identity service.
+
+For more information, see:
+http://developer.openstack.org/api-ref-identity-v2.html#identity-auth-v2
+
+Example to Create an Unscoped Token from a Password
+
+	authOpts := gophercloud.AuthOptions{
+		Username: "user",
+		Password: "pass"
+	}
+
+	token, err := tokens.Create(identityClient, authOpts).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Token from a Tenant ID and Password
+
+	authOpts := gophercloud.AuthOptions{
+		Username: "user",
+		Password: "password",
+		TenantID: "fc394f2ab2df4114bde39905f800dc57"
+	}
+
+	token, err := tokens.Create(identityClient, authOpts).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Token from a Tenant Name and Password
+
+	authOpts := gophercloud.AuthOptions{
+		Username:   "user",
+		Password:   "password",
+		TenantName: "tenantname"
+	}
+
+	token, err := tokens.Create(identityClient, authOpts).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+*/
+package tokens

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens/requests.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens/requests.go
@@ -1,0 +1,103 @@
+package tokens
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+
+// PasswordCredentialsV2 represents the required options to authenticate
+// with a username and password.
+type PasswordCredentialsV2 struct {
+	Username string `json:"username" required:"true"`
+	Password string `json:"password" required:"true"`
+}
+
+// TokenCredentialsV2 represents the required options to authenticate
+// with a token.
+type TokenCredentialsV2 struct {
+	ID string `json:"id,omitempty" required:"true"`
+}
+
+// AuthOptionsV2 wraps a gophercloud AuthOptions in order to adhere to the
+// AuthOptionsBuilder interface.
+type AuthOptionsV2 struct {
+	PasswordCredentials *PasswordCredentialsV2 `json:"passwordCredentials,omitempty" xor:"TokenCredentials"`
+
+	// The TenantID and TenantName fields are optional for the Identity V2 API.
+	// Some providers allow you to specify a TenantName instead of the TenantId.
+	// Some require both. Your provider's authentication policies will determine
+	// how these fields influence authentication.
+	TenantID   string `json:"tenantId,omitempty"`
+	TenantName string `json:"tenantName,omitempty"`
+
+	// TokenCredentials allows users to authenticate (possibly as another user)
+	// with an authentication token ID.
+	TokenCredentials *TokenCredentialsV2 `json:"token,omitempty" xor:"PasswordCredentials"`
+}
+
+// AuthOptionsBuilder allows extensions to add additional parameters to the
+// token create request.
+type AuthOptionsBuilder interface {
+	// ToTokenCreateMap assembles the Create request body, returning an error
+	// if parameters are missing or inconsistent.
+	ToTokenV2CreateMap() (map[string]interface{}, error)
+}
+
+// AuthOptions are the valid options for Openstack Identity v2 authentication.
+// For field descriptions, see gophercloud.AuthOptions.
+type AuthOptions struct {
+	IdentityEndpoint string `json:"-"`
+	Username         string `json:"username,omitempty"`
+	Password         string `json:"password,omitempty"`
+	TenantID         string `json:"tenantId,omitempty"`
+	TenantName       string `json:"tenantName,omitempty"`
+	AllowReauth      bool   `json:"-"`
+	TokenID          string
+}
+
+// ToTokenV2CreateMap builds a token request body from the given AuthOptions.
+func (opts AuthOptions) ToTokenV2CreateMap() (map[string]interface{}, error) {
+	v2Opts := AuthOptionsV2{
+		TenantID:   opts.TenantID,
+		TenantName: opts.TenantName,
+	}
+
+	if opts.Password != "" {
+		v2Opts.PasswordCredentials = &PasswordCredentialsV2{
+			Username: opts.Username,
+			Password: opts.Password,
+		}
+	} else {
+		v2Opts.TokenCredentials = &TokenCredentialsV2{
+			ID: opts.TokenID,
+		}
+	}
+
+	b, err := gophercloud.BuildRequestBody(v2Opts, "auth")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Create authenticates to the identity service and attempts to acquire a Token.
+// Generally, rather than interact with this call directly, end users should
+// call openstack.AuthenticatedClient(), which abstracts all of the gory details
+// about navigating service catalogs and such.
+func Create(client *gophercloud.ServiceClient, auth AuthOptionsBuilder) (r CreateResult) {
+	b, err := auth.ToTokenV2CreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(CreateURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes:     []int{200, 203},
+		MoreHeaders: map[string]string{"X-Auth-Token": ""},
+	})
+	return
+}
+
+// Get validates and retrieves information for user's token.
+func Get(client *gophercloud.ServiceClient, token string) (r GetResult) {
+	_, r.Err = client.Get(GetURL(client, token), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 203},
+	})
+	return
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens/results.go
@@ -1,0 +1,174 @@
+package tokens
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tenants"
+)
+
+// Token provides only the most basic information related to an authentication
+// token.
+type Token struct {
+	// ID provides the primary means of identifying a user to the OpenStack API.
+	// OpenStack defines this field as an opaque value, so do not depend on its
+	// content. It is safe, however, to compare for equality.
+	ID string
+
+	// ExpiresAt provides a timestamp in ISO 8601 format, indicating when the
+	// authentication token becomes invalid. After this point in time, future
+	// API requests made using this  authentication token will respond with
+	// errors. Either the caller will need to reauthenticate manually, or more
+	// preferably, the caller should exploit automatic re-authentication.
+	// See the AuthOptions structure for more details.
+	ExpiresAt time.Time
+
+	// Tenant provides information about the tenant to which this token grants
+	// access.
+	Tenant tenants.Tenant
+}
+
+// Role is a role for a user.
+type Role struct {
+	Name string `json:"name"`
+}
+
+// User is an OpenStack user.
+type User struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	UserName string `json:"username"`
+	Roles    []Role `json:"roles"`
+}
+
+// Endpoint represents a single API endpoint offered by a service.
+// It provides the public and internal URLs, if supported, along with a region
+// specifier, again if provided.
+//
+// The significance of the Region field will depend upon your provider.
+//
+// In addition, the interface offered by the service will have version
+// information associated with it through the VersionId, VersionInfo, and
+// VersionList fields, if provided or supported.
+//
+// In all cases, fields which aren't supported by the provider and service
+// combined will assume a zero-value ("").
+type Endpoint struct {
+	TenantID    string `json:"tenantId"`
+	PublicURL   string `json:"publicURL"`
+	InternalURL string `json:"internalURL"`
+	AdminURL    string `json:"adminURL"`
+	Region      string `json:"region"`
+	VersionID   string `json:"versionId"`
+	VersionInfo string `json:"versionInfo"`
+	VersionList string `json:"versionList"`
+}
+
+// CatalogEntry provides a type-safe interface to an Identity API V2 service
+// catalog listing.
+//
+// Each class of service, such as cloud DNS or block storage services, will have
+// a single CatalogEntry representing it.
+//
+// Note: when looking for the desired service, try, whenever possible, to key
+// off the type field. Otherwise, you'll tie the representation of the service
+// to a specific provider.
+type CatalogEntry struct {
+	// Name will contain the provider-specified name for the service.
+	Name string `json:"name"`
+
+	// Type will contain a type string if OpenStack defines a type for the
+	// service. Otherwise, for provider-specific services, the provider may assign
+	// their own type strings.
+	Type string `json:"type"`
+
+	// Endpoints will let the caller iterate over all the different endpoints that
+	// may exist for the service.
+	Endpoints []Endpoint `json:"endpoints"`
+}
+
+// ServiceCatalog provides a view into the service catalog from a previous,
+// successful authentication.
+type ServiceCatalog struct {
+	Entries []CatalogEntry
+}
+
+// CreateResult is the response from a Create request. Use ExtractToken() to
+// interpret it as a Token, or ExtractServiceCatalog() to interpret it as a
+// service catalog.
+type CreateResult struct {
+	gophercloud.Result
+}
+
+// GetResult is the deferred response from a Get call, which is the same with a
+// Created token. Use ExtractUser() to interpret it as a User.
+type GetResult struct {
+	CreateResult
+}
+
+// ExtractToken returns the just-created Token from a CreateResult.
+func (r CreateResult) ExtractToken() (*Token, error) {
+	var s struct {
+		Access struct {
+			Token struct {
+				Expires string         `json:"expires"`
+				ID      string         `json:"id"`
+				Tenant  tenants.Tenant `json:"tenant"`
+			} `json:"token"`
+		} `json:"access"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	expiresTs, err := time.Parse(gophercloud.RFC3339Milli, s.Access.Token.Expires)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Token{
+		ID:        s.Access.Token.ID,
+		ExpiresAt: expiresTs,
+		Tenant:    s.Access.Token.Tenant,
+	}, nil
+}
+
+// ExtractTokenID implements the gophercloud.AuthResult interface. The returned
+// string is the same as the ID field of the Token struct returned from
+// ExtractToken().
+func (r CreateResult) ExtractTokenID() (string, error) {
+	var s struct {
+		Access struct {
+			Token struct {
+				ID string `json:"id"`
+			} `json:"token"`
+		} `json:"access"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Access.Token.ID, err
+}
+
+// ExtractServiceCatalog returns the ServiceCatalog that was generated along
+// with the user's Token.
+func (r CreateResult) ExtractServiceCatalog() (*ServiceCatalog, error) {
+	var s struct {
+		Access struct {
+			Entries []CatalogEntry `json:"serviceCatalog"`
+		} `json:"access"`
+	}
+	err := r.ExtractInto(&s)
+	return &ServiceCatalog{Entries: s.Access.Entries}, err
+}
+
+// ExtractUser returns the User from a GetResult.
+func (r GetResult) ExtractUser() (*User, error) {
+	var s struct {
+		Access struct {
+			User User `json:"user"`
+		} `json:"access"`
+	}
+	err := r.ExtractInto(&s)
+	return &s.Access.User, err
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens/urls.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v2/tokens/urls.go
@@ -1,0 +1,13 @@
+package tokens
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+
+// CreateURL generates the URL used to create new Tokens.
+func CreateURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("tokens")
+}
+
+// GetURL generates the URL used to Validate Tokens.
+func GetURL(client *gophercloud.ServiceClient, token string) string {
+	return client.ServiceURL("tokens", token)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/extensions/trusts/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/extensions/trusts/doc.go
@@ -1,0 +1,58 @@
+/*
+Package trusts enables management of OpenStack Identity Trusts.
+
+Example to Create a Token with Username, Password, and Trust ID
+
+	var trustToken struct {
+		tokens.Token
+		trusts.TokenExt
+	}
+
+	authOptions := tokens.AuthOptions{
+		UserID:   "username",
+		Password: "password",
+	}
+
+	createOpts := trusts.AuthOptsExt{
+		AuthOptionsBuilder: authOptions,
+		TrustID:            "de0945a",
+	}
+
+	err := tokens.Create(identityClient, createOpts).ExtractInto(&trustToken)
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Trust
+
+	expiresAt := time.Date(2019, 12, 1, 14, 0, 0, 999999999, time.UTC)
+	createOpts := trusts.CreateOpts{
+	    ExpiresAt:         &expiresAt,
+	    Impersonation:     true,
+	    AllowRedelegation: true,
+	    ProjectID:         "9b71012f5a4a4aef9193f1995fe159b2",
+	    Roles: []trusts.Role{
+	        {
+	            Name: "member",
+	        },
+	    },
+	    TrusteeUserID: "ecb37e88cc86431c99d0332208cb6fbf",
+	    TrustorUserID: "959ed913a32c4ec88c041c98e61cbbc3",
+	}
+
+	trust, err := trusts.Create(identityClient, createOpts).Extract()
+	if err != nil {
+	    panic(err)
+	}
+
+	fmt.Printf("Trust: %+v\n", trust)
+
+Example to Delete a Trust
+
+	trustID := "3422b7c113894f5d90665e1a79655e23"
+	err := trusts.Delete(identityClient, trustID).ExtractErr()
+	if err != nil {
+	    panic(err)
+	}
+*/
+package trusts

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/extensions/trusts/requests.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/extensions/trusts/requests.go
@@ -1,0 +1,117 @@
+package trusts
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens"
+)
+
+// AuthOptsExt extends the base Identity v3 tokens AuthOpts with a TrustID.
+type AuthOptsExt struct {
+	tokens.AuthOptionsBuilder
+
+	// TrustID is the ID of the trust.
+	TrustID string `json:"id"`
+}
+
+// ToTokenV3CreateMap builds a create request body from the AuthOpts.
+func (opts AuthOptsExt) ToTokenV3CreateMap(scope map[string]interface{}) (map[string]interface{}, error) {
+	return opts.AuthOptionsBuilder.ToTokenV3CreateMap(scope)
+}
+
+// ToTokenV3ScopeMap builds a scope from AuthOpts.
+func (opts AuthOptsExt) ToTokenV3ScopeMap() (map[string]interface{}, error) {
+	b, err := opts.AuthOptionsBuilder.ToTokenV3ScopeMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.TrustID != "" {
+		if b == nil {
+			b = make(map[string]interface{})
+		}
+		b["OS-TRUST:trust"] = map[string]interface{}{
+			"id": opts.TrustID,
+		}
+	}
+
+	return b, nil
+}
+
+func (opts AuthOptsExt) CanReauth() bool {
+	return opts.AuthOptionsBuilder.CanReauth()
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type CreateOptsBuilder interface {
+	ToTrustCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts provides options used to create a new trust.
+type CreateOpts struct {
+	// Impersonation allows the trustee to impersonate the trustor.
+	Impersonation bool `json:"impersonation"`
+
+	// TrusteeUserID is a user who is capable of consuming the trust.
+	TrusteeUserID string `json:"trustee_user_id" required:"true"`
+
+	// TrustorUserID is a user who created the trust.
+	TrustorUserID string `json:"trustor_user_id" required:"true"`
+
+	// AllowRedelegation enables redelegation of a trust.
+	AllowRedelegation bool `json:"allow_redelegation,omitempty"`
+
+	// ExpiresAt sets expiration time on trust.
+	ExpiresAt *time.Time `json:"-"`
+
+	// ProjectID identifies the project.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// RedelegationCount specifies a depth of the redelegation chain.
+	RedelegationCount int `json:"redelegation_count,omitempty"`
+
+	// RemainingUses specifies how many times a trust can be used to get a token.
+	RemainingUses int `json:"remaining_uses,omitempty"`
+
+	// Roles specifies roles that need to be granted to trustee.
+	Roles []Role `json:"roles,omitempty"`
+}
+
+// ToTrustCreateMap formats a CreateOpts into a create request.
+func (opts CreateOpts) ToTrustCreateMap() (map[string]interface{}, error) {
+	parent := "trust"
+
+	b, err := gophercloud.BuildRequestBody(opts, parent)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.ExpiresAt != nil {
+		if v, ok := b[parent].(map[string]interface{}); ok {
+			v["expires_at"] = opts.ExpiresAt.Format(gophercloud.RFC3339Milli)
+		}
+	}
+
+	return b, nil
+}
+
+// Create creates a new Trust.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToTrustCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), &b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// Delete deletes a trust.
+func Delete(client *gophercloud.ServiceClient, trustID string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, trustID), nil)
+	return
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/extensions/trusts/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/extensions/trusts/results.go
@@ -1,0 +1,60 @@
+package trusts
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+
+type trustResult struct {
+	gophercloud.Result
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a Trust.
+type CreateResult struct {
+	trustResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr to
+// determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract interprets any trust result as a Trust.
+func (r trustResult) Extract() (*Trust, error) {
+	var s struct {
+		Trust *Trust `json:"trust"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Trust, err
+}
+
+// TrusteeUser represents the trusted user ID of a trust.
+type TrusteeUser struct {
+	ID string `json:"id"`
+}
+
+// TrustorUser represents the trusting user ID of a trust.
+type TrustorUser struct {
+	ID string `json:"id"`
+}
+
+// Trust represents a delegated authorization request between two
+// identities.
+type Trust struct {
+	ID                 string      `json:"id"`
+	Impersonation      bool        `json:"impersonation"`
+	TrusteeUser        TrusteeUser `json:"trustee_user"`
+	TrustorUser        TrustorUser `json:"trustor_user"`
+	RedelegatedTrustID string      `json:"redelegated_trust_id"`
+	RedelegationCount  int         `json:"redelegation_count"`
+}
+
+// Role specifies a single role that is granted to a trustee.
+type Role struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// TokenExt represents an extension of the base token result.
+type TokenExt struct {
+	Trust Trust `json:"OS-TRUST:trust"`
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/extensions/trusts/urls.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/extensions/trusts/urls.go
@@ -1,0 +1,21 @@
+package trusts
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+
+const resourcePath = "OS-TRUST/trusts"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens/doc.go
@@ -1,0 +1,107 @@
+/*
+Package tokens provides information and interaction with the token API
+resource for the OpenStack Identity service.
+
+For more information, see:
+http://developer.openstack.org/api-ref-identity-v3.html#tokens-v3
+
+Example to Create a Token From a Username and Password
+
+	authOptions := tokens.AuthOptions{
+		UserID:   "username",
+		Password: "password",
+	}
+
+	token, err := tokens.Create(identityClient, authOptions).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Token From a Username, Password, and Domain
+
+	authOptions := tokens.AuthOptions{
+		UserID:   "username",
+		Password: "password",
+		DomainID: "default",
+	}
+
+	token, err := tokens.Create(identityClient, authOptions).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+	authOptions = tokens.AuthOptions{
+		UserID:     "username",
+		Password:   "password",
+		DomainName: "default",
+	}
+
+	token, err = tokens.Create(identityClient, authOptions).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Token From a Token
+
+	authOptions := tokens.AuthOptions{
+		TokenID: "token_id",
+	}
+
+	token, err := tokens.Create(identityClient, authOptions).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Token from a Username and Password with Project ID Scope
+
+	scope := tokens.Scope{
+		ProjectID: "0fe36e73809d46aeae6705c39077b1b3",
+	}
+
+	authOptions := tokens.AuthOptions{
+		Scope:    &scope,
+		UserID:   "username",
+		Password: "password",
+	}
+
+	token, err = tokens.Create(identityClient, authOptions).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Token from a Username and Password with Domain ID Scope
+
+	scope := tokens.Scope{
+		DomainID: "default",
+	}
+
+	authOptions := tokens.AuthOptions{
+		Scope:    &scope,
+		UserID:   "username",
+		Password: "password",
+	}
+
+	token, err = tokens.Create(identityClient, authOptions).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Token from a Username and Password with Project Name Scope
+
+	scope := tokens.Scope{
+		ProjectName: "project_name",
+		DomainID:    "default",
+	}
+
+	authOptions := tokens.AuthOptions{
+		Scope:    &scope,
+		UserID:   "username",
+		Password: "password",
+	}
+
+	token, err = tokens.Create(identityClient, authOptions).ExtractToken()
+	if err != nil {
+		panic(err)
+	}
+*/
+package tokens

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens/requests.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens/requests.go
@@ -1,0 +1,150 @@
+package tokens
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+
+// AuthOptionsBuilder provides the ability for extensions to add additional
+// parameters to AuthOptions. Extensions must satisfy all required methods.
+type AuthOptionsBuilder interface {
+	// ToTokenV3CreateMap assembles the Create request body, returning an error
+	// if parameters are missing or inconsistent.
+	ToTokenV3CreateMap(map[string]interface{}) (map[string]interface{}, error)
+	ToTokenV3ScopeMap() (map[string]interface{}, error)
+	CanReauth() bool
+}
+
+// AuthOptions represents options for authenticating a user.
+type AuthOptions struct {
+	// IdentityEndpoint specifies the HTTP endpoint that is required to work with
+	// the Identity API of the appropriate version. While it's ultimately needed
+	// by all of the identity services, it will often be populated by a
+	// provider-level function.
+	IdentityEndpoint string `json:"-"`
+
+	// Username is required if using Identity V2 API. Consult with your provider's
+	// control panel to discover your account's username. In Identity V3, either
+	// UserID or a combination of Username and DomainID or DomainName are needed.
+	Username string `json:"username,omitempty"`
+	UserID   string `json:"id,omitempty"`
+
+	Password string `json:"password,omitempty"`
+
+	// At most one of DomainID and DomainName must be provided if using Username
+	// with Identity V3. Otherwise, either are optional.
+	DomainID   string `json:"-"`
+	DomainName string `json:"name,omitempty"`
+
+	// AllowReauth should be set to true if you grant permission for Gophercloud
+	// to cache your credentials in memory, and to allow Gophercloud to attempt
+	// to re-authenticate automatically if/when your token expires.  If you set
+	// it to false, it will not cache these settings, but re-authentication will
+	// not be possible.  This setting defaults to false.
+	AllowReauth bool `json:"-"`
+
+	// TokenID allows users to authenticate (possibly as another user) with an
+	// authentication token ID.
+	TokenID string `json:"-"`
+
+	// Authentication through Application Credentials requires supplying name, project and secret
+	// For project we can use TenantID
+	ApplicationCredentialID     string `json:"-"`
+	ApplicationCredentialName   string `json:"-"`
+	ApplicationCredentialSecret string `json:"-"`
+}
+
+// ToTokenV3CreateMap builds a request body from AuthOptions.
+func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[string]interface{}, error) {
+	gophercloudAuthOpts := gophercloud.AuthOptions{
+		Username:                    opts.Username,
+		UserID:                      opts.UserID,
+		Password:                    opts.Password,
+		DomainID:                    opts.DomainID,
+		DomainName:                  opts.DomainName,
+		AllowReauth:                 opts.AllowReauth,
+		TokenID:                     opts.TokenID,
+		ApplicationCredentialID:     opts.ApplicationCredentialID,
+		ApplicationCredentialName:   opts.ApplicationCredentialName,
+		ApplicationCredentialSecret: opts.ApplicationCredentialSecret,
+	}
+
+	return gophercloudAuthOpts.ToTokenV3CreateMap(scope)
+}
+
+// ToTokenV3CreateMap builds a scope request body from AuthOptions.
+func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
+
+	gophercloudAuthOpts := gophercloud.AuthOptions{
+		DomainID:   opts.DomainID,
+		DomainName: opts.DomainName,
+	}
+
+	return gophercloudAuthOpts.ToTokenV3ScopeMap()
+}
+
+func (opts *AuthOptions) CanReauth() bool {
+	return opts.AllowReauth
+}
+
+func subjectTokenHeaders(c *gophercloud.ServiceClient, subjectToken string) map[string]string {
+	return map[string]string{
+		"X-Subject-Token": subjectToken,
+	}
+}
+
+// Create authenticates and either generates a new token, or changes the Scope
+// of an existing token.
+func Create(c *gophercloud.ServiceClient, opts AuthOptionsBuilder) (r CreateResult) {
+	scope, err := opts.ToTokenV3ScopeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	b, err := opts.ToTokenV3CreateMap(scope)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := c.Post(tokenURL(c), b, &r.Body, &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{"X-Auth-Token": ""},
+	})
+	r.Err = err
+	if resp != nil {
+		r.Header = resp.Header
+	}
+	return
+}
+
+// Get validates and retrieves information about another token.
+func Get(c *gophercloud.ServiceClient, token string) (r GetResult) {
+	resp, err := c.Get(tokenURL(c), &r.Body, &gophercloud.RequestOpts{
+		MoreHeaders: subjectTokenHeaders(c, token),
+		OkCodes:     []int{200, 203},
+	})
+	if resp != nil {
+		r.Header = resp.Header
+	}
+	r.Err = err
+	return
+}
+
+// Validate determines if a specified token is valid or not.
+func Validate(c *gophercloud.ServiceClient, token string) (bool, error) {
+	resp, err := c.Head(tokenURL(c), &gophercloud.RequestOpts{
+		MoreHeaders: subjectTokenHeaders(c, token),
+		OkCodes:     []int{200, 204, 404},
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return resp.StatusCode == 200 || resp.StatusCode == 204, nil
+}
+
+// Revoke immediately makes specified token invalid.
+func Revoke(c *gophercloud.ServiceClient, token string) (r RevokeResult) {
+	_, r.Err = c.Delete(tokenURL(c), &gophercloud.RequestOpts{
+		MoreHeaders: subjectTokenHeaders(c, token),
+	})
+	return
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens/results.go
@@ -1,0 +1,194 @@
+package tokens
+
+import (
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+// Endpoint represents a single API endpoint offered by a service.
+// It matches either a public, internal or admin URL.
+// If supported, it contains a region specifier, again if provided.
+// The significance of the Region field will depend upon your provider.
+type Endpoint struct {
+	ID        string `json:"id"`
+	Region    string `json:"region"`
+	RegionID  string `json:"region_id"`
+	Interface string `json:"interface"`
+	URL       string `json:"url"`
+}
+
+// CatalogEntry provides a type-safe interface to an Identity API V3 service
+// catalog listing. Each class of service, such as cloud DNS or block storage
+// services, could have multiple CatalogEntry representing it (one by interface
+// type, e.g public, admin or internal).
+//
+// Note: when looking for the desired service, try, whenever possible, to key
+// off the type field. Otherwise, you'll tie the representation of the service
+// to a specific provider.
+type CatalogEntry struct {
+	// Service ID
+	ID string `json:"id"`
+
+	// Name will contain the provider-specified name for the service.
+	Name string `json:"name"`
+
+	// Type will contain a type string if OpenStack defines a type for the
+	// service. Otherwise, for provider-specific services, the provider may
+	// assign their own type strings.
+	Type string `json:"type"`
+
+	// Endpoints will let the caller iterate over all the different endpoints that
+	// may exist for the service.
+	Endpoints []Endpoint `json:"endpoints"`
+}
+
+// ServiceCatalog provides a view into the service catalog from a previous,
+// successful authentication.
+type ServiceCatalog struct {
+	Entries []CatalogEntry `json:"catalog"`
+}
+
+// Domain provides information about the domain to which this token grants
+// access.
+type Domain struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// User represents a user resource that exists in the Identity Service.
+type User struct {
+	Domain Domain `json:"domain"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+}
+
+// Role provides information about roles to which User is authorized.
+type Role struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Project provides information about project to which User is authorized.
+type Project struct {
+	Domain Domain `json:"domain"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+}
+
+// commonResult is the response from a request. A commonResult has various
+// methods which can be used to extract different details about the result.
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a shortcut for ExtractToken.
+// This function is deprecated and still present for backward compatibility.
+func (r commonResult) Extract() (*Token, error) {
+	return r.ExtractToken()
+}
+
+// ExtractToken interprets a commonResult as a Token.
+func (r commonResult) ExtractToken() (*Token, error) {
+	var s Token
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the token itself from the stored headers.
+	s.ID = r.Header.Get("X-Subject-Token")
+
+	return &s, err
+}
+
+// ExtractTokenID implements the gophercloud.AuthResult interface. The returned
+// string is the same as the ID field of the Token struct returned from
+// ExtractToken().
+func (r CreateResult) ExtractTokenID() (string, error) {
+	return r.Header.Get("X-Subject-Token"), r.Err
+}
+
+// ExtractTokenID implements the gophercloud.AuthResult interface. The returned
+// string is the same as the ID field of the Token struct returned from
+// ExtractToken().
+func (r GetResult) ExtractTokenID() (string, error) {
+	return r.Header.Get("X-Subject-Token"), r.Err
+}
+
+// ExtractServiceCatalog returns the ServiceCatalog that was generated along
+// with the user's Token.
+func (r commonResult) ExtractServiceCatalog() (*ServiceCatalog, error) {
+	var s ServiceCatalog
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractUser returns the User that is the owner of the Token.
+func (r commonResult) ExtractUser() (*User, error) {
+	var s struct {
+		User *User `json:"user"`
+	}
+	err := r.ExtractInto(&s)
+	return s.User, err
+}
+
+// ExtractRoles returns Roles to which User is authorized.
+func (r commonResult) ExtractRoles() ([]Role, error) {
+	var s struct {
+		Roles []Role `json:"roles"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Roles, err
+}
+
+// ExtractProject returns Project to which User is authorized.
+func (r commonResult) ExtractProject() (*Project, error) {
+	var s struct {
+		Project *Project `json:"project"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Project, err
+}
+
+// ExtractDomain returns Domain to which User is authorized.
+func (r commonResult) ExtractDomain() (*Domain, error) {
+	var s struct {
+		Domain *Domain `json:"domain"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Domain, err
+}
+
+// CreateResult is the response from a Create request. Use ExtractToken()
+// to interpret it as a Token, or ExtractServiceCatalog() to interpret it
+// as a service catalog.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult is the response from a Get request. Use ExtractToken()
+// to interpret it as a Token, or ExtractServiceCatalog() to interpret it
+// as a service catalog.
+type GetResult struct {
+	commonResult
+}
+
+// RevokeResult is response from a Revoke request.
+type RevokeResult struct {
+	commonResult
+}
+
+// Token is a string that grants a user access to a controlled set of services
+// in an OpenStack provider. Each Token is valid for a set length of time.
+type Token struct {
+	// ID is the issued token.
+	ID string `json:"id"`
+
+	// ExpiresAt is the timestamp at which this token will no longer be accepted.
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.ExtractIntoStructPtr(v, "token")
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens/urls.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/identity/v3/tokens/urls.go
@@ -1,0 +1,7 @@
+package tokens
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+
+func tokenURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("auth", "tokens")
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stackresources/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stackresources/doc.go
@@ -1,0 +1,70 @@
+/*
+Package stackresources provides operations for working with stack resources.
+A resource is a template artifact that represents some component of your
+desired architecture (a Cloud Server, a group of scaled Cloud Servers, a load
+balancer, some configuration management system, and so forth).
+
+Example of get resource information in stack
+
+	rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
+	if rsrc_result.Err != nil {
+	    panic(rsrc_result.Err)
+	}
+	rsrc, err := rsrc_result.Extract()
+	if err != nil {
+	    panic(err)
+	}
+
+Example for list stack resources
+
+	all_stack_rsrc_pages, err := stackresources.List(client, stack.Name, stack.ID, nil).AllPages()
+	if err != nil {
+	    panic(err)
+	}
+
+	all_stack_rsrcs, err := stackresources.ExtractResources(all_stack_rsrc_pages)
+	if err != nil {
+	    panic(err)
+	}
+
+	fmt.Println("Resource List:")
+	for _, rsrc := range all_stack_rsrcs {
+	    // Get information of a resource in stack
+	    rsrc_result := stackresources.Get(client, stack.Name, stack.ID, rsrc.Name)
+	    if rsrc_result.Err != nil {
+	        panic(rsrc_result.Err)
+	    }
+	    rsrc, err := rsrc_result.Extract()
+	    if err != nil {
+	        panic(err)
+	    }
+	    fmt.Println("Resource Name: ", rsrc.Name, ", Physical ID: ", rsrc.PhysicalID, ", Status: ", rsrc.Status)
+	}
+
+Example for get resource type schema
+
+	schema_result := stackresources.Schema(client, "OS::Heat::Stack")
+	if schema_result.Err != nil {
+	    panic(schema_result.Err)
+	}
+	schema, err := schema_result.Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println("Schema for resource type OS::Heat::Stack")
+	fmt.Println(schema.SupportStatus)
+
+Example for get resource type Template
+
+	tmp_result := stackresources.Template(client, "OS::Heat::Stack")
+	if tmp_result.Err != nil {
+	    panic(tmp_result.Err)
+	}
+	tmp, err := tmp_result.Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println("Template for resource type OS::Heat::Stack")
+	fmt.Println(string(tmp))
+*/
+package stackresources

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stackresources/requests.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stackresources/requests.go
@@ -1,0 +1,113 @@
+package stackresources
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// Find retrieves stack resources for the given stack name.
+func Find(c *gophercloud.ServiceClient, stackName string) (r FindResult) {
+	_, r.Err = c.Get(findURL(c, stackName), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToStackResourceListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Marker and Limit are used for pagination.
+type ListOpts struct {
+	// Include resources from nest stacks up to Depth levels of recursion.
+	Depth int `q:"nested_depth"`
+}
+
+// ToStackResourceListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToStackResourceListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list resources for the given stack.
+func List(client *gophercloud.ServiceClient, stackName, stackID string, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client, stackName, stackID)
+	if opts != nil {
+		query, err := opts.ToStackResourceListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ResourcePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get retreives data for the given stack resource.
+func Get(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, stackName, stackID, resourceName), &r.Body, nil)
+	return
+}
+
+// Metadata retreives the metadata for the given stack resource.
+func Metadata(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) (r MetadataResult) {
+	_, r.Err = c.Get(metadataURL(c, stackName, stackID, resourceName), &r.Body, nil)
+	return
+}
+
+// ListTypes makes a request against the API to list resource types.
+func ListTypes(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listTypesURL(client), func(r pagination.PageResult) pagination.Page {
+		return ResourceTypePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Schema retreives the schema for the given resource type.
+func Schema(c *gophercloud.ServiceClient, resourceType string) (r SchemaResult) {
+	_, r.Err = c.Get(schemaURL(c, resourceType), &r.Body, nil)
+	return
+}
+
+// Template retreives the template representation for the given resource type.
+func Template(c *gophercloud.ServiceClient, resourceType string) (r TemplateResult) {
+	_, r.Err = c.Get(templateURL(c, resourceType), &r.Body, nil)
+	return
+}
+
+// MarkUnhealthyOpts contains the common options struct used in this package's
+// MarkUnhealthy operations.
+type MarkUnhealthyOpts struct {
+	// A boolean indicating whether the target resource should be marked as unhealthy.
+	MarkUnhealthy bool `json:"mark_unhealthy"`
+	// The reason for the current stack resource state.
+	ResourceStatusReason string `json:"resource_status_reason,omitempty"`
+}
+
+// MarkUnhealthyOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the MarkUnhealthy operation in this package
+type MarkUnhealthyOptsBuilder interface {
+	ToMarkUnhealthyMap() (map[string]interface{}, error)
+}
+
+// ToMarkUnhealthyMap validates that a template was supplied and calls
+// the ToMarkUnhealthyMap private function.
+func (opts MarkUnhealthyOpts) ToMarkUnhealthyMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// MarkUnhealthy marks the specified resource in the stack as unhealthy.
+func MarkUnhealthy(c *gophercloud.ServiceClient, stackName, stackID, resourceName string, opts MarkUnhealthyOptsBuilder) (r MarkUnhealthyResult) {
+	b, err := opts.ToMarkUnhealthyMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Patch(markUnhealthyURL(c, stackName, stackID, resourceName), b, nil, nil)
+	return
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stackresources/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stackresources/results.go
@@ -1,0 +1,212 @@
+package stackresources
+
+import (
+	"encoding/json"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// Resource represents a stack resource.
+type Resource struct {
+	Attributes     map[string]interface{} `json:"attributes"`
+	CreationTime   time.Time              `json:"-"`
+	Description    string                 `json:"description"`
+	Links          []gophercloud.Link     `json:"links"`
+	LogicalID      string                 `json:"logical_resource_id"`
+	Name           string                 `json:"resource_name"`
+	ParentResource string                 `json:"parent_resource"`
+	PhysicalID     string                 `json:"physical_resource_id"`
+	RequiredBy     []interface{}          `json:"required_by"`
+	Status         string                 `json:"resource_status"`
+	StatusReason   string                 `json:"resource_status_reason"`
+	Type           string                 `json:"resource_type"`
+	UpdatedTime    time.Time              `json:"-"`
+}
+
+func (r *Resource) UnmarshalJSON(b []byte) error {
+	type tmp Resource
+	var s struct {
+		tmp
+		CreationTime string `json:"creation_time"`
+		UpdatedTime  string `json:"updated_time"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Resource(s.tmp)
+
+	if s.CreationTime != "" {
+		t, err := time.Parse(time.RFC3339, s.CreationTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.CreationTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.CreationTime = t
+	}
+
+	if s.UpdatedTime != "" {
+		t, err := time.Parse(time.RFC3339, s.UpdatedTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.UpdatedTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.UpdatedTime = t
+	}
+
+	return nil
+}
+
+// FindResult represents the result of a Find operation.
+type FindResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a slice of Resource objects and is called after a
+// Find operation.
+func (r FindResult) Extract() ([]Resource, error) {
+	var s struct {
+		Resources []Resource `json:"resources"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Resources, err
+}
+
+// ResourcePage abstracts the raw results of making a List() request against the API.
+// As OpenStack extensions may freely alter the response bodies of structures returned to the client, you may only safely access the
+// data provided through the ExtractResources call.
+type ResourcePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a page contains no Server results.
+func (r ResourcePage) IsEmpty() (bool, error) {
+	resources, err := ExtractResources(r)
+	return len(resources) == 0, err
+}
+
+// ExtractResources interprets the results of a single page from a List() call, producing a slice of Resource entities.
+func ExtractResources(r pagination.Page) ([]Resource, error) {
+	var s struct {
+		Resources []Resource `json:"resources"`
+	}
+	err := (r.(ResourcePage)).ExtractInto(&s)
+	return s.Resources, err
+}
+
+// GetResult represents the result of a Get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a Resource object and is called after a
+// Get operation.
+func (r GetResult) Extract() (*Resource, error) {
+	var s struct {
+		Resource *Resource `json:"resource"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Resource, err
+}
+
+// MetadataResult represents the result of a Metadata operation.
+type MetadataResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a map object and is called after a
+// Metadata operation.
+func (r MetadataResult) Extract() (map[string]string, error) {
+	var s struct {
+		Meta map[string]string `json:"metadata"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Meta, err
+}
+
+// ResourceTypePage abstracts the raw results of making a ListTypes() request against the API.
+// As OpenStack extensions may freely alter the response bodies of structures returned to the client, you may only safely access the
+// data provided through the ExtractResourceTypes call.
+type ResourceTypePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ResourceTypePage contains no resource types.
+func (r ResourceTypePage) IsEmpty() (bool, error) {
+	rts, err := ExtractResourceTypes(r)
+	return len(rts) == 0, err
+}
+
+// ResourceTypes represents the type that holds the result of ExtractResourceTypes.
+// We define methods on this type to sort it before output
+type ResourceTypes []string
+
+func (r ResourceTypes) Len() int {
+	return len(r)
+}
+
+func (r ResourceTypes) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+func (r ResourceTypes) Less(i, j int) bool {
+	return r[i] < r[j]
+}
+
+// ExtractResourceTypes extracts and returns resource types.
+func ExtractResourceTypes(r pagination.Page) (ResourceTypes, error) {
+	var s struct {
+		ResourceTypes ResourceTypes `json:"resource_types"`
+	}
+	err := (r.(ResourceTypePage)).ExtractInto(&s)
+	return s.ResourceTypes, err
+}
+
+// TypeSchema represents a stack resource schema.
+type TypeSchema struct {
+	Attributes    map[string]interface{} `json:"attributes"`
+	Properties    map[string]interface{} `json:"properties"`
+	ResourceType  string                 `json:"resource_type"`
+	SupportStatus map[string]interface{} `json:"support_status"`
+}
+
+// SchemaResult represents the result of a Schema operation.
+type SchemaResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a TypeSchema object and is called after a
+// Schema operation.
+func (r SchemaResult) Extract() (*TypeSchema, error) {
+	var s *TypeSchema
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// TemplateResult represents the result of a Template operation.
+type TemplateResult struct {
+	gophercloud.Result
+}
+
+// Extract returns the template and is called after a
+// Template operation.
+func (r TemplateResult) Extract() ([]byte, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	template, err := json.MarshalIndent(r.Body, "", "  ")
+	return template, err
+}
+
+// MarkUnhealthyResult represents the result of a mark unhealthy operation.
+type MarkUnhealthyResult struct {
+	gophercloud.ErrResult
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stackresources/urls.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stackresources/urls.go
@@ -1,0 +1,35 @@
+package stackresources
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+
+func findURL(c *gophercloud.ServiceClient, stackName string) string {
+	return c.ServiceURL("stacks", stackName, "resources")
+}
+
+func listURL(c *gophercloud.ServiceClient, stackName, stackID string) string {
+	return c.ServiceURL("stacks", stackName, stackID, "resources")
+}
+
+func getURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName)
+}
+
+func metadataURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName, "metadata")
+}
+
+func listTypesURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("resource_types")
+}
+
+func schemaURL(c *gophercloud.ServiceClient, typeName string) string {
+	return c.ServiceURL("resource_types", typeName)
+}
+
+func templateURL(c *gophercloud.ServiceClient, typeName string) string {
+	return c.ServiceURL("resource_types", typeName, "template")
+}
+
+func markUnhealthyURL(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) string {
+	return c.ServiceURL("stacks", stackName, stackID, "resources", resourceName)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/doc.go
@@ -1,0 +1,241 @@
+/*
+Package stacks provides operation for working with Heat stacks. A stack is a
+group of resources (servers, load balancers, databases, and so forth)
+combined to fulfill a useful purpose. Based on a template, Heat orchestration
+engine creates an instantiated set of resources (a stack) to run the
+application framework or component specified (in the template). A stack is a
+running instance of a template. The result of creating a stack is a deployment
+of the application framework or component.
+
+# Prepare required import packages
+
+import (
+
+	"fmt"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks"
+
+)
+
+Example of Preparing Orchestration client:
+
+	client, err := openstack.NewOrchestrationV1(provider,  gophercloud.EndpointOpts{Region: "RegionOne"})
+
+Example of List Stack:
+
+	all_stack_pages, err := stacks.List(client, nil).AllPages()
+	if err != nil {
+	    panic(err)
+	}
+
+	all_stacks, err := stacks.ExtractStacks(all_stack_pages)
+	if err != nil {
+	    panic(err)
+	}
+
+	for _, stack := range all_stacks {
+	    fmt.Printf("%+v\n", stack)
+	}
+
+Example to Create an Stack
+
+	// Create Template
+	t := make(map[string]interface{})
+	f, err := ioutil.ReadFile("template.yaml")
+	if err != nil {
+	    panic(err)
+	}
+	err = yaml.Unmarshal(f, t)
+	if err != nil {
+	    panic(err)
+	}
+
+	template := &stacks.Template{}
+	template.TE = stacks.TE{
+	    Bin: f,
+	}
+	// Create Environment if needed
+	t_env := make(map[string]interface{})
+	f_env, err := ioutil.ReadFile("env.yaml")
+	if err != nil {
+	    panic(err)
+	}
+	err = yaml.Unmarshal(f_env, t_env)
+	if err != nil {
+	    panic(err)
+	}
+
+	env := &stacks.Environment{}
+	env.TE = stacks.TE{
+	    Bin: f_env,
+	}
+
+	// Remember, the priority of parameters you given through
+	// Parameters is higher than the parameters you provided in EnvironmentOpts.
+	params := make(map[string]string)
+	params["number_of_nodes"] = 1
+	tags := []string{"example-stack"}
+	createOpts := &stacks.CreateOpts{
+	    // The name of the stack. It must start with an alphabetic character.
+	    Name:       "testing_group",
+	    // A structure that contains either the template file or url. Call the
+	    // associated methods to extract the information relevant to send in a create request.
+	    TemplateOpts: template,
+	    // A structure that contains details for the environment of the stack.
+	    EnvironmentOpts: env,
+	    // User-defined parameters to pass to the template.
+	    Parameters: params,
+	    // A list of tags to assosciate with the Stack
+	    Tags: tags,
+	}
+
+	r := stacks.Create(client, createOpts)
+	//dcreated_stack := stacks.CreatedStack()
+	if r.Err != nil {
+	    panic(r.Err)
+	}
+	created_stack, err := r.Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Printf("Created Stack: %v", created_stack.ID)
+
+Example for Get Stack
+
+	get_result := stacks.Get(client, stackName, created_stack.ID)
+	if get_result.Err != nil {
+	    panic(get_result.Err)
+	}
+	stack, err := get_result.Extract()
+	if err != nil {
+	    panic(err)
+	}
+	fmt.Println("Get Stack: Name: ", stack.Name, ", ID: ", stack.ID, ", Status: ", stack.Status)
+
+Example for Find Stack
+
+	find_result  := stacks.Find(client, stackIdentity)
+	if find_result.Err != nil {
+		panic(find_result.Err)
+	}
+	stack, err := find_result.Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Find Stack: Name: ", stack.Name, ", ID: ", stack.ID, ", Status: ", stack.Status)
+
+Example for Delete Stack
+
+	del_r := stacks.Delete(client, stackName, created_stack.ID)
+	if del_r.Err != nil {
+	    panic(del_r.Err)
+	}
+	fmt.Println("Deleted Stack: ", stackName)
+
+Summary of  Behavior Between Stack Update and UpdatePatch Methods :
+
+# Function | Test Case | Result
+
+Update()	| Template AND Parameters WITH Conflict | Parameter takes priority, parameters are set in raw_template.environment overlay
+Update()	| Template ONLY | Template updates, raw_template.environment overlay is removed
+Update()	| Parameters ONLY | No update, template is required
+
+UpdatePatch() 	| Template AND Parameters WITH Conflict | Parameter takes priority, parameters are set in raw_template.environment overlay
+UpdatePatch() 	| Template ONLY | Template updates, but raw_template.environment overlay is not removed, existing parameter values will remain
+UpdatePatch() 	| Parameters ONLY | Parameters (raw_template.environment) is updated, excluded values are unchanged
+
+The PUT Update() function will remove parameters from the raw_template.environment overlay
+if they are excluded from the operation, whereas PATCH Update() will never be destructive to the
+raw_template.environment overlay.  It is not possible to expose the raw_template values with a
+patch update once they have been added to the environment overlay with the PATCH verb, but
+newly added values that do not have a corresponding key in the overlay will display the
+raw_template value.
+
+Example to Update a Stack Using the Update (PUT) Method
+
+	t := make(map[string]interface{})
+	f, err := ioutil.ReadFile("template.yaml")
+	if err != nil {
+		panic(err)
+	}
+	err = yaml.Unmarshal(f, t)
+	if err != nil {
+		panic(err)
+	}
+
+	template := stacks.Template{}
+	template.TE = stacks.TE{
+		Bin: f,
+	}
+
+	var params = make(map[string]interface{})
+	params["number_of_nodes"] = 2
+
+	stackName := "my_stack"
+	stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
+
+	stackOpts := &stacks.UpdateOpts{
+		Parameters: params,
+		TemplateOpts: &template,
+	}
+
+	res := stacks.Update(orchestrationClient, stackName, stackId, stackOpts)
+	if res.Err != nil {
+		panic(res.Err)
+	}
+
+Example to Update a Stack Using the UpdatePatch (PATCH) Method
+
+	var params = make(map[string]interface{})
+	params["number_of_nodes"] = 2
+
+	stackName := "my_stack"
+	stackId := "d68cc349-ccc5-4b44-a17d-07f068c01e5a"
+
+	stackOpts := &stacks.UpdateOpts{
+		Parameters: params,
+	}
+
+	res := stacks.UpdatePatch(orchestrationClient, stackName, stackId, stackOpts)
+	if res.Err != nil {
+		panic(res.Err)
+	}
+
+Example YAML Template Containing a Heat::ResourceGroup With Three Nodes
+
+	heat_template_version: 2016-04-08
+
+	parameters:
+		number_of_nodes:
+			type: number
+			default: 3
+			description: the number of nodes
+		node_flavor:
+			type: string
+			default: m1.small
+			description: node flavor
+		node_image:
+			type: string
+			default: centos7.5-latest
+			description: node os image
+		node_network:
+			type: string
+			default: my-node-network
+			description: node network name
+
+	resources:
+		resource_group:
+			type: OS::Heat::ResourceGroup
+			properties:
+			count: { get_param: number_of_nodes }
+			resource_def:
+				type: OS::Nova::Server
+				properties:
+					name: my_nova_server_%index%
+					image: { get_param: node_image }
+					flavor: { get_param: node_flavor }
+					networks:
+						- network: {get_param: node_network}
+*/
+package stacks

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/environment.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/environment.go
@@ -1,0 +1,134 @@
+package stacks
+
+import "strings"
+
+// Environment is a structure that represents stack environments
+type Environment struct {
+	TE
+}
+
+// EnvironmentSections is a map containing allowed sections in a stack environment file
+var EnvironmentSections = map[string]bool{
+	"parameters":         true,
+	"parameter_defaults": true,
+	"resource_registry":  true,
+}
+
+// Validate validates the contents of the Environment
+func (e *Environment) Validate() error {
+	if e.Parsed == nil {
+		if err := e.Parse(); err != nil {
+			return err
+		}
+	}
+	for key := range e.Parsed {
+		if _, ok := EnvironmentSections[key]; !ok {
+			return ErrInvalidEnvironment{Section: key}
+		}
+	}
+	return nil
+}
+
+// Parse environment file to resolve the URL's of the resources. This is done by
+// reading from the `Resource Registry` section, which is why the function is
+// named GetRRFileContents.
+func (e *Environment) getRRFileContents(ignoreIf igFunc) error {
+	// initialize environment if empty
+	if e.Files == nil {
+		e.Files = make(map[string]string)
+	}
+	if e.fileMaps == nil {
+		e.fileMaps = make(map[string]string)
+	}
+
+	// get the resource registry
+	rr := e.Parsed["resource_registry"]
+
+	// search the resource registry for URLs
+	switch rr.(type) {
+	// process further only if the resource registry is a map
+	case map[string]interface{}, map[interface{}]interface{}:
+		rrMap, err := toStringKeys(rr)
+		if err != nil {
+			return err
+		}
+		// the resource registry might contain a base URL for the resource. If
+		// such a field is present, use it. Otherwise, use the default base URL.
+		var baseURL string
+		if val, ok := rrMap["base_url"]; ok {
+			baseURL = val.(string)
+		} else {
+			baseURL = e.baseURL
+		}
+
+		// The contents of the resource may be located in a remote file, which
+		// will be a template. Instantiate a temporary template to manage the
+		// contents.
+		tempTemplate := new(Template)
+		tempTemplate.baseURL = baseURL
+		tempTemplate.client = e.client
+
+		// Fetch the contents of remote resource URL's
+		if err = tempTemplate.getFileContents(rr, ignoreIf, false); err != nil {
+			return err
+		}
+		// check the `resources` section (if it exists) for more URL's. Note that
+		// the previous call to GetFileContents was (deliberately) not recursive
+		// as we want more control over where to look for URL's
+		if val, ok := rrMap["resources"]; ok {
+			switch val.(type) {
+			// process further only if the contents are a map
+			case map[string]interface{}, map[interface{}]interface{}:
+				resourcesMap, err := toStringKeys(val)
+				if err != nil {
+					return err
+				}
+				for _, v := range resourcesMap {
+					switch v.(type) {
+					case map[string]interface{}, map[interface{}]interface{}:
+						resourceMap, err := toStringKeys(v)
+						if err != nil {
+							return err
+						}
+						var resourceBaseURL string
+						// if base_url for the resource type is defined, use it
+						if val, ok := resourceMap["base_url"]; ok {
+							resourceBaseURL = val.(string)
+						} else {
+							resourceBaseURL = baseURL
+						}
+						tempTemplate.baseURL = resourceBaseURL
+						if err := tempTemplate.getFileContents(v, ignoreIf, false); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+		// if the resource registry contained any URL's, store them. This can
+		// then be passed as parameter to api calls to Heat api.
+		e.Files = tempTemplate.Files
+		return nil
+	default:
+		return nil
+	}
+}
+
+// function to choose keys whose values are other environment files
+func ignoreIfEnvironment(key string, value interface{}) bool {
+	// base_url and hooks refer to components which cannot have urls
+	if key == "base_url" || key == "hooks" {
+		return true
+	}
+	// if value is not string, it cannot be a URL
+	valueString, ok := value.(string)
+	if !ok {
+		return true
+	}
+	// if value contains `::`, it must be a reference to another resource type
+	// e.g. OS::Nova::Server : Rackspace::Cloud::Server
+	if strings.Contains(valueString, "::") {
+		return true
+	}
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/errors.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/errors.go
@@ -1,0 +1,41 @@
+package stacks
+
+import (
+	"fmt"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+type ErrInvalidEnvironment struct {
+	gophercloud.BaseError
+	Section string
+}
+
+func (e ErrInvalidEnvironment) Error() string {
+	return fmt.Sprintf("Environment has wrong section: %s", e.Section)
+}
+
+type ErrInvalidDataFormat struct {
+	gophercloud.BaseError
+}
+
+func (e ErrInvalidDataFormat) Error() string {
+	return fmt.Sprintf("Data in neither json nor yaml format.")
+}
+
+type ErrInvalidTemplateFormatVersion struct {
+	gophercloud.BaseError
+	Version string
+}
+
+func (e ErrInvalidTemplateFormatVersion) Error() string {
+	return fmt.Sprintf("Template format version not found.")
+}
+
+type ErrTemplateRequired struct {
+	gophercloud.BaseError
+}
+
+func (e ErrTemplateRequired) Error() string {
+	return fmt.Sprintf("Template required for this function.")
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/fixtures.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/fixtures.go
@@ -1,0 +1,199 @@
+package stacks
+
+// ValidJSONTemplate is a valid OpenStack Heat template in JSON format
+const ValidJSONTemplate = `
+{
+  "heat_template_version": "2014-10-16",
+  "parameters": {
+    "flavor": {
+      "default": "debian2G",
+      "description": "Flavor for the server to be created",
+      "hidden": true,
+      "type": "string"
+    }
+  },
+  "resources": {
+    "test_server": {
+      "properties": {
+        "flavor": "2 GB General Purpose v1",
+        "image": "Debian 7 (Wheezy) (PVHVM)",
+        "name": "test-server"
+      },
+      "type": "OS::Nova::Server"
+    }
+  }
+}
+`
+
+// ValidYAMLTemplate is a valid OpenStack Heat template in YAML format
+const ValidYAMLTemplate = `
+heat_template_version: 2014-10-16
+parameters:
+  flavor:
+    type: string
+    description: Flavor for the server to be created
+    default: debian2G
+    hidden: true
+resources:
+  test_server:
+    type: "OS::Nova::Server"
+    properties:
+      name: test-server
+      flavor: 2 GB General Purpose v1
+      image: Debian 7 (Wheezy) (PVHVM)
+`
+
+// InvalidTemplateNoVersion is an invalid template as it has no `version` section
+const InvalidTemplateNoVersion = `
+parameters:
+  flavor:
+    type: string
+    description: Flavor for the server to be created
+    default: debian2G
+    hidden: true
+resources:
+  test_server:
+    type: "OS::Nova::Server"
+    properties:
+      name: test-server
+      flavor: 2 GB General Purpose v1
+      image: Debian 7 (Wheezy) (PVHVM)
+`
+
+// ValidJSONEnvironment is a valid environment for a stack in JSON format
+const ValidJSONEnvironment = `
+{
+	"parameters": {
+		"user_key": "userkey"
+	},
+	"resource_registry": {
+		"My::WP::Server": "file:///home/shardy/git/heat-templates/hot/F18/WordPress_Native.yaml",
+		"OS::Quantum*": "OS::Neutron*",
+		"AWS::CloudWatch::Alarm": "file:///etc/heat/templates/AWS_CloudWatch_Alarm.yaml",
+		"OS::Metering::Alarm": "OS::Ceilometer::Alarm",
+		"AWS::RDS::DBInstance": "file:///etc/heat/templates/AWS_RDS_DBInstance.yaml",
+		"resources": {
+			"my_db_server": {
+				"OS::DBInstance": "file:///home/mine/all_my_cool_templates/db.yaml"
+			},
+			"my_server": {
+				"OS::DBInstance": "file:///home/mine/all_my_cool_templates/db.yaml",
+				"hooks": "pre-create"
+			},
+			"nested_stack": {
+				"nested_resource": {
+					"hooks": "pre-update"
+				},
+				"another_resource": {
+					"hooks": [
+						"pre-create",
+						"pre-update"
+					]
+				}
+			}
+		}
+	}
+}
+`
+
+// ValidYAMLEnvironment is a valid environment for a stack in YAML format
+const ValidYAMLEnvironment = `
+parameters:
+  user_key: userkey
+resource_registry:
+  My::WP::Server: file:///home/shardy/git/heat-templates/hot/F18/WordPress_Native.yaml
+  # allow older templates with Quantum in them.
+  "OS::Quantum*": "OS::Neutron*"
+  # Choose your implementation of AWS::CloudWatch::Alarm
+  "AWS::CloudWatch::Alarm": "file:///etc/heat/templates/AWS_CloudWatch_Alarm.yaml"
+  #"AWS::CloudWatch::Alarm": "OS::Heat::CWLiteAlarm"
+  "OS::Metering::Alarm": "OS::Ceilometer::Alarm"
+  "AWS::RDS::DBInstance": "file:///etc/heat/templates/AWS_RDS_DBInstance.yaml"
+  resources:
+    my_db_server:
+      "OS::DBInstance": file:///home/mine/all_my_cool_templates/db.yaml
+    my_server:
+      "OS::DBInstance": file:///home/mine/all_my_cool_templates/db.yaml
+      hooks: pre-create
+    nested_stack:
+      nested_resource:
+        hooks: pre-update
+      another_resource:
+        hooks: [pre-create, pre-update]
+`
+
+// InvalidEnvironment is an invalid environment as it has an extra section called `resources`
+const InvalidEnvironment = `
+parameters:
+	flavor:
+		type: string
+		description: Flavor for the server to be created
+		default: debian2G
+		hidden: true
+resources:
+	test_server:
+		type: "OS::Nova::Server"
+		properties:
+			name: test-server
+			flavor: 2 GB General Purpose v1
+			image: Debian 7 (Wheezy) (PVHVM)
+parameter_defaults:
+	KeyName: heat_key
+`
+
+// ValidJSONEnvironmentParsed is the expected parsed version of ValidJSONEnvironment
+var ValidJSONEnvironmentParsed = map[string]interface{}{
+	"parameters": map[string]interface{}{
+		"user_key": "userkey",
+	},
+	"resource_registry": map[string]interface{}{
+		"My::WP::Server":         "file:///home/shardy/git/heat-templates/hot/F18/WordPress_Native.yaml",
+		"OS::Quantum*":           "OS::Neutron*",
+		"AWS::CloudWatch::Alarm": "file:///etc/heat/templates/AWS_CloudWatch_Alarm.yaml",
+		"OS::Metering::Alarm":    "OS::Ceilometer::Alarm",
+		"AWS::RDS::DBInstance":   "file:///etc/heat/templates/AWS_RDS_DBInstance.yaml",
+		"resources": map[string]interface{}{
+			"my_db_server": map[string]interface{}{
+				"OS::DBInstance": "file:///home/mine/all_my_cool_templates/db.yaml",
+			},
+			"my_server": map[string]interface{}{
+				"OS::DBInstance": "file:///home/mine/all_my_cool_templates/db.yaml",
+				"hooks":          "pre-create",
+			},
+			"nested_stack": map[string]interface{}{
+				"nested_resource": map[string]interface{}{
+					"hooks": "pre-update",
+				},
+				"another_resource": map[string]interface{}{
+					"hooks": []interface{}{
+						"pre-create",
+						"pre-update",
+					},
+				},
+			},
+		},
+	},
+}
+
+// ValidJSONTemplateParsed is the expected parsed version of ValidJSONTemplate
+var ValidJSONTemplateParsed = map[string]interface{}{
+	"heat_template_version": "2014-10-16",
+	"parameters": map[string]interface{}{
+		"flavor": map[string]interface{}{
+			"default":     "debian2G",
+			"description": "Flavor for the server to be created",
+			"hidden":      true,
+			"type":        "string",
+		},
+	},
+	"resources": map[string]interface{}{
+		"test_server": map[string]interface{}{
+			"properties": map[string]interface{}{
+				"flavor": "2 GB General Purpose v1",
+				"image":  "Debian 7 (Wheezy) (PVHVM)",
+				"name":   "test-server",
+			},
+			"type": "OS::Nova::Server",
+		},
+	},
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/requests.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/requests.go
@@ -1,0 +1,522 @@
+package stacks
+
+import (
+	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// CreateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the main Create operation in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type CreateOptsBuilder interface {
+	ToStackCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is the common options struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	// The name of the stack. It must start with an alphabetic character.
+	Name string `json:"stack_name" required:"true"`
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	TemplateOpts *Template `json:"-" required:"true"`
+	// Enables or disables deletion of all stack resources when a stack
+	// creation fails. Default is true, meaning all resources are not deleted when
+	// stack creation fails.
+	DisableRollback *bool `json:"disable_rollback,omitempty"`
+	// A structure that contains details for the environment of the stack.
+	EnvironmentOpts *Environment `json:"-"`
+	// User-defined parameters to pass to the template.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// The timeout for stack creation in minutes.
+	Timeout int `json:"timeout_mins,omitempty"`
+	// A list of tags to assosciate with the Stack
+	Tags []string `json:"-"`
+}
+
+// ToStackCreateMap casts a CreateOpts struct to a map.
+func (opts CreateOpts) ToStackCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.Parse(); err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
+		return nil, err
+	}
+	opts.TemplateOpts.fixFileRefs()
+	b["template"] = string(opts.TemplateOpts.Bin)
+
+	files := make(map[string]string)
+	for k, v := range opts.TemplateOpts.Files {
+		files[k] = v
+	}
+
+	if opts.EnvironmentOpts != nil {
+		if err := opts.EnvironmentOpts.Parse(); err != nil {
+			return nil, err
+		}
+		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
+			return nil, err
+		}
+		opts.EnvironmentOpts.fixFileRefs()
+		for k, v := range opts.EnvironmentOpts.Files {
+			files[k] = v
+		}
+		b["environment"] = string(opts.EnvironmentOpts.Bin)
+	}
+
+	if len(files) > 0 {
+		b["files"] = files
+	}
+
+	if opts.Tags != nil {
+		b["tags"] = strings.Join(opts.Tags, ",")
+	}
+
+	return b, nil
+}
+
+// Create accepts a CreateOpts struct and creates a new stack using the values
+// provided.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToStackCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, nil)
+	return
+}
+
+// AdoptOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the Adopt function in this package. Since many
+// extensions decorate or modify the common logic, it is useful for them to
+// satisfy a basic interface in order for them to be used.
+type AdoptOptsBuilder interface {
+	ToStackAdoptMap() (map[string]interface{}, error)
+}
+
+// AdoptOpts is the common options struct used in this package's Adopt
+// operation.
+type AdoptOpts struct {
+	// Existing resources data represented as a string to add to the
+	// new stack. Data returned by Abandon could be provided as AdoptsStackData.
+	AdoptStackData string `json:"adopt_stack_data" required:"true"`
+	// The name of the stack. It must start with an alphabetic character.
+	Name string `json:"stack_name" required:"true"`
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	TemplateOpts *Template `json:"-" required:"true"`
+	// The timeout for stack creation in minutes.
+	Timeout int `json:"timeout_mins,omitempty"`
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	//TemplateOpts *Template `json:"-" required:"true"`
+	// Enables or disables deletion of all stack resources when a stack
+	// creation fails. Default is true, meaning all resources are not deleted when
+	// stack creation fails.
+	DisableRollback *bool `json:"disable_rollback,omitempty"`
+	// A structure that contains details for the environment of the stack.
+	EnvironmentOpts *Environment `json:"-"`
+	// User-defined parameters to pass to the template.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+}
+
+// ToStackAdoptMap casts a CreateOpts struct to a map.
+func (opts AdoptOpts) ToStackAdoptMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.Parse(); err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
+		return nil, err
+	}
+	opts.TemplateOpts.fixFileRefs()
+	b["template"] = string(opts.TemplateOpts.Bin)
+
+	files := make(map[string]string)
+	for k, v := range opts.TemplateOpts.Files {
+		files[k] = v
+	}
+
+	if opts.EnvironmentOpts != nil {
+		if err := opts.EnvironmentOpts.Parse(); err != nil {
+			return nil, err
+		}
+		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
+			return nil, err
+		}
+		opts.EnvironmentOpts.fixFileRefs()
+		for k, v := range opts.EnvironmentOpts.Files {
+			files[k] = v
+		}
+		b["environment"] = string(opts.EnvironmentOpts.Bin)
+	}
+
+	if len(files) > 0 {
+		b["files"] = files
+	}
+
+	return b, nil
+}
+
+// Adopt accepts an AdoptOpts struct and creates a new stack using the resources
+// from another stack.
+func Adopt(c *gophercloud.ServiceClient, opts AdoptOptsBuilder) (r AdoptResult) {
+	b, err := opts.ToStackAdoptMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(adoptURL(c), b, &r.Body, nil)
+	return
+}
+
+// SortDir is a type for specifying in which direction to sort a list of stacks.
+type SortDir string
+
+// SortKey is a type for specifying by which key to sort a list of stacks.
+type SortKey string
+
+var (
+	// SortAsc is used to sort a list of stacks in ascending order.
+	SortAsc SortDir = "asc"
+	// SortDesc is used to sort a list of stacks in descending order.
+	SortDesc SortDir = "desc"
+	// SortName is used to sort a list of stacks by name.
+	SortName SortKey = "name"
+	// SortStatus is used to sort a list of stacks by status.
+	SortStatus SortKey = "status"
+	// SortCreatedAt is used to sort a list of stacks by date created.
+	SortCreatedAt SortKey = "created_at"
+	// SortUpdatedAt is used to sort a list of stacks by date updated.
+	SortUpdatedAt SortKey = "updated_at"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToStackListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the network attributes you want to see returned.
+type ListOpts struct {
+	// TenantID is the UUID of the tenant. A tenant is also known as
+	// a project.
+	TenantID string `q:"tenant_id"`
+
+	// ID filters the stack list by a stack ID
+	ID string `q:"id"`
+
+	// Status filters the stack list by a status.
+	Status string `q:"status"`
+
+	// Name filters the stack list by a name.
+	Name string `q:"name"`
+
+	// Marker is the ID of last-seen item.
+	Marker string `q:"marker"`
+
+	// Limit is an integer value for the limit of values to return.
+	Limit int `q:"limit"`
+
+	// SortKey allows you to sort by stack_name, stack_status, creation_time, or
+	// update_time key.
+	SortKey SortKey `q:"sort_keys"`
+
+	// SortDir sets the direction, and is either `asc` or `desc`.
+	SortDir SortDir `q:"sort_dir"`
+
+	// AllTenants is a bool to show all tenants.
+	AllTenants bool `q:"global_tenant"`
+
+	// ShowDeleted set to `true` to include deleted stacks in the list.
+	ShowDeleted bool `q:"show_deleted"`
+
+	// ShowNested set to `true` to include nested stacks in the list.
+	ShowNested bool `q:"show_nested"`
+
+	// Tags lists stacks that contain one or more simple string tags.
+	Tags string `q:"tags"`
+
+	// TagsAny lists stacks that contain one or more simple string tags.
+	TagsAny string `q:"tags_any"`
+
+	// NotTags lists stacks that do not contain one or more simple string tags.
+	NotTags string `q:"not_tags"`
+
+	// NotTagsAny lists stacks that do not contain one or more simple string tags.
+	NotTagsAny string `q:"not_tags_any"`
+}
+
+// ToStackListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToStackListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// stacks. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToStackListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return StackPage{pagination.SinglePageBase(r)}
+	}
+	return pagination.NewPager(c, url, createPage)
+}
+
+// Get retreives a stack based on the stack name and stack ID.
+func Get(c *gophercloud.ServiceClient, stackName, stackID string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, stackName, stackID), &r.Body, nil)
+	return
+}
+
+// Find retrieves a stack based on the stack name or stack ID.
+func Find(c *gophercloud.ServiceClient, stackIdentity string) (r GetResult) {
+	_, r.Err = c.Get(findURL(c, stackIdentity), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the Update operation in this package.
+type UpdateOptsBuilder interface {
+	ToStackUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdatePatchOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the UpdatePatch operation in this package
+type UpdatePatchOptsBuilder interface {
+	ToStackUpdatePatchMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains the common options struct used in this package's Update
+// and UpdatePatch operations.
+type UpdateOpts struct {
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	TemplateOpts *Template `json:"-"`
+	// A structure that contains details for the environment of the stack.
+	EnvironmentOpts *Environment `json:"-"`
+	// User-defined parameters to pass to the template.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// The timeout for stack creation in minutes.
+	Timeout int `json:"timeout_mins,omitempty"`
+	// A list of tags to associate with the Stack
+	Tags []string `json:"-"`
+}
+
+// ToStackUpdateMap validates that a template was supplied and calls
+// the toStackUpdateMap private function.
+func (opts UpdateOpts) ToStackUpdateMap() (map[string]interface{}, error) {
+	if opts.TemplateOpts == nil {
+		return nil, ErrTemplateRequired{}
+	}
+	return toStackUpdateMap(opts)
+}
+
+// ToStackUpdatePatchMap calls the private function toStackUpdateMap
+// directly.
+func (opts UpdateOpts) ToStackUpdatePatchMap() (map[string]interface{}, error) {
+	return toStackUpdateMap(opts)
+}
+
+// ToStackUpdateMap casts a CreateOpts struct to a map.
+func toStackUpdateMap(opts UpdateOpts) (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	files := make(map[string]string)
+
+	if opts.TemplateOpts != nil {
+		if err := opts.TemplateOpts.Parse(); err != nil {
+			return nil, err
+		}
+
+		if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
+			return nil, err
+		}
+		opts.TemplateOpts.fixFileRefs()
+		b["template"] = string(opts.TemplateOpts.Bin)
+
+		for k, v := range opts.TemplateOpts.Files {
+			files[k] = v
+		}
+	}
+
+	if opts.EnvironmentOpts != nil {
+		if err := opts.EnvironmentOpts.Parse(); err != nil {
+			return nil, err
+		}
+		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
+			return nil, err
+		}
+		opts.EnvironmentOpts.fixFileRefs()
+		for k, v := range opts.EnvironmentOpts.Files {
+			files[k] = v
+		}
+		b["environment"] = string(opts.EnvironmentOpts.Bin)
+	}
+
+	if len(files) > 0 {
+		b["files"] = files
+	}
+
+	if opts.Tags != nil {
+		b["tags"] = strings.Join(opts.Tags, ",")
+	}
+
+	return b, nil
+}
+
+// Update accepts an UpdateOpts struct and updates an existing stack using the
+//
+//	http PUT verb with the values provided. opts.TemplateOpts is required.
+func Update(c *gophercloud.ServiceClient, stackName, stackID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToStackUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, stackName, stackID), b, nil, nil)
+	return
+}
+
+// Update accepts an UpdateOpts struct and updates an existing stack using the
+//
+//	http PATCH verb with the values provided. opts.TemplateOpts is not required.
+func UpdatePatch(c *gophercloud.ServiceClient, stackName, stackID string, opts UpdatePatchOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToStackUpdatePatchMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Patch(updateURL(c, stackName, stackID), b, nil, nil)
+	return
+}
+
+// Delete deletes a stack based on the stack name and stack ID.
+func Delete(c *gophercloud.ServiceClient, stackName, stackID string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, stackName, stackID), nil)
+	return
+}
+
+// PreviewOptsBuilder is the interface options structs have to satisfy in order
+// to be used in the Preview operation in this package.
+type PreviewOptsBuilder interface {
+	ToStackPreviewMap() (map[string]interface{}, error)
+}
+
+// PreviewOpts contains the common options struct used in this package's Preview
+// operation.
+type PreviewOpts struct {
+	// The name of the stack. It must start with an alphabetic character.
+	Name string `json:"stack_name" required:"true"`
+	// The timeout for stack creation in minutes.
+	Timeout int `json:"timeout_mins" required:"true"`
+	// A structure that contains either the template file or url. Call the
+	// associated methods to extract the information relevant to send in a create request.
+	TemplateOpts *Template `json:"-" required:"true"`
+	// Enables or disables deletion of all stack resources when a stack
+	// creation fails. Default is true, meaning all resources are not deleted when
+	// stack creation fails.
+	DisableRollback *bool `json:"disable_rollback,omitempty"`
+	// A structure that contains details for the environment of the stack.
+	EnvironmentOpts *Environment `json:"-"`
+	// User-defined parameters to pass to the template.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+}
+
+// ToStackPreviewMap casts a PreviewOpts struct to a map.
+func (opts PreviewOpts) ToStackPreviewMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.Parse(); err != nil {
+		return nil, err
+	}
+
+	if err := opts.TemplateOpts.getFileContents(opts.TemplateOpts.Parsed, ignoreIfTemplate, true); err != nil {
+		return nil, err
+	}
+	opts.TemplateOpts.fixFileRefs()
+	b["template"] = string(opts.TemplateOpts.Bin)
+
+	files := make(map[string]string)
+	for k, v := range opts.TemplateOpts.Files {
+		files[k] = v
+	}
+
+	if opts.EnvironmentOpts != nil {
+		if err := opts.EnvironmentOpts.Parse(); err != nil {
+			return nil, err
+		}
+		if err := opts.EnvironmentOpts.getRRFileContents(ignoreIfEnvironment); err != nil {
+			return nil, err
+		}
+		opts.EnvironmentOpts.fixFileRefs()
+		for k, v := range opts.EnvironmentOpts.Files {
+			files[k] = v
+		}
+		b["environment"] = string(opts.EnvironmentOpts.Bin)
+	}
+
+	if len(files) > 0 {
+		b["files"] = files
+	}
+
+	return b, nil
+}
+
+// Preview accepts a PreviewOptsBuilder interface and creates a preview of a stack using the values
+// provided.
+func Preview(c *gophercloud.ServiceClient, opts PreviewOptsBuilder) (r PreviewResult) {
+	b, err := opts.ToStackPreviewMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(previewURL(c), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Abandon deletes the stack with the provided stackName and stackID, but leaves its
+// resources intact, and returns data describing the stack and its resources.
+func Abandon(c *gophercloud.ServiceClient, stackName, stackID string) (r AbandonResult) {
+	_, r.Err = c.Delete(abandonURL(c, stackName, stackID), &gophercloud.RequestOpts{
+		JSONResponse: &r.Body,
+		OkCodes:      []int{200},
+	})
+	return
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/results.go
@@ -1,0 +1,301 @@
+package stacks
+
+import (
+	"encoding/json"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination"
+)
+
+// CreatedStack represents the object extracted from a Create operation.
+type CreatedStack struct {
+	ID    string             `json:"id"`
+	Links []gophercloud.Link `json:"links"`
+}
+
+// CreateResult represents the result of a Create operation.
+type CreateResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a CreatedStack object and is called after a
+// Create operation.
+func (r CreateResult) Extract() (*CreatedStack, error) {
+	var s struct {
+		CreatedStack *CreatedStack `json:"stack"`
+	}
+	err := r.ExtractInto(&s)
+	return s.CreatedStack, err
+}
+
+// AdoptResult represents the result of an Adopt operation. AdoptResult has the
+// same form as CreateResult.
+type AdoptResult struct {
+	CreateResult
+}
+
+// StackPage is a pagination.Pager that is returned from a call to the List function.
+type StackPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Stacks.
+func (r StackPage) IsEmpty() (bool, error) {
+	stacks, err := ExtractStacks(r)
+	return len(stacks) == 0, err
+}
+
+// ListedStack represents an element in the slice extracted from a List operation.
+type ListedStack struct {
+	CreationTime time.Time          `json:"-"`
+	Description  string             `json:"description"`
+	ID           string             `json:"id"`
+	Links        []gophercloud.Link `json:"links"`
+	Name         string             `json:"stack_name"`
+	Status       string             `json:"stack_status"`
+	StatusReason string             `json:"stack_status_reason"`
+	Tags         []string           `json:"tags"`
+	UpdatedTime  time.Time          `json:"-"`
+}
+
+func (r *ListedStack) UnmarshalJSON(b []byte) error {
+	type tmp ListedStack
+	var s struct {
+		tmp
+		CreationTime string `json:"creation_time"`
+		UpdatedTime  string `json:"updated_time"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = ListedStack(s.tmp)
+
+	if s.CreationTime != "" {
+		t, err := time.Parse(time.RFC3339, s.CreationTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.CreationTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.CreationTime = t
+	}
+
+	if s.UpdatedTime != "" {
+		t, err := time.Parse(time.RFC3339, s.UpdatedTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.UpdatedTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.UpdatedTime = t
+	}
+
+	return nil
+}
+
+// ExtractStacks extracts and returns a slice of ListedStack. It is used while iterating
+// over a stacks.List call.
+func ExtractStacks(r pagination.Page) ([]ListedStack, error) {
+	var s struct {
+		ListedStacks []ListedStack `json:"stacks"`
+	}
+	err := (r.(StackPage)).ExtractInto(&s)
+	return s.ListedStacks, err
+}
+
+// RetrievedStack represents the object extracted from a Get operation.
+type RetrievedStack struct {
+	Capabilities        []interface{}            `json:"capabilities"`
+	CreationTime        time.Time                `json:"-"`
+	Description         string                   `json:"description"`
+	DisableRollback     bool                     `json:"disable_rollback"`
+	ID                  string                   `json:"id"`
+	Links               []gophercloud.Link       `json:"links"`
+	NotificationTopics  []interface{}            `json:"notification_topics"`
+	Outputs             []map[string]interface{} `json:"outputs"`
+	Parameters          map[string]string        `json:"parameters"`
+	Name                string                   `json:"stack_name"`
+	Status              string                   `json:"stack_status"`
+	StatusReason        string                   `json:"stack_status_reason"`
+	Tags                []string                 `json:"tags"`
+	TemplateDescription string                   `json:"template_description"`
+	Timeout             int                      `json:"timeout_mins"`
+	UpdatedTime         time.Time                `json:"-"`
+}
+
+func (r *RetrievedStack) UnmarshalJSON(b []byte) error {
+	type tmp RetrievedStack
+	var s struct {
+		tmp
+		CreationTime string `json:"creation_time"`
+		UpdatedTime  string `json:"updated_time"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = RetrievedStack(s.tmp)
+
+	if s.CreationTime != "" {
+		t, err := time.Parse(time.RFC3339, s.CreationTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.CreationTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.CreationTime = t
+	}
+
+	if s.UpdatedTime != "" {
+		t, err := time.Parse(time.RFC3339, s.UpdatedTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.UpdatedTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.UpdatedTime = t
+	}
+
+	return nil
+}
+
+// GetResult represents the result of a Get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a RetrievedStack object and is called after a
+// Get operation.
+func (r GetResult) Extract() (*RetrievedStack, error) {
+	var s struct {
+		Stack *RetrievedStack `json:"stack"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Stack, err
+}
+
+// UpdateResult represents the result of a Update operation.
+type UpdateResult struct {
+	gophercloud.ErrResult
+}
+
+// DeleteResult represents the result of a Delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// PreviewedStack represents the result of a Preview operation.
+type PreviewedStack struct {
+	Capabilities        []interface{}      `json:"capabilities"`
+	CreationTime        time.Time          `json:"-"`
+	Description         string             `json:"description"`
+	DisableRollback     bool               `json:"disable_rollback"`
+	ID                  string             `json:"id"`
+	Links               []gophercloud.Link `json:"links"`
+	Name                string             `json:"stack_name"`
+	NotificationTopics  []interface{}      `json:"notification_topics"`
+	Parameters          map[string]string  `json:"parameters"`
+	Resources           []interface{}      `json:"resources"`
+	TemplateDescription string             `json:"template_description"`
+	Timeout             int                `json:"timeout_mins"`
+	UpdatedTime         time.Time          `json:"-"`
+}
+
+func (r *PreviewedStack) UnmarshalJSON(b []byte) error {
+	type tmp PreviewedStack
+	var s struct {
+		tmp
+		CreationTime string `json:"creation_time"`
+		UpdatedTime  string `json:"updated_time"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = PreviewedStack(s.tmp)
+
+	if s.CreationTime != "" {
+		t, err := time.Parse(time.RFC3339, s.CreationTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.CreationTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.CreationTime = t
+	}
+
+	if s.UpdatedTime != "" {
+		t, err := time.Parse(time.RFC3339, s.UpdatedTime)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339NoZ, s.UpdatedTime)
+			if err != nil {
+				return err
+			}
+		}
+		r.UpdatedTime = t
+	}
+
+	return nil
+}
+
+// PreviewResult represents the result of a Preview operation.
+type PreviewResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to a PreviewedStack object and is called after a
+// Preview operation.
+func (r PreviewResult) Extract() (*PreviewedStack, error) {
+	var s struct {
+		PreviewedStack *PreviewedStack `json:"stack"`
+	}
+	err := r.ExtractInto(&s)
+	return s.PreviewedStack, err
+}
+
+// AbandonedStack represents the result of an Abandon operation.
+type AbandonedStack struct {
+	Status             string                 `json:"status"`
+	Name               string                 `json:"name"`
+	Template           map[string]interface{} `json:"template"`
+	Action             string                 `json:"action"`
+	ID                 string                 `json:"id"`
+	Resources          map[string]interface{} `json:"resources"`
+	Files              map[string]string      `json:"files"`
+	StackUserProjectID string                 `json:"stack_user_project_id"`
+	ProjectID          string                 `json:"project_id"`
+	Environment        map[string]interface{} `json:"environment"`
+}
+
+// AbandonResult represents the result of an Abandon operation.
+type AbandonResult struct {
+	gophercloud.Result
+}
+
+// Extract returns a pointer to an AbandonedStack object and is called after an
+// Abandon operation.
+func (r AbandonResult) Extract() (*AbandonedStack, error) {
+	var s *AbandonedStack
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// String converts an AbandonResult to a string. This is useful to when passing
+// the result of an Abandon operation to an AdoptOpts AdoptStackData field.
+func (r AbandonResult) String() (string, error) {
+	out, err := json.Marshal(r)
+	return string(out), err
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/template.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/template.go
@@ -1,0 +1,141 @@
+package stacks
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+// Template is a structure that represents OpenStack Heat templates
+type Template struct {
+	TE
+}
+
+// TemplateFormatVersions is a map containing allowed variations of the template format version
+// Note that this contains the permitted variations of the _keys_ not the values.
+var TemplateFormatVersions = map[string]bool{
+	"HeatTemplateFormatVersion": true,
+	"heat_template_version":     true,
+	"AWSTemplateFormatVersion":  true,
+}
+
+// Validate validates the contents of the Template
+func (t *Template) Validate() error {
+	if t.Parsed == nil {
+		if err := t.Parse(); err != nil {
+			return err
+		}
+	}
+	var invalid string
+	for key := range t.Parsed {
+		if _, ok := TemplateFormatVersions[key]; ok {
+			return nil
+		}
+		invalid = key
+	}
+	return ErrInvalidTemplateFormatVersion{Version: invalid}
+}
+
+// GetFileContents recursively parses a template to search for urls. These urls
+// are assumed to point to other templates (known in OpenStack Heat as child
+// templates). The contents of these urls are fetched and stored in the `Files`
+// parameter of the template structure. This is the only way that a user can
+// use child templates that are located in their filesystem; urls located on the
+// web (e.g. on github or swift) can be fetched directly by Heat engine.
+func (t *Template) getFileContents(te interface{}, ignoreIf igFunc, recurse bool) error {
+	// initialize template if empty
+	if t.Files == nil {
+		t.Files = make(map[string]string)
+	}
+	if t.fileMaps == nil {
+		t.fileMaps = make(map[string]string)
+	}
+	switch te.(type) {
+	// if te is a map
+	case map[string]interface{}, map[interface{}]interface{}:
+		teMap, err := toStringKeys(te)
+		if err != nil {
+			return err
+		}
+		for k, v := range teMap {
+			value, ok := v.(string)
+			if !ok {
+				// if the value is not a string, recursively parse that value
+				if err := t.getFileContents(v, ignoreIf, recurse); err != nil {
+					return err
+				}
+			} else if !ignoreIf(k, value) {
+				// at this point, the k, v pair has a reference to an external template.
+				// The assumption of heatclient is that value v is a reference
+				// to a file in the users environment
+
+				// create a new child template
+				childTemplate := new(Template)
+
+				// initialize child template
+
+				// get the base location of the child template
+				baseURL, err := gophercloud.NormalizePathURL(t.baseURL, value)
+				if err != nil {
+					return err
+				}
+				childTemplate.baseURL = baseURL
+				childTemplate.client = t.client
+
+				// fetch the contents of the child template
+				if err := childTemplate.Parse(); err != nil {
+					return err
+				}
+
+				// process child template recursively if required. This is
+				// required if the child template itself contains references to
+				// other templates
+				if recurse {
+					if err := childTemplate.getFileContents(childTemplate.Parsed, ignoreIf, recurse); err != nil {
+						return err
+					}
+				}
+				// update parent template with current child templates' content.
+				// At this point, the child template has been parsed recursively.
+				t.fileMaps[value] = childTemplate.URL
+				t.Files[childTemplate.URL] = string(childTemplate.Bin)
+
+			}
+		}
+		return nil
+	// if te is a slice, call the function on each element of the slice.
+	case []interface{}:
+		teSlice := te.([]interface{})
+		for i := range teSlice {
+			if err := t.getFileContents(teSlice[i], ignoreIf, recurse); err != nil {
+				return err
+			}
+		}
+	// if te is anything else, return
+	case string, bool, float64, nil, int:
+		return nil
+	default:
+		return gophercloud.ErrUnexpectedType{Actual: fmt.Sprintf("%v", reflect.TypeOf(te))}
+	}
+	return nil
+}
+
+// function to choose keys whose values are other template files
+func ignoreIfTemplate(key string, value interface{}) bool {
+	// key must be either `get_file` or `type` for value to be a URL
+	if key != "get_file" && key != "type" {
+		return true
+	}
+	// value must be a string
+	valueString, ok := value.(string)
+	if !ok {
+		return true
+	}
+	// `.template` and `.yaml` are allowed suffixes for template URLs when referred to by `type`
+	if key == "type" && !(strings.HasSuffix(valueString, ".template") || strings.HasSuffix(valueString, ".yaml")) {
+		return true
+	}
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/urls.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/urls.go
@@ -1,0 +1,39 @@
+package stacks
+
+import "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("stacks")
+}
+
+func adoptURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, name, id string) string {
+	return c.ServiceURL("stacks", name, id)
+}
+
+func findURL(c *gophercloud.ServiceClient, identity string) string {
+	return c.ServiceURL("stacks", identity)
+}
+
+func updateURL(c *gophercloud.ServiceClient, name, id string) string {
+	return getURL(c, name, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, name, id string) string {
+	return getURL(c, name, id)
+}
+
+func previewURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("stacks", "preview")
+}
+
+func abandonURL(c *gophercloud.ServiceClient, name, id string) string {
+	return c.ServiceURL("stacks", name, id, "abandon")
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/utils.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/orchestration/v1/stacks/utils.go
@@ -1,0 +1,161 @@
+package stacks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+// Client is an interface that expects a Get method similar to http.Get. This
+// is needed for unit testing, since we can mock an http client. Thus, the
+// client will usually be an http.Client EXCEPT in unit tests.
+type Client interface {
+	Get(string) (*http.Response, error)
+}
+
+// TE is a base structure for both Template and Environment
+type TE struct {
+	// Bin stores the contents of the template or environment.
+	Bin []byte
+	// URL stores the URL of the template. This is allowed to be a 'file://'
+	// for local files.
+	URL string
+	// Parsed contains a parsed version of Bin. Since there are 2 different
+	// fields referring to the same value, you must be careful when accessing
+	// this filed.
+	Parsed map[string]interface{}
+	// Files contains a mapping between the urls in templates to their contents.
+	Files map[string]string
+	// fileMaps is a map used internally when determining Files.
+	fileMaps map[string]string
+	// baseURL represents the location of the template or environment file.
+	baseURL string
+	// client is an interface which allows TE to fetch contents from URLS
+	client Client
+}
+
+// Fetch fetches the contents of a TE from its URL. Once a TE structure has a
+// URL, call the fetch method to fetch the contents.
+func (t *TE) Fetch() error {
+	// if the baseURL is not provided, use the current directors as the base URL
+	if t.baseURL == "" {
+		u, err := getBasePath()
+		if err != nil {
+			return err
+		}
+		t.baseURL = u
+	}
+
+	// if the contents are already present, do nothing.
+	if t.Bin != nil {
+		return nil
+	}
+
+	// get a fqdn from the URL using the baseURL of the TE. For local files,
+	// the URL's will have the `file` scheme.
+	u, err := gophercloud.NormalizePathURL(t.baseURL, t.URL)
+	if err != nil {
+		return err
+	}
+	t.URL = u
+
+	// get an HTTP client if none present
+	if t.client == nil {
+		t.client = getHTTPClient()
+	}
+
+	// use the client to fetch the contents of the TE
+	resp, err := t.client.Get(t.URL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	t.Bin = body
+	return nil
+}
+
+// get the basepath of the TE
+func getBasePath() (string, error) {
+	basePath, err := filepath.Abs(".")
+	if err != nil {
+		return "", err
+	}
+	u, err := gophercloud.NormalizePathURL("", basePath)
+	if err != nil {
+		return "", err
+	}
+	return u, nil
+}
+
+// get a an HTTP client to retrieve URL's. This client allows the use of `file`
+// scheme since we may need to fetch files from users filesystem
+func getHTTPClient() Client {
+	transport := &http.Transport{}
+	transport.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+	return &http.Client{Transport: transport}
+}
+
+// Parse will parse the contents and then validate. The contents MUST be either JSON or YAML.
+func (t *TE) Parse() error {
+	if err := t.Fetch(); err != nil {
+		return err
+	}
+	if jerr := json.Unmarshal(t.Bin, &t.Parsed); jerr != nil {
+		if yerr := yaml.Unmarshal(t.Bin, &t.Parsed); yerr != nil {
+			return ErrInvalidDataFormat{}
+		}
+	}
+	return t.Validate()
+}
+
+// Validate validates the contents of TE
+func (t *TE) Validate() error {
+	return nil
+}
+
+// igfunc is a parameter used by GetFileContents and GetRRFileContents to check
+// for valid URL's.
+type igFunc func(string, interface{}) bool
+
+// convert map[interface{}]interface{} to map[string]interface{}
+func toStringKeys(m interface{}) (map[string]interface{}, error) {
+	switch m.(type) {
+	case map[string]interface{}, map[interface{}]interface{}:
+		typedMap := make(map[string]interface{})
+		if _, ok := m.(map[interface{}]interface{}); ok {
+			for k, v := range m.(map[interface{}]interface{}) {
+				typedMap[k.(string)] = v
+			}
+		} else {
+			typedMap = m.(map[string]interface{})
+		}
+		return typedMap, nil
+	default:
+		return nil, gophercloud.ErrUnexpectedType{Expected: "map[string]interface{}/map[interface{}]interface{}", Actual: fmt.Sprintf("%v", reflect.TypeOf(m))}
+	}
+}
+
+// fix the reference to files by replacing relative URL's by absolute
+// URL's
+func (t *TE) fixFileRefs() {
+	tStr := string(t.Bin)
+	if t.fileMaps == nil {
+		return
+	}
+	for k, v := range t.fileMaps {
+		tStr = strings.Replace(tStr, k, v, -1)
+	}
+	t.Bin = []byte(tStr)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/utils/base_endpoint.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/utils/base_endpoint.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// BaseEndpoint will return a URL without the /vX.Y
+// portion of the URL.
+func BaseEndpoint(endpoint string) (string, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
+	}
+
+	u.RawQuery, u.Fragment = "", ""
+
+	path := u.Path
+	versionRe := regexp.MustCompile("v[0-9.]+/?")
+
+	if version := versionRe.FindString(path); version != "" {
+		versionIndex := strings.Index(path, version)
+		u.Path = path[:versionIndex]
+	}
+
+	return u.String(), nil
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/utils/choose_version.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack/utils/choose_version.go
@@ -1,0 +1,111 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+// Version is a supported API version, corresponding to a vN package within the appropriate service.
+type Version struct {
+	ID       string
+	Suffix   string
+	Priority int
+}
+
+var goodStatus = map[string]bool{
+	"current":   true,
+	"supported": true,
+	"stable":    true,
+}
+
+// ChooseVersion queries the base endpoint of an API to choose the most recent non-experimental alternative from a service's
+// published versions.
+// It returns the highest-Priority Version among the alternatives that are provided, as well as its corresponding endpoint.
+func ChooseVersion(client *gophercloud.ProviderClient, recognized []*Version) (*Version, string, error) {
+	type linkResp struct {
+		Href string `json:"href"`
+		Rel  string `json:"rel"`
+	}
+
+	type valueResp struct {
+		ID     string     `json:"id"`
+		Status string     `json:"status"`
+		Links  []linkResp `json:"links"`
+	}
+
+	type versionsResp struct {
+		Values []valueResp `json:"values"`
+	}
+
+	type response struct {
+		Versions versionsResp `json:"versions"`
+	}
+
+	normalize := func(endpoint string) string {
+		if !strings.HasSuffix(endpoint, "/") {
+			return endpoint + "/"
+		}
+		return endpoint
+	}
+	identityEndpoint := normalize(client.IdentityEndpoint)
+
+	// If a full endpoint is specified, check version suffixes for a match first.
+	for _, v := range recognized {
+		if strings.HasSuffix(identityEndpoint, v.Suffix) {
+			return v, identityEndpoint, nil
+		}
+	}
+
+	var resp response
+	_, err := client.Request("GET", client.IdentityBase, &gophercloud.RequestOpts{
+		JSONResponse: &resp,
+		OkCodes:      []int{200, 300},
+	})
+
+	if err != nil {
+		return nil, "", err
+	}
+
+	var highest *Version
+	var endpoint string
+
+	for _, value := range resp.Versions.Values {
+		href := ""
+		for _, link := range value.Links {
+			if link.Rel == "self" {
+				href = normalize(link.Href)
+			}
+		}
+
+		for _, version := range recognized {
+			if strings.Contains(value.ID, version.ID) {
+				// Prefer a version that exactly matches the provided endpoint.
+				if href == identityEndpoint {
+					if href == "" {
+						return nil, "", fmt.Errorf("Endpoint missing in version %s response from %s", value.ID, client.IdentityBase)
+					}
+					return version, href, nil
+				}
+
+				// Otherwise, find the highest-priority version with a whitelisted status.
+				if goodStatus[strings.ToLower(value.Status)] {
+					if highest == nil || version.Priority > highest.Priority {
+						highest = version
+						endpoint = href
+					}
+				}
+			}
+		}
+	}
+
+	if highest == nil {
+		return nil, "", fmt.Errorf("No supported version available from endpoint %s", client.IdentityBase)
+	}
+	if endpoint == "" {
+		return nil, "", fmt.Errorf("Endpoint missing in version %s response from %s", highest.ID, client.IdentityBase)
+	}
+
+	return highest, endpoint, nil
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/http.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/http.go
@@ -1,0 +1,60 @@
+package pagination
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+// PageResult stores the HTTP response that returned the current page of results.
+type PageResult struct {
+	gophercloud.Result
+	url.URL
+}
+
+// PageResultFrom parses an HTTP response as JSON and returns a PageResult containing the
+// results, interpreting it as JSON if the content type indicates.
+func PageResultFrom(resp *http.Response) (PageResult, error) {
+	var parsedBody interface{}
+
+	defer resp.Body.Close()
+	rawBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return PageResult{}, err
+	}
+
+	if strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
+		err = json.Unmarshal(rawBody, &parsedBody)
+		if err != nil {
+			return PageResult{}, err
+		}
+	} else {
+		parsedBody = rawBody
+	}
+
+	return PageResultFromParsed(resp, parsedBody), err
+}
+
+// PageResultFromParsed constructs a PageResult from an HTTP response that has already had its
+// body parsed as JSON (and closed).
+func PageResultFromParsed(resp *http.Response, body interface{}) PageResult {
+	return PageResult{
+		Result: gophercloud.Result{
+			Body:   body,
+			Header: resp.Header,
+		},
+		URL: *resp.Request.URL,
+	}
+}
+
+// Request performs an HTTP request and extracts the http.Response from the result.
+func Request(client *gophercloud.ServiceClient, headers map[string]string, url string) (*http.Response, error) {
+	return client.Get(url, nil, &gophercloud.RequestOpts{
+		MoreHeaders: headers,
+		OkCodes:     []int{200, 204, 300},
+	})
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/linked.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/linked.go
@@ -1,0 +1,92 @@
+package pagination
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+// LinkedPageBase may be embedded to implement a page that provides navigational "Next" and "Previous" links within its result.
+type LinkedPageBase struct {
+	PageResult
+
+	// LinkPath lists the keys that should be traversed within a response to arrive at the "next" pointer.
+	// If any link along the path is missing, an empty URL will be returned.
+	// If any link results in an unexpected value type, an error will be returned.
+	// When left as "nil", []string{"links", "next"} will be used as a default.
+	LinkPath []string
+}
+
+// NextPageURL extracts the pagination structure from a JSON response and returns the "next" link, if one is present.
+// It assumes that the links are available in a "links" element of the top-level response object.
+// If this is not the case, override NextPageURL on your result type.
+func (current LinkedPageBase) NextPageURL() (string, error) {
+	var path []string
+	var key string
+
+	if current.LinkPath == nil {
+		path = []string{"links", "next"}
+	} else {
+		path = current.LinkPath
+	}
+
+	submap, ok := current.Body.(map[string]interface{})
+	if !ok {
+		err := gophercloud.ErrUnexpectedType{}
+		err.Expected = "map[string]interface{}"
+		err.Actual = fmt.Sprintf("%v", reflect.TypeOf(current.Body))
+		return "", err
+	}
+
+	for {
+		key, path = path[0], path[1:]
+
+		value, ok := submap[key]
+		if !ok {
+			return "", nil
+		}
+
+		if len(path) > 0 {
+			submap, ok = value.(map[string]interface{})
+			if !ok {
+				err := gophercloud.ErrUnexpectedType{}
+				err.Expected = "map[string]interface{}"
+				err.Actual = fmt.Sprintf("%v", reflect.TypeOf(value))
+				return "", err
+			}
+		} else {
+			if value == nil {
+				// Actual null element.
+				return "", nil
+			}
+
+			url, ok := value.(string)
+			if !ok {
+				err := gophercloud.ErrUnexpectedType{}
+				err.Expected = "string"
+				err.Actual = fmt.Sprintf("%v", reflect.TypeOf(value))
+				return "", err
+			}
+
+			return url, nil
+		}
+	}
+}
+
+// IsEmpty satisifies the IsEmpty method of the Page interface
+func (current LinkedPageBase) IsEmpty() (bool, error) {
+	if b, ok := current.Body.([]interface{}); ok {
+		return len(b) == 0, nil
+	}
+	err := gophercloud.ErrUnexpectedType{}
+	err.Expected = "[]interface{}"
+	err.Actual = fmt.Sprintf("%v", reflect.TypeOf(current.Body))
+	return true, err
+}
+
+// GetBody returns the linked page's body. This method is needed to satisfy the
+// Page interface.
+func (current LinkedPageBase) GetBody() interface{} {
+	return current.Body
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/marker.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/marker.go
@@ -1,0 +1,58 @@
+package pagination
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+// MarkerPage is a stricter Page interface that describes additional functionality required for use with NewMarkerPager.
+// For convenience, embed the MarkedPageBase struct.
+type MarkerPage interface {
+	Page
+
+	// LastMarker returns the last "marker" value on this page.
+	LastMarker() (string, error)
+}
+
+// MarkerPageBase is a page in a collection that's paginated by "limit" and "marker" query parameters.
+type MarkerPageBase struct {
+	PageResult
+
+	// Owner is a reference to the embedding struct.
+	Owner MarkerPage
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (current MarkerPageBase) NextPageURL() (string, error) {
+	currentURL := current.URL
+
+	mark, err := current.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+
+	q := currentURL.Query()
+	q.Set("marker", mark)
+	currentURL.RawQuery = q.Encode()
+
+	return currentURL.String(), nil
+}
+
+// IsEmpty satisifies the IsEmpty method of the Page interface
+func (current MarkerPageBase) IsEmpty() (bool, error) {
+	if b, ok := current.Body.([]interface{}); ok {
+		return len(b) == 0, nil
+	}
+	err := gophercloud.ErrUnexpectedType{}
+	err.Expected = "[]interface{}"
+	err.Actual = fmt.Sprintf("%v", reflect.TypeOf(current.Body))
+	return true, err
+}
+
+// GetBody returns the linked page's body. This method is needed to satisfy the
+// Page interface.
+func (current MarkerPageBase) GetBody() interface{} {
+	return current.Body
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/pager.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/pager.go
@@ -1,0 +1,251 @@
+package pagination
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+var (
+	// ErrPageNotAvailable is returned from a Pager when a next or previous page is requested, but does not exist.
+	ErrPageNotAvailable = errors.New("The requested page does not exist.")
+)
+
+// Page must be satisfied by the result type of any resource collection.
+// It allows clients to interact with the resource uniformly, regardless of whether or not or how it's paginated.
+// Generally, rather than implementing this interface directly, implementors should embed one of the concrete PageBase structs,
+// instead.
+// Depending on the pagination strategy of a particular resource, there may be an additional subinterface that the result type
+// will need to implement.
+type Page interface {
+	// NextPageURL generates the URL for the page of data that follows this collection.
+	// Return "" if no such page exists.
+	NextPageURL() (string, error)
+
+	// IsEmpty returns true if this Page has no items in it.
+	IsEmpty() (bool, error)
+
+	// GetBody returns the Page Body. This is used in the `AllPages` method.
+	GetBody() interface{}
+}
+
+// Pager knows how to advance through a specific resource collection, one page at a time.
+type Pager struct {
+	client *gophercloud.ServiceClient
+
+	initialURL string
+
+	createPage func(r PageResult) Page
+
+	firstPage Page
+
+	Err error
+
+	// Headers supplies additional HTTP headers to populate on each paged request.
+	Headers map[string]string
+}
+
+// NewPager constructs a manually-configured pager.
+// Supply the URL for the first page, a function that requests a specific page given a URL, and a function that counts a page.
+func NewPager(client *gophercloud.ServiceClient, initialURL string, createPage func(r PageResult) Page) Pager {
+	return Pager{
+		client:     client,
+		initialURL: initialURL,
+		createPage: createPage,
+	}
+}
+
+// WithPageCreator returns a new Pager that substitutes a different page creation function. This is
+// useful for overriding List functions in delegation.
+func (p Pager) WithPageCreator(createPage func(r PageResult) Page) Pager {
+	return Pager{
+		client:     p.client,
+		initialURL: p.initialURL,
+		createPage: createPage,
+	}
+}
+
+func (p Pager) fetchNextPage(url string) (Page, error) {
+	resp, err := Request(p.client, p.Headers, url)
+	if err != nil {
+		return nil, err
+	}
+
+	remembered, err := PageResultFrom(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.createPage(remembered), nil
+}
+
+// EachPage iterates over each page returned by a Pager, yielding one at a time to a handler function.
+// Return "false" from the handler to prematurely stop iterating.
+func (p Pager) EachPage(handler func(Page) (bool, error)) error {
+	if p.Err != nil {
+		return p.Err
+	}
+	currentURL := p.initialURL
+	for {
+		var currentPage Page
+
+		// if first page has already been fetched, no need to fetch it again
+		if p.firstPage != nil {
+			currentPage = p.firstPage
+			p.firstPage = nil
+		} else {
+			var err error
+			currentPage, err = p.fetchNextPage(currentURL)
+			if err != nil {
+				return err
+			}
+		}
+
+		empty, err := currentPage.IsEmpty()
+		if err != nil {
+			return err
+		}
+		if empty {
+			return nil
+		}
+
+		ok, err := handler(currentPage)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+
+		currentURL, err = currentPage.NextPageURL()
+		if err != nil {
+			return err
+		}
+		if currentURL == "" {
+			return nil
+		}
+	}
+}
+
+// AllPages returns all the pages from a `List` operation in a single page,
+// allowing the user to retrieve all the pages at once.
+func (p Pager) AllPages() (Page, error) {
+	// pagesSlice holds all the pages until they get converted into as Page Body.
+	var pagesSlice []interface{}
+	// body will contain the final concatenated Page body.
+	var body reflect.Value
+
+	// Grab a first page to ascertain the page body type.
+	firstPage, err := p.fetchNextPage(p.initialURL)
+	if err != nil {
+		return nil, err
+	}
+	// Store the page type so we can use reflection to create a new mega-page of
+	// that type.
+	pageType := reflect.TypeOf(firstPage)
+
+	// if it's a single page, just return the firstPage (first page)
+	if _, found := pageType.FieldByName("SinglePageBase"); found {
+		return firstPage, nil
+	}
+
+	// store the first page to avoid getting it twice
+	p.firstPage = firstPage
+
+	// Switch on the page body type. Recognized types are `map[string]interface{}`,
+	// `[]byte`, and `[]interface{}`.
+	switch pb := firstPage.GetBody().(type) {
+	case map[string]interface{}:
+		// key is the map key for the page body if the body type is `map[string]interface{}`.
+		var key string
+		// Iterate over the pages to concatenate the bodies.
+		err = p.EachPage(func(page Page) (bool, error) {
+			b := page.GetBody().(map[string]interface{})
+			for k, v := range b {
+				// If it's a linked page, we don't want the `links`, we want the other one.
+				if !strings.HasSuffix(k, "links") {
+					// check the field's type. we only want []interface{} (which is really []map[string]interface{})
+					switch vt := v.(type) {
+					case []interface{}:
+						key = k
+						pagesSlice = append(pagesSlice, vt...)
+					}
+				}
+			}
+			return true, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		// Set body to value of type `map[string]interface{}`
+		body = reflect.MakeMap(reflect.MapOf(reflect.TypeOf(key), reflect.TypeOf(pagesSlice)))
+		body.SetMapIndex(reflect.ValueOf(key), reflect.ValueOf(pagesSlice))
+	case []byte:
+		// Iterate over the pages to concatenate the bodies.
+		err = p.EachPage(func(page Page) (bool, error) {
+			b := page.GetBody().([]byte)
+			pagesSlice = append(pagesSlice, b)
+			// seperate pages with a comma
+			pagesSlice = append(pagesSlice, []byte{10})
+			return true, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(pagesSlice) > 0 {
+			// Remove the trailing comma.
+			pagesSlice = pagesSlice[:len(pagesSlice)-1]
+		}
+		var b []byte
+		// Combine the slice of slices in to a single slice.
+		for _, slice := range pagesSlice {
+			b = append(b, slice.([]byte)...)
+		}
+		// Set body to value of type `bytes`.
+		body = reflect.New(reflect.TypeOf(b)).Elem()
+		body.SetBytes(b)
+	case []interface{}:
+		// Iterate over the pages to concatenate the bodies.
+		err = p.EachPage(func(page Page) (bool, error) {
+			b := page.GetBody().([]interface{})
+			pagesSlice = append(pagesSlice, b...)
+			return true, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		// Set body to value of type `[]interface{}`
+		body = reflect.MakeSlice(reflect.TypeOf(pagesSlice), len(pagesSlice), len(pagesSlice))
+		for i, s := range pagesSlice {
+			body.Index(i).Set(reflect.ValueOf(s))
+		}
+	default:
+		err := gophercloud.ErrUnexpectedType{}
+		err.Expected = "map[string]interface{}/[]byte/[]interface{}"
+		err.Actual = fmt.Sprintf("%T", pb)
+		return nil, err
+	}
+
+	// Each `Extract*` function is expecting a specific type of page coming back,
+	// otherwise the type assertion in those functions will fail. pageType is needed
+	// to create a type in this method that has the same type that the `Extract*`
+	// function is expecting and set the Body of that object to the concatenated
+	// pages.
+	page := reflect.New(pageType)
+	// Set the page body to be the concatenated pages.
+	page.Elem().FieldByName("Body").Set(body)
+	// Set any additional headers that were pass along. The `objectstorage` pacakge,
+	// for example, passes a Content-Type header.
+	h := make(http.Header)
+	for k, v := range p.Headers {
+		h.Add(k, v)
+	}
+	page.Elem().FieldByName("Header").Set(reflect.ValueOf(h))
+	// Type assert the page to a Page interface so that the type assertion in the
+	// `Extract*` methods will work.
+	return page.Elem().Interface().(Page), err
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/pkg.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/pkg.go
@@ -1,0 +1,4 @@
+/*
+Package pagination contains utilities and convenience structs that implement common pagination idioms within OpenStack APIs.
+*/
+package pagination

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/single.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/pagination/single.go
@@ -1,0 +1,33 @@
+package pagination
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+)
+
+// SinglePageBase may be embedded in a Page that contains all of the results from an operation at once.
+type SinglePageBase PageResult
+
+// NextPageURL always returns "" to indicate that there are no more pages to return.
+func (current SinglePageBase) NextPageURL() (string, error) {
+	return "", nil
+}
+
+// IsEmpty satisifies the IsEmpty method of the Page interface
+func (current SinglePageBase) IsEmpty() (bool, error) {
+	if b, ok := current.Body.([]interface{}); ok {
+		return len(b) == 0, nil
+	}
+	err := gophercloud.ErrUnexpectedType{}
+	err.Expected = "[]interface{}"
+	err.Actual = fmt.Sprintf("%v", reflect.TypeOf(current.Body))
+	return true, err
+}
+
+// GetBody returns the single page's body. This method is needed to satisfy the
+// Page interface.
+func (current SinglePageBase) GetBody() interface{} {
+	return current.Body
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/params.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/params.go
@@ -1,0 +1,491 @@
+package gophercloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+/*
+BuildRequestBody builds a map[string]interface from the given `struct`. If
+parent is not an empty string, the final map[string]interface returned will
+encapsulate the built one. For example:
+
+	disk := 1
+	createOpts := flavors.CreateOpts{
+	  ID:         "1",
+	  Name:       "m1.tiny",
+	  Disk:       &disk,
+	  RAM:        512,
+	  VCPUs:      1,
+	  RxTxFactor: 1.0,
+	}
+
+	body, err := gophercloud.BuildRequestBody(createOpts, "flavor")
+
+The above example can be run as-is, however it is recommended to look at how
+BuildRequestBody is used within Gophercloud to more fully understand how it
+fits within the request process as a whole rather than use it directly as shown
+above.
+*/
+func BuildRequestBody(opts interface{}, parent string) (map[string]interface{}, error) {
+	optsValue := reflect.ValueOf(opts)
+	if optsValue.Kind() == reflect.Ptr {
+		optsValue = optsValue.Elem()
+	}
+
+	optsType := reflect.TypeOf(opts)
+	if optsType.Kind() == reflect.Ptr {
+		optsType = optsType.Elem()
+	}
+
+	optsMap := make(map[string]interface{})
+	if optsValue.Kind() == reflect.Struct {
+		//fmt.Printf("optsValue.Kind() is a reflect.Struct: %+v\n", optsValue.Kind())
+		for i := 0; i < optsValue.NumField(); i++ {
+			v := optsValue.Field(i)
+			f := optsType.Field(i)
+
+			if f.Name != strings.Title(f.Name) {
+				//fmt.Printf("Skipping field: %s...\n", f.Name)
+				continue
+			}
+
+			//fmt.Printf("Starting on field: %s...\n", f.Name)
+
+			zero := isZero(v)
+			//fmt.Printf("v is zero?: %v\n", zero)
+
+			// if the field has a required tag that's set to "true"
+			if requiredTag := f.Tag.Get("required"); requiredTag == "true" {
+				//fmt.Printf("Checking required field [%s]:\n\tv: %+v\n\tisZero:%v\n", f.Name, v.Interface(), zero)
+				// if the field's value is zero, return a missing-argument error
+				if zero {
+					// if the field has a 'required' tag, it can't have a zero-value
+					err := ErrMissingInput{}
+					err.Argument = f.Name
+					return nil, err
+				}
+			}
+
+			if xorTag := f.Tag.Get("xor"); xorTag != "" {
+				//fmt.Printf("Checking `xor` tag for field [%s] with value %+v:\n\txorTag: %s\n", f.Name, v, xorTag)
+				xorField := optsValue.FieldByName(xorTag)
+				var xorFieldIsZero bool
+				if reflect.ValueOf(xorField.Interface()) == reflect.Zero(xorField.Type()) {
+					xorFieldIsZero = true
+				} else {
+					if xorField.Kind() == reflect.Ptr {
+						xorField = xorField.Elem()
+					}
+					xorFieldIsZero = isZero(xorField)
+				}
+				if !(zero != xorFieldIsZero) {
+					err := ErrMissingInput{}
+					err.Argument = fmt.Sprintf("%s/%s", f.Name, xorTag)
+					err.Info = fmt.Sprintf("Exactly one of %s and %s must be provided", f.Name, xorTag)
+					return nil, err
+				}
+			}
+
+			if orTag := f.Tag.Get("or"); orTag != "" {
+				//fmt.Printf("Checking `or` tag for field with:\n\tname: %+v\n\torTag:%s\n", f.Name, orTag)
+				//fmt.Printf("field is zero?: %v\n", zero)
+				if zero {
+					orField := optsValue.FieldByName(orTag)
+					var orFieldIsZero bool
+					if reflect.ValueOf(orField.Interface()) == reflect.Zero(orField.Type()) {
+						orFieldIsZero = true
+					} else {
+						if orField.Kind() == reflect.Ptr {
+							orField = orField.Elem()
+						}
+						orFieldIsZero = isZero(orField)
+					}
+					if orFieldIsZero {
+						err := ErrMissingInput{}
+						err.Argument = fmt.Sprintf("%s/%s", f.Name, orTag)
+						err.Info = fmt.Sprintf("At least one of %s and %s must be provided", f.Name, orTag)
+						return nil, err
+					}
+				}
+			}
+
+			jsonTag := f.Tag.Get("json")
+			if jsonTag == "-" {
+				continue
+			}
+
+			if v.Kind() == reflect.Slice || (v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Slice) {
+				sliceValue := v
+				if sliceValue.Kind() == reflect.Ptr {
+					sliceValue = sliceValue.Elem()
+				}
+
+				for i := 0; i < sliceValue.Len(); i++ {
+					element := sliceValue.Index(i)
+					if element.Kind() == reflect.Struct || (element.Kind() == reflect.Ptr && element.Elem().Kind() == reflect.Struct) {
+						_, err := BuildRequestBody(element.Interface(), "")
+						if err != nil {
+							return nil, err
+						}
+					}
+				}
+			}
+			if v.Kind() == reflect.Struct || (v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Struct) {
+				if zero {
+					//fmt.Printf("value before change: %+v\n", optsValue.Field(i))
+					if jsonTag != "" {
+						jsonTagPieces := strings.Split(jsonTag, ",")
+						if len(jsonTagPieces) > 1 && jsonTagPieces[1] == "omitempty" {
+							if v.CanSet() {
+								if !v.IsNil() {
+									if v.Kind() == reflect.Ptr {
+										v.Set(reflect.Zero(v.Type()))
+									}
+								}
+								//fmt.Printf("value after change: %+v\n", optsValue.Field(i))
+							}
+						}
+					}
+					continue
+				}
+
+				//fmt.Printf("Calling BuildRequestBody with:\n\tv: %+v\n\tf.Name:%s\n", v.Interface(), f.Name)
+				_, err := BuildRequestBody(v.Interface(), f.Name)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		//fmt.Printf("opts: %+v \n", opts)
+
+		b, err := json.Marshal(opts)
+		if err != nil {
+			return nil, err
+		}
+
+		//fmt.Printf("string(b): %s\n", string(b))
+
+		err = json.Unmarshal(b, &optsMap)
+		if err != nil {
+			return nil, err
+		}
+
+		//fmt.Printf("optsMap: %+v\n", optsMap)
+
+		if parent != "" {
+			optsMap = map[string]interface{}{parent: optsMap}
+		}
+		//fmt.Printf("optsMap after parent added: %+v\n", optsMap)
+		return optsMap, nil
+	}
+	// Return an error if the underlying type of 'opts' isn't a struct.
+	return nil, fmt.Errorf("Options type is not a struct.")
+}
+
+// EnabledState is a convenience type, mostly used in Create and Update
+// operations. Because the zero value of a bool is FALSE, we need to use a
+// pointer instead to indicate zero-ness.
+type EnabledState *bool
+
+// Convenience vars for EnabledState values.
+var (
+	iTrue  = true
+	iFalse = false
+
+	Enabled  EnabledState = &iTrue
+	Disabled EnabledState = &iFalse
+)
+
+// IPVersion is a type for the possible IP address versions. Valid instances
+// are IPv4 and IPv6
+type IPVersion int
+
+const (
+	// IPv4 is used for IP version 4 addresses
+	IPv4 IPVersion = 4
+	// IPv6 is used for IP version 6 addresses
+	IPv6 IPVersion = 6
+)
+
+// IntToPointer is a function for converting integers into integer pointers.
+// This is useful when passing in options to operations.
+func IntToPointer(i int) *int {
+	return &i
+}
+
+/*
+MaybeString is an internal function to be used by request methods in individual
+resource packages.
+
+It takes a string that might be a zero value and returns either a pointer to its
+address or nil. This is useful for allowing users to conveniently omit values
+from an options struct by leaving them zeroed, but still pass nil to the JSON
+serializer so they'll be omitted from the request body.
+*/
+func MaybeString(original string) *string {
+	if original != "" {
+		return &original
+	}
+	return nil
+}
+
+/*
+MaybeInt is an internal function to be used by request methods in individual
+resource packages.
+
+Like MaybeString, it accepts an int that may or may not be a zero value, and
+returns either a pointer to its address or nil. It's intended to hint that the
+JSON serializer should omit its field.
+*/
+func MaybeInt(original int) *int {
+	if original != 0 {
+		return &original
+	}
+	return nil
+}
+
+/*
+func isUnderlyingStructZero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Ptr:
+		return isUnderlyingStructZero(v.Elem())
+	default:
+		return isZero(v)
+	}
+}
+*/
+
+var t time.Time
+
+func isZero(v reflect.Value) bool {
+	//fmt.Printf("\n\nchecking isZero for value: %+v\n", v)
+	switch v.Kind() {
+	case reflect.Ptr:
+		if v.IsNil() {
+			return true
+		}
+		return false
+	case reflect.Func, reflect.Map, reflect.Slice:
+		return v.IsNil()
+	case reflect.Array:
+		z := true
+		for i := 0; i < v.Len(); i++ {
+			z = z && isZero(v.Index(i))
+		}
+		return z
+	case reflect.Struct:
+		if v.Type() == reflect.TypeOf(t) {
+			if v.Interface().(time.Time).IsZero() {
+				return true
+			}
+			return false
+		}
+		z := true
+		for i := 0; i < v.NumField(); i++ {
+			z = z && isZero(v.Field(i))
+		}
+		return z
+	}
+	// Compare other types directly:
+	z := reflect.Zero(v.Type())
+	//fmt.Printf("zero type for value: %+v\n\n\n", z)
+	return v.Interface() == z.Interface()
+}
+
+/*
+BuildQueryString is an internal function to be used by request methods in
+individual resource packages.
+
+It accepts a tagged structure and expands it into a URL struct. Field names are
+converted into query parameters based on a "q" tag. For example:
+
+	type struct Something {
+	   Bar string `q:"x_bar"`
+	   Baz int    `q:"lorem_ipsum"`
+	}
+
+	instance := Something{
+	   Bar: "AAA",
+	   Baz: "BBB",
+	}
+
+will be converted into "?x_bar=AAA&lorem_ipsum=BBB".
+
+The struct's fields may be strings, integers, or boolean values. Fields left at
+their type's zero value will be omitted from the query.
+*/
+func BuildQueryString(opts interface{}) (*url.URL, error) {
+	optsValue := reflect.ValueOf(opts)
+	if optsValue.Kind() == reflect.Ptr {
+		optsValue = optsValue.Elem()
+	}
+
+	optsType := reflect.TypeOf(opts)
+	if optsType.Kind() == reflect.Ptr {
+		optsType = optsType.Elem()
+	}
+
+	params := url.Values{}
+
+	if optsValue.Kind() == reflect.Struct {
+		for i := 0; i < optsValue.NumField(); i++ {
+			v := optsValue.Field(i)
+			f := optsType.Field(i)
+			qTag := f.Tag.Get("q")
+
+			// if the field has a 'q' tag, it goes in the query string
+			if qTag != "" {
+				tags := strings.Split(qTag, ",")
+
+				// if the field is set, add it to the slice of query pieces
+				if !isZero(v) {
+				loop:
+					switch v.Kind() {
+					case reflect.Ptr:
+						v = v.Elem()
+						goto loop
+					case reflect.String:
+						params.Add(tags[0], v.String())
+					case reflect.Int:
+						params.Add(tags[0], strconv.FormatInt(v.Int(), 10))
+					case reflect.Bool:
+						params.Add(tags[0], strconv.FormatBool(v.Bool()))
+					case reflect.Slice:
+						switch v.Type().Elem() {
+						case reflect.TypeOf(0):
+							for i := 0; i < v.Len(); i++ {
+								params.Add(tags[0], strconv.FormatInt(v.Index(i).Int(), 10))
+							}
+						default:
+							for i := 0; i < v.Len(); i++ {
+								params.Add(tags[0], v.Index(i).String())
+							}
+						}
+					case reflect.Map:
+						if v.Type().Key().Kind() == reflect.String && v.Type().Elem().Kind() == reflect.String {
+							var s []string
+							for _, k := range v.MapKeys() {
+								value := v.MapIndex(k).String()
+								s = append(s, fmt.Sprintf("'%s':'%s'", k.String(), value))
+							}
+							params.Add(tags[0], fmt.Sprintf("{%s}", strings.Join(s, ", ")))
+						}
+					}
+				} else {
+					// if the field has a 'required' tag, it can't have a zero-value
+					if requiredTag := f.Tag.Get("required"); requiredTag == "true" {
+						return &url.URL{}, fmt.Errorf("Required query parameter [%s] not set.", f.Name)
+					}
+				}
+			}
+		}
+
+		return &url.URL{RawQuery: params.Encode()}, nil
+	}
+	// Return an error if the underlying type of 'opts' isn't a struct.
+	return nil, fmt.Errorf("Options type is not a struct.")
+}
+
+/*
+BuildHeaders is an internal function to be used by request methods in
+individual resource packages.
+
+It accepts an arbitrary tagged structure and produces a string map that's
+suitable for use as the HTTP headers of an outgoing request. Field names are
+mapped to header names based in "h" tags.
+
+	type struct Something {
+	  Bar string `h:"x_bar"`
+	  Baz int    `h:"lorem_ipsum"`
+	}
+
+	instance := Something{
+	  Bar: "AAA",
+	  Baz: "BBB",
+	}
+
+will be converted into:
+
+	map[string]string{
+	  "x_bar": "AAA",
+	  "lorem_ipsum": "BBB",
+	}
+
+Untagged fields and fields left at their zero values are skipped. Integers,
+booleans and string values are supported.
+*/
+func BuildHeaders(opts interface{}) (map[string]string, error) {
+	optsValue := reflect.ValueOf(opts)
+	if optsValue.Kind() == reflect.Ptr {
+		optsValue = optsValue.Elem()
+	}
+
+	optsType := reflect.TypeOf(opts)
+	if optsType.Kind() == reflect.Ptr {
+		optsType = optsType.Elem()
+	}
+
+	optsMap := make(map[string]string)
+	if optsValue.Kind() == reflect.Struct {
+		for i := 0; i < optsValue.NumField(); i++ {
+			v := optsValue.Field(i)
+			f := optsType.Field(i)
+			hTag := f.Tag.Get("h")
+
+			// if the field has a 'h' tag, it goes in the header
+			if hTag != "" {
+				tags := strings.Split(hTag, ",")
+
+				// if the field is set, add it to the slice of query pieces
+				if !isZero(v) {
+					switch v.Kind() {
+					case reflect.String:
+						optsMap[tags[0]] = v.String()
+					case reflect.Int:
+						optsMap[tags[0]] = strconv.FormatInt(v.Int(), 10)
+					case reflect.Bool:
+						optsMap[tags[0]] = strconv.FormatBool(v.Bool())
+					}
+				} else {
+					// if the field has a 'required' tag, it can't have a zero-value
+					if requiredTag := f.Tag.Get("required"); requiredTag == "true" {
+						return optsMap, fmt.Errorf("Required header [%s] not set.", f.Name)
+					}
+				}
+			}
+
+		}
+		return optsMap, nil
+	}
+	// Return an error if the underlying type of 'opts' isn't a struct.
+	return optsMap, fmt.Errorf("Options type is not a struct.")
+}
+
+// IDSliceToQueryString takes a slice of elements and converts them into a query
+// string. For example, if name=foo and slice=[]int{20, 40, 60}, then the
+// result would be `?name=20&name=40&name=60'
+func IDSliceToQueryString(name string, ids []int) string {
+	str := ""
+	for k, v := range ids {
+		if k == 0 {
+			str += "?"
+		} else {
+			str += "&"
+		}
+		str += fmt.Sprintf("%s=%s", name, strconv.Itoa(v))
+	}
+	return str
+}
+
+// IntWithinRange returns TRUE if an integer falls within a defined range, and
+// FALSE if not.
+func IntWithinRange(val, min, max int) bool {
+	return val > min && val < max
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/provider_client.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/provider_client.go
@@ -1,0 +1,539 @@
+package gophercloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// DefaultUserAgent is the default User-Agent string set in the request header.
+const DefaultUserAgent = "gophercloud/2.0.0"
+
+// UserAgent represents a User-Agent header.
+type UserAgent struct {
+	// prepend is the slice of User-Agent strings to prepend to DefaultUserAgent.
+	// All the strings to prepend are accumulated and prepended in the Join method.
+	prepend []string
+}
+
+// Prepend prepends a user-defined string to the default User-Agent string. Users
+// may pass in one or more strings to prepend.
+func (ua *UserAgent) Prepend(s ...string) {
+	ua.prepend = append(s, ua.prepend...)
+}
+
+// Join concatenates all the user-defined User-Agend strings with the default
+// Gophercloud User-Agent string.
+func (ua *UserAgent) Join() string {
+	uaSlice := append(ua.prepend, DefaultUserAgent)
+	return strings.Join(uaSlice, " ")
+}
+
+// ProviderClient stores details that are required to interact with any
+// services within a specific provider's API.
+//
+// Generally, you acquire a ProviderClient by calling the NewClient method in
+// the appropriate provider's child package, providing whatever authentication
+// credentials are required.
+type ProviderClient struct {
+	// IdentityBase is the base URL used for a particular provider's identity
+	// service - it will be used when issuing authenticatation requests. It
+	// should point to the root resource of the identity service, not a specific
+	// identity version.
+	IdentityBase string
+
+	// IdentityEndpoint is the identity endpoint. This may be a specific version
+	// of the identity service. If this is the case, this endpoint is used rather
+	// than querying versions first.
+	IdentityEndpoint string
+
+	// TokenID is the ID of the most recently issued valid token.
+	// NOTE: Aside from within a custom ReauthFunc, this field shouldn't be set by an application.
+	// To safely read or write this value, call `Token` or `SetToken`, respectively
+	TokenID string
+
+	// EndpointLocator describes how this provider discovers the endpoints for
+	// its constituent services.
+	EndpointLocator EndpointLocator
+
+	// HTTPClient allows users to interject arbitrary http, https, or other transit behaviors.
+	HTTPClient http.Client
+
+	// UserAgent represents the User-Agent header in the HTTP request.
+	UserAgent UserAgent
+
+	// ReauthFunc is the function used to re-authenticate the user if the request
+	// fails with a 401 HTTP response code. This a needed because there may be multiple
+	// authentication functions for different Identity service versions.
+	ReauthFunc func() error
+
+	// Throwaway determines whether if this client is a throw-away client. It's a copy of user's provider client
+	// with the token and reauth func zeroed. Such client can be used to perform reauthorization.
+	Throwaway bool
+
+	// Context is the context passed to the HTTP request.
+	Context context.Context
+
+	// mut is a mutex for the client. It protects read and write access to client attributes such as getting
+	// and setting the TokenID.
+	mut *sync.RWMutex
+
+	// reauthmut is a mutex for reauthentication it attempts to ensure that only one reauthentication
+	// attempt happens at one time.
+	reauthmut *reauthlock
+
+	authResult AuthResult
+}
+
+// reauthlock represents a set of attributes used to help in the reauthentication process.
+type reauthlock struct {
+	sync.RWMutex
+	// This channel is non-nil during reauthentication. It can be used to ask the
+	// goroutine doing Reauthenticate() for its result. Look at the implementation
+	// of Reauthenticate() for details.
+	ongoing chan<- (chan<- error)
+}
+
+// AuthenticatedHeaders returns a map of HTTP headers that are common for all
+// authenticated service requests. Blocks if Reauthenticate is in progress.
+func (client *ProviderClient) AuthenticatedHeaders() (m map[string]string) {
+	if client.IsThrowaway() {
+		return
+	}
+	if client.reauthmut != nil {
+		// If a Reauthenticate is in progress, wait for it to complete.
+		client.reauthmut.Lock()
+		ongoing := client.reauthmut.ongoing
+		client.reauthmut.Unlock()
+		if ongoing != nil {
+			responseChannel := make(chan error)
+			ongoing <- responseChannel
+			_ = <-responseChannel
+		}
+	}
+	t := client.Token()
+	if t == "" {
+		return
+	}
+	return map[string]string{"X-Auth-Token": t}
+}
+
+// UseTokenLock creates a mutex that is used to allow safe concurrent access to the auth token.
+// If the application's ProviderClient is not used concurrently, this doesn't need to be called.
+func (client *ProviderClient) UseTokenLock() {
+	client.mut = new(sync.RWMutex)
+	client.reauthmut = new(reauthlock)
+}
+
+// GetAuthResult returns the result from the request that was used to obtain a
+// provider client's Keystone token.
+//
+// The result is nil when authentication has not yet taken place, when the token
+// was set manually with SetToken(), or when a ReauthFunc was used that does not
+// record the AuthResult.
+func (client *ProviderClient) GetAuthResult() AuthResult {
+	if client.mut != nil {
+		client.mut.RLock()
+		defer client.mut.RUnlock()
+	}
+	return client.authResult
+}
+
+// Token safely reads the value of the auth token from the ProviderClient. Applications should
+// call this method to access the token instead of the TokenID field
+func (client *ProviderClient) Token() string {
+	if client.mut != nil {
+		client.mut.RLock()
+		defer client.mut.RUnlock()
+	}
+	return client.TokenID
+}
+
+// SetToken safely sets the value of the auth token in the ProviderClient. Applications may
+// use this method in a custom ReauthFunc.
+//
+// WARNING: This function is deprecated. Use SetTokenAndAuthResult() instead.
+func (client *ProviderClient) SetToken(t string) {
+	if client.mut != nil {
+		client.mut.Lock()
+		defer client.mut.Unlock()
+	}
+	client.TokenID = t
+	client.authResult = nil
+}
+
+// SetTokenAndAuthResult safely sets the value of the auth token in the
+// ProviderClient and also records the AuthResult that was returned from the
+// token creation request. Applications may call this in a custom ReauthFunc.
+func (client *ProviderClient) SetTokenAndAuthResult(r AuthResult) error {
+	tokenID := ""
+	var err error
+	if r != nil {
+		tokenID, err = r.ExtractTokenID()
+		if err != nil {
+			return err
+		}
+	}
+
+	if client.mut != nil {
+		client.mut.Lock()
+		defer client.mut.Unlock()
+	}
+	client.TokenID = tokenID
+	client.authResult = r
+	return nil
+}
+
+// CopyTokenFrom safely copies the token from another ProviderClient into the
+// this one.
+func (client *ProviderClient) CopyTokenFrom(other *ProviderClient) {
+	if client.mut != nil {
+		client.mut.Lock()
+		defer client.mut.Unlock()
+	}
+	if other.mut != nil && other.mut != client.mut {
+		other.mut.RLock()
+		defer other.mut.RUnlock()
+	}
+	client.TokenID = other.TokenID
+	client.authResult = other.authResult
+}
+
+// IsThrowaway safely reads the value of the client Throwaway field.
+func (client *ProviderClient) IsThrowaway() bool {
+	if client.reauthmut != nil {
+		client.reauthmut.RLock()
+		defer client.reauthmut.RUnlock()
+	}
+	return client.Throwaway
+}
+
+// SetThrowaway safely sets the value of the client Throwaway field.
+func (client *ProviderClient) SetThrowaway(v bool) {
+	if client.reauthmut != nil {
+		client.reauthmut.Lock()
+		defer client.reauthmut.Unlock()
+	}
+	client.Throwaway = v
+}
+
+// Reauthenticate calls client.ReauthFunc in a thread-safe way. If this is
+// called because of a 401 response, the caller may pass the previous token. In
+// this case, the reauthentication can be skipped if another thread has already
+// reauthenticated in the meantime. If no previous token is known, an empty
+// string should be passed instead to force unconditional reauthentication.
+func (client *ProviderClient) Reauthenticate(previousToken string) error {
+	if client.ReauthFunc == nil {
+		return nil
+	}
+
+	if client.reauthmut == nil {
+		return client.ReauthFunc()
+	}
+
+	messages := make(chan (chan<- error))
+
+	// Check if a Reauthenticate is in progress, or start one if not.
+	client.reauthmut.Lock()
+	ongoing := client.reauthmut.ongoing
+	if ongoing == nil {
+		client.reauthmut.ongoing = messages
+	}
+	client.reauthmut.Unlock()
+
+	// If Reauthenticate is running elsewhere, wait for its result.
+	if ongoing != nil {
+		responseChannel := make(chan error)
+		ongoing <- responseChannel
+		return <-responseChannel
+	}
+
+	// Perform the actual reauthentication.
+	var err error
+	if previousToken == "" || client.TokenID == previousToken {
+		err = client.ReauthFunc()
+	} else {
+		err = nil
+	}
+
+	// Mark Reauthenticate as finished.
+	client.reauthmut.Lock()
+	client.reauthmut.ongoing = nil
+	client.reauthmut.Unlock()
+
+	// Report result to all other interested goroutines.
+	//
+	// This happens in a separate goroutine because another goroutine might have
+	// acquired a copy of `client.reauthmut.ongoing` before we cleared it, but not
+	// have come around to sending its request. By answering in a goroutine, we
+	// can have that goroutine linger until all responseChannels have been sent.
+	// When GC has collected all sendings ends of the channel, our receiving end
+	// will be closed and the goroutine will end.
+	go func() {
+		for responseChannel := range messages {
+			responseChannel <- err
+		}
+	}()
+	return err
+}
+
+// RequestOpts customizes the behavior of the provider.Request() method.
+type RequestOpts struct {
+	// JSONBody, if provided, will be encoded as JSON and used as the body of the HTTP request. The
+	// content type of the request will default to "application/json" unless overridden by MoreHeaders.
+	// It's an error to specify both a JSONBody and a RawBody.
+	JSONBody interface{}
+	// RawBody contains an io.Reader that will be consumed by the request directly. No content-type
+	// will be set unless one is provided explicitly by MoreHeaders.
+	RawBody io.Reader
+	// JSONResponse, if provided, will be populated with the contents of the response body parsed as
+	// JSON.
+	JSONResponse interface{}
+	// OkCodes contains a list of numeric HTTP status codes that should be interpreted as success. If
+	// the response has a different code, an error will be returned.
+	OkCodes []int
+	// MoreHeaders specifies additional HTTP headers to be provide on the request. If a header is
+	// provided with a blank value (""), that header will be *omitted* instead: use this to suppress
+	// the default Accept header or an inferred Content-Type, for example.
+	MoreHeaders map[string]string
+	// ErrorContext specifies the resource error type to return if an error is encountered.
+	// This lets resources override default error messages based on the response status code.
+	ErrorContext error
+}
+
+// requestState contains temporary state for a single ProviderClient.Request() call.
+type requestState struct {
+	// This flag indicates if we have reauthenticated during this request because of a 401 response.
+	// It ensures that we don't reauthenticate multiple times for a single request. If we
+	// reauthenticate, but keep getting 401 responses with the fresh token, reauthenticating some more
+	// will just get us into an infinite loop.
+	hasReauthenticated bool
+}
+
+var applicationJSON = "application/json"
+
+// Request performs an HTTP request using the ProviderClient's current HTTPClient. An authentication
+// header will automatically be provided.
+func (client *ProviderClient) Request(method, url string, options *RequestOpts) (*http.Response, error) {
+	return client.doRequest(method, url, options, &requestState{
+		hasReauthenticated: false,
+	})
+}
+
+func (client *ProviderClient) doRequest(method, url string, options *RequestOpts, state *requestState) (*http.Response, error) {
+	var body io.Reader
+	var contentType *string
+
+	// Derive the content body by either encoding an arbitrary object as JSON, or by taking a provided
+	// io.ReadSeeker as-is. Default the content-type to application/json.
+	if options.JSONBody != nil {
+		if options.RawBody != nil {
+			return nil, errors.New("please provide only one of JSONBody or RawBody to gophercloud.Request()")
+		}
+
+		rendered, err := json.Marshal(options.JSONBody)
+		if err != nil {
+			return nil, err
+		}
+
+		body = bytes.NewReader(rendered)
+		contentType = &applicationJSON
+	}
+
+	if options.RawBody != nil {
+		body = options.RawBody
+	}
+
+	// Construct the http.Request.
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if client.Context != nil {
+		req = req.WithContext(client.Context)
+	}
+
+	// Populate the request headers. Apply options.MoreHeaders last, to give the caller the chance to
+	// modify or omit any header.
+	if contentType != nil {
+		req.Header.Set("Content-Type", *contentType)
+	}
+	req.Header.Set("Accept", applicationJSON)
+
+	// Set the User-Agent header
+	req.Header.Set("User-Agent", client.UserAgent.Join())
+
+	if options.MoreHeaders != nil {
+		for k, v := range options.MoreHeaders {
+			if v != "" {
+				req.Header.Set(k, v)
+			} else {
+				req.Header.Del(k)
+			}
+		}
+	}
+
+	// get latest token from client
+	for k, v := range client.AuthenticatedHeaders() {
+		req.Header.Set(k, v)
+	}
+
+	// Set connection parameter to close the connection immediately when we've got the response
+	req.Close = true
+
+	prereqtok := req.Header.Get("X-Auth-Token")
+
+	// Issue the request.
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Allow default OkCodes if none explicitly set
+	okc := options.OkCodes
+	if okc == nil {
+		okc = defaultOkCodes(method)
+	}
+
+	// Validate the HTTP response status.
+	var ok bool
+	for _, code := range okc {
+		if resp.StatusCode == code {
+			ok = true
+			break
+		}
+	}
+
+	if !ok {
+		body, _ := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		respErr := ErrUnexpectedResponseCode{
+			URL:      url,
+			Method:   method,
+			Expected: options.OkCodes,
+			Actual:   resp.StatusCode,
+			Body:     body,
+		}
+
+		errType := options.ErrorContext
+		switch resp.StatusCode {
+		case http.StatusBadRequest:
+			err = ErrDefault400{respErr}
+			if error400er, ok := errType.(Err400er); ok {
+				err = error400er.Error400(respErr)
+			}
+		case http.StatusUnauthorized:
+			if client.ReauthFunc != nil && !state.hasReauthenticated {
+				err = client.Reauthenticate(prereqtok)
+				if err != nil {
+					e := &ErrUnableToReauthenticate{}
+					e.ErrOriginal = respErr
+					return nil, e
+				}
+				if options.RawBody != nil {
+					if seeker, ok := options.RawBody.(io.Seeker); ok {
+						seeker.Seek(0, 0)
+					}
+				}
+				state.hasReauthenticated = true
+				resp, err = client.doRequest(method, url, options, state)
+				if err != nil {
+					switch err.(type) {
+					case *ErrUnexpectedResponseCode:
+						e := &ErrErrorAfterReauthentication{}
+						e.ErrOriginal = err.(*ErrUnexpectedResponseCode)
+						return nil, e
+					default:
+						e := &ErrErrorAfterReauthentication{}
+						e.ErrOriginal = err
+						return nil, e
+					}
+				}
+				return resp, nil
+			}
+			err = ErrDefault401{respErr}
+			if error401er, ok := errType.(Err401er); ok {
+				err = error401er.Error401(respErr)
+			}
+		case http.StatusForbidden:
+			err = ErrDefault403{respErr}
+			if error403er, ok := errType.(Err403er); ok {
+				err = error403er.Error403(respErr)
+			}
+		case http.StatusNotFound:
+			err = ErrDefault404{respErr}
+			if error404er, ok := errType.(Err404er); ok {
+				err = error404er.Error404(respErr)
+			}
+		case http.StatusMethodNotAllowed:
+			err = ErrDefault405{respErr}
+			if error405er, ok := errType.(Err405er); ok {
+				err = error405er.Error405(respErr)
+			}
+		case http.StatusRequestTimeout:
+			err = ErrDefault408{respErr}
+			if error408er, ok := errType.(Err408er); ok {
+				err = error408er.Error408(respErr)
+			}
+		case http.StatusConflict:
+			err = ErrDefault409{respErr}
+			if error409er, ok := errType.(Err409er); ok {
+				err = error409er.Error409(respErr)
+			}
+		case 429:
+			err = ErrDefault429{respErr}
+			if error429er, ok := errType.(Err429er); ok {
+				err = error429er.Error429(respErr)
+			}
+		case http.StatusInternalServerError:
+			err = ErrDefault500{respErr}
+			if error500er, ok := errType.(Err500er); ok {
+				err = error500er.Error500(respErr)
+			}
+		case http.StatusServiceUnavailable:
+			err = ErrDefault503{respErr}
+			if error503er, ok := errType.(Err503er); ok {
+				err = error503er.Error503(respErr)
+			}
+		}
+
+		if err == nil {
+			err = respErr
+		}
+
+		return resp, err
+	}
+
+	// Parse the response body as JSON, if requested to do so.
+	if options.JSONResponse != nil {
+		defer resp.Body.Close()
+		if err := json.NewDecoder(resp.Body).Decode(options.JSONResponse); err != nil {
+			return nil, err
+		}
+	}
+
+	return resp, nil
+}
+
+func defaultOkCodes(method string) []int {
+	switch {
+	case method == "GET":
+		return []int{200}
+	case method == "POST":
+		return []int{201, 202}
+	case method == "PUT":
+		return []int{201, 202}
+	case method == "PATCH":
+		return []int{200, 202, 204}
+	case method == "DELETE":
+		return []int{202, 204}
+	}
+
+	return []int{}
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/results.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/results.go
@@ -1,0 +1,448 @@
+package gophercloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+/*
+Result is an internal type to be used by individual resource packages, but its
+methods will be available on a wide variety of user-facing embedding types.
+
+It acts as a base struct that other Result types, returned from request
+functions, can embed for convenience. All Results capture basic information
+from the HTTP transaction that was performed, including the response body,
+HTTP headers, and any errors that happened.
+
+Generally, each Result type will have an Extract method that can be used to
+further interpret the result's payload in a specific context. Extensions or
+providers can then provide additional extraction functions to pull out
+provider- or extension-specific information as well.
+*/
+type Result struct {
+	// Body is the payload of the HTTP response from the server. In most cases,
+	// this will be the deserialized JSON structure.
+	Body interface{}
+
+	// Header contains the HTTP header structure from the original response.
+	Header http.Header
+
+	// Err is an error that occurred during the operation. It's deferred until
+	// extraction to make it easier to chain the Extract call.
+	Err error
+}
+
+// ExtractInto allows users to provide an object into which `Extract` will extract
+// the `Result.Body`. This would be useful for OpenStack providers that have
+// different fields in the response object than OpenStack proper.
+func (r Result) ExtractInto(to interface{}) error {
+	if r.Err != nil {
+		return r.Err
+	}
+
+	if reader, ok := r.Body.(io.Reader); ok {
+		if readCloser, ok := reader.(io.Closer); ok {
+			defer readCloser.Close()
+		}
+		return json.NewDecoder(reader).Decode(to)
+	}
+
+	b, err := json.Marshal(r.Body)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(b, to)
+
+	return err
+}
+
+func (r Result) extractIntoPtr(to interface{}, label string) error {
+	if label == "" {
+		return r.ExtractInto(&to)
+	}
+
+	var m map[string]interface{}
+	err := r.ExtractInto(&m)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(m[label])
+	if err != nil {
+		return err
+	}
+
+	toValue := reflect.ValueOf(to)
+	if toValue.Kind() == reflect.Ptr {
+		toValue = toValue.Elem()
+	}
+
+	switch toValue.Kind() {
+	case reflect.Slice:
+		typeOfV := toValue.Type().Elem()
+		if typeOfV.Kind() == reflect.Struct {
+			if typeOfV.NumField() > 0 && typeOfV.Field(0).Anonymous {
+				newSlice := reflect.MakeSlice(reflect.SliceOf(typeOfV), 0, 0)
+
+				if mSlice, ok := m[label].([]interface{}); ok {
+					for _, v := range mSlice {
+						// For each iteration of the slice, we create a new struct.
+						// This is to work around a bug where elements of a slice
+						// are reused and not overwritten when the same copy of the
+						// struct is used:
+						//
+						// https://github.com/golang/go/issues/21092
+						// https://github.com/golang/go/issues/24155
+						// https://play.golang.org/p/NHo3ywlPZli
+						newType := reflect.New(typeOfV).Elem()
+
+						b, err := json.Marshal(v)
+						if err != nil {
+							return err
+						}
+
+						// This is needed for structs with an UnmarshalJSON method.
+						// Technically this is just unmarshalling the response into
+						// a struct that is never used, but it's good enough to
+						// trigger the UnmarshalJSON method.
+						for i := 0; i < newType.NumField(); i++ {
+							s := newType.Field(i).Addr().Interface()
+
+							// Unmarshal is used rather than NewDecoder to also work
+							// around the above-mentioned bug.
+							err = json.Unmarshal(b, s)
+							if err != nil {
+								return err
+							}
+						}
+
+						newSlice = reflect.Append(newSlice, newType)
+					}
+				}
+
+				// "to" should now be properly modeled to receive the
+				// JSON response body and unmarshal into all the correct
+				// fields of the struct or composed extension struct
+				// at the end of this method.
+				toValue.Set(newSlice)
+			}
+		}
+	case reflect.Struct:
+		typeOfV := toValue.Type()
+		if typeOfV.NumField() > 0 && typeOfV.Field(0).Anonymous {
+			for i := 0; i < toValue.NumField(); i++ {
+				toField := toValue.Field(i)
+				if toField.Kind() == reflect.Struct {
+					s := toField.Addr().Interface()
+					err = json.NewDecoder(bytes.NewReader(b)).Decode(s)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	err = json.Unmarshal(b, &to)
+	return err
+}
+
+// ExtractIntoStructPtr will unmarshal the Result (r) into the provided
+// interface{} (to).
+//
+// NOTE: For internal use only
+//
+// `to` must be a pointer to an underlying struct type
+//
+// If provided, `label` will be filtered out of the response
+// body prior to `r` being unmarshalled into `to`.
+func (r Result) ExtractIntoStructPtr(to interface{}, label string) error {
+	if r.Err != nil {
+		return r.Err
+	}
+
+	t := reflect.TypeOf(to)
+	if k := t.Kind(); k != reflect.Ptr {
+		return fmt.Errorf("Expected pointer, got %v", k)
+	}
+	switch t.Elem().Kind() {
+	case reflect.Struct:
+		return r.extractIntoPtr(to, label)
+	default:
+		return fmt.Errorf("Expected pointer to struct, got: %v", t)
+	}
+}
+
+// ExtractIntoSlicePtr will unmarshal the Result (r) into the provided
+// interface{} (to).
+//
+// NOTE: For internal use only
+//
+// `to` must be a pointer to an underlying slice type
+//
+// If provided, `label` will be filtered out of the response
+// body prior to `r` being unmarshalled into `to`.
+func (r Result) ExtractIntoSlicePtr(to interface{}, label string) error {
+	if r.Err != nil {
+		return r.Err
+	}
+
+	t := reflect.TypeOf(to)
+	if k := t.Kind(); k != reflect.Ptr {
+		return fmt.Errorf("Expected pointer, got %v", k)
+	}
+	switch t.Elem().Kind() {
+	case reflect.Slice:
+		return r.extractIntoPtr(to, label)
+	default:
+		return fmt.Errorf("Expected pointer to slice, got: %v", t)
+	}
+}
+
+// PrettyPrintJSON creates a string containing the full response body as
+// pretty-printed JSON. It's useful for capturing test fixtures and for
+// debugging extraction bugs. If you include its output in an issue related to
+// a buggy extraction function, we will all love you forever.
+func (r Result) PrettyPrintJSON() string {
+	pretty, err := json.MarshalIndent(r.Body, "", "  ")
+	if err != nil {
+		panic(err.Error())
+	}
+	return string(pretty)
+}
+
+// ErrResult is an internal type to be used by individual resource packages, but
+// its methods will be available on a wide variety of user-facing embedding
+// types.
+//
+// It represents results that only contain a potential error and
+// nothing else. Usually, if the operation executed successfully, the Err field
+// will be nil; otherwise it will be stocked with a relevant error. Use the
+// ExtractErr method
+// to cleanly pull it out.
+type ErrResult struct {
+	Result
+}
+
+// ExtractErr is a function that extracts error information, or nil, from a result.
+func (r ErrResult) ExtractErr() error {
+	return r.Err
+}
+
+/*
+HeaderResult is an internal type to be used by individual resource packages, but
+its methods will be available on a wide variety of user-facing embedding types.
+
+It represents a result that only contains an error (possibly nil) and an
+http.Header. This is used, for example, by the objectstorage packages in
+openstack, because most of the operations don't return response bodies, but do
+have relevant information in headers.
+*/
+type HeaderResult struct {
+	Result
+}
+
+// ExtractInto allows users to provide an object into which `Extract` will
+// extract the http.Header headers of the result.
+func (r HeaderResult) ExtractInto(to interface{}) error {
+	if r.Err != nil {
+		return r.Err
+	}
+
+	tmpHeaderMap := map[string]string{}
+	for k, v := range r.Header {
+		if len(v) > 0 {
+			tmpHeaderMap[k] = v[0]
+		}
+	}
+
+	b, err := json.Marshal(tmpHeaderMap)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(b, to)
+
+	return err
+}
+
+// RFC3339Milli describes a common time format used by some API responses.
+const RFC3339Milli = "2006-01-02T15:04:05.999999Z"
+
+type JSONRFC3339Milli time.Time
+
+func (jt *JSONRFC3339Milli) UnmarshalJSON(data []byte) error {
+	b := bytes.NewBuffer(data)
+	dec := json.NewDecoder(b)
+	var s string
+	if err := dec.Decode(&s); err != nil {
+		return err
+	}
+	t, err := time.Parse(RFC3339Milli, s)
+	if err != nil {
+		return err
+	}
+	*jt = JSONRFC3339Milli(t)
+	return nil
+}
+
+const RFC3339MilliNoZ = "2006-01-02T15:04:05.999999"
+
+type JSONRFC3339MilliNoZ time.Time
+
+func (jt *JSONRFC3339MilliNoZ) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(RFC3339MilliNoZ, s)
+	if err != nil {
+		return err
+	}
+	*jt = JSONRFC3339MilliNoZ(t)
+	return nil
+}
+
+type JSONRFC1123 time.Time
+
+func (jt *JSONRFC1123) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC1123, s)
+	if err != nil {
+		return err
+	}
+	*jt = JSONRFC1123(t)
+	return nil
+}
+
+type JSONUnix time.Time
+
+func (jt *JSONUnix) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	unix, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	t = time.Unix(unix, 0)
+	*jt = JSONUnix(t)
+	return nil
+}
+
+// RFC3339NoZ is the time format used in Heat (Orchestration).
+const RFC3339NoZ = "2006-01-02T15:04:05"
+
+type JSONRFC3339NoZ time.Time
+
+func (jt *JSONRFC3339NoZ) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(RFC3339NoZ, s)
+	if err != nil {
+		return err
+	}
+	*jt = JSONRFC3339NoZ(t)
+	return nil
+}
+
+// RFC3339ZNoT is the time format used in Zun (Containers Service).
+const RFC3339ZNoT = "2006-01-02 15:04:05-07:00"
+
+type JSONRFC3339ZNoT time.Time
+
+func (jt *JSONRFC3339ZNoT) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(RFC3339ZNoT, s)
+	if err != nil {
+		return err
+	}
+	*jt = JSONRFC3339ZNoT(t)
+	return nil
+}
+
+// RFC3339ZNoTNoZ is another time format used in Zun (Containers Service).
+const RFC3339ZNoTNoZ = "2006-01-02 15:04:05"
+
+type JSONRFC3339ZNoTNoZ time.Time
+
+func (jt *JSONRFC3339ZNoTNoZ) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(RFC3339ZNoTNoZ, s)
+	if err != nil {
+		return err
+	}
+	*jt = JSONRFC3339ZNoTNoZ(t)
+	return nil
+}
+
+/*
+Link is an internal type to be used in packages of collection resources that are
+paginated in a certain way.
+
+It's a response substructure common to many paginated collection results that is
+used to point to related pages. Usually, the one we care about is the one with
+Rel field set to "next".
+*/
+type Link struct {
+	Href string `json:"href"`
+	Rel  string `json:"rel"`
+}
+
+/*
+ExtractNextURL is an internal function useful for packages of collection
+resources that are paginated in a certain way.
+
+It attempts to extract the "next" URL from slice of Link structs, or
+"" if no such URL is present.
+*/
+func ExtractNextURL(links []Link) (string, error) {
+	var url string
+
+	for _, l := range links {
+		if l.Rel == "next" {
+			url = l.Href
+		}
+	}
+
+	if url == "" {
+		return "", nil
+	}
+
+	return url, nil
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/service_client.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/service_client.go
@@ -1,0 +1,154 @@
+package gophercloud
+
+import (
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ServiceClient stores details required to interact with a specific service API implemented by a provider.
+// Generally, you'll acquire these by calling the appropriate `New` method on a ProviderClient.
+type ServiceClient struct {
+	// ProviderClient is a reference to the provider that implements this service.
+	*ProviderClient
+
+	// Endpoint is the base URL of the service's API, acquired from a service catalog.
+	// It MUST end with a /.
+	Endpoint string
+
+	// ResourceBase is the base URL shared by the resources within a service's API. It should include
+	// the API version and, like Endpoint, MUST end with a / if set. If not set, the Endpoint is used
+	// as-is, instead.
+	ResourceBase string
+
+	// This is the service client type (e.g. compute, sharev2).
+	// NOTE: FOR INTERNAL USE ONLY. DO NOT SET. GOPHERCLOUD WILL SET THIS.
+	// It is only exported because it gets set in a different package.
+	Type string
+
+	// The microversion of the service to use. Set this to use a particular microversion.
+	Microversion string
+
+	// MoreHeaders allows users (or Gophercloud) to set service-wide headers on requests. Put another way,
+	// values set in this field will be set on all the HTTP requests the service client sends.
+	MoreHeaders map[string]string
+}
+
+// ResourceBaseURL returns the base URL of any resources used by this service. It MUST end with a /.
+func (client *ServiceClient) ResourceBaseURL() string {
+	if client.ResourceBase != "" {
+		return client.ResourceBase
+	}
+	return client.Endpoint
+}
+
+// ServiceURL constructs a URL for a resource belonging to this provider.
+func (client *ServiceClient) ServiceURL(parts ...string) string {
+	return client.ResourceBaseURL() + strings.Join(parts, "/")
+}
+
+func (client *ServiceClient) initReqOpts(url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) {
+	if v, ok := (JSONBody).(io.Reader); ok {
+		opts.RawBody = v
+	} else if JSONBody != nil {
+		opts.JSONBody = JSONBody
+	}
+
+	if JSONResponse != nil {
+		opts.JSONResponse = JSONResponse
+	}
+
+	if opts.MoreHeaders == nil {
+		opts.MoreHeaders = make(map[string]string)
+	}
+
+	if client.Microversion != "" {
+		client.setMicroversionHeader(opts)
+	}
+}
+
+// Get calls `Request` with the "GET" HTTP verb.
+func (client *ServiceClient) Get(url string, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	if opts == nil {
+		opts = new(RequestOpts)
+	}
+	client.initReqOpts(url, nil, JSONResponse, opts)
+	return client.Request("GET", url, opts)
+}
+
+// Post calls `Request` with the "POST" HTTP verb.
+func (client *ServiceClient) Post(url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	if opts == nil {
+		opts = new(RequestOpts)
+	}
+	client.initReqOpts(url, JSONBody, JSONResponse, opts)
+	return client.Request("POST", url, opts)
+}
+
+// Put calls `Request` with the "PUT" HTTP verb.
+func (client *ServiceClient) Put(url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	if opts == nil {
+		opts = new(RequestOpts)
+	}
+	client.initReqOpts(url, JSONBody, JSONResponse, opts)
+	return client.Request("PUT", url, opts)
+}
+
+// Patch calls `Request` with the "PATCH" HTTP verb.
+func (client *ServiceClient) Patch(url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	if opts == nil {
+		opts = new(RequestOpts)
+	}
+	client.initReqOpts(url, JSONBody, JSONResponse, opts)
+	return client.Request("PATCH", url, opts)
+}
+
+// Delete calls `Request` with the "DELETE" HTTP verb.
+func (client *ServiceClient) Delete(url string, opts *RequestOpts) (*http.Response, error) {
+	if opts == nil {
+		opts = new(RequestOpts)
+	}
+	client.initReqOpts(url, nil, nil, opts)
+	return client.Request("DELETE", url, opts)
+}
+
+// Head calls `Request` with the "HEAD" HTTP verb.
+func (client *ServiceClient) Head(url string, opts *RequestOpts) (*http.Response, error) {
+	if opts == nil {
+		opts = new(RequestOpts)
+	}
+	client.initReqOpts(url, nil, nil, opts)
+	return client.Request("HEAD", url, opts)
+}
+
+func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
+	switch client.Type {
+	case "compute":
+		opts.MoreHeaders["X-OpenStack-Nova-API-Version"] = client.Microversion
+	case "sharev2":
+		opts.MoreHeaders["X-OpenStack-Manila-API-Version"] = client.Microversion
+	case "volume":
+		opts.MoreHeaders["X-OpenStack-Volume-API-Version"] = client.Microversion
+	case "baremetal":
+		opts.MoreHeaders["X-OpenStack-Ironic-API-Version"] = client.Microversion
+	case "baremetal-introspection":
+		opts.MoreHeaders["X-OpenStack-Ironic-Inspector-API-Version"] = client.Microversion
+	}
+
+	if client.Type != "" {
+		opts.MoreHeaders["OpenStack-API-Version"] = client.Type + " " + client.Microversion
+	}
+}
+
+// Request carries out the HTTP operation for the service client
+func (client *ServiceClient) Request(method, url string, options *RequestOpts) (*http.Response, error) {
+	if len(client.MoreHeaders) > 0 {
+		if options == nil {
+			options = new(RequestOpts)
+		}
+		for k, v := range client.MoreHeaders {
+			options.MoreHeaders[k] = v
+		}
+	}
+	return client.ProviderClient.Request(method, url, options)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/testhelper/convenience.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/testhelper/convenience.go
@@ -1,0 +1,348 @@
+package testhelper
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	logBodyFmt = "\033[1;31m%s %s\033[0m"
+	greenCode  = "\033[0m\033[1;32m"
+	yellowCode = "\033[0m\033[1;33m"
+	resetCode  = "\033[0m\033[1;31m"
+)
+
+func prefix(depth int) string {
+	_, file, line, _ := runtime.Caller(depth)
+	return fmt.Sprintf("Failure in %s, line %d:", filepath.Base(file), line)
+}
+
+func green(str interface{}) string {
+	return fmt.Sprintf("%s%#v%s", greenCode, str, resetCode)
+}
+
+func yellow(str interface{}) string {
+	return fmt.Sprintf("%s%#v%s", yellowCode, str, resetCode)
+}
+
+func logFatal(t *testing.T, str string) {
+	t.Fatalf(logBodyFmt, prefix(3), str)
+}
+
+func logError(t *testing.T, str string) {
+	t.Errorf(logBodyFmt, prefix(3), str)
+}
+
+type diffLogger func([]string, interface{}, interface{})
+
+type visit struct {
+	a1  uintptr
+	a2  uintptr
+	typ reflect.Type
+}
+
+// Recursively visits the structures of "expected" and "actual". The diffLogger function will be
+// invoked with each different value encountered, including the reference path that was followed
+// to get there.
+func deepDiffEqual(expected, actual reflect.Value, visited map[visit]bool, path []string, logDifference diffLogger) {
+	defer func() {
+		// Fall back to the regular reflect.DeepEquals function.
+		if r := recover(); r != nil {
+			var e, a interface{}
+			if expected.IsValid() {
+				e = expected.Interface()
+			}
+			if actual.IsValid() {
+				a = actual.Interface()
+			}
+
+			if !reflect.DeepEqual(e, a) {
+				logDifference(path, e, a)
+			}
+		}
+	}()
+
+	if !expected.IsValid() && actual.IsValid() {
+		logDifference(path, nil, actual.Interface())
+		return
+	}
+	if expected.IsValid() && !actual.IsValid() {
+		logDifference(path, expected.Interface(), nil)
+		return
+	}
+	if !expected.IsValid() && !actual.IsValid() {
+		return
+	}
+
+	hard := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct:
+			return true
+		}
+		return false
+	}
+
+	if expected.CanAddr() && actual.CanAddr() && hard(expected.Kind()) {
+		addr1 := expected.UnsafeAddr()
+		addr2 := actual.UnsafeAddr()
+
+		if addr1 > addr2 {
+			addr1, addr2 = addr2, addr1
+		}
+
+		if addr1 == addr2 {
+			// References are identical. We can short-circuit
+			return
+		}
+
+		typ := expected.Type()
+		v := visit{addr1, addr2, typ}
+		if visited[v] {
+			// Already visited.
+			return
+		}
+
+		// Remember this visit for later.
+		visited[v] = true
+	}
+
+	switch expected.Kind() {
+	case reflect.Array:
+		for i := 0; i < expected.Len(); i++ {
+			hop := append(path, fmt.Sprintf("[%d]", i))
+			deepDiffEqual(expected.Index(i), actual.Index(i), visited, hop, logDifference)
+		}
+		return
+	case reflect.Slice:
+		if expected.IsNil() != actual.IsNil() {
+			logDifference(path, expected.Interface(), actual.Interface())
+			return
+		}
+		if expected.Len() == actual.Len() && expected.Pointer() == actual.Pointer() {
+			return
+		}
+		for i := 0; i < expected.Len(); i++ {
+			hop := append(path, fmt.Sprintf("[%d]", i))
+			deepDiffEqual(expected.Index(i), actual.Index(i), visited, hop, logDifference)
+		}
+		return
+	case reflect.Interface:
+		if expected.IsNil() != actual.IsNil() {
+			logDifference(path, expected.Interface(), actual.Interface())
+			return
+		}
+		deepDiffEqual(expected.Elem(), actual.Elem(), visited, path, logDifference)
+		return
+	case reflect.Ptr:
+		deepDiffEqual(expected.Elem(), actual.Elem(), visited, path, logDifference)
+		return
+	case reflect.Struct:
+		for i, n := 0, expected.NumField(); i < n; i++ {
+			field := expected.Type().Field(i)
+			hop := append(path, "."+field.Name)
+			deepDiffEqual(expected.Field(i), actual.Field(i), visited, hop, logDifference)
+		}
+		return
+	case reflect.Map:
+		if expected.IsNil() != actual.IsNil() {
+			logDifference(path, expected.Interface(), actual.Interface())
+			return
+		}
+		if expected.Len() == actual.Len() && expected.Pointer() == actual.Pointer() {
+			return
+		}
+
+		var keys []reflect.Value
+		if expected.Len() >= actual.Len() {
+			keys = expected.MapKeys()
+		} else {
+			keys = actual.MapKeys()
+		}
+
+		for _, k := range keys {
+			expectedValue := expected.MapIndex(k)
+			actualValue := actual.MapIndex(k)
+
+			if !expectedValue.IsValid() {
+				logDifference(path, nil, actual.Interface())
+				return
+			}
+			if !actualValue.IsValid() {
+				logDifference(path, expected.Interface(), nil)
+				return
+			}
+
+			hop := append(path, fmt.Sprintf("[%v]", k))
+			deepDiffEqual(expectedValue, actualValue, visited, hop, logDifference)
+		}
+		return
+	case reflect.Func:
+		if expected.IsNil() != actual.IsNil() {
+			logDifference(path, expected.Interface(), actual.Interface())
+		}
+		return
+	default:
+		if expected.Interface() != actual.Interface() {
+			logDifference(path, expected.Interface(), actual.Interface())
+		}
+	}
+}
+
+func deepDiff(expected, actual interface{}, logDifference diffLogger) {
+	if expected == nil || actual == nil {
+		logDifference([]string{}, expected, actual)
+		return
+	}
+
+	expectedValue := reflect.ValueOf(expected)
+	actualValue := reflect.ValueOf(actual)
+
+	if expectedValue.Type() != actualValue.Type() {
+		logDifference([]string{}, expected, actual)
+		return
+	}
+	deepDiffEqual(expectedValue, actualValue, map[visit]bool{}, []string{}, logDifference)
+}
+
+// AssertEquals compares two arbitrary values and performs a comparison. If the
+// comparison fails, a fatal error is raised that will fail the test
+func AssertEquals(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		logFatal(t, fmt.Sprintf("expected %s but got %s", green(expected), yellow(actual)))
+	}
+}
+
+// CheckEquals is similar to AssertEquals, except with a non-fatal error
+func CheckEquals(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		logError(t, fmt.Sprintf("expected %s but got %s", green(expected), yellow(actual)))
+	}
+}
+
+// AssertDeepEquals - like Equals - performs a comparison - but on more complex
+// structures that requires deeper inspection
+func AssertDeepEquals(t *testing.T, expected, actual interface{}) {
+	pre := prefix(2)
+
+	differed := false
+	deepDiff(expected, actual, func(path []string, expected, actual interface{}) {
+		differed = true
+		t.Errorf("\033[1;31m%sat %s expected %s, but got %s\033[0m",
+			pre,
+			strings.Join(path, ""),
+			green(expected),
+			yellow(actual))
+	})
+	if differed {
+		logFatal(t, "The structures were different.")
+	}
+}
+
+// CheckDeepEquals is similar to AssertDeepEquals, except with a non-fatal error
+func CheckDeepEquals(t *testing.T, expected, actual interface{}) {
+	pre := prefix(2)
+
+	deepDiff(expected, actual, func(path []string, expected, actual interface{}) {
+		t.Errorf("\033[1;31m%s at %s expected %s, but got %s\033[0m",
+			pre,
+			strings.Join(path, ""),
+			green(expected),
+			yellow(actual))
+	})
+}
+
+func isByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) bool {
+	return bytes.Equal(expectedBytes, actualBytes)
+}
+
+// AssertByteArrayEquals a convenience function for checking whether two byte arrays are equal
+func AssertByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) {
+	if !isByteArrayEquals(t, expectedBytes, actualBytes) {
+		logFatal(t, "The bytes differed.")
+	}
+}
+
+// CheckByteArrayEquals a convenience function for silent checking whether two byte arrays are equal
+func CheckByteArrayEquals(t *testing.T, expectedBytes []byte, actualBytes []byte) {
+	if !isByteArrayEquals(t, expectedBytes, actualBytes) {
+		logError(t, "The bytes differed.")
+	}
+}
+
+// isJSONEquals is a utility function that implements JSON comparison for AssertJSONEquals and
+// CheckJSONEquals.
+func isJSONEquals(t *testing.T, expectedJSON string, actual interface{}) bool {
+	var parsedExpected, parsedActual interface{}
+	err := json.Unmarshal([]byte(expectedJSON), &parsedExpected)
+	if err != nil {
+		t.Errorf("Unable to parse expected value as JSON: %v", err)
+		return false
+	}
+
+	jsonActual, err := json.Marshal(actual)
+	AssertNoErr(t, err)
+	err = json.Unmarshal(jsonActual, &parsedActual)
+	AssertNoErr(t, err)
+
+	if !reflect.DeepEqual(parsedExpected, parsedActual) {
+		prettyExpected, err := json.MarshalIndent(parsedExpected, "", "  ")
+		if err != nil {
+			t.Logf("Unable to pretty-print expected JSON: %v\n%s", err, expectedJSON)
+		} else {
+			// We can't use green() here because %#v prints prettyExpected as a byte array literal, which
+			// is... unhelpful. Converting it to a string first leaves "\n" uninterpreted for some reason.
+			t.Logf("Expected JSON:\n%s%s%s", greenCode, prettyExpected, resetCode)
+		}
+
+		prettyActual, err := json.MarshalIndent(actual, "", "  ")
+		if err != nil {
+			t.Logf("Unable to pretty-print actual JSON: %v\n%#v", err, actual)
+		} else {
+			// We can't use yellow() for the same reason.
+			t.Logf("Actual JSON:\n%s%s%s", yellowCode, prettyActual, resetCode)
+		}
+
+		return false
+	}
+	return true
+}
+
+// AssertJSONEquals serializes a value as JSON, parses an expected string as JSON, and ensures that
+// both are consistent. If they aren't, the expected and actual structures are pretty-printed and
+// shown for comparison.
+//
+// This is useful for comparing structures that are built as nested map[string]interface{} values,
+// which are a pain to construct as literals.
+func AssertJSONEquals(t *testing.T, expectedJSON string, actual interface{}) {
+	if !isJSONEquals(t, expectedJSON, actual) {
+		logFatal(t, "The generated JSON structure differed.")
+	}
+}
+
+// CheckJSONEquals is similar to AssertJSONEquals, but nonfatal.
+func CheckJSONEquals(t *testing.T, expectedJSON string, actual interface{}) {
+	if !isJSONEquals(t, expectedJSON, actual) {
+		logError(t, "The generated JSON structure differed.")
+	}
+}
+
+// AssertNoErr is a convenience function for checking whether an error value is
+// an actual error
+func AssertNoErr(t *testing.T, e error) {
+	if e != nil {
+		logFatal(t, fmt.Sprintf("unexpected error %s", yellow(e.Error())))
+	}
+}
+
+// CheckNoErr is similar to AssertNoErr, except with a non-fatal error
+func CheckNoErr(t *testing.T, e error) {
+	if e != nil {
+		logError(t, fmt.Sprintf("unexpected error %s", yellow(e.Error())))
+	}
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/testhelper/doc.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/testhelper/doc.go
@@ -1,0 +1,4 @@
+/*
+Package testhelper container methods that are useful for writing unit tests.
+*/
+package testhelper

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/testhelper/http_responses.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/testhelper/http_responses.go
@@ -1,0 +1,91 @@
+package testhelper
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+var (
+	// Mux is a multiplexer that can be used to register handlers.
+	Mux *http.ServeMux
+
+	// Server is an in-memory HTTP server for testing.
+	Server *httptest.Server
+)
+
+// SetupHTTP prepares the Mux and Server.
+func SetupHTTP() {
+	Mux = http.NewServeMux()
+	Server = httptest.NewServer(Mux)
+}
+
+// TeardownHTTP releases HTTP-related resources.
+func TeardownHTTP() {
+	Server.Close()
+}
+
+// Endpoint returns a fake endpoint that will actually target the Mux.
+func Endpoint() string {
+	return Server.URL + "/"
+}
+
+// TestFormValues ensures that all the URL parameters given to the http.Request are the same as values.
+func TestFormValues(t *testing.T, r *http.Request, values map[string]string) {
+	want := url.Values{}
+	for k, v := range values {
+		want.Add(k, v)
+	}
+
+	r.ParseForm()
+	if !reflect.DeepEqual(want, r.Form) {
+		t.Errorf("Request parameters = %v, want %v", r.Form, want)
+	}
+}
+
+// TestMethod checks that the Request has the expected method (e.g. GET, POST).
+func TestMethod(t *testing.T, r *http.Request, expected string) {
+	if expected != r.Method {
+		t.Errorf("Request method = %v, expected %v", r.Method, expected)
+	}
+}
+
+// TestHeader checks that the header on the http.Request matches the expected value.
+func TestHeader(t *testing.T, r *http.Request, header string, expected string) {
+	if actual := r.Header.Get(header); expected != actual {
+		t.Errorf("Header %s = %s, expected %s", header, actual, expected)
+	}
+}
+
+// TestBody verifies that the request body matches an expected body.
+func TestBody(t *testing.T, r *http.Request, expected string) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("Unable to read body: %v", err)
+	}
+	str := string(b)
+	if expected != str {
+		t.Errorf("Body = %s, expected %s", str, expected)
+	}
+}
+
+// TestJSONRequest verifies that the JSON payload of a request matches an expected structure, without asserting things about
+// whitespace or ordering.
+func TestJSONRequest(t *testing.T, r *http.Request, expected string) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("Unable to read request body: %v", err)
+	}
+
+	var actualJSON interface{}
+	err = json.Unmarshal(b, &actualJSON)
+	if err != nil {
+		t.Errorf("Unable to parse request body as JSON: %v", err)
+	}
+
+	CheckJSONEquals(t, expected, actualJSON)
+}

--- a/cluster-autoscaler/cloudprovider/vke/gophercloud/util.go
+++ b/cluster-autoscaler/cloudprovider/vke/gophercloud/util.go
@@ -1,0 +1,102 @@
+package gophercloud
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// WaitFor polls a predicate function, once per second, up to a timeout limit.
+// This is useful to wait for a resource to transition to a certain state.
+// To handle situations when the predicate might hang indefinitely, the
+// predicate will be prematurely cancelled after the timeout.
+// Resource packages will wrap this in a more convenient function that's
+// specific to a certain resource, but it can also be useful on its own.
+func WaitFor(timeout int, predicate func() (bool, error)) error {
+	type WaitForResult struct {
+		Success bool
+		Error   error
+	}
+
+	start := time.Now().Unix()
+
+	for {
+		// If a timeout is set, and that's been exceeded, shut it down.
+		if timeout >= 0 && time.Now().Unix()-start >= int64(timeout) {
+			return fmt.Errorf("A timeout occurred")
+		}
+
+		time.Sleep(1 * time.Second)
+
+		var result WaitForResult
+		ch := make(chan bool, 1)
+		go func() {
+			defer close(ch)
+			satisfied, err := predicate()
+			result.Success = satisfied
+			result.Error = err
+		}()
+
+		select {
+		case <-ch:
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.Success {
+				return nil
+			}
+		// If the predicate has not finished by the timeout, cancel it.
+		case <-time.After(time.Duration(timeout) * time.Second):
+			return fmt.Errorf("A timeout occurred")
+		}
+	}
+}
+
+// NormalizeURL is an internal function to be used by provider clients.
+//
+// It ensures that each endpoint URL has a closing `/`, as expected by
+// ServiceClient's methods.
+func NormalizeURL(url string) string {
+	if !strings.HasSuffix(url, "/") {
+		return url + "/"
+	}
+	return url
+}
+
+// NormalizePathURL is used to convert rawPath to a fqdn, using basePath as
+// a reference in the filesystem, if necessary. basePath is assumed to contain
+// either '.' when first used, or the file:// type fqdn of the parent resource.
+// e.g. myFavScript.yaml => file://opt/lib/myFavScript.yaml
+func NormalizePathURL(basePath, rawPath string) (string, error) {
+	u, err := url.Parse(rawPath)
+	if err != nil {
+		return "", err
+	}
+	// if a scheme is defined, it must be a fqdn already
+	if u.Scheme != "" {
+		return u.String(), nil
+	}
+	// if basePath is a url, then child resources are assumed to be relative to it
+	bu, err := url.Parse(basePath)
+	if err != nil {
+		return "", err
+	}
+	var basePathSys, absPathSys string
+	if bu.Scheme != "" {
+		basePathSys = filepath.FromSlash(bu.Path)
+		absPathSys = filepath.Join(basePathSys, rawPath)
+		bu.Path = filepath.ToSlash(absPathSys)
+		return bu.String(), nil
+	}
+
+	absPathSys = filepath.Join(basePath, rawPath)
+	u.Path = filepath.ToSlash(absPathSys)
+	if err != nil {
+		return "", err
+	}
+	u.Scheme = "file"
+	return u.String(), nil
+
+}

--- a/cluster-autoscaler/cloudprovider/vke/sdk/configuration.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/configuration.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Use variables for easier test overload
+var (
+	systemConfigPath = "/etc/vke.conf"
+	userConfigPath   = "/.vke.conf" // prefixed with homeDir
+	localConfigPath  = "./vke.conf"
+)
+
+func (c *Client) loadConfig(endpointName string) error {
+	// Load real endpoint URL by name. If endpoint contains a '/', consider it as a URL
+	if strings.Contains(endpointName, "/") {
+		c.endpoint = endpointName
+	} else {
+		c.endpoint = Endpoints[endpointName]
+	}
+
+	// If we still have no valid endpoint, AppKey or AppSecret, return an error
+	if c.endpoint == "" {
+		return fmt.Errorf("unknown endpoint '%s', consider checking 'Endpoints' list of using an URL", endpointName)
+	}
+	if c.AppKey == "" {
+		return fmt.Errorf("missing application key, please check your configuration or consult the documentation to create one")
+	}
+	if c.AppSecret == "" {
+		return fmt.Errorf("missing application secret, please check your configuration or consult the documentation to create one")
+	}
+
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/vke/sdk/error.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/error.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const canadianTenantSyncErrorMessage = "Internal Server Error"
+
+// APIError represents an error that can occurred while calling the API.
+type APIError struct {
+	// Error message.
+	Message string
+	// HTTP code.
+	Code int
+	// ID of the request
+	QueryID string
+}
+
+func (err *APIError) Error() string {
+	return fmt.Sprintf("Error %d: %q", err.Code, err.Message)
+}
+
+type (
+	// Error struct
+	Error struct {
+		StatusCode int
+		Method     string
+		Path       string
+		Type       string
+		Message    string
+	}
+)
+
+func (e Error) Error() string {
+	return fmt.Sprintf("%d: %s", e.StatusCode, e.Message)
+}
+
+// IsPossiblyCanadianTenantSyncError returns whether the given error and URL could be due to the tenant being canadian and too recent.
+// This is a temporary fix until the issue is correctly handled
+func IsPossiblyCanadianTenantSyncError(err error, url string) bool {
+	var apiError *APIError
+	return (strings.HasPrefix(url, VKE) || strings.HasPrefix(url, os.Getenv("VKE_URL"))) &&
+		errors.As(err, &apiError) &&
+		apiError.Code == http.StatusInternalServerError &&
+		apiError.Message == canadianTenantSyncErrorMessage
+}

--- a/cluster-autoscaler/cloudprovider/vke/sdk/flavor.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/flavor.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 )
 
+// Flavor represents a VKE machine flavor usable for node templates.
 type Flavor struct {
 	Id       string `json:"id"`
 	Category string `json:"category"`

--- a/cluster-autoscaler/cloudprovider/vke/sdk/flavor.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/flavor.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"context"
+	"fmt"
+)
+
+type Flavor struct {
+	Id       string `json:"id"`
+	Category string `json:"category"`
+	State    string `json:"state"`
+	VCPUs    int    `json:"vCPUs"`
+	GPUs     int    `json:"gpus"`
+	RAM      int    `json:"ram"`
+}
+
+// ListClusterFlavors allows to display flavors available for nodes templates
+func (c *Client) ListClusterFlavors(ctx context.Context, clusterID string) ([]Flavor, error) {
+	flavors := make([]Flavor, 0)
+
+	return flavors, c.CallAPIWithContext(
+		ctx,
+		"GET",
+		fmt.Sprintf("/cluster/%s/flavors", clusterID),
+		nil,
+		&flavors,
+		nil,
+		nil,
+		true,
+	)
+}

--- a/cluster-autoscaler/cloudprovider/vke/sdk/logger.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/logger.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"net/http"
+)
+
+// Logger is the interface that should be implemented for loggers that wish to
+// log HTTP requests and HTTP responses.
+type Logger interface {
+	// LogRequest logs an HTTP request.
+	LogRequest(*http.Request)
+
+	// LogResponse logs an HTTP response.
+	LogResponse(*http.Response)
+}

--- a/cluster-autoscaler/cloudprovider/vke/sdk/mock.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/mock.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// ClientMock mocks the API client
+type ClientMock struct {
+	mock.Mock
+}
+
+// ListNodePools mocks API call for listing node pools in a cluster
+func (m *ClientMock) ListNodePools(ctx context.Context, clusterID string) ([]NodePool, error) {
+	args := m.Called(ctx, clusterID)
+	return args.Get(0).([]NodePool), args.Error(1)
+}
+
+// ListNodePoolNodes mocks API call for listing nodes in a pool
+func (m *ClientMock) ListNodePoolNodes(ctx context.Context, clusterID string, poolID string) ([]Node, error) {
+	args := m.Called(ctx, clusterID, poolID)
+	return args.Get(0).([]Node), args.Error(1)
+}
+
+// DeleteNode mocks API call to delete a node
+func (m *ClientMock) DeleteNode(ctx context.Context, clusterID string, nodeGroupID string, id string) error {
+	args := m.Called(ctx, clusterID, nodeGroupID, id)
+	return args.Error(0)
+}
+
+// ListClusterFlavors mocks API call for listing available flavors in a cluster
+func (m *ClientMock) ListClusterFlavors(ctx context.Context, clusterID string) ([]Flavor, error) {
+	args := m.Called(ctx, clusterID)
+	return args.Get(0).([]Flavor), args.Error(1)
+}
+
+// AddNode mocks API call for adding a node to a node pool
+func (m *ClientMock) AddNode(ctx context.Context, clusterID string, nodeGroupID string) (*Node, error) {
+	args := m.Called(ctx, clusterID, nodeGroupID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*Node), args.Error(1)
+}

--- a/cluster-autoscaler/cloudprovider/vke/sdk/node.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/node.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// type Node struct {
+// 	ID         string `json:"id"`
+// 	InstanceID string `json:"instanceId"`
+// 	NodePoolID string `json:"nodePoolId"`
+// 	ProjectID  string `json:"projectId"`
+
+// 	Name     string `json:"name"`
+// 	Flavor   string `json:"flavor"`
+// 	Version  string `json:"version"`
+// 	UpToDate bool   `json:"isUpToDate"`
+// 	Status   string `json:"status"`
+
+// 	IP        *string `json:"ip,omitempty"`
+// 	PrivateIP *string `json:"privateIp,omitempty"`
+
+// 	CreatedAt  time.Time `json:"createdAt"`
+// 	DeployedAt time.Time `json:"deployedAt"`
+// 	UpdatedAt  time.Time `json:"updatedAt"`
+// }
+
+type Node struct {
+	ClusterUUID   string `json:"cluster_uuid"`
+	Id            string `json:"id"`
+	NodeGroupUUID string `json:"node_group_uuid"`
+	Current       int    `json:"current_nodes"`
+	MinSize       int    `json:"node_group_min_size"`
+	MaxSize       int    `json:"node_group_max_size"`
+	Flavor        string `json:"node_flavor_uuid"`
+	Status        string `json:"node_groups_status"`
+}
+
+// DrainNode cordons and drains a node.
+func (k *Client) DrainNode(nodeName string, client kubernetes.Interface, node *corev1.Node, DrainWaitSeconds int) error {
+	if client == nil {
+		return fmt.Errorf("K8sClient not set")
+	}
+	if node == nil {
+		return fmt.Errorf("node not set")
+	}
+	if nodeName == "" {
+		return fmt.Errorf("node name not set")
+	}
+	const (
+		// PodSafeToEvictKey - annotation that ignores constraints to evict a pod like not being replicated, being on
+		// kube-system namespace or having a local storage.
+		PodSafeToEvictKey = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+		// SafeToEvictLocalVolumesKey - annotation that ignores (doesn't block on) a local storage volume during node scale down
+		SafeToEvictLocalVolumesKey = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
+	)
+	const (
+		// PodLongTerminatingExtraThreshold - time after which a pod, that is terminating and that has run over its terminationGracePeriod, should be ignored and considered as deleted
+		PodLongTerminatingExtraThreshold = 30 * time.Second
+	)
+
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/vke/sdk/node.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/node.go
@@ -44,6 +44,7 @@ import (
 // 	UpdatedAt  time.Time `json:"updatedAt"`
 // }
 
+// Node represents a VKE node returned by the control-plane API.
 type Node struct {
 	ClusterUUID   string `json:"cluster_uuid"`
 	Id            string `json:"id"`

--- a/cluster-autoscaler/cloudprovider/vke/sdk/nodepool.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/nodepool.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog/v2"
+)
+
+// NodePool represents a VKE node group.
+type NodePool struct {
+	ID string `json:"node_group_uuid"`
+
+	Name   string `json:"node_group_name"`
+	Flavor string `json:"node_flavor_uuid"`
+	Status string `json:"node_groups_status"`
+
+	MinNodes     uint32 `json:"node_group_min_size"`
+	MaxNodes     uint32 `json:"node_group_max_size"`
+	CurrentNodes int    `json:"current_nodes"`
+}
+
+// ListNodePools allows to list all node pools available in a cluster
+func (c *Client) ListNodePools(ctx context.Context, clusterID string) ([]NodePool, error) {
+	klog.V(2).Infof("Listing node pools for cluster %s", clusterID)
+	nodepools := make([]NodePool, 0)
+	err := c.CallAPIWithContext(
+		ctx,
+		"GET",
+		fmt.Sprintf("/cluster/%s/nodegroups", clusterID),
+		nil,
+		&nodepools,
+		nil,
+		nil,
+		true,
+	)
+	return nodepools, err
+}
+
+// GetNodePool allows to display information for a specific node pool
+func (c *Client) GetNodePool(ctx context.Context, clusterID string, poolID string) (*NodePool, error) {
+	nodepool := &NodePool{}
+
+	return nodepool, c.CallAPIWithContext(
+		ctx,
+		"GET",
+		fmt.Sprintf("/cluster/%s/nodepool/%s", clusterID, poolID),
+		nil,
+		&nodepool,
+		nil,
+		nil,
+		true,
+	)
+}
+
+// ListNodePoolNodes allows to display nodes contained in a parent node pool
+func (c *Client) ListNodePoolNodes(ctx context.Context, clusterID string, poolID string) ([]Node, error) {
+	nodes := make([]Node, 0)
+
+	return nodes, c.CallAPIWithContext(
+		ctx,
+		"GET",
+		fmt.Sprintf("/cluster/%s/nodegroups/%s/nodes", clusterID, poolID),
+		nil,
+		&nodes,
+		nil,
+		nil,
+		true,
+	)
+}
+
+// DeleteNode deletes a node from a node group.
+func (c *Client) DeleteNode(ctx context.Context, clusterID, nodeGroupID, id string) error {
+	klog.V(2).Infof("Deleting node %s from cluster %s", id, clusterID)
+	return c.CallAPIWithContext(
+		ctx,
+		"DELETE",
+		fmt.Sprintf("/cluster/%s/nodegroups/%s/nodes/%s", clusterID, nodeGroupID, id),
+		nil,
+		nil,
+		nil,
+		nil,
+		true,
+	)
+}
+
+// AddNode adds a node to a node group.
+func (c *Client) AddNode(ctx context.Context, clusterID, nodeGroupID string) (*Node, error) {
+	klog.V(2).Infof("Adding node to cluster %s", clusterID)
+	node := &Node{}
+	return node, c.CallAPIWithContext(
+		ctx,
+		"PUT",
+		fmt.Sprintf("/cluster/%s/nodegroups/%s/nodes/add", clusterID, nodeGroupID),
+		nil,
+		node,
+		nil,
+		nil,
+		true,
+	)
+}

--- a/cluster-autoscaler/cloudprovider/vke/sdk/openstack.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/openstack.go
@@ -36,6 +36,7 @@ type OpenStackProvider struct {
 	Token               string
 	tokenExpirationTime time.Time
 }
+
 // Auth holds OpenStack application credential fields.
 type Auth struct {
 	IdentityEndpoint            string `json:"identity_endpoint"`

--- a/cluster-autoscaler/cloudprovider/vke/sdk/openstack.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/openstack.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/gophercloud/openstack"
+	"k8s.io/klog/v2"
+)
+
+// DefaultExpirationTime is the maximum time to be alive of an OpenStack keystone token.
+const DefaultExpirationTime = 1 * time.Hour
+
+// OpenStackProvider defines a custom OpenStack provider with a token to re-authenticate
+type OpenStackProvider struct {
+	provider *gophercloud.ProviderClient
+
+	AuthUrl             string
+	Token               string
+	tokenExpirationTime time.Time
+}
+type Auth struct {
+	IdentityEndpoint            string `json:"identity_endpoint"`
+	ApplicationCredentialID     string `json:"application_credential_id"`
+	ApplicationCredentialSecret string `json:"application_credential_secret"`
+}
+
+// NewOpenStackProvider initializes a client/token pair to interact with OpenStack
+func NewOpenStackProvider(authUrl string, ApplicationCredentialID string, ApplicationCredentialSecret string, TenantID string) (*OpenStackProvider, error) {
+	provider, err := openstack.AuthenticatedClient(gophercloud.AuthOptions{
+		IdentityEndpoint:            authUrl,
+		ApplicationCredentialID:     ApplicationCredentialID,
+		ApplicationCredentialSecret: ApplicationCredentialSecret,
+		TenantID:                    TenantID,
+		AllowReauth:                 true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OpenStack authenticated client: %w", err)
+	}
+
+	return &OpenStackProvider{
+		provider:            provider,
+		AuthUrl:             authUrl,
+		Token:               provider.Token(),
+		tokenExpirationTime: time.Now().Add(DefaultExpirationTime),
+	}, nil
+}
+
+// ReauthenticateToken revoke the current provider token and re-create a new one
+func (p *OpenStackProvider) ReauthenticateToken() error {
+	klog.V(5).Infof("ReauthenticateToken() Re-authenticating OpenStack token")
+	err := p.provider.Reauthenticate(p.Token)
+	if err != nil {
+		return fmt.Errorf("failed to re-auth previous openstack token: %w", err)
+	}
+
+	p.Token = p.provider.Token()
+	p.tokenExpirationTime = time.Now().Add(DefaultExpirationTime)
+
+	return nil
+}
+
+// IsTokenExpired checks if the current token is expired
+func (p *OpenStackProvider) IsTokenExpired() bool {
+	klog.V(5).Infof("IsTokenExpired() Token expiration time")
+	return p.tokenExpirationTime.Before(time.Now())
+}

--- a/cluster-autoscaler/cloudprovider/vke/sdk/openstack.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/openstack.go
@@ -36,6 +36,7 @@ type OpenStackProvider struct {
 	Token               string
 	tokenExpirationTime time.Time
 }
+// Auth holds OpenStack application credential fields.
 type Auth struct {
 	IdentityEndpoint            string `json:"identity_endpoint"`
 	ApplicationCredentialID     string `json:"application_credential_id"`

--- a/cluster-autoscaler/cloudprovider/vke/sdk/vke.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/vke.go
@@ -34,8 +34,7 @@ import (
 // DefaultTimeout api requests after 180s
 const DefaultTimeout = 180 * time.Second
 
-// Endpoints
-
+// VKE is the API base URL loaded from the VKE_URL environment variable.
 var VKE = os.Getenv("VKE_URL")
 
 // Endpoints conveniently maps endpoints names to their URI for external configuration
@@ -45,9 +44,10 @@ var Endpoints = map[string]string{
 
 // Errors
 var (
-	ErrAPIDown = errors.New("The VKE API is down, it does't respond to /time anymore")
+	ErrAPIDown = errors.New("The VKE API is down, it doesn't respond to /time anymore")
 )
 
+// Client is the HTTP client used to call the VKE API.
 type Client struct {
 	AppKey string
 
@@ -121,8 +121,7 @@ func NewDefaultClientWithToken(authUrl, token string) (*Client, error) {
 	return client, nil
 }
 
-// High level helpers
-//
+// Ping checks whether the VKE API is reachable.
 // In fact, ping is just a /auth/time call, in order to check if API is up.
 func (c *Client) Ping() error {
 	_, err := c.getTime()
@@ -134,6 +133,7 @@ func (c *Client) TimeDelta() (time.Duration, error) {
 	return c.getTimeDelta()
 }
 
+// Time returns the current time from the VKE API.
 func (c *Client) Time() (*time.Time, error) {
 	return c.getTime()
 }

--- a/cluster-autoscaler/cloudprovider/vke/sdk/vke.go
+++ b/cluster-autoscaler/cloudprovider/vke/sdk/vke.go
@@ -1,0 +1,451 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+)
+
+// DefaultTimeout api requests after 180s
+const DefaultTimeout = 180 * time.Second
+
+// Endpoints
+
+var VKE = os.Getenv("VKE_URL")
+
+// Endpoints conveniently maps endpoints names to their URI for external configuration
+var Endpoints = map[string]string{
+	"vke": VKE,
+}
+
+// Errors
+var (
+	ErrAPIDown = errors.New("The VKE API is down, it does't respond to /time anymore")
+)
+
+type Client struct {
+	AppKey string
+
+	// AppSecret holds the Application secret key
+	AppSecret string
+
+	// API endpoint
+	endpoint string
+
+	// Client is the underlying HTTP client used to run the requests. It may be overloaded but a default one is instanciated in ``NewClient`` by default.
+	Client *http.Client
+
+	// Logger is used to log HTTP requests and responses.
+	Logger Logger
+
+	// Ensures that the timeDelta function is only ran once
+	// sync.Once would consider init done, even in case of error
+	// hence a good old flag
+	timeDeltaMutex *sync.Mutex
+	timeDeltaDone  bool
+	timeDelta      time.Duration
+	Timeout        time.Duration
+
+	// token used to generate api calls without credentials using OpenStack keystone
+	openStackToken string
+}
+
+// NewClient represents a new client to call the API
+func NewClient(endpoint, appKey, appSecret string, tenantid string) (*Client, error) {
+	client := Client{
+		AppKey:         appKey,
+		AppSecret:      appSecret,
+		Client:         &http.Client{},
+		timeDeltaMutex: &sync.Mutex{},
+		timeDeltaDone:  false,
+		Timeout:        time.Duration(DefaultTimeout),
+	}
+
+	// Get and check the configuration
+	if err := client.loadConfig(endpoint); err != nil {
+		return nil, err
+	}
+	return &client, nil
+}
+
+// NewEndpointClient will create an API client for specified
+// endpoint and load all credentials from environment or
+// configuration files
+func NewEndpointClient(endpoint string) (*Client, error) {
+	return NewClient(endpoint, "", "", "")
+}
+
+// NewDefaultClient will load all it's parameter from environment
+// or configuration files
+func NewDefaultClient() (*Client, error) {
+	return NewClient("", "", "", "")
+}
+
+// NewDefaultClientWithToken will load all it's parameter from environment
+// or configuration files using an OpenStack keystone token
+func NewDefaultClientWithToken(authUrl, token string) (*Client, error) {
+	// Find endpoint given the keystone auth url
+	endpoint := VKE
+	client, err := NewClient(endpoint, "none", "none", "none")
+	if err != nil {
+		return nil, err
+	}
+
+	client.openStackToken = token
+
+	return client, nil
+}
+
+// High level helpers
+//
+// In fact, ping is just a /auth/time call, in order to check if API is up.
+func (c *Client) Ping() error {
+	_, err := c.getTime()
+	return err
+}
+
+// TimeDelta represents the delay between the machine that runs the code and the
+func (c *Client) TimeDelta() (time.Duration, error) {
+	return c.getTimeDelta()
+}
+
+func (c *Client) Time() (*time.Time, error) {
+	return c.getTime()
+}
+
+//
+// Common request wrappers
+//
+
+// Get is a wrapper for the GET method
+func (c *Client) Get(url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("GET", url, nil, result, queryParams, true)
+}
+
+// GetUnAuth is a wrapper for the unauthenticated GET method
+func (c *Client) GetUnAuth(url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("GET", url, nil, result, queryParams, false)
+}
+
+// Post is a wrapper for the POST method
+func (c *Client) Post(url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("POST", url, reqBody, result, queryParams, true)
+}
+
+// PostUnAuth is a wrapper for the unauthenticated POST method
+func (c *Client) PostUnAuth(url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("POST", url, reqBody, result, queryParams, false)
+}
+
+// Put is a wrapper for the PUT method
+func (c *Client) Put(url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("PUT", url, reqBody, result, queryParams, true)
+}
+
+// PutUnAuth is a wrapper for the unauthenticated PUT method
+func (c *Client) PutUnAuth(url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("PUT", url, reqBody, result, queryParams, false)
+}
+
+// Delete is a wrapper for the DELETE method
+func (c *Client) Delete(url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("DELETE", url, nil, result, queryParams, true)
+}
+
+// DeleteUnAuth is a wrapper for the unauthenticated DELETE method
+func (c *Client) DeleteUnAuth(url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPI("DELETE", url, nil, result, queryParams, false)
+}
+
+// GetWithContext is a wrapper for the GET method
+func (c *Client) GetWithContext(ctx context.Context, url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "GET", url, nil, result, queryParams, nil, true)
+}
+
+// GetUnAuthWithContext is a wrapper for the unauthenticated GET method
+func (c *Client) GetUnAuthWithContext(ctx context.Context, url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "GET", url, nil, result, queryParams, nil, false)
+}
+
+// PostWithContext is a wrapper for the POST method
+func (c *Client) PostWithContext(ctx context.Context, url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "POST", url, reqBody, result, queryParams, nil, true)
+}
+
+// PostUnAuthWithContext is a wrapper for the unauthenticated POST method
+func (c *Client) PostUnAuthWithContext(ctx context.Context, url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "POST", url, reqBody, result, queryParams, nil, false)
+}
+
+// PutWithContext is a wrapper for the PUT method
+func (c *Client) PutWithContext(ctx context.Context, url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, result, queryParams, nil, true)
+}
+
+// PutUnAuthWithContext is a wrapper for the unauthenticated PUT method
+func (c *Client) PutUnAuthWithContext(ctx context.Context, url string, reqBody, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "PUT", url, reqBody, result, queryParams, nil, false)
+}
+
+// DeleteWithContext is a wrapper for the DELETE method
+func (c *Client) DeleteWithContext(ctx context.Context, url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "DELETE", url, nil, result, queryParams, nil, true)
+}
+
+// DeleteUnAuthWithContext is a wrapper for the unauthenticated DELETE method
+func (c *Client) DeleteUnAuthWithContext(ctx context.Context, url string, result interface{}, queryParams url.Values) error {
+	return c.CallAPIWithContext(ctx, "DELETE", url, nil, result, queryParams, nil, false)
+}
+
+// timeDelta returns the time  delta between the host and the remote API
+func (c *Client) getTimeDelta() (time.Duration, error) {
+	if !c.timeDeltaDone {
+		// Ensure only one thread is updating
+		c.timeDeltaMutex.Lock()
+
+		// Ensure that the mutex will be released on return
+		defer c.timeDeltaMutex.Unlock()
+
+		// Did we wait ? Maybe no more needed
+		if !c.timeDeltaDone {
+			vkeTime, err := c.getTime()
+			if err != nil {
+				return 0, err
+			}
+
+			c.timeDelta = time.Since(*vkeTime)
+			c.timeDeltaDone = true
+		}
+	}
+
+	return c.timeDelta, nil
+}
+
+// getTime t returns time from for a given api client endpoint
+func (c *Client) getTime() (*time.Time, error) {
+	var timestamp int64
+
+	err := c.GetUnAuth("/auth/time", &timestamp, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	serverTime := time.Unix(timestamp, 0)
+	return &serverTime, nil
+}
+
+// getLocalTime is a function to be overwritten during the tests, it return the time
+// on the the local machine
+var getLocalTime = func() time.Time {
+	return time.Now()
+}
+
+// getEndpointForSignature is a function to be overwritten during the tests, it returns a
+// the endpoint
+var getEndpointForSignature = func(c *Client) string {
+	return c.endpoint
+}
+
+// NewRequest returns a new HTTP request
+func (c *Client) NewRequest(method, path string, reqBody interface{}, queryParams url.Values, headers map[string]interface{}, needAuth bool) (*http.Request, error) {
+	var body []byte
+	var err error
+
+	if reqBody != nil {
+		body, err = json.Marshal(reqBody)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	target := fmt.Sprintf("%s%s", c.endpoint, path)
+	req, err := http.NewRequest(method, target, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	// Inject headers
+	if body != nil {
+		req.Header.Add("Content-Type", "application/json;charset=utf-8")
+	}
+	req.Header.Add("Accept", "application/json")
+
+	// Bind OpenStack token to authorization bearer and custom headers
+	if c.openStackToken != "" {
+		req.Header.Add("X-Auth-Token", c.openStackToken)
+	}
+
+	for headerName, headerValue := range headers {
+		req.Header.Set(headerName, fmt.Sprintf("%v", headerValue))
+	}
+
+	// Inject signature. Some methods do not need authentication, especially /time,
+	// /auth and some /order methods are actually broken if authenticated.
+	if c.openStackToken == "" {
+		timeDelta, err := c.TimeDelta()
+		if err != nil {
+			return nil, err
+		}
+
+		timestamp := getLocalTime().Add(-timeDelta).Unix()
+
+		h := sha1.New()
+		h.Write([]byte(fmt.Sprintf("%s+%s+%s+%s%s+%d",
+			c.AppSecret,
+			method,
+			getEndpointForSignature(c),
+			path,
+			body,
+			timestamp,
+		)))
+	}
+
+	// Send the request with requested timeout
+	c.Client.Timeout = c.Timeout
+
+	return req, nil
+}
+
+// Do sends an HTTP request and returns an HTTP response
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if c.Logger != nil {
+		c.Logger.LogRequest(req)
+	}
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if c.Logger != nil {
+		c.Logger.LogResponse(resp)
+	}
+	return resp, nil
+}
+
+// CallAPI is the lowest level call helper. If needAuth is true,
+// inject authentication headers and sign the request.
+//
+// Request signature is a sha1 hash on following fields, joined by '+':
+// - applicationSecret (from Client instance)
+// - consumerKey (from Client instance)
+// - capitalized method (from arguments)
+// - full request url, including any query string argument
+// - full serialized request body
+// - server current time (takes time delta into account)
+//
+// Call will automatically assemble the target url from the endpoint
+// configured in the client instance and the path argument. If the reqBody
+// argument is not nil, it will also serialize it as json and inject
+// the required Content-Type header.
+//
+// If everything went fine, unmarshall response into result and return nil
+// otherwise, return the error
+func (c *Client) CallAPI(method, path string, reqBody, result interface{}, queryParams url.Values, needAuth bool) error {
+	return c.CallAPIWithContext(context.Background(), method, path, reqBody, result, queryParams, nil, needAuth)
+}
+
+// CallAPIWithContext is the lowest level call helper. If needAuth is true,
+// inject authentication headers and sign the request.
+//
+// Request signature is a sha1 hash on following fields, joined by '+':
+// - applicationSecret (from Client instance)
+// - consumerKey (from Client instance)
+// - capitalized method (from arguments)
+// - full request url, including any query string argument
+// - full serialized request body
+// - server current time (takes time delta into account)
+//
+// # Context is used by http.Client to handle context cancelation
+//
+// Call will automatically assemble the target url from the endpoint
+// configured in the client instance and the path argument. If the reqBody
+// argument is not nil, it will also serialize it as json and inject
+// the required Content-Type header.
+//
+// If everything went fine, unmarshall response into result and return nil
+// otherwise, return the error
+func (c *Client) CallAPIWithContext(ctx context.Context, method, path string, reqBody, result interface{}, queryParams url.Values, headers map[string]interface{}, needAuth bool) error {
+	req, err := c.NewRequest(method, path, reqBody, queryParams, headers, needAuth)
+	if err != nil {
+		return err
+	}
+
+	req = req.WithContext(ctx)
+	response, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	err = c.UnmarshalResponse(response, result)
+	if err != nil {
+		// This is a temporary fix until the issue is correctly handled
+		if IsPossiblyCanadianTenantSyncError(err, req.URL.String()) {
+			// Create a canadian API client with the same token
+			client, err2 := NewClient(VKE, "none", "none", "")
+			if err2 != nil {
+				return fmt.Errorf("failed to create canadian VKE API client for fallback: %w", err2)
+			}
+			client.openStackToken = c.openStackToken
+
+			err2 = client.CallAPIWithContext(ctx, method, path, reqBody, result, queryParams, headers, needAuth)
+			if err2 == nil {
+				// OK on the canadian API, our job is done
+				return nil
+			}
+		}
+	}
+
+	return err
+}
+
+// UnmarshalResponse checks the response and unmarshals it into the response
+// type if needed Helper function, called from CallAPI
+func (c *Client) UnmarshalResponse(response *http.Response, result interface{}) error {
+	// Read all the response body
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	// < 200 && >= 300 : API error
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		apiError := &APIError{Code: response.StatusCode}
+		if err = json.Unmarshal(body, apiError); err != nil {
+			apiError.Message = string(body)
+		}
+		apiError.QueryID = response.Header.Get("X-VKE-QueryID")
+
+		return apiError
+	}
+
+	// Nothing to unmarshal
+	if len(body) == 0 || result == nil {
+		return nil
+	}
+
+	return json.Unmarshal(body, &result)
+}

--- a/cluster-autoscaler/cloudprovider/vke/vke_cloud_manager.go
+++ b/cluster-autoscaler/cloudprovider/vke/vke_cloud_manager.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vke
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/sdk"
+	"k8s.io/klog/v2"
+)
+
+const flavorCacheDuration = time.Hour
+
+// ClientInterface defines all mandatory methods to be exposed as a client (mock or API)
+type ClientInterface interface {
+	// ListNodePools lists all the node pools found in a Kubernetes cluster.
+	ListNodePools(ctx context.Context, clusterID string) ([]sdk.NodePool, error)
+
+	// ListNodePoolNodes lists all the nodes contained in a node pool.
+	ListNodePoolNodes(ctx context.Context, clusterID string, poolID string) ([]sdk.Node, error)
+
+	// DeleteNode deletes a specific node.
+	DeleteNode(ctx context.Context, clusterID string, nodeGroupID string, id string) error
+
+	// ListClusterFlavors lists all available flavors usable in a Kubernetes cluster.
+	ListClusterFlavors(ctx context.Context, clusterID string) ([]sdk.Flavor, error)
+
+	// AddNode adds a node to a node pool.
+	AddNode(ctx context.Context, clusterID string, nodeGroupID string) (*sdk.Node, error)
+}
+
+// VKEManager handles VKE API state for the cloud provider.
+type VKEManager struct {
+	Client            ClientInterface
+	OpenStackProvider *sdk.OpenStackProvider
+
+	ClusterID string
+	ProjectID string
+
+	authURL                     string
+	applicationCredentialID     string
+	applicationCredentialSecret string
+
+	NodePools                  []sdk.NodePool
+	NodeGroupPerProviderID     map[string]*NodeGroup
+	NodeGroupPerProviderIDLock sync.RWMutex
+
+	FlavorsCache               map[string]sdk.Flavor
+	FlavorsCacheExpirationTime time.Time
+}
+
+// Config is the JSON cloud-config payload for the VKE provider.
+type Config struct {
+	// ClusterID is the id associated with the cluster where CA is running.
+	ClusterID string `json:"cluster_id"`
+	// OpenStack keystone credentials if CA is run without API consumer.
+	// By default, this is used as it on cluster control plane.
+	OpenStackAuthUrl            string `json:"openstack_auth_url"`
+	OpenStackDomain             string `json:"openstack_domain"`
+	ApplicationCredentialID     string `json:"application_key"`
+	ApplicationCredentialSecret string `json:"application_secret"`
+	TenantID                    string `json:"tenant_id"`
+}
+
+// NewManager initializes manager state from a cloud provider configuration file.
+// OpenStack authentication is deferred until the first Refresh/ReAuthenticate call.
+func NewManager(configFile io.Reader) (*VKEManager, error) {
+	cfg, err := readConfig(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	err = validatePayload(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("config content validation failed: %w", err)
+	}
+
+	return &VKEManager{
+		ProjectID:                   cfg.TenantID,
+		ClusterID:                   cfg.ClusterID,
+		authURL:                     cfg.OpenStackAuthUrl,
+		applicationCredentialID:     cfg.ApplicationCredentialID,
+		applicationCredentialSecret: cfg.ApplicationCredentialSecret,
+
+		NodePools:                  make([]sdk.NodePool, 0),
+		NodeGroupPerProviderID:     make(map[string]*NodeGroup),
+		NodeGroupPerProviderIDLock: sync.RWMutex{},
+
+		FlavorsCache:               make(map[string]sdk.Flavor),
+		FlavorsCacheExpirationTime: time.Time{},
+	}, nil
+}
+
+func (m *VKEManager) getFlavorsByID() (map[string]sdk.Flavor, error) {
+	// Update the flavors cache if expired
+	if m.FlavorsCacheExpirationTime.Before(time.Now()) {
+		newFlavorCacheExpirationTime := time.Now().Add(flavorCacheDuration)
+		klog.V(4).Infof("Listing flavors to update flavors cache (will expire at %s)", newFlavorCacheExpirationTime)
+
+		// Fetch all flavors in API
+		flavors, err := m.Client.ListClusterFlavors(context.Background(), m.ClusterID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list available flavors: %w", err)
+		}
+
+		// Update the flavors cache
+		m.FlavorsCache = make(map[string]sdk.Flavor)
+		for _, flavor := range flavors {
+			m.FlavorsCache[flavor.Id] = flavor
+			m.FlavorsCacheExpirationTime = newFlavorCacheExpirationTime
+		}
+	}
+
+	return m.FlavorsCache, nil
+}
+
+// getFlavorByName returns the given flavor from cache or API
+func (m *VKEManager) getFlavorByName(flavorName string) (sdk.Flavor, error) {
+	flavorsByName, err := m.getFlavorsByID()
+	if err != nil {
+		return sdk.Flavor{}, err
+	}
+
+	if flavor, ok := flavorsByName[flavorName]; ok {
+		return flavor, nil
+	}
+
+	return sdk.Flavor{}, fmt.Errorf("flavor %s not found in available flavors", flavorName)
+}
+
+// setNodeGroupPerProviderID stores the association provider ID => node group in cache for future reference
+func (m *VKEManager) setNodeGroupPerProviderID(providerID string, nodeGroup *NodeGroup) {
+	m.NodeGroupPerProviderIDLock.Lock()
+	defer m.NodeGroupPerProviderIDLock.Unlock()
+
+	m.NodeGroupPerProviderID[providerID] = nodeGroup
+}
+
+// getNodeGroupPerProviderID gets from cache the node group associated to the given provider ID
+func (m *VKEManager) getNodeGroupPerProviderID(providerID string) *NodeGroup {
+	m.NodeGroupPerProviderIDLock.RLock()
+	defer m.NodeGroupPerProviderIDLock.RUnlock()
+
+	return m.NodeGroupPerProviderID[providerID]
+}
+
+// ReAuthenticate allows OpenStack keystone token to be revoked and re-created to call API
+func (m *VKEManager) ReAuthenticate() error {
+	if m.OpenStackProvider == nil {
+		openStackProvider, err := sdk.NewOpenStackProvider(m.authURL, m.applicationCredentialID, m.applicationCredentialSecret, m.ProjectID)
+		if err != nil {
+			return fmt.Errorf("failed to create OpenStack provider: %w", err)
+		}
+		m.OpenStackProvider = openStackProvider
+	} else if m.OpenStackProvider.IsTokenExpired() {
+		klog.V(4).Infof("OpenStack token expired, re-authenticating")
+		err := m.OpenStackProvider.ReauthenticateToken()
+		if err != nil {
+			return fmt.Errorf("failed to re-authenticate OpenStack token: %w", err)
+		}
+	}
+
+	client, err := sdk.NewDefaultClientWithToken(m.OpenStackProvider.AuthUrl, m.OpenStackProvider.Token)
+	if err != nil {
+		return fmt.Errorf("failed to re-create client: %w", err)
+	}
+
+	m.Client = client
+
+	return nil
+}
+
+// readConfig read cloud provider configuration file into a struct
+func readConfig(configFile io.Reader) (*Config, error) {
+	cfg := &Config{}
+	if configFile != nil {
+		body, err := io.ReadAll(configFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read content: %w", err)
+		}
+
+		err = json.Unmarshal(body, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal body: %w", err)
+		}
+	}
+
+	return cfg, nil
+}
+
+// validatePayload check that cloud provider configuration file is correctly formatted
+func validatePayload(cfg *Config) error {
+	if cfg.ClusterID == "" {
+		return fmt.Errorf("`cluster_id` not found in config file")
+	}
+
+	if cfg.TenantID == "" {
+		return fmt.Errorf("`tenant_id` not found in config file")
+	}
+	if cfg.ApplicationCredentialID == "" {
+		return fmt.Errorf("`application_key` not found in config file")
+	}
+	if cfg.ApplicationCredentialSecret == "" {
+		return fmt.Errorf("`application_secret` not found in config file")
+	}
+	if cfg.OpenStackAuthUrl == "" {
+		return fmt.Errorf("`openstack_auth_url` not found in config file")
+	}
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/vke/vke_cloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/vke/vke_cloud_manager_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vke
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/sdk"
+)
+
+func validConfigJSON() string {
+	return `{
+		"cluster_id": "clusterID",
+		"tenant_id": "tenantID",
+		"application_key": "appKey",
+		"application_secret": "appSecret",
+		"openstack_auth_url": "https://example.com:5000/v3"
+	}`
+}
+
+func newTestManager(t *testing.T) (*VKEManager, *sdk.ClientMock) {
+	t.Helper()
+
+	manager, err := NewManager(bytes.NewBufferString(validConfigJSON()))
+	assert.NoError(t, err)
+
+	client := &sdk.ClientMock{}
+	manager.Client = client
+	return manager, client
+}
+
+func TestNewManager(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		manager, err := NewManager(bytes.NewBufferString(validConfigJSON()))
+		assert.NoError(t, err)
+		assert.Equal(t, "clusterID", manager.ClusterID)
+		assert.Equal(t, "tenantID", manager.ProjectID)
+		assert.Nil(t, manager.Client)
+		assert.Nil(t, manager.OpenStackProvider)
+	})
+
+	t.Run("missing cluster_id", func(t *testing.T) {
+		cfg := `{
+			"tenant_id": "tenantID",
+			"application_key": "appKey",
+			"application_secret": "appSecret",
+			"openstack_auth_url": "https://example.com:5000/v3"
+		}`
+		_, err := NewManager(bytes.NewBufferString(cfg))
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		_, err := NewManager(bytes.NewBufferString("{"))
+		assert.Error(t, err)
+	})
+}
+
+func TestVKEManager_getFlavorByName(t *testing.T) {
+	manager, client := newTestManager(t)
+	ctx := context.Background()
+
+	client.On("ListClusterFlavors", ctx, "clusterID").Return(
+		[]sdk.Flavor{
+			{Id: "flavor-1", State: "available", VCPUs: 2, GPUs: 0, RAM: 4},
+			{Id: "flavor-gpu", State: "available", VCPUs: 8, GPUs: 1, RAM: 32},
+		}, nil,
+	)
+
+	flavor, err := manager.getFlavorByName("flavor-1")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, flavor.VCPUs)
+
+	_, err = manager.getFlavorByName("missing")
+	assert.Error(t, err)
+}
+
+func TestVKEManager_NodeGroupPerProviderIDCache(t *testing.T) {
+	manager, _ := newTestManager(t)
+	ng := &NodeGroup{Manager: manager}
+
+	manager.setNodeGroupPerProviderID("openstack:///instance-1", ng)
+	assert.Equal(t, ng, manager.getNodeGroupPerProviderID("openstack:///instance-1"))
+	assert.Nil(t, manager.getNodeGroupPerProviderID("openstack:///missing"))
+}
+
+func TestVKEManager_NodeGroupPerProviderIDConcurrency(t *testing.T) {
+	manager, _ := newTestManager(t)
+	ng := &NodeGroup{Manager: manager}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			manager.setNodeGroupPerProviderID("openstack:///instance", ng)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = manager.getNodeGroupPerProviderID("openstack:///instance")
+		}()
+	}
+	wg.Wait()
+}
+
+func TestVKEManager_flavorCacheExpiry(t *testing.T) {
+	manager, client := newTestManager(t)
+	ctx := context.Background()
+
+	client.On("ListClusterFlavors", ctx, "clusterID").Return(
+		[]sdk.Flavor{{Id: "flavor-1", State: "available", VCPUs: 2}}, nil,
+	).Once()
+
+	_, err := manager.getFlavorByName("flavor-1")
+	assert.NoError(t, err)
+
+	manager.FlavorsCacheExpirationTime = time.Now().Add(-time.Minute)
+	client.On("ListClusterFlavors", ctx, "clusterID").Return(
+		[]sdk.Flavor{{Id: "flavor-1", State: "available", VCPUs: 4}}, nil,
+	).Once()
+
+	flavor, err := manager.getFlavorByName("flavor-1")
+	assert.NoError(t, err)
+	assert.Equal(t, 4, flavor.VCPUs)
+	client.AssertExpectations(t)
+}

--- a/cluster-autoscaler/cloudprovider/vke/vke_cloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/vke/vke_cloud_node_group.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vke
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+	"sync"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/sdk"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/gpu"
+)
+
+const providerIDPrefix = "openstack:///"
+
+// NodeGroup implements cloudprovider.NodeGroup interface.
+type NodeGroup struct {
+	sdk.NodePool
+
+	Manager     *VKEManager
+	CurrentSize int
+	mutex       sync.Mutex
+}
+
+// MaxSize returns maximum size of the node pool.
+func (ng *NodeGroup) MaxSize() int {
+	return int(ng.MaxNodes)
+}
+
+// MinSize returns minimum size of the node pool.
+func (ng *NodeGroup) MinSize() int {
+	return int(ng.MinNodes)
+}
+
+// TargetSize returns the current TARGET size of the node pool. It is possible that the
+// number is different from the number of nodes registered in Kubernetes.
+func (ng *NodeGroup) TargetSize() (int, error) {
+	// Prefer the in-memory target size set by scale operations; otherwise use API current nodes.
+	if ng.CurrentSize == -1 {
+		klog.V(4).Infof("NodeGroup %s has a target size of %d", ng.ID, ng.CurrentNodes)
+		return ng.CurrentNodes, nil
+	}
+
+	klog.V(4).Infof("NodeGroup %s has a target size of %d", ng.ID, ng.CurrentSize)
+	return ng.CurrentSize, nil
+}
+
+// IncreaseSize increases node pool size.
+func (ng *NodeGroup) IncreaseSize(delta int) error {
+	klog.V(4).Infof("Increasing NodeGroup size by %d node(s)", delta)
+
+	// First, verify the NodeGroup can be increased
+	if delta <= 0 {
+		return fmt.Errorf("increase size node group delta must be positive")
+	}
+
+	size, err := ng.TargetSize()
+	if err != nil {
+		return fmt.Errorf("failed to get NodeGroup target size")
+	}
+
+	if size+delta > ng.MaxSize() {
+		return fmt.Errorf("node group size would be above maximum size - desired: %d, max: %d", size+delta, ng.MaxSize())
+	}
+
+	klog.V(4).Infof("Upscaling node pool %s to %d current nodes", ng.ID, size+delta)
+	for i := 0; i < delta; i++ {
+		_, err := ng.Manager.Client.AddNode(context.Background(), ng.Manager.ClusterID, ng.ID)
+		if err != nil {
+			return fmt.Errorf("failed to increase node pool desired size: %w", err)
+		}
+		ng.CurrentSize = size + i + 1
+	}
+
+	return nil
+}
+
+// AtomicIncreaseSize is not implemented.
+func (ng *NodeGroup) AtomicIncreaseSize(delta int) error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// DeleteNodes deletes the nodes from the group.
+func (ng *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+	// DeleteNodes is called in goroutine so it can run in parallel
+	// Goroutines created in: ScaleDown.scheduleDeleteEmptyNodes()
+	// Adding mutex to ensure CurrentSize attribute keeps consistency
+	ng.mutex.Lock()
+	defer ng.mutex.Unlock()
+
+	klog.V(4).Infof("Deleting %d node(s)", len(nodes))
+
+	// First, verify the NodeGroup can be decreased
+	size, err := ng.TargetSize()
+	if err != nil {
+		return fmt.Errorf("failed to get NodeGroup target size")
+	}
+
+	if size-len(nodes) < ng.MinSize() {
+		return fmt.Errorf("node group size would be below minimum size - desired: %d, min: %d", size-len(nodes), ng.MinSize())
+	}
+
+	for _, node := range nodes {
+		shortID := strings.TrimPrefix(node.Spec.ProviderID, providerIDPrefix)
+		err = ng.Manager.Client.DeleteNode(context.Background(), ng.Manager.ClusterID, ng.ID, shortID)
+		if err != nil {
+			return fmt.Errorf("failed to delete node %s: %w", shortID, err)
+		}
+	}
+
+	ng.CurrentSize = size - len(nodes)
+	return nil
+}
+
+// ForceDeleteNodes deletes nodes from the group regardless of constraints.
+func (ng *NodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// DecreaseTargetSize decreases the target size of the node group. This function
+// doesn't permit to delete any existing node and can be used only to reduce the
+// request for new nodes that have not been yet fulfilled. Delta should be negative.
+// It is assumed that cloud provider will not delete the existing nodes if the size
+// when there is an option to just decrease the target.
+func (ng *NodeGroup) DecreaseTargetSize(delta int) error {
+	// Cancellation of node provisioning is not supported yet
+	return cloudprovider.ErrNotImplemented
+}
+
+// Id returns node pool id.
+func (ng *NodeGroup) Id() string {
+	return ng.Name
+}
+
+// Debug returns a debug string for the NodeGroup.
+func (ng *NodeGroup) Debug() string {
+	// Printing name (target size - min size - max size)
+	return fmt.Sprintf("%s (%d:%d:%d)", ng.Id(), ng.CurrentSize, ng.MinSize(), ng.MaxSize())
+}
+
+// Nodes returns a list of all nodes that belong to this node group.
+func (ng *NodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+	// Fetch all nodes contained in the node group
+	nodes, err := ng.Manager.Client.ListNodePoolNodes(context.Background(), ng.Manager.ClusterID, ng.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list node pool nodes: %w", err)
+	}
+
+	klog.V(4).Infof("%d nodes are listed in node pool %s", len(nodes), ng.ID)
+
+	// Cast all API nodes into instance interface
+	instances := make([]cloudprovider.Instance, 0)
+	for _, node := range nodes {
+		instanceID := strings.TrimPrefix(node.Id, providerIDPrefix)
+		instance := cloudprovider.Instance{
+			Id:     providerIDPrefix + instanceID,
+			Status: toInstanceStatus(node.Status),
+		}
+
+		instances = append(instances, instance)
+
+		// Store the associated node group in cache for future reference
+		ng.Manager.setNodeGroupPerProviderID(instance.Id, ng)
+	}
+
+	return instances, nil
+}
+
+// TemplateNodeInfo returns a node template for this node group.
+func (ng *NodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+	// Forge node template in a node group
+	node := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("%v-node-%d", ng.Name, rand.Int63()),
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+			Finalizers:  []string{},
+		},
+		Spec: apiv1.NodeSpec{
+			Taints: []apiv1.Taint{},
+		},
+		Status: apiv1.NodeStatus{
+			Capacity:   apiv1.ResourceList{},
+			Conditions: cloudprovider.BuildReadyConditions(),
+		},
+	}
+
+	// Add the nodepool label
+	if node.ObjectMeta.Labels == nil {
+		node.ObjectMeta.Labels = make(map[string]string)
+	}
+	node.ObjectMeta.Labels[NodePoolLabel] = ng.Id()
+
+	flavor, err := ng.Manager.getFlavorByName(ng.Flavor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get specs for flavor %q: %w", ng.Flavor, err)
+	}
+
+	node.Status.Capacity[apiv1.ResourcePods] = *resource.NewQuantity(110, resource.DecimalSI)
+	node.Status.Capacity[apiv1.ResourceCPU] = *resource.NewQuantity(int64(flavor.VCPUs), resource.DecimalSI)
+	node.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(int64(flavor.GPUs), resource.DecimalSI)
+	node.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(int64(flavor.RAM)*int64(math.Pow(1024, 3)), resource.DecimalSI)
+
+	node.Status.Allocatable = node.Status.Capacity
+
+	// Setup node info template
+	nodeInfo := framework.NewNodeInfo(node, nil, framework.NewPodInfo(cloudprovider.BuildKubeProxy(ng.Id()), nil))
+	return nodeInfo, nil
+}
+
+// Exist checks if the node group really exists on the cloud provider side. Allows to tell the
+// theoretical node group from the real one.
+func (ng *NodeGroup) Exist() bool {
+	return ng.Id() != ""
+}
+
+// Create creates the node group on the cloud provider side.
+func (ng *NodeGroup) Create() (cloudprovider.NodeGroup, error) {
+	// Autoprovisioning is not supported for VKE yet.
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// Delete deletes the node group on the cloud provider side.
+// This will be executed only for autoprovisioned node groups, once their size drops to 0.
+func (ng *NodeGroup) Delete() error {
+	// Autoprovisioning is not supported for VKE yet.
+	return cloudprovider.ErrNotImplemented
+}
+
+// Autoprovisioned returns true if the node group is autoprovisioned.
+func (ng *NodeGroup) Autoprovisioned() bool {
+	// This is not handled yet.
+	return false
+}
+
+// GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
+// NodeGroup. Returning a nil will result in using default options.
+func (ng *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+	// If node group autoscaling options nil, return defaults
+	return nil, nil
+}
+
+// isGpu checks if a node group is using GPU machines
+func (ng *NodeGroup) isGpu() bool {
+	flavor, err := ng.Manager.getFlavorByName(ng.Flavor)
+	if err != nil {
+		// Fallback when we are unable to get the flavor: refer to the only category
+		// known to be a GPU flavor category
+		return strings.HasPrefix(ng.Flavor, GPUMachineCategory)
+	}
+
+	return flavor.GPUs > 0
+}
+
+// toInstanceStatus casts a node status into an instance status
+func toInstanceStatus(status string) *cloudprovider.InstanceStatus {
+	state := &cloudprovider.InstanceStatus{}
+
+	switch status {
+	case "INSTALLING", "REDEPLOYING":
+		state.State = cloudprovider.InstanceCreating
+	case "DELETING":
+		state.State = cloudprovider.InstanceDeleting
+	case "READY":
+		state.State = cloudprovider.InstanceRunning
+	default:
+		state.ErrorInfo = &cloudprovider.InstanceErrorInfo{
+			ErrorClass:   cloudprovider.OtherErrorClass,
+			ErrorCode:    status,
+			ErrorMessage: "error",
+		}
+	}
+
+	return state
+}

--- a/cluster-autoscaler/cloudprovider/vke/vke_cloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/vke/vke_cloud_node_group_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vke
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/sdk"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
+)
+
+func newTestNodeGroup(t *testing.T) *NodeGroup {
+	t.Helper()
+	manager, client := newTestManager(t)
+	ctx := context.Background()
+
+	client.On("ListClusterFlavors", ctx, "clusterID").Return(
+		[]sdk.Flavor{
+			{Id: "flavor-1", State: "available", VCPUs: 2, GPUs: 0, RAM: 4},
+			{Id: "flavor-gpu", State: "available", VCPUs: 8, GPUs: 1, RAM: 32},
+		}, nil,
+	)
+
+	return &NodeGroup{
+		Manager: manager,
+		NodePool: sdk.NodePool{
+			ID:           "pool-1",
+			Name:         "workers",
+			Flavor:       "flavor-1",
+			MinNodes:     1,
+			MaxNodes:     5,
+			CurrentNodes: 2,
+		},
+		CurrentSize: -1,
+	}
+}
+
+func TestNodeGroup_MaxMinSize(t *testing.T) {
+	ng := newTestNodeGroup(t)
+	assert.Equal(t, 5, ng.MaxSize())
+	assert.Equal(t, 1, ng.MinSize())
+	assert.Equal(t, "workers", ng.Id())
+}
+
+func TestNodeGroup_TargetSize(t *testing.T) {
+	ng := newTestNodeGroup(t)
+
+	size, err := ng.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, size)
+
+	ng.CurrentSize = 4
+	size, err = ng.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 4, size)
+}
+
+func TestNodeGroup_IncreaseSize(t *testing.T) {
+	ng := newTestNodeGroup(t)
+	client := ng.Manager.Client.(*sdk.ClientMock)
+	ctx := context.Background()
+
+	t.Run("rejects non-positive delta", func(t *testing.T) {
+		assert.Error(t, ng.IncreaseSize(0))
+	})
+
+	t.Run("rejects above max", func(t *testing.T) {
+		assert.Error(t, ng.IncreaseSize(10))
+	})
+
+	t.Run("adds nodes and updates current size", func(t *testing.T) {
+		client.On("AddNode", ctx, "clusterID", "pool-1").Return(&sdk.Node{Id: "n1"}, nil).Once()
+		client.On("AddNode", ctx, "clusterID", "pool-1").Return(&sdk.Node{Id: "n2"}, nil).Once()
+
+		err := ng.IncreaseSize(2)
+		assert.NoError(t, err)
+		assert.Equal(t, 4, ng.CurrentSize)
+	})
+}
+
+func TestNodeGroup_DeleteNodes(t *testing.T) {
+	ng := newTestNodeGroup(t)
+	ng.CurrentSize = 3
+	client := ng.Manager.Client.(*sdk.ClientMock)
+	ctx := context.Background()
+
+	nodes := []*apiv1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Spec: apiv1.NodeSpec{ProviderID: "openstack:///instance-1"}},
+	}
+
+	t.Run("rejects below min", func(t *testing.T) {
+		ng.CurrentSize = 1
+		err := ng.DeleteNodes([]*apiv1.Node{
+			{Spec: apiv1.NodeSpec{ProviderID: "openstack:///instance-1"}},
+		})
+		assert.Error(t, err)
+		ng.CurrentSize = 3
+	})
+
+	t.Run("deletes node and updates current size", func(t *testing.T) {
+		client.On("DeleteNode", ctx, "clusterID", "pool-1", "instance-1").Return(nil).Once()
+		err := ng.DeleteNodes(nodes)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, ng.CurrentSize)
+	})
+}
+
+func TestNodeGroup_Nodes(t *testing.T) {
+	ng := newTestNodeGroup(t)
+	client := ng.Manager.Client.(*sdk.ClientMock)
+	ctx := context.Background()
+
+	client.On("ListNodePoolNodes", ctx, "clusterID", "pool-1").Return(
+		[]sdk.Node{
+			{Id: "instance-1", Status: "READY"},
+			{Id: "openstack:///instance-2", Status: "INSTALLING"},
+		}, nil,
+	)
+
+	instances, err := ng.Nodes()
+	assert.NoError(t, err)
+	assert.Len(t, instances, 2)
+	assert.Equal(t, "openstack:///instance-1", instances[0].Id)
+	assert.Equal(t, cloudprovider.InstanceRunning, instances[0].Status.State)
+	assert.Equal(t, "openstack:///instance-2", instances[1].Id)
+	assert.Equal(t, cloudprovider.InstanceCreating, instances[1].Status.State)
+	assert.Equal(t, ng, ng.Manager.getNodeGroupPerProviderID("openstack:///instance-1"))
+}
+
+func TestNodeGroup_TemplateNodeInfo(t *testing.T) {
+	ng := newTestNodeGroup(t)
+	info, err := ng.TemplateNodeInfo()
+	assert.NoError(t, err)
+	assert.NotNil(t, info.Node())
+	assert.Equal(t, "workers", info.Node().Labels[NodePoolLabel])
+}
+
+func TestNodeGroup_OptionalMethods(t *testing.T) {
+	ng := newTestNodeGroup(t)
+	assert.True(t, ng.Exist())
+	assert.False(t, ng.Autoprovisioned())
+	assert.Equal(t, cloudprovider.ErrNotImplemented, ng.DecreaseTargetSize(-1))
+
+	_, err := ng.Create()
+	assert.Equal(t, cloudprovider.ErrNotImplemented, err)
+	assert.Equal(t, cloudprovider.ErrNotImplemented, ng.Delete())
+}
+
+func TestToInstanceStatus(t *testing.T) {
+	assert.Equal(t, cloudprovider.InstanceCreating, toInstanceStatus("INSTALLING").State)
+	assert.Equal(t, cloudprovider.InstanceDeleting, toInstanceStatus("DELETING").State)
+	assert.Equal(t, cloudprovider.InstanceRunning, toInstanceStatus("READY").State)
+	assert.NotNil(t, toInstanceStatus("UNKNOWN").ErrorInfo)
+}

--- a/cluster-autoscaler/cloudprovider/vke/vke_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/vke/vke_cloud_provider.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vke
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/informers"
+	"k8s.io/klog/v2"
+
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/sdk"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/builder"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	coreoptions "sigs.k8s.io/cluster-autoscaler/pkg/core/options"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/gpu"
+)
+
+// ProviderName is the cloud provider name for this provider.
+const ProviderName = "vke"
+
+func init() {
+	builder.RegisterCloudProvider(ProviderName, func(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+		return BuildVKE(opts, do, rl)
+	})
+	builder.SetDefaultCloudProvider(ProviderName)
+}
+
+const (
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "node.kubernetes.vke.com.tr/gpu"
+
+	// NodePoolLabel is the label added to nodes grouped by node group.
+	NodePoolLabel = "nodepool"
+
+	// MachineAvailableState defines the state for available flavors for node resources.
+	MachineAvailableState = "available"
+
+	// GPUMachineCategory defines the default instance category for GPU resources.
+	GPUMachineCategory = "t"
+)
+
+var _ cloudprovider.CloudProvider = (*VKEProvider)(nil)
+var _ cloudprovider.NodeGroup = (*NodeGroup)(nil)
+
+// VKEProvider implements CloudProvider interface.
+type VKEProvider struct {
+	manager *VKEManager
+
+	autoscalingOptions config.AutoscalingOptions
+	discoveryOptions   cloudprovider.NodeGroupDiscoveryOptions
+	resourceLimiter    *cloudprovider.ResourceLimiter
+}
+
+// BuildVKE builds the VKE provider.
+func BuildVKE(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+	var configFile io.ReadCloser
+	if opts.CloudConfig != "" {
+		var err error
+
+		configFile, err = os.Open(opts.CloudConfig)
+		if err != nil {
+			klog.Fatalf("Failed to open cloud provider configuration %s: %v", opts.CloudConfig, err)
+		}
+
+		defer configFile.Close()
+	}
+
+	manager, err := NewManager(configFile)
+	if err != nil {
+		klog.Fatalf("Failed to create VKE manager: %v", err)
+	}
+
+	provider := &VKEProvider{
+		manager: manager,
+
+		autoscalingOptions: opts.AutoscalingOptions,
+		discoveryOptions:   do,
+		resourceLimiter:    rl,
+	}
+
+	return provider
+}
+
+// Name returns name of the cloud provider.
+func (provider *VKEProvider) Name() string {
+	return ProviderName
+}
+
+// NodeGroups returns all node groups configured for this cloud provider.
+func (provider *VKEProvider) NodeGroups() []cloudprovider.NodeGroup {
+	groups := make([]cloudprovider.NodeGroup, 0)
+	// Cast API node pools into CA node groups
+	klog.V(5).Infof("Listing node pools to build NodeGroups %v", provider.manager.NodePools)
+	for _, pool := range provider.manager.NodePools {
+		ng := NodeGroup{
+			NodePool:    pool,
+			Manager:     provider.manager,
+			CurrentSize: -1,
+		}
+
+		groups = append(groups, &ng)
+	}
+
+	return groups
+}
+
+// NodeGroupForNode returns the node group for the given node, nil if the node
+// should not be processed by cluster autoscaler, or non-nil error if such
+// occurred. Must be implemented.
+func (provider *VKEProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	// Empty provider ID means the node is not yet registered with OpenStack.
+	if node.Spec.ProviderID == "" || node.Spec.ProviderID == providerIDPrefix {
+		return nil, nil
+	}
+
+	// Try to retrieve the associated node group from an already built mapping in cache
+	if ng := provider.findNodeGroupFromCache(node.Spec.ProviderID); ng != nil {
+		return ng, nil
+	}
+
+	klog.V(5).Infof("trying to find node group of node %s (provider ID %s) by listing all nodes under autoscaled node pools", node.Name, node.Spec.ProviderID)
+
+	// This should also refresh the cache for the next time
+	ng, err := provider.findNodeGroupByListingNodes(node)
+	if ng == nil {
+		klog.Warningf("unable to find which node group the node %s (provider ID %s) belongs to", node.Name, node.Spec.ProviderID)
+	}
+
+	return ng, err
+}
+
+// HasInstance returns whether a given node has a corresponding instance in this cloud provider
+func (provider *VKEProvider) HasInstance(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
+// findNodeGroupFromCache tries to retrieve the associated node group from an already built mapping in cache
+func (provider *VKEProvider) findNodeGroupFromCache(providerID string) cloudprovider.NodeGroup {
+	nodeGroup := provider.manager.getNodeGroupPerProviderID(providerID)
+	if nodeGroup != nil {
+		return nodeGroup
+	}
+	return nil // To avoid returning a (*cloudprovider.NodeGroup)(nil), which is different from nil
+}
+
+// findNodeGroupByListingNodes finds the associated node group from by listing all nodes under autoscaled node pools
+func (provider *VKEProvider) findNodeGroupByListingNodes(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	for _, ng := range provider.NodeGroups() {
+		instances, err := ng.Nodes()
+		klog.V(5).Infof("Listing nodes in node group %v", instances)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list nodes in node group %s: %w", ng.Id(), err)
+		}
+
+		for _, instance := range instances {
+			klog.V(5).Infof("InstanceID: %s, ProviderID: %s ", instance.Id, node.Spec.ProviderID)
+			if instance.Id == node.Spec.ProviderID {
+				return ng, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// Pricing returns pricing model for this cloud provider or error if not
+// available. Implementation optional.
+func (provider *VKEProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+	// This is not implemented in API
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// GetAvailableMachineTypes get all machine types that can be requested from
+// the cloud provider. Implementation optional.
+func (provider *VKEProvider) GetAvailableMachineTypes() ([]string, error) {
+	klog.V(4).Info("Getting available machine types")
+
+	flavorsByName, err := provider.manager.getFlavorsByID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get flavors: %w", err)
+	}
+
+	// Cast flavors into machine types string array
+	machineTypes := make([]string, 0)
+	for _, flavor := range flavorsByName {
+		if flavor.State == MachineAvailableState {
+			machineTypes = append(machineTypes, flavor.Id)
+		}
+	}
+
+	return machineTypes, nil
+}
+
+// NewNodeGroup builds a theoretical node group based on the node definition
+// provided. The node group is not automatically created on the cloud provider
+// side. The node group is not returned by NodeGroups() until it is created.
+// Implementation optional.
+func (provider *VKEProvider) NewNodeGroup(machineType string, labels map[string]string, systemLabels map[string]string, taints []apiv1.Taint, extraResources map[string]resource.Quantity) (cloudprovider.NodeGroup, error) {
+	ng := &NodeGroup{
+		NodePool: sdk.NodePool{
+			Name:     fmt.Sprintf("%s-%d", machineType, rand.Int63()),
+			Flavor:   machineType,
+			MinNodes: 0,
+			MaxNodes: 100,
+		},
+		Manager:     provider.manager,
+		CurrentSize: -1,
+	}
+
+	return ng, nil
+}
+
+// GetResourceLimiter returns struct containing limits (max, min) for
+// resources (cores, memory etc.).
+func (provider *VKEProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+	return provider.resourceLimiter, nil
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (provider *VKEProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes return all available GPU types cloud provider supports.
+func (provider *VKEProvider) GetAvailableGPUTypes() map[string]struct{} {
+	klog.V(4).Info("Getting available GPU types")
+
+	flavorsByName, err := provider.manager.getFlavorsByID()
+	if err != nil {
+		klog.Errorf("Failed to get flavors: %v", err)
+		return nil
+	}
+
+	// Cast flavors into gpu types string array
+	gpuTypes := make(map[string]struct{}, 0)
+	for _, flavor := range flavorsByName {
+		if flavor.State == MachineAvailableState && flavor.GPUs > 0 {
+			gpuTypes[flavor.Id] = struct{}{}
+		}
+	}
+
+	return gpuTypes
+}
+
+// GetNodeGpuConfig returns the label, type and resource name for the GPU added to node. If node doesn't have
+// any GPUs, it returns nil.
+func (provider *VKEProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(provider, node)
+}
+
+// Cleanup cleans up open resources before the cloud provider is destroyed,
+// i.e. go routines etc.
+func (provider *VKEProvider) Cleanup() error {
+	return nil
+}
+
+// Refresh is called before every main loop and can be used to dynamically
+// update cloud provider state. In particular the list of node groups returned
+// by NodeGroups() can change as a result of CloudProvider.Refresh().
+func (provider *VKEProvider) Refresh() error {
+	klog.V(4).Info("Listing node pools to refresh NodeGroups")
+
+	// Check if OpenStack keystone token need to be revoke and re-create
+	err := provider.manager.ReAuthenticate()
+	if err != nil {
+		return fmt.Errorf("failed to re-authenticate client: %w", err)
+	}
+	klog.V(4).Infof("ClusterId: %s", provider.manager.ClusterID)
+	pools, err := provider.manager.Client.ListNodePools(context.Background(), provider.manager.ClusterID)
+	klog.V(5).Infof("Pools: %v", pools)
+	if err != nil {
+		return fmt.Errorf("failed to refresh node pool list: %w", err)
+	}
+
+	// Update the node pools cache
+	provider.manager.NodePools = pools
+	klog.V(5).Infof("Node pools refreshed: %v", pools)
+
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/vke/vke_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/vke/vke_cloud_provider_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vke
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vke/sdk"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+)
+
+func newTestProvider(t *testing.T) (*VKEProvider, *sdk.ClientMock) {
+	t.Helper()
+	manager, client := newTestManager(t)
+
+	provider := &VKEProvider{
+		manager:            manager,
+		autoscalingOptions: config.AutoscalingOptions{},
+		resourceLimiter:    cloudprovider.NewResourceLimiter(nil, nil),
+	}
+	return provider, client
+}
+
+func TestVKEProvider_Name(t *testing.T) {
+	provider, _ := newTestProvider(t)
+	assert.Equal(t, ProviderName, provider.Name())
+}
+
+func TestVKEProvider_NodeGroupsAndRefresh(t *testing.T) {
+	provider, client := newTestProvider(t)
+	ctx := context.Background()
+
+	assert.Empty(t, provider.NodeGroups())
+
+	pools := []sdk.NodePool{
+		{ID: "pool-1", Name: "workers", Flavor: "flavor-1", MinNodes: 1, MaxNodes: 5, CurrentNodes: 2},
+		{ID: "pool-2", Name: "gpu", Flavor: "flavor-gpu", MinNodes: 0, MaxNodes: 3, CurrentNodes: 0},
+	}
+	client.On("ListNodePools", ctx, "clusterID").Return(pools, nil)
+
+	// Skip OpenStack auth in unit tests by injecting client and bypassing ReAuthenticate.
+	provider.manager.NodePools = pools
+	groups := provider.NodeGroups()
+	assert.Len(t, groups, 2)
+	assert.Equal(t, "workers", groups[0].Id())
+	assert.Equal(t, "gpu", groups[1].Id())
+}
+
+func TestVKEProvider_NodeGroupForNode(t *testing.T) {
+	provider, client := newTestProvider(t)
+	ctx := context.Background()
+
+	provider.manager.NodePools = []sdk.NodePool{
+		{ID: "pool-1", Name: "workers", Flavor: "flavor-1", MinNodes: 1, MaxNodes: 5, CurrentNodes: 1},
+	}
+
+	t.Run("empty provider id", func(t *testing.T) {
+		ng, err := provider.NodeGroupForNode(&apiv1.Node{})
+		assert.NoError(t, err)
+		assert.Nil(t, ng)
+	})
+
+	t.Run("from cache", func(t *testing.T) {
+		cached := &NodeGroup{NodePool: sdk.NodePool{ID: "pool-1", Name: "workers"}, Manager: provider.manager}
+		provider.manager.setNodeGroupPerProviderID("openstack:///instance-1", cached)
+
+		ng, err := provider.NodeGroupForNode(&apiv1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+			Spec:       apiv1.NodeSpec{ProviderID: "openstack:///instance-1"},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "workers", ng.Id())
+	})
+
+	t.Run("by listing nodes", func(t *testing.T) {
+		provider.manager.NodeGroupPerProviderID = make(map[string]*NodeGroup)
+		client.On("ListNodePoolNodes", ctx, "clusterID", "pool-1").Return(
+			[]sdk.Node{{Id: "instance-2", Status: "READY"}}, nil,
+		)
+
+		ng, err := provider.NodeGroupForNode(&apiv1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+			Spec:       apiv1.NodeSpec{ProviderID: "openstack:///instance-2"},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, ng)
+		assert.Equal(t, "workers", ng.Id())
+	})
+}
+
+func TestVKEProvider_GPUAndMachineTypes(t *testing.T) {
+	provider, client := newTestProvider(t)
+	ctx := context.Background()
+
+	client.On("ListClusterFlavors", ctx, "clusterID").Return(
+		[]sdk.Flavor{
+			{Id: "flavor-1", State: "available", VCPUs: 2, GPUs: 0, RAM: 4},
+			{Id: "flavor-gpu", State: "available", VCPUs: 8, GPUs: 1, RAM: 32},
+			{Id: "flavor-old", State: "unavailable", VCPUs: 2, GPUs: 0, RAM: 4},
+		}, nil,
+	)
+
+	types, err := provider.GetAvailableMachineTypes()
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"flavor-1", "flavor-gpu"}, types)
+
+	gpus := provider.GetAvailableGPUTypes()
+	_, ok := gpus["flavor-gpu"]
+	assert.True(t, ok)
+	assert.Equal(t, GPULabel, provider.GPULabel())
+}
+
+func TestVKEProvider_OptionalMethods(t *testing.T) {
+	provider, _ := newTestProvider(t)
+
+	_, pricingErr := provider.Pricing()
+	assert.Equal(t, cloudprovider.ErrNotImplemented, pricingErr)
+
+	_, hasErr := provider.HasInstance(&apiv1.Node{})
+	assert.Equal(t, cloudprovider.ErrNotImplemented, hasErr)
+
+	assert.NoError(t, provider.Cleanup())
+
+	rl, err := provider.GetResourceLimiter()
+	assert.NoError(t, err)
+	assert.NotNil(t, rl)
+}

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -154,6 +154,7 @@ skipped_names = [
     "cluster-autoscaler/cloudprovider/digitalocean/godo",
     "cluster-autoscaler/cloudprovider/externalgrpc/protos",
     "cluster-autoscaler/cloudprovider/magnum/gophercloud",
+    "cluster-autoscaler/cloudprovider/vke/gophercloud",
     "cluster-autoscaler/cloudprovider/ionoscloud/ionos-cloud-sdk-go",
     "cluster-autoscaler/cloudprovider/hetzner/hcloud-go",
     "cluster-autoscaler/cloudprovider/oci",

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -36,6 +36,7 @@ find_files() {
         -o -wholename '*/vendor/*' \
         -o -wholename '*/zz_generated.deepcopy.go' \
         -o -wholename './cluster-autoscaler/cloudprovider/magnum/gophercloud/*' \
+        -o -wholename './cluster-autoscaler/cloudprovider/vke/gophercloud/*' \
         -o -wholename './cluster-autoscaler/cloudprovider/digitalocean/godo/*' \
         -o -wholename './cluster-autoscaler/cloudprovider/bizflycloud/gobizfly/*' \
         -o -wholename './cluster-autoscaler/cloudprovider/externalgrpc/protos/*' \

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -24,6 +24,7 @@ cd "${KUBE_ROOT}"
 GOLINT=${GOLINT:-"golint"}
 excluded_packages=(
   'cluster-autoscaler/cloudprovider/magnum/gophercloud'
+  'cluster-autoscaler/cloudprovider/vke/gophercloud'
   'cluster-autoscaler/cloudprovider/digitalocean/godo'
   'cluster-autoscaler/cloudprovider/bizflycloud/gobizfly'
   'cluster-autoscaler/cloudprovider/brightbox/gobrightbox'

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -23,6 +23,7 @@ DIR=$(dirname $0)
 git ls-files --full-name \
     | grep -v -e vendor \
     | grep -v cluster-autoscaler/cloudprovider/magnum/gophercloud \
+    | grep -v cluster-autoscaler/cloudprovider/vke/gophercloud \
     | grep -v cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3 \
     | grep -v cluster-autoscaler/cloudprovider/digitalocean/godo \
     | grep -v cluster-autoscaler/cloudprovider/hetzner/hcloud-go \


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds an in-tree Cluster Autoscaler cloud provider for PortvMind Public Cloud Kubernetes Engine(https://github.com/vmindtech/vke).

VKE exposes node groups via its control-plane API and authenticates with
OpenStack application credentials. This integration allows CA to scale VKE
worker node groups up/down using `--cloud-provider=vke`.

Includes:
- VKE cloud provider implementation (`cloudprovider/vke`)
- Builder wiring (`builder_all.go`, `builder_vke.go`)
- Provider docs, examples, OWNERS, and unit tests

#### Which issue(s) this PR fixes:
<!--
If there is no tracking issue yet, leave this empty or link a discussion.
Do not invent an issue number.
-->
Fixes #

#### Special notes for your reviewer:

- Follows the managed node-pool pattern used by providers such as OVHcloud / DigitalOcean / Vultr.
- SDK and gophercloud are vendored under `cloudprovider/vke/` (no new top-level go.mod dependency).
- Optional interfaces (`Pricing`, `HasInstance`, node-group auto-provisioning) return `ErrNotImplemented`.
- Auth is deferred to the first `Refresh()` / `ReAuthenticate()` call.
- Scale-up uses the VKE add-node API; scale-down deletes specific nodes.
- Node `ProviderID` format: `openstack:///<instance-id>`
- Config via `--cloud-config` JSON + `VKE_URL` env var (see `cloudprovider/vke/README.md`).
- Unit tests: `go test ./cloudprovider/vke/...`
- Dev smoke tested: scale-up / scale-down on a VKE cluster.

#### Does this PR introduce a user-facing change?
<!--
Yes: new cloud provider users can enable.
-->
```release-note
Add VKE cloud provider support for Cluster Autoscaler (`--cloud-provider=vke`).