### PR TITLE
Add reactive CPU startup boost unboosting

### DIFF
--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -160,6 +160,7 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `admission-controller-status-lease-timeout` | duration | 1m0s | The time after which the admission controller status is considered stale and the updater stops evicting pods. Must be longer than the admission controller's --status-lease-update-interval flag. |
 | `alsologtostderr` | bool | false | log to standard error as well as files (no effect when -logtostderr=true) |
 | `alsologtostderrthreshold` | severity |  | logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true) |
+| `concurrent-cpu-startup-boost-syncs` | int | 1 | The number of workers processing CPU startup boost unboosting concurrently. |
 | `evict-after-oom-threshold` | duration | 10m0s | The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start. |
 | `eviction-rate-burst` | int | 1 | Burst of pods that can be evicted. |
 | `eviction-rate-limit` | float | -1 | Number of pods that can be evicted per second. A rate limit set to 0 or -1 will disable the rate limiter. |

--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -154,6 +154,7 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 | `address` | string |  ":8943" | The address to expose Prometheus metrics.  |
 | `alsologtostderr` |  |  | log to standard error as well as files (no effect when -logtostderr=true) |
 | `alsologtostderrthreshold` | severity |  | logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true) |
+| `concurrent-cpu-startup-boost-syncs` | int |  1 | The number of workers processing CPU startup boost unboosting concurrently.  |
 | `evict-after-oom-threshold` |  |  10m0s | duration                              The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start.  |
 | `eviction-rate-burst` | int |  1 | Burst of pods that can be evicted.  |
 | `eviction-rate-limit` | float |  -1 | Number of pods that can be evicted per seconds. A rate limit set to 0 or -1 will disable the rate limiter.  |

