### PR TITLE
VPA recommender: support max capping to zero

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
@@ -252,7 +252,7 @@ func maybeCapToPolicyMax(recommended resource.Quantity, resourceName corev1.Reso
 func maybeCapToMax(recommended resource.Quantity, resourceName corev1.ResourceName,
 	maxAllowed corev1.ResourceList) (resource.Quantity, bool) {
 	maxResource, found := maxAllowed[resourceName]
-	if found && !maxResource.IsZero() && recommended.Cmp(maxResource) > 0 {
+	if found && recommended.Cmp(maxResource) > 0 {
 		return maxResource, true
 	}
 	return recommended, false
@@ -261,7 +261,7 @@ func maybeCapToMax(recommended resource.Quantity, resourceName corev1.ResourceNa
 func maybeCapToMin(recommended resource.Quantity, resourceName corev1.ResourceName,
 	minAllowed corev1.ResourceList) (resource.Quantity, bool) {
 	minResource, found := minAllowed[resourceName]
-	if found && !minResource.IsZero() && recommended.Cmp(minResource) < 0 {
+	if found && recommended.Cmp(minResource) < 0 {
 		return minResource, true
 	}
 	return recommended, false
@@ -381,10 +381,17 @@ func getBoundaryRecommendation(recommendation corev1.ResourceList,
 	}
 	boundaryCpu := GetBoundaryRequest(corev1.ResourceCPU, containerRequests.Cpu(), containerLimits.Cpu(), boundaryLimit.Cpu(), defaultLimit.Cpu())
 	boundaryMem := GetBoundaryRequest(corev1.ResourceMemory, containerRequests.Memory(), containerLimits.Memory(), boundaryLimit.Memory(), defaultLimit.Memory())
-	return corev1.ResourceList{
-		corev1.ResourceCPU:    *boundaryCpu,
-		corev1.ResourceMemory: *boundaryMem,
+	// GetBoundaryRequest returns a zero quantity when there is no boundary for
+	// the resource so we omit zero quantities so that a missing boundary does
+	// not cap the corresponding resource to zero
+	result := corev1.ResourceList{}
+	if !boundaryCpu.IsZero() {
+		result[corev1.ResourceCPU] = *boundaryCpu
 	}
+	if !boundaryMem.IsZero() {
+		result[corev1.ResourceMemory] = *boundaryMem
+	}
+	return result
 }
 
 type containerWithRecommendation struct {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
@@ -263,6 +263,58 @@ func TestRecommendationCappedToMinMaxPolicy(t *testing.T) {
 	}, res.ContainerRecommendations[0].UpperBound)
 }
 
+func TestRecommendationCappedToZeroMaxPolicy(t *testing.T) {
+	containerName := "ctr-name"
+	pod := test.Pod().WithName("pod1").AddContainer(test.Container().WithName(containerName).Get()).Get()
+	podRecommendation := vpa_types.RecommendedPodResources{
+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+			{
+				ContainerName: containerName,
+				Target: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+				UncappedTarget: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+	}
+	policy := vpa_types.PodResourcePolicy{
+		ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+			{
+				ContainerName: containerName,
+				MaxAllowed: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+				},
+			},
+		},
+	}
+
+	vpa := test.VerticalPodAutoscaler().WithContainer(containerName).Get()
+	vpa.Spec.ResourcePolicy = &policy
+	vpa.Status.Recommendation = &podRecommendation
+
+	res, annotations, err := NewCappingRecommendationProcessor(&fakeLimitRangeCalculator{}).Apply(vpa, pod)
+	assert.NoError(t, err)
+	assert.Equal(t, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("0"),
+		corev1.ResourceMemory: resource.MustParse("0"),
+	}, res.ContainerRecommendations[0].Target)
+
+	assert.Contains(t, annotations, containerName)
+	assert.Contains(t, annotations[containerName], "cpu capped to maxAllowed")
+	assert.Contains(t, annotations[containerName], "memory capped to maxAllowed")
+
+	// The uncapped target is left alone so the original recommendation stays visible.
+	assert.Equal(t, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("100m"),
+		corev1.ResourceMemory: resource.MustParse("100Mi"),
+	}, res.ContainerRecommendations[0].UncappedTarget)
+}
+
 var podRecommendation *vpa_types.RecommendedPodResources = &vpa_types.RecommendedPodResources{
 	ContainerRecommendations: []vpa_types.RecommendedContainerResources{
 		{
@@ -595,6 +647,119 @@ func TestApplyVPAPolicy(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:              "resource policy has max allowed of zero",
+			PodRecommendation: recommendation,
+			ResourcePolicy: &vpa_types.PodResourcePolicy{
+				ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+					{
+						ContainerName: "foo",
+						MaxAllowed: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+					},
+				},
+			},
+			GlobalMaxAllowed: nil,
+			Expected: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "foo",
+						Target: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+						LowerBound: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+						UpperBound: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+						UncappedTarget: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("42m"),
+							corev1.ResourceMemory: resource.MustParse("42Mi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:              "resource policy has max allowed of zero and global max allowed is set",
+			PodRecommendation: recommendation,
+			ResourcePolicy: &vpa_types.PodResourcePolicy{
+				ContainerPolicies: []vpa_types.ContainerResourcePolicy{
+					{
+						ContainerName: "foo",
+						MaxAllowed: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+					},
+				},
+			},
+			GlobalMaxAllowed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("30m"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
+			},
+			Expected: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "foo",
+						Target: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+						LowerBound: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+						UpperBound: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+						UncappedTarget: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("42m"),
+							corev1.ResourceMemory: resource.MustParse("42Mi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:              "resource policy is nil and global max allowed is zero",
+			PodRecommendation: recommendation,
+			ResourcePolicy:    nil,
+			GlobalMaxAllowed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0"),
+				corev1.ResourceMemory: resource.MustParse("0"),
+			},
+			Expected: &vpa_types.RecommendedPodResources{
+				ContainerRecommendations: []vpa_types.RecommendedContainerResources{
+					{
+						ContainerName: "foo",
+						Target: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+						LowerBound: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+						UpperBound: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+						UncappedTarget: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("42m"),
+							corev1.ResourceMemory: resource.MustParse("42Mi"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -691,6 +856,130 @@ func TestApplyCapsToLimitRange(t *testing.T) {
 	assert.Contains(t, annotations, "container")
 	assert.ElementsMatch(t, []string{"cpu capped to fit Max in container LimitRange", "memory capped to fit Min in container LimitRange"}, annotations["container"])
 	assert.Equal(t, expectedRecommendation, *processedRecommendation)
+}
+
+func TestGetBoundaryRecommendation(t *testing.T) {
+	tests := []struct {
+		name              string
+		containerRequests corev1.ResourceList
+		containerLimits   corev1.ResourceList
+		boundaryLimit     corev1.ResourceList
+		defaultLimit      corev1.ResourceList
+		expect            corev1.ResourceList
+	}{
+		{
+			name:          "boundary limit is nil",
+			boundaryLimit: nil,
+			expect:        corev1.ResourceList{},
+		},
+		{
+			name: "container has no limits so there is no boundary",
+			containerRequests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("50M"),
+			},
+			containerLimits: nil,
+			boundaryLimit: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
+			},
+			expect: corev1.ResourceList{},
+		},
+		{
+			name: "container has no cpu limit so only memory has a boundary",
+			containerRequests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("50M"),
+			},
+			containerLimits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("100M"),
+			},
+			boundaryLimit: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
+			},
+			expect: corev1.ResourceList{
+				corev1.ResourceMemory: *resource.NewQuantity(100000000, resource.DecimalSI), // (50M*200M)/100M
+			},
+		},
+		{
+			name: "boundary limit is missing memory so only cpu has a boundary",
+			containerRequests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("50M"),
+			},
+			containerLimits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("100M"),
+			},
+			boundaryLimit: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"),
+			},
+			expect: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(2000, resource.DecimalSI), // (1*4)/2
+			},
+		},
+		{
+			name: "limit range default is used when the container has no limits",
+			containerRequests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("50M"),
+			},
+			containerLimits: nil,
+			boundaryLimit: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
+			},
+			defaultLimit: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("100M"),
+			},
+			expect: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI), // (1*4)/2
+				corev1.ResourceMemory: *resource.NewQuantity(100000000, resource.DecimalSI), // (50M*200M)/100M
+			},
+		},
+		{
+			name:              "container has no requests so the boundary is the boundary limit",
+			containerRequests: nil,
+			containerLimits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("100M"),
+			},
+			boundaryLimit: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
+			},
+			expect: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
+			},
+		},
+		{
+			name: "cpu boundary rounds down to zero so it is omitted",
+			containerRequests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1m"),
+				corev1.ResourceMemory: resource.MustParse("50M"),
+			},
+			containerLimits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("100M"),
+			},
+			boundaryLimit: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("200M"),
+			},
+			expect: corev1.ResourceList{
+				corev1.ResourceMemory: *resource.NewQuantity(100000000, resource.DecimalSI),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getBoundaryRecommendation(nil, tc.containerRequests, tc.containerLimits, tc.boundaryLimit, tc.defaultLimit)
+			assert.Equal(t, tc.expect, got)
+		})
+	}
 }
 
 func TestApplyPodLimitRange(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

This PR allows VPA recommendations to be capped to zero.

TODO: Does this also try to set the limit to 0 if the request is 0 and limit is non-zero?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We are currently generating VPA resources for all cluster workloads to scale down overprovisioned requests. However, for workloads that have no request or a zero request set for a resource, the only way to stop VPA scaling the request up is by removing the resource from the list of controlled resources or setting the container scaling mode to `Off`. This is not ideal as it means we stop getting uncapped recommendations for that resource.

This also means that if we decide to scale workloads up in the future we cannot configure VPA to actively scale back down to rollback in case of issues (e.g. mass evictions). Today we have to disable VPA and manually delete/roll Pods (or cap recommendations to a very small value).

This PR fixes this by respecting zero values in container policy `maxAllowed` by capping the recommendation to zero.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I have treated this as a bug and have marked it as such since setting a resource to zero in `maxAllowed` is valid in the VPA spec but it is ignored today. However, this could potentially break users if they already have `maxAllowed` set to zero as VPA will start setting recommendations to zero on upgrade when previously VPA would have been actively vertically scaling.

Is there a better way to shout about this change other than describing it in the release notes to warn users?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Respect VPA container resource policy maxAllowed when set to zero
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-valued CPU and memory limits are now applied correctly when explicitly configured.
  * Recommendations are no longer incorrectly capped to zero when resource boundaries are absent or incomplete.
  * Zero-valued CPU and memory recommendations are omitted when appropriate, preserving accurate autoscaling results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->