### PR TITLE
Update Cluster Autoscaler Helm chart defaults to v1.36.0

### DIFF
--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.59.0
+version: 9.59.1

--- a/cluster-autoscaler/charts/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/charts/cluster-autoscaler/README.md
@@ -503,7 +503,7 @@ vpa:
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |
 | image.repository | string | `"registry.k8s.io/autoscaling/cluster-autoscaler"` | Image repository |
-| image.tag | string | `"v1.35.0"` | Image tag |
+| image.tag | string | `"v1.36.0"` | Image tag |
 | initContainers | list | `[]` | Any additional init containers. |
 | kubeTargetVersionOverride | string | `""` | Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands. |
 | kwokConfigMapName | string | `"kwok-provider-config"` | configmap for configuring kwok provider |

--- a/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
@@ -303,7 +303,7 @@ image:
   # image.repository -- Image repository
   repository: registry.k8s.io/autoscaling/cluster-autoscaler
   # image.tag -- Image tag
-  tag: v1.35.0
+  tag: v1.36.0
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## Summary

This PR updates the Cluster Autoscaler Helm chart defaults to use the
`registry.k8s.io/autoscaling/cluster-autoscaler:v1.36.0` image.

### Changes

- Update default `image.tag` from `v1.35.0` to `v1.36.0`
- Update the Helm chart README to reflect the new default image tag
- Bump the Helm chart version to `9.59.1`

### Validation

- Verified that `registry.k8s.io/autoscaling/cluster-autoscaler:v1.36.0` is available.
- Ran:

```bash
helm lint cluster-autoscaler/charts/cluster-autoscaler
```

Related to #9985

```release-note
NONE
```