### PR TITLE
Prevent atomic node groups from burning ClusterAutoscalerScaleDownNodeRemovalLatency SLO

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
@@ -216,6 +216,13 @@ func WithTemplate(template *framework.NodeInfo) NodeGroupOption {
 	}
 }
 
+// WithNGOptions sets the autoscaling options of the node group.
+func WithNGOptions(opts *config.NodeGroupAutoscalingOptions) NodeGroupOption {
+	return func(n *NodeGroup) {
+		n.opts = opts
+	}
+}
+
 // WithNodeGarbageCollectionDelay can be used to simulate Node objects hanging around in the K8s API for some time after their VMs are deleted.
 func WithNodeGarbageCollectionDelay(delay time.Duration) NodeGroupOption {
 	return func(n *NodeGroup) {
@@ -317,6 +324,7 @@ type NodeGroup struct {
 	// nodeReadinessDelay can be used to simulate Node objects taking some time to transition to Ready after they appear in the K8s API. If unset,
 	// the Nodes will appear as Ready immediately after registration.
 	nodeReadinessDelay time.Duration
+	opts               *config.NodeGroupAutoscalingOptions
 }
 
 // MaxSize returns the maximum size of the node group.
@@ -439,7 +447,16 @@ func (n *NodeGroup) Autoprovisioned() bool {
 
 // GetOptions returns autoscaling options specific to this node group.
 func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, nil
+	n.RLock()
+	defer n.RUnlock()
+	return n.opts, nil
+}
+
+// SetOptions sets the autoscaling options for the node group.
+func (n *NodeGroup) SetOptions(opts *config.NodeGroupAutoscalingOptions) {
+	n.Lock()
+	defer n.Unlock()
+	n.opts = opts
 }
 
 // TargetSize returns the current target size of the node group.

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -306,11 +306,13 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 
 	timer := time.NewTimer(p.autoscalingCtx.ScaleDownSimulationTimeout)
 	var skippedNodes []string
+	atomicGroups := p.groupAtomicNodes(currentlyUnneededNodeNames)
+	processedAtomicGroups := make(map[string]bool)
 
 	for i, nodeName := range currentlyUnneededNodeNames {
 		if timedOut(timer) {
-			skippedNodes = append(skippedNodes, currentlyUnneededNodeNames[i:]...)
-			klog.Warningf("%d out of %d nodes skipped in scale down simulation due to timeout.", len(currentlyUnneededNodeNames)-i, len(currentlyUnneededNodeNames))
+			skippedNodes = p.appendUnprocessed(skippedNodes, currentlyUnneededNodeNames[i:], processedAtomicGroups)
+			klog.Warningf("%d out of %d nodes skipped in scale down simulation due to timeout.", len(skippedNodes), len(currentlyUnneededNodeNames))
 			break
 		}
 
@@ -320,9 +322,30 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 			continue
 		}
 		node := nodeInfo.Node()
-		_, isAtomic := atomic.IsAtomicNodeGroup(p.autoscalingCtx, node)
+		nodeGroup, isAtomic := atomic.IsAtomicNodeGroup(p.autoscalingCtx, node)
 
-		if !isAtomic && nonAtomicRemovableCount >= p.unneededNodesLimit() {
+		if isAtomic && nodeGroup != nil {
+			ngID := nodeGroup.Id()
+			if processedAtomicGroups[ngID] {
+				continue
+			}
+			groupRemovable, groupUnremovableCount, groupSkipped, timedOut := p.simulateAtomicNodeGroup(ngID, atomicGroups[ngID], podDestinations, unremovableTimeout, timer)
+			if timedOut {
+				skippedNodes = p.appendUnprocessed(skippedNodes, currentlyUnneededNodeNames[i:], processedAtomicGroups)
+				klog.Warningf("%d out of %d nodes skipped in scale down simulation due to timeout.", len(skippedNodes), len(currentlyUnneededNodeNames))
+				break
+			}
+			processedAtomicGroups[ngID] = true
+			if len(groupRemovable) > 0 {
+				removableList = append(removableList, groupRemovable...)
+				atomicScaleDownNodesCount += len(groupRemovable)
+			}
+			unremovableCount += groupUnremovableCount
+			skippedNodes = append(skippedNodes, groupSkipped...)
+			continue
+		}
+
+		if nonAtomicRemovableCount >= p.unneededNodesLimit() {
 			skippedNodes = append(skippedNodes, nodeName)
 			klog.V(4).Infof("Skipping non-atomic node %s in scale down simulation: there are already %d non-atomic unneeded nodes.", nodeName, nonAtomicRemovableCount)
 			continue
@@ -337,12 +360,7 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 			delete(podDestinations, removable.Node.Name)
 			p.autoscalingCtx.RemainingPdbTracker.RemovePods(removable.PodsToReschedule)
 			removableList = append(removableList, *removable)
-			if isAtomic {
-				atomicScaleDownNodesCount++
-				klog.V(2).Infof("Considering node %s for atomic scale down. Total atomic scale down nodes count: %d", removable.Node.Name, atomicScaleDownNodesCount)
-			} else {
-				nonAtomicRemovableCount++
-			}
+			nonAtomicRemovableCount++
 		}
 		if unremovable != nil {
 			unremovableCount += 1
@@ -433,6 +451,123 @@ func (p *Planner) prefilterIncompleteAtomicNodeGroups(nodeNames []string, unremo
 	}
 
 	return filteredNodeNames, unremovableCount
+}
+
+// groupAtomicNodes groups unneeded atomic node names by their NodeGroup ID.
+func (p *Planner) groupAtomicNodes(nodeNames []string) map[string][]string {
+	atomicGroups := make(map[string][]string)
+	for _, nodeName := range nodeNames {
+		nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+		if err != nil || nodeInfo == nil || nodeInfo.Node() == nil {
+			continue
+		}
+		node := nodeInfo.Node()
+		nodeGroup, isAtomic := atomic.IsAtomicNodeGroup(p.autoscalingCtx, node)
+		if isAtomic && nodeGroup != nil {
+			ngID := nodeGroup.Id()
+			atomicGroups[ngID] = append(atomicGroups[ngID], nodeName)
+		}
+	}
+	return atomicGroups
+}
+
+// appendUnprocessed appends remaining node names to skippedNodes, excluding nodes belonging to
+// atomic node groups that were already simulated.
+func (p *Planner) appendUnprocessed(skippedNodes []string, nodeNames []string, processedAtomicGroups map[string]bool) []string {
+	for _, nodeName := range nodeNames {
+		nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+		if err == nil && nodeInfo != nil && nodeInfo.Node() != nil {
+			nodeGroup, isAtomic := atomic.IsAtomicNodeGroup(p.autoscalingCtx, nodeInfo.Node())
+			if isAtomic && nodeGroup != nil && processedAtomicGroups[nodeGroup.Id()] {
+				continue
+			}
+		}
+		skippedNodes = append(skippedNodes, nodeName)
+	}
+	return skippedNodes
+}
+
+// simulateAtomicNodeGroup simulates removal of all nodes in an atomic node group as an all-or-nothing unit.
+// If any node in the group is unremovable, simulation of remaining nodes is aborted early, and any temporary
+// podDestinations and RemainingPdbTracker mutations are rolled back.
+// Returns removableList for the group, unremovableCount, skippedNodes, and whether simulation timed out.
+func (p *Planner) simulateAtomicNodeGroup(
+	ngID string,
+	ngNodes []string,
+	podDestinations map[string]bool,
+	unremovableTimeout time.Time,
+	timer *time.Timer,
+) ([]simulator.NodeToBeRemoved, int, []string, bool) {
+	if timedOut(timer) {
+		return nil, 0, ngNodes, true
+	}
+
+	podDestinationsCopy := make(map[string]bool, len(podDestinations))
+	for k, v := range podDestinations {
+		podDestinationsCopy[k] = v
+	}
+	pdbsSnapshot := p.autoscalingCtx.RemainingPdbTracker.GetPdbs()
+
+	var groupRemovable []simulator.NodeToBeRemoved
+
+	for j, nodeName := range ngNodes {
+		if timedOut(timer) {
+			for k := range podDestinations {
+				delete(podDestinations, k)
+			}
+			for k, v := range podDestinationsCopy {
+				podDestinations[k] = v
+			}
+			if err := p.autoscalingCtx.RemainingPdbTracker.SetPdbs(pdbsSnapshot); err != nil {
+				klog.Errorf("failed to restore PDB snapshot on timeout for atomic group %s: %v", ngID, err)
+			}
+			return nil, 0, ngNodes, true
+		}
+
+		removable, unremovable := p.rs.SimulateNodeRemoval(nodeName, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
+		if removable != nil {
+			_, inParallel, _ := p.autoscalingCtx.RemainingPdbTracker.CanRemovePods(removable.PodsToReschedule)
+			if !inParallel {
+				removable.IsRisky = true
+			}
+			delete(podDestinations, removable.Node.Name)
+			p.autoscalingCtx.RemainingPdbTracker.RemovePods(removable.PodsToReschedule)
+			groupRemovable = append(groupRemovable, *removable)
+			continue
+		}
+
+		// Early-Abort: nodeName is unremovable. Because this is an atomic node group,
+		// if any node fails simulation, the entire group cannot scale down.
+		klog.V(2).Infof("Atomic node group %s cannot scale down because node %s is unremovable. Early aborting simulation for %d nodes.", ngID, nodeName, len(ngNodes))
+
+		for k := range podDestinations {
+			delete(podDestinations, k)
+		}
+		for k, v := range podDestinationsCopy {
+			podDestinations[k] = v
+		}
+		if err := p.autoscalingCtx.RemainingPdbTracker.SetPdbs(pdbsSnapshot); err != nil {
+			klog.Errorf("failed to restore PDB snapshot after early abort for atomic group %s: %v", ngID, err)
+		}
+
+		for idx, name := range ngNodes {
+			if idx == j && unremovable != nil {
+				p.unremovableNodes.AddTimeout(unremovable, unremovableTimeout)
+			} else {
+				nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(name)
+				if err == nil && nodeInfo != nil && nodeInfo.Node() != nil {
+					p.unremovableNodes.AddTimeout(&simulator.UnremovableNode{
+						Node:   nodeInfo.Node(),
+						Reason: simulator.AtomicScaleDownFailed,
+					}, unremovableTimeout)
+				}
+			}
+		}
+		return nil, len(ngNodes), nil, false
+	}
+
+	klog.V(2).Infof("Atomic node group %s with %d nodes successfully simulated for removal.", ngID, len(groupRemovable))
+	return groupRemovable, 0, nil, false
 }
 
 // isNodeAtomicScaleDown checks if the node would be considered for atomic scale down.

--- a/cluster-autoscaler/core/scaledown/planner/planner.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/scheduling"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/utilization"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/atomic"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	pod_util "k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 	klog "k8s.io/klog/v2"
@@ -290,28 +291,44 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 	unremovableCount := 0
 	var removableList []simulator.NodeToBeRemoved
 	atomicScaleDownNodesCount := 0
+	nonAtomicRemovableCount := 0
 	p.unremovableNodes.Update(p.autoscalingCtx.ClusterSnapshot, p.latestUpdate)
 	currentlyUnneededNodeNames, utilizationMap, ineligible := p.eligibilityChecker.FilterOutUnremovable(p.autoscalingCtx, scaleDownCandidates, p.latestUpdate, p.unremovableNodes)
 	for _, n := range ineligible {
 		p.unremovableNodes.Add(n)
 	}
 	p.nodeUtilizationMap = utilizationMap
+
+	// Prefilter incomplete atomic node groups so simulation isn't wasted on atomic groups that cannot scale down.
+	var prefilteredUnremovableCount int
+	currentlyUnneededNodeNames, prefilteredUnremovableCount = p.prefilterIncompleteAtomicNodeGroups(currentlyUnneededNodeNames, unremovableTimeout)
+	unremovableCount += prefilteredUnremovableCount
+
 	timer := time.NewTimer(p.autoscalingCtx.ScaleDownSimulationTimeout)
 	var skippedNodes []string
 
-	for i, node := range currentlyUnneededNodeNames {
+	for i, nodeName := range currentlyUnneededNodeNames {
 		if timedOut(timer) {
-			skippedNodes = currentlyUnneededNodeNames[i:]
+			skippedNodes = append(skippedNodes, currentlyUnneededNodeNames[i:]...)
 			klog.Warningf("%d out of %d nodes skipped in scale down simulation due to timeout.", len(currentlyUnneededNodeNames)-i, len(currentlyUnneededNodeNames))
 			break
 		}
-		if len(removableList)-atomicScaleDownNodesCount >= p.unneededNodesLimit() {
-			skippedNodes = currentlyUnneededNodeNames[i:]
-			klog.V(4).Infof("%d out of %d nodes skipped in scale down simulation: there are already %d unneeded nodes so no point in looking for more. Total atomic scale down nodes: %d", len(currentlyUnneededNodeNames)-i, len(currentlyUnneededNodeNames), len(removableList), atomicScaleDownNodesCount)
-			break
+
+		nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+		if err != nil || nodeInfo == nil || nodeInfo.Node() == nil {
+			klog.Errorf("failed to get node info for %s: %v", nodeName, err)
+			continue
+		}
+		node := nodeInfo.Node()
+		_, isAtomic := atomic.IsAtomicNodeGroup(p.autoscalingCtx, node)
+
+		if !isAtomic && nonAtomicRemovableCount >= p.unneededNodesLimit() {
+			skippedNodes = append(skippedNodes, nodeName)
+			klog.V(4).Infof("Skipping non-atomic node %s in scale down simulation: there are already %d non-atomic unneeded nodes.", nodeName, nonAtomicRemovableCount)
+			continue
 		}
 
-		removable, unremovable := p.rs.SimulateNodeRemoval(node, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
+		removable, unremovable := p.rs.SimulateNodeRemoval(nodeName, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
 		if removable != nil {
 			_, inParallel, _ := p.autoscalingCtx.RemainingPdbTracker.CanRemovePods(removable.PodsToReschedule)
 			if !inParallel {
@@ -320,9 +337,11 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 			delete(podDestinations, removable.Node.Name)
 			p.autoscalingCtx.RemainingPdbTracker.RemovePods(removable.PodsToReschedule)
 			removableList = append(removableList, *removable)
-			if p.atomicScaleDownNode(removable) {
+			if isAtomic {
 				atomicScaleDownNodesCount++
 				klog.V(2).Infof("Considering node %s for atomic scale down. Total atomic scale down nodes count: %d", removable.Node.Name, atomicScaleDownNodesCount)
+			} else {
+				nonAtomicRemovableCount++
 			}
 		}
 		if unremovable != nil {
@@ -330,6 +349,7 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 			p.unremovableNodes.AddTimeout(unremovable, unremovableTimeout)
 		}
 	}
+
 	p.handleUnprocessedNodes(skippedNodes)
 	p.unneededNodes.Update(p.autoscalingCtx, removableList, p.latestUpdate)
 	if unremovableCount > 0 {
@@ -337,26 +357,88 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 	}
 }
 
-// atomicScaleDownNode checks if the removable node would be considered for atomic scale down.
-func (p *Planner) atomicScaleDownNode(node *simulator.NodeToBeRemoved) bool {
-	nodeGroup, err := p.autoscalingCtx.CloudProvider.NodeGroupForNode(node.Node)
+// prefilterIncompleteAtomicNodeGroups identifies atomic node groups in currentlyUnneededNodeNames.
+// If an atomic node group has fewer unneeded candidates than its target size, it cannot be
+// atomically scaled down. Such incomplete atomic node groups are filtered out of simulation,
+// and their nodes are marked as unremovable.
+func (p *Planner) prefilterIncompleteAtomicNodeGroups(nodeNames []string, unremovableTimeout time.Time) ([]string, int) {
+	atomicGroupNodes := make(map[string][]string)
+	atomicGroupObj := make(map[string]cloudprovider.NodeGroup)
+	nodeNameToNode := make(map[string]*apiv1.Node)
+
+	for _, nodeName := range nodeNames {
+		nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+		if err != nil || nodeInfo == nil || nodeInfo.Node() == nil {
+			continue
+		}
+		node := nodeInfo.Node()
+		nodeNameToNode[nodeName] = node
+		nodeGroup, isAtomic := atomic.IsAtomicNodeGroup(p.autoscalingCtx, node)
+		if isAtomic && nodeGroup != nil {
+			ngID := nodeGroup.Id()
+			atomicGroupNodes[ngID] = append(atomicGroupNodes[ngID], nodeName)
+			atomicGroupObj[ngID] = nodeGroup
+		}
+	}
+
+	if len(atomicGroupNodes) == 0 {
+		return nodeNames, 0
+	}
+
+	incompleteNodes := make(map[string]bool)
+	unremovableCount := 0
+
+	allNodes, err := allNodes(p.autoscalingCtx.ClusterSnapshot)
 	if err != nil {
-		klog.Errorf("failed to get node info for %v: %s", node.Node.Name, err)
-		return false
+		return nil, 0
 	}
-	if nodeGroup == nil {
-		klog.Errorf("Node group for node %s not found", node.Node.Name)
-		return false
+
+	for ngID, unneededNodes := range atomicGroupNodes {
+		ng := atomicGroupObj[ngID]
+		targetSize, err := ng.TargetSize()
+		if err != nil {
+			klog.Errorf("Failed to get target size for node group %s: %v", ngID, err)
+			continue
+		}
+
+		if len(unneededNodes) < targetSize {
+			registeredCount, countErr := atomic.CountRegisteredNodesForGroup(ng, allNodes)
+			if countErr == nil && len(unneededNodes) >= registeredCount {
+				// All registered nodes in the snapshot are unneeded
+				continue
+			}
+			klog.V(2).Infof("Atomic node group %s has %d unneeded nodes out of target size %d. Filtering out from scale down simulation.", ngID, len(unneededNodes), targetSize)
+			for _, nodeName := range unneededNodes {
+				incompleteNodes[nodeName] = true
+				if node, ok := nodeNameToNode[nodeName]; ok {
+					p.unremovableNodes.AddTimeout(&simulator.UnremovableNode{
+						Node:   node,
+						Reason: simulator.AtomicScaleDownFailed,
+					}, unremovableTimeout)
+					unremovableCount++
+				}
+			}
+		}
 	}
-	autoscalingOptions, err := nodeGroup.GetOptions(p.autoscalingCtx.NodeGroupDefaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
-		klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
-		return false
+
+	if len(incompleteNodes) == 0 {
+		return nodeNames, 0
 	}
-	if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
-		return true
+
+	filteredNodeNames := make([]string, 0, len(nodeNames)-len(incompleteNodes))
+	for _, nodeName := range nodeNames {
+		if !incompleteNodes[nodeName] {
+			filteredNodeNames = append(filteredNodeNames, nodeName)
+		}
 	}
-	return false
+
+	return filteredNodeNames, unremovableCount
+}
+
+// isNodeAtomicScaleDown checks if the node would be considered for atomic scale down.
+func (p *Planner) isNodeAtomicScaleDown(node *apiv1.Node) bool {
+	_, isAtomic := atomic.IsAtomicNodeGroup(p.autoscalingCtx, node)
+	return isAtomic
 }
 
 // unneededNodesLimit returns the number of nodes after which calculating more

--- a/cluster-autoscaler/core/scaledown/planner/planner_test.go
+++ b/cluster-autoscaler/core/scaledown/planner/planner_test.go
@@ -1297,6 +1297,6 @@ func TestAtomicScaleDownNodeNilGroup(t *testing.T) {
 		Node: n1,
 	}
 
-	result := p.atomicScaleDownNode(node)
+	result := p.isNodeAtomicScaleDown(node.Node)
 	assert.False(t, result)
 }

--- a/cluster-autoscaler/processors/nodes/scale_down_set_processor.go
+++ b/cluster-autoscaler/processors/nodes/scale_down_set_processor.go
@@ -18,14 +18,13 @@ package nodes
 
 import (
 	"slices"
-	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/annotations"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/atomic"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/klogx"
 	klog "k8s.io/klog/v2"
 )
@@ -132,15 +131,15 @@ func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(autoscalingCtx *
 			klog.V(2).Infof("Scheduling atomic scale down for all %v nodes from node group %s", len(consideredNodes), nodeGroup.Id())
 			nodesToBeRemoved = append(nodesToBeRemoved, consideredNodes...)
 		} else {
-			registeredNodes, err := p.getAllRegisteredNodesForNodeGroup(nodeGroup, allNodes)
+			registeredCount, err := atomic.CountRegisteredNodesForGroup(nodeGroup, allNodes)
 			if err != nil {
 				klog.Errorf("Failed to get registered nodes for group %s: %v", nodeGroup.Id(), err)
 				unremovableNodes = p.atomicScaleDownFailed(consideredNodes, ngSize, unremovableNodes, nodeGroup)
-			} else if len(registeredNodes) == len(consideredNodes) {
+			} else if registeredCount == len(consideredNodes) {
 				klog.V(2).Infof("Scheduling atomic scale down for all %v registered nodes from node group %s", len(consideredNodes), nodeGroup.Id())
 				nodesToBeRemoved = append(nodesToBeRemoved, consideredNodes...)
 			} else {
-				unremovableNodes = p.atomicScaleDownFailed(consideredNodes, len(registeredNodes), unremovableNodes, nodeGroup)
+				unremovableNodes = p.atomicScaleDownFailed(consideredNodes, registeredCount, unremovableNodes, nodeGroup)
 			}
 		}
 	}
@@ -167,29 +166,6 @@ func allNodes(s clustersnapshot.ClusterSnapshot) ([]*v1.Node, error) {
 		nodes[i] = ni.Node()
 	}
 	return nodes, nil
-}
-
-func (p *AtomicResizeFilteringProcessor) getAllRegisteredNodesForNodeGroup(nodeGroup cloudprovider.NodeGroup, allNodes []*v1.Node) ([]*v1.Node, error) {
-	allNodesInNodeGroup, err := nodeGroup.Nodes()
-	if err != nil {
-		return nil, err
-	}
-	nodeByNodeName := map[string]cloudprovider.Instance{}
-	for _, node := range allNodesInNodeGroup {
-		nodeByNodeName[node.Id] = node
-	}
-	var registeredNodesForNodeGroup []*v1.Node
-	for _, node := range allNodes {
-		if val, ok := node.Annotations[annotations.NodeUpcomingAnnotation]; ok {
-			if res, ok := strconv.ParseBool(val); ok == nil && res {
-				continue
-			}
-		}
-		if _, ok := nodeByNodeName[node.Spec.ProviderID]; ok {
-			registeredNodesForNodeGroup = append(registeredNodesForNodeGroup, node)
-		}
-	}
-	return registeredNodesForNodeGroup, nil
 }
 
 // CleanUp is called at CA termination

--- a/cluster-autoscaler/test/integration/inmemory/planner_test.go
+++ b/cluster-autoscaler/test/integration/inmemory/planner_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	fakecloudprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/test/integration"
+	synctestutils "k8s.io/autoscaler/cluster-autoscaler/test/integration/synctest"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+const (
+	plannerTestUnneededTime = 1 * time.Minute
+	plannerStepDuration     = 10 * time.Second
+)
+
+// TestPlanner_AtomicAndNonAtomicScaleDown verifies that the scaledown planner
+// correctly evaluates and processes both atomic and non-atomic node groups.
+func TestPlanner_AtomicAndNonAtomicScaleDown(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		// Create non-atomic node group with 2 nodes.
+		naTemplate := test.BuildTestNode("node-na", 1000, 1000, test.IsReady(true))
+		fakes.CloudProvider.AddNodeGroup("ng-nonatomic", fakecloudprovider.WithNodes(naTemplate, 2))
+
+		// Create atomic node group with ZeroOrMaxNodeScaling option and 2 nodes.
+		aTemplate := test.BuildTestNode("node-a", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Initial size check
+		sizeNonAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize()
+		assert.Equal(t, 2, sizeNonAtomic)
+		sizeAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize()
+		assert.Equal(t, 2, sizeAtomic)
+
+		// Run CA loop once to mark empty nodes as unneeded.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// Advance time past unneededTime to allow scale down actuation.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// Run loop again to complete removal of all unneeded nodes.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// Verify both non-atomic and atomic empty nodes are scaled down.
+		finalSizeNonAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize()
+		assert.Equal(t, 0, finalSizeNonAtomic, "Non-atomic empty nodes should be scaled down")
+
+		finalSizeAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize()
+		assert.Equal(t, 0, finalSizeAtomic, "Atomic empty nodes should be scaled down")
+	})
+}
+
+// TestPlanner_AtomicNodesProcessedAfterNonAtomicLimit verifies that when non-atomic simulation
+// hits the unneededNodesLimit, non-atomic loop breaks, but atomic nodes are still evaluated.
+func TestPlanner_AtomicNodesProcessedAfterNonAtomicLimit(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+			func(o *config.AutoscalingOptions) {
+				// Set MaxScaleDownParallelism to 1 so unneededNodesLimit() is capped at 2.
+				o.MaxScaleDownParallelism = 1
+			},
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		// Create 4 non-atomic nodes (exceeding limit of 2) in ng-nonatomic.
+		naTemplate := test.BuildTestNode("node-na", 1000, 1000, test.IsReady(true))
+		fakes.CloudProvider.AddNodeGroup("ng-nonatomic", fakecloudprovider.WithNodes(naTemplate, 4))
+
+		// Create atomic node group with ZeroOrMaxNodeScaling option and 2 nodes.
+		aTemplate := test.BuildTestNode("node-a", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Initial verification of target sizes
+		sizeNA, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize()
+		assert.Equal(t, 4, sizeNA)
+		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize()
+		assert.Equal(t, 2, sizeA)
+
+		// Run loop to mark unneeded
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// Advance past unneeded time and run scale down loop
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// Run subsequent iterations to allow scale down actuation of all evaluated nodes.
+		for i := 0; i < 5; i++ {
+			synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+		}
+
+		// Check that atomic nodes were evaluated and scaled down.
+		finalSizeAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize()
+		assert.Equal(t, 0, finalSizeAtomic, "Atomic nodes should be evaluated and scaled down even when non-atomic limit is reached")
+	})
+}
+
+// TestPlanner_SimulationTimeoutSkipsAtomicAndNonAtomic verifies that a simulation timeout
+// during non-atomic loop properly skips remaining non-atomic nodes and all atomic nodes.
+func TestPlanner_SimulationTimeoutSkipsAtomicAndNonAtomic(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+			func(o *config.AutoscalingOptions) {
+				// Set simulation timeout to negative duration to force immediate simulation timeout.
+				o.ScaleDownSimulationTimeout = -1 * time.Second
+			},
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		// Add destination helper node where pods can schedule if simulation runs.
+		destNode := test.BuildTestNode("dest-node", 10000, 10000, test.IsReady(true))
+		fakes.K8s.AddNode(destNode)
+
+		naTemplate := test.BuildTestNode("node-na", 1000, 1000, test.IsReady(true))
+		fakes.CloudProvider.AddNodeGroup("ng-nonatomic", fakecloudprovider.WithNodes(naTemplate, 2))
+
+		aTemplate := test.BuildTestNode("node-a", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Add scheduled pods to nodes so scale down simulation is required.
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-na-0", 100, 100, "ng-nonatomic-node-0"))
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-na-1", 100, 100, "ng-nonatomic-node-1"))
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-a-0", 100, 100, "ng-atomic-node-0"))
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-a-1", 100, 100, "ng-atomic-node-1"))
+
+		// Run CA loop. With simulation timeout <= 0, nodes should be skipped.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// Node groups should remain at original size because scale down simulation was skipped due to timeout.
+		sizeNA, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize()
+		assert.Equal(t, 2, sizeNA)
+		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize()
+		assert.Equal(t, 2, sizeA)
+	})
+}
+
+// TestPlanner_AtomicNodePdbHandling verifies scale down behavior when atomic nodes host pods subject to PDBs.
+func TestPlanner_AtomicNodePdbHandling(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		destNode := test.BuildTestNode("dest-node", 10000, 10000, test.IsReady(true))
+		fakes.K8s.AddNode(destNode)
+
+		aTemplate := test.BuildTestNode("node-a", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Create PDB allowing at most 1 pod disruption at a time
+		maxUnavailable := intstr.FromInt32(1)
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app-pdb",
+				Namespace: "default",
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MaxUnavailable: &maxUnavailable,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "test"},
+				},
+			},
+		}
+		_, err = fakes.KubeClient.PolicyV1().PodDisruptionBudgets("default").Create(ctx, pdb, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		pod0 := test.BuildScheduledTestPod("pod-a-0", 100, 100, "ng-atomic-node-0")
+		pod0.Labels = map[string]string{"app": "test"}
+		pod1 := test.BuildScheduledTestPod("pod-a-1", 100, 100, "ng-atomic-node-1")
+		pod1.Labels = map[string]string{"app": "test"}
+		fakes.K8s.AddPod(pod0)
+		fakes.K8s.AddPod(pod1)
+
+		// Run CA loop once to mark unneeded and run simulation.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// Run loop to actuate.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize()
+		assert.LessOrEqual(t, sizeA, 2, "Atomic node group evaluation with PDB succeeded")
+	})
+}
+
+// TestPlanner_IncompleteAtomicNodeGroupPrefiltered verifies that an atomic node group
+// with fewer unneeded nodes than its target size is prefiltered out before simulation,
+// and its target size remains unchanged.
+func TestPlanner_IncompleteAtomicNodeGroupPrefiltered(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		// Create atomic node group with ZeroOrMaxNodeScaling option and 2 nodes.
+		aTemplate := test.BuildTestNode("node", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Add a non-removable pod to node 0 of ng-atomic so node 0 is NOT unneeded.
+		blockingPod := test.BuildScheduledTestPod("blocking-pod", 100, 100, "ng-atomic-node-0")
+		blockingPod.Annotations = map[string]string{
+			"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+		}
+		fakes.K8s.AddPod(blockingPod)
+
+		// Run CA loop once to process candidates.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// Advance past unneeded time and run scale down loop.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// The atomic node group should NOT scale down because only 1 of 2 nodes was unneeded.
+		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize()
+		assert.Equal(t, 2, sizeA, "Incomplete atomic node group should be prefiltered and remain at target size 2")
+	})
+}

--- a/cluster-autoscaler/utils/atomic/atomic.go
+++ b/cluster-autoscaler/utils/atomic/atomic.go
@@ -1,0 +1,68 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"strconv"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/annotations"
+	klog "k8s.io/klog/v2"
+)
+
+// IsAtomicNodeGroup returns the node group and true if the given node belongs to an atomic node group (ZeroOrMaxNodeScaling).
+func IsAtomicNodeGroup(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node) (cloudprovider.NodeGroup, bool) {
+	nodeGroup, err := autoscalingCtx.CloudProvider.NodeGroupForNode(node)
+	if err != nil || nodeGroup == nil {
+		return nil, false
+	}
+	autoscalingOptions, err := nodeGroup.GetOptions(autoscalingCtx.NodeGroupDefaults)
+	if err != nil && err != cloudprovider.ErrNotImplemented {
+		klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
+		return nil, false
+	}
+	if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
+		return nodeGroup, true
+	}
+	return nil, false
+}
+
+// CountRegisteredNodesForGroup returns the number of registered (non-upcoming) nodes in allNodes belonging to nodeGroup.
+func CountRegisteredNodesForGroup(ng cloudprovider.NodeGroup, allNodes []*apiv1.Node) (int, error) {
+	nodesInGroup, err := ng.Nodes()
+	if err != nil {
+		return 0, err
+	}
+	nodeByProviderID := make(map[string]bool, len(nodesInGroup))
+	for _, node := range nodesInGroup {
+		nodeByProviderID[node.Id] = true
+	}
+	count := 0
+	for _, node := range allNodes {
+		if val, ok := node.Annotations[annotations.NodeUpcomingAnnotation]; ok {
+			if res, ok := strconv.ParseBool(val); ok == nil && res {
+				continue
+			}
+		}
+		if nodeByProviderID[node.Spec.ProviderID] {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/cluster-autoscaler/utils/atomic/atomic_test.go
+++ b/cluster-autoscaler/utils/atomic/atomic_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+
+	testprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/annotations"
+)
+
+func TestIsAtomicNodeGroup(t *testing.T) {
+	n1 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       apiv1.NodeSpec{ProviderID: "n1"},
+	}
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	atomicOpts := &config.NodeGroupAutoscalingOptions{
+		ZeroOrMaxNodeScaling: true,
+	}
+	provider.AddNodeGroupWithCustomOptions("ng-atomic", 0, 10, 2, atomicOpts)
+	provider.AddNode("ng-atomic", n1)
+
+	n2 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n2"},
+		Spec:       apiv1.NodeSpec{ProviderID: "n2"},
+	}
+	provider.AddNodeGroup("ng-standard", 0, 10, 2)
+	provider.AddNode("ng-standard", n2)
+
+	autoscalingCtx := ca_context.AutoscalingContext{
+		CloudProvider: provider,
+	}
+
+	ng, isAtomic := IsAtomicNodeGroup(&autoscalingCtx, n1)
+	assert.True(t, isAtomic)
+	assert.Equal(t, "ng-atomic", ng.Id())
+
+	ng2, isAtomic2 := IsAtomicNodeGroup(&autoscalingCtx, n2)
+	assert.False(t, isAtomic2)
+	assert.Nil(t, ng2)
+}
+
+func TestCountRegisteredNodesForGroup(t *testing.T) {
+	n1 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       apiv1.NodeSpec{ProviderID: "n1"},
+	}
+	n2 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "n2",
+			Annotations: map[string]string{annotations.NodeUpcomingAnnotation: "true"},
+		},
+		Spec: apiv1.NodeSpec{ProviderID: "n2"},
+	}
+	n3 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n3"},
+		Spec:       apiv1.NodeSpec{ProviderID: "n3"},
+	}
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 0, 10, 3)
+	provider.AddNode("ng1", n1)
+	provider.AddNode("ng1", n2)
+	provider.AddNode("ng1", n3)
+
+	ng := provider.GetNodeGroup("ng1")
+	allNodes := []*apiv1.Node{n1, n2, n3}
+	count, err := CountRegisteredNodesForGroup(ng, allNodes)
+	assert.NoError(t, err)
+	// n2 has NodeUpcomingAnnotation=true, so registered count should be 2
+	assert.Equal(t, 2, count)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

This PR refactors scale-down simulation for Atomic Node Pools (`ZeroOrMaxNodeScaling=true`) to evaluate candidate groups as all-or-nothing units with early-abort while preserving fair interleaving between atomic and non-atomic node groups.

Previously, the scale-down planner simulated atomic node pools node-by-node in arbitrary order:
    1. If a node late in an atomic node group failed removal simulation (e.g., due to an unevictable pod or PDB limit), all earlier simulations for that group were wasted.
    2. Nodes from partially removable atomic groups were added to `removableList` (`unneededNodes`) and registered in `NodeLatencyTracker`. When later in the scaled down process node group was rejected from scaling down because of being incomplete, those partially simulated nodes remained trapped in tracking across cycles, ticking past the 600s threshold and triggering false SLO latency alerts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes b/524606761

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
