### PR TITLE
VPA recommender: backfill checkpoint when a VPA is newly tracked

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -279,25 +279,34 @@ func (feeder *clusterStateFeeder) setVpaCheckpoint(checkpoint *vpa_types.Vertica
 	return nil
 }
 
-// backfillCheckpoint loads any persisted checkpoint for a VPA the first time
-// this recommender instance starts tracking it. This covers both the normal
-// startup path and a VPA whose .spec.recommenders is changed at runtime to
-// select this (already running) recommender: without this, such a VPA would
-// never get its checkpoint history back, since checkpoints were otherwise
-// only read once, at startup. See kubernetes/autoscaler#9241.
-func (feeder *clusterStateFeeder) backfillCheckpoint(vpaID model.VpaID) {
-	checkpoints, err := feeder.vpaCheckpointLister.VerticalPodAutoscalerCheckpoints(vpaID.Namespace).List(labels.Everything())
-	if err != nil {
-		klog.ErrorS(err, "Cannot list VPA checkpoints", "namespace", vpaID.Namespace)
-		return
+// backfillCheckpoints loads any persisted checkpoints for VPAs the first time
+// this recommender instance starts tracking them. This covers the normal
+// startup path, a VPA whose .spec.recommenders is changed at runtime to
+// select this (already running) recommender, and a VPA whose pod selector
+// change caused AddOrUpdateVpa to recreate its in-memory object: in every
+// case the fresh Vpa object would otherwise keep an empty
+// ContainersInitialAggregateState, since checkpoints were previously only
+// read once, at startup. See kubernetes/autoscaler#9241.
+func (feeder *clusterStateFeeder) backfillCheckpoints(vpaIDs map[model.VpaID]bool) {
+	namespaces := make(map[string]bool)
+	for vpaID := range vpaIDs {
+		namespaces[vpaID.Namespace] = true
 	}
-	for _, checkpoint := range checkpoints {
-		if checkpoint.Spec.VPAObjectName != vpaID.VpaName {
+	for namespace := range namespaces {
+		checkpoints, err := feeder.vpaCheckpointLister.VerticalPodAutoscalerCheckpoints(namespace).List(labels.Everything())
+		if err != nil {
+			klog.ErrorS(err, "Cannot list VPA checkpoints", "namespace", namespace)
 			continue
 		}
-		klog.V(3).InfoS("Loading checkpoint for VPA", "vpa", klog.KRef(vpaID.Namespace, vpaID.VpaName), "checkpoint", checkpoint.Name, "container", checkpoint.Spec.ContainerName)
-		if err := feeder.setVpaCheckpoint(checkpoint); err != nil {
-			klog.ErrorS(err, "Error while loading checkpoint", "vpa", klog.KRef(vpaID.Namespace, vpaID.VpaName), "checkpoint", checkpoint.Name)
+		for _, checkpoint := range checkpoints {
+			vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
+			if !vpaIDs[vpaID] {
+				continue
+			}
+			klog.V(3).InfoS("Loading checkpoint for VPA", "vpa", klog.KRef(vpaID.Namespace, vpaID.VpaName), "checkpoint", checkpoint.Name, "container", checkpoint.Spec.ContainerName)
+			if err := feeder.setVpaCheckpoint(checkpoint); err != nil {
+				klog.ErrorS(err, "Error while loading checkpoint", "vpa", klog.KRef(vpaID.Namespace, vpaID.VpaName), "checkpoint", checkpoint.Name)
+			}
 		}
 	}
 }
@@ -439,12 +448,18 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 	klog.V(3).InfoS("Fetching VPAs", "count", len(vpaCRDs))
 	// Add or update existing VPAs in the model.
 	vpaKeys := make(map[model.VpaID]bool)
+	// newVpaIDs collects VPAs whose in-memory object is new this cycle - either
+	// never tracked before, or recreated by AddOrUpdateVpa because their pod
+	// selector changed. Detecting this by object identity (not just key
+	// presence) matters: a recreated VPA keeps the same VpaID but loses its
+	// previously loaded ContainersInitialAggregateState.
+	newVpaIDs := make(map[model.VpaID]bool)
 	for _, vpaCRD := range vpaCRDs {
 		vpaID := model.VpaID{
 			Namespace: vpaCRD.Namespace,
 			VpaName:   vpaCRD.Name,
 		}
-		_, alreadyTracked := feeder.clusterState.VPAs()[vpaID]
+		previousVpa := feeder.clusterState.VPAs()[vpaID]
 
 		selector, conditions := feeder.getSelector(ctx, vpaCRD)
 		klog.V(4).InfoS("Using selector", "selector", selector.String(), "vpa", klog.KObj(vpaCRD))
@@ -461,10 +476,13 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 				}
 			}
 
-			if !alreadyTracked {
-				feeder.backfillCheckpoint(vpaID)
+			if feeder.clusterState.VPAs()[vpaID] != previousVpa {
+				newVpaIDs[vpaID] = true
 			}
 		}
+	}
+	if len(newVpaIDs) > 0 {
+		feeder.backfillCheckpoints(newVpaIDs)
 	}
 	// Delete non-existent VPAs from the model.
 	for vpaID := range feeder.clusterState.VPAs() {

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -295,9 +295,9 @@ func (feeder *clusterStateFeeder) backfillCheckpoint(vpaID model.VpaID) {
 		if checkpoint.Spec.VPAObjectName != vpaID.VpaName {
 			continue
 		}
-		klog.V(3).InfoS("Loading checkpoint for VPA", "checkpoint", klog.KRef(checkpoint.Namespace, checkpoint.Spec.VPAObjectName), "container", checkpoint.Spec.ContainerName)
+		klog.V(3).InfoS("Loading checkpoint for VPA", "vpa", klog.KRef(vpaID.Namespace, vpaID.VpaName), "checkpoint", checkpoint.Name, "container", checkpoint.Spec.ContainerName)
 		if err := feeder.setVpaCheckpoint(checkpoint); err != nil {
-			klog.ErrorS(err, "Error while loading checkpoint")
+			klog.ErrorS(err, "Error while loading checkpoint", "vpa", klog.KRef(vpaID.Namespace, vpaID.VpaName), "checkpoint", checkpoint.Name)
 		}
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -279,35 +279,32 @@ func (feeder *clusterStateFeeder) setVpaCheckpoint(checkpoint *vpa_types.Vertica
 	return nil
 }
 
+// backfillCheckpoint loads any persisted checkpoint for a VPA the first time
+// this recommender instance starts tracking it. This covers both the normal
+// startup path and a VPA whose .spec.recommenders is changed at runtime to
+// select this (already running) recommender: without this, such a VPA would
+// never get its checkpoint history back, since checkpoints were otherwise
+// only read once, at startup. See kubernetes/autoscaler#9241.
+func (feeder *clusterStateFeeder) backfillCheckpoint(vpaID model.VpaID) {
+	checkpoints, err := feeder.vpaCheckpointLister.VerticalPodAutoscalerCheckpoints(vpaID.Namespace).List(labels.Everything())
+	if err != nil {
+		klog.ErrorS(err, "Cannot list VPA checkpoints", "namespace", vpaID.Namespace)
+		return
+	}
+	for _, checkpoint := range checkpoints {
+		if checkpoint.Spec.VPAObjectName != vpaID.VpaName {
+			continue
+		}
+		klog.V(3).InfoS("Loading checkpoint for VPA", "checkpoint", klog.KRef(checkpoint.Namespace, checkpoint.Spec.VPAObjectName), "container", checkpoint.Spec.ContainerName)
+		if err := feeder.setVpaCheckpoint(checkpoint); err != nil {
+			klog.ErrorS(err, "Error while loading checkpoint")
+		}
+	}
+}
+
 func (feeder *clusterStateFeeder) InitFromCheckpoints(ctx context.Context) {
 	klog.V(3).InfoS("Initializing VPA from checkpoints")
 	feeder.LoadVPAs(ctx)
-
-	checkpointList, err := feeder.vpaCheckpointLister.List(labels.Everything())
-	if err != nil {
-		klog.ErrorS(err, "Cannot list VPA checkpoints")
-	}
-	klog.V(3).InfoS("Fetching VPA checkpoints", "count", len(checkpointList))
-
-	namespaces := make(map[string]bool)
-	for _, v := range feeder.clusterState.VPAs() {
-		namespaces[v.ID.Namespace] = true
-	}
-
-	for namespace := range namespaces {
-		if feeder.shouldIgnoreNamespace(namespace) {
-			klog.V(3).InfoS("Skipping loading VPA Checkpoints from namespace.", "namespace", namespace, "vpaObjectNamespace", feeder.vpaObjectNamespace, "ignoredNamespaces", feeder.ignoredNamespaces)
-			continue
-		}
-
-		for _, checkpoint := range checkpointList {
-			klog.V(3).InfoS("Loading checkpoint for VPA", "checkpoint", klog.KRef(checkpoint.Namespace, checkpoint.Spec.VPAObjectName), "container", checkpoint.Spec.ContainerName)
-			err = feeder.setVpaCheckpoint(checkpoint)
-			if err != nil {
-				klog.ErrorS(err, "Error while loading checkpoint")
-			}
-		}
-	}
 }
 
 func (feeder *clusterStateFeeder) GarbageCollectCheckpoints(ctx context.Context) {
@@ -447,6 +444,7 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 			Namespace: vpaCRD.Namespace,
 			VpaName:   vpaCRD.Name,
 		}
+		_, alreadyTracked := feeder.clusterState.VPAs()[vpaID]
 
 		selector, conditions := feeder.getSelector(ctx, vpaCRD)
 		klog.V(4).InfoS("Using selector", "selector", selector.String(), "vpa", klog.KObj(vpaCRD))
@@ -461,6 +459,10 @@ func (feeder *clusterStateFeeder) LoadVPAs(ctx context.Context) {
 				} else {
 					feeder.clusterState.VPAs()[vpaID].SetCondition(condition.conditionType, true, "", condition.message)
 				}
+			}
+
+			if !alreadyTracked {
+				feeder.backfillCheckpoint(vpaID)
 			}
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -362,13 +362,19 @@ func TestLoadVPAs(t *testing.T) {
 			vpaLister := &test.VerticalPodAutoscalerListerMock{}
 			vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpa}, nil)
 
+			checkpointNamespaceLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+			checkpointNamespaceLister.On("List").Return([]*vpa_types.VerticalPodAutoscalerCheckpoint{}, nil)
+			checkpointLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+			checkpointLister.On("VerticalPodAutoscalerCheckpoints", "testNamespace").Return(checkpointNamespaceLister)
+
 			targetSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
 			clusterState := model.NewClusterState(testGcPeriod)
 
 			clusterStateFeeder := clusterStateFeeder{
-				vpaLister:       vpaLister,
-				clusterState:    clusterState,
-				selectorFetcher: targetSelectorFetcher,
+				vpaLister:           vpaLister,
+				vpaCheckpointLister: checkpointLister,
+				clusterState:        clusterState,
+				selectorFetcher:     targetSelectorFetcher,
 				controllerFetcher: &fakeControllerFetcher{
 					key: tc.topMostWellKnownOrScalableKey,
 					err: tc.findTopMostWellKnownOrScalableError,
@@ -1086,4 +1092,86 @@ func TestCanCleanupCheckpoints(t *testing.T) {
 	for _, vpa := range vpas {
 		assert.NotContains(t, deletedCheckpoints, vpa.Name)
 	}
+}
+
+// TestCheckpointBackfilledOnRecommenderReassignment covers
+// kubernetes/autoscaler#9241: previously, InitFromCheckpoints ran exactly
+// once, at recommender startup, and only backfilled checkpoints for VPAs
+// that filterVPAs already resolved to this recommender's name at that
+// instant. If a VPA's .spec.recommenders was changed *after* startup to
+// point at this (already running) recommender, the regular LoadVPAs
+// reconcile loop picked it up as a brand new VPA with an empty
+// ContainersInitialAggregateState — the checkpoint was never read again, so
+// its history was lost forever for this recommender instance. LoadVPAs now
+// backfills the checkpoint the first time it starts tracking any VPA.
+func TestCheckpointBackfilledOnRecommenderReassignment(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, tctx := ktesting.NewTestContext(t)
+
+	const namespace = "default"
+	const vpaName = "app"
+	const containerName = "container"
+
+	// VPA initially selects the "default" recommender, not "frugal".
+	vpa := test.VerticalPodAutoscaler().WithName(vpaName).WithNamespace(namespace).
+		WithContainer(containerName).WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
+		Kind: kind, Name: name1, APIVersion: apiVersion,
+	}).WithRecommender("default").Get()
+
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpa}, nil)
+
+	checkpoint := &vpa_types.VerticalPodAutoscalerCheckpoint{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vpaName},
+		Spec: vpa_types.VerticalPodAutoscalerCheckpointSpec{
+			VPAObjectName: vpaName,
+			ContainerName: containerName,
+		},
+		Status: vpa_types.VerticalPodAutoscalerCheckpointStatus{
+			Version:           model.SupportedCheckpointVersion,
+			TotalSamplesCount: 100,
+			FirstSampleStart:  metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour)),
+			LastSampleStart:   metav1.NewTime(time.Now()),
+		},
+	}
+	checkpointNamespaceLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointNamespaceLister.On("List").Return([]*vpa_types.VerticalPodAutoscalerCheckpoint{checkpoint}, nil)
+	checkpointLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointLister.On("VerticalPodAutoscalerCheckpoints", namespace).Return(checkpointNamespaceLister)
+
+	targetSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
+
+	clusterState := model.NewClusterState(testGcPeriod)
+	feeder := clusterStateFeeder{
+		vpaLister:           vpaLister,
+		vpaCheckpointLister: checkpointLister,
+		clusterState:        clusterState,
+		selectorFetcher:     targetSelectorFetcher,
+		controllerFetcher:   &fakeControllerFetcher{},
+		recommenderName:     "frugal",
+	}
+
+	// Simulates the "frugal" recommender's one-time startup checkpoint load,
+	// while the VPA still selects "default" — frugal never sees it.
+	feeder.InitFromCheckpoints(tctx)
+
+	vpaID := model.VpaID{Namespace: namespace, VpaName: vpaName}
+	assert.NotContains(t, clusterState.VPAs(), vpaID,
+		"sanity check: frugal recommender should not track a VPA that doesn't select it yet")
+
+	// Now the VPA is reassigned to "frugal" at runtime (spec update), and the
+	// regular reconcile loop (LoadVPAs, not InitFromCheckpoints) picks it up.
+	vpa.Spec.Recommenders = []*vpa_types.VerticalPodAutoscalerRecommenderSelector{{Name: "frugal"}}
+	targetSelectorFetcher.EXPECT().Fetch(vpa).Return(parseLabelSelector("app = test"), nil)
+
+	feeder.LoadVPAs(tctx)
+
+	assert.Contains(t, clusterState.VPAs(), vpaID, "VPA should now be tracked by the frugal recommender")
+	storedVpa := clusterState.VPAs()[vpaID]
+	assert.NotEmpty(t, storedVpa.ContainersInitialAggregateState,
+		"checkpoint history must be backfilled the first time this recommender starts tracking a VPA, even after startup (kubernetes/autoscaler#9241)")
+	cs, ok := storedVpa.ContainersInitialAggregateState[containerName]
+	assert.True(t, ok)
+	assert.Equal(t, checkpoint.Status.TotalSamplesCount, cs.TotalSamplesCount)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1172,6 +1173,98 @@ func TestCheckpointBackfilledOnRecommenderReassignment(t *testing.T) {
 	assert.NotEmpty(t, storedVpa.ContainersInitialAggregateState,
 		"checkpoint history must be backfilled the first time this recommender starts tracking a VPA, even after startup (kubernetes/autoscaler#9241)")
 	cs, ok := storedVpa.ContainersInitialAggregateState[containerName]
+	assert.True(t, ok)
+	assert.Equal(t, checkpoint.Status.TotalSamplesCount, cs.TotalSamplesCount)
+}
+
+// TestCheckpointBackfilledWhenSelectorChangeRecreatesVpa covers the other half
+// of kubernetes/autoscaler#9241: AddOrUpdateVpa recreates the in-memory Vpa
+// object (dropping ContainersInitialAggregateState) not only when a VPA is
+// new to this recommender, but also when an already-tracked VPA's pod
+// selector changes for real. A check based only on VpaID presence in
+// clusterState.VPAs() would miss this case, since the key was already
+// present before the call; detecting the Vpa object's pointer identity
+// changing catches it too.
+func TestCheckpointBackfilledWhenSelectorChangeRecreatesVpa(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, tctx := ktesting.NewTestContext(t)
+
+	const ns = "default"
+	const vpaName = "app"
+	const containerName = "container"
+
+	vpa := test.VerticalPodAutoscaler().WithName(vpaName).WithNamespace(ns).
+		WithContainer(containerName).WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
+		Kind: kind, Name: name1, APIVersion: apiVersion,
+	}).WithRecommender("frugal").Get()
+
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpa}, nil)
+
+	checkpoint := &vpa_types.VerticalPodAutoscalerCheckpoint{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: vpaName},
+		Spec: vpa_types.VerticalPodAutoscalerCheckpointSpec{
+			VPAObjectName: vpaName,
+			ContainerName: containerName,
+		},
+		Status: vpa_types.VerticalPodAutoscalerCheckpointStatus{
+			Version:           model.SupportedCheckpointVersion,
+			TotalSamplesCount: 100,
+			FirstSampleStart:  metav1.NewTime(time.Now().Add(-7 * 24 * time.Hour)),
+			LastSampleStart:   metav1.NewTime(time.Now()),
+		},
+	}
+	checkpointNamespaceLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointNamespaceLister.On("List").Return([]*vpa_types.VerticalPodAutoscalerCheckpoint{checkpoint}, nil)
+	checkpointLister := &test.VerticalPodAutoscalerCheckPointListerMock{}
+	checkpointLister.On("VerticalPodAutoscalerCheckpoints", ns).Return(checkpointNamespaceLister)
+
+	targetSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
+
+	clusterState := model.NewClusterState(testGcPeriod)
+	feeder := clusterStateFeeder{
+		vpaLister:           vpaLister,
+		vpaCheckpointLister: checkpointLister,
+		clusterState:        clusterState,
+		selectorFetcher:     targetSelectorFetcher,
+		controllerFetcher: &fakeControllerFetcher{
+			// Must resolve to exactly vpa's own targetRef so validateTargetRef
+			// succeeds and getSelector passes the fetched selector through
+			// unchanged, instead of falling back to labels.Nothing().
+			key: &controllerfetcher.ControllerKeyWithAPIVersion{
+				ControllerKey: controllerfetcher.ControllerKey{Kind: kind, Name: name1, Namespace: ns},
+				ApiVersion:    apiVersion,
+			},
+		},
+		recommenderName: "frugal",
+	}
+
+	vpaID := model.VpaID{Namespace: ns, VpaName: vpaName}
+
+	// First tick: VPA is new to this recommender, gets checkpoint backfilled
+	// (already covered by TestCheckpointBackfilledOnRecommenderReassignment,
+	// exercised again here just to set up the "already tracked" starting
+	// point for the real regression check below).
+	targetSelectorFetcher.EXPECT().Fetch(vpa).Return(parseLabelSelector("app = old"), nil)
+	feeder.LoadVPAs(tctx)
+	require.Contains(t, clusterState.VPAs(), vpaID)
+	firstVpa := clusterState.VPAs()[vpaID]
+	require.NotEmpty(t, firstVpa.ContainersInitialAggregateState)
+
+	// Second tick: the VPA's pod selector changes for real (e.g. the target's
+	// labels changed). AddOrUpdateVpa deletes and recreates the in-memory Vpa
+	// object because of this, same as it always has - this is not a
+	// recommender reassignment.
+	targetSelectorFetcher.EXPECT().Fetch(vpa).Return(parseLabelSelector("app = new"), nil)
+	feeder.LoadVPAs(tctx)
+
+	require.Contains(t, clusterState.VPAs(), vpaID)
+	recreatedVpa := clusterState.VPAs()[vpaID]
+	assert.NotSame(t, firstVpa, recreatedVpa, "sanity check: a real selector change must recreate the Vpa object")
+	assert.NotEmpty(t, recreatedVpa.ContainersInitialAggregateState,
+		"checkpoint history must be backfilled again when a selector change recreates an already-tracked VPA, not only when it is new to this recommender (kubernetes/autoscaler#9241)")
+	cs, ok := recreatedVpa.ContainersInitialAggregateState[containerName]
 	assert.True(t, ok)
 	assert.Equal(t, checkpoint.Status.TotalSamplesCount, cs.TotalSamplesCount)
 }

