### PR TITLE
addon-resizer: add CI workflow for build and test

### DIFF
--- a/.github/workflows/addon-resizer.yaml
+++ b/.github/workflows/addon-resizer.yaml
@@ -5,10 +5,12 @@ on:
     paths:
       - 'addon-resizer/**'
       - '!addon-resizer/**/*.md'
+      - '.github/workflows/addon-resizer.yaml'
   pull_request:
     paths:
       - 'addon-resizer/**'
       - '!addon-resizer/**/*.md'
+      - '.github/workflows/addon-resizer.yaml'
 
 permissions:
   contents: read

--- a/.github/workflows/addon-resizer.yaml
+++ b/.github/workflows/addon-resizer.yaml
@@ -1,0 +1,39 @@
+name: Addon Resizer
+
+on:
+  push:
+    paths:
+      - 'addon-resizer/**'
+      - '!addon-resizer/**/*.md'
+  pull_request:
+    paths:
+      - 'addon-resizer/**'
+      - '!addon-resizer/**/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: 'addon-resizer/go.mod'
+          cache-dependency-path: 'addon-resizer/go.sum'
+
+      - name: Build
+        working-directory: addon-resizer
+        run: go build ./...
+
+      - name: Vet
+        working-directory: addon-resizer
+        run: go vet ./...
+
+      - name: Test
+        working-directory: addon-resizer
+        run: go test ./...


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Addresses the CI/CD gap called out in #9675: addon-resizer currently has no CI at all — pull requests against `addon-resizer-release-1.8` (including the open dependabot PRs) run no builds or tests, and there is no workflow covering `addon-resizer/` on any branch.

This adds a GitHub Actions workflow, modeled on the existing VPA workflows (same pinned action SHAs), that runs `go build`, `go vet` and `go test` for the addon-resizer module on every push/PR touching `addon-resizer/**`.

Follow-up candidates (happy to send PRs): a golangci-lint job to match VPA, and a govulncheck job so security regressions like the ones fixed in #10112 surface automatically.

**Which issue(s) this PR fixes:**

Related to #9675

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

---

**Update:** I test-ran this workflow on a fork before asking anyone to review it. The `go vet` step surfaced 3 pre-existing findings in the module (malformed struct tag + two copylocks in tests) — fixed in #10114, which should merge before this one so the workflow lands green. With #10114 applied, the full workflow (build/vet/test) passes: see the successful run on the fork branch [`ci-selftest`](https://github.com/semx/autoscaler/actions?query=branch%3Aci-selftest).