--- a/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost/README.md
+++ b/vertical-pod-autoscaler/enhancements/7862-cpu-startup-boost/README.md
@@ -11,6 +11,7 @@
   - [Validation](#validation)
     - [Static Validation](#static-validation)
     - [Dynamic Validation](#dynamic-validation)
+  - [Reactive Unboosting Architecture](#reactive-unboosting-architecture)
   - [Mitigating Failed In-Place Downsizes](#mitigating-failed-in-place-downsizes)
   - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
     - [How can this feature be enabled / disabled in a live cluster?](#how-can-this-feature-be-enabled--disabled-in-a-live-cluster)
@@ -94,11 +95,20 @@ VPA Admission Controller
     *   If `ControlledValues` is `RequestsAndLimits` (the default), the CPU limit is also boosted.
         The new limit is calculated to maintain the container's original limit-to-request ratio, applied to the new boosted CPU request. In cases where this ratio cannot be established (e.g., if the original CPU limit was unspecified), the limit will not be changed by the boost.
 
-1. The VPA Updater monitors pods targeted by the VPA object and when the pod
-condition is `Ready` and `StartupBoost.CPU.DurationSeconds` has elapsed, it scales
-down the CPU resources to the appropriate non-boosted value. This "unboosting"
-resizes the pod to whatever the recommendation is at that moment. The specific
-behavior is determined by the VPA `updatePolicy`:
+1. The VPA Updater reactively unbooosts pods using an event-driven workqueue.
+   A shared pod informer watches for pod add/update events. When a pod becomes
+   `Ready` and has a CPU startup boost annotation, it is enqueued to a
+   rate-limiting workqueue. Dedicated boost worker goroutines process the queue:
+
+    * If the boost duration has not yet expired, the pod is re-enqueued with a
+    precise delay matching the remaining boost duration (using `AddAfter`),
+    avoiding unnecessary polling.
+    * Once the pod is `Ready` and `StartupBoost.CPU.DurationSeconds` has elapsed,
+    the worker scales down the CPU resources to the appropriate non-boosted
+    value. This "unboosting" resizes the pod to whatever the recommendation is
+    at that moment.
+
+    The specific unboosting behavior is determined by the VPA `updatePolicy`:
     * If `updatePolicy` is `Auto`, `Recreate` or `InPlaceOrRecreate`, the VPA
     Updater will apply the current VPA recommendation, even if it's higher than
     the boosted value.
@@ -106,6 +116,10 @@ behavior is determined by the VPA `updatePolicy`:
     container policy, the VPA Updater will revert the CPU resources to the
     values specified in the pod spec.
     * The scale down is applied [in-place](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources).
+
+    The main `RunOnce` loop excludes pods with active CPU startup boost
+    annotations from standard eviction and in-place update processing, so they
+    are only handled by the boost workers.
 
 ### API Changes
 
@@ -214,6 +228,35 @@ are created/updated:
   parsed as a `float64` (e.g., `500m`), the API must reject the `startupBoost`
   configuration as invalid.
 
+### Reactive Unboosting Architecture
+
+During the alpha phase of the feature, the unboosting mechanism was changed from
+a synchronous scan inside the updater's main `RunOnce` loop (which iterated over
+all pods every cycle) to a reactive, event-driven model:
+
+1. **Shared pod informer**: The updater uses a `SharedInformerFactory` for pods
+   (replacing a standalone reflector-based `PodLister`). This allows both the
+   pod lister and pod event handlers to share the same cache.
+
+2. **Workqueue**: A `TypedRateLimitingInterface[string]` workqueue with
+   exponential back-off is used to track pods that need unboosting. Pod
+   add/update events are filtered — only pods that are `Ready`, have a CPU boost
+   annotation, and are not in an ignored namespace are enqueued.
+
+3. **Dedicated boost workers**: Configurable via the
+   `--concurrent-cpu-startup-boost-syncs` flag (default: `1`), one or more
+   goroutines consume from the workqueue. Each worker:
+   * Looks up the pod and its controlling VPA.
+   * If the boost duration has not yet expired, re-enqueues with a precise delay
+     (`AddAfter`) equal to the remaining time, so no unnecessary polling occurs.
+   * If the boost has expired, performs the in-place unboost, respecting
+     disruption budget and rate limiting.
+   * If the VPA cannot be found after `5` retries, the item is dropped.
+
+4. **Graceful shutdown**: The updater handles `SIGTERM`/`SIGINT` signals. On
+   shutdown, the workqueue is drained and worker goroutines are waited on via a
+   `WaitGroup`.
+
 ### Mitigating Failed In-Place Downsizes
 
 The VPA Updater **will not** evict a pod if it attempted to scaled the pod down
@@ -240,7 +283,8 @@ Enabling of feature gates `CPUStartupBoost` will cause the following to happen:
   * admission-controller to **accept** new VPA objects being created with
 `StartupBoost` configured.
   * admission-controller to **boost** CPU resources.
-  * updater to **unboost** the CPU resources.
+  * updater to register pod event handlers and start boost worker goroutines to
+  reactively **unboost** CPU resources.
 
 Disabling of feature gates `CPUStartupBoost` will cause the following to happen:
   * admission-controller to **reject** new VPA objects being created with
@@ -249,9 +293,12 @@ Disabling of feature gates `CPUStartupBoost` will cause the following to happen:
     know that they are using a feature gated feature.
   * admission-controller **to not** boost CPU resources, should it encounter a
   VPA configured with a `StartupBoost` config.
-  * updater **to not** unboost CPU resources when pods meet the scale down
-  requirements, should it encounter a VPA configured with a `StartupBoost`
-  config.
+  * updater **to not** register pod event handlers or start boost workers. Pods
+  with existing boost annotations will not be unboosted.
+
+The updater also accepts the following flag when `CPUStartupBoost` is enabled:
+  * `--concurrent-cpu-startup-boost-syncs` (default: `1`): The number of worker
+  goroutines processing CPU startup boost unboosting concurrently.
 
 ### Kubernetes Version Compatibility
 
@@ -449,6 +496,7 @@ spec:
 
 ## Implementation History
 
+* 2026-08-11: Replace synchronous unboosting in `RunOnce` with a reactive, event-driven workqueue processed by dedicated boost worker goroutines.
 * 2026-02-02: Change `startupBoost.cpu.duration` to `startupBoost.cpu.durationSeconds` and its type from string to int32 (seconds).
 * 2025-10-04: Update `startupBoost.cpu.type` field to correctly indicate it is a required field, not optional. The field has no default value and must be explicitly set to either "Factor" or "Quantity".
 * 2025-08-05: Make some API changes and clarify behavior during and after boost period in the workflow section.

--- a/vertical-pod-autoscaler/pkg/updater/config/config.go
+++ b/vertical-pod-autoscaler/pkg/updater/config/config.go
@@ -52,6 +52,8 @@ type UpdaterConfig struct {
 	DefaultUpdateThreshold     float64
 	PodLifetimeUpdateThreshold time.Duration
 	EvictAfterOOMThreshold     time.Duration
+
+	ConcurrentCPUStartupBoostSyncs int
 }
 
 // DefaultUpdaterConfig returns a UpdaterConfig with default values
@@ -75,6 +77,8 @@ func DefaultUpdaterConfig() *UpdaterConfig {
 		DefaultUpdateThreshold:     0.1,
 		PodLifetimeUpdateThreshold: time.Hour * 12,
 		EvictAfterOOMThreshold:     10 * time.Minute,
+
+		ConcurrentCPUStartupBoostSyncs: 1,
 	}
 }
 
@@ -99,6 +103,7 @@ func InitUpdaterFlags() *UpdaterConfig {
 	flag.Float64Var(&config.DefaultUpdateThreshold, "pod-update-threshold", config.DefaultUpdateThreshold, "Ignore updates that have priority lower than the value of this flag")
 	flag.DurationVar(&config.PodLifetimeUpdateThreshold, "in-recommendation-bounds-eviction-lifetime-threshold", config.PodLifetimeUpdateThreshold, "Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range")
 	flag.DurationVar(&config.EvictAfterOOMThreshold, "evict-after-oom-threshold", config.EvictAfterOOMThreshold, `The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start.`)
+	flag.IntVar(&config.ConcurrentCPUStartupBoostSyncs, "concurrent-cpu-startup-boost-syncs", config.ConcurrentCPUStartupBoostSyncs, "The number of workers processing CPU startup boost unboosting concurrently.")
 
 	// These need to happen last. kube_flag.InitFlags() synchronizes and parses
 	// flags from the flag package to pflag, so feature gates must be added to
@@ -115,6 +120,11 @@ func InitUpdaterFlags() *UpdaterConfig {
 
 // ValidateUpdaterConfig performs validation of the updater flags
 func ValidateUpdaterConfig(config *UpdaterConfig) {
+	// TODO (omerap12): fill validation to all updater config flags.
+	if config.ConcurrentCPUStartupBoostSyncs <= 0 {
+		klog.ErrorS(nil, "--concurrent-cpu-startup-boost-syncs should be positive")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
 	common.ValidateCommonConfig(config.CommonFlags)
 
 	if config.AdmissionControllerStatusLeaseTimeout <= 0 {

--- a/vertical-pod-autoscaler/pkg/updater/config/config.go
+++ b/vertical-pod-autoscaler/pkg/updater/config/config.go
@@ -47,6 +47,8 @@ type UpdaterConfig struct {
 	DefaultUpdateThreshold     float64
 	PodLifetimeUpdateThreshold time.Duration
 	EvictAfterOOMThreshold     time.Duration
+
+	ConcurrentCPUStartupBoostSyncs int
 }
 
 // DefaultUpdaterConfig returns a UpdaterConfig with default values
@@ -63,9 +65,10 @@ func DefaultUpdaterConfig() *UpdaterConfig {
 		UseAdmissionControllerStatus: true,
 		InPlaceSkipDisruptionBudget:  false,
 
-		DefaultUpdateThreshold:     0.1,
-		PodLifetimeUpdateThreshold: time.Hour * 12,
-		EvictAfterOOMThreshold:     10 * time.Minute,
+		DefaultUpdateThreshold:         0.1,
+		PodLifetimeUpdateThreshold:     time.Hour * 12,
+		EvictAfterOOMThreshold:         10 * time.Minute,
+		ConcurrentCPUStartupBoostSyncs: 1,
 	}
 }
 
@@ -86,6 +89,7 @@ func InitUpdaterFlags() *UpdaterConfig {
 	flag.Float64Var(&config.DefaultUpdateThreshold, "pod-update-threshold", config.DefaultUpdateThreshold, "Ignore updates that have priority lower than the value of this flag")
 	flag.DurationVar(&config.PodLifetimeUpdateThreshold, "in-recommendation-bounds-eviction-lifetime-threshold", config.PodLifetimeUpdateThreshold, "Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range")
 	flag.DurationVar(&config.EvictAfterOOMThreshold, "evict-after-oom-threshold", config.EvictAfterOOMThreshold, `The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start.`)
+	flag.IntVar(&config.ConcurrentCPUStartupBoostSyncs, "concurrent-cpu-startup-boost-syncs", config.ConcurrentCPUStartupBoostSyncs, "The number of workers processing CPU startup boost unboosting concurrently.")
 
 	// These need to happen last. kube_flag.InitFlags() synchronizes and parses
 	// flags from the flag package to pflag, so feature gates must be added to

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -19,6 +19,7 @@ package logic
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"time"
 
@@ -26,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
@@ -37,6 +37,7 @@ import (
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/set"
 
@@ -56,6 +57,9 @@ import (
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
+// TODO(omerap12): Should we make this configurable?
+const maxVPALookupRetries = 5
+
 // logDeprecationWarnings logs deprecation warnings for VPAs using deprecated modes
 func logDeprecationWarnings(vpa *vpa_types.VerticalPodAutoscaler) {
 	if vpa.Spec.UpdatePolicy != nil &&
@@ -70,6 +74,14 @@ func logDeprecationWarnings(vpa *vpa_types.VerticalPodAutoscaler) {
 type Updater interface {
 	// RunOnce represents single iteration in the main-loop of Updater
 	RunOnce(context.Context)
+	// RunBoostWorker processes the startup boost unboost queue until ctx is cancelled.
+	RunBoostWorker(context.Context)
+	// PodAddHandler handles pod add events for the startup boost unboost queue.
+	PodAddHandler(obj any)
+	// PodUpdateHandler handles pod update events for the startup boost unboost queue.
+	PodUpdateHandler(oldObj, curObj any)
+	// ShutDown shuts down the boost work queue.
+	ShutDown()
 }
 
 type updater struct {
@@ -92,6 +104,8 @@ type updater struct {
 	defaultUpdateThreshold       float64
 	podLifetimeUpdateThreshold   time.Duration
 	evictAfterOOMThreshold       time.Duration
+	podInformer                  cache.SharedIndexInformer
+	cpuStartupBoostQueue         workqueue.TypedRateLimitingInterface[string]
 }
 
 // NewUpdater creates Updater with given configuration
@@ -99,7 +113,7 @@ func NewUpdater(
 	kubeClient kube_client.Interface,
 	vpaClient *vpa_clientset.Clientset,
 	kubeInformerFactory informers.SharedInformerFactory,
-	podLister listersv1.PodLister,
+	podInformerFactory informers.SharedInformerFactory,
 	minReplicasForEviction int,
 	evictionRateLimit float64,
 	evictionRateBurst int,
@@ -133,9 +147,9 @@ func NewUpdater(
 		inPlaceSkipDisruptionBudget,
 	)
 
-	return &updater{
+	u := &updater{
 		vpaLister:                    vpa_api_util.NewVpasLister(vpaClient, make(chan struct{}), namespace),
-		podLister:                    podLister,
+		podLister:                    podInformerFactory.Core().V1().Pods().Lister(),
 		eventRecorder:                newEventRecorder(kubeClient),
 		restrictionFactory:           factory,
 		recommendationProcessor:      recommendationProcessor,
@@ -157,7 +171,24 @@ func NewUpdater(
 		defaultUpdateThreshold:     defaultUpdateThreshold,
 		podLifetimeUpdateThreshold: podLifetimeUpdateThreshold,
 		evictAfterOOMThreshold:     evictAfterOOMThreshold,
-	}, nil
+	}
+	if features.Enabled(features.CPUStartupBoost) {
+		u.podInformer = podInformerFactory.Core().V1().Pods().Informer()
+		u.cpuStartupBoostQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[string](100*time.Millisecond, 1000*time.Second),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: "cpu-startup-boost",
+			},
+		)
+		if _, err := u.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    u.PodAddHandler,
+			UpdateFunc: u.PodUpdateHandler,
+		}); err != nil {
+			return nil, fmt.Errorf("adding Pod event handler: %w", err)
+		}
+	}
+
+	return u, nil
 }
 
 // RunOnce represents single iteration in the main-loop of Updater
@@ -187,7 +218,6 @@ func (u *updater) RunOnce(ctx context.Context) {
 	vpas := make([]*vpa_api_util.VpaWithSelector, 0)
 
 	inPlaceFeatureEnabled := features.Enabled(features.InPlace)
-	cpuStartupBoostFeatureEnabled := features.Enabled(features.CPUStartupBoost)
 	for _, vpa := range vpaList {
 		if slices.Contains(u.ignoredNamespaces, vpa.Namespace) {
 			klog.V(3).InfoS("Skipping VPA object in ignored namespace", "vpa", klog.KObj(vpa), "namespace", vpa.Namespace)
@@ -207,7 +237,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 		}
 		selector, err := u.selectorFetcher.Fetch(ctx, vpa)
 		if err != nil {
-			klog.V(3).InfoS("Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa))
+			klog.V(3).ErrorS(err, "Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa))
 			continue
 		}
 
@@ -286,45 +316,16 @@ func (u *updater) RunOnce(ctx context.Context) {
 		metrics_updater.InitCounters(vpaSize, vpa.Name, vpa.Namespace, updateMode)
 
 		inPlaceLimiter := u.restrictionFactory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
-		podsAvailableForUpdate := make([]*corev1.Pod, 0)
-		podsToUnboost := make([]*corev1.Pod, 0)
 		withInPlaceUpdated := false
 
-		if cpuStartupBoostFeatureEnabled && vpa_api_util.HasStartupBoost(vpa) {
-			// First, handle unboosting for pods that have finished their startup period.
-			for _, pod := range livePods {
-				if len(vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa)) > 0 {
-					podsToUnboost = append(podsToUnboost, pod)
-				}
-				if !vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
-					podsAvailableForUpdate = append(podsAvailableForUpdate, pod)
-				}
-			}
-
-			// Perform unboosting
-			for _, pod := range podsToUnboost {
-				if inPlaceLimiter.CanUnboost(pod, vpa) {
-					klog.V(2).InfoS("Unboosting pod", "pod", klog.KObj(pod))
-					err = u.inPlaceRateLimiter.Wait(ctx)
-					if err != nil {
-						klog.V(0).InfoS("In-place rate limiter wait failed for unboosting", "error", err)
-						return
-					}
-					err := inPlaceLimiter.InPlaceUpdate(pod, vpa, u.eventRecorder)
-					if err != nil {
-						klog.V(0).InfoS("Unboosting failed", "error", err, "pod", klog.KObj(pod))
-						metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, "UnboostError")
-					} else {
-						klog.V(2).InfoS("Successfully unboosted pod", "pod", klog.KObj(pod))
-						withInPlaceUpdated = true
-						metrics_updater.AddInPlaceUpdatedPod(vpaSize, vpa.Name, vpa.Namespace)
-					}
-				}
-			}
-		} else {
-			// CPU Startup Boost is not enabled or configured for this VPA,
-			// so all live pods are available for potential standard VPA updates.
-			podsAvailableForUpdate = livePods
+		// Exclude pods with an active CPU startup boost from standard eviction/in-place processing.
+		// These pods are handled separately by the RunBoostWorker queue, which unbooosts them
+		// via in-place update once the boost duration expires — avoiding unnecessary evictions.
+		podsAvailableForUpdate := livePods
+		if features.Enabled(features.CPUStartupBoost) && vpa_api_util.HasStartupBoost(vpa) {
+			podsAvailableForUpdate = filterPods(livePods, func(pod *corev1.Pod) bool {
+				return !vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod)
+			})
 		}
 
 		if updateMode == vpa_types.UpdateModeOff || updateMode == vpa_types.UpdateModeInitial {
@@ -477,6 +478,195 @@ func (u *updater) recordInfeasibleAttempt(pod *corev1.Pod, vpa *vpa_types.Vertic
 	klog.V(2).InfoS("Recorded infeasible attempt, will retry when recommendation changes", "pod", klog.KObj(pod))
 }
 
+func (u *updater) PodAddHandler(obj any) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		klog.InfoS("Expected Pod", "got", obj)
+		return
+	}
+	if vpa_api_util.IsPodReady(pod) && vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) && !slices.Contains(u.ignoredNamespaces, pod.Namespace) {
+		u.enqueuePod(pod)
+	}
+}
+
+func (u *updater) PodUpdateHandler(_, curObj any) {
+	curPod, ok := curObj.(*corev1.Pod)
+	if !ok {
+		klog.InfoS("Expected Pod", "got", curObj)
+		return
+	}
+
+	if vpa_api_util.IsPodReady(curPod) && vpa_api_util.PodHasCPUBoostInProgressAnnotation(curPod) && !slices.Contains(u.ignoredNamespaces, curPod.Namespace) {
+		u.enqueuePod(curPod)
+	}
+}
+
+func (u *updater) enqueuePod(obj any) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	u.cpuStartupBoostQueue.Add(key)
+}
+
+func (u *updater) RunBoostWorker(ctx context.Context) {
+	logger := klog.FromContext(ctx).WithName("boost-worker")
+	ctx = klog.NewContext(ctx, logger)
+	if !cache.WaitForCacheSync(ctx.Done(), u.podInformer.HasSynced) {
+		klog.ErrorS(nil, "Failed to sync pod informer cache")
+		return
+	}
+	for u.processNextBoostItem(ctx) {
+	}
+	logger.Info("VPA updater is shutting down")
+}
+
+func (u *updater) ShutDown() {
+	u.cpuStartupBoostQueue.ShutDown()
+}
+
+func (u *updater) processNextBoostItem(ctx context.Context) bool {
+	key, quit := u.cpuStartupBoostQueue.Get()
+	if quit {
+		return false
+	}
+	defer u.cpuStartupBoostQueue.Done(key)
+
+	logger := klog.FromContext(ctx)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "Failed to split key", "key", key)
+		u.cpuStartupBoostQueue.Forget(key)
+		return true
+	}
+	pod, err := u.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(4).Info("Pod no longer exists, skipping", "key", key)
+			u.cpuStartupBoostQueue.Forget(key)
+			return true
+		}
+		// other transient error we should retry
+		logger.Error(err, "Failed to get pod", "pod", name, "namespace", namespace)
+		u.cpuStartupBoostQueue.AddRateLimited(key)
+		return true
+	}
+
+	logger = logger.WithValues("pod", klog.KObj(pod))
+
+	if !vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
+		logger.V(4).Info("Pod is not in boosted state, skipping")
+		u.cpuStartupBoostQueue.Forget(key)
+		return true
+	}
+
+	vpaWithSelector, err := u.getControllingVPAForPod(ctx, pod)
+	if err != nil {
+		logger.Error(err, "Failed to get controlling VPA")
+		u.cpuStartupBoostQueue.AddRateLimited(key)
+		return true
+	}
+	if vpaWithSelector == nil {
+		if u.cpuStartupBoostQueue.NumRequeues(key) > maxVPALookupRetries {
+			logger.V(2).Info("No controlling VPA found for pod after retries, deferring until next resync", "maxRetries", maxVPALookupRetries)
+			u.cpuStartupBoostQueue.Forget(key)
+			return true
+		}
+		logger.V(4).Info("No controlling VPA found for pod, re-enqueueing")
+		u.cpuStartupBoostQueue.AddRateLimited(key)
+		return true
+	}
+	vpa := vpaWithSelector.Vpa
+
+	expiredAnnotations := vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa)
+	if len(expiredAnnotations) > 0 {
+		logger.V(4).Info("Found expired boost annotations", "count", len(expiredAnnotations))
+		allPodsPerVPA, err := u.podLister.Pods(namespace).List(vpaWithSelector.Selector)
+		if err != nil {
+			logger.Error(err, "Failed to list pods for VPA", "vpa", klog.KObj(vpa))
+			u.cpuStartupBoostQueue.AddRateLimited(key)
+			return true
+		}
+		livePods := filterDeletedPods(allPodsPerVPA)
+		vpaSize := len(livePods)
+
+		creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := u.restrictionFactory.GetCreatorMaps(livePods, vpa)
+		if err != nil {
+			logger.Error(err, "Failed to get creator maps for unboosting")
+			u.cpuStartupBoostQueue.AddRateLimited(key)
+			return true
+		}
+		inPlaceLimiter := u.restrictionFactory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+		if !inPlaceLimiter.CanUnboost(pod, vpa) {
+			logger.V(4).Info("Cannot unboost pod yet, re-enqueueing")
+			u.cpuStartupBoostQueue.AddRateLimited(key)
+			return true
+		}
+
+		logger.V(2).Info("Unboosting pod")
+		if err := u.inPlaceRateLimiter.Wait(ctx); err != nil {
+			logger.Error(err, "In-place rate limiter wait failed for unboosting")
+			u.cpuStartupBoostQueue.AddRateLimited(key)
+			return true
+		}
+		if err := inPlaceLimiter.InPlaceUpdate(pod, vpa, u.eventRecorder); err != nil {
+			logger.Error(err, "Unboosting failed")
+			metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, "UnboostError")
+			u.cpuStartupBoostQueue.AddRateLimited(key)
+			return true
+		}
+		logger.V(2).Info("Successfully unboosted pod")
+		metrics_updater.AddInPlaceUpdatedPod(vpaSize, vpa.Name, vpa.Namespace)
+		u.cpuStartupBoostQueue.Forget(key)
+		return true
+	}
+
+	remaining := vpa_api_util.GetBoostRemainingDuration(pod, vpa)
+	if remaining > 0 {
+		logger.V(4).Info("Boost still active, re-enqueueing", "remainingDuration", remaining)
+		u.cpuStartupBoostQueue.Forget(key)
+		u.cpuStartupBoostQueue.AddAfter(key, remaining)
+	} else if len(expiredAnnotations) == 0 && vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
+		// Pod has boost annotations but neither expired nor remaining — likely the pod
+		// is not yet Ready in the lister cache. Re-enqueue to retry shortly.
+		logger.V(4).Info("Pod has boost annotations but not yet Ready in cache, re-enqueueing")
+		u.cpuStartupBoostQueue.AddRateLimited(key)
+	} else {
+		logger.V(4).Info("No remaining boost duration")
+		u.cpuStartupBoostQueue.Forget(key)
+	}
+	return true
+}
+
+// getControllingVPAForPod gets the controlling VPA for a pod.
+//
+// TODO(omerap12): We should revisit this.
+// Every time the boost worker processes a pod, it lists ALL VPAs in the pod's namespace and fetches selectors for each.
+// In clusters with many VPAs this is expensive (I know there is a lister so the list operation is in memory but maybe we can do something better).
+//
+// TODO(omerap12): Move this function to the utils package since it shares code with the admission controller.
+func (u *updater) getControllingVPAForPod(ctx context.Context, pod *corev1.Pod) (*vpa_api_util.VpaWithSelector, error) {
+	vpaList, err := u.vpaLister.VerticalPodAutoscalers(pod.Namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	vpas := make([]*vpa_api_util.VpaWithSelector, 0, len(vpaList))
+	for _, vpa := range vpaList {
+		selector, err := u.selectorFetcher.Fetch(ctx, vpa)
+		if err != nil {
+			klog.V(3).ErrorS(err, "Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa))
+			continue
+		}
+		vpas = append(vpas, &vpa_api_util.VpaWithSelector{
+			Vpa:      vpa,
+			Selector: selector,
+		})
+	}
+	return vpa_api_util.GetControllingVPAForPod(ctx, pod, vpas, u.controllerFetcher), nil
+}
+
 func getRateLimiter(rateLimit float64, rateLimitBurst int) *rate.Limiter {
 	var rateLimiter *rate.Limiter
 	if rateLimit <= 0 {
@@ -554,20 +744,6 @@ func filterDeletedPods(pods []*corev1.Pod) []*corev1.Pod {
 	return filterPods(pods, func(pod *corev1.Pod) bool {
 		return pod.DeletionTimestamp == nil
 	})
-}
-
-// NewPodLister creates a new PodLister that lists pods based on the provided kubeClient and namespace.
-// It filters out pods that are not scheduled (spec.nodeName is empty) and pods that are in Succeeded or Failed phase, as these pods are not relevant for eviction or in-place updates.
-func NewPodLister(kubeClient kube_client.Interface, namespace string, stopCh <-chan struct{}) listersv1.PodLister {
-	selector := fields.ParseSelectorOrDie("spec.nodeName!=" + "" + ",status.phase!=" +
-		string(corev1.PodSucceeded) + ",status.phase!=" + string(corev1.PodFailed))
-	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", namespace, selector)
-	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	podLister := listersv1.NewPodLister(store)
-	podReflector := cache.NewReflector(podListWatch, &corev1.Pod{}, store, time.Hour)
-	go podReflector.Run(stopCh)
-
-	return podLister
 }
 
 func newEventRecorder(kubeClient kube_client.Interface) record.EventRecorder {

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -526,20 +526,22 @@ func (u *updater) processNextBoostItem(ctx context.Context) bool {
 	}
 	defer u.cpuStartupBoostQueue.Done(key)
 
+	logger := klog.FromContext(ctx)
+
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		klog.ErrorS(err, "Failed to split key", "key", key)
+		logger.Error(err, "Failed to split key", "key", key)
 		u.cpuStartupBoostQueue.Forget(key)
 		return true
 	}
 	pod, err := u.podLister.Pods(namespace).Get(name)
 	if err != nil {
-		klog.V(4).InfoS("Pod no longer exists, skipping", "key", key)
+		logger.V(4).Info("Pod no longer exists, skipping", "key", key)
 		u.cpuStartupBoostQueue.Forget(key)
 		return true
 	}
 
-	logger := klog.FromContext(ctx).WithName("boost-worker").WithValues("pod", klog.KObj(pod))
+	logger = logger.WithValues("pod", klog.KObj(pod))
 
 	if !vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
 		logger.V(4).Info("Pod is not in boosted state, skipping")

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -168,7 +168,12 @@ func NewUpdater(
 	}
 	if features.Enabled(features.CPUStartupBoost) {
 		u.podInformer = kubeInformerFactory.Core().V1().Pods().Informer()
-		u.cpuStartupBoostQueue = workqueue.NewTypedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[string](100*time.Millisecond, 1000*time.Second))
+		u.cpuStartupBoostQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[string](100*time.Millisecond, 1000*time.Second),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: "cpu-startup-boost",
+			},
+		)
 		if _, err := u.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    u.PodAddHandler,
 			UpdateFunc: u.PodUpdateHandler,
@@ -226,7 +231,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 		}
 		selector, err := u.selectorFetcher.Fetch(ctx, vpa)
 		if err != nil {
-			klog.V(3).InfoS("Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa), "error", err)
+			klog.V(3).ErrorS(err, "Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa))
 			continue
 		}
 
@@ -470,7 +475,7 @@ func (u *updater) recordInfeasibleAttempt(pod *corev1.Pod, vpa *vpa_types.Vertic
 func (u *updater) PodAddHandler(obj any) {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
-		klog.ErrorS(nil, "Expected Pod", "got", pod)
+		klog.InfoS("Expected Pod", "got", pod)
 		return
 	}
 	if vpa_api_util.IsPodReady(pod) && vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
@@ -481,7 +486,7 @@ func (u *updater) PodAddHandler(obj any) {
 func (u *updater) PodUpdateHandler(_, curObj any) {
 	curPod, ok := curObj.(*corev1.Pod)
 	if !ok {
-		klog.ErrorS(nil, "Expected Pod", "got", curObj)
+		klog.InfoS("Expected Pod", "got", curObj)
 		return
 	}
 
@@ -499,13 +504,14 @@ func (u *updater) enqueuePod(obj any) {
 }
 
 func (u *updater) RunBoostWorker(ctx context.Context) {
+	logger := klog.FromContext(ctx).WithName("boost-worker")
+	ctx = klog.NewContext(ctx, logger)
 	if !cache.WaitForCacheSync(ctx.Done(), u.podInformer.HasSynced) {
 		klog.ErrorS(nil, "Failed to sync pod informer cache")
 		return
 	}
 	for u.processNextBoostItem(ctx) {
 	}
-	logger := klog.FromContext(ctx)
 	logger.Info("VPA updater is shutting down")
 }
 
@@ -526,7 +532,6 @@ func (u *updater) processNextBoostItem(ctx context.Context) bool {
 		u.cpuStartupBoostQueue.Forget(key)
 		return true
 	}
-	klog.V(4).InfoS("Working on", "podNamespace", namespace, "podName", name)
 	pod, err := u.podLister.Pods(namespace).Get(name)
 	if err != nil {
 		klog.V(4).InfoS("Pod no longer exists, skipping", "key", key)
@@ -534,20 +539,22 @@ func (u *updater) processNextBoostItem(ctx context.Context) bool {
 		return true
 	}
 
+	logger := klog.FromContext(ctx).WithName("boost-worker").WithValues("pod", klog.KObj(pod))
+
 	if !vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
-		klog.V(4).InfoS("Pod is not in boosted state, skipping", "pod", klog.KObj(pod))
+		logger.V(4).Info("Pod is not in boosted state, skipping")
 		u.cpuStartupBoostQueue.Forget(key)
 		return true
 	}
 
 	vpaWithSelector, err := u.getControllingVPAForPod(ctx, pod)
 	if err != nil {
-		klog.ErrorS(err, "Failed to get controlling VPA", "pod", klog.KObj(pod))
+		logger.Error(err, "Failed to get controlling VPA")
 		u.cpuStartupBoostQueue.AddRateLimited(key)
 		return true
 	}
 	if vpaWithSelector == nil {
-		klog.V(4).InfoS("No controlling VPA found for pod, skipping", "pod", klog.KObj(pod))
+		logger.V(4).Info("No controlling VPA found for pod, skipping")
 		u.cpuStartupBoostQueue.Forget(key)
 		return true
 	}
@@ -555,10 +562,10 @@ func (u *updater) processNextBoostItem(ctx context.Context) bool {
 
 	expiredAnnotations := vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa)
 	if len(expiredAnnotations) > 0 {
-		klog.V(4).InfoS("Found expired boost annotations", "pod", klog.KObj(pod), "count", len(expiredAnnotations))
+		logger.V(4).Info("Found expired boost annotations", "count", len(expiredAnnotations))
 		allPodsPerVPA, err := u.podLister.Pods(namespace).List(vpaWithSelector.Selector)
 		if err != nil {
-			klog.ErrorS(err, "Failed to list pods for VPA", "vpa", klog.KObj(vpa))
+			logger.Error(err, "Failed to list pods for VPA", "vpa", klog.KObj(vpa))
 			u.cpuStartupBoostQueue.AddRateLimited(key)
 			return true
 		}
@@ -567,46 +574,46 @@ func (u *updater) processNextBoostItem(ctx context.Context) bool {
 
 		creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := u.restrictionFactory.GetCreatorMaps(livePods, vpa)
 		if err != nil {
-			klog.ErrorS(err, "Failed to get creator maps for unboosting", "pod", klog.KObj(pod))
+			logger.Error(err, "Failed to get creator maps for unboosting")
 			u.cpuStartupBoostQueue.AddRateLimited(key)
 			return true
 		}
 		inPlaceLimiter := u.restrictionFactory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
 		if !inPlaceLimiter.CanUnboost(pod, vpa) {
-			klog.V(4).InfoS("Cannot unboost pod yet, re-enqueueing", "pod", klog.KObj(pod))
+			logger.V(4).Info("Cannot unboost pod yet, re-enqueueing")
 			u.cpuStartupBoostQueue.AddRateLimited(key)
 			return true
 		}
 
-		klog.V(2).InfoS("Unboosting pod", "pod", klog.KObj(pod))
+		logger.V(2).Info("Unboosting pod")
 		if err := u.inPlaceRateLimiter.Wait(ctx); err != nil {
-			klog.ErrorS(err, "In-place rate limiter wait failed for unboosting")
+			logger.Error(err, "In-place rate limiter wait failed for unboosting")
 			return true
 		}
 		if err := inPlaceLimiter.InPlaceUpdate(pod, vpa, u.eventRecorder); err != nil {
-			klog.ErrorS(err, "Unboosting failed", "pod", klog.KObj(pod))
+			logger.Error(err, "Unboosting failed")
 			metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, "UnboostError")
 			u.cpuStartupBoostQueue.AddRateLimited(key)
 			return true
 		}
-		klog.V(2).InfoS("Successfully unboosted pod", "pod", klog.KObj(pod))
+		logger.V(2).Info("Successfully unboosted pod")
 		metrics_updater.AddInPlaceUpdatedPod(vpaSize, vpa.Name, vpa.Namespace)
 		u.cpuStartupBoostQueue.Forget(key)
 	}
 
 	remaining := vpa_api_util.GetBoostRemainingDuration(pod, vpa)
 	if remaining > 0 {
-		klog.V(4).InfoS("Boost still active, re-enqueueing", "pod", klog.KObj(pod), "remainingDuration", remaining)
+		logger.V(4).Info("Boost still active, re-enqueueing", "remainingDuration", remaining)
 		u.cpuStartupBoostQueue.Forget(key)
 		u.cpuStartupBoostQueue.AddAfter(key, remaining)
 	} else if len(expiredAnnotations) == 0 && vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
 		// Pod has boost annotations but neither expired nor remaining — likely the pod
 		// is not yet Ready in the lister cache. Re-enqueue to retry shortly.
-		klog.V(4).InfoS("Pod has boost annotations but not yet Ready in cache, re-enqueueing", "pod", klog.KObj(pod))
+		logger.V(4).Info("Pod has boost annotations but not yet Ready in cache, re-enqueueing")
 		u.cpuStartupBoostQueue.AddRateLimited(key)
 	} else {
-		klog.V(4).InfoS("No remaining boost duration", "pod", klog.KObj(pod))
+		logger.V(4).Info("No remaining boost duration")
 		u.cpuStartupBoostQueue.Forget(key)
 	}
 	return true
@@ -625,7 +632,7 @@ func (u *updater) getControllingVPAForPod(ctx context.Context, pod *corev1.Pod) 
 	for _, vpa := range vpaList {
 		selector, err := u.selectorFetcher.Fetch(ctx, vpa)
 		if err != nil {
-			klog.V(3).InfoS("Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa), "error", err)
+			klog.V(3).ErrorS(err, "Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa))
 			continue
 		}
 		vpas = append(vpas, &vpa_api_util.VpaWithSelector{

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -19,6 +19,7 @@ package logic
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/set"
 
@@ -70,6 +72,14 @@ func logDeprecationWarnings(vpa *vpa_types.VerticalPodAutoscaler) {
 type Updater interface {
 	// RunOnce represents single iteration in the main-loop of Updater
 	RunOnce(context.Context)
+	// RunBoostWorker processes the startup boost unboost queue until ctx is cancelled.
+	RunBoostWorker(context.Context)
+	// PodAddHandler handles pod add events for the startup boost unboost queue.
+	PodAddHandler(obj any)
+	// PodUpdateHandler handles pod update events for the startup boost unboost queue.
+	PodUpdateHandler(oldObj, curObj any)
+	// ShutDown shuts down the boost work queue.
+	ShutDown()
 }
 
 type updater struct {
@@ -91,6 +101,8 @@ type updater struct {
 	defaultUpdateThreshold       float64
 	podLifetimeUpdateThreshold   time.Duration
 	evictAfterOOMThreshold       time.Duration
+	podInformer                  cache.SharedIndexInformer
+	cpuStartupBoostQueue         workqueue.TypedRateLimitingInterface[string]
 }
 
 // NewUpdater creates Updater with given configuration
@@ -130,7 +142,7 @@ func NewUpdater(
 		inPlaceSkipDisruptionBudget,
 	)
 
-	return &updater{
+	u := &updater{
 		vpaLister:                    vpa_api_util.NewVpasLister(vpaClient, make(chan struct{}), namespace),
 		podLister:                    podLister,
 		eventRecorder:                newEventRecorder(kubeClient),
@@ -153,7 +165,19 @@ func NewUpdater(
 		defaultUpdateThreshold:     defaultUpdateThreshold,
 		podLifetimeUpdateThreshold: podLifetimeUpdateThreshold,
 		evictAfterOOMThreshold:     evictAfterOOMThreshold,
-	}, nil
+	}
+	if features.Enabled(features.CPUStartupBoost) {
+		u.podInformer = kubeInformerFactory.Core().V1().Pods().Informer()
+		u.cpuStartupBoostQueue = workqueue.NewTypedRateLimitingQueue(workqueue.NewTypedItemExponentialFailureRateLimiter[string](100*time.Millisecond, 1000*time.Second))
+		if _, err := u.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    u.PodAddHandler,
+			UpdateFunc: u.PodUpdateHandler,
+		}); err != nil {
+			return nil, fmt.Errorf("adding Pod event handler: %w", err)
+		}
+	}
+
+	return u, nil
 }
 
 // RunOnce represents single iteration in the main-loop of Updater
@@ -183,7 +207,6 @@ func (u *updater) RunOnce(ctx context.Context) {
 	vpas := make([]*vpa_api_util.VpaWithSelector, 0)
 
 	inPlaceFeatureEnabled := features.Enabled(features.InPlace)
-	cpuStartupBoostFeatureEnabled := features.Enabled(features.CPUStartupBoost)
 	for _, vpa := range vpaList {
 		if slices.Contains(u.ignoredNamespaces, vpa.Namespace) {
 			klog.V(3).InfoS("Skipping VPA object in ignored namespace", "vpa", klog.KObj(vpa), "namespace", vpa.Namespace)
@@ -203,7 +226,7 @@ func (u *updater) RunOnce(ctx context.Context) {
 		}
 		selector, err := u.selectorFetcher.Fetch(ctx, vpa)
 		if err != nil {
-			klog.V(3).InfoS("Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa))
+			klog.V(3).InfoS("Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa), "error", err)
 			continue
 		}
 
@@ -282,45 +305,16 @@ func (u *updater) RunOnce(ctx context.Context) {
 		metrics_updater.InitCounters(vpaSize, vpa.Name, vpa.Namespace, updateMode)
 
 		inPlaceLimiter := u.restrictionFactory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
-		podsAvailableForUpdate := make([]*corev1.Pod, 0)
-		podsToUnboost := make([]*corev1.Pod, 0)
 		withInPlaceUpdated := false
 
-		if cpuStartupBoostFeatureEnabled && vpa_api_util.HasStartupBoost(vpa) {
-			// First, handle unboosting for pods that have finished their startup period.
-			for _, pod := range livePods {
-				if len(vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa)) > 0 {
-					podsToUnboost = append(podsToUnboost, pod)
-				}
-				if !vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
-					podsAvailableForUpdate = append(podsAvailableForUpdate, pod)
-				}
-			}
-
-			// Perform unboosting
-			for _, pod := range podsToUnboost {
-				if inPlaceLimiter.CanUnboost(pod, vpa) {
-					klog.V(2).InfoS("Unboosting pod", "pod", klog.KObj(pod))
-					err = u.inPlaceRateLimiter.Wait(ctx)
-					if err != nil {
-						klog.V(0).InfoS("In-place rate limiter wait failed for unboosting", "error", err)
-						return
-					}
-					err := inPlaceLimiter.InPlaceUpdate(pod, vpa, u.eventRecorder)
-					if err != nil {
-						klog.V(0).InfoS("Unboosting failed", "error", err, "pod", klog.KObj(pod))
-						metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, "UnboostError")
-					} else {
-						klog.V(2).InfoS("Successfully unboosted pod", "pod", klog.KObj(pod))
-						withInPlaceUpdated = true
-						metrics_updater.AddInPlaceUpdatedPod(vpaSize, vpa.Name, vpa.Namespace)
-					}
-				}
-			}
-		} else {
-			// CPU Startup Boost is not enabled or configured for this VPA,
-			// so all live pods are available for potential standard VPA updates.
-			podsAvailableForUpdate = livePods
+		// Exclude pods with an active CPU startup boost from standard eviction/in-place processing.
+		// These pods are handled separately by the RunBoostWorker queue, which unbooosts them
+		// via in-place update once the boost duration expires — avoiding unnecessary evictions.
+		podsAvailableForUpdate := livePods
+		if features.Enabled(features.CPUStartupBoost) && vpa_api_util.HasStartupBoost(vpa) {
+			podsAvailableForUpdate = filterPods(livePods, func(pod *corev1.Pod) bool {
+				return !vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod)
+			})
 		}
 
 		if updateMode == vpa_types.UpdateModeOff || updateMode == vpa_types.UpdateModeInitial {
@@ -471,6 +465,175 @@ func (u *updater) cleanupStaleInfeasibleAttempts(livePodUIDs set.Set[types.UID])
 func (u *updater) recordInfeasibleAttempt(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) {
 	u.infeasibleAttempts[pod.UID] = vpa.Status.Recommendation
 	klog.V(2).InfoS("Recorded infeasible attempt, will retry when recommendation changes", "pod", klog.KObj(pod))
+}
+
+func (u *updater) PodAddHandler(obj any) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		klog.ErrorS(nil, "Expected Pod", "got", pod)
+		return
+	}
+	if vpa_api_util.IsPodReady(pod) && vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
+		u.enqueuePod(pod)
+	}
+}
+
+func (u *updater) PodUpdateHandler(_, curObj any) {
+	curPod, ok := curObj.(*corev1.Pod)
+	if !ok {
+		klog.ErrorS(nil, "Expected Pod", "got", curObj)
+		return
+	}
+
+	if vpa_api_util.IsPodReady(curPod) && vpa_api_util.PodHasCPUBoostInProgressAnnotation(curPod) {
+		u.enqueuePod(curPod)
+	}
+}
+
+func (u *updater) enqueuePod(obj any) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	u.cpuStartupBoostQueue.Add(key)
+}
+
+func (u *updater) RunBoostWorker(ctx context.Context) {
+	if !cache.WaitForCacheSync(ctx.Done(), u.podInformer.HasSynced) {
+		klog.ErrorS(nil, "Failed to sync pod informer cache")
+		return
+	}
+	for u.processNextBoostItem(ctx) {
+	}
+	logger := klog.FromContext(ctx)
+	logger.Info("VPA updater is shutting down")
+}
+
+func (u *updater) ShutDown() {
+	u.cpuStartupBoostQueue.ShutDown()
+}
+
+func (u *updater) processNextBoostItem(ctx context.Context) bool {
+	key, quit := u.cpuStartupBoostQueue.Get()
+	if quit {
+		return false
+	}
+	defer u.cpuStartupBoostQueue.Done(key)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split key", "key", key)
+		u.cpuStartupBoostQueue.Forget(key)
+		return true
+	}
+	klog.V(4).InfoS("Working on", "podNamespace", namespace, "podName", name)
+	pod, err := u.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		klog.V(4).InfoS("Pod no longer exists, skipping", "key", key)
+		u.cpuStartupBoostQueue.Forget(key)
+		return true
+	}
+
+	if !vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
+		klog.V(4).InfoS("Pod is not in boosted state, skipping", "pod", klog.KObj(pod))
+		u.cpuStartupBoostQueue.Forget(key)
+		return true
+	}
+
+	vpaWithSelector, err := u.getControllingVPAForPod(ctx, pod)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get controlling VPA", "pod", klog.KObj(pod))
+		u.cpuStartupBoostQueue.AddRateLimited(key)
+		return true
+	}
+	if vpaWithSelector == nil {
+		klog.V(4).InfoS("No controlling VPA found for pod, skipping", "pod", klog.KObj(pod))
+		u.cpuStartupBoostQueue.Forget(key)
+		return true
+	}
+	vpa := vpaWithSelector.Vpa
+
+	expiredAnnotations := vpa_api_util.GetExpiredStartupCPUBoostAnnotations(pod, vpa)
+	if len(expiredAnnotations) > 0 {
+		klog.V(4).InfoS("Found expired boost annotations", "pod", klog.KObj(pod), "count", len(expiredAnnotations))
+		allPodsPerVPA, err := u.podLister.Pods(namespace).List(vpaWithSelector.Selector)
+		if err != nil {
+			klog.ErrorS(err, "Failed to list pods for VPA", "vpa", klog.KObj(vpa))
+			u.cpuStartupBoostQueue.AddRateLimited(key)
+			return true
+		}
+		livePods := filterDeletedPods(allPodsPerVPA)
+		vpaSize := len(livePods)
+
+		creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := u.restrictionFactory.GetCreatorMaps(livePods, vpa)
+		if err != nil {
+			klog.ErrorS(err, "Failed to get creator maps for unboosting", "pod", klog.KObj(pod))
+			u.cpuStartupBoostQueue.AddRateLimited(key)
+			return true
+		}
+		inPlaceLimiter := u.restrictionFactory.NewPodsInPlaceRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+
+		if !inPlaceLimiter.CanUnboost(pod, vpa) {
+			klog.V(4).InfoS("Cannot unboost pod yet, re-enqueueing", "pod", klog.KObj(pod))
+			u.cpuStartupBoostQueue.AddRateLimited(key)
+			return true
+		}
+
+		klog.V(2).InfoS("Unboosting pod", "pod", klog.KObj(pod))
+		if err := u.inPlaceRateLimiter.Wait(ctx); err != nil {
+			klog.ErrorS(err, "In-place rate limiter wait failed for unboosting")
+			return true
+		}
+		if err := inPlaceLimiter.InPlaceUpdate(pod, vpa, u.eventRecorder); err != nil {
+			klog.ErrorS(err, "Unboosting failed", "pod", klog.KObj(pod))
+			metrics_updater.RecordFailedInPlaceUpdate(vpaSize, vpa.Name, vpa.Namespace, "UnboostError")
+			u.cpuStartupBoostQueue.AddRateLimited(key)
+			return true
+		}
+		klog.V(2).InfoS("Successfully unboosted pod", "pod", klog.KObj(pod))
+		metrics_updater.AddInPlaceUpdatedPod(vpaSize, vpa.Name, vpa.Namespace)
+		u.cpuStartupBoostQueue.Forget(key)
+	}
+
+	remaining := vpa_api_util.GetBoostRemainingDuration(pod, vpa)
+	if remaining > 0 {
+		klog.V(4).InfoS("Boost still active, re-enqueueing", "pod", klog.KObj(pod), "remainingDuration", remaining)
+		u.cpuStartupBoostQueue.Forget(key)
+		u.cpuStartupBoostQueue.AddAfter(key, remaining)
+	} else if len(expiredAnnotations) == 0 && vpa_api_util.PodHasCPUBoostInProgressAnnotation(pod) {
+		// Pod has boost annotations but neither expired nor remaining — likely the pod
+		// is not yet Ready in the lister cache. Re-enqueue to retry shortly.
+		klog.V(4).InfoS("Pod has boost annotations but not yet Ready in cache, re-enqueueing", "pod", klog.KObj(pod))
+		u.cpuStartupBoostQueue.AddRateLimited(key)
+	} else {
+		klog.V(4).InfoS("No remaining boost duration", "pod", klog.KObj(pod))
+		u.cpuStartupBoostQueue.Forget(key)
+	}
+	return true
+}
+
+// TODO(omerap12):
+// we should revisit it.
+// Every time the boost worker processes a pod, it lists ALL VPAs and fetches selectors for each.
+// In clusters with many VPAs this is expensive (I know there is a lister so the list operation is in memory but maybe we can do something better)
+func (u *updater) getControllingVPAForPod(ctx context.Context, pod *corev1.Pod) (*vpa_api_util.VpaWithSelector, error) {
+	vpaList, err := u.vpaLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	vpas := make([]*vpa_api_util.VpaWithSelector, 0, len(vpaList))
+	for _, vpa := range vpaList {
+		selector, err := u.selectorFetcher.Fetch(ctx, vpa)
+		if err != nil {
+			klog.V(3).InfoS("Skipping VPA object because we cannot fetch selector", "vpa", klog.KObj(vpa), "error", err)
+			continue
+		}
+		vpas = append(vpas, &vpa_api_util.VpaWithSelector{
+			Vpa:      vpa,
+			Selector: selector,
+		})
+	}
+	return vpa_api_util.GetControllingVPAForPod(ctx, pod, vpas, u.controllerFetcher), nil
 }
 
 func getRateLimiter(rateLimit float64, rateLimitBurst int) *rate.Limiter {

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/set"
 
@@ -144,7 +145,7 @@ func TestRunOnce_Mode(t *testing.T) {
 			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
-			expectedInPlacedCount: 5,
+			expectedInPlacedCount: 0,
 			canEvict:              true,
 			canInPlaceUpdate:      utils.InPlaceApproved,
 			isCPUBoostTest:        true,
@@ -155,7 +156,7 @@ func TestRunOnce_Mode(t *testing.T) {
 			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
-			expectedInPlacedCount: 5,
+			expectedInPlacedCount: 0,
 			canEvict:              true,
 			canInPlaceUpdate:      utils.InPlaceApproved,
 			isCPUBoostTest:        true,
@@ -166,7 +167,7 @@ func TestRunOnce_Mode(t *testing.T) {
 			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
-			expectedInPlacedCount: 5,
+			expectedInPlacedCount: 0,
 			canEvict:              true,
 			canInPlaceUpdate:      utils.InPlaceApproved,
 			isCPUBoostTest:        true,
@@ -177,7 +178,7 @@ func TestRunOnce_Mode(t *testing.T) {
 			shouldInPlaceFail:     true,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
-			expectedInPlacedCount: 5,
+			expectedInPlacedCount: 0,
 			canEvict:              true,
 			canInPlaceUpdate:      utils.InPlaceApproved,
 			isCPUBoostTest:        true,
@@ -739,7 +740,7 @@ func TestRunOnce_AutoUnboostThenEvict(t *testing.T) {
 		priorityProcessor:            priority.NewProcessor(),
 	}
 
-	// Cycle 1: Unboost the cpu
+	// Cycle 1: Pods have boost annotations — RunOnce skips them (handled by queue worker)
 	for i := range pods {
 		pods[i].Annotations = map[string]string{annotations.GetStartupCPUBoostAnnotationKey(containerName): ""}
 		pods[i].Status.Conditions = []corev1.PodCondition{
@@ -748,22 +749,18 @@ func TestRunOnce_AutoUnboostThenEvict(t *testing.T) {
 				Status: corev1.ConditionTrue,
 			},
 		}
-		inplace.On("CanUnboost", pods[i], vpaObj).Return(true).Once()
-		inplace.On("InPlaceUpdate", pods[i], nil).Return(nil)
 	}
 	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaObj}, nil).Once()
 	podLister.On("List").Return(pods, nil).Once()
 	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
 
 	updater.RunOnce(context.Background())
-	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 5)
-	inplace.AssertNumberOfCalls(t, "CanUnboost", 5)
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 0)
 	eviction.AssertNumberOfCalls(t, "Evict", 0)
 
-	// Cycle 2: Regular patch which will lead to eviction
+	// Cycle 2: Boost annotations removed — pods go through normal eviction path
 	for i := range pods {
 		pods[i].Annotations = nil
-		inplace.On("CanUnboost", pods[i], vpaObj).Return(false).Once()
 		eviction.On("CanEvict", pods[i]).Return(true)
 		eviction.On("Evict", pods[i], nil).Return(nil)
 	}
@@ -772,8 +769,7 @@ func TestRunOnce_AutoUnboostThenEvict(t *testing.T) {
 	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
 
 	updater.RunOnce(context.Background())
-	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 5) // all 5 from previous run only
-	inplace.AssertNumberOfCalls(t, "CanUnboost", 5)    // all 5 from previous run only
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 0)
 	eviction.AssertNumberOfCalls(t, "Evict", 5)
 }
 
@@ -836,7 +832,7 @@ func TestRunOnce_AutoUnboostThenInPlace(t *testing.T) {
 		priorityProcessor:            priority.NewProcessor(),
 	}
 
-	// Cycle 1: Unboost the cpu
+	// Cycle 1: Pods have boost annotations — RunOnce skips them (handled by queue worker)
 	for i := range pods {
 		pods[i].Annotations = map[string]string{annotations.GetStartupCPUBoostAnnotationKey(containerName): ""}
 		pods[i].Status.Conditions = []corev1.PodCondition{
@@ -845,22 +841,18 @@ func TestRunOnce_AutoUnboostThenInPlace(t *testing.T) {
 				Status: corev1.ConditionTrue,
 			},
 		}
-		inplace.On("CanUnboost", pods[i], vpaObj).Return(true).Once()
-		inplace.On("InPlaceUpdate", pods[i], nil).Return(nil)
 	}
 	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaObj}, nil).Once()
 	podLister.On("List").Return(pods, nil).Once()
 	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
 
 	updater.RunOnce(context.Background())
-	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 5)
-	inplace.AssertNumberOfCalls(t, "CanUnboost", 5)
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 0)
 	eviction.AssertNumberOfCalls(t, "Evict", 0)
 
-	// Cycle 2: Regular patch which will lead to eviction
+	// Cycle 2: Boost annotations removed — pods go through normal in-place update path
 	for i := range pods {
 		pods[i].Annotations = nil
-		inplace.On("CanUnboost", pods[i], vpaObj).Return(false).Once()
 		inplace.On("CanInPlaceUpdate", pods[i]).Return(utils.InPlaceApproved)
 		inplace.On("InPlaceUpdate", pods[i], nil).Return(nil)
 	}
@@ -869,8 +861,7 @@ func TestRunOnce_AutoUnboostThenInPlace(t *testing.T) {
 	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
 
 	updater.RunOnce(context.Background())
-	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 10)
-	inplace.AssertNumberOfCalls(t, "CanUnboost", 5) // all 5 from previous run only
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 5)
 	eviction.AssertNumberOfCalls(t, "Evict", 0)
 }
 
@@ -924,4 +915,116 @@ func TestIsInfeasibleError(t *testing.T) {
 			assert.Equal(t, tc.want, isInfeasibleError(tc.err))
 		})
 	}
