### PR TITLE
[Scaledown] Partial taint actuation

### DIFF
--- a/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/test/fake_cloud_provider.go
@@ -238,6 +238,13 @@ func WithNodeReadinessDelay(delay time.Duration) NodeGroupOption {
 	}
 }
 
+// WithNodeGroupOptions sets the autoscaling options for the node group.
+func WithNodeGroupOptions(opts *config.NodeGroupAutoscalingOptions) NodeGroupOption {
+	return func(n *NodeGroup) {
+		n.opts = opts
+	}
+}
+
 // AddNodeGroup is a helper for tests to add a group with its template.
 func (c *CloudProvider) AddNodeGroup(id string, opts ...NodeGroupOption) *NodeGroup {
 	c.Lock()
@@ -317,6 +324,9 @@ type NodeGroup struct {
 	// nodeReadinessDelay can be used to simulate Node objects taking some time to transition to Ready after they appear in the K8s API. If unset,
 	// the Nodes will appear as Ready immediately after registration.
 	nodeReadinessDelay time.Duration
+
+	// opts contains the autoscaling options for this node group.
+	opts *config.NodeGroupAutoscalingOptions
 }
 
 // MaxSize returns the maximum size of the node group.
@@ -439,7 +449,7 @@ func (n *NodeGroup) Autoprovisioned() bool {
 
 // GetOptions returns autoscaling options specific to this node group.
 func (n *NodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, nil
+	return n.opts, nil
 }
 
 // TargetSize returns the current target size of the node group.

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -385,6 +385,8 @@ type AutoscalingOptions struct {
 	PendingPodsBatchingTimeout time.Duration
 	// GracefulDegradationEnabled tells if graceful degradation for unschedulable pods is enabled.
 	GracefulDegradationEnabled bool
+	// PartialTaintActuation determines whether successfully tainted nodes in non-atomic nodegroups will still be deleted if other nodes in the batch fail to taint.
+	PartialTaintActuationEnabled bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/cluster-autoscaler/config/flags/flags.go
+++ b/cluster-autoscaler/config/flags/flags.go
@@ -106,15 +106,16 @@ var (
 			"for scale down when some candidates from previous iteration are no longer valid."+
 			"When calculating the pool size for additional candidates we take"+
 			"max(#nodes * scale-down-candidates-pool-ratio, scale-down-candidates-pool-min-count).")
-	schedulerConfigFile         = flag.String(config.SchedulerConfigFileFlag, "", "scheduler-config allows changing configuration of in-tree scheduler plugins acting on PreFilter and Filter extension points")
-	nodeDeletionDelayTimeout    = flag.Duration("node-deletion-delay-timeout", 2*time.Minute, "Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node.")
-	nodeDeletionBatcherInterval = flag.Duration("node-deletion-batcher-interval", 0*time.Second, "How long CA ScaleDown gather nodes to delete them in batch.")
-	scanInterval                = flag.Duration("scan-interval", config.DefaultScanInterval, "How often cluster is reevaluated for scale up or down")
-	maxNodesTotal               = flag.Int("max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
-	coresTotal                  = flag.String("cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
-	memoryTotal                 = flag.String("memory-total", minMaxFlagString(0, config.DefaultMaxClusterMemory), "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
-	gpuTotal                    = multiStringFlag("gpu-total", "Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE.")
-	cloudProviderFlag           = flag.String("cloud-provider", cloudBuilder.DefaultCloudProvider(),
+	partialTaintActuationEnabled = flag.Bool("partial-taint-actuation-enabled", false, "If true, Cluster Autoscaler will proceed with deleting successfully tainted nodes in non-atomic nodegroups even if individual node taints fail in the same batch.")
+	schedulerConfigFile          = flag.String(config.SchedulerConfigFileFlag, "", "scheduler-config allows changing configuration of in-tree scheduler plugins acting on PreFilter and Filter extension points")
+	nodeDeletionDelayTimeout     = flag.Duration("node-deletion-delay-timeout", 2*time.Minute, "Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node.")
+	nodeDeletionBatcherInterval  = flag.Duration("node-deletion-batcher-interval", 0*time.Second, "How long CA ScaleDown gather nodes to delete them in batch.")
+	scanInterval                 = flag.Duration("scan-interval", config.DefaultScanInterval, "How often cluster is reevaluated for scale up or down")
+	maxNodesTotal                = flag.Int("max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
+	coresTotal                   = flag.String("cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
+	memoryTotal                  = flag.String("memory-total", minMaxFlagString(0, config.DefaultMaxClusterMemory), "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
+	gpuTotal                     = multiStringFlag("gpu-total", "Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE.")
+	cloudProviderFlag            = flag.String("cloud-provider", cloudBuilder.DefaultCloudProvider(),
 		"Cloud provider type. Available values: ["+strings.Join(cloudBuilder.AvailableCloudProviders(), ",")+"]")
 	maxBulkSoftTaintCount      = flag.Int("max-bulk-soft-taint-count", 10, "Maximum number of nodes that can be tainted/untainted PreferNoSchedule at the same time. Set to 0 to turn off such tainting.")
 	maxBulkSoftTaintTime       = flag.Duration("max-bulk-soft-taint-time", 3*time.Second, "Maximum duration of tainting/untainting nodes as PreferNoSchedule at the same time.")
@@ -381,6 +382,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		ScaleDownNonEmptyCandidatesCount: *scaleDownNonEmptyCandidatesCount,
 		ScaleDownCandidatesPoolRatio:     *scaleDownCandidatesPoolRatio,
 		ScaleDownCandidatesPoolMinCount:  *scaleDownCandidatesPoolMinCount,
+		PartialTaintActuationEnabled:     *partialTaintActuationEnabled,
 		DrainPriorityConfig:              drainPriorityConfigMap,
 		SchedulerConfig:                  parsedSchedConfig,
 		WriteStatusConfigMap:             *writeStatusConfigMapFlag,

--- a/cluster-autoscaler/core/scaledown/actuation/actuator.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator.go
@@ -135,6 +135,13 @@ func (a *Actuator) startDeletion(empty, drain []*apiv1.Node, force bool) (status
 	deletionStartTime := time.Now()
 	defer func() { metrics.UpdateDuration(metrics.ScaleDownNodeDeletion, time.Since(deletionStartTime)) }()
 
+	var nodesToClean []*apiv1.Node
+	defer func() {
+		if len(nodesToClean) > 0 {
+			a.cleanNodesToBeDeleted(nodesToClean)
+		}
+	}()
+
 	scaledDownNodes := make([]*status.ScaleDownNode, 0)
 	emptyToDelete, drainToDelete := a.budgetProcessor.CropNodes(a.nodeDeletionTracker, empty, drain)
 	if len(emptyToDelete) == 0 && len(drainToDelete) == 0 {
@@ -143,25 +150,31 @@ func (a *Actuator) startDeletion(empty, drain []*apiv1.Node, force bool) (status
 
 	if len(emptyToDelete) > 0 {
 		// Taint all empty nodes synchronously
-		nodeDeleteDelayAfterTaint, err := a.taintNodesSync(emptyToDelete)
+		taintRes, err := a.taintNodesSync(emptyToDelete)
+		if len(taintRes.nodesToClean) > 0 {
+			nodesToClean = append(nodesToClean, taintRes.nodesToClean...)
+		}
 		if err != nil {
 			return status.ScaleDownError, scaledDownNodes, err
 		}
 
-		emptyScaledDown := a.deleteAsyncEmpty(emptyToDelete, nodeDeleteDelayAfterTaint, force)
+		emptyScaledDown := a.deleteAsyncEmpty(taintRes.successfulNodes, taintRes.delayAfterTaint, force)
 		scaledDownNodes = append(scaledDownNodes, emptyScaledDown...)
 	}
 
 	if len(drainToDelete) > 0 {
 		// Taint all nodes that need drain synchronously, but don't start any drain/deletion yet. Otherwise, pods evicted from one to-be-deleted node
 		// could get recreated on another.
-		nodeDeleteDelayAfterTaint, err := a.taintNodesSync(drainToDelete)
+		taintRes, err := a.taintNodesSync(drainToDelete)
+		if len(taintRes.nodesToClean) > 0 {
+			nodesToClean = append(nodesToClean, taintRes.nodesToClean...)
+		}
 		if err != nil {
 			return status.ScaleDownError, scaledDownNodes, err
 		}
 
 		// All nodes involved in the scale-down should be tainted now - start draining and deleting nodes asynchronously.
-		drainScaledDown := a.deleteAsyncDrain(drainToDelete, nodeDeleteDelayAfterTaint, force)
+		drainScaledDown := a.deleteAsyncDrain(taintRes.successfulNodes, taintRes.delayAfterTaint, force)
 		scaledDownNodes = append(scaledDownNodes, drainScaledDown...)
 	}
 
@@ -193,9 +206,15 @@ func (a *Actuator) deleteAsyncEmpty(NodeGroupViews []*budgets.NodeGroupView, nod
 	return reportedSDNodes
 }
 
+type taintNodesResult struct {
+	delayAfterTaint time.Duration
+	successfulNodes []*budgets.NodeGroupView
+	nodesToClean    []*apiv1.Node
+}
+
 // taintNodesSync synchronously taints all provided nodes with NoSchedule. If tainting fails for any of the nodes, already
-// applied taints are cleaned up.
-func (a *Actuator) taintNodesSync(NodeGroupViews []*budgets.NodeGroupView) (time.Duration, errors.AutoscalerError) {
+// applied taints are cleaned up. It returns a taintNodesResult containing the actual node delay, the successfully tainted NodeGroupViews, and a list of nodes to clean up, as well as any fatal error.
+func (a *Actuator) taintNodesSync(NodeGroupViews []*budgets.NodeGroupView) (taintNodesResult, errors.AutoscalerError) {
 	nodesToTaint := make([]*apiv1.Node, 0)
 	var updateLatencyTracker *UpdateLatencyTracker
 	nodeDeleteDelayAfterTaint := a.nodeDeleteDelayAfterTaint
@@ -207,57 +226,191 @@ func (a *Actuator) taintNodesSync(NodeGroupViews []*budgets.NodeGroupView) (time
 	for _, bucket := range NodeGroupViews {
 		for _, node := range bucket.Nodes {
 			if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
+				// The start timestamps pushed to the tracker prior to this block are captured before client-go token bucket rate-limiting (QPS/burst).
+				// Therefore, this metric inherently measures: [client-side throttle queue time + network round trip + API server propagation time].
 				updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, time.Now()}
 			}
 			nodesToTaint = append(nodesToTaint, node)
 		}
 	}
-	failedTaintedNodes := make(chan struct {
+
+	var successfulNodeGroupViews []*budgets.NodeGroupView
+	var globalNodesToClean []*apiv1.Node
+	var retErr errors.AutoscalerError
+
+	if a.autoscalingCtx.AutoscalingOptions.PartialTaintActuationEnabled {
+		failedNodes := a.applyTaintsConcurrently(nodesToTaint)
+
+		if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
+			// ExpectedCount relies entirely on the network response. If a node taint call throws a network timeout but implicitly succeeds
+			// on the server, expectedCount drops but a start timestamp was already recorded. The tracker loop may hit its expected count early
+			// and underestimate max latency. This is a known, accepted compromise.
+			expectedCount := len(nodesToTaint) - len(failedNodes)
+			if expectedCount == 0 {
+				close(updateLatencyTracker.ExpectedNodeCountChan)
+			} else {
+				updateLatencyTracker.ExpectedNodeCountChan <- expectedCount
+				latency, ok := <-updateLatencyTracker.ResultChan
+				if ok {
+					a.pastLatencies.RegisterElement(latency)
+					a.pastLatencies.DropNotNewerThan(time.Now().Add(-1 * pastLatencyExpireDuration))
+					nodeDeleteDelayAfterTaint = 2 * maxLatency(a.pastLatencies.ToSlice())
+				}
+			}
+		}
+
+		if len(failedNodes) > 0 {
+			klog.Warningf("Couldn't taint %d nodes with ToBeDeleted, proceeding with partial scale down or bucket cleanup", len(failedNodes))
+			for _, node := range nodesToTaint {
+				if err, ok := failedNodes[node.Name]; ok {
+					a.autoscalingCtx.Recorder.Eventf(node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to mark the node as toBeDeleted/unschedulable: %v", err)
+				}
+			}
+			successfulNodeGroupViews, globalNodesToClean = a.resolveTaintFailures(NodeGroupViews, failedNodes)
+			if len(successfulNodeGroupViews) == 0 {
+				retErr = errors.NewAutoscalerErrorf(errors.ApiCallError, "couldn't taint %d nodes with ToBeDeleted and no nodes can be scaled down", len(failedNodes))
+			}
+		} else {
+			successfulNodeGroupViews = NodeGroupViews
+		}
+	} else {
+		failedTaintedNodes := make(chan struct {
+			node *apiv1.Node
+			err  error
+		}, len(nodesToTaint))
+		taintedNodes := make(chan *apiv1.Node, len(nodesToTaint))
+		workqueue.ParallelizeUntil(context.Background(), maxConcurrentNodesTainting, len(nodesToTaint), func(piece int) {
+			node := nodesToTaint[piece]
+			err := a.taintNode(node)
+			if err != nil {
+				failedTaintedNodes <- struct {
+					node *apiv1.Node
+					err  error
+				}{node: node, err: err}
+			} else {
+				taintedNodes <- node
+			}
+		})
+		close(failedTaintedNodes)
+		close(taintedNodes)
+		failedCount := len(failedTaintedNodes)
+		if failedCount > 0 {
+			for nodeWithError := range failedTaintedNodes {
+				a.autoscalingCtx.Recorder.Eventf(nodeWithError.node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to mark the node as toBeDeleted/unschedulable: %v", nodeWithError.err)
+			}
+			// Clean up already applied taints in case of issues.
+			for taintedNode := range taintedNodes {
+				globalNodesToClean = append(globalNodesToClean, taintedNode)
+			}
+			retErr = errors.NewAutoscalerErrorf(errors.ApiCallError, "couldn't taint %d nodes with ToBeDeleted", failedCount)
+		} else {
+			successfulNodeGroupViews = NodeGroupViews
+		}
+
+		if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
+			if len(successfulNodeGroupViews) == 0 {
+				close(updateLatencyTracker.ExpectedNodeCountChan)
+			} else {
+				expectedCount := 0
+				for _, bucket := range successfulNodeGroupViews {
+					expectedCount += len(bucket.Nodes)
+				}
+				updateLatencyTracker.ExpectedNodeCountChan <- expectedCount
+				latency, ok := <-updateLatencyTracker.ResultChan
+				if ok {
+					a.pastLatencies.RegisterElement(latency)
+					a.pastLatencies.DropNotNewerThan(time.Now().Add(-1 * pastLatencyExpireDuration))
+					nodeDeleteDelayAfterTaint = 2 * maxLatency(a.pastLatencies.ToSlice())
+				}
+			}
+		}
+	}
+
+	return taintNodesResult{
+		delayAfterTaint: nodeDeleteDelayAfterTaint,
+		successfulNodes: successfulNodeGroupViews,
+		nodesToClean:    globalNodesToClean,
+	}, retErr
+}
+
+// applyTaintsConcurrently attempts to add the ToBeDeleted taint to all nodes in the batch.
+// It executes via workqueue.ParallelizeUntil to prevent single-node networking latency from bottlenecking the loop.
+// Returns a map of node names to errors for nodes that failed the network taint call.
+func (a *Actuator) applyTaintsConcurrently(nodesToTaint []*apiv1.Node) map[string]error {
+	type taintResult struct {
 		node *apiv1.Node
 		err  error
-	}, len(nodesToTaint))
-	taintedNodes := make(chan *apiv1.Node, len(nodesToTaint))
+	}
+	results := make(chan taintResult, len(nodesToTaint))
+
 	workqueue.ParallelizeUntil(context.Background(), maxConcurrentNodesTainting, len(nodesToTaint), func(piece int) {
 		node := nodesToTaint[piece]
 		err := a.taintNode(node)
-		if err != nil {
-			failedTaintedNodes <- struct {
-				node *apiv1.Node
-				err  error
-			}{node: node, err: err}
-		} else {
-			taintedNodes <- node
-		}
+		results <- taintResult{node: node, err: err}
 	})
-	close(failedTaintedNodes)
-	close(taintedNodes)
-	if len(failedTaintedNodes) > 0 {
-		for nodeWithError := range failedTaintedNodes {
-			a.autoscalingCtx.Recorder.Eventf(nodeWithError.node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to mark the node as toBeDeleted/unschedulable: %v", nodeWithError.err)
-		}
-		// Clean up already applied taints in case of issues.
-		for taintedNode := range taintedNodes {
-			_, _ = taints.CleanToBeDeleted(taintedNode, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
-		}
-		if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
-			close(updateLatencyTracker.AwaitOrStopChan)
-		}
-		return nodeDeleteDelayAfterTaint, errors.NewAutoscalerErrorf(errors.ApiCallError, "couldn't taint %d nodes with ToBeDeleted", len(failedTaintedNodes))
-	}
+	close(results)
 
-	if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
-		updateLatencyTracker.AwaitOrStopChan <- true
-		latency, ok := <-updateLatencyTracker.ResultChan
-		if ok {
-			a.pastLatencies.RegisterElement(latency)
-			a.pastLatencies.DropNotNewerThan(time.Now().Add(-1 * pastLatencyExpireDuration))
-			// CA is expected to wait 3 times the round-trip time between CA and the api-server.
-			// At this point, we have already tainted all the nodes.
-			// Therefore, the nodeDeleteDelayAfterTaint is set 2 times the maximum latency observed during the last hour.
-			nodeDeleteDelayAfterTaint = 2 * maxLatency(a.pastLatencies.ToSlice())
+	failedNodes := make(map[string]error)
+	for res := range results {
+		if res.err != nil {
+			failedNodes[res.node.Name] = res.err
 		}
 	}
-	return nodeDeleteDelayAfterTaint, nil
+	return failedNodes
+}
+
+// resolveTaintFailures evaluates how to handle taint failures in a batch of nodes.
+//
+// When actuator fails to apply a taint to a node:
+//   - If the node is from an atomic nodegroup, actuator must clean up all successfully applied taints in this nodegroup. The group won't be scaled down.
+//   - If the node is from a regular, non-atomic nodegorup, other successfully tainted nodes from this nodegroup can be deleted.
+//
+// It returns nodes (grouped by nodegroup) that can proceed to deletion, and a list of nodes that require taint cleanup.
+func (a *Actuator) resolveTaintFailures(nodeGroupViews []*budgets.NodeGroupView, failedNodes map[string]error) ([]*budgets.NodeGroupView, []*apiv1.Node) {
+	var successfulNodeGroupViews []*budgets.NodeGroupView
+	var globalNodesToClean []*apiv1.Node
+
+	for _, bucket := range nodeGroupViews {
+		opts, err := bucket.Group.GetOptions(a.autoscalingCtx.NodeGroupDefaults)
+		isAtomic := false
+		if err != nil {
+			klog.Warningf("Failed to get options for node group %v: %v, assuming atomic node to be safe", bucket.Group.Id(), err)
+			isAtomic = true
+		} else if opts != nil && opts.ZeroOrMaxNodeScaling {
+			isAtomic = true
+		}
+
+		var successfulBucket *budgets.NodeGroupView
+		var toClean []*apiv1.Node
+
+		if isAtomic {
+			successfulBucket, toClean = resolveAtomicBucketFailures(bucket, failedNodes)
+		} else {
+			successfulBucket, toClean = resolveNonAtomicBucketFailures(bucket, failedNodes)
+		}
+
+		if successfulBucket != nil {
+			successfulNodeGroupViews = append(successfulNodeGroupViews, successfulBucket)
+		}
+		if len(toClean) > 0 {
+			globalNodesToClean = append(globalNodesToClean, toClean...)
+		}
+	}
+	return successfulNodeGroupViews, globalNodesToClean
+}
+
+// cleanNodesToBeDeleted executes the rollback of ToBeDeleted taints concurrently across all nodes provided.
+// This is typically deferred to run at the absolute end of the StartDeletion loop so as not to stall the healthy path.
+func (a *Actuator) cleanNodesToBeDeleted(nodes []*apiv1.Node) {
+	if a.autoscalingCtx.AutoscalingOptions.PartialTaintActuationEnabled {
+		workqueue.ParallelizeUntil(context.Background(), maxConcurrentNodesTainting, len(nodes), func(piece int) {
+			_, _ = taints.CleanToBeDeleted(nodes[piece], a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
+		})
+	} else {
+		for _, node := range nodes {
+			_, _ = taints.CleanToBeDeleted(node, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
+		}
+	}
 }
 
 // deleteAsyncDrain asynchronously starts deletions with drain for all provided nodes. scaledDownNodes return value contains all nodes for which
@@ -364,25 +517,25 @@ func (a *Actuator) deleteNodesAsync(nodes []*apiv1.Node, nodeGroup cloudprovider
 func (a *Actuator) scaleDownNodeToReport(node *apiv1.Node, drain bool) (*status.ScaleDownNode, error) {
 	nodeGroup, err := a.autoscalingCtx.CloudProvider.NodeGroupForNode(node)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewAutoscalerErrorf(errors.InternalError, "failed to get node group for node %s: %v", node.Name, err)
 	}
 	if nodeGroup == nil {
 		return nil, errors.NewAutoscalerErrorf(errors.NodeGroupDoesNotExistError, "no node group for node %s", node.Name)
 	}
 	nodeInfo, err := a.autoscalingCtx.ClusterSnapshot.GetNodeInfo(node.Name)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewAutoscalerErrorf(errors.InternalError, "failed to get node info for %s: %v", node.Name, err)
 	}
 
 	ignoreDaemonSetsUtilization, err := a.configGetter.GetIgnoreDaemonSetsUtilization(nodeGroup)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewAutoscalerErrorf(errors.InternalError, "failed to get ignoreDaemonSetsUtilization for node group %s: %v", nodeGroup.Id(), err)
 	}
 
 	gpuConfig := a.autoscalingCtx.CloudProvider.GetNodeGpuConfig(node)
 	utilInfo, err := utilization.Calculate(nodeInfo, ignoreDaemonSetsUtilization, a.autoscalingCtx.IgnoreMirrorPodsUtilization, a.autoscalingCtx.DynamicResourceAllocationEnabled, gpuConfig, time.Now())
 	if err != nil {
-		return nil, err
+		return nil, errors.NewAutoscalerErrorf(errors.InternalError, "failed to calculate utilization for %s: %v", node.Name, err)
 	}
 	var evictedPods []*apiv1.Pod
 	if drain {
@@ -446,4 +599,50 @@ func joinPodNames(pods []*apiv1.Pod) string {
 		names = append(names, pod.Name)
 	}
 	return strings.Join(names, ",")
+}
+
+// resolveAtomicBucketFailures handles partial taint failures for zero-or-max atomic NodeGroups (like TPU slices).
+// An atomic NodeGroup must scale entirely or not at all; if even one node fails tainting, the entire bucket is rolled back.
+func resolveAtomicBucketFailures(bucket *budgets.NodeGroupView, failedNodes map[string]error) (*budgets.NodeGroupView, []*apiv1.Node) {
+	bucketFailed := false
+	for _, node := range bucket.Nodes {
+		if failedNodes[node.Name] != nil {
+			bucketFailed = true
+			break
+		}
+	}
+	if bucketFailed {
+		var toClean []*apiv1.Node
+		for _, node := range bucket.Nodes {
+			if failedNodes[node.Name] == nil {
+				toClean = append(toClean, node)
+			}
+		}
+		return nil, toClean
+	}
+	return bucket, nil
+}
+
+// resolveNonAtomicBucketFailures handles partial taint failures for standard, non-atomic NodeGroups.
+// It safely separates the batch, allowing successfully tainted nodes to proceed to immediate deletion while returning failed ones for cleanup.
+func resolveNonAtomicBucketFailures(bucket *budgets.NodeGroupView, failedNodes map[string]error) (*budgets.NodeGroupView, []*apiv1.Node) {
+	successfulNodes := make([]*apiv1.Node, 0, len(bucket.Nodes))
+
+	for _, node := range bucket.Nodes {
+		if failedNodes[node.Name] == nil {
+			successfulNodes = append(successfulNodes, node)
+		}
+	}
+
+	if len(successfulNodes) == len(bucket.Nodes) {
+		return bucket, nil
+	}
+
+	if len(successfulNodes) > 0 {
+		newBucket := *bucket
+		newBucket.Nodes = successfulNodes
+		return &newBucket, nil
+	}
+
+	return nil, nil
 }

--- a/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/actuator_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/utilization"
+	caerrors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -71,21 +72,23 @@ type scaleDownStatusInfo struct {
 }
 
 type startDeletionTestCase struct {
-	defaultOnly           bool // Set to true to only run default deletion logic tests.
-	forcedOnly            bool // Set to true to only run forced deletion logic tests.
-	nodeGroups            map[string]*testprovider.TestNodeGroup
-	emptyNodes            []nodeGroupViewInfo
-	drainNodes            []nodeGroupViewInfo
-	pods                  map[string][]*apiv1.Pod
-	failedPodDrain        map[string]bool
-	failedNodeDeletion    map[string]bool
-	failedNodeTaint       map[string]bool
-	wantStatus            scaleDownStatusInfo
-	wantErr               error
-	wantDeletedPods       []string
-	wantDeletedNodes      []string
-	wantTaintUpdates      map[string][][]apiv1.Taint
-	wantNodeDeleteResults map[string]status.NodeDeleteResult
+	defaultOnly                   bool // Set to true to only run default deletion logic tests.
+	forcedOnly                    bool // Set to true to only run forced deletion logic tests.
+	nodeGroups                    map[string]*testprovider.TestNodeGroup
+	emptyNodes                    []nodeGroupViewInfo
+	drainNodes                    []nodeGroupViewInfo
+	pods                          map[string][]*apiv1.Pod
+	failedPodDrain                map[string]bool
+	failedNodeDeletion            map[string]bool
+	failedNodeTaint               map[string]bool
+	partialTaintActuationEnabled  bool
+	dynamicNodeDeleteDelayEnabled bool
+	wantStatus                    scaleDownStatusInfo
+	wantErr                       error
+	wantDeletedPods               []string
+	wantDeletedNodes              []string
+	wantTaintUpdates              map[string][][]apiv1.Taint
+	wantNodeDeleteResults         map[string]status.NodeDeleteResult
 }
 
 func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, force bool, suffix string) map[string]startDeletionTestCase {
@@ -178,6 +181,274 @@ func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, force bool, suf
 			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
 				"atomic-2-node-0": {ResultType: status.NodeDeleteOk},
 				"atomic-2-node-1": {ResultType: status.NodeDeleteOk},
+			},
+		},
+		"empty node deletion with failed taint": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-4": sizedNodeGroup("test-4", 4, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-4", 0, 4},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-4-node-1": true,
+			},
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownError,
+			},
+			wantErr:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted"),
+			wantDeletedNodes: nil,
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"test-4-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"test-4-node-2": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"test-4-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
+			},
+		},
+
+		"empty node deletion with all taints failing, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-3": sizedNodeGroup("test-3", 3, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-3", 0, 3},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-3-node-0": true,
+				"test-3-node-1": true,
+				"test-3-node-2": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownError,
+			},
+			wantErr:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 3 nodes with ToBeDeleted and no nodes can be scaled down"),
+			wantDeletedNodes: nil,
+			wantTaintUpdates: map[string][][]apiv1.Taint{},
+		},
+		"drain node deletion with failed taint, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-4": sizedNodeGroup("test-4", 4, false, ignoreDaemonSetsUtilization),
+			},
+			drainNodes: []nodeGroupViewInfo{
+				{"test-4", 0, 4},
+			},
+			pods: map[string][]*apiv1.Pod{
+				"test-4-node-0": removablePods(1, "test-4-node-0"),
+				"test-4-node-1": removablePods(1, "test-4-node-1"),
+				"test-4-node-2": removablePods(1, "test-4-node-2"),
+				"test-4-node-3": removablePods(1, "test-4-node-3"),
+			},
+			failedNodeTaint: map[string]bool{
+				"test-4-node-1": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownNodeDeleteStarted,
+				scaledDownNodes: []scaleDownNodeInfo{
+					{
+						name:        "test-4-node-0",
+						nodeGroup:   "test-4",
+						utilInfo:    generateUtilInfo(0.125, 0.125),
+						evictedPods: removablePods(1, "test-4-node-0"),
+					},
+					{
+						name:        "test-4-node-2",
+						nodeGroup:   "test-4",
+						utilInfo:    generateUtilInfo(0.125, 0.125),
+						evictedPods: removablePods(1, "test-4-node-2"),
+					},
+					{
+						name:        "test-4-node-3",
+						nodeGroup:   "test-4",
+						utilInfo:    generateUtilInfo(0.125, 0.125),
+						evictedPods: removablePods(1, "test-4-node-3"),
+					},
+				},
+			},
+			wantErr: nil,
+			wantDeletedNodes: []string{
+				"test-4-node-0",
+				"test-4-node-2",
+				"test-4-node-3",
+			},
+			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
+				"test-4-node-0": {ResultType: status.NodeDeleteOk},
+				"test-4-node-2": {ResultType: status.NodeDeleteOk},
+				"test-4-node-3": {ResultType: status.NodeDeleteOk},
+			},
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"test-4-node-0": {
+					{toBeDeletedTaint},
+				},
+				"test-4-node-2": {
+					{toBeDeletedTaint},
+				},
+				"test-4-node-3": {
+					{toBeDeletedTaint},
+				},
+			},
+		},
+
+		"drain atomic node deletion with failed taint, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"atomic-4": sizedNodeGroup("atomic-4", 4, true, ignoreDaemonSetsUtilization),
+			},
+			drainNodes: []nodeGroupViewInfo{
+				{"atomic-4", 0, 4},
+			},
+			pods: map[string][]*apiv1.Pod{
+				"atomic-4-node-0": removablePods(1, "atomic-4-node-0"),
+				"atomic-4-node-1": removablePods(1, "atomic-4-node-1"),
+				"atomic-4-node-2": removablePods(1, "atomic-4-node-2"),
+				"atomic-4-node-3": removablePods(1, "atomic-4-node-3"),
+			},
+			failedNodeTaint: map[string]bool{
+				"atomic-4-node-1": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result:          status.ScaleDownError,
+				scaledDownNodes: nil,
+			},
+			wantErr:               cmpopts.AnyError,
+			wantDeletedNodes:      nil,
+			wantNodeDeleteResults: map[string]status.NodeDeleteResult{},
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"atomic-4-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-2": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
+			},
+		},
+		"empty node deletion with failed taint, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-4": sizedNodeGroup("test-4", 4, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-4", 0, 4},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-4-node-1": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownNodeDeleteStarted,
+				scaledDownNodes: []scaleDownNodeInfo{
+					{
+						name:      "test-4-node-0",
+						nodeGroup: "test-4",
+						utilInfo:  generateUtilInfo(0, 0),
+					},
+					{
+						name:      "test-4-node-2",
+						nodeGroup: "test-4",
+						utilInfo:  generateUtilInfo(0, 0),
+					},
+					{
+						name:      "test-4-node-3",
+						nodeGroup: "test-4",
+						utilInfo:  generateUtilInfo(0, 0),
+					},
+				},
+			},
+			wantDeletedNodes: []string{
+				"test-4-node-0",
+				"test-4-node-2",
+				"test-4-node-3",
+			},
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"test-4-node-0": {
+					{toBeDeletedTaint},
+				},
+				"test-4-node-2": {
+					{toBeDeletedTaint},
+				},
+				"test-4-node-3": {
+					{toBeDeletedTaint},
+				},
+			},
+			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
+				"test-4-node-0": {ResultType: status.NodeDeleteOk},
+				"test-4-node-2": {ResultType: status.NodeDeleteOk},
+				"test-4-node-3": {ResultType: status.NodeDeleteOk},
+			},
+		},
+		"empty atomic node deletion with failed taint": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"atomic-4": sizedNodeGroup("atomic-4", 4, true, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"atomic-4", 0, 4},
+			},
+			failedNodeTaint: map[string]bool{
+				"atomic-4-node-1": true,
+			},
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownError,
+			},
+			wantErr:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted"),
+			wantDeletedNodes: nil,
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"atomic-4-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-2": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
+			},
+		},
+		"empty atomic node deletion with failed taint, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"atomic-4": sizedNodeGroup("atomic-4", 4, true, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"atomic-4", 0, 4},
+			},
+			failedNodeTaint: map[string]bool{
+				"atomic-4-node-1": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownError,
+			},
+			wantErr:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted and no nodes can be scaled down"),
+			wantDeletedNodes: nil,
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"atomic-4-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-2": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
 			},
 		},
 		"deletion with drain": {
@@ -569,6 +840,26 @@ func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, force bool, suf
 				},
 				"test-node-1": {
 					{toBeDeletedTaint},
+				},
+				"atomic-6-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-6-node-1": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-6-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-6-node-4": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-6-node-5": {
+					{toBeDeletedTaint},
+					{},
 				},
 			},
 			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
