### PR TITLE
Add github action to run go benchmarks for VPA

### DIFF
--- a/.github/workflows/vpa-benchmark.yaml
+++ b/.github/workflows/vpa-benchmark.yaml
@@ -1,0 +1,66 @@
+name: Vertical Pod Autoscaler
+
+on:
+  pull_request:
+    paths:
+      - 'vertical-pod-autoscaler/**'
+      - '!vertical-pod-autoscaler/**/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Go Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: pr
+
+      - name: Checkout Base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: base
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: pr/vertical-pod-autoscaler/go.mod
+          cache-dependency-path: pr/vertical-pod-autoscaler/go.sum
+
+      - name: Run Benchmark (Base branch)
+        shell: bash
+        run: |
+          cd base/vertical-pod-autoscaler
+          go test -run='^$' -bench=. -count=10 ./... | tee ../../base.txt
+
+      - name: Run Benchmark (PR branch)
+        shell: bash
+        run: |
+          cd pr/vertical-pod-autoscaler
+          go test -run='^$' -bench=. -count=10 ./... | tee ../../pr.txt
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260813145340-fd4a688df892
+
+      - name: Compare Results
+        shell: bash
+        run: |
+          echo "### Vertical Pod Autoscaler Benchmark Results" >> $GITHUB_STEP_SUMMARY
+          echo "Comparing PR branch against \`"$GITHUB_BASE_REF"\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [ -s base.txt ] && [ -s pr.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            $(go env GOPATH)/bin/benchstat base.txt pr.txt | tee benchstat.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          
+            # Fail if any regression is >= 10%
+            grep -qE '\+[1-9][0-9].*%' benchstat.txt && { echo "Regression detected >= 10%"; exit 1; } || true
+          else
+            echo "Error: Benchmark results not found or empty." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add github action to run go benchmarks for VPA
This will also fail if the PR introduces a change that slows existing benchmarks by 10%

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Relates to https://github.com/kubernetes/autoscaler/pull/10126

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated performance benchmarking for the Vertical Pod Autoscaler.
  * Compares results against the baseline to identify performance changes.
  * Repeated benchmark runs improve result consistency.
  * Performance comparisons are included in test summaries for easier review.
  * Flags regressions exceeding 10% or missing results before changes are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->