### PR TITLE
VPA: skip non-increasing OOM samples across aggregation windows

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -53,6 +53,12 @@ type ContainerState struct {
 	memoryPeak ResourceAmount
 	// Max memory usage estimated from an OOM event in the current aggregation interval.
 	oomPeak ResourceAmount
+	// Last synthetic OOM sample value successfully added to the histogram.
+	// Survives aggregation window shifts (unlike oomPeak). Used to avoid
+	// re-seeding the histogram with a non-increasing OOM sample on every
+	// subsequent kill when the request is stuck (e.g. at maxAllowed).
+	// See kubernetes/autoscaler#9521.
+	lastRecordedOOMSample ResourceAmount
 	// End time of the current memory aggregation interval (not inclusive).
 	WindowEnd time.Time
 	// Start of the latest memory usage sample that was aggregated.
@@ -219,6 +225,14 @@ func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory 
 	memoryNeeded := ResourceAmountMax(memoryUsed+MemoryAmountFromBytes(container.GetOOMMinBumpUp()),
 		ScaleResource(memoryUsed, container.GetOOMBumpUpRatio()))
 
+	// Skip re-inserting a non-increasing synthetic OOM sample. The first bump
+	// still enters the histogram (so uncappedTarget can exceed maxAllowed), but
+	// repeated OOMs at the same capped request must not re-seed the decaying
+	// histogram every aggregation interval (#9521).
+	if container.lastRecordedOOMSample > 0 && memoryNeeded <= container.lastRecordedOOMSample {
+		return nil
+	}
+
 	oomMemorySample := ContainerUsageSample{
 		MeasureStart: timestamp,
 		Usage:        memoryNeeded,
@@ -227,6 +241,7 @@ func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory 
 	if !container.addMemorySample(&oomMemorySample, true) {
 		return errors.New("adding OOM sample failed")
 	}
+	container.lastRecordedOOMSample = memoryNeeded
 	return nil
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
@@ -210,6 +210,42 @@ func TestRecordOOMInNewWindow(t *testing.T) {
 	assert.NoError(t, test.container.RecordOOM(testTimestamp.Add(2*memoryAggregationInterval), ResourceAmount(1000*mb)))
 }
 
+// TestRecordOOMSkipsNonIncreasingSampleAcrossWindows covers #9521: when a
+// workload is stuck at a capped request, each OOM would otherwise re-insert the
+// same synthetic sample after every aggregation window shift and keep
+// uncappedTarget inflated. Equal/lower synthetic OOMs must not re-seed the histogram.
+func TestRecordOOMSkipsNonIncreasingSampleAcrossWindows(t *testing.T) {
+	test := newContainerTest()
+	// Match the issue scenario: high bump ratio, request already at the effective cap.
+	test.aggregateContainerState.OOMBumpUpRatio = 2.0
+	test.aggregateContainerState.OOMMinBumpUp = 0
+	interval := GetAggregationsConfig().MemoryAggregationIntervalDuration
+	windowEnd := testTimestamp.Add(interval)
+
+	const request = 1000 * mb
+	// First OOM: 1000*mb * 2.0 → 2000*mb sample.
+	test.mockMemoryHistogram.On("AddSample", 2000.0*mb, 1.0, windowEnd).Once()
+	assert.NoError(t, test.container.RecordOOM(testTimestamp, ResourceAmount(request)))
+
+	// Later windows, same request → same synthetic value → no further AddSample.
+	// (If dedup were missing, each call would AddSample again after WindowEnd shifts.)
+	later := testTimestamp.Add(2 * interval)
+	assert.NoError(t, test.container.RecordOOM(later, ResourceAmount(request)))
+	assert.NoError(t, test.container.RecordOOM(later.Add(interval), ResourceAmount(request)))
+
+	// Higher request (policy raised / larger need) → new sample recorded.
+	// WindowEnd is still the first OOM's window (skipped OOMs do not advance it).
+	higherTS := later.Add(2 * interval)
+	// shift = (higherTS - windowEnd).Truncate(interval) + interval
+	// windowEnd = testTimestamp+interval; higherTS = testTimestamp+4*interval
+	// shift = 3*interval + interval = 4*interval → newWindowEnd = testTimestamp+5*interval
+	higherWindowEnd := testTimestamp.Add(5 * interval)
+	test.mockMemoryHistogram.On("AddSample", 3000.0*mb, 1.0, higherWindowEnd).Once()
+	assert.NoError(t, test.container.RecordOOM(higherTS, ResourceAmount(1500*mb)))
+
+	test.mockMemoryHistogram.AssertExpectations(t)
+}
+
 // TestRecordOOMFreshOOMNearWindowBoundaryIsNotDiscarded reproduces
 // https://github.com/kubernetes/autoscaler/issues/8548.
 //


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When memory is stuck at `maxAllowed`, each OOM still inserts the same synthetic sample (`request × oom-bump-up-ratio`) after every aggregation window. That re-seeds the histogram and keeps `uncappedTarget` much higher than real usage for a long time (#9521).

This change records the first synthetic OOM sample as today (so `uncappedTarget` can still go above `maxAllowed` and show that the cap is too low). Later OOMs with the same or lower synthetic value are skipped. A higher OOM still updates the histogram.

This is different from #9526 / #9905, which capped samples at `maxAllowed` and removed that signal.

#### Which issue(s) this PR fixes:

Fixes #9521

#### Special notes for your reviewer:

Design note was posted on the issue. I used an AI coding assistant to help draft the approach and tests; I reviewed the change myself.

#### Does this PR introduce a user-facing change?

```release-note
VPA recommender no longer re-inserts non-increasing synthetic OOM memory samples on every aggregation window, so uncappedTarget does not stay inflated after repeated OOMs under a stable capped request.
```