+}
+
+type podNamespaceListerStub struct {
+	pods []*corev1.Pod
+}
+
+func (s *podNamespaceListerStub) List(_ labels.Selector) ([]*corev1.Pod, error) {
+	return s.pods, nil
+}
+
+func (s *podNamespaceListerStub) Get(name string) (*corev1.Pod, error) {
+	for _, p := range s.pods {
+		if p.Name == name {
+			return p, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(corev1.Resource("pods"), name)
+}
+
+func TestProcessNextBoostItem_RetryExhaustion_ThenResync(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, features.MutableFeatureGate, features.CPUStartupBoost, true)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	containerName := "container1"
+	replicas := int32(1)
+	rc := corev1.ReplicationController{
+		TypeMeta:   metav1.TypeMeta{Kind: "ReplicationController", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "rc", Namespace: "default"},
+		Spec:       corev1.ReplicationControllerSpec{Replicas: &replicas},
+	}
+
+	pod := test.Pod().WithName("boost-pod").
+		AddContainer(test.Container().WithName(containerName).WithCPURequest(resource.MustParse("1")).WithMemRequest(resource.MustParse("100M")).Get()).
+		WithCreator(&rc.ObjectMeta, &rc.TypeMeta).
+		WithLabels(map[string]string{"app": "testingApp"}).
+		WithAnnotations(map[string]string{annotations.GetStartupCPUBoostAnnotationKey(containerName): ""}).
+		WithPodConditions([]corev1.PodCondition{{
+			Type:               corev1.PodReady,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Minute)),
+		}}).
+		Get()
+
+	selector := parseLabelSelector("app = testingApp")
+	vpaObj := test.VerticalPodAutoscaler().
+		WithContainer(containerName).
+		WithTarget("2", "200M").
+		WithMinAllowed(containerName, "1", "100M").
+		WithMaxAllowed(containerName, "3", "1G").
+		WithTargetRef(&autoscalingv1.CrossVersionObjectReference{Kind: rc.Kind, Name: rc.Name, APIVersion: rc.APIVersion}).
+		WithCPUStartupBoost(vpa_types.FactorStartupBoostType, nil, nil, 60).
+		Get()
+
+	inplace := &test.PodsInPlaceRestrictionMock{}
+	factory := &restriction.FakePodsRestrictionFactory{InPlace: inplace}
+
+	podNSLister := &podNamespaceListerStub{pods: []*corev1.Pod{pod}}
+	podLister := &test.PodListerMock{}
+	podLister.On("Pods", "default").Return(podNSLister)
+
+	emptyVPANSLister := &test.VerticalPodAutoscalerListerMock{}
+	emptyVPANSLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{}, nil)
+
+	fullVPANSLister := &test.VerticalPodAutoscalerListerMock{}
+	fullVPANSLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaObj}, nil)
+
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	vpaLister.On("VerticalPodAutoscalers", "default").Return(emptyVPANSLister).Times(7)
+	vpaLister.On("VerticalPodAutoscalers", "default").Return(fullVPANSLister).Once()
+
+	mockSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
+	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
+
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.NewTypedItemExponentialFailureRateLimiter[string](0, 0),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test-boost"},
+	)
+	defer queue.ShutDown()
+
+	u := &updater{
+		vpaLister:            vpaLister,
+		podLister:            podLister,
+		restrictionFactory:   factory,
+		inPlaceRateLimiter:   rate.NewLimiter(rate.Inf, 0),
+		selectorFetcher:      mockSelectorFetcher,
+		controllerFetcher:    controllerfetcher.FakeControllerFetcher{},
+		cpuStartupBoostQueue: queue,
+	}
+
+	ctx := context.Background()
+	queue.Add("default/boost-pod")
+
+	// Phase 1: exhaust VPA-lookup retries.
+	// Calls 1-6 find no VPA and re-enqueue (NumRequeues 0→5, all ≤ maxVPALookupRetries).
+	// Call 7: NumRequeues=6 > 5, item is forgotten.
+	for i := range maxVPALookupRetries + 2 {
+		assert.True(t, u.processNextBoostItem(ctx), "iteration %d", i)
+	}
+	assert.Equal(t, 0, queue.Len(), "queue should be empty after retry exhaustion")
+
+	// Phase 2: resync re-enqueues the pod via PodUpdateHandler.
+	u.PodUpdateHandler(nil, pod)
+	assert.Equal(t, 1, queue.Len(), "queue should have 1 item after resync")
+
+	// Phase 3: VPA is now resolvable. Boost expired, unboost succeeds.
+	inplace.On("CanUnboost", pod, vpaObj).Return(true)
+	inplace.On("InPlaceUpdate", pod, nil).Return(nil)
+
+	assert.True(t, u.processNextBoostItem(ctx))
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 1)
+	assert.Equal(t, 0, queue.Len(), "queue should be empty after successful unboost")
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater_test.go
@@ -144,7 +144,7 @@ func TestRunOnce_Mode(t *testing.T) {
 			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
-			expectedInPlacedCount: 5,
+			expectedInPlacedCount: 0,
 			canEvict:              true,
 			canInPlaceUpdate:      utils.InPlaceApproved,
 			isCPUBoostTest:        true,
@@ -155,7 +155,7 @@ func TestRunOnce_Mode(t *testing.T) {
 			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
-			expectedInPlacedCount: 5,
+			expectedInPlacedCount: 0,
 			canEvict:              true,
 			canInPlaceUpdate:      utils.InPlaceApproved,
 			isCPUBoostTest:        true,
@@ -166,7 +166,7 @@ func TestRunOnce_Mode(t *testing.T) {
 			shouldInPlaceFail:     false,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
-			expectedInPlacedCount: 5,
+			expectedInPlacedCount: 0,
 			canEvict:              true,
 			canInPlaceUpdate:      utils.InPlaceApproved,
 			isCPUBoostTest:        true,
@@ -177,7 +177,7 @@ func TestRunOnce_Mode(t *testing.T) {
 			shouldInPlaceFail:     true,
 			expectFetchCalls:      true,
 			expectedEvictionCount: 0,
-			expectedInPlacedCount: 5,
+			expectedInPlacedCount: 0,
 			canEvict:              true,
 			canInPlaceUpdate:      utils.InPlaceApproved,
 			isCPUBoostTest:        true,
@@ -739,7 +739,7 @@ func TestRunOnce_AutoUnboostThenEvict(t *testing.T) {
 		priorityProcessor:            priority.NewProcessor(),
 	}
 
-	// Cycle 1: Unboost the cpu
+	// Cycle 1: Pods have boost annotations — RunOnce skips them (handled by queue worker)
 	for i := range pods {
 		pods[i].Annotations = map[string]string{annotations.GetStartupCPUBoostAnnotationKey(containerName): ""}
 		pods[i].Status.Conditions = []corev1.PodCondition{
@@ -748,22 +748,18 @@ func TestRunOnce_AutoUnboostThenEvict(t *testing.T) {
 				Status: corev1.ConditionTrue,
 			},
 		}
-		inplace.On("CanUnboost", pods[i], vpaObj).Return(true).Once()
-		inplace.On("InPlaceUpdate", pods[i], nil).Return(nil)
 	}
 	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaObj}, nil).Once()
 	podLister.On("List").Return(pods, nil).Once()
 	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
 
 	updater.RunOnce(context.Background())
-	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 5)
-	inplace.AssertNumberOfCalls(t, "CanUnboost", 5)
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 0)
 	eviction.AssertNumberOfCalls(t, "Evict", 0)
 
