### PR TITLE
Fix e2e test flake

### DIFF
--- a/vertical-pod-autoscaler/test/e2e/v1/autoscaling_utils.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/autoscaling_utils.go
@@ -29,35 +29,26 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/test/e2e/utils"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
-	e2eendpointslice "k8s.io/kubernetes/test/e2e/framework/endpointslice"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
 	"k8s.io/kubernetes/test/e2e/framework/resource"
-	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 
-	scaleclient "k8s.io/client-go/scale"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 const (
 	dynamicConsumptionTimeInSeconds = 30
-	dynamicRequestSizeInMillicores  = 20
-	dynamicRequestSizeInMegabytes   = 100
-	dynamicRequestSizeCustomMetric  = 10
-	port                            = 80
 	targetPort                      = 8080
 	timeoutRC                       = 120 * time.Second
 	invalidKind                     = "ERROR: invalid workload kind for resource consumer"
-	customMetricName                = "QPS"
 	serviceInitializationTimeout    = 2 * time.Minute
 	serviceInitializationInterval   = 15 * time.Second
 	stressImage                     = "registry.k8s.io/e2e-test-images/agnhost:2.53"
@@ -77,279 +68,253 @@ var (
 )
 
 /*
-ResourceConsumer is a tool for testing. It helps create specified usage of CPU or memory (Warning: memory not supported)
+ResourceConsumer is a tool for testing. It helps create specified usage of CPU or memory.
+Load is sent directly to each pod via the Kubernetes pod proxy API, so no
+service, kube-proxy or resource-consumer-controller pod is involved.
 typical use case:
-rc.ConsumeCPU(600)
+rc.ConsumeCPUPerPod(600)
 // ... check your assumption here
-rc.ConsumeCPU(300)
+rc.ConsumeCPUPerPod(300)
 // ... check your assumption here
 */
 type ResourceConsumer struct {
 	name                     string
-	controllerName           string
 	kind                     schema.GroupVersionKind
 	nsName                   string
 	clientSet                clientset.Interface
-	scaleClient              scaleclient.ScalesGetter
-	cpu                      chan int
-	mem                      chan int
-	customMetric             chan int
-	stopCPU                  chan int
-	stopMem                  chan int
-	stopCustomMetric         chan int
+	cpuPerPod                chan int
+	memPerPod                chan int
+	stopCPUPerPod            chan int
+	stopMemPerPod            chan int
 	stopWaitGroup            sync.WaitGroup
 	consumptionTimeInSeconds int
 	sleepTime                time.Duration
-	requestSizeInMillicores  int
-	requestSizeInMegabytes   int
-	requestSizeCustomMetric  int
 }
 
-// NewDynamicResourceConsumer is a wrapper to create a new dynamic ResourceConsumer
-func NewDynamicResourceConsumer(name, nsName string, kind schema.GroupVersionKind, replicas, initCPUTotal, initMemoryTotal, initCustomMetric int, cpuLimit, memLimit int64, clientset clientset.Interface, scaleClient scaleclient.ScalesGetter) *ResourceConsumer {
-	return newResourceConsumer(name, nsName, kind, replicas, initCPUTotal, initMemoryTotal, initCustomMetric, dynamicConsumptionTimeInSeconds,
-		dynamicRequestSizeInMillicores, dynamicRequestSizeInMegabytes, dynamicRequestSizeCustomMetric, cpuLimit, memLimit, clientset, scaleClient, nil, nil)
+// NewDynamicResourceConsumer is a wrapper to create a new dynamic ResourceConsumer.
+func NewDynamicResourceConsumer(name, nsName string, kind schema.GroupVersionKind, replicas, initCPUTotal, initMemoryTotal int, cpuLimit, memLimit int64, clientset clientset.Interface) *ResourceConsumer {
+	return newResourceConsumer(name, nsName, kind, replicas, initCPUTotal, initMemoryTotal, dynamicConsumptionTimeInSeconds,
+		cpuLimit, memLimit, clientset, nil)
 }
 
 /*
-NewResourceConsumer creates new ResourceConsumer
+newResourceConsumer creates new ResourceConsumer
 initCPUTotal argument is in millicores
 initMemoryTotal argument is in megabytes
 memLimit argument is in megabytes, memLimit is a maximum amount of memory that can be consumed by a single pod
 cpuLimit argument is in millicores, cpuLimit is a maximum amount of cpu that can be consumed by a single pod
 */
-func newResourceConsumer(name, nsName string, kind schema.GroupVersionKind, replicas, initCPUTotal, initMemoryTotal, initCustomMetric, consumptionTimeInSeconds, requestSizeInMillicores,
-	requestSizeInMegabytes int, requestSizeCustomMetric int, cpuLimit, memLimit int64, clientset clientset.Interface, scaleClient scaleclient.ScalesGetter, podAnnotations, serviceAnnotations map[string]string) *ResourceConsumer {
+func newResourceConsumer(name, nsName string, kind schema.GroupVersionKind, replicas, initCPUTotal, initMemoryTotal, consumptionTimeInSeconds int,
+	cpuLimit, memLimit int64, clientset clientset.Interface, podAnnotations map[string]string) *ResourceConsumer {
 	if podAnnotations == nil {
 		podAnnotations = make(map[string]string)
 	}
-	if serviceAnnotations == nil {
-		serviceAnnotations = make(map[string]string)
-	}
-	runServiceAndWorkloadForResourceConsumer(clientset, nsName, name, kind, replicas, cpuLimit, memLimit, podAnnotations, serviceAnnotations)
+	runWorkloadForResourceConsumer(clientset, nsName, name, kind, replicas, cpuLimit, memLimit, podAnnotations)
 	rc := &ResourceConsumer{
 		name:                     name,
-		controllerName:           name + "-ctrl",
 		kind:                     kind,
 		nsName:                   nsName,
 		clientSet:                clientset,
-		scaleClient:              scaleClient,
-		cpu:                      make(chan int),
-		mem:                      make(chan int),
-		customMetric:             make(chan int),
-		stopCPU:                  make(chan int),
-		stopMem:                  make(chan int),
-		stopCustomMetric:         make(chan int),
+		cpuPerPod:                make(chan int),
+		memPerPod:                make(chan int),
+		stopCPUPerPod:            make(chan int),
+		stopMemPerPod:            make(chan int),
 		consumptionTimeInSeconds: consumptionTimeInSeconds,
 		sleepTime:                time.Duration(consumptionTimeInSeconds) * time.Second,
-		requestSizeInMillicores:  requestSizeInMillicores,
-		requestSizeInMegabytes:   requestSizeInMegabytes,
-		requestSizeCustomMetric:  requestSizeCustomMetric,
 	}
 
-	go rc.makeConsumeCPURequests()
-	rc.ConsumeCPU(initCPUTotal)
-
-	go rc.makeConsumeMemRequests()
-	rc.ConsumeMem(initMemoryTotal)
-	go rc.makeConsumeCustomMetric()
-	rc.ConsumeCustomMetric(initCustomMetric)
+	rc.stopWaitGroup.Add(1)
+	go rc.makeConsumeCPUPerPodRequests()
+	rc.ConsumeCPUPerPod(initCPUTotal)
+	rc.stopWaitGroup.Add(1)
+	go rc.makeConsumeMemPerPodRequests()
+	rc.ConsumeMemPerPod(initMemoryTotal)
 	return rc
 }
 
-// ConsumeCPU consumes given number of CPU
-func (rc *ResourceConsumer) ConsumeCPU(millicores int) {
-	framework.Logf("RC %s: consume %v millicores in total", rc.name, millicores)
-	rc.cpu <- millicores
+// ConsumeCPUPerPod sends CPU load directly to each consumer pod via the
+// Kubernetes pod proxy API, bypassing kube-proxy's non-deterministic load
+// balancing. millicoresTotal is divided evenly across all running pods,
+// guaranteeing each pod receives an equal share.
+func (rc *ResourceConsumer) ConsumeCPUPerPod(millicoresTotal int) {
+	framework.Logf("RC %s: consume %v millicores in total (evenly distributed per pod)", rc.name, millicoresTotal)
+	rc.cpuPerPod <- millicoresTotal
 }
 
-// ConsumeMem consumes given number of Mem
-func (rc *ResourceConsumer) ConsumeMem(megabytes int) {
-	framework.Logf("RC %s: consume %v MB in total", rc.name, megabytes)
-	rc.mem <- megabytes
+// ConsumeMemPerPod is the memory equivalent of ConsumeCPUPerPod:
+// megabytesTotal is divided evenly across all running pods and sent directly
+// via the Kubernetes pod proxy API.
+func (rc *ResourceConsumer) ConsumeMemPerPod(megabytesTotal int) {
+	framework.Logf("RC %s: consume %v MB in total (evenly distributed per pod)", rc.name, megabytesTotal)
+	rc.memPerPod <- megabytesTotal
 }
 
-// ConsumeCustomMetric consumes given number of custom metric
-func (rc *ResourceConsumer) ConsumeCustomMetric(amount int) {
-	framework.Logf("RC %s: consume custom metric %v in total", rc.name, amount)
-	rc.customMetric <- amount
-}
-
-func (rc *ResourceConsumer) makeConsumeCPURequests() {
+func (rc *ResourceConsumer) makeConsumeCPUPerPodRequests() {
 	defer ginkgo.GinkgoRecover()
-	rc.stopWaitGroup.Add(1)
 	defer rc.stopWaitGroup.Done()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Cancel in-flight requests as soon as the stop channel closes, so CleanUp
+	// isn't blocked waiting for a long poll to finish.
+	go func() {
+		<-rc.stopCPUPerPod
+		cancel()
+	}()
 	sleepTime := time.Duration(0)
-	millicores := 0
+	millicoresTotal := 0
 	for {
 		select {
-		case millicores = <-rc.cpu:
-			framework.Logf("RC %s: setting consumption to %v millicores in total", rc.name, millicores)
+		case millicoresTotal = <-rc.cpuPerPod:
+			framework.Logf("RC %s: setting per-pod CPU to %v millicores total", rc.name, millicoresTotal)
 		case <-time.After(sleepTime):
-			framework.Logf("RC %s: sending request to consume %d millicores", rc.name, millicores)
-			rc.sendConsumeCPURequest(millicores)
+			if millicoresTotal != 0 {
+				framework.Logf("RC %s: sending per-pod CPU request: %d millicores total", rc.name, millicoresTotal)
+				rc.sendConsumeCPUPerPodRequest(ctx, millicoresTotal)
+			}
 			sleepTime = rc.sleepTime
-		case <-rc.stopCPU:
-			framework.Logf("RC %s: stopping CPU consumer", rc.name)
+		case <-rc.stopCPUPerPod:
+			framework.Logf("RC %s: stopping per-pod CPU consumer", rc.name)
 			return
 		}
 	}
 }
 
-func (rc *ResourceConsumer) makeConsumeMemRequests() {
+func (rc *ResourceConsumer) makeConsumeMemPerPodRequests() {
 	defer ginkgo.GinkgoRecover()
-	rc.stopWaitGroup.Add(1)
 	defer rc.stopWaitGroup.Done()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Cancel in-flight requests as soon as the stop channel closes, so CleanUp
+	// isn't blocked waiting for a long poll to finish.
+	go func() {
+		<-rc.stopMemPerPod
+		cancel()
+	}()
 	sleepTime := time.Duration(0)
-	megabytes := 0
+	megabytesTotal := 0
 	for {
 		select {
-		case megabytes = <-rc.mem:
-			framework.Logf("RC %s: setting consumption to %v MB in total", rc.name, megabytes)
+		case megabytesTotal = <-rc.memPerPod:
+			framework.Logf("RC %s: setting per-pod mem to %v MB total", rc.name, megabytesTotal)
 		case <-time.After(sleepTime):
-			framework.Logf("RC %s: sending request to consume %d MB", rc.name, megabytes)
-			rc.sendConsumeMemRequest(megabytes)
+			if megabytesTotal != 0 {
+				framework.Logf("RC %s: sending per-pod mem request: %d MB total", rc.name, megabytesTotal)
+				rc.sendConsumeMemPerPodRequest(ctx, megabytesTotal)
+			}
 			sleepTime = rc.sleepTime
-		case <-rc.stopMem:
-			framework.Logf("RC %s: stopping mem consumer", rc.name)
+		case <-rc.stopMemPerPod:
+			framework.Logf("RC %s: stopping per-pod mem consumer", rc.name)
 			return
 		}
 	}
 }
 
-func (rc *ResourceConsumer) makeConsumeCustomMetric() {
-	defer ginkgo.GinkgoRecover()
-	rc.stopWaitGroup.Add(1)
-	defer rc.stopWaitGroup.Done()
-	sleepTime := time.Duration(0)
-	delta := 0
-	for {
-		select {
-		case delta = <-rc.customMetric:
-			framework.Logf("RC %s: setting bump of metric %s to %d in total", rc.name, customMetricName, delta)
-		case <-time.After(sleepTime):
-			framework.Logf("RC %s: sending request to consume %d of custom metric %s", rc.name, delta, customMetricName)
-			rc.sendConsumeCustomMetric(delta)
-			sleepTime = rc.sleepTime
-		case <-rc.stopCustomMetric:
-			framework.Logf("RC %s: stopping metric consumer", rc.name)
-			return
+func (rc *ResourceConsumer) sendConsumeCPUPerPodRequest(ctx context.Context, millicoresTotal int) {
+	rc.sendConsumePerPodRequests(ctx, "ConsumeCPU", "millicores", millicoresTotal)
+}
+
+func (rc *ResourceConsumer) sendConsumeMemPerPodRequest(ctx context.Context, megabytesTotal int) {
+	rc.sendConsumePerPodRequests(ctx, "ConsumeMem", "megabytes", megabytesTotal)
+}
+
+// sendConsumePerPodRequests distributes load evenly across all running pods
+// by sending requests directly via the Kubernetes pod proxy API. This
+// bypasses kube-proxy load balancing, guaranteeing each pod receives exactly
+// its share.
+func (rc *ResourceConsumer) sendConsumePerPodRequests(ctx context.Context, endpoint, valueParam string, total int) {
+	ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
+	defer cancel()
+
+	var readyPods []string
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (done bool, err error) {
+		readyPods = nil
+		pods, err := rc.clientSet.CoreV1().Pods(rc.nsName).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("name=%s", rc.name),
+		})
+		if err != nil {
+			framework.Logf("%s per pod: failed to list pods: %v", endpoint, err)
+			return false, nil
 		}
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if pod.Status.Phase != v1.PodRunning || pod.DeletionTimestamp != nil {
+				continue
+			}
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+					readyPods = append(readyPods, pod.Name)
+					break
+				}
+			}
+		}
+		if len(readyPods) == 0 {
+			framework.Logf("%s per pod: no running pods labeled name=%s", endpoint, rc.name)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		// The pods may be under eviction by the VPA updater. Skip this tick and
+		// retry after the next sleep interval.
+		framework.Logf("%s per pod: no ready pods to send load to: %v", endpoint, err)
+		return
 	}
-}
 
-func (rc *ResourceConsumer) sendConsumeCPURequest(millicores int) {
-	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
-	defer cancel()
+	perPodValue := total / len(readyPods)
+	if perPodValue == 0 {
+		perPodValue = 1
+	}
 
-	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (done bool, err error) {
-		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
-		framework.ExpectNoError(err)
-		req := proxyRequest.Namespace(rc.nsName).
-			Name(rc.controllerName).
-			Suffix("ConsumeCPU").
-			Param("millicores", strconv.Itoa(millicores)).
-			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
-			Param("requestSizeMillicores", strconv.Itoa(rc.requestSizeInMillicores))
-		framework.Logf("ConsumeCPU URL: %v", *req.URL())
-		_, err = req.DoRaw(ctx)
-		if err != nil {
-			framework.Logf("ConsumeCPU failure: %v", err)
-			return false, nil
-		}
-		return true, nil
-	})
+	framework.Logf("%s per pod: distributing %d %s across %d pods (%d per pod)",
+		endpoint, total, valueParam, len(readyPods), perPodValue)
 
-	framework.ExpectNoError(err)
-}
-
-// sendConsumeMemRequest sends POST request for memory consumption
-func (rc *ResourceConsumer) sendConsumeMemRequest(megabytes int) {
-	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
-	defer cancel()
-
-	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (done bool, err error) {
-		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
-		framework.ExpectNoError(err)
-		req := proxyRequest.Namespace(rc.nsName).
-			Name(rc.controllerName).
-			Suffix("ConsumeMem").
-			Param("megabytes", strconv.Itoa(megabytes)).
-			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
-			Param("requestSizeMegabytes", strconv.Itoa(rc.requestSizeInMegabytes))
-		framework.Logf("ConsumeMem URL: %v", *req.URL())
-		_, err = req.DoRaw(ctx)
-		if err != nil {
-			framework.Logf("ConsumeMem failure: %v", err)
-			return false, nil
-		}
-		return true, nil
-	})
-
-	framework.ExpectNoError(err)
-}
-
-// sendConsumeCustomMetric sends POST request for custom metric consumption
-func (rc *ResourceConsumer) sendConsumeCustomMetric(delta int) {
-	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
-	defer cancel()
-
-	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (done bool, err error) {
-		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
-		framework.ExpectNoError(err)
-		req := proxyRequest.Namespace(rc.nsName).
-			Name(rc.controllerName).
-			Suffix("BumpMetric").
-			Param("metric", customMetricName).
-			Param("delta", strconv.Itoa(delta)).
-			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
-			Param("requestSizeMetrics", strconv.Itoa(rc.requestSizeCustomMetric))
-		framework.Logf("ConsumeCustomMetric URL: %v", *req.URL())
-		_, err = req.DoRaw(ctx)
-		if err != nil {
-			framework.Logf("ConsumeCustomMetric failure: %v", err)
-			return false, nil
-		}
-		return true, nil
-	})
-	framework.ExpectNoError(err)
+	var wg sync.WaitGroup
+	for _, podName := range readyPods {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			// Pod proxy URL: /api/v1/namespaces/{ns}/pods/{podname}:{port}/proxy/{path}
+			// Both service and pod proxy support the name:port format. Without an explicit
+			// port the API server defaults to port 80, but resource-consumer listens on
+			// targetPort (8080), so the port must be specified.
+			err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (done bool, err error) {
+				_, podErr := rc.clientSet.CoreV1().RESTClient().Post().
+					Resource("pods").
+					Namespace(rc.nsName).
+					Name(fmt.Sprintf("%s:%d", name, targetPort)).
+					SubResource("proxy").
+					Suffix(endpoint).
+					Param(valueParam, strconv.Itoa(perPodValue)).
+					Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
+					DoRaw(ctx)
+				if podErr != nil {
+					framework.Logf("%s per pod: error sending to pod %s: %v", endpoint, name, podErr)
+					return false, nil
+				}
+				return true, nil
+			})
+			if err != nil {
+				// The pod may have been evicted or recreated by the VPA updater;
+				// its replacement will get its share on the next tick.
+				framework.Logf("%s per pod: giving up on pod %s: %v", endpoint, name, err)
+			}
+		}(podName)
+	}
+	wg.Wait()
 }
 
 // CleanUp clean up the background goroutines responsible for consuming resources.
 func (rc *ResourceConsumer) CleanUp() {
 	ginkgo.By(fmt.Sprintf("Removing consuming RC %s", rc.name))
-	close(rc.stopCPU)
-	close(rc.stopMem)
-	close(rc.stopCustomMetric)
+	close(rc.stopCPUPerPod)
+	close(rc.stopMemPerPod)
 	rc.stopWaitGroup.Wait()
-	// Wait some time to ensure all child goroutines are finished.
-	time.Sleep(10 * time.Second)
 	kind := rc.kind.GroupKind()
 	framework.ExpectNoError(resource.DeleteResourceAndWaitForGC(context.TODO(), rc.clientSet, kind, rc.nsName, rc.name))
-	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(context.TODO(), rc.name, metav1.DeleteOptions{}))
-	framework.ExpectNoError(resource.DeleteResourceAndWaitForGC(context.TODO(), rc.clientSet, schema.GroupKind{Kind: "ReplicationController"}, rc.nsName, rc.controllerName))
-	framework.ExpectNoError(rc.clientSet.CoreV1().Services(rc.nsName).Delete(context.TODO(), rc.controllerName, metav1.DeleteOptions{}))
 }
 
