### PR TITLE
VPA admission controller: make status lease configurable

### DIFF
--- a/vertical-pod-autoscaler/docs/flags.md
+++ b/vertical-pod-autoscaler/docs/flags.md
@@ -42,6 +42,9 @@ This document is auto-generated from the flag definitions in the VPA admission-c
 | `reload-cert` | bool | false | If set to true, reload leaf and CA certificates when changed. |
 | `skip-headers` | bool | false | If true, avoid header prefixes in the log messages |
 | `skip-log-headers` | bool | false | If true, avoid headers when opening log files (no effect when -logtostderr=true) |
+| `status-lease-name` | string | "vpa-admission-controller" | The name of the Lease object used to publish the admission controller status. Must match the updater's --admission-controller-status-lease-name flag. |
+| `status-lease-namespace` | string |  | The namespace of the Lease object used to publish the admission controller status. Defaults to the value of the NAMESPACE environment variable, or kube-system if that is also unset. Must match the updater's --admission-controller-status-lease-namespace flag. |
+| `status-lease-update-interval` | duration | 10s | How often the admission controller status Lease is renewed. This is also the timeout for each renewal attempt. Must be well below the updater's --admission-controller-status-lease-timeout flag, otherwise the updater will consider the admission controller unhealthy and stop evicting pods. |
 | `stderrthreshold` | severity | info | set the log level threshold for writing to standard error |
 | `tls-cert-file` | string | "/etc/tls-certs/serverCert.pem" | Path to server certificate PEM file. |
 | `tls-ciphers` | string |  | A comma-separated or colon-separated list of ciphers to accept. Only works when min-tls-version is set to tls1_2. |
@@ -152,6 +155,9 @@ This document is auto-generated from the flag definitions in the VPA updater cod
 |------|------|---------|-------------|
 | `add-dir-header` | bool | false | If true, adds the file directory to the header of the log messages |
 | `address` | string | ":8943" | The address to expose Prometheus metrics. |
+| `admission-controller-status-lease-name` | string | "vpa-admission-controller" | The name of the Lease object used to check the admission controller status. Must match the admission controller's --status-lease-name flag. |
+| `admission-controller-status-lease-namespace` | string |  | The namespace of the Lease object used to check the admission controller status. Defaults to the value of the NAMESPACE environment variable, or kube-system if that is also unset. Must match the admission controller's --status-lease-namespace flag. |
+| `admission-controller-status-lease-timeout` | duration | 1m0s | The time after which the admission controller status is considered stale and the updater stops evicting pods. Must be longer than the admission controller's --status-lease-update-interval flag. |
 | `alsologtostderr` | bool | false | log to standard error as well as files (no effect when -logtostderr=true) |
 | `alsologtostderrthreshold` | severity |  | logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true) |
 | `evict-after-oom-threshold` | duration | 10m0s | The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start. |

--- a/vertical-pod-autoscaler/pkg/admission-controller/config/config.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"flag"
 	"os"
+	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,6 +28,7 @@ import (
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 )
 
 // CertsConfig holds configuration related to TLS certificates
@@ -58,6 +60,10 @@ type AdmissionControllerConfig struct {
 	WebhookLabels        string
 	RegisterByURL        bool
 
+	StatusLeaseName           string
+	StatusLeaseNamespace      string
+	StatusLeaseUpdateInterval time.Duration
+
 	MaxAllowedCPUBoost resource.QuantityValue
 }
 
@@ -84,6 +90,10 @@ func DefaultAdmissionControllerConfig() *AdmissionControllerConfig {
 		RegisterWebhook:      true,
 		WebhookLabels:        "",
 		RegisterByURL:        false,
+
+		StatusLeaseName:           status.AdmissionControllerStatusName,
+		StatusLeaseNamespace:      "",
+		StatusLeaseUpdateInterval: 10 * time.Second,
 
 		MaxAllowedCPUBoost: resource.QuantityValue{},
 	}
