### PR TITLE
VPA recommender: keep checkpoint history across target selector flips

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -449,6 +449,18 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 		}
 
 		selector, conditions := feeder.getSelector(ctx, vpaCRD)
+		// If the target controller is briefly unresolvable (informer not ready,
+		// workload mid-recreate), getSelector returns labels.Nothing(). Prefer
+		// the previously known selector so LoadVPAs does not flip ""→real and
+		// wipe checkpoint history. Conditions still record ConfigUnsupported.
+		// See kubernetes/autoscaler#9891.
+		if selector == nil || selector.String() == "" {
+			if existing, ok := feeder.clusterState.VPAs()[vpaID]; ok && existing.PodSelector != nil && existing.PodSelector.String() != "" {
+				klog.V(3).InfoS("Keeping previous VPA selector after targetRef resolution failure",
+					"selector", existing.PodSelector.String(), "vpa", klog.KObj(vpaCRD))
+				selector = existing.PodSelector
+			}
+		}
 		klog.V(4).InfoS("Using selector", "selector", selector.String(), "vpa", klog.KObj(vpaCRD))
 
 		if feeder.clusterState.AddOrUpdateVpa(vpaCRD, selector) == nil {

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -347,12 +347,12 @@ func (cluster *clusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 	return nil
 }
 
-// isEmptySelector reports whether s is nil or labels.Nothing()-like (empty
-// string form). Both Nothing and Everything stringify to "" in some cases;
-// callers only pass Nothing on target resolution failure, which is the case
-// we care about for #9891.
+// isEmptySelector reports whether s is the labels.Nothing() sentinel used to
+// signal a target resolution failure (see #9891). Both Nothing and
+// Everything stringify to "", so Empty() (true only for Everything) is
+// checked too, to avoid mistaking an all-matching selector for a failure.
 func isEmptySelector(s labels.Selector) bool {
-	return s == nil || s.String() == ""
+	return s == nil || (s.String() == "" && !s.Empty())
 }
 
 // DeleteVpa removes a VPA with the given ID from the clusterState.

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -302,16 +302,34 @@ func (cluster *clusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 	}
 
 	vpa, vpaExists := cluster.vpas[vpaID]
+	var preservedInitialState ContainerNameToAggregateStateMap
 	if vpaExists && (vpa.PodSelector.String() != selector.String()) {
-		// Pod selector was changed. Delete the VPA object and recreate
-		// it with the new selector.
-		if err := cluster.DeleteVpa(vpaID); err != nil {
-			return err
+		// A transient targetRef resolution failure yields labels.Nothing()
+		// (empty selector string). That is not a real selector change — keep
+		// the previous selector so we do not wipe checkpointed history.
+		// See kubernetes/autoscaler#9891.
+		if isEmptySelector(selector) && !isEmptySelector(vpa.PodSelector) {
+			selector = vpa.PodSelector
+		} else {
+			// Real selector change (including ""→real after a failed first
+			// resolve): recreate the VPA object but keep
+			// ContainersInitialAggregateState (loaded from checkpoints).
+			// Without this, InitFromCheckpoints followed by a selector flip
+			// discards the just-loaded history and the next checkpoint write
+			// overwrites the CR with thin data.
+			preservedInitialState = vpa.ContainersInitialAggregateState
+			if err := cluster.DeleteVpa(vpaID); err != nil {
+				return err
+			}
+			vpaExists = false
+			vpa = nil
 		}
-		vpaExists = false
 	}
 	if !vpaExists {
 		vpa = NewVpa(vpaID, selector, apiObject.CreationTimestamp.Time)
+		if len(preservedInitialState) > 0 {
+			vpa.ContainersInitialAggregateState = preservedInitialState
+		}
 		cluster.vpas[vpaID] = vpa
 		for aggregationKey, aggregation := range cluster.aggregateStateMap {
 			vpa.UseAggregationIfMatching(aggregationKey, aggregation)
@@ -327,6 +345,14 @@ func (cluster *clusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
 	vpa.SetAPIVersion(apiObject.GetObjectKind().GroupVersionKind().Version)
 	vpa.Generation = apiObject.Generation
 	return nil
+}
+
+// isEmptySelector reports whether s is nil or labels.Nothing()-like (empty
+// string form). Both Nothing and Everything stringify to "" in some cases;
+// callers only pass Nothing on target resolution failure, which is the case
+// we care about for #9891.
+func isEmptySelector(s labels.Selector) bool {
+	return s == nil || s.String() == ""
 }
 
 // DeleteVpa removes a VPA with the given ID from the clusterState.

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -469,6 +469,59 @@ func TestUpdatePodSelector(t *testing.T) {
 	assert.Contains(t, vpa.aggregateContainerStates, cluster.aggregateStateKeyForContainerID(testContainerID))
 }
 
+// TestAddOrUpdateVpaKeepsSelectorOnEmptyFlip covers kubernetes/autoscaler#9891:
+// a transient targetRef failure yields labels.Nothing() (empty string). That
+// must not recreate the VPA or drop checkpointed aggregate state.
+func TestAddOrUpdateVpaKeepsSelectorOnEmptyFlip(t *testing.T) {
+	cluster := NewClusterState(testGcPeriod)
+	vpa := addTestVpa(cluster)
+	cs := NewAggregateContainerState()
+	vpa.ContainersInitialAggregateState[testContainerID.ContainerName] = cs
+
+	apiObject := test.VerticalPodAutoscaler().WithNamespace(testVpaID.Namespace).
+		WithName(testVpaID.VpaName).WithContainer(testContainerID.ContainerName).
+		WithAnnotations(testAnnotations).WithTargetRef(testTargetRef).Get()
+
+	// Simulate getSelector failure: labels.Nothing().
+	err := cluster.AddOrUpdateVpa(apiObject, labels.Nothing())
+	assert.NoError(t, err)
+
+	stored := cluster.VPAs()[testVpaID]
+	assert.False(t, isEmptySelector(stored.PodSelector),
+		"previous non-empty selector must be retained when update uses empty selector")
+	assert.Equal(t, vpa.PodSelector.String(), stored.PodSelector.String())
+	assert.Same(t, cs, stored.ContainersInitialAggregateState[testContainerID.ContainerName],
+		"checkpointed initial aggregate state must not be discarded")
+}
+
+// TestAddOrUpdateVpaPreservesInitialStateOnRealSelectorChange covers the
+// InitFromCheckpoints race: VPA created with empty selector, checkpoint loaded,
+// then selector becomes real — history must survive the recreate.
+func TestAddOrUpdateVpaPreservesInitialStateOnRealSelectorChange(t *testing.T) {
+	cluster := NewClusterState(testGcPeriod)
+	apiObject := test.VerticalPodAutoscaler().WithNamespace(testVpaID.Namespace).
+		WithName(testVpaID.VpaName).WithContainer(testContainerID.ContainerName).
+		WithAnnotations(testAnnotations).WithTargetRef(testTargetRef).Get()
+
+	// First load: empty selector (target not yet resolvable).
+	err := cluster.AddOrUpdateVpa(apiObject, labels.Nothing())
+	assert.NoError(t, err)
+	vpa := cluster.VPAs()[testVpaID]
+	cs := NewAggregateContainerState()
+	vpa.ContainersInitialAggregateState[testContainerID.ContainerName] = cs
+
+	// Second load: real selector (controllers now available).
+	labelSelector, _ := metav1.ParseToLabelSelector(testSelectorStr)
+	parsedSelector, _ := metav1.LabelSelectorAsSelector(labelSelector)
+	err = cluster.AddOrUpdateVpa(apiObject, parsedSelector)
+	assert.NoError(t, err)
+
+	stored := cluster.VPAs()[testVpaID]
+	assert.Equal(t, parsedSelector.String(), stored.PodSelector.String())
+	assert.Same(t, cs, stored.ContainersInitialAggregateState[testContainerID.ContainerName],
+		"ContainersInitialAggregateState must survive empty→real selector recreate")
+}
+
 // Test setting ResourcePolicy and UpdatePolicy on adding or updating VPA object
 func TestAddOrUpdateVPAPolicies(t *testing.T) {
 	testVpaBuilder := test.VerticalPodAutoscaler().WithName(testVpaID.VpaName).

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -522,6 +522,19 @@ func TestAddOrUpdateVpaPreservesInitialStateOnRealSelectorChange(t *testing.T) {
 		"ContainersInitialAggregateState must survive empty→real selector recreate")
 }
 
+// TestIsEmptySelector verifies isEmptySelector only matches labels.Nothing(),
+// not labels.Everything() — both stringify to "" but must be told apart
+// (see PR #10095 review discussion).
+func TestIsEmptySelector(t *testing.T) {
+	assert.True(t, isEmptySelector(nil))
+	assert.True(t, isEmptySelector(labels.Nothing()))
+	assert.False(t, isEmptySelector(labels.Everything()))
+
+	realSelector, err := labels.Parse(testSelectorStr)
+	assert.NoError(t, err)
+	assert.False(t, isEmptySelector(realSelector))
+}
+
 // Test setting ResourcePolicy and UpdatePolicy on adding or updating VPA object
 func TestAddOrUpdateVPAPolicies(t *testing.T) {
 	testVpaBuilder := test.VerticalPodAutoscaler().WithName(testVpaID.VpaName).


### PR DESCRIPTION
#### What this PR does / why we need it

With checkpoint storage, a brief failure to resolve a VPA `targetRef`
(recommender start before controller informers are ready, or the target
workload gone during node consolidation) made `getSelector` return
`labels.Nothing()` (empty selector).

`AddOrUpdateVpa` treated empty → real as a selector change, deleted the
in-memory VPA, and created a new one with an empty
`ContainersInitialAggregateState`. The next checkpoint write then
replaced days of history with only fresh samples. The memory target can
collapse and pods can OOM on the next traffic spike.

This matches https://github.com/kubernetes/autoscaler/issues/9891.

#### Changes

1. **Keep the previous selector** when the new selector is empty and the
   VPA already had a non-empty one (transient resolve failure).
2. **Preserve `ContainersInitialAggregateState`** when a real selector
   change still recreates the in-memory VPA (including the first
   empty→real transition after `InitFromCheckpoints`).
3. In `LoadVPAs`, prefer the stored selector if target fetch fails.

#### Which issue(s) this PR fixes

Fixes #9891

#### Special notes for your reviewer

- AI tools helped with code search, the patch, tests, and this text. I
  reviewed the control flow and unit tests myself.
- Unit tests cover empty-selector retention and history survival on
  empty→real recreate. No full recommender e2e with leadership churn.

#### Does this PR introduce a user-facing change?

```release-note
VPA recommender: checkpoint history is no longer wiped when a VPA target is briefly unresolvable (e.g. during recommender restart or workload reschedule).
```