### PR TITLE
VPA InPlace: treat ResizeError as deferred, not infeasible

### DIFF
--- a/vertical-pod-autoscaler/docs/features.md
+++ b/vertical-pod-autoscaler/docs/features.md
@@ -229,7 +229,7 @@ When a pod is currently undergoing a resize, VPA checks the resize status report
 | `ResizeDeferred` | Wait for kubelet to proceed |
 | `ResizeInProgress` | Wait for completion |
 | `ResizeInfeasible` | Store as infeasible, skip pod |
-| `ResizeError` | Treat as infeasible, retry when recommendation changes |
+| `ResizeError` | Transient kubelet error; defer and retry next loop |
 | `ResizeNone` | No resize pending, proceed with update evaluation |
 
 ### Infeasible Attempt Tracking

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction.go
@@ -62,9 +62,9 @@ type PodsInPlaceRestriction interface {
 	// CanInPlaceUpdate checks if a pod can be safely updated in-place.
 	// Returns:
 	//   - InPlaceApproved: The pod can be updated in-place immediately.
-	//   - InPlaceDeferred: The update should be deferred (e.g., pod is pending, already updating, or group is not disruptable).
+	//   - InPlaceDeferred: The update should be deferred (e.g., pod is pending, already updating, group is not disruptable, or kubelet reported a resize error; on failure VPA defers and retries next loop without caching permanent infeasibility).
 	//   - InPlaceEvict: The pod should be evicted instead of updated in-place.
-	//   - InPlaceInfeasible: The in-place update is infeasible (node can't accommodate it or error occurred). Will only retry when recommendation changes.
+	//   - InPlaceInfeasible: The in-place update is infeasible (node can't accommodate it). Will only retry when recommendation changes.
 	//
 	// The updateMode parameter affects the decision:
 	//   - UpdateModeInPlace: Waits indefinitely for in-progress updates.
@@ -156,9 +156,9 @@ func (ip *PodsInPlaceRestrictionImpl) CanInPlaceUpdate(pod *corev1.Pod, vpa *vpa
 				klog.V(4).InfoS("In-place update in progress, waiting for completion", "pod", klog.KObj(pod))
 				return utils.InPlaceDeferred
 			case utils.ResizeStatusError:
-				// Error during resize, will retry if recommendation changes.
-				klog.V(4).ErrorS(nil, "Not retrying in-place resize because the kubelet reported an error; VPA will retry only after a recommendation changes", "pod", klog.KObj(pod))
-				return utils.InPlaceInfeasible
+				// Transient kubelet error; retry next loop without caching as permanent infeasibility.
+				klog.V(4).InfoS("Deferring in-place resize because the kubelet reported an error", "pod", klog.KObj(pod))
+				return utils.InPlaceDeferred
 			default:
 				klog.V(4).InfoS("Deferring in-place update because the Pod reports an unrecognized resize status", "pod", klog.KObj(pod), "resizeStatus", resizeStatus)
 				return utils.InPlaceDeferred

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_inplace_restriction_test.go
@@ -1132,7 +1132,7 @@ func TestInPlaceModeResizeStatuses(t *testing.T) {
 			clockTime:          time.UnixMilli(3600000),
 		},
 		{
-			name: "InPlace mode - ResizeStatusError returns InPlaceInfeasible (retry)",
+			name: "InPlace mode - ResizeStatusError returns InPlaceDeferred",
 			podConditions: []corev1.PodCondition{
 				{
 					Type:    corev1.PodResizeInProgress,
@@ -1142,7 +1142,7 @@ func TestInPlaceModeResizeStatuses(t *testing.T) {
 				},
 			},
 			updateMode:         vpa_types.UpdateModeInPlace,
-			expectedDecision:   utils.InPlaceInfeasible,
+			expectedDecision:   utils.InPlaceDeferred,
 			lastInPlaceAttempt: time.UnixMilli(0),
 			clockTime:          time.UnixMilli(3600000),
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Kubelet `ResizeStatusError` (for example a temporary missing memory usage reading) was mapped to `InPlaceInfeasible`. That stores the recommendation in `infeasibleAttempts`. The Updater only retries when a later recommendation has a **lower** resource.

So this could get stuck:

1. Resize for recommendation A hits a transient kubelet error → A is cached as infeasible.
2. Kubelet recovers and may apply A.
3. Recommendation B is higher than A.
4. B is skipped until the Updater restarts.

**Fix:** return `InPlaceDeferred` for `ResizeStatusError` instead of `InPlaceInfeasible`. No infeasible cache write; the next loop can retry. True capacity infeasibility (`ResizeInfeasible`) is unchanged.

#### Which issue(s) this PR fixes:

Fixes #10093

#### Special notes for your reviewer:

- Small change only (per review): decision mapping + docs/test expectation.
- Covered by `InPlace mode - ResizeStatusError returns InPlaceDeferred`.
- AI tools helped with investigation and this text. I reviewed the change myself.

#### Does this PR introduce a user-facing change?

```release-note
VPA InPlace: treat transient kubelet ResizeError as deferred, not permanent infeasibility, so a later higher recommendation is not skipped until Updater restart.
```