### PR TITLE
Add GetMatchingVPA benchmark

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_benchmark_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_benchmark_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpa
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
+	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+)
+
+type fixedSelectorFetcher struct {
+	selector labels.Selector
+}
+
+func (f *fixedSelectorFetcher) Fetch(_ context.Context, _ *vpa_types.VerticalPodAutoscaler) (labels.Selector, error) {
+	return f.selector, nil
+}
+
+// setupMatcherBenchmark populates a cache with vpaCount VPAs in the pod's namespace, each
+// targeting a distinct workload. Exactly one VPA targets the pod's owner; the matcher still
+// scans all of them.
+func setupMatcherBenchmark(b *testing.B, vpaCount int) (Matcher, *corev1.Pod) {
+	b.Helper()
+
+	owner := appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("workload-%d", vpaCount-1),
+			Namespace: "default",
+		},
+	}
+	pod := test.Pod().WithName("bench-pod").
+		WithLabels(map[string]string{"app": "test"}).
+		AddContainer(test.Container().WithName("bench-container").Get()).
+		WithCreator(&owner.ObjectMeta, &owner.TypeMeta).
+		Get()
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+
+	for i := range vpaCount {
+		vpa := test.VerticalPodAutoscaler().
+			WithContainer("bench-container").
+			WithName(fmt.Sprintf("vpa-%d", i)).
+			WithUpdateMode(vpa_types.UpdateModeRecreate).
+			WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
+				Kind:       "StatefulSet",
+				Name:       fmt.Sprintf("workload-%d", i),
+				APIVersion: "apps/v1",
+			}).
+			Get()
+		if err := indexer.Add(vpa); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	selectorFetcher := &fixedSelectorFetcher{selector: parseLabelSelector("app = test")}
+	matcher := NewMatcher(vpa_lister.NewVerticalPodAutoscalerLister(indexer), selectorFetcher, controllerfetcher.FakeControllerFetcher{})
+	return matcher, pod
+}
+
+func BenchmarkGetMatchingVPA(b *testing.B) {
+	ctx := context.Background()
+
+	for _, vpaCount := range []int{1, 10, 100, 1000, 10000} {
+		matcher, pod := setupMatcherBenchmark(b, vpaCount)
+		expectedVPAName := fmt.Sprintf("vpa-%d", vpaCount-1)
+
+		b.Run(fmt.Sprintf("vpas=%d", vpaCount), func(b *testing.B) {
+			b.ReportAllocs()
+			got := matcher.GetMatchingVPA(ctx, pod)
+			if got == nil || got.Name != expectedVPAName {
+				b.Fatal("expected a matching VPA")
+			}
+			for b.Loop() {
+				matcher.GetMatchingVPA(ctx, pod)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I'd like to see if I can improve this lookup. Before doing that, we need a test to ensure it's an improvement.

The plan is to get a benchmark into master, then add it to CI, then try improve it.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarking for matching workloads to their applicable autoscaling configuration.
  * Covers scenarios ranging from 1 to 10,000 autoscaling configurations.
  * Reports memory allocations and verifies that matching returns the expected result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->