--- a/vertical-pod-autoscaler/test/e2e/v1/recommender.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/recommender.go
@@ -169,6 +169,81 @@ var _ = utils.RecommenderE2eDescribe("Checkpoints", func() {
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
+
+	// Covers kubernetes/autoscaler#9241: a checkpoint that pre-dates its VPA (e.g. left
+	// over from before a VPA was reassigned to this recommender) must be picked up the
+	// first time the recommender starts tracking that VPA, not only on recommender
+	// restart. This VPA is new to the recommender the same way a reassigned one would
+	// be, without needing a second recommender instance.
+	f.It("is loaded for a VPA that becomes newly tracked", framework.WithSlow(), framework.WithSerial(), func() {
+		ns := f.Namespace.Name
+		vpaClientSet := utils.GetVpaClientSet(f)
+
+		ginkgo.By("Setting up hamster deployment")
+		SetupHamsterDeployment(f, "100m", "100Mi", utils.DefaultHamsterReplicas)
+
+		containerName := utils.GetHamsterContainerNameByIndex(0)
+		vpaCRD := test.VerticalPodAutoscaler().
+			WithName("hamster-vpa").
+			WithNamespace(ns).
+			WithTargetRef(utils.HamsterTargetRef).
+			WithContainer(containerName).
+			Get()
+
+		ginkgo.By("Pre-creating a populated checkpoint before the VPA exists, simulating one left over from a previous recommender")
+		firstSampleStart := metav1.NewTime(time.Now().Add(-time.Hour))
+		const preloadedSamplesCount = 999999
+		checkpoint := &vpa_types.VerticalPodAutoscalerCheckpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", vpaCRD.Name, containerName),
+				Namespace: ns,
+			},
+			Spec: vpa_types.VerticalPodAutoscalerCheckpointSpec{
+				VPAObjectName: vpaCRD.Name,
+				ContainerName: containerName,
+			},
+			Status: vpa_types.VerticalPodAutoscalerCheckpointStatus{
+				Version:           model.SupportedCheckpointVersion,
+				FirstSampleStart:  firstSampleStart,
+				LastUpdateTime:    firstSampleStart,
+				TotalSamplesCount: preloadedSamplesCount,
+			},
+		}
+		created, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).Create(context.TODO(), checkpoint, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// The API server truncates FirstSampleStart to RFC3339 (second) precision, so compare
+		// against the server's round-tripped value rather than the pre-Create nanosecond-precision one.
+		firstSampleStart = created.Status.FirstSampleStart
+
+		ginkgo.By("Installing the VPA so it becomes newly tracked by the recommender")
+		utils.InstallVPA(f, vpaCRD)
+
+		ginkgo.By("Waiting for the pre-existing checkpoint to be updated")
+		var updatedCheckpoint *vpa_types.VerticalPodAutoscalerCheckpoint
+		err = wait.PollUntilContextTimeout(context.Background(), utils.PollInterval, utils.PollTimeout, true, func(ctx context.Context) (bool, error) {
+			c, err := vpaClientSet.AutoscalingV1().VerticalPodAutoscalerCheckpoints(ns).Get(ctx, checkpoint.Name, metav1.GetOptions{})
+			if err != nil {
+				klog.ErrorS(err, "Error getting VPA checkpoint")
+				return false, nil
+			}
+			if !c.Status.LastUpdateTime.After(firstSampleStart.Time) {
+				return false, nil
+			}
+			updatedCheckpoint = c
+			return true, nil
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking that firstSampleStart was preserved, proving the checkpoint was loaded rather than reset")
+		gomega.Expect(updatedCheckpoint.Status.FirstSampleStart.Equal(&firstSampleStart)).To(gomega.BeTrue(),
+			fmt.Sprintf("firstSampleStart changed after the VPA became newly tracked: was %v, now %v",
+				firstSampleStart, updatedCheckpoint.Status.FirstSampleStart))
+
+		ginkgo.By("Checking that totalSamplesCount built on top of the preloaded value rather than starting from zero")
+		gomega.Expect(updatedCheckpoint.Status.TotalSamplesCount).To(gomega.BeNumerically(">", preloadedSamplesCount),
+			fmt.Sprintf("totalSamplesCount should have increased from the preloaded checkpoint value: was %d, now %d",
+				preloadedSamplesCount, updatedCheckpoint.Status.TotalSamplesCount))
+	})
 })
 
 var _ = utils.RecommenderE2eDescribe("VPA CRD object", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The recommender loads old checkpoint data only one time, when it starts. It uses this data to fill in history for each VPA.

But there is a problem: if a VPA changes its `.spec.recommenders` field later (for example, it moves from the `default` recommender to a `frugal` recommender), the new recommender does not read the checkpoint again. The recommender only reads checkpoints at startup, for VPAs it already knows about at that time.

So when a VPA moves to a new recommender after that recommender has already started, the new recommender treats it as a brand new VPA. It starts with empty history. All the old checkpoint data is lost for this recommender, even though the checkpoint still exists.

The same kind of loss also happens in a second case: a VPA that this recommender already tracks, whose pod selector changes for a real reason (its target's labels changed). `AddOrUpdateVpa` deletes and recreates the in-memory VPA object in that case too, which also drops its loaded checkpoint history, even though the recommender never stopped tracking it and its `.spec.recommenders` never changed.

This matches https://github.com/kubernetes/autoscaler/issues/9241.

#### Changes

1. Added a new function `backfillCheckpoints`. It loads checkpoints for VPAs the first time this recommender starts tracking them (or starts tracking them again after their in-memory object was recreated). This can happen at startup, later when a VPA is moved to this recommender, or when a VPA's pod selector changes for real.
2. `LoadVPAs` now detects this by comparing the VPA object itself (not just its name) before and after each update, since `AddOrUpdateVpa` recreates the object both when a VPA is new and when its selector changes. It calls `backfillCheckpoints` once per pass for every VPA that is new this way, grouped by namespace so each namespace's checkpoints are only listed once.
3. `InitFromCheckpoints` is now much simpler. It just calls `LoadVPAs`, because `LoadVPAs` already loads checkpoints for new VPAs.
4. Added an e2e test in `test/e2e/v1/recommender.go` (`Checkpoints` describe block): it creates a checkpoint before the VPA exists, then creates the VPA, and checks that the already-running recommender loads the old checkpoint instead of starting from zero. This does not need a second recommender — a VPA that is brand new to a recommender behaves the same way a reassigned one would.
5. Small log fix in `backfillCheckpoints`: the log line labeled the VPA reference with the key `"checkpoint"`, and the error log had no VPA/checkpoint context at all. Now both are logged as separate, correctly named fields.

#### Which issue(s) this PR fixes:

Fixes #9241

#### Special notes for your reviewer:

⚠️ I used an AI coding assistant to help find the root cause, write the code, and write the tests. I read and checked all the code and tests myself before opening this PR. Please review carefully, since this touches how checkpoint history is loaded.

I wrote unit tests first to show the bug (checkpoint data was lost after a VPA changed recommenders, and separately after a real selector change recreated an already-tracked VPA), and checked both failed without the fix and passed with the fix.

Earlier version of this PR only handled the recommender-reassignment case, checking whether the VPA's name was already known to this recommender. That missed the selector-change case, since the name stays the same even though the object is recreated. Comparing the VPA object itself, not just its name, catches both.

I ran the new e2e test for real: `kind` cluster, recommender image built from this branch, deployed via the chart in `hack/deploy-for-e2e-locally.sh recommender`, then `ginkgo --focus="is loaded for a VPA that becomes newly tracked" v1/v1.test`. Result: `Ran 1 of 629 Specs ... 1 Passed | 0 Failed`. The recommender's own logs show the new code path firing: `"Loading checkpoint for VPA" vpa=".../hamster-vpa" checkpoint="hamster-vpa-hamster" container="hamster"`.

#### Does this PR introduce a user-facing change?

```release-note
VPA recommender: checkpoint history is no longer lost when a VPA is moved to a different recommender after that recommender has already started.
```