-	// Cycle 2: Regular patch which will lead to eviction
+	// Cycle 2: Boost annotations removed — pods go through normal eviction path
 	for i := range pods {
 		pods[i].Annotations = nil
-		inplace.On("CanUnboost", pods[i], vpaObj).Return(false).Once()
 		eviction.On("CanEvict", pods[i]).Return(true)
 		eviction.On("Evict", pods[i], nil).Return(nil)
 	}
@@ -772,8 +768,7 @@ func TestRunOnce_AutoUnboostThenEvict(t *testing.T) {
 	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
 
 	updater.RunOnce(context.Background())
-	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 5) // all 5 from previous run only
-	inplace.AssertNumberOfCalls(t, "CanUnboost", 5)    // all 5 from previous run only
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 0)
 	eviction.AssertNumberOfCalls(t, "Evict", 5)
 }
 
@@ -836,7 +831,7 @@ func TestRunOnce_AutoUnboostThenInPlace(t *testing.T) {
 		priorityProcessor:            priority.NewProcessor(),
 	}
 
-	// Cycle 1: Unboost the cpu
+	// Cycle 1: Pods have boost annotations — RunOnce skips them (handled by queue worker)
 	for i := range pods {
 		pods[i].Annotations = map[string]string{annotations.GetStartupCPUBoostAnnotationKey(containerName): ""}
 		pods[i].Status.Conditions = []corev1.PodCondition{
@@ -845,22 +840,18 @@ func TestRunOnce_AutoUnboostThenInPlace(t *testing.T) {
 				Status: corev1.ConditionTrue,
 			},
 		}
-		inplace.On("CanUnboost", pods[i], vpaObj).Return(true).Once()
-		inplace.On("InPlaceUpdate", pods[i], nil).Return(nil)
 	}
 	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaObj}, nil).Once()
 	podLister.On("List").Return(pods, nil).Once()
 	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
 
 	updater.RunOnce(context.Background())