@@ -112,6 +122,10 @@ func InitAdmissionControllerFlags() *AdmissionControllerConfig {
 	flag.StringVar(&config.WebhookLabels, "webhook-labels", config.WebhookLabels, "Comma separated list of labels to add to the webhook object. Format: key1:value1,key2:value2")
 	flag.BoolVar(&config.RegisterByURL, "register-by-url", config.RegisterByURL, "If set to true, admission webhook will be registered by URL (webhookAddress:webhookPort) instead of by service name")
 
+	flag.StringVar(&config.StatusLeaseName, "status-lease-name", config.StatusLeaseName, "The name of the Lease object used to publish the admission controller status. Must match the updater's --admission-controller-status-lease-name flag.")
+	flag.StringVar(&config.StatusLeaseNamespace, "status-lease-namespace", config.StatusLeaseNamespace, "The namespace of the Lease object used to publish the admission controller status. Defaults to the value of the NAMESPACE environment variable, or "+status.AdmissionControllerStatusNamespace+" if that is also unset. Must match the updater's --admission-controller-status-lease-namespace flag.")
+	flag.DurationVar(&config.StatusLeaseUpdateInterval, "status-lease-update-interval", config.StatusLeaseUpdateInterval, "How often the admission controller status Lease is renewed. This is also the timeout for each renewal attempt. Must be well below the updater's --admission-controller-status-lease-timeout flag, otherwise the updater will consider the admission controller unhealthy and stop evicting pods.")
+
 	flag.Var(&config.MaxAllowedCPUBoost, "max-allowed-cpu-boost", "Maximum amount of CPU that will be applied for a container with boost.")
 
 	// These need to happen last. kube_flag.InitFlags() synchronizes and parses
@@ -130,4 +144,9 @@ func InitAdmissionControllerFlags() *AdmissionControllerConfig {
 // ValidateAdmissionControllerConfig performs validation of the admission-controller flags
 func ValidateAdmissionControllerConfig(config *AdmissionControllerConfig) {
 	common.ValidateCommonConfig(config.CommonFlags)
+
+	if config.StatusLeaseUpdateInterval <= 0 {
+		klog.ErrorS(nil, "--status-lease-update-interval must be positive.")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
 }

--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -49,7 +49,6 @@ import (
 
 const (
 	defaultResyncPeriod                        = 10 * time.Minute
-	statusUpdateInterval                       = 10 * time.Second
 	scaleCacheEntryLifetime      time.Duration = time.Hour
 	scaleCacheEntryFreshnessTime time.Duration = 10 * time.Minute
 	scaleCacheEntryJitterFactor  float64       = 1.
@@ -110,11 +109,14 @@ func main() {
 	if config.Namespace != "" {
 		statusNamespace = config.Namespace
 	}
+	if config.StatusLeaseNamespace != "" {
+		statusNamespace = config.StatusLeaseNamespace
+	}
 	statusUpdater := status.NewUpdater(
 		kubeClient,
-		status.AdmissionControllerStatusName,
+		config.StatusLeaseName,
 		statusNamespace,
-		statusUpdateInterval,
+		config.StatusLeaseUpdateInterval,
 		hostname,
 	)
 

--- a/vertical-pod-autoscaler/pkg/updater/config/config.go
+++ b/vertical-pod-autoscaler/pkg/updater/config/config.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/features"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/status"
 )
 
 // UpdaterConfig holds all configuration for the admission controller component
@@ -43,6 +44,10 @@ type UpdaterConfig struct {
 	Address                      string
 	UseAdmissionControllerStatus bool
 	InPlaceSkipDisruptionBudget  bool
+
+	AdmissionControllerStatusLeaseName      string
+	AdmissionControllerStatusLeaseNamespace string
+	AdmissionControllerStatusLeaseTimeout   time.Duration
 
 	DefaultUpdateThreshold     float64
 	PodLifetimeUpdateThreshold time.Duration
@@ -62,6 +67,10 @@ func DefaultUpdaterConfig() *UpdaterConfig {
 		Address:                      ":8943",
 		UseAdmissionControllerStatus: true,
 		InPlaceSkipDisruptionBudget:  false,
+
+		AdmissionControllerStatusLeaseName:      status.AdmissionControllerStatusName,
+		AdmissionControllerStatusLeaseNamespace: "",
+		AdmissionControllerStatusLeaseTimeout:   status.AdmissionControllerStatusTimeout,
 
 		DefaultUpdateThreshold:     0.1,
 		PodLifetimeUpdateThreshold: time.Hour * 12,
@@ -83,6 +92,10 @@ func InitUpdaterFlags() *UpdaterConfig {
 	flag.BoolVar(&config.UseAdmissionControllerStatus, "use-admission-controller-status", config.UseAdmissionControllerStatus, "If true, updater will only evict pods when admission controller status is valid.")
 	flag.BoolVar(&config.InPlaceSkipDisruptionBudget, "in-place-skip-disruption-budget", config.InPlaceSkipDisruptionBudget, "[BETA] If true, VPA updater skips disruption budget checks for in-place pod updates when all containers have NotRequired resize policy (or no policy defined) for both CPU and memory resources. Disruption budgets are still respected when any container has RestartContainer resize policy for any resource.")
 
+	flag.StringVar(&config.AdmissionControllerStatusLeaseName, "admission-controller-status-lease-name", config.AdmissionControllerStatusLeaseName, "The name of the Lease object used to check the admission controller status. Must match the admission controller's --status-lease-name flag.")
+	flag.StringVar(&config.AdmissionControllerStatusLeaseNamespace, "admission-controller-status-lease-namespace", config.AdmissionControllerStatusLeaseNamespace, "The namespace of the Lease object used to check the admission controller status. Defaults to the value of the NAMESPACE environment variable, or "+status.AdmissionControllerStatusNamespace+" if that is also unset. Must match the admission controller's --status-lease-namespace flag.")
+	flag.DurationVar(&config.AdmissionControllerStatusLeaseTimeout, "admission-controller-status-lease-timeout", config.AdmissionControllerStatusLeaseTimeout, "The time after which the admission controller status is considered stale and the updater stops evicting pods. Must be longer than the admission controller's --status-lease-update-interval flag.")
+
 	flag.Float64Var(&config.DefaultUpdateThreshold, "pod-update-threshold", config.DefaultUpdateThreshold, "Ignore updates that have priority lower than the value of this flag")
 	flag.DurationVar(&config.PodLifetimeUpdateThreshold, "in-recommendation-bounds-eviction-lifetime-threshold", config.PodLifetimeUpdateThreshold, "Pods that live for at least that long can be evicted even if their request is within the [MinRecommended...MaxRecommended] range")
 	flag.DurationVar(&config.EvictAfterOOMThreshold, "evict-after-oom-threshold", config.EvictAfterOOMThreshold, `The default duration to evict pods that have OOMed in less than evict-after-oom-threshold since start.`)
@@ -103,4 +116,9 @@ func InitUpdaterFlags() *UpdaterConfig {
 // ValidateUpdaterConfig performs validation of the updater flags
 func ValidateUpdaterConfig(config *UpdaterConfig) {
 	common.ValidateCommonConfig(config.CommonFlags)
+
+	if config.AdmissionControllerStatusLeaseTimeout <= 0 {
+		klog.ErrorS(nil, "--admission-controller-status-lease-timeout must be positive.")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -85,6 +85,7 @@ type updater struct {
 	selectorFetcher              target.VpaTargetSelectorFetcher
 	useAdmissionControllerStatus bool
 	statusValidator              status.Validator
+	statusTimeout                time.Duration
 	controllerFetcher            controllerfetcher.ControllerFetcher
 	ignoredNamespaces            []string
 	infeasibleAttempts           map[types.UID]*vpa_types.RecommendedPodResources
@@ -108,7 +109,9 @@ func NewUpdater(
 	defaultUpdateThreshold float64,
 	podLifetimeUpdateThreshold time.Duration,
 	evictAfterOOMThreshold time.Duration,
+	statusLeaseName string,
 	statusNamespace string,
+	statusTimeout time.Duration,
 	recommendationProcessor vpa_api_util.RecommendationProcessor,
 	evictionAdmission priority.PodEvictionAdmission,
 	selectorFetcher target.VpaTargetSelectorFetcher,
@@ -145,9 +148,10 @@ func NewUpdater(
 		useAdmissionControllerStatus: useAdmissionControllerStatus,
 		statusValidator: status.NewValidator(
 			kubeClient,
-			status.AdmissionControllerStatusName,
+			statusLeaseName,
 			statusNamespace,
 		),
+		statusTimeout:              statusTimeout,
 		infeasibleAttempts:         make(map[types.UID]*vpa_types.RecommendedPodResources),
 		ignoredNamespaces:          ignoredNamespaces,
 		defaultUpdateThreshold:     defaultUpdateThreshold,
@@ -162,13 +166,13 @@ func (u *updater) RunOnce(ctx context.Context) {
 	defer timer.ObserveTotal()
 
 	if u.useAdmissionControllerStatus {
-		isValid, err := u.statusValidator.IsStatusValid(ctx, status.AdmissionControllerStatusTimeout)
+		isValid, err := u.statusValidator.IsStatusValid(ctx, u.statusTimeout)
 		if err != nil {
 			klog.ErrorS(err, "Error getting Admission Controller status. Skipping update loop")
 			return
 		}
 		if !isValid {
-			klog.V(0).InfoS("Admission Controller status is not valid. Skipping update loop", "timeout", status.AdmissionControllerStatusTimeout)
+			klog.V(0).InfoS("Admission Controller status is not valid. Skipping update loop", "timeout", u.statusTimeout)
 			return
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -166,6 +166,9 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 	if config.Namespace != "" {
 		admissionControllerStatusNamespace = config.Namespace
 	}
+	if config.AdmissionControllerStatusLeaseNamespace != "" {
+		admissionControllerStatusNamespace = config.AdmissionControllerStatusLeaseNamespace
+	}
 
 	ignoredNamespaces := strings.Split(commonFlag.IgnoredVpaObjectNamespaces, ",")
 
@@ -187,7 +190,9 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
 		config.DefaultUpdateThreshold,
 		config.PodLifetimeUpdateThreshold,
 		config.EvictAfterOOMThreshold,
+		config.AdmissionControllerStatusLeaseName,
 		admissionControllerStatusNamespace,
+		config.AdmissionControllerStatusLeaseTimeout,
 		vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator),
 		priority.NewScalingDirectionPodEvictionAdmission(),
 		targetSelectorFetcher,

--- a/vertical-pod-autoscaler/pkg/utils/status/status_updater.go
+++ b/vertical-pod-autoscaler/pkg/utils/status/status_updater.go
@@ -63,7 +63,7 @@ func (su *Updater) Run(stopCh <-chan struct{}) {
 }
 
 func (su *Updater) updateStatus() {
-	// The lease renewal has timeout of the given update interval (10s).
+	// The lease renewal has timeout of the given update interval.
 	// If the lease cannot be renewed in the allotted time (for example due to client-side throttling),
 	// the vpa-updater will consider that vpa-admission-controller as unhealthy and won't evict Pods in endless loop.
 	ctx, cancel := context.WithTimeout(context.Background(), su.updateInterval)


### PR DESCRIPTION
#### What type of PR is this?

This PR makes the admission controller status lease configurable (name, namespace, update interval) with corresponding configuration in the updater (name, namespace, timeout).

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We are currently running 2 instances of VPA; a main VPA instance to vertically scale cluster workloads and another one to vertically scale the main instance (this is to allow the main VPA instance to be vertically scaled without introducing a cyclic dependency).

However, because the admission controller lease isn't configurable, the admission controllers for the 2 instances share a lease so the main updater may evict Pods even when its corresponding VPA admission controller is down.

This PR fixes this by making the lease configurable so that we can have separate admissions controller status leases for the separate VPA instances.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
VPA admission controller flags added:
- --status-lease-name
- --status-lease-namespace
- --status-lease-update-interval
VPA updater flags added:
- --admission-controller-status-lease-name
- --admission-controller-status-lease-namespace
- --admission-controller-status-lease-timeout
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable status Lease names, namespaces, renewal intervals, and timeouts for the admission controller and updater.
  - Added command-line options to customize status Lease behavior.
  - Admission-controller status checks now honor the configured Lease settings.
- **Bug Fixes**
  - Added validation to reject non-positive Lease intervals and timeouts.
- **Documentation**
  - Documented the new Lease configuration, monitoring, and command-line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->