-func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, ns, name string, kind schema.GroupVersionKind, replicas int, cpuRequestMillis, memRequestMb int64, podAnnotations, serviceAnnotations map[string]string) {
+func runWorkloadForResourceConsumer(c clientset.Interface, ns, name string, kind schema.GroupVersionKind, replicas int, cpuRequestMillis, memRequestMb int64, podAnnotations map[string]string) {
 	ginkgo.By(fmt.Sprintf("Running consuming RC %s via %s with %v replicas", name, kind, replicas))
-	_, err := c.CoreV1().Services(ns).Create(context.TODO(), &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Annotations: serviceAnnotations,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Port:       port,
-				TargetPort: intstr.FromInt(targetPort),
-			}},
-
-			Selector: map[string]string{
-				"name": name,
-			},
-		},
-	}, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
 
 	rcConfig := testutils.RCConfig{
 		Client:      c,
@@ -383,42 +348,6 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, ns, name st
 	default:
 		framework.Failf(invalidKind)
 	}
-
-	ginkgo.By(fmt.Sprintf("Running controller"))
-	controllerName := name + "-ctrl"
-	_, err = c.CoreV1().Services(ns).Create(context.TODO(), &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: controllerName,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Port:       port,
-				TargetPort: intstr.FromInt(targetPort),
-			}},
-
-			Selector: map[string]string{
-				"name": controllerName,
-			},
-		},
-	}, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
-
-	dnsClusterFirst := v1.DNSClusterFirst
-	controllerRcConfig := testutils.RCConfig{
-		Client:    c,
-		Image:     imageutils.GetE2EImage(imageutils.Agnhost),
-		Name:      controllerName,
-		Namespace: ns,
-		Timeout:   timeoutRC,
-		Replicas:  1,
-		Command:   []string{"/agnhost", "resource-consumer-controller", "--consumer-service-name=" + name, "--consumer-service-namespace=" + ns, "--consumer-port=80"},
-		DNSPolicy: &dnsClusterFirst,
-	}
-	framework.ExpectNoError(e2erc.RunRC(context.TODO(), controllerRcConfig))
-
-	// Wait for endpoints to propagate for the controller service.
-	framework.ExpectNoError(e2eendpointslice.WaitForEndpointCount(
-		context.TODO(), c, ns, controllerName, 1))
 }
 
 // runReplicaSet launches (and verifies correctness) of a replicaset.