-	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 5)
-	inplace.AssertNumberOfCalls(t, "CanUnboost", 5)
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 0)
 	eviction.AssertNumberOfCalls(t, "Evict", 0)
 
-	// Cycle 2: Regular patch which will lead to eviction
+	// Cycle 2: Boost annotations removed — pods go through normal in-place update path
 	for i := range pods {
 		pods[i].Annotations = nil
-		inplace.On("CanUnboost", pods[i], vpaObj).Return(false).Once()
 		inplace.On("CanInPlaceUpdate", pods[i]).Return(utils.InPlaceApproved)
 		inplace.On("InPlaceUpdate", pods[i], nil).Return(nil)
 	}
@@ -869,8 +860,7 @@ func TestRunOnce_AutoUnboostThenInPlace(t *testing.T) {
 	mockSelectorFetcher.EXPECT().Fetch(gomock.Eq(vpaObj)).Return(selector, nil)
 
 	updater.RunOnce(context.Background())
-	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 10)
-	inplace.AssertNumberOfCalls(t, "CanUnboost", 5) // all 5 from previous run only
+	inplace.AssertNumberOfCalls(t, "InPlaceUpdate", 5)
 	eviction.AssertNumberOfCalls(t, "Evict", 0)
 }
 

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -20,12 +20,18 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"reflect"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
@@ -38,6 +44,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
 	updater_config "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/config"