@@ -996,11 +1287,9 @@ func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, force bool, suf
 			wantTaintUpdates: map[string][][]apiv1.Taint{
 				"test-node-0": {
 					{toBeDeletedTaint},
-					{},
 				},
 				"test-node-1": {
 					{toBeDeletedTaint},
-					{},
 				},
 			},
 			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
@@ -1151,7 +1440,14 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 			defer nodesLock.Unlock()
 			update := action.(core.UpdateAction)
 			obj := update.GetObject().(*apiv1.Node)
-			if tc.failedNodeTaint[obj.Name] {
+			hasToBeDeletedTaint := false
+			for _, taint := range obj.Spec.Taints {
+				if taint.Key == taints.ToBeDeletedTaint {
+					hasToBeDeletedTaint = true
+					break
+				}
+			}
+			if tc.failedNodeTaint[obj.Name] && hasToBeDeletedTaint {
 				return true, nil, fmt.Errorf("SIMULATED ERROR: won't taint")
 			}
 			nt := nodeTaints{
@@ -1208,10 +1504,12 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 
 	// Set up other needed structures and options.
 	opts := config.AutoscalingOptions{
-		MaxScaleDownParallelism:        10,
-		MaxDrainParallelism:            5,
-		MaxPodEvictionTime:             0,
-		DaemonSetEvictionForEmptyNodes: true,
+		MaxScaleDownParallelism:                 10,
+		MaxDrainParallelism:                     5,
+		MaxPodEvictionTime:                      0,
+		DaemonSetEvictionForEmptyNodes:          true,
+		PartialTaintActuationEnabled:            tc.partialTaintActuationEnabled,
+		DynamicNodeDeleteDelayAfterTaintEnabled: tc.dynamicNodeDeleteDelayEnabled,
 	}
 
 	allPods := []*apiv1.Pod{}
@@ -1227,7 +1525,16 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 		t.Fatalf("Couldn't create daemonset lister")
 	}
 
-	registry := kube_util.NewListerRegistry(nil, nil, podLister, pdbLister, dsLister, nil, nil, nil, nil)
+	allExpectedNodes := make([]*apiv1.Node, 0)
+	for _, n := range allEmptyNodes {
+		allExpectedNodes = append(allExpectedNodes, n)
+	}
+	for _, n := range allDrainNodes {
+		allExpectedNodes = append(allExpectedNodes, n)
+	}
+	nodeLister := kube_util.NewTestNodeLister(allExpectedNodes)
+
+	registry := kube_util.NewListerRegistry(nodeLister, nil, podLister, pdbLister, dsLister, nil, nil, nil, nil)
 	autoscalingCtx, err := NewScaleTestAutoscalingContext(opts, fakeClient, registry, provider, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Couldn't set up autoscaling context: %v", err)
@@ -1376,34 +1683,68 @@ taintsLoop:
 
 func TestStartDeletion(t *testing.T) {
 	testSets := []map[string]startDeletionTestCase{
-		// IgnoreDaemonSetsUtilization is false
 		getStartDeletionTestCases(false, false, "testNg1"),
-		// IgnoreDaemonSetsUtilization is true
 		getStartDeletionTestCases(true, false, "testNg2"),
 	}
 
 	for _, testSet := range testSets {
 		for tn, tc := range testSet {
-			t.Run(tn, func(t *testing.T) {
-				runStartDeletionTest(t, tc, false)
-			})
+			if !tc.partialTaintActuationEnabled {
+				t.Run(fmt.Sprintf("%s-partialActuationEnabled:false", tn), func(t *testing.T) {
+					runStartDeletionTest(t, tc, false)
+				})
+			}
+		}
+	}
+}
+
+func TestStartDeletionThroughputOptimized(t *testing.T) {
+	testSets := []map[string]startDeletionTestCase{
+		getStartDeletionTestCases(false, false, "testNg1"),
+		getStartDeletionTestCases(true, false, "testNg2"),
+	}
+
+	for _, testSet := range testSets {
+		for tn, tc := range testSet {
+			if tc.partialTaintActuationEnabled {
+				t.Run(fmt.Sprintf("%s-partialActuationEnabled:true", tn), func(t *testing.T) {
+					runStartDeletionTest(t, tc, false)
+				})
+			}
 		}
 	}
 }
 
 func TestStartForceDeletion(t *testing.T) {
 	testSets := []map[string]startDeletionTestCase{
-		// IgnoreDaemonSetsUtilization is false
 		getStartDeletionTestCases(false, true, "testNg1"),
-		// IgnoreDaemonSetsUtilization is true
 		getStartDeletionTestCases(true, true, "testNg2"),
 	}
 
 	for _, testSet := range testSets {
 		for tn, tc := range testSet {
-			t.Run(tn, func(t *testing.T) {
-				runStartDeletionTest(t, tc, true)
-			})
+			if !tc.partialTaintActuationEnabled {
+				t.Run(fmt.Sprintf("%s-partialActuationEnabled:false", tn), func(t *testing.T) {
+					runStartDeletionTest(t, tc, true)
+				})
+			}
+		}
+	}
+}
+
+func TestStartForceDeletionThroughputOptimized(t *testing.T) {
+	testSets := []map[string]startDeletionTestCase{
+		getStartDeletionTestCases(false, true, "testNg1"),
+		getStartDeletionTestCases(true, true, "testNg2"),
+	}
+
+	for _, testSet := range testSets {
+		for tn, tc := range testSet {
+			if tc.partialTaintActuationEnabled {
+				t.Run(fmt.Sprintf("%s-partialActuationEnabled:true", tn), func(t *testing.T) {
+					runStartDeletionTest(t, tc, true)
+				})
+			}
 		}
 	}
 }
@@ -1719,4 +2060,134 @@ func waitForDeletionResultsCount(ndt *deletiontracker.NodeDeletionTracker, resul
 		}
 	}
 	return fmt.Errorf("timed out while waiting for node deletion results")
+}
+
+type expectedActuationResult struct {
+	status       status.ScaleDownResult
+	err          error
+	deletedNodes []string
+}
+
+type partialTaintingTestCase struct {
+	description     string
+	nodeGroupName   string
+	nodeGroups      map[string]*testprovider.TestNodeGroup
+	emptyNodes      []nodeGroupViewInfo
+	failedNodeTaint map[string]bool
+	enabled         expectedActuationResult
+	disabled        expectedActuationResult
+}
+
+func TestStartDeletion_PartialTaintActuation(t *testing.T) {
+	ignoreDaemonSetsUtilization := false
+	cases := []partialTaintingTestCase{
+		{
+			description:   "empty node deletion with partial taint failure",
+			nodeGroupName: "test-3",
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-3": sizedNodeGroup("test-3", 3, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-3", 0, 3},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-3-node-1": true,
+			},
+			disabled: expectedActuationResult{
+				status:       status.ScaleDownError,
+				err:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted"),
+				deletedNodes: nil,
+			},
+			enabled: expectedActuationResult{
+				status:       status.ScaleDownNodeDeleteStarted,
+				err:          nil,
+				deletedNodes: []string{"test-3-node-0", "test-3-node-2"},
+			},
+		},
+		{
+			description:   "empty node deletion with all taints failing",
+			nodeGroupName: "test-3",
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-3": sizedNodeGroup("test-3", 3, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-3", 0, 3},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-3-node-0": true,
+				"test-3-node-1": true,
+				"test-3-node-2": true,
+			},
+			disabled: expectedActuationResult{
+				status:       status.ScaleDownError,
+				err:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 3 nodes with ToBeDeleted"),
+				deletedNodes: nil,
+			},
+			enabled: expectedActuationResult{
+				status:       status.ScaleDownError,
+				err:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 3 nodes with ToBeDeleted and no nodes can be scaled down"),
+				deletedNodes: nil,
+			},
+		},
+	}
+
+	buildExpected := func(wantResult status.ScaleDownResult, wantDeleted []string, nodeGroupName string) (scaleDownStatusInfo, map[string]status.NodeDeleteResult, map[string][][]apiv1.Taint) {
+		statusInfo := scaleDownStatusInfo{result: wantResult}
+		var deleteResults map[string]status.NodeDeleteResult
+		var taintUpdates map[string][][]apiv1.Taint
+		toBeDeletedTaint := apiv1.Taint{Key: taints.ToBeDeletedTaint, Effect: apiv1.TaintEffectNoSchedule}
+
+		if len(wantDeleted) > 0 {
+			deleteResults = make(map[string]status.NodeDeleteResult)
+			taintUpdates = make(map[string][][]apiv1.Taint)
+			for _, node := range wantDeleted {
+				statusInfo.scaledDownNodes = append(statusInfo.scaledDownNodes, scaleDownNodeInfo{
+					name:      node,
+					nodeGroup: nodeGroupName,
+					utilInfo:  generateUtilInfo(0, 0),
+				})
+				deleteResults[node] = status.NodeDeleteResult{ResultType: status.NodeDeleteOk}
+				taintUpdates[node] = [][]apiv1.Taint{{toBeDeletedTaint}}
+			}
+		}
+		return statusInfo, deleteResults, taintUpdates
+	}
+
+	for _, tc := range cases {
+		for _, dynamicDelayEnabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s-PartialTaintActuationEnabled:false-DynamicDelay:%v", tc.description, dynamicDelayEnabled), func(t *testing.T) {
+				statusInfo, deleteResults, taintUpdates := buildExpected(tc.disabled.status, tc.disabled.deletedNodes, tc.nodeGroupName)
+				baseTC := startDeletionTestCase{
+					nodeGroups:                    tc.nodeGroups,
+					emptyNodes:                    tc.emptyNodes,
+					failedNodeTaint:               tc.failedNodeTaint,
+					wantStatus:                    statusInfo,
+					wantErr:                       tc.disabled.err,
+					wantDeletedNodes:              tc.disabled.deletedNodes,
+					wantNodeDeleteResults:         deleteResults,
+					wantTaintUpdates:              taintUpdates,
+					partialTaintActuationEnabled:  false,
+					dynamicNodeDeleteDelayEnabled: dynamicDelayEnabled,
+				}
+				runStartDeletionTest(t, baseTC, false)
+			})
+
+			t.Run(fmt.Sprintf("%s-PartialTaintActuationEnabled:true-DynamicDelay:%v", tc.description, dynamicDelayEnabled), func(t *testing.T) {
+				statusInfo, deleteResults, taintUpdates := buildExpected(tc.enabled.status, tc.enabled.deletedNodes, tc.nodeGroupName)
+				baseTC := startDeletionTestCase{
+					nodeGroups:                    tc.nodeGroups,
+					emptyNodes:                    tc.emptyNodes,
+					failedNodeTaint:               tc.failedNodeTaint,
+					wantStatus:                    statusInfo,
+					wantErr:                       tc.enabled.err,
+					wantDeletedNodes:              tc.enabled.deletedNodes,
+					wantNodeDeleteResults:         deleteResults,
+					wantTaintUpdates:              taintUpdates,
+					partialTaintActuationEnabled:  true,
+					dynamicNodeDeleteDelayEnabled: dynamicDelayEnabled,
+				}
+				runStartDeletionTest(t, baseTC, false)
+			})
+		}
+	}
 }

