### PR TITLE
VPA Reduce replica count to try prevent flake

### DIFF
--- a/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
@@ -62,7 +62,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 	var (
 		rc *ResourceConsumer
 	)
-	replicas := 3
+	replicas := 2
 
 	ginkgo.AfterEach(func() {
 		rc.CleanUp()
@@ -225,7 +225,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with default recommender explicitly c
 	var (
 		rc *ResourceConsumer
 	)
-	replicas := 3
+	replicas := 2
 
 	ginkgo.AfterEach(func() {
 		rc.CleanUp()


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

I was looking into this flake: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-autoscaling-vpa-full-alpha-beta/2081320396694491136

It seems that when these two job run concurrently, their resizing stops, see:
1. https://prow.k8s.io/0d4989de-206c-406a-bda9-138776e22cad
2. https://prow.k8s.io/def38407-480f-4125-9c53-fbd6d3ccbcb1

My theory is that the nodes they are on are both saturated at the time, since there are 3x2 pods running.

I considered other options, like decreasing the threshold for success, but, decided to reduce the pod count in an attempt for this test to be less expensive to run overall.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