--- a/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
+++ b/vertical-pod-autoscaler/test/e2e/v1/full_vpa.go
@@ -83,11 +83,9 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 				replicas,
 				1,             /*initCPUTotal*/
 				10,            /*initMemoryTotal*/
-				1,             /*initCustomMetric*/
 				initialCPU,    /*cpuRequest*/
 				initialMemory, /*memRequest*/
-				f.ClientSet,
-				f.ScalesGetter)
+				f.ClientSet)
 
 			ginkgo.By("Setting up a VPA CRD")
 			targetRef := &autoscaling.CrossVersionObjectReference{
@@ -123,7 +121,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// consume more CPU to get a higher recommendation
-			rc.ConsumeCPU(600 * replicas)
+			rc.ConsumeCPUPerPod(600 * replicas)
 			err = waitForResourceRequestInRangeInPods(
 				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
 				ParseQuantityOrDie("500m"), ParseQuantityOrDie("1300m"))
@@ -141,7 +139,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 			// NOTE: large range given due to unpredictability of actual memory usage
 			// NOTE: longer timeout: the memory recommendation grows slower than CPU
 			// and the updater then applies it to the pods serially, ~1-2 min apart.
-			rc.ConsumeMem(1024 * replicas)
+			rc.ConsumeMemPerPod(1024 * replicas)
 			err = waitForResourceRequestInRangeInPods(
 				f, 2*utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
 				ParseQuantityOrDie("900Mi"), ParseQuantityOrDie("4000Mi"))
@@ -157,11 +155,9 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 				replicas,
 				1,             /*initCPUTotal*/
 				10,            /*initMemoryTotal*/
-				1,             /*initCustomMetric*/
 				initialCPU,    /*cpuRequest*/
 				initialMemory, /*memRequest*/
-				f.ClientSet,
-				f.ScalesGetter)
+				f.ClientSet)
 
 			ginkgo.By("Setting up a VPA CRD")
 			targetRef := &autoscaling.CrossVersionObjectReference{
@@ -196,7 +192,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// consume more CPU to get a higher recommendation
-			rc.ConsumeCPU(600 * replicas)
+			rc.ConsumeCPUPerPod(600 * replicas)
 			err = waitForResourceRequestInRangeInPods(
 				f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
 				ParseQuantityOrDie("500m"), ParseQuantityOrDie("1300m"))
@@ -214,7 +210,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA", func() {
 			// NOTE: large range given due to unpredictability of actual memory usage
 			// NOTE: longer timeout: the memory recommendation grows slower than CPU
 			// and the updater then evicts the pods serially, ~1-2 min apart.
-			rc.ConsumeMem(1024 * replicas)
+			rc.ConsumeMemPerPod(1024 * replicas)
 			err = waitForResourceRequestInRangeInPods(
 				f, 2*utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceMemory,
 				ParseQuantityOrDie("900Mi"), ParseQuantityOrDie("4000Mi"))
@@ -245,11 +241,9 @@ var _ = FullVpaE2eDescribe("Pods under VPA with default recommender explicitly c
 			replicas,
 			1,             /*initCPUTotal*/
 			10,            /*initMemoryTotal*/
-			1,             /*initCustomMetric*/
 			initialCPU,    /*cpuRequest*/
 			initialMemory, /*memRequest*/
-			f.ClientSet,
-			f.ScalesGetter)
+			f.ClientSet)
 
 		ginkgo.By("Setting up a VPA CRD with Recommender explicitly configured")
 		targetRef := &autoscaling.CrossVersionObjectReference{
@@ -285,7 +279,7 @@ var _ = FullVpaE2eDescribe("Pods under VPA with default recommender explicitly c
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// consume more CPU to get a higher recommendation
-		rc.ConsumeCPU(600 * replicas)
+		rc.ConsumeCPUPerPod(600 * replicas)
 		err = waitForResourceRequestInRangeInPods(
 			f, utils.PollTimeout, metav1.ListOptions{LabelSelector: "name=hamster"}, apiv1.ResourceCPU,
 			ParseQuantityOrDie("500m"), ParseQuantityOrDie("1300m"))
@@ -318,11 +312,9 @@ var _ = FullVpaE2eDescribe("Pods under VPA with non-recognized recommender expli
 			replicas,
 			1,             /*initCPUTotal*/
 			10,            /*initMemoryTotal*/
-			1,             /*initCustomMetric*/
 			initialCPU,    /*cpuRequest*/
 			initialMemory, /*memRequest*/
-			f.ClientSet,
-			f.ScalesGetter)
+			f.ClientSet)
 
 		// The control deployment is identical but has a VPA with the default
 		// recommender. Watching the control being updated proves the
@@ -334,11 +326,9 @@ var _ = FullVpaE2eDescribe("Pods under VPA with non-recognized recommender expli
 			replicas,
 			1,             /*initCPUTotal*/
 			10,            /*initMemoryTotal*/
-			1,             /*initCustomMetric*/
 			initialCPU,    /*cpuRequest*/
 			initialMemory, /*memRequest*/
-			f.ClientSet,
-			f.ScalesGetter)
+			f.ClientSet)
 
 		containerName := utils.GetHamsterContainerNameByIndex(0)
 