@@ -141,6 +148,9 @@ func defaultLeaderElectionConfiguration() componentbaseconfig.LeaderElectionConf
 }
 
 func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
+	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
@@ -151,10 +161,18 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		informers.WithNamespace(commonFlag.VpaObjectNamespace),
 		informers.WithTransform(client.StripManagedFields),
 	)
-	podLister := updater.NewPodLister(kubeClient, commonFlag.VpaObjectNamespace, stopCh)
+
+	podInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod,
+		informers.WithNamespace(commonFlag.VpaObjectNamespace),
+		informers.WithTransform(client.StripManagedFields),
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			// Filter out unscheduled pods and pods in terminal phases (Succeeded/Failed)
+			opts.FieldSelector = "spec.nodeName!=" + "" + ",status.phase!=" +
+				string(corev1.PodSucceeded) + ",status.phase!=" + string(corev1.PodFailed)
+		}),
+	)
 	targetSelectorFetcher := target.NewVpaTargetSelectorFetcher(kubeConfig, kubeClient, kubeFactory, stopCh)
 	controllerFetcher := controllerfetcher.NewControllerFetcher(kubeConfig, kubeClient, kubeFactory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor, stopCh)
-
 	var limitRangeCalculator limitrange.LimitRangeCalculator
 	limitRangeCalculator, err := limitrange.NewLimitsRangeCalculator(kubeFactory)
 	if err != nil {
@@ -180,7 +198,7 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		kubeClient,
 		vpaClient,
 		kubeFactory,
-		podLister,
+		podInformerFactory,
 		config.MinReplicas,
 		config.EvictionRateLimit,
 		config.EvictionRateBurst,
@@ -207,24 +225,51 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
-	// Start factories
 	kubeFactory.Start(stopCh)
-	informerMap := kubeFactory.WaitForCacheSync(stopCh)
-	for kind, synced := range informerMap {
-		if !synced {
-			klog.ErrorS(nil, fmt.Sprintf("Could not sync cache for the %s informer", kind.String()))
-			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	podInformerFactory.Start(stopCh)
+	for _, informerMap := range []map[reflect.Type]bool{
+		kubeFactory.WaitForCacheSync(stopCh),
+		podInformerFactory.WaitForCacheSync(stopCh),
+	} {
+		for kind, synced := range informerMap {
+			if !synced {
+				klog.ErrorS(nil, fmt.Sprintf("Could not sync cache for the %s informer", kind.String()))
+				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+			}
+		}
+	}
+
+	// Start boost worker only if CPUStartupBoost feature gate are enabled
+	if features.Enabled(features.CPUStartupBoost) {
+		var wg sync.WaitGroup
+		ctx, cancel := context.WithCancel(sigCtx)
+		defer func() {
+			cancel()
+			updater.ShutDown()
+			wg.Wait()
+		}()
+		for i := 0; i < config.ConcurrentCPUStartupBoostSyncs; i++ {
+			wg.Go(func() {
+				wait.UntilWithContext(ctx, updater.RunBoostWorker, time.Second)
+			})
 		}
 	}
 
 	// Start updating health check endpoint.
 	healthCheck.StartMonitoring()
 
-	ticker := time.Tick(config.UpdaterInterval)
-	for range ticker {
-		ctx, cancel := context.WithTimeout(context.Background(), config.UpdaterInterval)
-		updater.RunOnce(ctx)
-		healthCheck.UpdateLastActivity()
-		cancel()
+	ticker := time.NewTicker(config.UpdaterInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			loopCtx, loopCancel := context.WithTimeout(sigCtx, config.UpdaterInterval)
+			updater.RunOnce(loopCtx)
+			healthCheck.UpdateLastActivity()
+			loopCancel()
+		case <-sigCtx.Done():
+			klog.InfoS("Received shutdown signal, exiting")
+			return
+		}
 	}
 }

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
@@ -38,6 +40,7 @@ import (
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/patch"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
 	updater_config "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/config"
@@ -151,10 +154,10 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		informers.WithNamespace(commonFlag.VpaObjectNamespace),
 		informers.WithTransform(client.StripManagedFields),
 	)
+
 	podLister := updater.NewPodLister(kubeClient, commonFlag.VpaObjectNamespace, stopCh)
 	targetSelectorFetcher := target.NewVpaTargetSelectorFetcher(kubeConfig, kubeClient, kubeFactory, stopCh)
 	controllerFetcher := controllerfetcher.NewControllerFetcher(kubeConfig, kubeClient, kubeFactory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor, stopCh)
-
 	var limitRangeCalculator limitrange.LimitRangeCalculator
 	limitRangeCalculator, err := limitrange.NewLimitsRangeCalculator(kubeFactory)
 	if err != nil {
@@ -202,7 +205,6 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
-	// Start factories
 	kubeFactory.Start(stopCh)
 	informerMap := kubeFactory.WaitForCacheSync(stopCh)
 	for kind, synced := range informerMap {
@@ -212,14 +214,30 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		}
 	}
 
+	// Start boost worker only if CPUStartupBoost feature gate are enabled
+	if features.Enabled(features.CPUStartupBoost) {
+		var wg sync.WaitGroup
+		ctx, cancel := context.WithCancel(context.Background())
+		defer func() {
+			cancel()
+			updater.ShutDown()
+			wg.Wait()
+		}()
+		for i := 0; i < config.ConcurrentCPUStartupBoostSyncs; i++ {
+			wg.Go(func() {
+				wait.UntilWithContext(ctx, updater.RunBoostWorker, time.Second)
+			})
+		}
+	}
+
 	// Start updating health check endpoint.
 	healthCheck.StartMonitoring()
 
 	ticker := time.Tick(config.UpdaterInterval)
 	for range ticker {
-		ctx, cancel := context.WithTimeout(context.Background(), config.UpdaterInterval)
-		updater.RunOnce(ctx)
+		loopCtx, loopCancel := context.WithTimeout(context.Background(), config.UpdaterInterval)
+		updater.RunOnce(loopCtx)
 		healthCheck.UpdateLastActivity()
-		cancel()
+		loopCancel()
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -347,6 +347,35 @@ func getContainerCPUStartupBoostDuration(containerName string, vpa *vpa_types.Ve
 	return boostDuration
 }
 
+// GetBoostRemainingDuration returns the shortest remaining time until the next
+// container's startup boost expires. The caller should re-check after processing
+// in case other containers have longer durations still pending.
+// Returns 0 if all boosts have already expired or if the pod is not ready.
+func GetBoostRemainingDuration(pod *corev1.Pod, vpa *vpa_types.VerticalPodAutoscaler) time.Duration {
+	_, readyCond := GetPodCondition(&pod.Status, corev1.PodReady)
+	if readyCond == nil || readyCond.Status != corev1.ConditionTrue {
+		return 0
+	}
+	readyTime := readyCond.LastTransitionTime.Time
+
+	var minRemaining time.Duration
+	found := false
+	for k := range pod.Annotations {
+		if containerName, ok := strings.CutPrefix(k, annotations.StartupCPUBoostAnnotationPrefix); ok {
+			boostDuration := time.Duration(getContainerCPUStartupBoostDuration(containerName, vpa)) * time.Second
+			remaining := boostDuration - time.Since(readyTime)
+			if remaining <= 0 {
+				continue
+			}
+			if !found || remaining < minRemaining {
+				minRemaining = remaining
+				found = true
+			}
+		}
+	}
+	return minRemaining
+}
+
 // PodHasCPUBoostInProgressAnnotation returns true if the pod has any CPU boost in progress annotation.
 func PodHasCPUBoostInProgressAnnotation(pod *corev1.Pod) bool {
 	if pod.Annotations == nil {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -712,3 +712,246 @@ func TestPodHasCPUBoostInProgressAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBoostRemainingDuration(t *testing.T) {
+	makeVPAWithPodLevelBoost := func(duration int32) *vpa_types.VerticalPodAutoscaler {
+		return test.VerticalPodAutoscaler().
+			WithName("test-vpa").
+			WithNamespace("default").
+			WithContainer(containerName).
+			WithCPUStartupBoost(vpa_types.FactorStartupBoostType, new(int32(2)), nil, duration).
+			Get()
+	}
+
+	makeVPAWithContainerLevelBoost := func(container string, duration int32) *vpa_types.VerticalPodAutoscaler {
+		return test.VerticalPodAutoscaler().
+			WithName("test-vpa").
+			WithNamespace("default").
+			WithContainer(container).
+			WithContainerCPUStartupBoost(container, vpa_types.FactorStartupBoostType, new(int32(2)), nil, duration).
+			Get()
+	}
+
+	testCases := []struct {
+		name        string
+		pod         *corev1.Pod
+		vpa         *vpa_types.VerticalPodAutoscaler
+		expectZero  bool
+		expectRange [2]time.Duration // [min, max] inclusive; ignored if expectZero
+	}{
+		{
+			name: "pod not ready returns 0",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			vpa:        makeVPAWithPodLevelBoost(120),
+			expectZero: true,
+		},
+		{
+			name: "no ready condition returns 0",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{},
+			},
+			vpa:        makeVPAWithPodLevelBoost(120),
+			expectZero: true,
+		},
+		{
+			name: "boost already expired returns 0",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+						},
+					},
+				},
+			},
+			vpa:        makeVPAWithPodLevelBoost(60),
+			expectZero: true,
+		},
+		{
+			name: "no boost annotations returns 0",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa:        makeVPAWithPodLevelBoost(120),
+			expectZero: true,
+		},
+		{
+			name: "active boost returns remaining duration",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa:         makeVPAWithPodLevelBoost(120),
+			expectZero:  false,
+			expectRange: [2]time.Duration{110 * time.Second, 120 * time.Second},
+		},
+		{
+			name: "multiple containers returns shortest remaining",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/c1": "true",
+						"vpaCpuStartupBoost/c2": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa: func() *vpa_types.VerticalPodAutoscaler {
+				return test.VerticalPodAutoscaler().
+					WithName("test-vpa").
+					WithNamespace("default").
+					WithContainer("c1").
+					WithContainer("c2").
+					WithContainerCPUStartupBoost("c1", vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, 60).
+					WithContainerCPUStartupBoost("c2", vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, 300).
+					Get()
+			}(),
+			expectZero:  false,
+			expectRange: [2]time.Duration{50 * time.Second, 60 * time.Second},
+		},
+		{
+			name: "one expired one active returns active remaining",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/c1": "true",
+						"vpaCpuStartupBoost/c2": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-90 * time.Second)),
+						},
+					},
+				},
+			},
+			vpa: func() *vpa_types.VerticalPodAutoscaler {
+				return test.VerticalPodAutoscaler().
+					WithName("test-vpa").
+					WithNamespace("default").
+					WithContainer("c1").
+					WithContainer("c2").
+					WithContainerCPUStartupBoost("c1", vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, 60).
+					WithContainerCPUStartupBoost("c2", vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, 300).
+					Get()
+			}(),
+			expectZero:  false,
+			expectRange: [2]time.Duration{200 * time.Second, 210 * time.Second},
+		},
+		{
+			name: "non-boost annotations are ignored",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"some-other-annotation": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa:        makeVPAWithPodLevelBoost(120),
+			expectZero: true,
+		},
+		{
+			name: "container-level boost duration overrides pod-level",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa:         makeVPAWithContainerLevelBoost(containerName, 200),
+			expectZero:  false,
+			expectRange: [2]time.Duration{190 * time.Second, 200 * time.Second},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetBoostRemainingDuration(tc.pod, tc.vpa)
+			if tc.expectZero {
+				assert.Equal(t, time.Duration(0), result)
+			} else {
+				assert.GreaterOrEqual(t, result, tc.expectRange[0], "remaining duration should be >= lower bound")
+				assert.LessOrEqual(t, result, tc.expectRange[1], "remaining duration should be <= upper bound")
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api_test.go
@@ -712,3 +712,246 @@ func TestPodHasCPUBoostInProgressAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBoostRemainingDuration(t *testing.T) {
+	makeVPAWithPodLevelBoost := func(duration int32) *vpa_types.VerticalPodAutoscaler {
+		return test.VerticalPodAutoscaler().
+			WithName("test-vpa").
+			WithNamespace("default").
+			WithContainer(containerName).
+			WithCPUStartupBoost(vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, duration).
+			Get()
+	}
+
+	makeVPAWithContainerLevelBoost := func(container string, duration int32) *vpa_types.VerticalPodAutoscaler {
+		return test.VerticalPodAutoscaler().
+			WithName("test-vpa").
+			WithNamespace("default").
+			WithContainer(container).
+			WithContainerCPUStartupBoost(container, vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, duration).
+			Get()
+	}
+
+	testCases := []struct {
+		name        string
+		pod         *corev1.Pod
+		vpa         *vpa_types.VerticalPodAutoscaler
+		expectZero  bool
+		expectRange [2]time.Duration // [min, max] inclusive; ignored if expectZero
+	}{
+		{
+			name: "pod not ready returns 0",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			vpa:        makeVPAWithPodLevelBoost(120),
+			expectZero: true,
+		},
+		{
+			name: "no ready condition returns 0",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{},
+			},
+			vpa:        makeVPAWithPodLevelBoost(120),
+			expectZero: true,
+		},
+		{
+			name: "boost already expired returns 0",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+						},
+					},
+				},
+			},
+			vpa:        makeVPAWithPodLevelBoost(60),
+			expectZero: true,
+		},
+		{
+			name: "no boost annotations returns 0",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa:        makeVPAWithPodLevelBoost(120),
+			expectZero: true,
+		},
+		{
+			name: "active boost returns remaining duration",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa:         makeVPAWithPodLevelBoost(120),
+			expectZero:  false,
+			expectRange: [2]time.Duration{110 * time.Second, 120 * time.Second},
+		},
+		{
+			name: "multiple containers returns shortest remaining",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/c1": "true",
+						"vpaCpuStartupBoost/c2": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa: func() *vpa_types.VerticalPodAutoscaler {
+				return test.VerticalPodAutoscaler().
+					WithName("test-vpa").
+					WithNamespace("default").
+					WithContainer("c1").
+					WithContainer("c2").
+					WithContainerCPUStartupBoost("c1", vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, 60).
+					WithContainerCPUStartupBoost("c2", vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, 300).
+					Get()
+			}(),
+			expectZero:  false,
+			expectRange: [2]time.Duration{50 * time.Second, 60 * time.Second},
+		},
+		{
+			name: "one expired one active returns active remaining",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/c1": "true",
+						"vpaCpuStartupBoost/c2": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-90 * time.Second)),
+						},
+					},
+				},
+			},
+			vpa: func() *vpa_types.VerticalPodAutoscaler {
+				return test.VerticalPodAutoscaler().
+					WithName("test-vpa").
+					WithNamespace("default").
+					WithContainer("c1").
+					WithContainer("c2").
+					WithContainerCPUStartupBoost("c1", vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, 60).
+					WithContainerCPUStartupBoost("c2", vpa_types.FactorStartupBoostType, ptr.To[int32](2), nil, 300).
+					Get()
+			}(),
+			expectZero:  false,
+			expectRange: [2]time.Duration{200 * time.Second, 210 * time.Second},
+		},
+		{
+			name: "non-boost annotations are ignored",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"some-other-annotation": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa:        makeVPAWithPodLevelBoost(120),
+			expectZero: true,
+		},
+		{
+			name: "container-level boost duration overrides pod-level",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"vpaCpuStartupBoost/container1": "true",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			vpa:         makeVPAWithContainerLevelBoost(containerName, 200),
+			expectZero:  false,
+			expectRange: [2]time.Duration{190 * time.Second, 200 * time.Second},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetBoostRemainingDuration(tc.pod, tc.vpa)
+			if tc.expectZero {
+				assert.Equal(t, time.Duration(0), result)
+			} else {
+				assert.GreaterOrEqual(t, result, tc.expectRange[0], "remaining duration should be >= lower bound")
+				assert.LessOrEqual(t, result, tc.expectRange[1], "remaining duration should be <= upper bound")
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
@@ -492,7 +492,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 		})
 
 		// Flake to be fixed with https://github.com/kubernetes/autoscaler/issues/9698
