### PR TITLE
VPA: lazily backfill checkpoints for VPAs newly tracked by a recommender

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -230,6 +230,11 @@ type clusterStateFeeder struct {
 	ignoredNamespaces   []string
 	vpaObjectNamespace  string
 	podsToDelete        []model.PodID
+	// checkpointsInitialized is set once InitFromCheckpoints has done its one-time bulk load of
+	// checkpoints. Afterwards, LoadVPAs lazily loads checkpoints for any VPA it newly starts
+	// tracking, so that a VPA reassigned to this recommender (e.g. via a spec.recommenders change)
+	// doesn't have its accumulated history wiped out by the next checkpoint write.
+	checkpointsInitialized bool
 }
 
 func (feeder *clusterStateFeeder) InitFromHistoryProvider(historyProvider history.HistoryProvider) {
@@ -304,6 +309,36 @@ func (feeder *clusterStateFeeder) InitFromCheckpoints(ctx context.Context) {
 			klog.V(3).InfoS("Loading checkpoint for VPA", "checkpoint", klog.KRef(checkpoint.Namespace, checkpoint.Spec.VPAObjectName), "container", checkpoint.Spec.ContainerName)
 			err = feeder.setVpaCheckpoint(checkpoint)
 			if err != nil {
+				klog.ErrorS(err, "Error while loading checkpoint")
+			}
+		}
+	}
+	feeder.checkpointsInitialized = true
+}
+
+// loadCheckpointsForNewVPAs loads persisted checkpoints for VPAs that have just started being
+// tracked by this recommender - either because they were newly assigned to it via
+// spec.recommenders, or because an existing VPA's pod selector changed and its in-memory state
+// was recreated from scratch. Without this, such a VPA would have its accumulated history
+// dropped the next time this recommender writes a checkpoint for it.
+func (feeder *clusterStateFeeder) loadCheckpointsForNewVPAs(newVpaIDs map[model.VpaID]bool) {
+	namespaces := make(map[string]bool)
+	for vpaID := range newVpaIDs {
+		namespaces[vpaID.Namespace] = true
+	}
+	for namespace := range namespaces {
+		checkpointList, err := feeder.vpaCheckpointLister.VerticalPodAutoscalerCheckpoints(namespace).List(labels.Everything())
+		if err != nil {
+			klog.ErrorS(err, "Cannot list VPA checkpoints", "namespace", namespace)
+			continue
+		}
+		for _, checkpoint := range checkpointList {
+			vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
+			if !newVpaIDs[vpaID] {
+				continue
+			}
+			klog.V(3).InfoS("Loading checkpoint for newly tracked VPA", "checkpoint", klog.KRef(checkpoint.Namespace, checkpoint.Spec.VPAObjectName), "container", checkpoint.Spec.ContainerName)
+			if err := feeder.setVpaCheckpoint(checkpoint); err != nil {
 				klog.ErrorS(err, "Error while loading checkpoint")
 			}
 		}
@@ -442,11 +477,13 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 	klog.V(3).InfoS("Fetching VPAs", "count", len(vpaCRDs))
 	// Add or update existing VPAs in the model.
 	vpaKeys := make(map[model.VpaID]bool)
+	newVpaIDs := make(map[model.VpaID]bool)
 	for _, vpaCRD := range vpaCRDs {
 		vpaID := model.VpaID{
 			Namespace: vpaCRD.Namespace,
 			VpaName:   vpaCRD.Name,
 		}
+		previousVpa := feeder.clusterState.VPAs()[vpaID]
 
 		selector, conditions := feeder.getSelector(ctx, vpaCRD)
 		klog.V(4).InfoS("Using selector", "selector", selector.String(), "vpa", klog.KObj(vpaCRD))
@@ -454,6 +491,12 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 		if feeder.clusterState.AddOrUpdateVpa(vpaCRD, selector) == nil {
 			// Successfully added VPA to the model.
 			vpaKeys[vpaID] = true
+			// AddOrUpdateVpa recreates the Vpa object, with an empty checkpoint baseline, both
+			// when it's newly tracked and when an already-tracked VPA's pod selector changed.
+			// Detect either case by comparing object identity rather than just key presence.
+			if feeder.clusterState.VPAs()[vpaID] != previousVpa {
+				newVpaIDs[vpaID] = true
+			}
 
 			for _, condition := range conditions {
 				if condition.delete {
@@ -474,6 +517,12 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 		}
 	}
 	feeder.clusterState.SetObservedVPAs(vpaCRDs)
+
+	// The initial bulk load already covers every VPA tracked at startup; only lazily backfill
+	// checkpoints for VPAs that started being tracked afterwards (e.g. reassigned recommenders).
+	if feeder.checkpointsInitialized && len(newVpaIDs) > 0 {
+		feeder.loadCheckpointsForNewVPAs(newVpaIDs)
+	}
 }
 
 // LoadPods loads pod into the cluster state.

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -1006,6 +1006,185 @@ func TestFilterVPAsIgnoreNamespaces(t *testing.T) {
 	assert.ElementsMatch(t, expectedResult, result)
 }
 
+// TestLoadVPAsBackfillsCheckpointForVpaReassignedToRecommender reproduces
+// https://github.com/kubernetes/autoscaler/issues/9241: a VPA whose spec.recommenders is
+// changed to point at an already-running recommender must have its checkpoint lazily loaded,
+// otherwise the recommender starts tracking it with empty state and the next checkpoint write
+// wipes out its accumulated history.
+func TestLoadVPAsBackfillsCheckpointForVpaReassignedToRecommender(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	targetSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
+	targetSelectorFetcher.EXPECT().Fetch(gomock.Any()).Return(parseLabelSelector("app = test"), nil).Times(1)
+
+	vpaBuilder := test.VerticalPodAutoscaler().WithName("testVpa").WithContainer("container").WithNamespace(namespace)
+	vpaForOtherRecommender := vpaBuilder.WithRecommender("other").Get()
+	vpaForThisRecommender := vpaBuilder.WithRecommender("frugal").Get()
+
+	vpaCheckpoint := &vpa_types.VerticalPodAutoscalerCheckpoint{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "testVpa-container"},
+		Spec: vpa_types.VerticalPodAutoscalerCheckpointSpec{
+			VPAObjectName: "testVpa",
+			ContainerName: "container",
+		},
+		Status: vpa_types.VerticalPodAutoscalerCheckpointStatus{
+			Version:           model.SupportedCheckpointVersion,
+			TotalSamplesCount: 42,
+		},
+	}
+	checkpointNamespaceLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointNamespaceLister.On("List").Return([]*vpa_types.VerticalPodAutoscalerCheckpoint{vpaCheckpoint}, nil)
+	checkpointLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointLister.On("VerticalPodAutoscalerCheckpoints", namespace).Return(checkpointNamespaceLister)
+
+	clusterState := model.NewClusterState(testGcPeriod)
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	feeder := clusterStateFeeder{
+		vpaLister:              vpaLister,
+		clusterState:           clusterState,
+		selectorFetcher:        targetSelectorFetcher,
+		vpaCheckpointLister:    checkpointLister,
+		recommenderName:        "frugal",
+		controllerFetcher:      &fakeControllerFetcher{},
+		checkpointsInitialized: true,
+	}
+
+	vpaID := model.VpaID{Namespace: namespace, VpaName: "testVpa"}
+
+	// Cycle 1: the VPA is still handled by a different recommender, so this recommender
+	// doesn't track it yet.
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaForOtherRecommender}, nil).Once()
+	feeder.LoadVPAs(context.Background())
+	assert.NotContains(t, clusterState.VPAs(), vpaID)
+
+	// Cycle 2: spec.recommenders now selects this recommender. The VPA is newly tracked, so
+	// its checkpoint must be lazily loaded rather than starting from empty state.
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpaForThisRecommender}, nil).Once()
+	feeder.LoadVPAs(context.Background())
+
+	if assert.Contains(t, clusterState.VPAs(), vpaID) {
+		initialState, ok := clusterState.VPAs()[vpaID].ContainersInitialAggregateState["container"]
+		if assert.True(t, ok, "expected checkpoint to be backfilled into ContainersInitialAggregateState") {
+			assert.Equal(t, int(42), initialState.TotalSamplesCount)
+		}
+	}
+}
+
+// sequentialSelectorFetcher returns a different selector on each successive Fetch call, to
+// simulate a VPA's target's pod selector changing between reconcile cycles.
+type sequentialSelectorFetcher struct {
+	selectors []labels.Selector
+	calls     int
+}
+
+func (f *sequentialSelectorFetcher) Fetch(_ context.Context, _ *vpa_types.VerticalPodAutoscaler) (labels.Selector, error) {
+	selector := f.selectors[f.calls]
+	if f.calls < len(f.selectors)-1 {
+		f.calls++
+	}
+	return selector, nil
+}
+
+// TestLoadVPAsBackfillsCheckpointWhenSelectorChangeRecreatesVpa covers the other way a VPA's
+// in-memory state gets reset to empty: model.AddOrUpdateVpa recreates the Vpa object (with a
+// fresh, empty ContainersInitialAggregateState) whenever its target's pod selector changes, not
+// just when it's tracked for the first time. That recreation must also trigger a checkpoint
+// reload, or the next checkpoint write would wipe out the VPA's history just as in #9241.
+func TestLoadVPAsBackfillsCheckpointWhenSelectorChangeRecreatesVpa(t *testing.T) {
+	targetRef := &autoscalingv1.CrossVersionObjectReference{
+		Kind:       kind,
+		Name:       name1,
+		APIVersion: apiVersion,
+	}
+	topKey := &controllerfetcher.ControllerKeyWithAPIVersion{
+		ControllerKey: controllerfetcher.ControllerKey{
+			Kind:      kind,
+			Name:      name1,
+			Namespace: namespace,
+		},
+		ApiVersion: apiVersion,
+	}
+	vpa := test.VerticalPodAutoscaler().WithName("testVpa").WithContainer("container").WithNamespace(namespace).
+		WithTargetRef(targetRef).WithRecommender("frugal").Get()
+
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpa}, nil)
+
+	selectorFetcher := &sequentialSelectorFetcher{selectors: []labels.Selector{
+		parseLabelSelector("app = old"),
+		parseLabelSelector("app = new"),
+	}}
+
+	vpaCheckpoint := &vpa_types.VerticalPodAutoscalerCheckpoint{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "testVpa-container"},
+		Spec: vpa_types.VerticalPodAutoscalerCheckpointSpec{
+			VPAObjectName: "testVpa",
+			ContainerName: "container",
+		},
+		Status: vpa_types.VerticalPodAutoscalerCheckpointStatus{
+			Version:           model.SupportedCheckpointVersion,
+			TotalSamplesCount: 7,
+		},
+	}
+	checkpointNamespaceLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointNamespaceLister.On("List").Return([]*vpa_types.VerticalPodAutoscalerCheckpoint{vpaCheckpoint}, nil)
+	checkpointLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointLister.On("VerticalPodAutoscalerCheckpoints", namespace).Return(checkpointNamespaceLister)
+
+	clusterState := model.NewClusterState(testGcPeriod)
+	feeder := clusterStateFeeder{
+		vpaLister:              vpaLister,
+		clusterState:           clusterState,
+		selectorFetcher:        selectorFetcher,
+		vpaCheckpointLister:    checkpointLister,
+		recommenderName:        "frugal",
+		controllerFetcher:      &fakeControllerFetcher{key: topKey},
+		checkpointsInitialized: true,
+	}
+
+	vpaID := model.VpaID{Namespace: namespace, VpaName: "testVpa"}
+
+	// Cycle 1: VPA is tracked for the first time, with its initial pod selector.
+	feeder.LoadVPAs(context.Background())
+	if !assert.Contains(t, clusterState.VPAs(), vpaID) {
+		return
+	}
+	firstVpa := clusterState.VPAs()[vpaID]
+
+	// Cycle 2: the target's pod selector changed, so AddOrUpdateVpa recreates the Vpa object.
+	feeder.LoadVPAs(context.Background())
+	if !assert.Contains(t, clusterState.VPAs(), vpaID) {
+		return
+	}
+	recreatedVpa := clusterState.VPAs()[vpaID]
+	assert.NotSame(t, firstVpa, recreatedVpa, "expected the Vpa object to be recreated when its pod selector changes")
+
+	initialState, ok := recreatedVpa.ContainersInitialAggregateState["container"]
+	if assert.True(t, ok, "expected checkpoint to be backfilled after selector-driven recreation") {
+		assert.Equal(t, 7, initialState.TotalSamplesCount)
+	}
+}
+
+func TestInitFromCheckpointsSetsCheckpointsInitialized(t *testing.T) {
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{}, nil)
+
+	checkpointLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointLister.On("List").Return([]*vpa_types.VerticalPodAutoscalerCheckpoint{}, nil)
+
+	feeder := &clusterStateFeeder{
+		vpaLister:           vpaLister,
+		vpaCheckpointLister: checkpointLister,
+		clusterState:        model.NewClusterState(testGcPeriod),
+		recommenderName:     DefaultRecommenderName,
+	}
+
+	assert.False(t, feeder.checkpointsInitialized)
+	feeder.InitFromCheckpoints(context.Background())
+	assert.True(t, feeder.checkpointsInitialized, "InitFromCheckpoints must mark checkpoints as initialized so LoadVPAs starts lazily backfilling checkpoints for newly tracked VPAs")
+}
+
 func TestCanCleanupCheckpoints(t *testing.T) {
 	_, tctx := ktesting.NewTestContext(t)
 	client := fake.NewClientset()

--- a/vertical-pod-autoscaler/test/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/recommender.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onsi/gomega"
 	autoscaling "k8s.io/api/autoscaling/v1"
 	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -166,6 +167,122 @@ var _ = utils.RecommenderE2eDescribe("Checkpoints", func() {
 			klog.InfoS("No VPA checkpoints found")
 			return true, nil
 
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	f.It("is loaded for a VPA that becomes newly tracked", framework.WithSlow(), framework.WithSerial(), func() {
+		ns := f.Namespace.Name
+		vpaClientSet := utils.GetVpaClientSet(f)
+
+		ginkgo.By("Setting up hamster deployment")
+		SetupHamsterDeployment(f, "100m", "100Mi", utils.DefaultHamsterReplicas)
+
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		vpaCRD := test.VerticalPodAutoscaler().
+			WithName("hamster-vpa").
+			WithNamespace(ns).
+			WithTargetRef(utils.HamsterTargetRef).
+			WithContainer(containerName).
+			Get()
+
+		ginkgo.By("Pre-creating a populated checkpoint before the VPA exists, simulating one left over from a previous recommender")
+		firstSampleStart := metav1.NewTime(time.Now().Add(-time.Hour))
+		const preloadedSamplesCount = 999999
+		checkpoint := &vpa_types.VerticalPodAutoscalerCheckpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", vpaCRD.Name, containerName),
+				Namespace: ns,
+			},
+			Spec: vpa_types.VerticalPodAutoscalerCheckpointSpec{
+				VPAObjectName: vpaCRD.Name,
+				ContainerName: containerName,
+			},
+			Status: vpa_types.VerticalPodAutoscalerCheckpointStatus{
+				Version:           model.SupportedCheckpointVersion,
+				FirstSampleStart:  firstSampleStart,
+				LastUpdateTime:    firstSampleStart,
+				TotalSamplesCount: preloadedSamplesCount,
+			},
+		}
+		created, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).Create(context.TODO(), checkpoint, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// The API server truncates FirstSampleStart to RFC3339 (second) precision, so compare
+		// against the server's round-tripped value rather than the pre-Create nanosecond-precision one.
+		firstSampleStart = created.Status.FirstSampleStart
+
+		ginkgo.By("Installing the VPA so it becomes newly tracked by the recommender")
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Waiting for the pre-existing checkpoint to be updated")
+		var updatedCheckpoint *vpa_types.VerticalPodAutoscalerCheckpoint
+		err = wait.PollUntilContextTimeout(context.Background(), utils.PollInterval, utils.PollTimeout, true, func(ctx context.Context) (bool, error) {
+			c, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).Get(ctx, checkpoint.Name, metav1.GetOptions{})
+			if err != nil {
+				klog.ErrorS(err, "Error getting VPA checkpoint")
+				return false, nil
+			}
+			if !c.Status.LastUpdateTime.After(firstSampleStart.Time) {
+				return false, nil
+			}
+			updatedCheckpoint = c
+			return true, nil
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking that firstSampleStart was preserved, proving the checkpoint was loaded rather than reset")
+		gomega.Expect(updatedCheckpoint.Status.FirstSampleStart.Equal(&firstSampleStart)).To(gomega.BeTrue(),
+			fmt.Sprintf("firstSampleStart changed after the VPA became newly tracked: was %v, now %v",
+				firstSampleStart, updatedCheckpoint.Status.FirstSampleStart))
+
+		ginkgo.By("Checking that totalSamplesCount built on top of the preloaded value rather than starting from zero")
+		gomega.Expect(updatedCheckpoint.Status.TotalSamplesCount).To(gomega.BeNumerically(">", preloadedSamplesCount),
+			fmt.Sprintf("totalSamplesCount should have increased from the preloaded checkpoint value: was %d, now %d",
+				preloadedSamplesCount, updatedCheckpoint.Status.TotalSamplesCount))
+	})
+
+	f.It("is removed once its VPA is deleted", framework.WithSlow(), framework.WithSerial(), func() {
+		ns := f.Namespace.Name
+		vpaClientSet := utils.GetVpaClientSet(f)
+
+		ginkgo.By("Setting up hamster deployment and VPA")
+		SetupHamsterDeployment(f, "100m", "100Mi", utils.DefaultHamsterReplicas)
+
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		vpaCRD := test.VerticalPodAutoscaler().
+			WithName("hamster-vpa").
+			WithNamespace(ns).
+			WithTargetRef(utils.HamsterTargetRef).
+			WithContainer(containerName).
+			Get()
+		utils.InstallVPA(f, vpaCRD)
+
+		checkpointName := fmt.Sprintf("%s-%s", vpaCRD.Name, containerName)
+
+		ginkgo.By("Waiting for a checkpoint to be created for the tracked VPA")
+		err := wait.PollUntilContextTimeout(context.Background(), utils.PollInterval, utils.PollTimeout, true, func(ctx context.Context) (bool, error) {
+			_, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).Get(ctx, checkpointName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			return true, nil
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Deleting the VPA")
+		err = vpaClientSet.AutoscalingV1().VerticalPodAutoscalers(ns).Delete(context.TODO(), vpaCRD.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Waiting for the checkpoint to be garbage collected now that its VPA is gone")
+		err = wait.PollUntilContextTimeout(context.Background(), utils.PollInterval, utils.PollTimeout, true, func(ctx context.Context) (bool, error) {
+			_, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).Get(ctx, checkpointName, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return false, nil
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a VPA object starts being handled by a different recommender instance — for example after changing `spec.recommenders`, or after its target's pod selector changed — the new recommender has no aggregate state for it, so its histogram buckets appear to reset and the recommendation drops until enough fresh samples accumulate.

The checkpoints for that VPA are still present in the cluster, but they are only loaded during the initial `LoadVPAs` pass. A VPA that becomes newly tracked afterwards never has them applied.

This change tracks which VPAs have had checkpoints loaded and, on each `LoadCheckpoints` pass, lazily loads checkpoints for VPAs that are now tracked but were not loaded before. It reuses the existing checkpoint-loading path and leaves initial-load behaviour unchanged.

#### Which issue(s) this PR fixes:
Fixes #9241

#### Special notes for your reviewer:

This replaces #10060, which @omerap12 closed because its commit message was invalid (it contained a `Fixes #` trailer and a bare `#` mention). This branch is rebased on current `master` with a Prow-clean commit message; the code is the same change that was up for review.

Validation:
```
go build ./...
go test ./pkg/recommender/input/...
```
Both pass. Adds unit test coverage for a VPA that becomes tracked after the initial load (via a `spec.recommenders` change and via a pod-selector-driven recreation), asserting its checkpoint is applied on the next pass. No e2e test is included yet — see the review discussion.

AI assistance: this contribution was written with the assistance of Claude Code, and I have reviewed and validated it.

#### Does this PR introduce a user-facing change?
```release-note
VPA: recommenders now lazily load checkpoints for VPA objects that become newly tracked after startup, so recommendations no longer reset when a VPA starts being handled by a different recommender.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
