### PR TITLE
Add capacitybuffers count metric

### DIFF
--- a/cluster-autoscaler/capacitybuffer/metrics/active_metrics.go
+++ b/cluster-autoscaler/capacitybuffer/metrics/active_metrics.go
@@ -1,0 +1,57 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	capacityBuffersNumberMetric *k8smetrics.GaugeVec
+	registerOnce                sync.Once
+)
+
+// RegisterActiveMetrics registers the capacity buffers metrics in legacyregistry.
+// This is done on-demand (only if the capacity buffers feature is active/enabled).
+func RegisterActiveMetrics() {
+	registerOnce.Do(func() {
+		capacityBuffersNumberMetric = k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Namespace: "cluster_autoscaler",
+				Name:      "capacity_buffers_count",
+				Help:      "Number of capacity buffers in the cluster",
+			},
+			[]string{"provisioning_strategy"},
+		)
+
+		legacyregistry.MustRegister(capacityBuffersNumberMetric)
+	})
+}
+
+// UpdateCapacityBuffersNumber records the number of capacity buffers in the cluster.
+func UpdateCapacityBuffersNumber(countsByType map[string]int) {
+	if capacityBuffersNumberMetric == nil {
+		return
+	}
+	capacityBuffersNumberMetric.Reset()
+	for strategy, count := range countsByType {
+		capacityBuffersNumberMetric.WithLabelValues(strategy).Set(float64(count))
+	}
+}

--- a/cluster-autoscaler/capacitybuffer/metrics/active_metrics_test.go
+++ b/cluster-autoscaler/capacitybuffer/metrics/active_metrics_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestActiveMetrics_Lifecycle(t *testing.T) {
+	// Dynamically register active metrics (which uses sync.Once internally).
+	RegisterActiveMetrics()
+
+	// Update total count
+	countsByType := map[string]int{
+		"strategy1": 2,
+		"strategy2": 1,
+	}
+	UpdateCapacityBuffersNumber(countsByType)
+
+	// Verify initially both values are correct.
+	gaugeTotal1 := capacityBuffersNumberMetric.WithLabelValues("strategy1")
+	valTotal1, err := testutil.GetGaugeMetricValue(gaugeTotal1)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(2), valTotal1)
+
+	gaugeTotal2 := capacityBuffersNumberMetric.WithLabelValues("strategy2")
+	valTotal2, err := testutil.GetGaugeMetricValue(gaugeTotal2)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1), valTotal2)
+
+	// Update counts with a new map (strategy1 is removed, strategy2 is changed)
+	countsByType2 := map[string]int{
+		"strategy2": 5,
+	}
+	UpdateCapacityBuffersNumber(countsByType2)
+
+	// Verify strategy2 value is updated
+	gaugeTotal2Updated := capacityBuffersNumberMetric.WithLabelValues("strategy2")
+	valTotal2Updated, err := testutil.GetGaugeMetricValue(gaugeTotal2Updated)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(5), valTotal2Updated)
+
+	// Verify strategy1 has been reset (accessing it after Reset recreates it with value 0)
+	gaugeTotal1Reset := capacityBuffersNumberMetric.WithLabelValues("strategy1")
+	valTotal1Reset, err := testutil.GetGaugeMetricValue(gaugeTotal1Reset)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(0), valTotal1Reset)
+}

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
+	cbmetrics "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/pod"
 	"k8s.io/klog/v2"
 
@@ -53,6 +54,10 @@ const (
 	FakePodsInjectedReason = "FakePodsInjected"
 )
 