--- a/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker.go
@@ -96,17 +96,20 @@ func (u *UpdateLatencyTracker) Start() {
 	}
 }
 
-// drainStartTimeChan safely and non-blockingly pulls all pending items out
-// of StartTimeChan until it's completely empty. It uses a select-default idiom
-// to avoid deadlocking, which is a risk when using `len(chan) > 0` checks
-// due to concurrent race conditions.
+// drainStartTimeChan pulls all pending items out  of u.StartTimeChan.
+// Returns immediately if u.StartTimeChan is empty.
 func (u *UpdateLatencyTracker) drainStartTimeChan() {
+DrainLoop:
 	for {
 		select {
-		case ntst := <-u.StartTimeChan:
+		case ntst, ok := <-u.StartTimeChan:
+			if !ok {
+				break DrainLoop
+			}
 			u.startTimestamp[ntst.nodeName] = ntst.startTime
 		default:
-			return // Channel is empty, safely exit without blocking.
+			// Channel is empty, safely exit without blocking.
+			break DrainLoop
 		}
 	}
 }

--- a/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker.go
+++ b/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker.go
@@ -25,7 +25,8 @@ import (
 )
 
 const sleepDurationWhenPolling = 50 * time.Millisecond
-const waitForTaintingTimeoutDuration = 30 * time.Second
+
+var waitForTaintingTimeoutDuration = 30 * time.Second
 
 type nodeTaintStartTime struct {
 	nodeName  string
@@ -42,16 +43,15 @@ type UpdateLatencyTracker struct {
 	// Sends node tainting start timestamps to the tracker
 	StartTimeChan            chan nodeTaintStartTime
 	sleepDurationWhenPolling time.Duration
-	// Passing a bool will wait for all the started nodes to get tainted and calculate
-	// latency based on latencies observed. (If all the nodes did not get tained within
-	// waitForTaintingTimeoutDuration after passing a bool, latency calculation will be
-	// aborted and the ResultChan will be closed without returning a value) Closing the
-	// AwaitOrStopChan without passing any bool will abort the latency calculation.
-	AwaitOrStopChan chan bool
+	// ExpectedNodeCountChan receives the capacity limit seeded precisely to the count
+	// of successfully tainted nodes. This instructs the tracker to discard start stamps
+	// of any node that failed its API request to bypass the hang.
+	ExpectedNodeCountChan chan int
 	// Communicate back the measured latency
 	ResultChan chan time.Duration
 	// now is used only to make the testing easier
-	now func() time.Time
+	now   func() time.Time
+	sleep func(time.Duration)
 }
 
 // NewUpdateLatencyTracker returns a new NewUpdateLatencyTracker object
@@ -61,11 +61,12 @@ func NewUpdateLatencyTracker(nodeLister kubernetes.NodeLister) *UpdateLatencyTra
 		finishTimestamp:          map[string]time.Time{},
 		remainingNodeCount:       0,
 		nodeLister:               nodeLister,
-		StartTimeChan:            make(chan nodeTaintStartTime),
+		StartTimeChan:            make(chan nodeTaintStartTime, 10000),
 		sleepDurationWhenPolling: sleepDurationWhenPolling,
-		AwaitOrStopChan:          make(chan bool),
+		ExpectedNodeCountChan:    make(chan int, 1),
 		ResultChan:               make(chan time.Duration),
 		now:                      time.Now,
+		sleep:                    time.Sleep,
 	}
 }
 
