### PR TITLE
Create a proposal for ephemeral capacity buffers

### DIFF
--- a/cluster-autoscaler/proposals/ephemeral-buffers.md
+++ b/cluster-autoscaler/proposals/ephemeral-buffers.md
@@ -1,0 +1,321 @@
+# Ephemeral CapacityBuffers (workload-filled, one-shot)
+
+#### Author: jicowan
+
+A follow-up to the [CapacityBuffer API proposal](./buffers.md) (#8151). It defines a shared
+`buffer.x-k8s.io/ephemeral-capacity` provisioning-strategy contract; a reference implementation
+exists in Karpenter.
+
+# Timeline
+
+## Alpha
+
+- [ ] Agree on the `buffer.x-k8s.io/ephemeral-capacity` strategy semantics (this proposal)
+- [ ] Reference implementation in a buffer-consuming autoscaler (Karpenter — implementation ready)
+- [ ] Document the workload-fill + latch contract for other consumers (CA, GKE CCC)
+
+## Beta / V1 graduation criteria
+
+- [ ] Second OSS implementation of the strategy (e.g. cluster-autoscaler)
+- [ ] E2e coverage of the fill → latch → no-refill lifecycle
+- [ ] In use for at least one full version behind the CapacityBuffer feature gate
+
+# Summary
+
+The `CapacityBuffer` API (autoscaling.x-k8s.io) today defines *steady-state* spare capacity: the
+`active-capacity` provisioning strategy continuously maintains a buffer and refills it as workloads
+consume it. This proposal adds a second, **one-shot** provisioning strategy,
+`buffer.x-k8s.io/ephemeral-capacity`, for **gang / batch workloads**: the buffer pre-provisions a
+fixed amount of capacity, is *filled* by a matching workload as its pods are scheduled, and once
+filled transitions to a terminal state and **stops provisioning** — it does not refill.
+
+This is the follow-up already anticipated in the CapacityBuffer proposal
+([`buffers.md`](./buffers.md)), which lists under "Out of scope, may be added as follow up
+proposals":
+
+> *"Buffer dedicated for workload: mark the buffer as dedicated for pods defined by PodSelector. It
+> would count the pods matching the selector as filling in the buffer space. Example usecase: I
+> want to keep buffer for scaling, but I know the usual maximum needed for my workload."*
+
+This proposal specifies that "filled-by-workload" behavior and adds the one-shot / completion
+semantics needed for batch. It builds on — rather than competes with — the in-review **capped
+capacity buffers** proposal: ephemeral reuses capped's fill-by-selector accounting but adds a
+*terminal* latch that capped deliberately omits. The two are complementary operating points
+(repeating capped keeps capacity warm for a stream of jobs; one-shot ephemeral stops paying between
+runs) — users pick per workload. See [Alternatives](#use-capped-capacity-buffers-instead).
+
+# Motivation
+
+The `active-capacity` strategy is the right shape for "keep N spare CPUs warm at all times." It is
+the wrong shape for **gang-scheduled batch jobs** (ML training, HPC, CI/CD run-to-completion),
+where the user wants to pre-provision capacity for *a specific run* so the job schedules promptly,
+and then have provisioning **stop** once the job is placed — not a standing buffer that refills
+after the job completes and keeps incurring cost.
+
+With `active-capacity` there is no terminal state: a buffer sized for a gang job refills after the
+gang finishes and provisions capacity indefinitely for a job that already ran. There is no way to
+express "provision X once, for this workload, then stop."
+
+The community has repeatedly asked for batch/Kueue-oriented capacity provisioning
+([kubernetes-sigs/karpenter#2571](https://github.com/kubernetes-sigs/karpenter/issues/2571),
+[#742](https://github.com/kubernetes-sigs/karpenter/issues/742),
+[#3138](https://github.com/kubernetes-sigs/karpenter/issues/3138)), and Kueue's cold-start problem
+(admit → pods pend → autoscaler reacts → nodes appear late) is the canonical case. Kueue drives
+Cluster Autoscaler's `ProvisioningRequest` for exactly this, but that API is not universally
+implemented across autoscalers; expressing the same intent as a CapacityBuffer *strategy* makes it
+available to any buffer-consuming autoscaler.
+
+## Goals
+
+* Define a `buffer.x-k8s.io/ephemeral-capacity` provisioning strategy in the shared
+  `buffer.x-k8s.io` namespace, with semantics any autoscaler can implement.
+* Allow a buffer to be **filled by a matching workload** (pods selected by a label selector count
+  as consuming the buffer as they are scheduled).
+* Give the buffer **completion semantics**: once filled (or after an optional deadline), it is
+  terminal — it stops provisioning and does not refill.
+* Reuse the existing `CapacityBuffer` object, status-condition machinery, and consumer integration
+  points — no new CRD.
+
+## Non-Goals
+
+* **Reserving/guaranteeing the capacity for specific pods.** Like `active-capacity`, the buffer
+  makes capacity *exist*; it does not guarantee only the target workload lands on it. Exclusivity
+  is achieved out-of-band (e.g. node taints) until the scheduler offers capacity reservation. This
+  mirrors the base proposal's Non-Goal.
+* **Gang pod scheduling.** This provisions *nodes*; all-or-nothing *binding* remains the job of a
+  gang scheduler (Kueue, Volcano, YuniKorn, kube-scheduler coscheduling).
+* **Coupling the buffer to a specific batch scheduler or workload CRD.** Fill is detected from
+  generic pod state (see Design Details), not from any scheduler's objects.
+* **Auto-deleting the buffer object.** A filled buffer becomes terminal but is not garbage
+  collected; cleanup is left to the user or a future TTL follow-up.
+
+# Proposal
+
+A new value for the existing `spec.provisioningStrategy` field:
+`buffer.x-k8s.io/ephemeral-capacity`. Because `provisioningStrategy` is already an open string in
+the CapacityBuffer API, this adds a strategy without a schema change.
+
+An ephemeral buffer behaves as follows:
+
+1. **Provision once.** The buffer controller resolves the pod spec and replica count exactly as
+   today; the autoscaler provisions capacity for the resulting virtual pods.
+2. **Fill by matching workload.** Pods selected by a label selector, in the buffer's namespace,
+   that are *scheduled* (bound to a node) count as consuming ("filling") the buffer's capacity.
+3. **Latch and stop.** When filled matching capacity covers the buffer's intended capacity — or an
+   optional fill deadline elapses — the buffer transitions to a terminal `Fulfilled` condition,
+   stops contributing capacity, and its now-surplus nodes are reclaimed by normal consolidation.
+   It does **not** refill if the workload later leaves.
+
+This differs from the base proposal's "buffer dedicated for workload" follow-up in one way: that
+sketch is steady-state (count matching pods as filling, but keep maintaining the buffer). The
+ephemeral strategy adds the **terminal / one-shot** semantics that batch requires.
+
+### Selecting the matching workload
+
+The pods that fill the buffer are identified by a label selector scoped to the buffer's own
+namespace (cross-namespace matching is intentionally excluded to avoid accidental overlap on common
+labels). An optional deadline bounds how long an unfilled buffer holds capacity before giving up.
+See Design Details for the concrete surface.
+
+### Why "scheduled" (bound) and not a scheduler-specific signal?
+
+Fill must be detected without depending on any particular gang scheduler. A pod being **bound to a
+node** (`spec.nodeName` set) is a universal lifecycle fact produced by every scheduler via the
+Binding subresource. Scheduler-specific status (e.g. the `PodScheduled=Unschedulable` condition) is
+inconsistent across Volcano/YuniKorn/Kueue and unsuitable as a portable signal. See Design Details.
+
+## Out of scope, may be added as follow up proposals
+
+* **Hold-until-Running:** latch on pods reaching `Running` rather than merely bound (adds image-pull
+  latency; bound is the earlier, cheaper signal).
+* **Native reservation/exclusivity:** once the scheduler offers capacity reservation, replace the
+  taint-based exclusivity workaround.
+* **TTL / auto-deletion** of terminal ephemeral buffers.
+* **First-class spec fields** for the selector/deadline (initially expressed via annotations by
+  consumers that prefer to avoid a shared-schema change).
+
+## User Stories
+
+### Story 1 — Kueue-admitted training gang
+
+A user submits an 8-pod all-or-nothing training Job via Kueue. They create an ephemeral buffer
+sized to the gang so that, on admission, the pods schedule immediately onto pre-warmed nodes
+instead of waiting for a cold-start scale-up. Once the gang is scheduled the buffer latches
+`Fulfilled` and stops provisioning; when the job completes, the nodes are reclaimed and the buffer
+does not refill.
+
+```yaml
+apiVersion: autoscaling.x-k8s.io/v1alpha1
+kind: CapacityBuffer
+metadata:
+  name: gang-warmup
+  namespace: my-namespace
+spec:
+  provisioningStrategy: buffer.x-k8s.io/ephemeral-capacity
+  podTemplateRef:
+    name: gang-shape          # matches the gang's pod shape
+  replicas: 8
+  # matching-workload selector + optional deadline: see Design Details
+```
+
+### Story 2 — Periodic batch run
+
+An admin runs a nightly batch job needing N nodes for its duration. An ephemeral buffer
+pre-provisions the capacity for that run and is filled by the job's pods; after the run the capacity
+is reclaimed. Because the buffer is one-shot, it does not re-provision between runs (a fresh buffer,
+or a scheduled buffer follow-up, is used for the next run).
+
+# Design Details
+
+## Proposed API
+
+No changes to the `CapacityBufferSpec` / `CapacityBufferStatus` Go types are required. This proposal
+adds:
+
+1. A **provisioning-strategy constant**:
+
+   ```go
+   // Provisions capacity once, is filled by a matching workload, then stops
+   // provisioning permanently (does not refill). For gang/batch workloads.
+   const EphemeralProvisioningStrategy = "buffer.x-k8s.io/ephemeral-capacity"
+   ```
+
+2. A **terminal status condition** `Fulfilled` (a standard `metav1.Condition`; the existing
+   `Conditions []metav1.Condition` field carries it, so no type change):
+   - `Fulfilled=True, reason=BufferFilled` — matching scheduled capacity covered the buffer.
+   - `Fulfilled=True, reason=FillDeadlineExceeded` — the optional deadline elapsed unfilled.
+
+3. **Matching-workload configuration.** Two inputs are required: a label selector for the filling
+   pods, and an optional fill deadline. This proposal recommends these be expressible **without a
+   shared-schema change initially** (e.g. as well-known annotations on the CapacityBuffer), with
+   promotion to first-class spec fields (`spec.matchingPodSelector`, `spec.fillDeadline`) as a
+   follow-up once semantics are settled. Consumers MUST agree on the annotation keys; a reference
+   set (used by the Karpenter implementation) is `buffer.x-k8s.io/match-selector` and
+   `buffer.x-k8s.io/fill-deadline`. **Open question: annotations vs. spec fields for v1.**
+
+## Responsibility split (controller vs. autoscaler)
+
+Consistent with the base proposal:
+
+* **Buffer controller** — resolves the pod spec / replica count and sets `ReadyForProvisioning`
+  exactly as for `active-capacity`. It is strategy-agnostic.
+* **Autoscaler (buffer consumer)** — recognizes the `ephemeral-capacity` strategy and implements the
+  fill/latch behavior: sums matching *bound* pod capacity, compares to the buffer's intended
+  capacity, sets `Fulfilled`, and stops contributing capacity for a fulfilled buffer.
+
+The **fill signal is `spec.nodeName != ""`** on matching pods (with any scheduling gates cleared),
+summed as resource requests and compared against `replicas × pod-spec requests`. Comparison is
+capacity-based across all requested resource dimensions (cpu, memory, extended/GPU), not
+pod-count-based, so a workload whose pod shape differs from the template still fills correctly on a
+resource basis.
+
+## Conditions
+
+Adds to the base proposal's condition set:
+
+* `Fulfilled` — set by the consuming autoscaler for `ephemeral-capacity` buffers; terminal. Once
+  true, the buffer contributes no further capacity and does not refill.
+
+## Interaction with gang scheduling (important)
+
+The fill/latch semantics interact with *how* the workload is bound:
+
+* **True gang scheduler** (Volcano, YuniKorn gang, kube-scheduler coscheduling): binding is
+  all-or-nothing. An undersized buffer causes the scheduler to bind nothing until total cluster
+  capacity suffices; the buffer therefore does not latch prematurely and the workload only runs once
+  all capacity is present. Undersizing costs pre-warming benefit, not correctness.
+* **Incremental binding** (e.g. Kueue plain quota admission → kube-scheduler): pods bind one at a
+  time; an undersized buffer can latch after only part of the workload binds. For strictly
+  all-or-nothing jobs this is a pre-existing property of quota-only admission (independent of the
+  buffer). Recommendation: pair ephemeral buffers with a gang scheduler for all-or-nothing
+  workloads, and set the buffer's pod template + replicas to the workload's true shape and count.
+
+## Scalability
+
+* **New API calls?** No new object types. The consumer lists pods (already required for scheduling)
+  and patches CapacityBuffer status (already done for `active-capacity`).
+* **New API types?** No.
+* **Object growth?** One additional status condition per ephemeral buffer.
+* **Steady-state cost?** *Lower* than `active-capacity`: a fulfilled ephemeral buffer stops
+  producing virtual pods, so it drops out of the scheduling simulation entirely once latched.
+
+# Alternatives
+
+## Extend the base "buffer dedicated for workload" follow-up as steady-state only
+
+The base proposal's sketch counts matching pods as filling but keeps maintaining the buffer. That
+does not serve batch: it never stops. Ephemeral adds the terminal semantics. (This proposal can be
+seen as making that follow-up concrete *and* adding a one-shot mode.)
+
+## Use capped capacity buffers instead
+
+The **capped capacity buffers** proposal (in review in `kubernetes/autoscaler`) is the closest
+existing work: it adds a `MatchingPodSelector` / `MatchingTargetNodeSelector` and "shrink as
+filled" accounting, where matching pods are deducted from the buffer's intended size and the
+autoscaler provisions only the remainder. Ephemeral reuses that same fill-accounting idea — so the
+two are complementary, not competing, and an ephemeral implementation can build directly on capped
+buffers' selector + `IntendedSize` machinery.
+
+Capped buffers are explicitly **steady-state / repeating**. From the capped proposal: *"Once the
+workload ends (pods are removed) the buffer will maintain empty capacity again."* Its lifecycle is
+`empty(X) → filled → empty(X) → …` forever. Ephemeral's is `empty(X) → filled → done`. Neither is
+universally "right" — they serve different operating points, and the choice is a real tradeoff:
+
+* **Capped (repeating) is better for a bursty-but-frequent stream of gang jobs.** If you have many
+  gang jobs queued back-to-back, a repeating buffer keeps capacity warm between them: as one job
+  finishes and the buffer empties, it re-provisions so the *next* job schedules immediately. With a
+  one-shot buffer, each job needs a fresh CapacityBuffer created and provisioned before it can use
+  pre-warmed capacity, reintroducing cold-start latency (and node churn) for every job after the
+  first. Note the per-job buffer need not be created by a human — a controller (e.g. one watching a
+  job queue or a Kueue Workload) can mint an ephemeral buffer per job, which removes the *authoring*
+  latency but not the *provisioning* latency: the new nodes still have to come up between jobs. So
+  automation narrows the gap but doesn't close it; a repeating buffer that stays warm still wins on
+  latency for a dense stream.
+* **Ephemeral (one-shot) is better when you don't want to pay between jobs.** For an occasional or
+  one-off run — or when idle capacity between runs is not worth its cost — a repeating buffer keeps
+  provisioning after the job completes, spending on capacity for a job that already ran. One-shot
+  stops, and the nodes are reclaimed.
+
+Note that repeating buffers occupy a *middle* band, and it is a genuinely narrow one. If the job
+stream is frequent and steady enough that you want capacity always available, the churn-free answer
+is not a buffer at all — it is a **static NodePool** (a fixed floor of always-on nodes). A buffer
+that perpetually refills to a constant size is a more complex, less direct way to hold stable
+capacity than simply declaring that capacity. So repeating buffers are the right tool specifically
+for **bursty-but-frequent** streams — enough churn that a static floor would waste capacity at the
+troughs, but frequent enough that per-job one-shot provisioning would pay cold-start too often.
+Outside that band the choice collapses cleanly: **static NodePool** for stable demand, **ephemeral
+buffer** for occasional / cost-bounded runs.
+
+So the gap capped leaves is not a flaw to fix but a **mode it deliberately omits**: capped has no
+way to express "provision once for this run, then stop." Ephemeral supplies that terminal mode. The
+delta over capped is small and additive: a `provisioningStrategy` value plus a one-shot `Fulfilled`
+condition ("once filled, stop and do not refill"). If the capped proposal merges first, ephemeral
+becomes a thin strategy on top of its selector/`IntendedSize` accounting; if not, ephemeral can
+define the minimal fill surface it needs directly. Either way, ephemeral is not an alternative
+*design* to capped — it is the complementary one-shot mode, and users pick per workload:
+**repeating for a warm pipeline of jobs, ephemeral for cost-bounded or one-off runs.**
+
+## Use ProvisioningRequest instead
+
+Cluster Autoscaler's `ProvisioningRequest` (atomic, one-shot, Kueue-integrated) is the closest
+existing primitive. It is not implemented by all autoscalers (e.g. Karpenter has no support, and
+CA's `best-effort-atomic-scale-up` is unimplemented on some cloud providers), so expressing the
+intent as a portable CapacityBuffer *strategy* reaches more of the ecosystem. The two can coexist.
+
+## A separate CRD
+
+Rejected — reuses zero of the CapacityBuffer machinery and fragments the API. `provisioningStrategy`
+is designed for exactly this kind of extension.
+
+# Open Questions
+
+1. **Config surface:** annotations (no shared-schema change) vs. first-class spec fields
+   (`matchingPodSelector`, `fillDeadline`) for the matching workload + deadline. If annotations,
+   agree on well-known keys across consumers.
+2. **`Fulfilled` stickiness:** terminal for the object's lifetime (re-arm by delete/recreate) vs.
+   re-armable by spec edit.
+3. **Undersized-buffer signal:** should a consumer emit a warning when observed matching pods imply
+   the workload is larger than the buffer's intended capacity (primarily relevant under incremental
+   binding)? The Karpenter reference implementation includes a detailed analysis of this case.
+4. **Relationship to a future "scheduled buffer" follow-up** for recurring batch (buffer active only
+   during certain windows) — is ephemeral composable with it, or an alternative?

--- a/cluster-autoscaler/proposals/ephemeral-buffers.md
+++ b/cluster-autoscaler/proposals/ephemeral-buffers.md
@@ -105,9 +105,19 @@ one-shot GKE `standby-capacity` buffer, not just active capacity.
   (fill or deadline) the consumer withdraws virtual pods. A `scalableRef` buffer manages capacity by
   scaling an existing resource rather than by emitting virtual pods, so its terminal behavior (does
   the consumer scale the referent down? leave it? by how much?) is undefined and materially
-  different. v1 one-shot therefore requires **`podTemplateRef` + `replicas`** (also the only shape
-  with an immutable target — see [snapshotting](#snapshotting-the-target-for-mutable-target-buffers)).
-  Defining `scalableRef`/`percentage` teardown is deferred to a follow-up.
+  different. Defining `scalableRef`/`percentage` teardown is deferred to a follow-up.
+* **Mutable / derived targets — out of v1 scope.** For v1 one-shot the target chunk count is
+  **exactly `spec.replicas`**, and it must be **fixed** for the cycle. Concretely v1 requires
+  **`podTemplateRef` + `replicas`** and additionally:
+  * **`limits` is not supported with `refillStrategy: none`.** The base API lets `limits` cap the
+    resolved target below `replicas` (a `replicas: 8` object can resolve to a target of 4), which
+    would make the `target − consumedReplicas` remainder ambiguous. A one-shot buffer that also sets
+    `limits` should be rejected (or `limits` ignored) in v1.
+  * **`spec.replicas` is treated as immutable for the cycle.** A one-shot buffer does not re-arm;
+    editing `replicas` mid-cycle is unsupported — recreate the object to start a new cycle.
+  Supporting `limits` or a mutable/derived target requires persisting a resolved-target snapshot; see
+  [snapshotting](#snapshotting-the-target-for-mutable-target-buffers). That is the forward path, not
+  v1.
 
 # Proposal
 
@@ -149,20 +159,24 @@ where the equivalent accounting is *non*-monotonic — freed capacity is recreat
 ### Snapshotting the target for mutable-target buffers
 
 The remainder is computed against the buffer's **target** chunk count, not its currently-provisioned
-count. For a `podTemplateRef` + `replicas` buffer the target is simply `spec.replicas` and is
-**immutable** for the lifetime of the one-shot cycle: consumption does *not* decrement it, so
-`replicas − consumedReplicas` stays correct (confirmed on KWOK — `status.replicas` remains the
-configured target as chunks are consumed). This is the only shape in v1 scope (see Non-Goals).
+count. The target is the *resolved* replica count the buffer controller reports in
+`status.replicas`. In v1 scope — `podTemplateRef` + `replicas`, no `limits`, immutable `replicas`
+(see Non-Goals) — this resolved target equals `spec.replicas` and is **fixed** for the cycle:
+consumption does *not* decrement it, so `replicas − consumedReplicas` stays correct (confirmed on
+KWOK — `status.replicas` remains the configured target as chunks are consumed). The reference
+implementation reads `status.replicas` as the target and advances `consumedReplicas` monotonically,
+clamped to it; a reconcile or controller restart therefore re-reads the same fixed value.
 
-For buffers whose target is **derived and can change** — `percentage` of a `scalableRef`, or
-`limits`-bounded sizing — the resolved target could drift mid-cycle, which would corrupt the
-`target − consumed` remainder (e.g. an 8→6 target with `consumed=2` would emit `6−2=4`,
-double-counting consumption). Such buffers MUST **snapshot the resolved target** when the one-shot
-cycle begins, compute the remainder and the `Fulfilled` check against that snapshot, and **clamp**
-`consumedReplicas` to it. **Snapshot lifecycle:** the snapshot is taken once per cycle; a one-shot
-buffer does not re-arm, so **recreating (delete + create) the `CapacityBuffer` starts a new cycle**
-with a fresh snapshot. (Since v1 scopes ephemeral to `podTemplateRef` + `replicas`, snapshotting is a
-forward-looking requirement for when mutable-target shapes are brought in scope.)
+Any shape whose target is **derived and can change** — `percentage` of a `scalableRef`, or a
+`limits`-capped target, or an edited `replicas` — is out of v1 scope precisely because the resolved
+target could drift mid-cycle and corrupt the `target − consumed` remainder (e.g. an 8→6 target with
+`consumed=2` would emit `6−2=4`, double-counting consumption; a restart could latch `Fulfilled`
+against the wrong target). To bring such shapes in scope, the consumer MUST **persist the resolved
+target snapshot** when the one-shot cycle begins and compute the remainder, the clamp, and the
+`Fulfilled` check against that snapshot. **Snapshot lifecycle:** the snapshot is taken once per
+cycle; a one-shot buffer does not re-arm, so **recreating (delete + create) the `CapacityBuffer`
+starts a new cycle** with a fresh snapshot. This is the forward path; v1 avoids the problem by
+fixing the target (rejecting `limits` and target edits) rather than persisting a snapshot.
 
 ## `fillDeadlineSeconds`
 
@@ -214,10 +228,10 @@ Summed requests are a `ResourceList` with several dimensions (CPU, memory, exten
 "divide by the per-chunk requests" has no single scalar answer — CPU alone might imply 2 chunks
 while memory implies 1. The rule, which every consumer MUST use so counts agree:
 
-```
+```text
 consumedChunks = min over each resource r in perChunk, with perChunk[r] > 0, of
                      floor( boundSum[r] / perChunk[r] )
-                 clamped to [0, replicas]
+                 clamped to [0, target]   // target = resolved replica count (see below)
 ```
 
 * **MIN, not MAX** — a chunk is a whole pod-shape and requires *all* its dimensions; the binding
@@ -325,13 +339,20 @@ type CapacityBufferSpec struct {
     // refillStrategy controls what happens to buffer capacity consumed by real workloads.
     // "recreate" maintains the buffer size; "recreateUpToLimit" is the capped behavior;
     // "none" is one-shot (consumed capacity is not recreated).
-    // An omitted/empty value defaults to "recreate" — i.e. existing objects (which have no
-    // refillStrategy) keep today's behavior, so this is a backward-compatible addition.
+    // An omitted/empty value MUST be treated as "recreate" by consumers — i.e. objects created
+    // before this field existed keep today's behavior, so this is a backward-compatible addition.
     // (Field name and values are under discussion; alt. name onCapacityConsumption.)
     // +optional
-    // +kubebuilder:validation:Enum=recreate;none        // recreateUpToLimit added by capped buffers
-    // +default="recreate"
+    // +kubebuilder:validation:Enum=recreate;recreateUpToLimit;none
+    // +kubebuilder:default=recreate
     RefillStrategy *string `json:"refillStrategy,omitempty" protobuf:"bytes,7,opt,name=refillStrategy"`
+    // NOTE ON THE ENUM: the enum above lists all three shared values. This proposal defines only
+    // "none"; "recreateUpToLimit" is defined by the capped-buffers proposal. If the two proposals
+    // land separately, each consumer's transitional schema validates the subset it implements
+    // (Karpenter's reference impl currently validates recreate;none) and the full enum is unioned
+    // once both merge. The default marker uses the +kubebuilder:default form to match the existing
+    // CapacityBuffer fields (e.g. provisioningStrategy). Consumers that do not server-side default
+    // (e.g. Karpenter, which treats a nil value as "recreate" in code) need no schema default.
 
     // fillDeadlineSeconds bounds, in seconds, how long a one-shot (refillStrategy=none) buffer
     // keeps trying to provision if it is never filled. On expiry the autoscaler withdraws

--- a/cluster-autoscaler/proposals/ephemeral-buffers.md
+++ b/cluster-autoscaler/proposals/ephemeral-buffers.md
@@ -89,13 +89,25 @@ one-shot GKE `standby-capacity` buffer, not just active capacity.
   this proposal defers that field to capped and, in the reference implementation, uses an interim
   annotation. Note this proposal *does* define the **consumption-tracking result** — the monotonic
   `consumedReplicas` high-water and the shrink/latch semantics built on it — since those are what
-  distinguish one-shot from capped; only the *selector input* defers to capped.
+  distinguish one-shot from capped; only the *selector input* defers to capped. The **exclusive
+  pod-ownership rule** (one bound pod fills exactly one buffer, deterministically) is part of that
+  shared selector contract and likewise defers to capped; the interim requirement until it lands is
+  that annotation selector values do not overlap within a namespace (see
+  [Ownership and the readiness boundary](#ownership-and-the-readiness-boundary)).
 * **Reserving/guaranteeing capacity for specific pods.** Exclusivity remains out-of-band (node
   taints) until the scheduler offers capacity reservation — same as the base proposal.
 * **Gang pod scheduling.** This provisions *nodes*; all-or-nothing binding stays with the gang
   scheduler (Kueue, Volcano, YuniKorn, coscheduling).
 * **Auto-deleting the buffer object.** A completed one-shot buffer is terminal but not garbage
   collected; cleanup is left to the user or a future TTL follow-up.
+* **`scalableRef` (and `percentage`) one-shot buffers — out of v1 scope.** The shrink/latch/deadline
+  semantics here are defined in terms of the buffer's **virtual pods**: on shrink and on terminal
+  (fill or deadline) the consumer withdraws virtual pods. A `scalableRef` buffer manages capacity by
+  scaling an existing resource rather than by emitting virtual pods, so its terminal behavior (does
+  the consumer scale the referent down? leave it? by how much?) is undefined and materially
+  different. v1 one-shot therefore requires **`podTemplateRef` + `replicas`** (also the only shape
+  with an immutable target — see [snapshotting](#snapshotting-the-target-for-mutable-target-buffers)).
+  Defining `scalableRef`/`percentage` teardown is deferred to a follow-up.
 
 # Proposal
 
@@ -134,6 +146,24 @@ fills or the deadline hits. Shrink-as-fill eliminates that: a half-filled buffer
 `N − consumed` empty chunks + the consumed capacity. (Contrast with `recreate`/`recreateUpToLimit`,
 where the equivalent accounting is *non*-monotonic — freed capacity is recreated.)
 
+### Snapshotting the target for mutable-target buffers
+
+The remainder is computed against the buffer's **target** chunk count, not its currently-provisioned
+count. For a `podTemplateRef` + `replicas` buffer the target is simply `spec.replicas` and is
+**immutable** for the lifetime of the one-shot cycle: consumption does *not* decrement it, so
+`replicas − consumedReplicas` stays correct (confirmed on KWOK — `status.replicas` remains the
+configured target as chunks are consumed). This is the only shape in v1 scope (see Non-Goals).
+
+For buffers whose target is **derived and can change** — `percentage` of a `scalableRef`, or
+`limits`-bounded sizing — the resolved target could drift mid-cycle, which would corrupt the
+`target − consumed` remainder (e.g. an 8→6 target with `consumed=2` would emit `6−2=4`,
+double-counting consumption). Such buffers MUST **snapshot the resolved target** when the one-shot
+cycle begins, compute the remainder and the `Fulfilled` check against that snapshot, and **clamp**
+`consumedReplicas` to it. **Snapshot lifecycle:** the snapshot is taken once per cycle; a one-shot
+buffer does not re-arm, so **recreating (delete + create) the `CapacityBuffer` starts a new cycle**
+with a fresh snapshot. (Since v1 scopes ephemeral to `podTemplateRef` + `replicas`, snapshotting is a
+forward-looking requirement for when mutable-target shapes are brought in scope.)
+
 ## `fillDeadlineSeconds`
 
 A one-shot buffer that is never filled would otherwise hold provisioning intent forever. An optional
@@ -143,33 +173,83 @@ not been filled within the deadline (measured from when it became ready for prov
 trying — the autoscaler **deletes the buffer's virtual pods** so no further capacity is provisioned
 for it. Note this does **not** forcibly delete
 already-provisioned capacity; nodes created for the buffer are reclaimed only when they are
-empty/underutilized, via normal consolidation. The buffer is marked terminal with reason
-`FillDeadlineExceeded`.
+empty/underutilized, via normal consolidation. The buffer is marked terminal with the **`Expired`**
+condition (reason `FillDeadlineExceeded`) — distinct from `Fulfilled`, so consumers can tell a
+timed-out buffer from a filled one (see [Status](#status-terminal-conditions-fulfilled-vs-expired)).
 
 `fillDeadline` is meaningful only for `refillStrategy: none` (a recreate/capped buffer has no
 "unfilled forever" state to bound).
 
-## Status: the `Fulfilled` condition
+## Status: terminal conditions (`Fulfilled` vs `Expired`)
 
-A one-shot buffer sets a terminal `Fulfilled` condition (a standard `metav1.Condition` on the
-existing `Conditions` field — no status-type change):
+A one-shot buffer reaches a terminal state via one of **two mutually-exclusive** conditions
+(standard `metav1.Condition`s on the existing `Conditions` field — no status-type change). Success
+and give-up are kept as *distinct* conditions so a consumer that inspects only condition status can
+tell them apart (an early draft reported both as `Fulfilled=True`, which conflated "filled" with
+"deadline elapsed unfilled"):
 
-* `Fulfilled=True, reason=BufferFilled` — the buffer's capacity was consumed by the matching
-  workload; it will not recreate.
-* `Fulfilled=True, reason=FillDeadlineExceeded` — the deadline elapsed unfilled; provisioning intent
-  was withdrawn.
+* `Fulfilled=True, reason=BufferFilled` — **success**: the buffer's capacity was consumed by the
+  matching workload; it will not recreate.
+* `Expired=True, reason=FillDeadlineExceeded` — **give-up**: the deadline elapsed before the buffer
+  filled; provisioning intent was withdrawn. The buffer was **not** filled.
+
+Both are terminal (the buffer emits zero virtual pods thereafter); `IsTerminal()` is
+"`Fulfilled` OR `Expired`". They never both become True.
 
 ## Measuring consumption
 
 The *selector input* (which pods count) defers to capped buffers; the *measurement* into
 `consumedReplicas` is defined here. A consumer sums the resource requests of matching pods that are
-**bound** (`spec.nodeName` set, no scheduling gates), divides by the per-chunk requests to get whole
-chunks consumed, and advances `consumedReplicas` to that value (never decreasing it — the monotonic
-high-water). **Bound-ness** is the signal deliberately: it is a universal lifecycle fact produced by
-every scheduler via the Binding subresource, whereas scheduler-specific conditions (e.g.
-`PodScheduled=Unschedulable`) are inconsistent across Volcano/YuniKorn/Kueue. The shared spec field
-for the selector is expected from capped buffers (`matchingPodSelector`); until it lands, the
-reference implementation uses an interim `karpenter.sh/*` annotation.
+**bound** (`spec.nodeName` set, no scheduling gates, past the readiness boundary below), then
+converts that summed `ResourceList` into a count of whole chunks consumed and advances
+`consumedReplicas` to it (never decreasing it — the monotonic high-water).
+
+**Bound-ness** is the signal deliberately: it is a universal lifecycle fact produced by every
+scheduler via the Binding subresource, whereas scheduler-specific conditions (e.g.
+`PodScheduled=Unschedulable`) are inconsistent across Volcano/YuniKorn/Kueue.
+
+### Multi-resource chunk accounting (deterministic rule)
+
+Summed requests are a `ResourceList` with several dimensions (CPU, memory, extended resources), so
+"divide by the per-chunk requests" has no single scalar answer — CPU alone might imply 2 chunks
+while memory implies 1. The rule, which every consumer MUST use so counts agree:
+
+```
+consumedChunks = min over each resource r in perChunk, with perChunk[r] > 0, of
+                     floor( boundSum[r] / perChunk[r] )
+                 clamped to [0, replicas]
+```
+
+* **MIN, not MAX** — a chunk is a whole pod-shape and requires *all* its dimensions; the binding
+  dimension is the scarcest, so the count is the minimum ratio. (MAX would over-count and latch
+  `Fulfilled` too early — a point raised and withdrawn in review.)
+* **`floor`** — partial chunks do not count.
+* **Zero / missing `perChunk[r]`** — dimensions whose per-chunk request is zero (or absent) are
+  skipped, not divided by. If *no* dimension has a positive per-chunk request, the result is 0.
+* **Clamp to `replicas`** — a workload larger than the buffer cannot consume more than the buffer's
+  target (see [snapshotting the target](#snapshotting-the-target-for-mutable-target-buffers)).
+
+The shared spec field for the selector is expected from capped buffers (`matchingPodSelector`);
+until it lands, the reference implementation uses an interim `karpenter.sh/*` annotation.
+
+### Ownership and the readiness boundary
+
+Because the selector contract is deferred, two measurement rules are specified here so fill counting
+is well-defined in the interim:
+
+* **Exclusive ownership.** A bound pod must advance at most one buffer's `consumedReplicas`;
+  otherwise a single pod matched by two buffers double-counts. The general deterministic
+  "one pod fills exactly one buffer" assignment is part of the shared selector contract and is
+  deferred to capped buffers. **Interim requirement:** `matchingPodSelector` (annotation) values
+  MUST NOT overlap within a namespace.
+* **Readiness boundary.** Only pods that became scheduled **at or after** the buffer went
+  `ReadyForProvisioning` count toward its fill — concretely, a pod counts when its `PodScheduled`
+  condition `lastTransitionTime` is not before the buffer's `ReadyForProvisioning`
+  `lastTransitionTime` (falling back to the pod's creation time when that condition is absent; when
+  neither is known the pod is counted rather than under-reporting real capacity). This prevents pods
+  that were already bound when the buffer became ready — capacity the buffer did not provision — from
+  consuming it. It is an *observable* rule, stronger than merely assuming the buffer is created
+  before its workload.
 
 ## Interaction with gang scheduling
 
@@ -200,7 +280,7 @@ scheduled the buffer is `Fulfilled` and stops; when the job completes the nodes 
 buffer does not refill.
 
 ```yaml
-apiVersion: autoscaling.x-k8s.io/v1alpha1
+apiVersion: autoscaling.x-k8s.io/v1beta1
 kind: CapacityBuffer
 metadata:
   name: gang-warmup
@@ -230,55 +310,70 @@ provisioning strategy.
 Adds two `CapacityBufferSpec` fields (the refill axis + deadline) and one `CapacityBufferStatus`
 field (the shrink high-water); reuses the capped proposal's selector for fill measurement:
 
+The new fields carry the same wire metadata as the existing `CapacityBuffer` fields — JSON tags,
+sequential protobuf field numbers, and kubebuilder validation — so generated clients and every
+consumer serialize and interpret them identically. Protobuf numbers continue the existing sequence
+(spec 1–6 and status 1–5 are taken by the base API); this proposal claims **spec 7–8** and reuses a
+free status slot for `consumedReplicas`. These match the numbers used by the Karpenter reference
+implementation.
+
 ```go
 type CapacityBufferSpec struct {
-    // ... existing fields (provisioningStrategy, podTemplateRef, scalableRef,
-    // replicas, percentage, limits) ...
+    // ... existing fields: provisioningStrategy (1), podTemplateRef (2), scalableRef (3),
+    // replicas (4), percentage (5), limits (6) ...
 
     // refillStrategy controls what happens to buffer capacity consumed by real workloads.
-    // "recreate" (default) maintains the buffer size; "recreateUpToLimit" is the capped
-    // behavior; "none" is one-shot (consumed capacity is not recreated).
+    // "recreate" maintains the buffer size; "recreateUpToLimit" is the capped behavior;
+    // "none" is one-shot (consumed capacity is not recreated).
+    // An omitted/empty value defaults to "recreate" — i.e. existing objects (which have no
+    // refillStrategy) keep today's behavior, so this is a backward-compatible addition.
     // (Field name and values are under discussion; alt. name onCapacityConsumption.)
     // +optional
-    RefillStrategy *string
+    // +kubebuilder:validation:Enum=recreate;none        // recreateUpToLimit added by capped buffers
+    // +default="recreate"
+    RefillStrategy *string `json:"refillStrategy,omitempty" protobuf:"bytes,7,opt,name=refillStrategy"`
 
     // fillDeadlineSeconds bounds, in seconds, how long a one-shot (refillStrategy=none) buffer
     // keeps trying to provision if it is never filled. On expiry the autoscaler withdraws
-    // provisioning intent (deletes the buffer's virtual pods); already-provisioned nodes are
-    // reclaimed only by normal consolidation when empty/underutilized. Applies only to
-    // refillStrategy=none. Integer-seconds (not metav1.Duration) per Kubernetes API convention
-    // (cf. activeDeadlineSeconds) — the kube-api-linter forbids Duration fields.
+    // provisioning intent (deletes the buffer's virtual pods) and marks the buffer Expired;
+    // already-provisioned nodes are reclaimed only by normal consolidation when
+    // empty/underutilized. Applies only to refillStrategy=none. Integer-seconds (not
+    // metav1.Duration) per Kubernetes API convention (cf. activeDeadlineSeconds) — the
+    // kube-api-linter forbids Duration fields.
     // +optional
-    FillDeadlineSeconds *int32
+    // +kubebuilder:validation:Minimum=1
+    FillDeadlineSeconds *int32 `json:"fillDeadlineSeconds,omitempty" protobuf:"varint,8,opt,name=fillDeadlineSeconds"`
 
     // matchingPodSelector — expected to be introduced by the capped buffers proposal; used to
     // measure which pods fill the buffer. Referenced here, not defined here.
 }
 
 type CapacityBufferStatus struct {
-    // ... existing fields (podTemplateRef, replicas, podTemplateGeneration,
-    // conditions, provisioningStrategy) ...
+    // ... existing fields: podTemplateRef (1), replicas (2), podTemplateGeneration (3),
+    // conditions (4), provisioningStrategy (5) ...
 
     // consumedReplicas is a monotonically non-decreasing high-water mark of how many chunks a
     // matching workload has consumed. The consumer emits replicas-consumedReplicas chunks
     // (shrink-as-fill) and never recreates consumed capacity; when it reaches replicas the buffer
     // becomes Fulfilled. Set by the consuming autoscaler.
     // +optional
-    ConsumedReplicas *int32
+    // +kubebuilder:validation:Minimum=0
+    ConsumedReplicas *int32 `json:"consumedReplicas,omitempty" protobuf:"varint,6,opt,name=consumedReplicas"`
 }
 ```
 
-Because `refillStrategy`, `fillDeadline`, and `consumedReplicas` are additions to the shared
+Because `refillStrategy`, `fillDeadlineSeconds`, and `consumedReplicas` are additions to the shared
 `autoscaling.x-k8s.io` CRD, they must land in the schema before a consumer can implement against
-them. The Karpenter reference implementation uses interim `karpenter.sh/*` annotations for the
+them. Existing objects omit `refillStrategy` and so default to `recreate`, preserving current
+behavior. The Karpenter reference implementation uses interim `karpenter.sh/*` annotations for the
 selector until the shared field exists, then migrates.
 
 ## Responsibility split (controller vs. autoscaler)
 
 Consistent with the base proposal: the **buffer controller** resolves pod spec / replicas and sets
 `ReadyForProvisioning`, strategy-agnostic. The **autoscaler (consumer)** honors `refillStrategy`:
-for `none`, it does not recreate consumed capacity, sets `Fulfilled` when filled or when
-`fillDeadline` elapses, and stops contributing virtual pods for a terminal buffer.
+for `none`, it does not recreate consumed capacity, sets `Fulfilled` when filled (or `Expired` when
+`fillDeadline` elapses unfilled), and stops contributing virtual pods for a terminal buffer.
 
 ## Why an orthogonal refill axis (not a provisioningStrategy value)
 
@@ -334,7 +429,8 @@ maintenance and cost drawbacks the base proposal already documents.
    behavior), and is the current behavior retconned as `recreate` explicitly?
 3. **`fillDeadline` scope and clock:** confirm it applies only to `none`, and that the deadline is
    measured from `ReadyForProvisioning`. On expiry: withdraw provisioning intent (delete virtual
-   pods) and mark `Fulfilled/FillDeadlineExceeded`, without force-deleting already-provisioned nodes.
+   pods) and mark `Expired/FillDeadlineExceeded` (distinct from `Fulfilled`), without force-deleting
+   already-provisioned nodes.
 4. **`Fulfilled` stickiness:** terminal for the object's lifetime (re-arm by delete/recreate) vs.
    re-armable by spec edit.
 5. **Dependency on consumption tracking:** this proposal assumes the capped buffers proposal lands

--- a/cluster-autoscaler/proposals/ephemeral-buffers.md
+++ b/cluster-autoscaler/proposals/ephemeral-buffers.md
@@ -1,148 +1,203 @@
-# Ephemeral CapacityBuffers (workload-filled, one-shot)
+# One-shot (ephemeral) CapacityBuffers via a refill strategy
 
 #### Author: jicowan
 
-A follow-up to the [CapacityBuffer API proposal](./buffers.md) (#8151). It defines a shared
-`buffer.x-k8s.io/ephemeral-capacity` provisioning-strategy contract; a reference implementation
-exists in Karpenter.
+A follow-up to the [CapacityBuffer API proposal](./buffers.md) (#8151). It adds one-shot
+(ephemeral) buffers for gang / batch workloads, expressed as a value on an orthogonal
+**refill-strategy** axis that also subsumes the current (recreate) and capped
+(recreate-up-to-limit) behaviors — rather than as a new `provisioningStrategy` value. (This
+framing reflects review discussion with @kkonrad and @jbtk; an earlier draft used a
+`provisioningStrategy` value.)
 
 # Timeline
 
 ## Alpha
 
-- [ ] Agree on the `buffer.x-k8s.io/ephemeral-capacity` strategy semantics (this proposal)
-- [ ] Reference implementation in a buffer-consuming autoscaler (Karpenter — implementation ready)
-- [ ] Document the workload-fill + latch contract for other consumers (CA, GKE CCC)
+- [ ] Agree on the refill-strategy field name/values (this proposal, coordinated with capped buffers)
+- [ ] Reference implementation in a buffer-consuming autoscaler (Karpenter — implementation ready,
+      currently keyed on an interim annotation; will adopt the spec field)
+- [ ] Document the one-shot (no-refill) + fill-deadline contract for other consumers (CA, GKE CCC)
 
 ## Beta / V1 graduation criteria
 
-- [ ] Second OSS implementation of the strategy (e.g. cluster-autoscaler)
-- [ ] E2e coverage of the fill → latch → no-refill lifecycle
+- [ ] Second OSS implementation of the one-shot behavior
+- [ ] E2e coverage of the fill → stop → no-refill lifecycle (and the fill-deadline path)
 - [ ] In use for at least one full version behind the CapacityBuffer feature gate
 
 # Summary
 
-The `CapacityBuffer` API (autoscaling.x-k8s.io) today defines *steady-state* spare capacity: the
-`active-capacity` provisioning strategy continuously maintains a buffer and refills it as workloads
-consume it. This proposal adds a second, **one-shot** provisioning strategy,
-`buffer.x-k8s.io/ephemeral-capacity`, for **gang / batch workloads**: the buffer pre-provisions a
-fixed amount of capacity, is *filled* by a matching workload as its pods are scheduled, and once
-filled transitions to a terminal state and **stops provisioning** — it does not refill.
+The `CapacityBuffer` API (autoscaling.x-k8s.io) today maintains *steady-state* spare capacity:
+capacity consumed by real workloads is **recreated** to keep the buffer at its configured size. That
+is the right behavior for keeping headroom warm, but the wrong behavior for **gang / batch
+workloads**, which want capacity pre-provisioned for a specific run and then provisioning to
+**stop** — not a buffer that refills after the run and keeps incurring cost.
 
-This is the follow-up already anticipated in the CapacityBuffer proposal
-([`buffers.md`](./buffers.md)), which lists under "Out of scope, may be added as follow up
-proposals":
+This proposal makes the buffer's **refill behavior** an explicit, first-class axis of the
+`CapacityBuffer` spec, orthogonal to `provisioningStrategy` (which describes the *kind* of capacity,
+e.g. `active-capacity`, GKE `standby-capacity`). The axis has three values:
 
-> *"Buffer dedicated for workload: mark the buffer as dedicated for pods defined by PodSelector. It
-> would count the pods matching the selector as filling in the buffer space. Example usecase: I
-> want to keep buffer for scaling, but I know the usual maximum needed for my workload."*
+| refill behavior | meaning | buffer type |
+|---|---|---|
+| recreate *(default)* | consumed capacity is recreated to maintain size | current buffers |
+| recreate-up-to-limit | recreate, bounded by a limit | capped buffers (in review) |
+| **none** | consumed capacity is **not** recreated — one-shot | **ephemeral (this proposal)** |
 
-This proposal specifies that "filled-by-workload" behavior and adds the one-shot / completion
-semantics needed for batch. It builds on — rather than competes with — the in-review **capped
-capacity buffers** proposal: ephemeral reuses capped's fill-by-selector accounting but adds a
-*terminal* latch that capped deliberately omits. The two are complementary operating points
-(repeating capped keeps capacity warm for a stream of jobs; one-shot ephemeral stops paying between
-runs) — users pick per workload. See [Alternatives](#use-capped-capacity-buffers-instead).
+The `none` value gives batch its **completion semantics**: provision once, let the workload consume
+the capacity, then stop. This proposal contributes the `none` value, **monotonic shrink-as-fill** (a
+`consumedReplicas` high-water mark so a partially-filled buffer provisions only its unfilled
+remainder and never recreates consumed capacity), and an optional **`fillDeadline`** bounding how
+long an unfilled one-shot buffer keeps trying.
+
+The *selector input* — how a buffer names which pods fill it (e.g. `matchingPodSelector`) — is
+**deferred to the capped buffers proposal**, which is already defining that field; one-shot reuses
+it. The *consumption result and shrink/latch semantics* built on it are defined here, since they are
+what distinguishes one-shot from capped.
 
 # Motivation
 
-The `active-capacity` strategy is the right shape for "keep N spare CPUs warm at all times." It is
-the wrong shape for **gang-scheduled batch jobs** (ML training, HPC, CI/CD run-to-completion),
-where the user wants to pre-provision capacity for *a specific run* so the job schedules promptly,
-and then have provisioning **stop** once the job is placed — not a standing buffer that refills
-after the job completes and keeps incurring cost.
-
-With `active-capacity` there is no terminal state: a buffer sized for a gang job refills after the
-gang finishes and provisions capacity indefinitely for a job that already ran. There is no way to
-express "provision X once, for this workload, then stop."
-
-The community has repeatedly asked for batch/Kueue-oriented capacity provisioning
+Community demand for batch/Kueue-oriented capacity provisioning is well established
 ([kubernetes-sigs/karpenter#2571](https://github.com/kubernetes-sigs/karpenter/issues/2571),
 [#742](https://github.com/kubernetes-sigs/karpenter/issues/742),
-[#3138](https://github.com/kubernetes-sigs/karpenter/issues/3138)), and Kueue's cold-start problem
-(admit → pods pend → autoscaler reacts → nodes appear late) is the canonical case. Kueue drives
-Cluster Autoscaler's `ProvisioningRequest` for exactly this, but that API is not universally
-implemented across autoscalers; expressing the same intent as a CapacityBuffer *strategy* makes it
-available to any buffer-consuming autoscaler.
+[#3138](https://github.com/kubernetes-sigs/karpenter/issues/3138)). The canonical case is Kueue's
+cold-start: a job is admitted, its pods pend, the autoscaler reacts, and nodes appear late. Kueue
+drives Cluster Autoscaler's `ProvisioningRequest` for this, but that API is not implemented across
+all autoscalers; expressing the intent through the portable `CapacityBuffer` API reaches any
+buffer-consuming autoscaler.
+
+The base CapacityBuffer proposal already anticipated the workload-filled case under "Out of scope,
+may be added as follow up proposals" (*"Buffer dedicated for workload: … count the pods matching the
+selector as filling in the buffer space"*). That sketch is steady-state; batch additionally needs
+the buffer to **stop** once filled. Framing this as a refill-strategy value (rather than a new
+provisioning strategy) lets the same one-shot semantics compose with **any** capacity kind — e.g. a
+one-shot GKE `standby-capacity` buffer, not just active capacity.
 
 ## Goals
 
-* Define a `buffer.x-k8s.io/ephemeral-capacity` provisioning strategy in the shared
-  `buffer.x-k8s.io` namespace, with semantics any autoscaler can implement.
-* Allow a buffer to be **filled by a matching workload** (pods selected by a label selector count
-  as consuming the buffer as they are scheduled).
-* Give the buffer **completion semantics**: once filled (or after an optional deadline), it is
-  terminal — it stops provisioning and does not refill.
-* Reuse the existing `CapacityBuffer` object, status-condition machinery, and consumer integration
-  points — no new CRD.
+* Add an explicit **refill-strategy** field to `CapacityBufferSpec`, orthogonal to
+  `provisioningStrategy`, with a **`none`** value meaning "do not recreate consumed capacity"
+  (one-shot).
+* Give one-shot buffers **completion semantics** (a terminal state; no refill after fill).
+* Add an optional **`fillDeadline`** so an unfilled one-shot buffer does not hold provisioning intent
+  indefinitely.
+* Compose with the existing (recreate) and capped (recreate-up-to-limit) behaviors on the same axis,
+  rather than introducing a parallel mechanism.
 
 ## Non-Goals
 
-* **Reserving/guaranteeing the capacity for specific pods.** Like `active-capacity`, the buffer
-  makes capacity *exist*; it does not guarantee only the target workload lands on it. Exclusivity
-  is achieved out-of-band (e.g. node taints) until the scheduler offers capacity reservation. This
-  mirrors the base proposal's Non-Goal.
-* **Gang pod scheduling.** This provisions *nodes*; all-or-nothing *binding* remains the job of a
-  gang scheduler (Kueue, Volcano, YuniKorn, kube-scheduler coscheduling).
-* **Coupling the buffer to a specific batch scheduler or workload CRD.** Fill is detected from
-  generic pod state (see Design Details), not from any scheduler's objects.
-* **Auto-deleting the buffer object.** A filled buffer becomes terminal but is not garbage
+* **Defining the shared matching-workload *selector* surface.** The spec field that names which
+  pods fill a buffer (e.g. `matchingPodSelector`) should be shared with the capped buffers proposal;
+  this proposal defers that field to capped and, in the reference implementation, uses an interim
+  annotation. Note this proposal *does* define the **consumption-tracking result** — the monotonic
+  `consumedReplicas` high-water and the shrink/latch semantics built on it — since those are what
+  distinguish one-shot from capped; only the *selector input* defers to capped.
+* **Reserving/guaranteeing capacity for specific pods.** Exclusivity remains out-of-band (node
+  taints) until the scheduler offers capacity reservation — same as the base proposal.
+* **Gang pod scheduling.** This provisions *nodes*; all-or-nothing binding stays with the gang
+  scheduler (Kueue, Volcano, YuniKorn, coscheduling).
+* **Auto-deleting the buffer object.** A completed one-shot buffer is terminal but not garbage
   collected; cleanup is left to the user or a future TTL follow-up.
 
 # Proposal
 
-A new value for the existing `spec.provisioningStrategy` field:
-`buffer.x-k8s.io/ephemeral-capacity`. Because `provisioningStrategy` is already an open string in
-the CapacityBuffer API, this adds a strategy without a schema change.
+## The refill-strategy axis
 
-An ephemeral buffer behaves as follows:
+Refill behavior becomes a spec field, orthogonal to `provisioningStrategy`. Naming is an open
+question carried over from the PR thread — the two candidates are `refillStrategy` and
+`onCapacityConsumption`; this document uses `refillStrategy` for concreteness, values TBD with
+capped buffers and @jbtk:
 
-1. **Provision once.** The buffer controller resolves the pod spec and replica count exactly as
-   today; the autoscaler provisions capacity for the resulting virtual pods.
-2. **Fill by matching workload.** Pods selected by a label selector, in the buffer's namespace,
-   that are *scheduled* (bound to a node) count as consuming ("filling") the buffer's capacity.
-3. **Latch and stop.** When filled matching capacity covers the buffer's intended capacity — or an
-   optional fill deadline elapses — the buffer transitions to a terminal `Fulfilled` condition,
-   stops contributing capacity, and its now-surplus nodes are reclaimed by normal consolidation.
-   It does **not** refill if the workload later leaves.
+| `refillStrategy` | alt. (`onCapacityConsumption`) | behavior |
+|---|---|---|
+| `recreate` *(default)* | `recreate` | current: consumed capacity is recreated to maintain size |
+| `recreateUpToLimit` | `recreateUpToLimit` | capped: recreate, bounded (capped buffers proposal) |
+| `none` | `doNothing` | one-shot: consumed capacity is **not** recreated (this proposal) |
 
-This differs from the base proposal's "buffer dedicated for workload" follow-up in one way: that
-sketch is steady-state (count matching pods as filling, but keep maintaining the buffer). The
-ephemeral strategy adds the **terminal / one-shot** semantics that batch requires.
+Choosing `refillStrategy: none` on a buffer of any `provisioningStrategy` makes it one-shot: it
+provisions its configured capacity once, the workload consumes it, and the buffer does not recreate
+what was consumed. Once fully consumed the buffer is **terminal** (a `Fulfilled` status condition,
+below); it will not refill even if the workload later leaves and the nodes are reclaimed by normal
+consolidation.
 
-### Selecting the matching workload
+## Shrink-as-fill (monotonic)
 
-The pods that fill the buffer are identified by a label selector scoped to the buffer's own
-namespace (cross-namespace matching is intentionally excluded to avoid accidental overlap on common
-labels). An optional deadline bounds how long an unfilled buffer holds capacity before giving up.
-See Design Details for the concrete surface.
+A one-shot buffer **shrinks as it fills**: as a matching workload's pods are scheduled onto the
+buffer's capacity, the buffer provisions only the *unfilled remainder* rather than its full size.
+This is tracked with a monotonically non-decreasing status field, `consumedReplicas` (a high-water
+mark of consumed chunks): the consumer emits `replicas − consumedReplicas` chunks, and because
+`consumedReplicas` never decreases, **consumed capacity is never recreated** — the defining property
+of `refillStrategy: none`. When `consumedReplicas` reaches `replicas`, the buffer latches
+`Fulfilled`.
 
-### Why "scheduled" (bound) and not a scheduler-specific signal?
+Without shrink, a partially-filled one-shot buffer would hold its *full* empty size **plus** the
+nodes the workload already occupies — transient over-provisioning until the buffer either fully
+fills or the deadline hits. Shrink-as-fill eliminates that: a half-filled buffer of N holds exactly
+`N − consumed` empty chunks + the consumed capacity. (Contrast with `recreate`/`recreateUpToLimit`,
+where the equivalent accounting is *non*-monotonic — freed capacity is recreated.)
 
-Fill must be detected without depending on any particular gang scheduler. A pod being **bound to a
-node** (`spec.nodeName` set) is a universal lifecycle fact produced by every scheduler via the
-Binding subresource. Scheduler-specific status (e.g. the `PodScheduled=Unschedulable` condition) is
-inconsistent across Volcano/YuniKorn/Kueue and unsuitable as a portable signal. See Design Details.
+## `fillDeadlineSeconds`
 
-## Out of scope, may be added as follow up proposals
+A one-shot buffer that is never filled would otherwise hold provisioning intent forever. An optional
+`fillDeadlineSeconds` (integer seconds — per Kubernetes API convention, cf. `activeDeadlineSeconds`,
+rather than a `metav1.Duration`, which the kube-api-linter forbids) bounds this: if the buffer has
+not been filled within the deadline (measured from when it became ready for provisioning), it stops
+trying — the autoscaler **deletes the buffer's virtual pods** so no further capacity is provisioned
+for it. Note this does **not** forcibly delete
+already-provisioned capacity; nodes created for the buffer are reclaimed only when they are
+empty/underutilized, via normal consolidation. The buffer is marked terminal with reason
+`FillDeadlineExceeded`.
 
-* **Hold-until-Running:** latch on pods reaching `Running` rather than merely bound (adds image-pull
-  latency; bound is the earlier, cheaper signal).
-* **Native reservation/exclusivity:** once the scheduler offers capacity reservation, replace the
-  taint-based exclusivity workaround.
-* **TTL / auto-deletion** of terminal ephemeral buffers.
-* **First-class spec fields** for the selector/deadline (initially expressed via annotations by
-  consumers that prefer to avoid a shared-schema change).
+`fillDeadline` is meaningful only for `refillStrategy: none` (a recreate/capped buffer has no
+"unfilled forever" state to bound).
 
-## User Stories
+## Status: the `Fulfilled` condition
 
-### Story 1 — Kueue-admitted training gang
+A one-shot buffer sets a terminal `Fulfilled` condition (a standard `metav1.Condition` on the
+existing `Conditions` field — no status-type change):
 
-A user submits an 8-pod all-or-nothing training Job via Kueue. They create an ephemeral buffer
-sized to the gang so that, on admission, the pods schedule immediately onto pre-warmed nodes
-instead of waiting for a cold-start scale-up. Once the gang is scheduled the buffer latches
-`Fulfilled` and stops provisioning; when the job completes, the nodes are reclaimed and the buffer
-does not refill.
+* `Fulfilled=True, reason=BufferFilled` — the buffer's capacity was consumed by the matching
+  workload; it will not recreate.
+* `Fulfilled=True, reason=FillDeadlineExceeded` — the deadline elapsed unfilled; provisioning intent
+  was withdrawn.
+
+## Measuring consumption
+
+The *selector input* (which pods count) defers to capped buffers; the *measurement* into
+`consumedReplicas` is defined here. A consumer sums the resource requests of matching pods that are
+**bound** (`spec.nodeName` set, no scheduling gates), divides by the per-chunk requests to get whole
+chunks consumed, and advances `consumedReplicas` to that value (never decreasing it — the monotonic
+high-water). **Bound-ness** is the signal deliberately: it is a universal lifecycle fact produced by
+every scheduler via the Binding subresource, whereas scheduler-specific conditions (e.g.
+`PodScheduled=Unschedulable`) are inconsistent across Volcano/YuniKorn/Kueue. The shared spec field
+for the selector is expected from capped buffers (`matchingPodSelector`); until it lands, the
+reference implementation uses an interim `karpenter.sh/*` annotation.
+
+## Interaction with gang scheduling
+
+The one-shot semantics interact with *how* the workload binds:
+
+* **True gang scheduler** (Volcano, YuniKorn gang, coscheduling): binding is all-or-nothing — no pod
+  binds until all can be placed. An undersized buffer therefore does not partially fill or terminate
+  early; the scheduler waits until total cluster capacity suffices, then binds atomically.
+  Undersizing costs pre-warming benefit, not correctness.
+* **Incremental binding** (e.g. Kueue plain quota admission → kube-scheduler): pods bind one at a
+  time, so an undersized one-shot buffer can be considered "filled" after only part of the workload
+  binds. For strictly all-or-nothing jobs this is a pre-existing property of quota-only admission
+  (independent of the buffer). Recommendation: pair one-shot buffers with a gang scheduler for
+  all-or-nothing workloads, and size the buffer to the workload.
+
+Note that **shrink-as-fill removes the transient over-provisioning** that incremental binding would
+otherwise cause: as each pod binds, the buffer drops the corresponding chunk (`consumedReplicas`
+rises), so a correctly-sized buffer holds `replicas − consumed` empty chunks throughout the ramp
+rather than its full size plus the occupied nodes.
+
+# User Stories
+
+## Story 1 — Kueue-admitted training gang
+
+A user submits an 8-pod all-or-nothing training Job via Kueue and creates a one-shot buffer sized to
+it so the gang schedules immediately on admission rather than cold-starting. Once the gang is
+scheduled the buffer is `Fulfilled` and stops; when the job completes the nodes are reclaimed and the
+buffer does not refill.
 
 ```yaml
 apiVersion: autoscaling.x-k8s.io/v1alpha1
@@ -151,171 +206,137 @@ metadata:
   name: gang-warmup
   namespace: my-namespace
 spec:
-  provisioningStrategy: buffer.x-k8s.io/ephemeral-capacity
+  # provisioningStrategy left default (active-capacity); the one-shot behavior is the refill axis:
+  refillStrategy: none          # do not recreate consumed capacity (one-shot)
+  fillDeadlineSeconds: 900      # 15m: give up + withdraw provisioning intent if never filled
   podTemplateRef:
-    name: gang-shape          # matches the gang's pod shape
+    name: gang-shape            # matches the gang's pod shape
   replicas: 8
-  # matching-workload selector + optional deadline: see Design Details
+  # matchingPodSelector (how fill is measured) comes from the capped buffers proposal
 ```
 
-### Story 2 — Periodic batch run
+## Story 2 — one-shot standby capacity (composition)
 
-An admin runs a nightly batch job needing N nodes for its duration. An ephemeral buffer
-pre-provisions the capacity for that run and is filled by the job's pods; after the run the capacity
-is reclaimed. Because the buffer is one-shot, it does not re-provision between runs (a fresh buffer,
-or a scheduled buffer follow-up, is used for the next run).
+Because refill behavior is orthogonal to capacity kind, a one-shot buffer can use a
+provider-specific capacity type. E.g. a GKE `standby-capacity` buffer (suspended nodes) that is also
+one-shot: `provisioningStrategy: buffer.gke.io/standby-capacity` + `refillStrategy: none`. This
+composition is the main reason to model one-shot on the refill axis rather than as its own
+provisioning strategy.
 
 # Design Details
 
 ## Proposed API
 
-No changes to the `CapacityBufferSpec` / `CapacityBufferStatus` Go types are required. This proposal
-adds:
+Adds two `CapacityBufferSpec` fields (the refill axis + deadline) and one `CapacityBufferStatus`
+field (the shrink high-water); reuses the capped proposal's selector for fill measurement:
 
-1. A **provisioning-strategy constant**:
+```go
+type CapacityBufferSpec struct {
+    // ... existing fields (provisioningStrategy, podTemplateRef, scalableRef,
+    // replicas, percentage, limits) ...
 
-   ```go
-   // Provisions capacity once, is filled by a matching workload, then stops
-   // provisioning permanently (does not refill). For gang/batch workloads.
-   const EphemeralProvisioningStrategy = "buffer.x-k8s.io/ephemeral-capacity"
-   ```
+    // refillStrategy controls what happens to buffer capacity consumed by real workloads.
+    // "recreate" (default) maintains the buffer size; "recreateUpToLimit" is the capped
+    // behavior; "none" is one-shot (consumed capacity is not recreated).
+    // (Field name and values are under discussion; alt. name onCapacityConsumption.)
+    // +optional
+    RefillStrategy *string
 
-2. A **terminal status condition** `Fulfilled` (a standard `metav1.Condition`; the existing
-   `Conditions []metav1.Condition` field carries it, so no type change):
-   - `Fulfilled=True, reason=BufferFilled` — matching scheduled capacity covered the buffer.
-   - `Fulfilled=True, reason=FillDeadlineExceeded` — the optional deadline elapsed unfilled.
+    // fillDeadlineSeconds bounds, in seconds, how long a one-shot (refillStrategy=none) buffer
+    // keeps trying to provision if it is never filled. On expiry the autoscaler withdraws
+    // provisioning intent (deletes the buffer's virtual pods); already-provisioned nodes are
+    // reclaimed only by normal consolidation when empty/underutilized. Applies only to
+    // refillStrategy=none. Integer-seconds (not metav1.Duration) per Kubernetes API convention
+    // (cf. activeDeadlineSeconds) — the kube-api-linter forbids Duration fields.
+    // +optional
+    FillDeadlineSeconds *int32
 
-3. **Matching-workload configuration.** Two inputs are required: a label selector for the filling
-   pods, and an optional fill deadline. This proposal recommends these be expressible **without a
-   shared-schema change initially** (e.g. as well-known annotations on the CapacityBuffer), with
-   promotion to first-class spec fields (`spec.matchingPodSelector`, `spec.fillDeadline`) as a
-   follow-up once semantics are settled. Consumers MUST agree on the annotation keys; a reference
-   set (used by the Karpenter implementation) is `buffer.x-k8s.io/match-selector` and
-   `buffer.x-k8s.io/fill-deadline`. **Open question: annotations vs. spec fields for v1.**
+    // matchingPodSelector — expected to be introduced by the capped buffers proposal; used to
+    // measure which pods fill the buffer. Referenced here, not defined here.
+}
+
+type CapacityBufferStatus struct {
+    // ... existing fields (podTemplateRef, replicas, podTemplateGeneration,
+    // conditions, provisioningStrategy) ...
+
+    // consumedReplicas is a monotonically non-decreasing high-water mark of how many chunks a
+    // matching workload has consumed. The consumer emits replicas-consumedReplicas chunks
+    // (shrink-as-fill) and never recreates consumed capacity; when it reaches replicas the buffer
+    // becomes Fulfilled. Set by the consuming autoscaler.
+    // +optional
+    ConsumedReplicas *int32
+}
+```
+
+Because `refillStrategy`, `fillDeadline`, and `consumedReplicas` are additions to the shared
+`autoscaling.x-k8s.io` CRD, they must land in the schema before a consumer can implement against
+them. The Karpenter reference implementation uses interim `karpenter.sh/*` annotations for the
+selector until the shared field exists, then migrates.
 
 ## Responsibility split (controller vs. autoscaler)
 
-Consistent with the base proposal:
+Consistent with the base proposal: the **buffer controller** resolves pod spec / replicas and sets
+`ReadyForProvisioning`, strategy-agnostic. The **autoscaler (consumer)** honors `refillStrategy`:
+for `none`, it does not recreate consumed capacity, sets `Fulfilled` when filled or when
+`fillDeadline` elapses, and stops contributing virtual pods for a terminal buffer.
 
-* **Buffer controller** — resolves the pod spec / replica count and sets `ReadyForProvisioning`
-  exactly as for `active-capacity`. It is strategy-agnostic.
-* **Autoscaler (buffer consumer)** — recognizes the `ephemeral-capacity` strategy and implements the
-  fill/latch behavior: sums matching *bound* pod capacity, compares to the buffer's intended
-  capacity, sets `Fulfilled`, and stops contributing capacity for a fulfilled buffer.
+## Why an orthogonal refill axis (not a provisioningStrategy value)
 
-The **fill signal is `spec.nodeName != ""`** on matching pods (with any scheduling gates cleared),
-summed as resource requests and compared against `replicas × pod-spec requests`. Comparison is
-capacity-based across all requested resource dimensions (cpu, memory, extended/GPU), not
-pod-count-based, so a workload whose pod shape differs from the template still fills correctly on a
-resource basis.
+This is the central revision from the original proposal, per PR review:
 
-## Conditions
-
-Adds to the base proposal's condition set:
-
-* `Fulfilled` — set by the consuming autoscaler for `ephemeral-capacity` buffers; terminal. Once
-  true, the buffer contributes no further capacity and does not refill.
-
-## Interaction with gang scheduling (important)
-
-The fill/latch semantics interact with *how* the workload is bound:
-
-* **True gang scheduler** (Volcano, YuniKorn gang, kube-scheduler coscheduling): binding is
-  all-or-nothing. An undersized buffer causes the scheduler to bind nothing until total cluster
-  capacity suffices; the buffer therefore does not latch prematurely and the workload only runs once
-  all capacity is present. Undersizing costs pre-warming benefit, not correctness.
-* **Incremental binding** (e.g. Kueue plain quota admission → kube-scheduler): pods bind one at a
-  time; an undersized buffer can latch after only part of the workload binds. For strictly
-  all-or-nothing jobs this is a pre-existing property of quota-only admission (independent of the
-  buffer). Recommendation: pair ephemeral buffers with a gang scheduler for all-or-nothing
-  workloads, and set the buffer's pod template + replicas to the workload's true shape and count.
-
-## Scalability
-
-* **New API calls?** No new object types. The consumer lists pods (already required for scheduling)
-  and patches CapacityBuffer status (already done for `active-capacity`).
-* **New API types?** No.
-* **Object growth?** One additional status condition per ephemeral buffer.
-* **Steady-state cost?** *Lower* than `active-capacity`: a fulfilled ephemeral buffer stops
-  producing virtual pods, so it drops out of the scheduling simulation entirely once latched.
+* `provisioningStrategy` describes the **kind** of capacity (active, GKE standby, provider-specific).
+  Refill behavior is a **different question** — what to do when that capacity is consumed — and
+  applies to every kind. Encoding "one-shot" as a provisioning strategy would prevent, e.g., a
+  one-shot standby buffer.
+* It **unifies** the three behaviors (recreate / recreate-up-to-limit / none) on one axis instead of
+  scattering them, and gives capped buffers and ephemeral buffers a shared home.
 
 # Alternatives
 
-## Extend the base "buffer dedicated for workload" follow-up as steady-state only
+## A new `provisioningStrategy` value (`buffer.x-k8s.io/ephemeral-capacity`)
 
-The base proposal's sketch counts matching pods as filling but keeps maintaining the buffer. That
-does not serve batch: it never stops. Ephemeral adds the terminal semantics. (This proposal can be
-seen as making that follow-up concrete *and* adding a one-shot mode.)
+The original form of this proposal. Rejected in review: conflates capacity *kind* with refill
+*behavior* and cannot compose one-shot with other capacity kinds (e.g. GKE standby). The
+refill-strategy axis supersedes it.
 
-## Use capped capacity buffers instead
+## Annotations instead of spec fields
 
-The **capped capacity buffers** proposal (in review in `kubernetes/autoscaler`) is the closest
-existing work: it adds a `MatchingPodSelector` / `MatchingTargetNodeSelector` and "shrink as
-filled" accounting, where matching pods are deducted from the buffer's intended size and the
-autoscaler provisions only the remainder. Ephemeral reuses that same fill-accounting idea — so the
-two are complementary, not competing, and an ephemeral implementation can build directly on capped
-buffers' selector + `IntendedSize` machinery.
+The interim Karpenter implementation uses `karpenter.sh/*` annotations. Rejected as the end state:
+opaque, unvalidated, and consumer-specific — the shared contract should be typed spec fields.
 
-Capped buffers are explicitly **steady-state / repeating**. From the capped proposal: *"Once the
-workload ends (pods are removed) the buffer will maintain empty capacity again."* Its lifecycle is
-`empty(X) → filled → empty(X) → …` forever. Ephemeral's is `empty(X) → filled → done`. Neither is
-universally "right" — they serve different operating points, and the choice is a real tradeoff:
+## Capped buffers alone
 
-* **Capped (repeating) is better for a bursty-but-frequent stream of gang jobs.** If you have many
-  gang jobs queued back-to-back, a repeating buffer keeps capacity warm between them: as one job
-  finishes and the buffer empties, it re-provisions so the *next* job schedules immediately. With a
-  one-shot buffer, each job needs a fresh CapacityBuffer created and provisioned before it can use
-  pre-warmed capacity, reintroducing cold-start latency (and node churn) for every job after the
-  first. Note the per-job buffer need not be created by a human — a controller (e.g. one watching a
-  job queue or a Kueue Workload) can mint an ephemeral buffer per job, which removes the *authoring*
-  latency but not the *provisioning* latency: the new nodes still have to come up between jobs. So
-  automation narrows the gap but doesn't close it; a repeating buffer that stays warm still wins on
-  latency for a dense stream.
-* **Ephemeral (one-shot) is better when you don't want to pay between jobs.** For an occasional or
-  one-off run — or when idle capacity between runs is not worth its cost — a repeating buffer keeps
-  provisioning after the job completes, spending on capacity for a job that already ran. One-shot
-  stops, and the nodes are reclaimed.
+Capped buffers are steady-state (recreate-up-to-limit): they refill after the workload leaves, which
+batch does not want. One-shot (`none`) is the missing value on the same axis. Note the tradeoff is
+real and not one-directional:
 
-Note that repeating buffers occupy a *middle* band, and it is a genuinely narrow one. If the job
-stream is frequent and steady enough that you want capacity always available, the churn-free answer
-is not a buffer at all — it is a **static NodePool** (a fixed floor of always-on nodes). A buffer
-that perpetually refills to a constant size is a more complex, less direct way to hold stable
-capacity than simply declaring that capacity. So repeating buffers are the right tool specifically
-for **bursty-but-frequent** streams — enough churn that a static floor would waste capacity at the
-troughs, but frequent enough that per-job one-shot provisioning would pay cold-start too often.
-Outside that band the choice collapses cleanly: **static NodePool** for stable demand, **ephemeral
-buffer** for occasional / cost-bounded runs.
+* **Static NodePool** — for stable demand, a fixed floor of always-on nodes is simpler than any
+  refilling buffer.
+* **Recreate / capped (repeating)** — best for a *bursty-but-frequent* stream of jobs: capacity
+  stays warm between runs. A controller can create one-shot buffers per job, which removes authoring
+  latency but not provisioning latency, so a warm repeating buffer still wins for dense streams.
+* **One-shot (`none`)** — best for occasional / one-off / cost-bounded runs, where paying for
+  capacity between runs is not worth it.
 
-So the gap capped leaves is not a flaw to fix but a **mode it deliberately omits**: capped has no
-way to express "provision once for this run, then stop." Ephemeral supplies that terminal mode. The
-delta over capped is small and additive: a `provisioningStrategy` value plus a one-shot `Fulfilled`
-condition ("once filled, stop and do not refill"). If the capped proposal merges first, ephemeral
-becomes a thin strategy on top of its selector/`IntendedSize` accounting; if not, ephemeral can
-define the minimal fill surface it needs directly. Either way, ephemeral is not an alternative
-*design* to capped — it is the complementary one-shot mode, and users pick per workload:
-**repeating for a warm pipeline of jobs, ephemeral for cost-bounded or one-off runs.**
+Users pick per workload; one-shot is additive, not a replacement.
 
-## Use ProvisioningRequest instead
+## Do nothing
 
-Cluster Autoscaler's `ProvisioningRequest` (atomic, one-shot, Kueue-integrated) is the closest
-existing primitive. It is not implemented by all autoscalers (e.g. Karpenter has no support, and
-CA's `best-effort-atomic-scale-up` is unimplemented on some cloud providers), so expressing the
-intent as a portable CapacityBuffer *strategy* reaches more of the ecosystem. The two can coexist.
-
-## A separate CRD
-
-Rejected — reuses zero of the CapacityBuffer machinery and fragments the API. `provisioningStrategy`
-is designed for exactly this kind of extension.
+Batch users work around the gap today with balloon pods or by over-provisioning NodePools, with the
+maintenance and cost drawbacks the base proposal already documents.
 
 # Open Questions
 
-1. **Config surface:** annotations (no shared-schema change) vs. first-class spec fields
-   (`matchingPodSelector`, `fillDeadline`) for the matching workload + deadline. If annotations,
-   agree on well-known keys across consumers.
-2. **`Fulfilled` stickiness:** terminal for the object's lifetime (re-arm by delete/recreate) vs.
+1. **Field name and values:** `refillStrategy` (`recreate` / `recreateUpToLimit` / `none`) vs.
+   `onCapacityConsumption` (`recreate` / `recreateUpToLimit` / `doNothing`). To be settled with the
+   capped buffers proposal and @jbtk so all three behaviors share one field.
+2. **Ownership of the default:** does `refillStrategy` default to `recreate` (preserving current
+   behavior), and is the current behavior retconned as `recreate` explicitly?
+3. **`fillDeadline` scope and clock:** confirm it applies only to `none`, and that the deadline is
+   measured from `ReadyForProvisioning`. On expiry: withdraw provisioning intent (delete virtual
+   pods) and mark `Fulfilled/FillDeadlineExceeded`, without force-deleting already-provisioned nodes.
+4. **`Fulfilled` stickiness:** terminal for the object's lifetime (re-arm by delete/recreate) vs.
    re-armable by spec edit.
-3. **Undersized-buffer signal:** should a consumer emit a warning when observed matching pods imply
-   the workload is larger than the buffer's intended capacity (primarily relevant under incremental
-   binding)? The Karpenter reference implementation includes a detailed analysis of this case.
-4. **Relationship to a future "scheduled buffer" follow-up** for recurring batch (buffer active only
-   during certain windows) — is ephemeral composable with it, or an alternative?
+5. **Dependency on consumption tracking:** this proposal assumes the capped buffers proposal lands
+   the fill-measurement mechanism (`matchingPodSelector`). If capped stalls, does one-shot need a
+   minimal fill surface of its own, or wait?

--- a/cluster-autoscaler/proposals/ephemeral-buffers.md
+++ b/cluster-autoscaler/proposals/ephemeral-buffers.md
@@ -90,10 +90,10 @@ one-shot GKE `standby-capacity` buffer, not just active capacity.
   annotation. Note this proposal *does* define the **consumption-tracking result** — the monotonic
   `consumedReplicas` high-water and the shrink/latch semantics built on it — since those are what
   distinguish one-shot from capped; only the *selector input* defers to capped. The **exclusive
-  pod-ownership rule** (one bound pod fills exactly one buffer, deterministically) is part of that
-  shared selector contract and likewise defers to capped; the interim requirement until it lands is
-  that annotation selector values do not overlap within a namespace (see
-  [Ownership and the readiness boundary](#ownership-and-the-readiness-boundary)).
+  pod-ownership rule** (one bound pod fills exactly one buffer, deterministically) is **defined in
+  this proposal**, not deferred: because selector overlap cannot be detected up front, this proposal
+  specifies a deterministic fill order across all refill strategies rather than forbidding overlap
+  (see [Deterministic fill order](#deterministic-fill-order-overlapping-selectors)).
 * **Reserving/guaranteeing capacity for specific pods.** Exclusivity remains out-of-band (node
   taints) until the scheduler offers capacity reservation — same as the base proposal.
 * **Gang pod scheduling.** This provisions *nodes*; all-or-nothing binding stays with the gang
@@ -246,24 +246,60 @@ consumedChunks = min over each resource r in perChunk, with perChunk[r] > 0, of
 The shared spec field for the selector is expected from capped buffers (`matchingPodSelector`);
 until it lands, the reference implementation uses an interim `karpenter.sh/*` annotation.
 
-### Ownership and the readiness boundary
+### Deterministic fill order (overlapping selectors)
 
-Because the selector contract is deferred, two measurement rules are specified here so fill counting
-is well-defined in the interim:
+A bound pod MUST advance at most one buffer's `consumedReplicas`; otherwise a pod matched by two
+buffers double-counts. An earlier draft tried to guarantee this by forbidding overlapping selectors
+within a namespace. That rule is **not enforceable**: overlap is a property of *pods*, not of
+selectors, and cannot be detected when the buffers are created. Two buffers matching `animal=cow`
+and `sound=moo` respectively are disjoint until a pod carrying *both* labels appears — and requiring
+users to enumerate every label so selectors stay disjoint is unusable (two workloads that share some
+labels but differ in others may legitimately want to share a buffer). Overlap is therefore
+**allowed**, and instead the pod→buffer assignment is made deterministic at measurement time.
 
-* **Exclusive ownership.** A bound pod must advance at most one buffer's `consumedReplicas`;
-  otherwise a single pod matched by two buffers double-counts. The general deterministic
-  "one pod fills exactly one buffer" assignment is part of the shared selector contract and is
-  deferred to capped buffers. **Interim requirement:** `matchingPodSelector` (annotation) values
-  MUST NOT overlap within a namespace.
-* **Readiness boundary.** Only pods that became scheduled **at or after** the buffer went
-  `ReadyForProvisioning` count toward its fill — concretely, a pod counts when its `PodScheduled`
-  condition `lastTransitionTime` is not before the buffer's `ReadyForProvisioning`
-  `lastTransitionTime` (falling back to the pod's creation time when that condition is absent; when
-  neither is known the pod is counted rather than under-reporting real capacity). This prevents pods
-  that were already bound when the buffer became ready — capacity the buffer did not provision — from
-  consuming it. It is an *observable* rule, stronger than merely assuming the buffer is created
-  before its workload.
+**Rule.** A bound pod (past the readiness boundary below) is credited to exactly one buffer: the
+first buffer, under the total order below, among all buffers in the pod's namespace whose selector
+matches it and which are **still filling** (non-terminal, `consumedReplicas < target`). Every other
+matching buffer ignores that pod. Every consumer MUST use this order so counts agree:
+
+1. **Refill strategy** — `none` (one-shot) before `recreateUpToLimit` (capped) before `recreate`.
+2. **Age** — older `creationTimestamp` first.
+3. **Name** — lexicographic `namespace/name` as the final tiebreak (`creationTimestamp` has
+   one-second resolution, so it alone is not a total order).
+
+**Why one-shot fills first.** The buffers that can reach a terminal state must be credited before the
+ones that cannot. A `recreate` buffer refills whatever is consumed regardless of who is credited;
+if it were credited for a pod that also matched a one-shot buffer, the `recreate` buffer would
+re-provision that capacity anyway *and* the one-shot buffer would never fill — it would hold its
+full empty size until `fillDeadline`, defeating its completion semantics and double-provisioning.
+Crediting the latching buffer first is the only assignment under which `refillStrategy: none` works
+in the presence of overlap. The same argument places capped (bounded, can latch) before `recreate`
+(unbounded, never latches), and it makes the latching buffers' credit independent of a steady-state
+buffer's lifecycle — deleting a `recreate` or capped buffer never changes what a one-shot buffer has
+already been credited.
+
+**Stickiness.** Ownership is decided once, when the pod first crosses the readiness boundary, and
+does not change thereafter. In particular, a pod counted toward a buffer that then latches terminal
+**stays counted there** — it contributed to the latch — and is not re-credited to a lower-priority
+buffer. Since `consumedReplicas` is a monotonic high-water, this is the only assignment under which
+the per-buffer sums stay stable across reconciles and controller restarts (a consumer recomputing
+ownership from scratch must therefore exclude pods already credited to a terminal buffer, e.g. by
+treating terminal buffers as still-matching for pods bound before their terminal transition).
+
+**Interaction with capped buffers.** This order is defined here for all three refill values so the
+capped buffers proposal inherits it rather than inventing a second one; it is the shared exclusive
+ownership rule for the `matchingPodSelector` field.
+
+### Readiness boundary
+
+Only pods that became scheduled **at or after** the buffer went `ReadyForProvisioning` count toward
+its fill — concretely, a pod counts when its `PodScheduled` condition `lastTransitionTime` is not
+before the buffer's `ReadyForProvisioning` `lastTransitionTime` (falling back to the pod's creation
+time when that condition is absent; when neither is known the pod is counted rather than
+under-reporting real capacity). This prevents pods that were already bound when the buffer became
+ready — capacity the buffer did not provision — from consuming it. It is an *observable* rule,
+stronger than merely assuming the buffer is created before its workload. A buffer that does not pass
+this boundary for a pod is not a candidate in the fill order above.
 
 ## Interaction with gang scheduling
 
@@ -456,4 +492,8 @@ maintenance and cost drawbacks the base proposal already documents.
    re-armable by spec edit.
 5. **Dependency on consumption tracking:** this proposal assumes the capped buffers proposal lands
    the fill-measurement mechanism (`matchingPodSelector`). If capped stalls, does one-shot need a
-   minimal fill surface of its own, or wait?
+   minimal fill surface of its own, or wait? (The exclusive-ownership / fill-order rule is no longer
+   part of this dependency — it is defined here for all refill strategies.)
+6. **Fill-order priority:** the order `none` → `recreateUpToLimit` → `recreate` (then age, then name)
+   is proposed here per review discussion. Confirm with the capped buffers work that capped is
+   comfortable being credited *after* one-shot when both match a pod.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**

Adds a proposal, `cluster-autoscaler/proposals/ephemeral-buffers.md`, for an **ephemeral
(workload-filled, one-shot)** provisioning strategy on the CapacityBuffer API:
`buffer.x-k8s.io/ephemeral-capacity`.

The existing `active-capacity` strategy maintains steady-state spare capacity and refills as
workloads consume it. That does not serve gang/batch workloads (ML training, HPC, run-to-completion
jobs), which want capacity pre-provisioned for a specific run so the job schedules promptly, then
provisioning to **stop** — not a standing buffer that refills after the job completes.

An ephemeral buffer provisions its capacity once, is *filled* by a matching workload as its pods are
scheduled (detected via pod binding, so it is scheduler-agnostic across Kueue/Volcano/YuniKorn),
then latches a terminal `Fulfilled` condition and stops provisioning with no refill.

This is the concrete continuation of the "buffer dedicated for workload" item already listed under
"Out of scope, may be added as follow up proposals" in the merged CapacityBuffer proposal (#8151),
adding the one-shot/terminal semantics batch requires. It is complementary to — and can build on —
the in-review capped capacity buffers work (it reuses fill-by-selector accounting and adds a
terminal latch that capped deliberately omits).

Doc-only; no code changes. A reference implementation exists in Karpenter.

**Which issue(s) this PR fixes**

Follow-up to #8151. (Not fixing an issue; opening for design discussion.)

**Special notes for your reviewer**

- Modeled on `buffers.md` (#8151); doc-only, mirrors that PR's shape.
- Would appreciate review from the CapacityBuffer authors/owners — /cc @jbtk
- Key open questions in the doc: config surface (annotations vs. spec fields), `Fulfilled`
  stickiness, and undersized-buffer handling under incremental vs. gang binding.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a proposal for one-shot capacity buffers with configurable refill strategies, including disabled refilling and capped recreation.
  * Added support for tracking consumed replicas and marking buffers as fulfilled or expired.
  * Added optional deadlines for filling capacity buffers.
  * Defined initial restrictions for fixed pod templates and replica targets, including behavior for unsupported edits and limits.
  * Documented multi-resource accounting, readiness, gang scheduling, and autoscaler interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->