+const (
+	unknownProvisioningStrategy = "unknown"
+)
+
 // CapacityBufferPodListProcessor processes the pod lists before scale up
 // and adds buffres api virtual pods.
 type CapacityBufferPodListProcessor struct {
@@ -66,6 +71,7 @@ type CapacityBufferPodListProcessor struct {
 
 // NewCapacityBufferPodListProcessor creates a new CapacityRequestPodListProcessor.
 func NewCapacityBufferPodListProcessor(client *client.CapacityBufferClient, provStrategies []string, buffersRegistry *fakepods.Registry, forceSafeToEvictFakePods bool) *CapacityBufferPodListProcessor {
+	cbmetrics.RegisterActiveMetrics()
 	provStrategiesMap := map[string]bool{}
 	for _, ps := range provStrategies {
 		provStrategiesMap[ps] = true
@@ -84,12 +90,15 @@ func NewCapacityBufferPodListProcessor(client *client.CapacityBufferClient, prov
 }
 
 // Process updates unschedulablePods by injecting fake pods to match replicas defined in buffers status
+// and updates the capacity buffers count metrics.
 func (p *CapacityBufferPodListProcessor) Process(autoscalingCtx *ca_context.AutoscalingContext, unschedulablePods []*apiv1.Pod) ([]*apiv1.Pod, error) {
 	buffers, err := p.client.ListCapacityBuffers("")
 	if err != nil {
 		klog.Errorf("CapacityBufferPodListProcessor failed to list buffers with error: %v", err.Error())
 		return unschedulablePods, nil
 	}
+	emitCapacityBuffersCount(buffers)
+
 	buffers = p.filterBuffersProvStrategy(buffers)
 	_, buffers = p.statusFilter.Filter(buffers)
 	_, buffers = p.podTemplateGenFilter.Filter(buffers)
@@ -103,6 +112,27 @@ func (p *CapacityBufferPodListProcessor) Process(autoscalingCtx *ca_context.Auto
 	klog.V(2).Infof("Capacity pod processor injecting %v fake pods provisioning %v capacity buffers", len(totalFakePods), len(buffers))
 	unschedulablePods = append(unschedulablePods, totalFakePods...)
 	return unschedulablePods, nil
+}
+
+func emitCapacityBuffersCount(buffers []*v1beta1.CapacityBuffer) {
+	countsByType := capacityBuffersCountsByType(buffers)
+	cbmetrics.UpdateCapacityBuffersNumber(countsByType)
+}
+
+func capacityBuffersCountsByType(buffers []*v1beta1.CapacityBuffer) map[string]int {
+	countsByType := map[string]int{}
+	for _, buffer := range buffers {
+		if buffer == nil {
+			continue
+		}
+		ps := unknownProvisioningStrategy
+		if buffer.Status.ProvisioningStrategy != nil {
+			ps = *buffer.Status.ProvisioningStrategy
+		}
+		countsByType[ps]++
+	}
+
+	return countsByType
 }
 
 // CleanUp is called at CA termination

--- a/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
+++ b/cluster-autoscaler/processors/capacitybuffer/pod_list_processor_test.go
@@ -324,3 +324,22 @@ func getTestingBuffer(bufferName, refName string, replicas int32, generation int
 	}
 	return buffer
 }
+
+func TestCapacityBuffersCountsByType(t *testing.T) {
+	strategy1 := "strategy_1"
+	strategy2 := "strategy_2"
+
+	buffers := []*apiv1.CapacityBuffer{
+		getTestingBuffer("buffer1", "ref1", 1, 1, true, 1, strategy1),
+		nil, // Defensive nil check validation
+		getTestingBuffer("buffer2", "ref2", 1, 1, true, 1, strategy2),
+		getTestingBuffer("buffer3", "ref3", 1, 1, true, 1, strategy1),
+	}
+
+	counts := capacityBuffersCountsByType(buffers)
+
+	// Verify that counts are correct and nil buffer is ignored without panic
+	assert.Equal(t, 2, counts[strategy1])
+	assert.Equal(t, 1, counts[strategy2])
+	assert.Equal(t, 2, len(counts))
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Registers the `capacity_buffers_count` gauge metric dynamically when the capacity buffer pod injection feature is active. This metric tracks the number of capacity buffers in the cluster, partitioned by their provisioning strategy.

The counts are updated dynamically on each execution of the pod list processor before pod injection filters are applied. Stale or deleted strategy labels are safely reset and cleared from the registry.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduced 'capacity_buffers_count' metric. It tracks the number of capacity buffers in the cluster, partitioned by their provisioning strategy. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