-		f.It("to a subset of containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), framework.WithFlaky(), ginkgo.FlakeAttempts(3), func() {
+		f.It("to a subset of containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), framework.WithFlaky(), func() {
 			ns := f.Namespace.Name
 
 			ginkgo.By("Setting up a VPA CRD with CPUStartupBoost")
@@ -565,7 +565,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 		})
 
 		// Flake to be fixed with https://github.com/kubernetes/autoscaler/issues/9698
-		f.It("with different durations for different containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), framework.WithFlaky(), ginkgo.FlakeAttempts(3), func() {
+		f.It("with different durations for different containers in a pod", framework.WithFeatureGate(features.CPUStartupBoost), framework.WithFlaky(), func() {
 			ns := f.Namespace.Name
 
 			ginkgo.By("Setting up a VPA CRD with CPUStartupBoost with different durations")

--- a/vertical-pod-autoscaler/test/e2e/v1/updater.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/updater.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/annotations"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/test/e2e/utils"
@@ -465,86 +464,6 @@ var _ = UpdaterE2eDescribe("Updater with PerVPAConfig", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })
-
-var _ = UpdaterE2eDescribe("Updater", func() {
-	f := framework.NewDefaultFramework("vertical-pod-autoscaling")
-	f.NamespacePodSecurityLevel = podsecurity.LevelBaseline
-
-	// Sets up a lease object updated periodically to signal - requires WithSerial()
-	f.It("Unboost pods when they become Ready", framework.WithFeatureGate(features.CPUStartupBoost), framework.WithSerial(), func() {
-		const statusUpdateInterval = 10 * time.Second
-
-		ginkgo.By("Setting up the Admission Controller status")
-		stopCh := make(chan struct{})
-		statusUpdater := status.NewUpdater(
-			f.ClientSet,
-			status.AdmissionControllerStatusName,
-			status.AdmissionControllerStatusNamespace,
-			statusUpdateInterval,
-			"e2e test",
-		)
-		defer func() {
-			// Schedule a cleanup of the Admission Controller status.
-			// Status is created outside the test namespace.
-			ginkgo.By("Deleting the Admission Controller status")
-			close(stopCh)
-			err := f.ClientSet.CoordinationV1().Leases(status.AdmissionControllerStatusNamespace).
-				Delete(context.TODO(), status.AdmissionControllerStatusName, metav1.DeleteOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		}()
-		statusUpdater.Run(stopCh)
-
-		podList := setupPodsForCPUBoost(f, "100m", "100Mi")
-		initialPods := podList.DeepCopy()
-
-		ginkgo.By("Waiting for pods to be in-place updated")
-		err := WaitForPodsUpdatedWithoutEviction(f, initialPods)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	})
-
-})
-
-func setupPodsForCPUBoost(f *framework.Framework, hamsterCPU, hamsterMemory string) *apiv1.PodList {
-	controller := &autoscaling.CrossVersionObjectReference{
-		APIVersion: "apps/v1",
-		Kind:       "Deployment",
-		Name:       "hamster-deployment",
-	}
-	ginkgo.By(fmt.Sprintf("Setting up a hamster %v", controller.Kind))
-	// Create pods with boosted CPU, which is 2x the target recommendation
-	boostedCPU := "200m"
-	setupHamsterController(f, controller.Kind, boostedCPU, hamsterMemory, utils.DefaultHamsterReplicas)
-	podList, err := GetHamsterPods(f)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	ginkgo.By("Setting up a VPA CRD")
-	containerName := utils.GetHamsterContainerNameByIndex(0)
-	factor := int32(2)
-	vpaCRD := test.VerticalPodAutoscaler().
-		WithName("hamster-vpa").
-		WithNamespace(f.Namespace.Name).
-		WithTargetRef(controller).
-		WithUpdateMode(vpa_types.UpdateModeAuto).
-		WithContainer(containerName).
-		WithCPUStartupBoost(vpa_types.FactorStartupBoostType, &factor, nil, 1).
-		AppendRecommendation(
-			test.Recommendation().
-				WithContainer(containerName).
-				WithTarget(hamsterCPU, hamsterMemory).
-				GetContainerResources(),
-		).
-		Get()
-
-	utils.InstallVPA(f, vpaCRD)
-
-	ginkgo.By("Annotating pods with boost annotation")
-	for _, pod := range podList.Items {
-		original, err := annotations.GetOriginalResourcesAnnotationValue(&pod.Spec.Containers[0])
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		AnnotatePod(f, pod.Name, annotations.GetStartupCPUBoostAnnotationKey(pod.Spec.Containers[0].Name), original)
-	}
-	return podList
-}
 
 func setupPodsForDownscalingEviction(f *framework.Framework, er []*vpa_types.EvictionRequirement, updateMode vpa_types.UpdateMode) *apiv1.PodList {
 	return setupPodsForEviction(f, "500m", "500Mi", er, updateMode)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds reactive mode for CPU startup boost. instead of relying on updater sync interval.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9414

#### Special notes for your reviewer:
I am not sure if this needed an AEP or not (I think not because this doesn't introduce any API change) but no strong opinions there.
If this works well, we can modify the entire updater to use this logic. (It's basically the same logic just tracking VPA objects and not pods).
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add reactive CPU startup boost unboosting
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous processing for CPU startup boost expiration.
  * Added configurable concurrency for CPU startup boost synchronization, defaulting to one worker.
  * Added retries, scheduling, and graceful shutdown for boost-related pod updates.
  * Added signal-aware shutdown for updater processing.

* **Bug Fixes**
  * Prevented regular updates from acting on pods with active CPU startup boosts.
  * Improved error visibility when selector information cannot be retrieved.

* **Documentation**
  * Documented the new updater concurrency setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->