@@ -74,8 +75,13 @@ func NewUpdateLatencyTracker(nodeLister kubernetes.NodeLister) *UpdateLatencyTra
 func (u *UpdateLatencyTracker) Start() {
 	for {
 		select {
-		case _, ok := <-u.AwaitOrStopChan:
+		case expectedCount, ok := <-u.ExpectedNodeCountChan:
 			if ok {
+				u.drainStartTimeChan()
+				u.remainingNodeCount = expectedCount - len(u.finishTimestamp)
+				if u.remainingNodeCount < 0 {
+					u.remainingNodeCount = 0
+				}
 				u.await()
 			}
 			return
@@ -86,7 +92,22 @@ func (u *UpdateLatencyTracker) Start() {
 		default:
 		}
 		u.updateFinishTime()
-		time.Sleep(u.sleepDurationWhenPolling)
+		u.sleep(u.sleepDurationWhenPolling)
+	}
+}
+
+// drainStartTimeChan safely and non-blockingly pulls all pending items out
+// of StartTimeChan until it's completely empty. It uses a select-default idiom
+// to avoid deadlocking, which is a risk when using `len(chan) > 0` checks
+// due to concurrent race conditions.
+func (u *UpdateLatencyTracker) drainStartTimeChan() {
+	for {
+		select {
+		case ntst := <-u.StartTimeChan:
+			u.startTimestamp[ntst.nodeName] = ntst.startTime
+		default:
+			return // Channel is empty, safely exit without blocking.
+		}
 	}
 }
 
@@ -110,7 +131,10 @@ func (u *UpdateLatencyTracker) updateFinishTime() {
 func (u *UpdateLatencyTracker) calculateLatency() time.Duration {
 	var maxLatency time.Duration = 0
 	for node, startTime := range u.startTimestamp {
-		endTime, _ := u.finishTimestamp[node]
+		endTime, ok := u.finishTimestamp[node]
+		if !ok {
+			continue
+		}
 		currentLatency := endTime.Sub(startTime)
 		if currentLatency > maxLatency {
 			maxLatency = currentLatency
@@ -120,19 +144,19 @@ func (u *UpdateLatencyTracker) calculateLatency() time.Duration {
 }
 
 func (u *UpdateLatencyTracker) await() {
-	waitingForTaintingStartTime := time.Now()
+	waitingForTaintingStartTime := u.now()
 	for {
 		switch {
-		case u.remainingNodeCount == 0:
+		case u.remainingNodeCount <= 0:
 			latency := u.calculateLatency()
 			u.ResultChan <- latency
 			return
-		case time.Now().After(waitingForTaintingStartTime.Add(waitForTaintingTimeoutDuration)):
+		case u.now().After(waitingForTaintingStartTime.Add(waitForTaintingTimeoutDuration)):
 			klog.Errorf("Timeout before tainting all nodes, latency measurement will be stale")
 			close(u.ResultChan)
 			return
 		default:
-			time.Sleep(u.sleepDurationWhenPolling)
+			u.sleep(u.sleepDurationWhenPolling)
 			u.updateFinishTime()
 		}
 	}

--- a/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker_test.go
@@ -186,12 +186,18 @@ func TestUpdateLatencyCalculation(t *testing.T) {
 			for _, node := range nodes {
 				updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, tc.startTime}
 			}
-			updateLatencyTracker.ExpectedNodeCountChan <- len(tc.nodes)
+			if tc.simulateZeroExpectedCount {
+				close(updateLatencyTracker.ExpectedNodeCountChan)
+				// Wait slightly to ensure Start() loop processes the closed channel.
+				time.Sleep(50 * time.Millisecond)
+			} else {
+				updateLatencyTracker.ExpectedNodeCountChan <- len(tc.nodes)
 
-			latency, ok := <-updateLatencyTracker.ResultChan
-			assert.Equal(t, tc.wantResultChanOpen, ok)
-			if ok {
-				assert.Equal(t, tc.wantLatency, latency)
+				latency, ok := <-updateLatencyTracker.ResultChan
+				assert.Equal(t, tc.wantResultChanOpen, ok)
+				if ok {
+					assert.Equal(t, tc.wantLatency, latency)
+				}
 			}
 		})
 	}

--- a/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker_test.go
+++ b/cluster-autoscaler/core/scaledown/actuation/update_latency_tracker_test.go
@@ -18,6 +18,7 @@ package actuation
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -28,52 +29,36 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
 )
 
-// mockClock is used to mock time.Now() when testing UpdateLatencyTracker
-// For the n th call to Now() it will return a timestamp after duration[n] to
-// the startTime if n < the length of durations. Otherwise, it will return current time.
 type mockClock struct {
-	startTime time.Time
-	durations []time.Duration
-	index     int
-	mutex     sync.Mutex
+	startTime   time.Time
+	currentTime time.Time
+	mutex       sync.Mutex
 }
 
-// Returns a new NewMockClock object
-func NewMockClock(startTime time.Time, durations []time.Duration) mockClock {
-	return mockClock{
-		startTime: startTime,
-		durations: durations,
-		index:     0,
+func NewMockClock(startTime time.Time) *mockClock {
+	return &mockClock{
+		startTime:   startTime,
+		currentTime: startTime,
 	}
 }
 
-// Returns a time after Nth duration from the start time if N < length of durations.
-// Otherwise, returns the current time
 func (m *mockClock) Now() time.Time {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	var timeToSend time.Time
-	if m.index < len(m.durations) {
-		timeToSend = m.startTime.Add(m.durations[m.index])
-	} else {
-		timeToSend = time.Now()
-	}
-	m.index += 1
-	return timeToSend
+	return m.currentTime
 }
 
-// Returns the number of times that the Now function was called
-func (m *mockClock) getIndex() int {
+func (m *mockClock) SetTime(t time.Time) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	return m.index
+	m.currentTime = t
 }
 
-// TestCustomNodeLister can be used to mock nodeLister Get call when testing delayed tainting
 type TestCustomNodeLister struct {
-	nodes                    map[string]*apiv1.Node
-	getCallCount             map[string]int
-	nodeTaintAfterNthGetCall map[string]int
+	nodes                  map[string]*apiv1.Node
+	getCallCount           map[string]int
+	nodeTaintAfterDuration map[string]time.Duration
+	clock                  *mockClock
 }
 
 // List returns all nodes in test lister.
@@ -85,15 +70,15 @@ func (l *TestCustomNodeLister) List() ([]*apiv1.Node, error) {
 	return nodes, nil
 }
 
-// Get returns node from test lister. Add ToBeDeletedTaint to the node
-// during the N th call specified in the nodeTaintAfterNthGetCall
 func (l *TestCustomNodeLister) Get(name string) (*apiv1.Node, error) {
 	for _, node := range l.nodes {
 		if node.Name == name {
 			l.getCallCount[node.Name] += 1
-			if _, ok := l.nodeTaintAfterNthGetCall[node.Name]; ok && l.getCallCount[node.Name] == l.nodeTaintAfterNthGetCall[node.Name] {
-				toBeDeletedTaint := apiv1.Taint{Key: taints.ToBeDeletedTaint, Effect: apiv1.TaintEffectNoSchedule}
-				node.Spec.Taints = append(node.Spec.Taints, toBeDeletedTaint)
+			if expectedDuration, ok := l.nodeTaintAfterDuration[node.Name]; ok {
+				if l.clock.Now().Sub(l.clock.startTime) >= expectedDuration {
+					toBeDeletedTaint := apiv1.Taint{Key: taints.ToBeDeletedTaint, Effect: apiv1.TaintEffectNoSchedule}
+					node.Spec.Taints = append(node.Spec.Taints, toBeDeletedTaint)
+				}
 			}
 			return node, nil
 		}
@@ -102,96 +87,111 @@ func (l *TestCustomNodeLister) Get(name string) (*apiv1.Node, error) {
 }
 
 // Return new TestCustomNodeLister object
-func NewTestCustomNodeLister(nodes map[string]*apiv1.Node, nodeTaintAfterNthGetCall map[string]int) *TestCustomNodeLister {
+func NewTestCustomNodeLister(nodes map[string]*apiv1.Node, nodeTaintAfterDuration map[string]time.Duration, clock *mockClock) *TestCustomNodeLister {
 	getCallCounts := map[string]int{}
 	for name := range nodes {
 		getCallCounts[name] = 0
 	}
 	return &TestCustomNodeLister{
-		nodes:                    nodes,
-		getCallCount:             getCallCounts,
-		nodeTaintAfterNthGetCall: nodeTaintAfterNthGetCall,
+		nodes:                  nodes,
+		getCallCount:           getCallCounts,
+		nodeTaintAfterDuration: nodeTaintAfterDuration,
+		clock:                  clock,
 	}
 }
 
 func TestUpdateLatencyCalculation(t *testing.T) {
+	oldTimeout := waitForTaintingTimeoutDuration
+	waitForTaintingTimeoutDuration = 150 * time.Millisecond
+	defer func() { waitForTaintingTimeoutDuration = oldTimeout }()
 
 	testCases := []struct {
 		description string
 		startTime   time.Time
 		nodes       []string
 		// If an entry is not added for a node, that node will never get tainted
-		nodeTaintAfterNthGetCall map[string]int
-		durations                []time.Duration
-		wantLatency              time.Duration
-		wantResultChanOpen       bool
+		nodeTaintAfterDuration    map[string]time.Duration
+		wantLatency               time.Duration
+		wantResultChanOpen        bool
+		simulateZeroExpectedCount bool
 	}{
 		{
-			description:              "latency when tainting a single node - node is tainted in the first call to the lister",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 1},
-			durations:                []time.Duration{100 * time.Millisecond},
-			wantLatency:              100 * time.Millisecond,
-			wantResultChanOpen:       true,
+			description:            "latency when tainting a single node - node is tainted in the first call to the lister",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond},
+			wantLatency:            100 * time.Millisecond,
+			wantResultChanOpen:     true,
 		},
 		{
-			description:              "latency when tainting a single node - node is not tainted in the first call to the lister",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 3},
-			durations:                []time.Duration{100 * time.Millisecond},
-			wantLatency:              100 * time.Millisecond,
-			wantResultChanOpen:       true,
+			description:            "latency when tainting a single node - node is not tainted in the first call to the lister",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond},
+			wantLatency:            100 * time.Millisecond,
+			wantResultChanOpen:     true,
 		},
 		{
-			description:              "latency when tainting multiple nodes - nodes are tainted in the first calls to the lister",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1", "n2"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 1, "n2": 1},
-			durations:                []time.Duration{100 * time.Millisecond, 150 * time.Millisecond},
-			wantLatency:              150 * time.Millisecond,
-			wantResultChanOpen:       true,
+			description:            "latency when tainting multiple nodes - nodes are tainted in the first calls to the lister",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1", "n2"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond, "n2": 150 * time.Millisecond},
+			wantLatency:            150 * time.Millisecond,
+			wantResultChanOpen:     true,
 		},
 		{
-			description:              "latency when tainting multiple nodes - nodes are not tainted in the first calls to the lister",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1", "n2"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 3, "n2": 5},
-			durations:                []time.Duration{100 * time.Millisecond, 150 * time.Millisecond},
-			wantLatency:              150 * time.Millisecond,
-			wantResultChanOpen:       true,
+			description:            "latency when tainting multiple nodes - nodes are not tainted in the first calls to the lister",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1", "n2"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond, "n2": 150 * time.Millisecond},
+			wantLatency:            150 * time.Millisecond,
+			wantResultChanOpen:     true,
 		},
 		{
-			description:              "Some nodes fails to taint before timeout",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1", "n3"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 1},
-			durations:                []time.Duration{100 * time.Millisecond, 150 * time.Millisecond},
-			wantResultChanOpen:       false,
+			description:            "Some nodes fails to taint before timeout",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1", "n3"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond},
+			wantResultChanOpen:     false,
+		},
+		{
+			description:               "Expected count is zero resulting in channel closure",
+			startTime:                 time.Now(),
+			nodes:                     []string{"n1"},
+			nodeTaintAfterDuration:    map[string]time.Duration{},
+			wantResultChanOpen:        false,
+			simulateZeroExpectedCount: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			mc := NewMockClock(tc.startTime, tc.durations)
+			mc := NewMockClock(tc.startTime)
 			nodes := map[string]*apiv1.Node{}
 			for _, name := range tc.nodes {
 				node := test.BuildTestNode(name, 100, 100)
 				nodes[name] = node
 			}
-			nodeLister := NewTestCustomNodeLister(nodes, tc.nodeTaintAfterNthGetCall)
+			nodeLister := NewTestCustomNodeLister(nodes, tc.nodeTaintAfterDuration, mc)
 			updateLatencyTracker := NewUpdateLatencyTrackerForTesting(nodeLister, mc.Now)
+
+			// Synthetically advance mock clock upon each sleep.
+			updateLatencyTracker.sleep = func(d time.Duration) {
+				mc.SetTime(mc.Now().Add(d))
+				// We must explicitly yield because advancing a fake clock doesn't block.
+				// Without this, the Start() loop could starve the main test thread on single-core setups (e.g. GOMAXPROCS=1).
+				runtime.Gosched()
+			}
 			go updateLatencyTracker.Start()
 			for _, node := range nodes {
 				updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, tc.startTime}
 			}
-			updateLatencyTracker.AwaitOrStopChan <- true
+			updateLatencyTracker.ExpectedNodeCountChan <- len(tc.nodes)
+
 			latency, ok := <-updateLatencyTracker.ResultChan
 			assert.Equal(t, tc.wantResultChanOpen, ok)
 			if ok {
 				assert.Equal(t, tc.wantLatency, latency)
-				assert.Equal(t, len(tc.durations), mc.getIndex())
 			}
 		})
 	}

--- a/cluster-autoscaler/test/integration/inmemory/scaledown_test.go
+++ b/cluster-autoscaler/test/integration/inmemory/scaledown_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	fakecloudprovider "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/test/integration"
+	synctestutils "k8s.io/autoscaler/cluster-autoscaler/test/integration/synctest"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/test"
+	k8s_testing "k8s.io/client-go/testing"
+)
+
+func TestScaleDown_PartialFailure(t *testing.T) {
+	testCases := []struct {
+		name                         string
+		partialTaintActuationEnabled bool
+		// If PartialTaintActuationEnabled is true, the non-atomic nodegroup will partially delete.
+		// If PartialTaintActuationEnabled is false, the legacy code synchronous logic is used, which aborts the entire targeted batch on any failure.
+		expectedTargetSizeNonAtomic int
+		expectedTargetSizeAtomic    int
+	}{
+		{
+			name:                         "PartialTaintActuation enabled",
+			partialTaintActuationEnabled: true,
+			expectedTargetSizeNonAtomic:  1, // 1 node deleted, 1 node failed
+			expectedTargetSizeAtomic:     2, // atomic group completely aborted
+		},
+		{
+			name:                         "PartialTaintActuation disabled",
+			partialTaintActuationEnabled: false,
+			expectedTargetSizeNonAtomic:  2,
+			expectedTargetSizeAtomic:     2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configBuilder := integration.NewTestConfig().
+				WithOverrides(
+					integration.WithScaleDownUnneededTime(time.Minute),
+					func(o *config.AutoscalingOptions) {
+						o.PartialTaintActuationEnabled = tc.partialTaintActuationEnabled
+					},
+				)
+
+			options := configBuilder.ResolveOptions()
+			infra := integration.SetupInfrastructure(t)
+			fakes := infra.Fakes
+
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer synctestutils.TearDown(cancel)
+
+				autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+				assert.NoError(t, err)
+
+				// Create atomic node group
+				atomicOpts := &config.NodeGroupAutoscalingOptions{ZeroOrMaxNodeScaling: true}
+				nAtomicTemplate := test.BuildTestNode("ng-atomic-node-template", 1000, 1000, test.IsReady(true))
+				fakes.CloudProvider.AddNodeGroup("ng-atomic",
+					fakecloudprovider.WithNodes(nAtomicTemplate, 2),
+					fakecloudprovider.WithNodeGroupOptions(atomicOpts),
+				)
+				// Create non-atomic node group
+				nNonAtomicTemplate := test.BuildTestNode("ng-nonatomic-node-template", 1000, 1000, test.IsReady(true))
+				fakes.CloudProvider.AddNodeGroup("ng-nonatomic",
+					fakecloudprovider.WithNodes(nNonAtomicTemplate, 2),
+				)
+
+				// Create happy-path node group with no errors
+				nHappyPathTemplate := test.BuildTestNode("ng-happy-path-node-template", 1000, 1000, test.IsReady(true))
+				fakes.CloudProvider.AddNodeGroup("ng-happy-path",
+					fakecloudprovider.WithNodes(nHappyPathTemplate, 2),
+				)
+
+				nodeToFailAtomic := "ng-atomic-node-0"
+				nodeToFailNonAtomic := "ng-nonatomic-node-0"
+
+				// Simulate API failure when applying ToBeDeletedTaint to specific nodes
+				fakes.KubeClient.Fake.PrependReactor("update", "nodes", func(action k8s_testing.Action) (handled bool, ret apimachineryruntime.Object, err error) {
+					updateAction, ok := action.(k8s_testing.UpdateAction)
+					if !ok {
+						return false, nil, nil
+					}
+					node, ok := updateAction.GetObject().(*corev1.Node)
+					if !ok {
+						return false, nil, nil
+					}
+
+					if node.Name == nodeToFailAtomic || node.Name == nodeToFailNonAtomic {
+						if taints.HasToBeDeletedTaint(node) {
+							return true, nil, fmt.Errorf("simulated network error updating taint on node %s", node.Name)
+						}
+					}
+					return false, nil, nil
+				})
+
+				// 1st loop: Marks non-atomic nodes as unneeded. Atomic node groups bypass unneeded time and attempt scale-down immediately, but fail due to taint errors.
+				synctestutils.RunOnceAfter(t, autoscaler, 10*time.Second)
+
+				// 2nd loop: timer exceeds unneeded time, deletion triggered
+				synctestutils.RunOnceAfter(t, autoscaler, time.Minute+time.Second)
+
+				// Verify expected target sizes after partial deletion
+				atomicGroup := fakes.CloudProvider.GetNodeGroup("ng-atomic")
+				assert.NotNil(t, atomicGroup, "expected ng-atomic group to exist")
+				atomicSize, err := atomicGroup.TargetSize()
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedTargetSizeAtomic, atomicSize, "atomic target size mismatch")
+
+				nonAtomicGroup := fakes.CloudProvider.GetNodeGroup("ng-nonatomic")
+				assert.NotNil(t, nonAtomicGroup, "expected ng-nonatomic group to exist")
+				nonAtomicSize, err := nonAtomicGroup.TargetSize()
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedTargetSizeNonAtomic, nonAtomicSize, fmt.Sprintf("nonatomic target size mismatch, PartialTaintActuation enabled: %v", tc.partialTaintActuationEnabled))
+
+				happyPathGroup := fakes.CloudProvider.GetNodeGroup("ng-happy-path")
+				assert.NotNil(t, happyPathGroup, "expected ng-happy-path group to exist")
+				happyPathSize, err := happyPathGroup.TargetSize()
+				assert.NoError(t, err)
+
+				if tc.partialTaintActuationEnabled {
+					assert.Equal(t, 0, happyPathSize, "expected happy path nodegroup to be fully scaled down")
+				} else {
+					assert.Equal(t, 2, happyPathSize, "expected happy path nodegroup to remain untouched in legacy fallback")
+				}
+
+				// Validate end state: the exact correct nodes are deleted, and all remaining nodes have no taints
+				var remainingNodeNames []string
+				for _, n := range fakes.K8s.Nodes().Items {
+					remainingNodeNames = append(remainingNodeNames, n.Name)
+					assert.False(t, taints.HasToBeDeletedTaint(&n), "node %s should have clean taints", n.Name)
+				}
+
+				if tc.partialTaintActuationEnabled {
+					assert.ElementsMatch(t, []string{"ng-atomic-node-0", "ng-atomic-node-1", "ng-nonatomic-node-0"}, remainingNodeNames, "expected successfully tainted non-atomic sibling to be deleted while failed nodes remain")
+				} else {
+					assert.ElementsMatch(t, []string{"ng-atomic-node-0", "ng-atomic-node-1", "ng-nonatomic-node-0", "ng-nonatomic-node-1", "ng-happy-path-node-0", "ng-happy-path-node-1"}, remainingNodeNames, "with PartialTaintActuation disabled, a taint failure aborts the entire scale-down batch and rolls back all nodes to remain untouched")
+				}
+			})
+		})
+	}
+}
+
+func TestScaleDown_HappyPath(t *testing.T) {
+	atomicNodeGroupConfig := fakecloudprovider.WithNodeGroupOptions(&config.NodeGroupAutoscalingOptions{ZeroOrMaxNodeScaling: true})
+	nonAtomicNodeGroupConfig := fakecloudprovider.WithNodeGroupOptions(&config.NodeGroupAutoscalingOptions{ZeroOrMaxNodeScaling: false})
+
+	testCases := []struct {
+		name            string
+		nodeGroupConfig fakecloudprovider.NodeGroupOption
+	}{
+		{
+			name:            "Atomic nodegroup",
+			nodeGroupConfig: atomicNodeGroupConfig,
+		},
+		{
+			name:            "Non-atomic nodegroup",
+			nodeGroupConfig: nonAtomicNodeGroupConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, partialTaintActuationEnabled := range []bool{true, false} {
+			testName := fmt.Sprintf("%s/PartialTaintActuation_enabled_%v", tc.name, partialTaintActuationEnabled)
+			t.Run(testName, func(t *testing.T) {
+				configBuilder := integration.NewTestConfig().
+					WithOverrides(
+						integration.WithScaleDownUnneededTime(time.Minute),
+						func(o *config.AutoscalingOptions) {
+							o.PartialTaintActuationEnabled = partialTaintActuationEnabled
+						},
+					)
+
+				options := configBuilder.ResolveOptions()
+				infra := integration.SetupInfrastructure(t)
+				fakes := infra.Fakes
+
+				synctest.Test(t, func(t *testing.T) {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer synctestutils.TearDown(cancel)
+
+					autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+					assert.NoError(t, err)
+
+					nTemplate := test.BuildTestNode("ng-node-template", 1000, 1000, test.IsReady(true))
+					fakes.CloudProvider.AddNodeGroup("ng",
+						fakecloudprovider.WithNodes(nTemplate, 2),
+						tc.nodeGroupConfig,
+					)
+
+					// 1st loop: Marks non-atomic nodes as unneeded.
+					synctestutils.MustRunOnceAfter(t, autoscaler, 10*time.Second)
+
+					// 2nd loop: timer exceeds unneeded time, deletion triggered for non-atomic nodes
+					synctestutils.MustRunOnceAfter(t, autoscaler, time.Minute+time.Second)
+
+					// Verify expected target sizes after deletion
+					group := fakes.CloudProvider.GetNodeGroup("ng")
+					assert.NotNil(t, group, "expected ng group to exist")
+					size, err := group.TargetSize()
+					assert.NoError(t, err)
+					assert.Equal(t, 0, size, "expected target size to be 0 for happy path scaledown")
+
+					// Validate end state: all nodes are deleted
+					var remainingNodeNames []string
+					for _, n := range fakes.K8s.Nodes().Items {
+						remainingNodeNames = append(remainingNodeNames, n.Name)
+						assert.False(t, taints.HasToBeDeletedTaint(&n), "node %s should have clean taints", n.Name)
+					}
+					assert.Empty(t, remainingNodeNames, "all nodes should be successfully deleted")
+				})
+			})
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, if at least one node couldn't be tainted in a batch of nodes selected for scaledown, taints are cleaned up from all nodes and none of the nodes in the batch are scaled down.

This PR adds a feature flag `--partial-taint-actuation-enabled`. If it is set to true, CA will scale down all nodes in non-atomic nodegroups that were successfully tainted. 

For atomic nodegroups, the behavior is unchanged. If any nodes from an atomic nodegroup weren't tainted successfully, the taints are cleaned up from all the nodes in this nodegroup. The only change is that with partial-taint-actuation-enabled set to true, cleanup is done in parallel  (maxConcurrentNodesTainting nodes at a time).

Integration tests for scaledown were added. 

PR also removes a 30s wait in the latency tracker unit tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds `--partial-taint-actuation-enabled` flag. If it is set to true, CA will scale down all nodes in non-atomic nodegroups that were successfully tainted. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
