### PR TITLE
Add support for apiserver_resource_objects metric

### DIFF
--- a/addon-resizer/nanny/kubernetes_client.go
+++ b/addon-resizer/nanny/kubernetes_client.go
@@ -24,6 +24,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -34,17 +35,23 @@ import (
 )
 
 const (
-	// objectCountMetricName is the preferred metric to be used to get number of nodes (present in Kubernetes 1.21 and higher)
+	// resourceObjectsMetricName is the metric with the number of pods and nodes (Kubernetes >=1.34 and higher, with group and resource labels)
+	resourceObjectsMetricName = "apiserver_resource_objects"
+
+	// objectCountMetricName is the metric with the number of pods and nodes (Kubernetes 1.21-1.36, with resource label)
 	objectCountMetricName = "apiserver_storage_objects"
-	// objectCountFallbackMetricName is the metric to be used to get number of nodes if objectCountMetricName metric is missing
+
+	// objectCountFallbackMetricName is the metric with the number of pods and nodes (Kubernetes <1.21)
 	objectCountFallbackMetricName = "etcd_object_counts"
-	// nodeResourceName is the label value for Nodes in objectCountFallbackMetricName and objectCountMetricName metrics.
-	nodeResourceName = "nodes"
-	// podResourceName is the label value for Pods in objectCountFallbackMetricName and objectCountMetricName metrics.
-	podResourceName = "pods"
-	// resourceLabel is the label name for resource.
-	resourceLabel               = "resource"
-	fmtText       expfmt.Format = `text/plain; version=` + expfmt.TextVersion + `; charset=utf-8`
+
+	fmtText expfmt.Format = `text/plain; version=` + expfmt.TextVersion + `; charset=utf-8`
+)
+
+var (
+	// nodeResourceLabels are the label values for nodes, that must match if present in the metric.
+	nodeResourceLabels = map[string]string{"group": "", "resource": "nodes"}
+	// podResourceLabels are the label values for pods, that must match if present in the metric.
+	podResourceLabels = map[string]string{"group": "", "resource": "pods"}
 )
 
 type kubernetesClient struct {
@@ -61,7 +68,7 @@ type kubernetesClient struct {
 // 2) using etcd_object_count metric exposed by kube-apiserver
 func (k *kubernetesClient) CountNodes() (uint64, error) {
 	if k.useMetrics {
-		return k.countResourcesThroughMetrics(nodeResourceName)
+		return k.countResourcesThroughMetrics(nodeResourceLabels)
 	}
 	return k.countNodesThroughAPI()
 }
@@ -71,7 +78,7 @@ func (k *kubernetesClient) CountNodes() (uint64, error) {
 // 2) using etcd_object_count metric exposed by kube-apiserver
 func (k *kubernetesClient) CountContainers() (uint64, error) {
 	if k.useMetrics {
-		return k.countResourcesThroughMetrics(podResourceName)
+		return k.countResourcesThroughMetrics(podResourceLabels)
 	}
 	return k.countContainersThroughAPI()
 }
@@ -113,16 +120,20 @@ func hasEqualValues(a string, b *string) bool {
 	return b != nil && a == *b
 }
 
-func extractMetricValueForResourceCount(mf dto.MetricFamily, resourceName, metricName string) (uint64, error) {
+func extractMetricValueForResourceCount(mf *dto.MetricFamily, matchLabels map[string]string, metricName string) (uint64, error) {
 	for _, metric := range mf.Metric {
-		hasLabel := false
+		matchesExpectedLabel := false
+		mismatchesExpectedLabel := false
 		for _, label := range metric.Label {
-			if hasEqualValues(resourceLabel, label.Name) && hasEqualValues(resourceName, label.Value) {
-				hasLabel = true
-				break
+			if expectValue, ok := matchLabels[label.GetName()]; ok {
+				if label.GetValue() == expectValue {
+					matchesExpectedLabel = true
+				} else {
+					mismatchesExpectedLabel = true
+				}
 			}
 		}
-		if !hasLabel {
+		if !matchesExpectedLabel || mismatchesExpectedLabel {
 			continue
 		}
 		if metric.Gauge == nil || metric.Gauge.Value == nil {
@@ -138,49 +149,56 @@ func extractMetricValueForResourceCount(mf dto.MetricFamily, resourceName, metri
 	return 0, fmt.Errorf("%s: no valid metric values", metricName)
 }
 
-func getResourceCountFromDecoder(resourceName string, decoder expfmt.Decoder) (uint64, error) {
-	var mf dto.MetricFamily
-	var preferredMetricValue, fallbackMetricValue uint64
-	var preferredMetricError, fallbackMetricError error
-	gotPrefferedMetric, gotFallbackMetric := false, false
+func getResourceCountFromDecoder(matchLabels map[string]string, decoder expfmt.Decoder) (uint64, error) {
+	var resourceObjectsMetricValue, deprecatedMetricValue, fallbackMetricValue uint64
+	var resourceObjectsMetricError, deprecatedMetricError, fallbackMetricError error
+	gotResourceObjectsMetric, gotDeprecatedMetric, gotFallbackMetric := false, false, false
 
 	for {
+		var mf dto.MetricFamily
 		if err := decoder.Decode(&mf); err != nil {
 			if err == io.EOF {
 				break
 			}
 			return 0, fmt.Errorf("decoding error: %v", err)
 		}
+		if hasEqualValues(resourceObjectsMetricName, mf.Name) {
+			resourceObjectsMetricValue, resourceObjectsMetricError = extractMetricValueForResourceCount(&mf, matchLabels, mf.GetName())
+			gotResourceObjectsMetric = true
+		}
 		if hasEqualValues(objectCountMetricName, mf.Name) {
-			preferredMetricValue, preferredMetricError = extractMetricValueForResourceCount(mf, resourceName, *mf.Name)
-			gotPrefferedMetric = true
+			deprecatedMetricValue, deprecatedMetricError = extractMetricValueForResourceCount(&mf, matchLabels, mf.GetName())
+			gotDeprecatedMetric = true
 		}
 		if hasEqualValues(objectCountFallbackMetricName, mf.Name) {
-			fallbackMetricValue, fallbackMetricError = extractMetricValueForResourceCount(mf, resourceName, *mf.Name)
+			fallbackMetricValue, fallbackMetricError = extractMetricValueForResourceCount(&mf, matchLabels, mf.GetName())
 			gotFallbackMetric = true
 		}
 	}
 
-	if gotPrefferedMetric && preferredMetricError == nil {
-		return preferredMetricValue, nil
+	if gotResourceObjectsMetric && resourceObjectsMetricError == nil {
+		return resourceObjectsMetricValue, nil
+	}
+	if gotDeprecatedMetric && deprecatedMetricError == nil {
+		return deprecatedMetricValue, nil
 	}
 	if gotFallbackMetric && fallbackMetricError == nil {
 		return fallbackMetricValue, nil
 	}
-	if gotFallbackMetric || gotPrefferedMetric {
-		return 0, fmt.Errorf("at least one metric present but all present metrics have errors: %v, %v", preferredMetricError, fallbackMetricError)
+	if gotFallbackMetric || gotDeprecatedMetric || gotResourceObjectsMetric {
+		return 0, fmt.Errorf("at least one metric present but all present metrics have errors: %v, %v, %v", resourceObjectsMetricError, deprecatedMetricError, fallbackMetricError)
 	}
 	return 0, fmt.Errorf("no metric set")
 }
 
-func (k *kubernetesClient) countResourcesThroughMetrics(resourceName string) (uint64, error) {
+func (k *kubernetesClient) countResourcesThroughMetrics(matchLabels map[string]string) (uint64, error) {
 	// Similarly as for listing resources, permissions for /metrics endpoint are needed.
 	// Other than that, endpoint is visible from everywhere.
 	reader, err := k.clientset.CoreV1().RESTClient().Get().RequestURI("/metrics").Stream(context.Background())
 	if err != nil {
 		return 0, err
 	}
-	return getResourceCountFromDecoder(resourceName, expfmt.NewDecoder(reader, fmtText))
+	return getResourceCountFromDecoder(matchLabels, expfmt.NewDecoder(reader, fmtText))
 }
 
 func (k *kubernetesClient) ContainerResources() (*corev1.ResourceRequirements, error) {

--- a/addon-resizer/nanny/kubernetes_client_test.go
+++ b/addon-resizer/nanny/kubernetes_client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	dto "github.com/prometheus/client_model/go"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -139,21 +140,21 @@ func getMetric(labelName, labelValue string, value float64) *dto.Metric {
 
 func TestExtractMetricValueForResourceCount(t *testing.T) {
 	testCases := []struct {
-		name         string
-		mf           dto.MetricFamily
-		resourceName string
-		expectCount  uint64
-		expectErr    error
+		name           string
+		mf             dto.MetricFamily
+		resourceLabels map[string]string
+		expectCount    uint64
+		expectErr      error
 	}{
 		{
-			name:         "(nodes) empty",
-			resourceName: nodeResourceName,
-			mf:           dto.MetricFamily{},
-			expectErr:    fmt.Errorf("metric name: no valid metric values"),
+			name:           "(nodes) empty",
+			resourceLabels: nodeResourceLabels,
+			mf:             dto.MetricFamily{},
+			expectErr:      fmt.Errorf("metric name: no valid metric values"),
 		},
 		{
-			name:         "(nodes) with proper value",
-			resourceName: nodeResourceName,
+			name:           "(nodes) with proper value",
+			resourceLabels: nodeResourceLabels,
 			mf: dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "nodes", 4.0),
@@ -162,8 +163,8 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 			expectCount: 4,
 		},
 		{
-			name:         "(nodes) only wrong label",
-			resourceName: nodeResourceName,
+			name:           "(nodes) only wrong label",
+			resourceLabels: nodeResourceLabels,
 			mf: dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("wrong", "nodes", 4.0),
@@ -172,8 +173,8 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 			expectErr: fmt.Errorf("metric name: no valid metric values"),
 		},
 		{
-			name:         "(nodes) only wrong label value",
-			resourceName: nodeResourceName,
+			name:           "(nodes) only wrong label value",
+			resourceLabels: nodeResourceLabels,
 			mf: dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "services", 4.0),
@@ -182,8 +183,8 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 			expectErr: fmt.Errorf("metric name: no valid metric values"),
 		},
 		{
-			name:         "(nodes) with negative value",
-			resourceName: nodeResourceName,
+			name:           "(nodes) with negative value",
+			resourceLabels: nodeResourceLabels,
 			mf: dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "nodes", -4.0),
@@ -192,14 +193,14 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 			expectErr: fmt.Errorf("metric name: metric unknown"),
 		},
 		{
-			name:         "(pods) empty",
-			resourceName: podResourceName,
-			mf:           dto.MetricFamily{},
-			expectErr:    fmt.Errorf("metric name: no valid metric values"),
+			name:           "(pods) empty",
+			resourceLabels: podResourceLabels,
+			mf:             dto.MetricFamily{},
+			expectErr:      fmt.Errorf("metric name: no valid metric values"),
 		},
 		{
-			name:         "(pods) with proper value",
-			resourceName: podResourceName,
+			name:           "(pods) with proper value",
+			resourceLabels: podResourceLabels,
 			mf: dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "pods", 6.0),
@@ -208,8 +209,8 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 			expectCount: 6,
 		},
 		{
-			name:         "(pods) only wrong label",
-			resourceName: podResourceName,
+			name:           "(pods) only wrong label",
+			resourceLabels: podResourceLabels,
 			mf: dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("wrong", "pods", 4.0),
@@ -218,8 +219,8 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 			expectErr: fmt.Errorf("metric name: no valid metric values"),
 		},
 		{
-			name:         "(pods) only wrong label value",
-			resourceName: podResourceName,
+			name:           "(pods) only wrong label value",
+			resourceLabels: podResourceLabels,
 			mf: dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "services", 4.0),
@@ -228,8 +229,8 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 			expectErr: fmt.Errorf("metric name: no valid metric values"),
 		},
 		{
-			name:         "(pods) with negative value",
-			resourceName: podResourceName,
+			name:           "(pods) with negative value",
+			resourceLabels: podResourceLabels,
 			mf: dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "pods", -4.0),
@@ -240,7 +241,7 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotCount, gotErr := extractMetricValueForResourceCount(tc.mf, tc.resourceName, "metric name")
+			gotCount, gotErr := extractMetricValueForResourceCount(&tc.mf, tc.resourceLabels, "metric name")
 			expectErrorOrCount(t, tc.expectErr, tc.expectCount, gotErr, gotCount)
 		})
 	}
@@ -264,12 +265,12 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 	preferredMetric := objectCountMetricName
 	fallbackMetric := objectCountFallbackMetricName
 	testCases := []struct {
-		name         string
-		metricValues []dto.MetricFamily
-		resourceName string
-		finalResult  error
-		expectValue  uint64
-		expectErr    error
+		name           string
+		metricValues   []dto.MetricFamily
+		resourceLabels map[string]string
+		finalResult    error
+		expectValue    uint64
+		expectErr      error
 	}{
 		{
 			name:        "empty",
@@ -277,9 +278,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectErr:   fmt.Errorf("no metric set"),
 		},
 		{
-			name:         "(nodes) with preferred metric",
-			finalResult:  io.EOF,
-			resourceName: nodeResourceName,
+			name:           "(nodes) with preferred metric",
+			finalResult:    io.EOF,
+			resourceLabels: nodeResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &preferredMetric,
@@ -291,9 +292,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectValue: 4,
 		},
 		{
-			name:         "(nodes) with fallback metric",
-			finalResult:  io.EOF,
-			resourceName: nodeResourceName,
+			name:           "(nodes) with fallback metric",
+			finalResult:    io.EOF,
+			resourceLabels: nodeResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
@@ -305,9 +306,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectValue: 4,
 		},
 		{
-			name:         "(nodes) with preferred and fallback metrics",
-			finalResult:  io.EOF,
-			resourceName: nodeResourceName,
+			name:           "(nodes) with preferred and fallback metrics",
+			finalResult:    io.EOF,
+			resourceLabels: nodeResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
@@ -330,9 +331,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectErr:   fmt.Errorf("decoding error: oops"),
 		},
 		{
-			name:         "(nodes) falls back on error in preferred metric",
-			finalResult:  io.EOF,
-			resourceName: nodeResourceName,
+			name:           "(nodes) falls back on error in preferred metric",
+			finalResult:    io.EOF,
+			resourceLabels: nodeResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
@@ -350,9 +351,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectValue: 4,
 		},
 		{
-			name:         "(nodes) reports error on both metrics",
-			finalResult:  io.EOF,
-			resourceName: nodeResourceName,
+			name:           "(nodes) reports error on both metrics",
+			finalResult:    io.EOF,
+			resourceLabels: nodeResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
@@ -367,12 +368,12 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 					},
 				},
 			},
-			expectErr: fmt.Errorf("at least one metric present but all present metrics have errors: apiserver_storage_objects: no valid metric values, etcd_object_counts: no valid metric values"),
+			expectErr: fmt.Errorf("at least one metric present but all present metrics have errors: <nil>, apiserver_storage_objects: no valid metric values, etcd_object_counts: no valid metric values"),
 		},
 		{
-			name:         "(nodes) multiple metrics in preferred metric family",
-			finalResult:  io.EOF,
-			resourceName: nodeResourceName,
+			name:           "(nodes) multiple metrics in preferred metric family",
+			finalResult:    io.EOF,
+			resourceLabels: nodeResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &preferredMetric,
@@ -390,9 +391,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectValue: 5.0,
 		},
 		{
-			name:         "(pods) with preferred metric",
-			finalResult:  io.EOF,
-			resourceName: podResourceName,
+			name:           "(pods) with preferred metric",
+			finalResult:    io.EOF,
+			resourceLabels: podResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &preferredMetric,
@@ -404,9 +405,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectValue: 10,
 		},
 		{
-			name:         "(pods) with fallback metric",
-			finalResult:  io.EOF,
-			resourceName: podResourceName,
+			name:           "(pods) with fallback metric",
+			finalResult:    io.EOF,
+			resourceLabels: podResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
@@ -418,9 +419,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectValue: 10,
 		},
 		{
-			name:         "(pods) with preferred and fallback metrics",
-			finalResult:  io.EOF,
-			resourceName: podResourceName,
+			name:           "(pods) with preferred and fallback metrics",
+			finalResult:    io.EOF,
+			resourceLabels: podResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
@@ -438,9 +439,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectValue: 15,
 		},
 		{
-			name:         "(pods) falls back on error in preferred metric",
-			finalResult:  io.EOF,
-			resourceName: podResourceName,
+			name:           "(pods) falls back on error in preferred metric",
+			finalResult:    io.EOF,
+			resourceLabels: podResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
@@ -458,9 +459,9 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			expectValue: 10,
 		},
 		{
-			name:         "(pods) reports error on both metrics",
-			finalResult:  io.EOF,
-			resourceName: podResourceName,
+			name:           "(pods) reports error on both metrics",
+			finalResult:    io.EOF,
+			resourceLabels: podResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
@@ -475,12 +476,12 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 					},
 				},
 			},
-			expectErr: fmt.Errorf("at least one metric present but all present metrics have errors: apiserver_storage_objects: no valid metric values, etcd_object_counts: no valid metric values"),
+			expectErr: fmt.Errorf("at least one metric present but all present metrics have errors: <nil>, apiserver_storage_objects: no valid metric values, etcd_object_counts: no valid metric values"),
 		},
 		{
-			name:         "(pods) multiple metrics in preferred metric family",
-			finalResult:  io.EOF,
-			resourceName: podResourceName,
+			name:           "(pods) multiple metrics in preferred metric family",
+			finalResult:    io.EOF,
+			resourceLabels: podResourceLabels,
 			metricValues: []dto.MetricFamily{
 				{
 					Name: &preferredMetric,
@@ -504,59 +505,89 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 				metricValues: tc.metricValues,
 				finalResult:  tc.finalResult,
 			}
-			gotCount, gotErr := getResourceCountFromDecoder(tc.resourceName, &fd)
+			gotCount, gotErr := getResourceCountFromDecoder(tc.resourceLabels, &fd)
 			expectErrorOrCount(t, tc.expectErr, tc.expectValue, gotErr, gotCount)
 		})
 	}
 }
 
 func TestGetResourceCountFromDecoder_MultpleLabels(t *testing.T) {
-	preferredMetric := objectCountMetricName
+	preferredMetric := resourceObjectsMetricName
 	value := 3.0
 	testCases := []struct {
-		name         string
-		labelName1   string
-		labelValue1  string
-		labelName2   string
-		labelValue2  string
-		resourceName string
+		name           string
+		metricLabels   map[string]string
+		resourceLabels map[string]string
+		expectCount    uint64
+		expectErr      error
 	}{
 		{
-			name:         "(nodes) get metric count with multiple labels",
-			labelName1:   resourceLabel,
-			labelValue1:  nodeResourceName,
-			labelName2:   "flavor",
-			labelValue2:  "up",
-			resourceName: nodeResourceName,
+			name:           "(nodes) get metric count with multiple labels",
+			metricLabels:   map[string]string{"resource": "nodes", "flavor": "up"},
+			resourceLabels: nodeResourceLabels,
+			expectCount:    3,
 		},
 		{
-			name:         "(pods) get metric count with multiple labels",
-			labelName1:   resourceLabel,
-			labelValue1:  podResourceName,
-			labelName2:   "flavor",
-			labelValue2:  "up",
-			resourceName: podResourceName,
+			name:           "(nodes) get metric count with missing group label",
+			metricLabels:   map[string]string{"resource": "nodes"},
+			resourceLabels: nodeResourceLabels,
+			expectCount:    3,
+		},
+		{
+			name:           "(nodes) get metric count with matching group label",
+			metricLabels:   map[string]string{"resource": "nodes", "group": ""},
+			resourceLabels: nodeResourceLabels,
+			expectCount:    3,
+		},
+		{
+			name:           "(nodes) get metric count with mismatched group label",
+			metricLabels:   map[string]string{"resource": "nodes", "group": "foo"},
+			resourceLabels: nodeResourceLabels,
+			expectCount:    0,
+			expectErr:      fmt.Errorf("at least one metric present but all present metrics have errors: apiserver_resource_objects: no valid metric values, <nil>, <nil>"),
+		},
+		{
+			name:           "(pods) get metric count with multiple labels",
+			metricLabels:   map[string]string{"resource": "pods", "flavor": "up"},
+			resourceLabels: podResourceLabels,
+			expectCount:    3,
+		},
+		{
+			name:           "(pods) get metric count with missing group label",
+			metricLabels:   map[string]string{"resource": "pods"},
+			resourceLabels: podResourceLabels,
+			expectCount:    3,
+		},
+		{
+			name:           "(pods) get metric count with matching group label",
+			metricLabels:   map[string]string{"resource": "pods", "group": ""},
+			resourceLabels: podResourceLabels,
+			expectCount:    3,
+		},
+		{
+			name:           "(pods) get metric count with mismatched group label",
+			metricLabels:   map[string]string{"resource": "pods", "group": "foo"},
+			resourceLabels: podResourceLabels,
+			expectCount:    0,
+			expectErr:      fmt.Errorf("at least one metric present but all present metrics have errors: apiserver_resource_objects: no valid metric values, <nil>, <nil>"),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+
+			metricLabelPairs := []*dto.LabelPair{}
+			for k, v := range tc.metricLabels {
+				metricLabelPairs = append(metricLabelPairs, &dto.LabelPair{Name: &k, Value: &v})
+			}
+
 			fd := fakeDecoder{
 				metricValues: []dto.MetricFamily{
 					{
 						Name: &preferredMetric,
 						Metric: []*dto.Metric{
 							{
-								Label: []*dto.LabelPair{
-									{
-										Name:  &tc.labelName1,
-										Value: &tc.labelValue1,
-									},
-									{
-										Name:  &tc.labelName2,
-										Value: &tc.labelValue2,
-									},
-								},
+								Label: metricLabelPairs,
 								Gauge: &dto.Gauge{
 									Value: &value,
 								},
@@ -566,8 +597,9 @@ func TestGetResourceCountFromDecoder_MultpleLabels(t *testing.T) {
 				},
 				finalResult: io.EOF,
 			}
-			gotCount, gotErr := getResourceCountFromDecoder(tc.resourceName, &fd)
-			expectErrorOrCount(t, nil, 3.0, gotErr, gotCount)
+			gotCount, gotErr := getResourceCountFromDecoder(tc.resourceLabels, &fd)
+			t.Log(gotCount, gotErr)
+			expectErrorOrCount(t, tc.expectErr, tc.expectCount, gotErr, gotCount)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature
/kind deprecation

#### What this PR does / why we need it:

Adds support for the `apiserver_resource_objects` metric, which is present in Kubernetes 1.34+ and replaces the deprecated `apiserver_storage_objects` metric which is no longer served in Kubernetes 1.37+.

xref https://github.com/kubernetes/kubernetes/pull/132965

#### Which issue(s) this PR fixes:

Fixes the addon-resizer nanny failing with "no metric set" errors in Kubernetes 1.37+

#### Does this PR introduce a user-facing change?
```release-note
Adds support for the `apiserver_resource_objects` metric, which is present in Kubernetes 1.34+ and replaces the deprecated `apiserver_storage_objects` metric which is no longer served in Kubernetes 1.37+.
```

cc @serathius @richabanker 