@@ -400,8 +390,8 @@ var _ = FullVpaE2eDescribe("Pods under VPA with non-recognized recommender expli
 
 		// consume more CPU in both deployments, so that both would get a higher
 		// recommendation if their VPAs were handled by a recognized recommender
-		rc.ConsumeCPU(600 * replicas)
-		rcControl.ConsumeCPU(600 * replicas)
+		rc.ConsumeCPUPerPod(600 * replicas)
+		rcControl.ConsumeCPUPerPod(600 * replicas)
 
 		ginkgo.By("Waiting for the control deployment to be updated")
 		err = waitForResourceRequestInRangeInPods(
@@ -483,11 +473,9 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 				replicas,
 				1,             /*initCPUTotal*/
 				10,            /*initMemoryTotal*/
-				1,             /*initCustomMetric*/
 				initialCPU,    /*cpuRequest*/
 				initialMemory, /*memRequest*/
-				f.ClientSet,
-				f.ScalesGetter)
+				f.ClientSet)
 
 			// Pods should be created with boosted CPU (10m * 20 = 200m)
 			err := waitForResourceRequestInRangeInPods(
@@ -532,11 +520,9 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 				replicas,
 				1,             /*initCPUTotal*/
 				10,            /*initMemoryTotal*/
-				1,             /*initCustomMetric*/
 				initialCPU,    /*cpuRequest*/
 				initialMemory, /*memRequest*/
-				f.ClientSet,
-				f.ScalesGetter)
+				f.ClientSet)
 
 			ginkgo.By("Adding a second container to the deployment")
 			deployment, err := f.ClientSet.AppsV1().Deployments(ns).Get(context.TODO(), "hamster", metav1.GetOptions{})
