### PR TITLE
addon-resizer: fix go vet findings

### DIFF
--- a/addon-resizer/go.mod
+++ b/addon-resizer/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/spf13/pflag v1.0.10
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
@@ -49,7 +50,6 @@ require (
 	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect

--- a/addon-resizer/nanny/apis/nannyconfig/v1alpha1/types.go
+++ b/addon-resizer/nanny/apis/nannyconfig/v1alpha1/types.go
@@ -24,7 +24,7 @@ import (
 
 // NannyConfiguration is a set of options that configure Nanny container.
 type NannyConfiguration struct {
-	metav1.TypeMeta `json:", inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	BaseCPU string `json:"baseCPU"`
 

--- a/addon-resizer/nanny/kubernetes_client_test.go
+++ b/addon-resizer/nanny/kubernetes_client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -141,7 +142,7 @@ func getMetric(labelName, labelValue string, value float64) *dto.Metric {
 func TestExtractMetricValueForResourceCount(t *testing.T) {
 	testCases := []struct {
 		name           string
-		mf             dto.MetricFamily
+		mf             *dto.MetricFamily
 		resourceLabels map[string]string
 		expectCount    uint64
 		expectErr      error
@@ -149,13 +150,13 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 		{
 			name:           "(nodes) empty",
 			resourceLabels: nodeResourceLabels,
-			mf:             dto.MetricFamily{},
+			mf:             &dto.MetricFamily{},
 			expectErr:      fmt.Errorf("metric name: no valid metric values"),
 		},
 		{
 			name:           "(nodes) with proper value",
 			resourceLabels: nodeResourceLabels,
-			mf: dto.MetricFamily{
+			mf: &dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "nodes", 4.0),
 				},
@@ -165,7 +166,7 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 		{
 			name:           "(nodes) only wrong label",
 			resourceLabels: nodeResourceLabels,
-			mf: dto.MetricFamily{
+			mf: &dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("wrong", "nodes", 4.0),
 				},
@@ -175,7 +176,7 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 		{
 			name:           "(nodes) only wrong label value",
 			resourceLabels: nodeResourceLabels,
-			mf: dto.MetricFamily{
+			mf: &dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "services", 4.0),
 				},
@@ -185,7 +186,7 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 		{
 			name:           "(nodes) with negative value",
 			resourceLabels: nodeResourceLabels,
-			mf: dto.MetricFamily{
+			mf: &dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "nodes", -4.0),
 				},
@@ -195,13 +196,13 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 		{
 			name:           "(pods) empty",
 			resourceLabels: podResourceLabels,
-			mf:             dto.MetricFamily{},
+			mf:             &dto.MetricFamily{},
 			expectErr:      fmt.Errorf("metric name: no valid metric values"),
 		},
 		{
 			name:           "(pods) with proper value",
 			resourceLabels: podResourceLabels,
-			mf: dto.MetricFamily{
+			mf: &dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "pods", 6.0),
 				},
@@ -211,7 +212,7 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 		{
 			name:           "(pods) only wrong label",
 			resourceLabels: podResourceLabels,
-			mf: dto.MetricFamily{
+			mf: &dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("wrong", "pods", 4.0),
 				},
@@ -221,7 +222,7 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 		{
 			name:           "(pods) only wrong label value",
 			resourceLabels: podResourceLabels,
-			mf: dto.MetricFamily{
+			mf: &dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "services", 4.0),
 				},
@@ -231,7 +232,7 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 		{
 			name:           "(pods) with negative value",
 			resourceLabels: podResourceLabels,
-			mf: dto.MetricFamily{
+			mf: &dto.MetricFamily{
 				Metric: []*dto.Metric{
 					getMetric("resource", "pods", -4.0),
 				},
@@ -241,14 +242,14 @@ func TestExtractMetricValueForResourceCount(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotCount, gotErr := extractMetricValueForResourceCount(&tc.mf, tc.resourceLabels, "metric name")
+			gotCount, gotErr := extractMetricValueForResourceCount(tc.mf, tc.resourceLabels, "metric name")
 			expectErrorOrCount(t, tc.expectErr, tc.expectCount, gotErr, gotCount)
 		})
 	}
 }
 
 type fakeDecoder struct {
-	metricValues []dto.MetricFamily
+	metricValues []*dto.MetricFamily
 	finalResult  error
 }
 
@@ -256,7 +257,8 @@ func (fd *fakeDecoder) Decode(output *dto.MetricFamily) error {
 	if len(fd.metricValues) == 0 {
 		return fd.finalResult
 	}
-	*output = fd.metricValues[len(fd.metricValues)-1]
+	output.Reset()
+	proto.Merge(output, fd.metricValues[len(fd.metricValues)-1])
 	fd.metricValues = fd.metricValues[:len(fd.metricValues)-1]
 	return nil
 }
@@ -266,7 +268,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 	fallbackMetric := objectCountFallbackMetricName
 	testCases := []struct {
 		name           string
-		metricValues   []dto.MetricFamily
+		metricValues   []*dto.MetricFamily
 		resourceLabels map[string]string
 		finalResult    error
 		expectValue    uint64
@@ -281,7 +283,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(nodes) with preferred metric",
 			finalResult:    io.EOF,
 			resourceLabels: nodeResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &preferredMetric,
 					Metric: []*dto.Metric{
@@ -295,7 +297,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(nodes) with fallback metric",
 			finalResult:    io.EOF,
 			resourceLabels: nodeResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
 					Metric: []*dto.Metric{
@@ -309,7 +311,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(nodes) with preferred and fallback metrics",
 			finalResult:    io.EOF,
 			resourceLabels: nodeResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
 					Metric: []*dto.Metric{
@@ -334,7 +336,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(nodes) falls back on error in preferred metric",
 			finalResult:    io.EOF,
 			resourceLabels: nodeResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
 					Metric: []*dto.Metric{
@@ -354,7 +356,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(nodes) reports error on both metrics",
 			finalResult:    io.EOF,
 			resourceLabels: nodeResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
 					Metric: []*dto.Metric{
@@ -374,7 +376,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(nodes) multiple metrics in preferred metric family",
 			finalResult:    io.EOF,
 			resourceLabels: nodeResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &preferredMetric,
 					Metric: []*dto.Metric{
@@ -394,7 +396,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(pods) with preferred metric",
 			finalResult:    io.EOF,
 			resourceLabels: podResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &preferredMetric,
 					Metric: []*dto.Metric{
@@ -408,7 +410,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(pods) with fallback metric",
 			finalResult:    io.EOF,
 			resourceLabels: podResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
 					Metric: []*dto.Metric{
@@ -422,7 +424,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(pods) with preferred and fallback metrics",
 			finalResult:    io.EOF,
 			resourceLabels: podResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
 					Metric: []*dto.Metric{
@@ -442,7 +444,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(pods) falls back on error in preferred metric",
 			finalResult:    io.EOF,
 			resourceLabels: podResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
 					Metric: []*dto.Metric{
@@ -462,7 +464,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(pods) reports error on both metrics",
 			finalResult:    io.EOF,
 			resourceLabels: podResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &fallbackMetric,
 					Metric: []*dto.Metric{
@@ -482,7 +484,7 @@ func TestGetResourceCountFromDecoder(t *testing.T) {
 			name:           "(pods) multiple metrics in preferred metric family",
 			finalResult:    io.EOF,
 			resourceLabels: podResourceLabels,
-			metricValues: []dto.MetricFamily{
+			metricValues: []*dto.MetricFamily{
 				{
 					Name: &preferredMetric,
 					Metric: []*dto.Metric{
@@ -582,7 +584,7 @@ func TestGetResourceCountFromDecoder_MultpleLabels(t *testing.T) {
 			}
 
 			fd := fakeDecoder{
-				metricValues: []dto.MetricFamily{
+				metricValues: []*dto.MetricFamily{
 					{
 						Name: &preferredMetric,
 						Metric: []*dto.Metric{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

`go vet ./...` currently fails on the addon-resizer module with three findings (nobody noticed because addon-resizer has no CI — see #9675 and #10113):

- `nannyconfig/v1alpha1/types.go`: struct tag `json:", inline"` — the space makes the tag malformed for `reflect.StructTag.Get`, so tooling reading the tag sees nothing.
- `kubernetes_client_test.go` (2 findings): ranging over / assigning `dto.MetricFamily` values copies the `sync.Mutex` inside `protoimpl.MessageState` (copylocks). Fixed by using `*dto.MetricFamily` in the test fixtures and `Reset()` + `proto.Merge` in the fake decoder, matching how protobuf messages are supposed to be copied.

`go build ./...`, `go vet ./...` and `go test ./...` all pass after this change. This unblocks the vet step of the CI workflow proposed in #10113 (verified green on a fork run with all three branches combined).

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
