### PR TITLE
VPA recommender: fix three memory leaks with large clusters / Prometheus history

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -59,7 +59,7 @@ const (
 // ClusterStateFeeder can update state of clusterState object.
 type ClusterStateFeeder interface {
 	// InitFromHistoryProvider loads historical pod spec into clusterState.
-	InitFromHistoryProvider(historyProvider history.HistoryProvider)
+	InitFromHistoryProvider(ctx context.Context, historyProvider history.HistoryProvider)
 
 	// InitFromCheckpoints loads historical checkpoints into clusterState.
 	InitFromCheckpoints(ctx context.Context)
@@ -232,13 +232,23 @@ type clusterStateFeeder struct {
 	podsToDelete        []model.PodID
 }
 
-func (feeder *clusterStateFeeder) InitFromHistoryProvider(historyProvider history.HistoryProvider) {
+func (feeder *clusterStateFeeder) InitFromHistoryProvider(ctx context.Context, historyProvider history.HistoryProvider) {
 	klog.V(3).InfoS("Initializing VPA from history provider")
+	if feeder.memorySaveMode {
+		// VPAs must be loaded first so that pods not matched by any VPA can be
+		// skipped below, otherwise the whole cluster history (potentially years
+		// of usage and label data for every pod) is loaded into memory upfront,
+		// defeating the purpose of memory saver mode.
+		feeder.LoadVPAs(ctx)
+	}
 	clusterHistory, err := historyProvider.GetClusterHistory()
 	if err != nil {
 		klog.ErrorS(err, "Cannot get cluster history")
 	}
 	for podID, podHistory := range clusterHistory {
+		if feeder.memorySaveMode && !feeder.matchesAnyVPA(podID.Namespace, podHistory.LastLabels) {
+			continue
+		}
 		klog.V(4).InfoS("Adding pod with labels", "pod", podID, "labels", podHistory.LastLabels)
 		feeder.clusterState.AddOrUpdatePod(podID, podHistory.LastLabels, corev1.PodUnknown)
 		for containerName, sampleList := range podHistory.Samples {
@@ -571,9 +581,15 @@ Loop:
 }
 
 func (feeder *clusterStateFeeder) matchesVPA(pod *spec.BasicPodSpec) bool {
+	return feeder.matchesAnyVPA(pod.ID.Namespace, pod.PodLabels)
+}
+
+// matchesAnyVPA returns true if any known VPA object in the given namespace
+// selects a pod with the given labels.
+func (feeder *clusterStateFeeder) matchesAnyVPA(namespace string, podLabels map[string]string) bool {
+	ls := labels.Set(podLabels)
 	for vpaKey, vpa := range feeder.clusterState.VPAs() {
-		podLabels := labels.Set(pod.PodLabels)
-		if vpaKey.Namespace == pod.ID.Namespace && vpa.PodSelector.Matches(podLabels) {
+		if vpaKey.Namespace == namespace && vpa.PodSelector.Matches(ls) {
 			return true
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
@@ -876,7 +876,7 @@ func TestClusterStateFeeder_InitFromHistoryProvider(t *testing.T) {
 	feeder := clusterStateFeeder{
 		clusterState: clusterState,
 	}
-	feeder.InitFromHistoryProvider(&provider)
+	feeder.InitFromHistoryProvider(context.Background(), &provider)
 	if !assert.Contains(t, feeder.clusterState.Pods(), pod1) {
 		return
 	}
@@ -897,6 +897,62 @@ func TestClusterStateFeeder_InitFromHistoryProvider(t *testing.T) {
 		return
 	}
 	assert.Equal(t, memAmount, containerState.GetMaxMemoryPeak())
+}
+
+// TestClusterStateFeeder_InitFromHistoryProviderMemorySaveMode verifies that,
+// with memory saver mode enabled, InitFromHistoryProvider only loads pods
+// matched by a VPA instead of unconditionally loading the whole cluster
+// history (which otherwise causes very high memory usage on large clusters,
+// see https://github.com/kubernetes/autoscaler/issues/5687).
+func TestClusterStateFeeder_InitFromHistoryProviderMemorySaveMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	targetRef := &autoscalingv1.CrossVersionObjectReference{
+		Kind:       kind,
+		Name:       name1,
+		APIVersion: apiVersion,
+	}
+	vpa := test.VerticalPodAutoscaler().WithName("test-vpa").WithNamespace(namespace).
+		WithContainer("container").WithTargetRef(targetRef).Get()
+
+	vpaLister := &test.VerticalPodAutoscalerListerMock{}
+	vpaLister.On("List").Return([]*vpa_types.VerticalPodAutoscaler{vpa}, nil)
+
+	targetSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
+	targetSelectorFetcher.EXPECT().Fetch(vpa).Return(parseLabelSelector("app = test"), nil)
+
+	feeder := clusterStateFeeder{
+		vpaLister:       vpaLister,
+		clusterState:    model.NewClusterState(testGcPeriod),
+		selectorFetcher: targetSelectorFetcher,
+		memorySaveMode:  true,
+		recommenderName: DefaultRecommenderName,
+		controllerFetcher: &fakeControllerFetcher{
+			key: &controllerfetcher.ControllerKeyWithAPIVersion{
+				ControllerKey: controllerfetcher.ControllerKey{
+					Kind:      kind,
+					Name:      name1,
+					Namespace: namespace,
+				},
+				ApiVersion: apiVersion,
+			},
+		},
+	}
+
+	matchingPod := model.PodID{Namespace: namespace, PodName: "matching-pod"}
+	nonMatchingPod := model.PodID{Namespace: namespace, PodName: "non-matching-pod"}
+	provider := fakeHistoryProvider{
+		history: map[model.PodID]*history.PodHistory{
+			matchingPod:    {LastLabels: map[string]string{"app": "test"}, Samples: map[string][]model.ContainerUsageSample{}},
+			nonMatchingPod: {LastLabels: map[string]string{"app": "other"}, Samples: map[string][]model.ContainerUsageSample{}},
+		},
+	}
+
+	feeder.InitFromHistoryProvider(context.Background(), &provider)
+
+	assert.Contains(t, feeder.clusterState.Pods(), matchingPod)
+	assert.NotContains(t, feeder.clusterState.Pods(), nonMatchingPod)
 }
 
 func TestFilterVPAs(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -83,6 +83,13 @@ type clusterState struct {
 	// Map with all label sets used by the aggregations. It serves as a cache
 	// that allows to quickly access labels.Set corresponding to a labelSetKey.
 	labelSetMap labelSetMap
+	// labelSetRefCount tracks how many pods currently have a given labelSetKey
+	// as their own label set. It lets us cheaply detect, on every pod add/update/
+	// delete, when a label set has no more live pods using it, without scanning
+	// all pods. Used to garbage collect labelSetMap entries and to eagerly drop
+	// AggregateContainerStates that were orphaned by a label change before they
+	// ever collected any samples.
+	labelSetRefCount map[labelSetKey]int
 
 	lastAggregateContainerStateGC time.Time
 	gcInterval                    time.Duration
@@ -136,6 +143,7 @@ func NewClusterState(gcInterval time.Duration) *clusterState {
 		emptyVPAs:                     make(map[VpaID]time.Time),
 		aggregateStateMap:             make(aggregateContainerStatesMap),
 		labelSetMap:                   make(labelSetMap),
+		labelSetRefCount:              make(map[labelSetKey]int),
 		lastAggregateContainerStateGC: time.Unix(0, 0),
 		gcInterval:                    gcInterval,
 	}
@@ -161,12 +169,15 @@ func (cluster *clusterState) AddOrUpdatePod(podID PodID, newLabels labels.Set, p
 	}
 
 	newlabelSetKey := cluster.getLabelSetKey(newLabels)
-	if podExists && pod.labelSetKey != newlabelSetKey {
+	oldLabelSetKey := pod.labelSetKey
+	labelsChanged := podExists && oldLabelSetKey != newlabelSetKey
+	if labelsChanged {
 		// This Pod is already counted in the old VPA, remove the link.
 		cluster.removePodFromItsVpa(pod)
 	}
-	if !podExists || pod.labelSetKey != newlabelSetKey {
+	if !podExists || labelsChanged {
 		pod.labelSetKey = newlabelSetKey
+		cluster.labelSetRefCount[newlabelSetKey]++
 		// Set the links between the containers and aggregations based on the current pod labels.
 		for containerName, container := range pod.Containers {
 			containerID := ContainerID{PodID: podID, ContainerName: containerName}
@@ -174,8 +185,44 @@ func (cluster *clusterState) AddOrUpdatePod(podID PodID, newLabels labels.Set, p
 		}
 
 		cluster.addPodToItsVpa(pod)
+
+		if labelsChanged {
+			cluster.releaseLabelSetKey(podID.Namespace, pod.Containers, oldLabelSetKey)
+		}
 	}
 	pod.Phase = phase
+}
+
+// releaseLabelSetKey decrements the reference count of a labelSetKey that a pod
+// no longer uses, because it was relabeled or removed from the cluster.
+// If no other pod uses that label set anymore, any AggregateContainerState that
+// was orphaned by the change and never collected any samples is deleted right
+// away, instead of waiting for the next periodic garbage collection pass.
+// AggregateContainerStates that did collect samples are intentionally left in
+// place - they still hold valid historical usage data and are reclaimed by
+// RateLimitedGarbageCollectAggregateCollectionStates once that data expires.
+func (cluster *clusterState) releaseLabelSetKey(namespace string, containers map[string]*ContainerState, oldLabelSetKey labelSetKey) {
+	cluster.labelSetRefCount[oldLabelSetKey]--
+	if cluster.labelSetRefCount[oldLabelSetKey] > 0 {
+		return
+	}
+	delete(cluster.labelSetRefCount, oldLabelSetKey)
+	for containerName := range containers {
+		oldKey := aggregateStateKey{
+			namespace:     namespace,
+			containerName: containerName,
+			labelSetKey:   oldLabelSetKey,
+			labelSetMap:   &cluster.labelSetMap,
+		}
+		state, exists := cluster.aggregateStateMap[oldKey]
+		if !exists || !state.isEmpty() {
+			continue
+		}
+		delete(cluster.aggregateStateMap, oldKey)
+		for _, vpa := range cluster.vpas {
+			vpa.DeleteAggregation(oldKey)
+		}
+	}
 }
 
 // SetInitContainers sets the names of init containers that belong to the pod.
@@ -227,6 +274,7 @@ func (cluster *clusterState) DeletePod(podID PodID) {
 	pod, found := cluster.pods[podID]
 	if found {
 		cluster.removePodFromItsVpa(pod)
+		cluster.releaseLabelSetKey(podID.Namespace, pod.Containers, pod.labelSetKey)
 	}
 	delete(cluster.pods, podID)
 }
@@ -443,6 +491,32 @@ func (cluster *clusterState) garbageCollectAggregateCollectionStates(ctx context
 		delete(cluster.aggregateStateMap, key)
 		for _, vpa := range cluster.vpas {
 			vpa.DeleteAggregation(key)
+		}
+	}
+	cluster.garbageCollectLabelSetMap()
+}
+
+// garbageCollectLabelSetMap removes labelSetMap entries that are no longer
+// referenced by any pod's current label set nor by any remaining entry in
+// aggregateStateMap. Without this, labelSetMap grows without bound over the
+// lifetime of the recommender process, since every distinct label set ever
+// observed (e.g. via --metric-for-pod-labels or rolling deployments changing
+// pod-template-hash) is cached there and previously never removed.
+func (cluster *clusterState) garbageCollectLabelSetMap() {
+	usedKeys := make(map[labelSetKey]bool, len(cluster.labelSetRefCount))
+	for key, count := range cluster.labelSetRefCount {
+		if count > 0 {
+			usedKeys[key] = true
+		}
+	}
+	for key := range cluster.aggregateStateMap {
+		if aggKey, ok := key.(aggregateStateKey); ok {
+			usedKeys[aggKey.labelSetKey] = true
+		}
+	}
+	for key := range cluster.labelSetMap {
+		if !usedKeys[key] {
+			delete(cluster.labelSetMap, key)
 		}
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -528,7 +528,7 @@ func TestNoUnboundedGrowthOnRepeatedRelabeling(t *testing.T) {
 	addTestContainer(t, cluster)
 
 	const relabelCount = 5000
-	for i := 0; i < relabelCount; i++ {
+	for i := range relabelCount {
 		churningLabels := labels.Set{"pod-template-hash": fmt.Sprintf("rev-%d", i)}
 		cluster.AddOrUpdatePod(testPodID, churningLabels, corev1.PodRunning)
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -431,6 +431,122 @@ func TestChangePodLabels(t *testing.T) {
 	assert.NotContains(t, vpa.aggregateContainerStates, aggregateStateKey)
 }
 
+// Verifies that when a pod's labels change and the old AggregateContainerState
+// never collected any samples and no other pod shares the old label set, the
+// orphaned state is garbage collected immediately - instead of lingering in
+// cluster.aggregateStateMap and vpa.aggregateContainerStates until the next
+// periodic (up to 8-day) sweep. See kubernetes/autoscaler#5687.
+func TestChangePodLabelsGarbageCollectsEmptyOrphanedAggregation(t *testing.T) {
+	cluster := NewClusterState(testGcPeriod)
+	vpa := addTestVpa(cluster)
+	addTestPod(cluster)
+	addTestContainer(t, cluster) // No usage samples recorded.
+
+	oldKey := cluster.aggregateStateKeyForContainerID(testContainerID)
+	assert.Contains(t, cluster.aggregateStateMap, oldKey)
+	assert.Contains(t, vpa.aggregateContainerStates, oldKey)
+
+	// Relabel the pod. It was the only pod using the old label set.
+	cluster.AddOrUpdatePod(testPodID, emptyLabels, corev1.PodRunning)
+
+	assert.NotContains(t, cluster.aggregateStateMap, oldKey)
+	assert.NotContains(t, vpa.aggregateContainerStates, oldKey)
+}
+
+// Verifies that relabeling a pod does not discard real historical usage data:
+// an orphaned AggregateContainerState that already collected samples is kept
+// alive (to be reclaimed later by the normal expiry-based GC), rather than
+// being dropped immediately like the empty case above.
+func TestChangePodLabelsKeepsNonEmptyOrphanedAggregation(t *testing.T) {
+	cluster := NewClusterState(testGcPeriod)
+	vpa := addTestVpa(cluster)
+	addTestPod(cluster)
+	assert.NoError(t, cluster.AddOrUpdateContainer(testContainerID, testRequest))
+	assert.NoError(t, cluster.AddSample(makeTestUsageSample()))
+
+	oldKey := cluster.aggregateStateKeyForContainerID(testContainerID)
+	assert.Contains(t, cluster.aggregateStateMap, oldKey)
+
+	// Relabel the pod. It was the only pod using the old label set.
+	cluster.AddOrUpdatePod(testPodID, emptyLabels, corev1.PodRunning)
+
+	// Historical data is preserved, still linked to the VPA, until the
+	// periodic GC reclaims it once it expires.
+	assert.Contains(t, cluster.aggregateStateMap, oldKey)
+	assert.Contains(t, vpa.aggregateContainerStates, oldKey)
+}
+
+// Verifies that labelSetMap entries no longer referenced by any live pod or
+// AggregateContainerState are garbage collected, instead of growing without
+// bound for the lifetime of the recommender process. See
+// kubernetes/autoscaler#5687.
+func TestGarbageCollectLabelSetMap(t *testing.T) {
+	ctx := context.Background()
+	cluster := NewClusterState(testGcPeriod)
+
+	podID1 := PodID{"namespace-1", "pod-1"}
+	podID2 := PodID{"namespace-1", "pod-2"}
+	containerID1 := ContainerID{podID1, "container-1"}
+	containerID2 := ContainerID{podID2, "container-1"}
+
+	cluster.AddOrUpdatePod(podID1, testLabels, corev1.PodRunning)
+	cluster.AddOrUpdatePod(podID2, emptyLabels, corev1.PodRunning)
+	assert.NoError(t, cluster.AddOrUpdateContainer(containerID1, testRequest))
+	assert.NoError(t, cluster.AddOrUpdateContainer(containerID2, testRequest))
+	assert.NoError(t, cluster.AddSample(&ContainerUsageSampleWithKey{
+		ContainerUsageSample: ContainerUsageSample{MeasureStart: testTimestamp, Usage: 1.0, Resource: ResourceCPU},
+		Container:            containerID1,
+	}))
+
+	assert.Len(t, cluster.labelSetMap, 2)
+
+	// Remove pod-2; its (empty) label set becomes unreferenced.
+	cluster.DeletePod(podID2)
+
+	// A GC pass should purge the now-unreferenced label set for pod-2, while
+	// keeping pod-1's label set since its aggregation still holds live data.
+	cluster.garbageCollectAggregateCollectionStates(ctx, testTimestamp.Add(time.Minute), testControllerFetcher)
+
+	assert.Len(t, cluster.labelSetMap, 1)
+	for key := range cluster.labelSetMap {
+		assert.Equal(t, labelSetKey(labels.Set(testLabels).String()), key)
+	}
+}
+
+// TestNoUnboundedGrowthOnRepeatedRelabeling reproduces the scenario reported in
+// kubernetes/autoscaler#5687: a pod whose labels keep changing (e.g. because
+// --metric-for-pod-labels re-derives labels on every history reload, or a
+// pod-template-hash-style label churns on every rolling deploy). Without the
+// fix, cluster.aggregateStateMap and cluster.labelSetMap would grow by one
+// entry per relabel, for as long as the recommender process runs. With the
+// fix, orphaned empty aggregations are dropped immediately (no GC needed) and
+// stale label sets are reclaimed on the next GC pass.
+func TestNoUnboundedGrowthOnRepeatedRelabeling(t *testing.T) {
+	ctx := context.Background()
+	cluster := NewClusterState(testGcPeriod)
+	addTestPod(cluster)
+	addTestContainer(t, cluster)
+
+	const relabelCount = 5000
+	for i := 0; i < relabelCount; i++ {
+		churningLabels := labels.Set{"pod-template-hash": fmt.Sprintf("rev-%d", i)}
+		cluster.AddOrUpdatePod(testPodID, churningLabels, corev1.PodRunning)
+	}
+
+	// Even without ever running GC, orphaned empty aggregations must not pile
+	// up: only the current label set's aggregation should remain.
+	assert.Len(t, cluster.aggregateStateMap, 1,
+		"aggregateStateMap grew unbounded across %d relabels instead of being cleaned up eagerly", relabelCount)
+
+	// labelSetMap cleanup is deferred to the periodic GC pass (it's cheap to
+	// batch), so before GC it may still hold stale entries...
+	cluster.garbageCollectAggregateCollectionStates(ctx, testTimestamp, testControllerFetcher)
+
+	// ...but after one GC pass only the currently-used label set must remain.
+	assert.Len(t, cluster.labelSetMap, 1,
+		"labelSetMap grew unbounded across %d relabels instead of being garbage collected", relabelCount)
+}
+
 // Creates a VPA and verifies that annotation updates work properly.
 func TestUpdateAnnotations(t *testing.T) {
 	cluster := NewClusterState(testGcPeriod)

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
@@ -221,7 +221,7 @@ func initHistoryProvider(ctx context.Context, rec Recommender, config *recommend
 		if err != nil {
 			return err
 		}
-		rec.GetClusterStateFeeder().InitFromHistoryProvider(provider)
+		rec.GetClusterStateFeeder().InitFromHistoryProvider(ctx, provider)
 	}
 	return nil
 }


### PR DESCRIPTION
# Warning! It's AI assisted PR

## Summary
- Honor `--memory-saver` in `InitFromHistoryProvider`: previously the full cluster history (all pods, all label sets) was loaded from Prometheus on startup regardless of memory saver mode, defeating its purpose.
- Garbage collect `clusterState.labelSetMap`, which previously grew without bound for the lifetime of the recommender process since entries were never removed.
- Eagerly drop `AggregateContainerState`s orphaned by a pod label change once no pod references them and they never collected samples, instead of waiting for the next (up to 8-day) periodic GC pass. Aggregations that already hold real usage data are left untouched until they expire normally.

Fixes #5687

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/recommender/...`
- [x] Added regression tests covering memory-saver filtering in `InitFromHistoryProvider`, eager cleanup of orphaned empty aggregations, retention of non-empty orphaned aggregations, and `labelSetMap` GC
- [x] Reproduced the unbounded growth against the pre-fix code with a relabel-churn stress test, then confirmed the same test passes bounded after the fix
