### PR TITLE
[cluster-autoscaler-release-1.34] PR#9703 Handle failed node creations without instance IDs by decreasing nodep…

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool.go
@@ -149,11 +149,24 @@ func (np *nodePool) DeleteNodes(nodes []*apiv1.Node) (err error) {
 	}
 
 	refs := make([]ocicommon.OciRef, 0, len(nodes))
+	nodesWithRefs := make([]*apiv1.Node, 0, len(nodes))
+	nodesWithoutInstanceID := 0
 
 	// even though the nodes param is an array, in reality, nodes only contains a single node
 	// Each node is deleted in its own DeleteNodes call, and all the calls are in parallel
 	// we will still loop through just to future proof this function
 	for _, node := range nodes {
+		ociRef, err := ocicommon.NodeToOciRef(node)
+		if err != nil {
+			return err
+		}
+		if ociRef.InstanceID == "" {
+			if node.Annotations[cloudprovider.FakeNodeReasonAnnotation] == cloudprovider.FakeNodeCreateError {
+				nodesWithoutInstanceID++
+				continue
+			}
+			return fmt.Errorf("node %s doesn't have an instance id so it can't be deleted", node.Name)
+		}
 		belongs, err := np.Belongs(node)
 		if err != nil {
 			return err
@@ -161,25 +174,27 @@ func (np *nodePool) DeleteNodes(nodes []*apiv1.Node) (err error) {
 		if !belongs {
 			return fmt.Errorf("%s belong to a different nodepool than %s", node.Name, np.Id())
 		}
-		ociRef, err := ocicommon.NodeToOciRef(node)
-		if err != nil {
-			return err
-		}
 
 		refs = append(refs, ociRef)
+		nodesWithRefs = append(nodesWithRefs, node)
 	}
 
-	if len(refs) == 0 {
-		return nil
+	if len(refs) > 0 {
+		deleteInstancesErr := np.manager.DeleteInstances(np, refs)
+		if deleteInstancesErr == nil {
+			// this will add taints to all the nodes. For now, we have only a single node deleted in a given call, but the implementation might change in the future
+			np.manager.TaintToPreventFurtherSchedulingOnRestart(nodesWithRefs, np.kubeClient)
+		} else {
+			klog.Warning("Error deleting instances", deleteInstancesErr)
+			return deleteInstancesErr
+		}
 	}
-	deleteInstancesErr := np.manager.DeleteInstances(np, refs)
-	if deleteInstancesErr == nil {
-		// this will add taints to all the nodes. For now, we have only a single node deleted in a given call, but the implementation might change in the future
-		np.manager.TaintToPreventFurtherSchedulingOnRestart(nodes, np.kubeClient)
-	} else {
-		klog.Warning("Error deleting instances", deleteInstancesErr)
+	if nodesWithoutInstanceID > 0 {
+		klog.Warningf("%d node(s) in node pool %s have no instance ID. Falling back to DecreaseTargetSize to clean up failed node creation.", nodesWithoutInstanceID, np.Id())
+		return np.DecreaseTargetSize(-nodesWithoutInstanceID)
 	}
-	return deleteInstancesErr
+
+	return nil
 }
 
 // ForceDeleteNodes deletes nodes from the group regardless of constraints.

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool_test.go
@@ -6,13 +6,15 @@ package nodepools
 
 import (
 	"context"
+	"testing"
+
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	ocicommon "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/common"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"testing"
 )
 
 func TestDeletePastMinSize(t *testing.T) {
@@ -52,10 +54,69 @@ func TestDeletePastMinSize(t *testing.T) {
 	}
 }
 
+func TestDeleteCreateErrorNodeWithoutInstanceIDDecreasesTargetSize(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	manager := &mockManager{
+		size:                           1,
+		existingNodePoolSizeViaCompute: 0,
+		nodes: []cloudprovider.Instance{
+			{
+				Status: &cloudprovider.InstanceStatus{
+					State: cloudprovider.InstanceCreating,
+					ErrorInfo: &cloudprovider.InstanceErrorInfo{
+						ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+						ErrorCode:    "QuotaExceeded",
+						ErrorMessage: "quota exceeded",
+					},
+				},
+			},
+		},
+	}
+	np := &nodePool{
+		kubeClient: client,
+		manager:    manager,
+		minSize:    0,
+		maxSize:    10,
+		id:         "abc",
+	}
+	manager.nodePool = np
+
+	nodeWithoutInstanceID := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				cloudprovider.FakeNodeReasonAnnotation: cloudprovider.FakeNodeCreateError,
+			},
+		},
+	}
+
+	if err := np.DeleteNodes([]*apiv1.Node{nodeWithoutInstanceID}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if manager.deleteInstancesCalled != 0 {
+		t.Fatalf("expected DeleteInstances not to be called, got %d calls", manager.deleteInstancesCalled)
+	}
+	if !manager.invalidateAndRefreshCacheCalled {
+		t.Fatalf("expected cache invalidation before decreasing target size")
+	}
+	if !manager.setSizeCalled {
+		t.Fatalf("expected SetNodePoolSize to be called")
+	}
+	if manager.setSize != 0 {
+		t.Fatalf("expected target size to be decreased to 0, got %d", manager.setSize)
+	}
+}
+
 type mockManager struct {
-	called    []string
-	nodePools []NodePool
-	nodes     []cloudprovider.Instance
+	called                          []string
+	nodePools                       []NodePool
+	nodes                           []cloudprovider.Instance
+	size                            int
+	setSize                         int
+	setSizeCalled                   bool
+	deleteInstancesCalled           int
+	existingNodePoolSizeViaCompute  int
+	invalidateAndRefreshCacheCalled bool
 
 	// used for GetNodePoolForInstance
 	nodePool NodePool
@@ -64,52 +125,74 @@ type mockManager struct {
 	timeOutErr error
 }
 
-func (m mockManager) Refresh() error {
+func (m *mockManager) Refresh() error {
 	m.called = append(m.called, "refresh")
 	return nil
 }
 
-func (m mockManager) Cleanup() error {
+func (m *mockManager) Cleanup() error {
 	m.called = append(m.called, "cleanup")
 	return nil
 }
 
-func (m mockManager) GetNodePools() []NodePool {
+func (m *mockManager) GetNodePools() []NodePool {
 	m.called = append(m.called, "get-node-pools")
 	return m.nodePools
 }
 
-func (m mockManager) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance, error) {
+func (m *mockManager) GetNodePoolNodes(np NodePool) ([]cloudprovider.Instance, error) {
 	m.called = append(m.called, "get-node-pool-nodes")
 	return m.nodes, nil
 }
 
-func (m mockManager) GetNodePoolForInstance(instance ocicommon.OciRef) (NodePool, error) {
+func (m *mockManager) GetExistingNodePoolSizeViaCompute(np NodePool) (int, error) {
+	m.called = append(m.called, "get-existing-node-pool-size-via-compute")
+	return m.existingNodePoolSizeViaCompute, nil
+}
+
+func (m *mockManager) GetNodePoolForInstance(instance ocicommon.OciRef) (NodePool, error) {
 	m.called = append(m.called, "get-node-pool-for-instance")
 	return m.nodePool, m.err
 }
 
-func (m mockManager) GetNodePoolTemplateNode(np NodePool) (*apiv1.Node, error) {
+func (m *mockManager) GetNodePoolTemplateNode(np NodePool) (*apiv1.Node, error) {
 	m.called = append(m.called, "get-node-pool-template-node")
 	panic("implement me")
 }
 
-func (m mockManager) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+func (m *mockManager) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
 	m.called = append(m.called, "get-resource-limiter")
 	panic("implement me")
 }
 
-func (m mockManager) GetNodePoolSize(np NodePool) (int, error) {
+func (m *mockManager) GetNodePoolSize(np NodePool) (int, error) {
 	m.called = append(m.called, "get-node-pool-size")
+	if m.size != 0 {
+		return m.size, nil
+	}
 	return np.MinSize() + 1, nil
 }
 
-func (m mockManager) SetNodePoolSize(np NodePool, size int) error {
+func (m *mockManager) SetNodePoolSize(np NodePool, size int) error {
 	m.called = append(m.called, "set-node-pool-size")
-	panic("implement me")
+	m.setSize = size
+	m.setSizeCalled = true
+	return nil
 }
 
-func (m mockManager) DeleteInstances(np NodePool, instances []ocicommon.OciRef) error {
+func (m *mockManager) DeleteInstances(np NodePool, instances []ocicommon.OciRef) error {
 	m.called = append(m.called, "delete-instances")
+	m.deleteInstancesCalled++
 	return m.timeOutErr
+}
+
+func (m *mockManager) InvalidateAndRefreshCache() error {
+	m.called = append(m.called, "invalidate-and-refresh-cache")
+	m.invalidateAndRefreshCacheCalled = true
+	return nil
+}
+
+func (m *mockManager) TaintToPreventFurtherSchedulingOnRestart(nodes []*apiv1.Node, client kubernetes.Interface) error {
+	m.called = append(m.called, "taint-to-prevent-further-scheduling-on-restart")
+	return nil
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes/autoscaler/pull/9703

/assign jackfrancis

Fixed OCI nodepool recovery when failed node creation leaves a node without an instance ID.

/kind bug


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed OCI nodepool recovery when failed node creation leaves a node without an instance ID.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```