@@ -610,11 +596,9 @@ var _ = FullVpaE2eDescribe("Pods under VPA with CPUStartupBoost", func() {
 				replicas,
 				1,             /*initCPUTotal*/
 				10,            /*initMemoryTotal*/
-				1,             /*initCustomMetric*/
 				initialCPU,    /*cpuRequest*/
 				initialMemory, /*memRequest*/
-				f.ClientSet,
-				f.ScalesGetter)
+				f.ClientSet)
 
 			ginkgo.By("Adding a second container to the deployment")
 			deployment, err := f.ClientSet.AppsV1().Deployments(ns).Get(context.TODO(), "hamster", metav1.GetOptions{})


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

There seems to be a flake when sending CPU usage to pods, since a service is used the spread isn't guaranteed to be even.

This PR introduces a few changes:

1. Remove the intermediate Pod, use the API servers proxy directly, and also speeds up the e2e test by not having to start the the Pod
2. Evenly divide traffic per pod (this is to reduce flakes)
3. Remove custom metrics (unused in VPA)

(this change is mostly AI driven) 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end resource consumption by distributing CPU and memory usage across running pods.
  * Added retries for pod discovery and resource requests to improve test reliability.

* **Refactor**
  * Simplified resource-consumer setup and cleanup.
  * Removed obsolete custom-metric consumption and service-based proxy configuration.
  * Updated resource-consumption flows to use per-pod CPU and memory operations.
  * Improved startup and shutdown handling for separate CPU and memory workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->