### PR TITLE
addon-resizer: add CPU requests-only mode

### DIFF
--- a/addon-resizer/main.go
+++ b/addon-resizer/main.go
@@ -39,6 +39,7 @@ const noValue = "MISSING"
 var (
 	// Flags to define the resource requirements.
 	baseCPU              = flag.String("cpu", noValue, "The base CPU resource requirement.")
+	cpuRequestsOnly      = flag.Bool("cpu-requests-only", false, "Manage CPU requests without managing CPU limits.")
 	cpuPerNode           = flag.String("extra-cpu", "0", "The amount of CPU to add per node.")
 	baseMemory           = flag.String("memory", noValue, "The base memory resource requirement.")
 	memoryPerNode        = flag.String("extra-memory", "0Mi", "The amount of memory to add per node.")
@@ -188,5 +189,6 @@ func main() {
 		},
 		pollPeriod,
 		*scaleDownDelay,
-		*scaleUpDelay)
+		*scaleUpDelay,
+		*cpuRequestsOnly)
 }

--- a/addon-resizer/nanny/nanny_lib.go
+++ b/addon-resizer/nanny/nanny_lib.go
@@ -73,6 +73,10 @@ func checkResource(estimatorResult *EstimatorResult, actual api.ResourceList, re
 func shouldOverwriteResources(estimatorResult *EstimatorResult, limits, reqs api.ResourceList, cpuRequestsOnly bool) (*api.ResourceRequirements, operation) {
 	for _, resourceType := range []api.ResourceName{api.ResourceCPU, api.ResourceMemory, api.ResourceStorage} {
 		if cpuRequestsOnly && resourceType == api.ResourceCPU {
+			if _, ok := estimatorResult.AcceptableRange.lower[resourceType]; !ok {
+				return nil, unknown
+			}
+
 			newReqs, op := checkResource(estimatorResult, reqs, resourceType)
 			if newReqs != nil {
 				log.V(4).Infof("Resource %s requests are out of bounds.", resourceType)

--- a/addon-resizer/nanny/nanny_lib.go
+++ b/addon-resizer/nanny/nanny_lib.go
@@ -70,16 +70,32 @@ func checkResource(estimatorResult *EstimatorResult, actual api.ResourceList, re
 // We'll over-write the resource limits if the limited resources are different, or if any limit is outside of the accepted range.
 // Returns null ResourceRequirements when no resources should be overridden.
 // Returned operation type (scale up/down or unknown) is calculated based on values taken from the first resource which requires overwrite.
-func shouldOverwriteResources(estimatorResult *EstimatorResult, limits, reqs api.ResourceList) (*api.ResourceRequirements, operation) {
-	for _, list := range []api.ResourceList{limits, reqs} {
-		for _, resourceType := range []api.ResourceName{api.ResourceCPU, api.ResourceMemory, api.ResourceStorage} {
+func shouldOverwriteResources(estimatorResult *EstimatorResult, limits, reqs api.ResourceList, cpuRequestsOnly bool) (*api.ResourceRequirements, operation) {
+	for _, resourceType := range []api.ResourceName{api.ResourceCPU, api.ResourceMemory, api.ResourceStorage} {
+		if cpuRequestsOnly && resourceType == api.ResourceCPU {
+			newReqs, op := checkResource(estimatorResult, reqs, resourceType)
+			if newReqs != nil {
+				log.V(4).Infof("Resource %s requests are out of bounds.", resourceType)
+				return &api.ResourceRequirements{
+					Limits:   limits,
+					Requests: *newReqs,
+				}, op
+			}
+			continue
+		}
+
+		for _, list := range []api.ResourceList{limits, reqs} {
 			newReqs, op := checkResource(estimatorResult, list, resourceType)
 			if newReqs != nil {
 				log.V(4).Infof("Resource %s is out of bounds.", resourceType)
-				return &api.ResourceRequirements{Limits: *newReqs, Requests: *newReqs}, op
+				return &api.ResourceRequirements{
+					Limits:   *newReqs,
+					Requests: *newReqs,
+				}, op
 			}
 		}
 	}
+
 	return nil, unknown
 }
 
@@ -100,7 +116,7 @@ type ResourceEstimator interface {
 // PollAPIServer periodically counts the number of nodes, estimates the expected
 // ResourceRequirements, compares them to the actual ResourceRequirements, and
 // updates the deployment with the expected ResourceRequirements if necessary.
-func PollAPIServer(k8s KubernetesClient, est ResourceEstimator, pollPeriod, scaleDownDelay, scaleUpDelay time.Duration) {
+func PollAPIServer(k8s KubernetesClient, est ResourceEstimator, pollPeriod, scaleDownDelay, scaleUpDelay time.Duration, cpuRequestsOnly bool) {
 	lastChange := time.Now()
 	lastResult := noChange
 
@@ -110,7 +126,7 @@ func PollAPIServer(k8s KubernetesClient, est ResourceEstimator, pollPeriod, scal
 			time.Sleep(pollPeriod)
 		}
 
-		if lastResult = updateResources(k8s, est, time.Now(), lastChange, scaleDownDelay, scaleUpDelay, lastResult); lastResult == overwrite {
+		if lastResult = updateResources(k8s, est, time.Now(), lastChange, scaleDownDelay, scaleUpDelay, lastResult, cpuRequestsOnly); lastResult == overwrite {
 			lastChange = time.Now()
 		}
 	}
@@ -122,7 +138,7 @@ func PollAPIServer(k8s KubernetesClient, est ResourceEstimator, pollPeriod, scal
 // It returns overwrite if deployment has been updated, postpone if the change
 // could not be applied due to scale up/down delay and noChange if the estimated
 // expected ResourceRequirements are in line with the actual ResourceRequirements.
-func updateResources(k8s KubernetesClient, est ResourceEstimator, now, lastChange time.Time, scaleDownDelay, scaleUpDelay time.Duration, prevResult updateResult) updateResult {
+func updateResources(k8s KubernetesClient, est ResourceEstimator, now, lastChange time.Time, scaleDownDelay, scaleUpDelay time.Duration, prevResult updateResult, cpuRequestsOnly bool) updateResult {
 
 	// Query the apiserver for the number of nodes.
 	num, err := k8s.CountNodes()
@@ -147,7 +163,7 @@ func updateResources(k8s KubernetesClient, est ResourceEstimator, now, lastChang
 	estimation := est.scaleWithNodes(num)
 
 	// If there's a difference, go ahead and set the new values.
-	overwriteResReq, op := shouldOverwriteResources(estimation, resources.Limits, resources.Requests)
+	overwriteResReq, op := shouldOverwriteResources(estimation, resources.Limits, resources.Requests, cpuRequestsOnly)
 	if overwriteResReq == nil {
 		log.V(4).Infof("Resources are within the expected limits. Actual: %+v, accepted range: %+v", jsonOrValue(*resources), jsonOrValue(estimation.AcceptableRange))
 		return noChange

--- a/addon-resizer/nanny/nanny_lib_test.go
+++ b/addon-resizer/nanny/nanny_lib_test.go
@@ -232,6 +232,7 @@ func TestShouldOverwriteResources(t *testing.T) {
 		{smallMemory, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, scaleUp, false},
 		{smallCPU, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, scaleUp, false},
 		{smallCPU, standardRecommended, &api.ResourceRequirements{Limits: smallCPU, Requests: belowStandard}, scaleUp, true},
+		{smallCPU, &EstimatorResult{}, nil, unknown, true},
 		{bigStorage, standardRecommended, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleDown, false},
 		{bigMemory, standardRecommended, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleDown, false},
 		{bigCPU, standardRecommended, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleDown, false},
@@ -277,6 +278,7 @@ func TestUpdateResources(t *testing.T) {
 		// Delay has passed
 		{smallCPU, standardRecommended, oneMinuteAgo, oneMinuteDelay, noDelay, &api.ResourceRequirements{belowStandard, belowStandard}, overwrite, false},
 		{smallCPU, standardRecommended, oneMinuteAgo, oneMinuteDelay, noDelay, &api.ResourceRequirements{Limits: smallCPU, Requests: belowStandard}, overwrite, true},
+		{smallCPU, &EstimatorResult{}, oneMinuteAgo, oneMinuteDelay, noDelay, nil, noChange, true},
 		{bigCPU, standardRecommended, oneMinuteAgo, noDelay, oneMinuteDelay, &api.ResourceRequirements{aboveStandard, aboveStandard}, overwrite, false},
 		{smallCPU, standardRecommended, oneHourAgo, oneMinuteDelay, noDelay, &api.ResourceRequirements{belowStandard, belowStandard}, overwrite, false},
 		{bigCPU, standardRecommended, oneHourAgo, noDelay, oneMinuteDelay, &api.ResourceRequirements{aboveStandard, aboveStandard}, overwrite, false},

--- a/addon-resizer/nanny/nanny_lib_test.go
+++ b/addon-resizer/nanny/nanny_lib_test.go
@@ -212,33 +212,35 @@ func TestCheckResources(t *testing.T) {
 
 func TestShouldOverwriteResources(t *testing.T) {
 	testCases := []struct {
-		res     api.ResourceList
-		e       *EstimatorResult
-		wantRes *api.ResourceRequirements
-		wantOp  operation
+		res             api.ResourceList
+		e               *EstimatorResult
+		wantRes         *api.ResourceRequirements
+		wantOp          operation
+		cpuRequestsOnly bool
 	}{
-		{standard, standardRecommended, nil, unknown},
-		{belowStandard, standardRecommended, nil, unknown},
-		{aboveStandard, standardRecommended, nil, unknown},
-		{standard, standardAcceptableAboveRecommended, nil, unknown},
-		{standard, standardAcceptableBelowRecommended, nil, unknown},
-		{standard, standardAboveAcceptable, &api.ResourceRequirements{belowStandard, belowStandard}, scaleDown},
-		{standard, standardBelowAcceptable, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleUp},
-		{noStorage, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, unknown},
-		{noMemory, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, unknown},
-		{noCPU, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, unknown},
-		{smallStorage, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, scaleUp},
-		{smallMemory, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, scaleUp},
-		{smallCPU, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, scaleUp},
-		{bigStorage, standardRecommended, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleDown},
-		{bigMemory, standardRecommended, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleDown},
-		{bigCPU, standardRecommended, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleDown},
+		{standard, standardRecommended, nil, unknown, false},
+		{belowStandard, standardRecommended, nil, unknown, false},
+		{aboveStandard, standardRecommended, nil, unknown, false},
+		{standard, standardAcceptableAboveRecommended, nil, unknown, false},
+		{standard, standardAcceptableBelowRecommended, nil, unknown, false},
+		{standard, standardAboveAcceptable, &api.ResourceRequirements{belowStandard, belowStandard}, scaleDown, false},
+		{standard, standardBelowAcceptable, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleUp, false},
+		{noStorage, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, unknown, false},
+		{noMemory, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, unknown, false},
+		{noCPU, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, unknown, false},
+		{smallStorage, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, scaleUp, false},
+		{smallMemory, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, scaleUp, false},
+		{smallCPU, standardRecommended, &api.ResourceRequirements{belowStandard, belowStandard}, scaleUp, false},
+		{smallCPU, standardRecommended, &api.ResourceRequirements{Limits: smallCPU, Requests: belowStandard}, scaleUp, true},
+		{bigStorage, standardRecommended, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleDown, false},
+		{bigMemory, standardRecommended, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleDown, false},
+		{bigCPU, standardRecommended, &api.ResourceRequirements{aboveStandard, aboveStandard}, scaleDown, false},
 
 		// Test successful comparison when not all ResourceNames are present.
-		{smallMemoryNoStorage, standardRecommendedNoStorage, &api.ResourceRequirements{belowStandardNoStorage, belowStandardNoStorage}, scaleUp},
+		{smallMemoryNoStorage, standardRecommendedNoStorage, &api.ResourceRequirements{belowStandardNoStorage, belowStandardNoStorage}, scaleUp, false},
 	}
 	for i, tc := range testCases {
-		gotRes, gotOp := shouldOverwriteResources(tc.e, tc.res, tc.res)
+		gotRes, gotOp := shouldOverwriteResources(tc.e, tc.res, tc.res, tc.cpuRequestsOnly)
 		if !reflect.DeepEqual(tc.wantRes, gotRes) || !reflect.DeepEqual(tc.wantOp, gotOp) {
 			t.Errorf("shouldOverwriteResources got (%v, %v), want (%v, %v) for test case %d.", gotRes, gotOp, tc.wantRes, tc.wantOp, i)
 		}
@@ -251,36 +253,38 @@ func TestUpdateResources(t *testing.T) {
 	oneMinuteAgo := now.Add(-time.Minute)
 	oneHourAgo := now.Add(-time.Hour)
 	testCases := []struct {
-		res     api.ResourceList
-		e       *EstimatorResult
-		lc      time.Time
-		sud     time.Duration
-		sdd     time.Duration
-		wantRes *api.ResourceRequirements
-		want    updateResult
+		res             api.ResourceList
+		e               *EstimatorResult
+		lc              time.Time
+		sud             time.Duration
+		sdd             time.Duration
+		wantRes         *api.ResourceRequirements
+		want            updateResult
+		cpuRequestsOnly bool
 	}{
 		// No changes to the resources
-		{standard, standardRecommended, now, noDelay, noDelay, nil, noChange},
-		{standard, standardRecommended, oneHourAgo, noDelay, noDelay, nil, noChange},
-		{standard, standardRecommended, oneHourAgo, oneMinuteDelay, noDelay, nil, noChange},
-		{standard, standardRecommended, oneHourAgo, noDelay, oneMinuteDelay, nil, noChange},
-		{standard, standardAcceptableAboveRecommended, now, noDelay, noDelay, nil, noChange},
-		{standard, standardAcceptableBelowRecommended, now, noDelay, noDelay, nil, noChange},
+		{standard, standardRecommended, now, noDelay, noDelay, nil, noChange, false},
+		{standard, standardRecommended, oneHourAgo, noDelay, noDelay, nil, noChange, false},
+		{standard, standardRecommended, oneHourAgo, oneMinuteDelay, noDelay, nil, noChange, false},
+		{standard, standardRecommended, oneHourAgo, noDelay, oneMinuteDelay, nil, noChange, false},
+		{standard, standardAcceptableAboveRecommended, now, noDelay, noDelay, nil, noChange, false},
+		{standard, standardAcceptableBelowRecommended, now, noDelay, noDelay, nil, noChange, false},
 		// Delay has not passed
-		{smallCPU, standardRecommended, tenSecondsAgo, oneMinuteDelay, noDelay, nil, postpone},
-		{smallCPU, standardRecommended, tenSecondsAgo, oneMinuteDelay, oneSecondDelay, nil, postpone},
-		{bigCPU, standardRecommended, tenSecondsAgo, noDelay, oneMinuteDelay, nil, postpone},
-		{bigCPU, standardRecommended, tenSecondsAgo, oneSecondDelay, oneMinuteDelay, nil, postpone},
+		{smallCPU, standardRecommended, tenSecondsAgo, oneMinuteDelay, noDelay, nil, postpone, false},
+		{smallCPU, standardRecommended, tenSecondsAgo, oneMinuteDelay, oneSecondDelay, nil, postpone, false},
+		{bigCPU, standardRecommended, tenSecondsAgo, noDelay, oneMinuteDelay, nil, postpone, false},
+		{bigCPU, standardRecommended, tenSecondsAgo, oneSecondDelay, oneMinuteDelay, nil, postpone, false},
 		// Delay has passed
-		{smallCPU, standardRecommended, oneMinuteAgo, oneMinuteDelay, noDelay, &api.ResourceRequirements{belowStandard, belowStandard}, overwrite},
-		{bigCPU, standardRecommended, oneMinuteAgo, noDelay, oneMinuteDelay, &api.ResourceRequirements{aboveStandard, aboveStandard}, overwrite},
-		{smallCPU, standardRecommended, oneHourAgo, oneMinuteDelay, noDelay, &api.ResourceRequirements{belowStandard, belowStandard}, overwrite},
-		{bigCPU, standardRecommended, oneHourAgo, noDelay, oneMinuteDelay, &api.ResourceRequirements{aboveStandard, aboveStandard}, overwrite},
+		{smallCPU, standardRecommended, oneMinuteAgo, oneMinuteDelay, noDelay, &api.ResourceRequirements{belowStandard, belowStandard}, overwrite, false},
+		{smallCPU, standardRecommended, oneMinuteAgo, oneMinuteDelay, noDelay, &api.ResourceRequirements{Limits: smallCPU, Requests: belowStandard}, overwrite, true},
+		{bigCPU, standardRecommended, oneMinuteAgo, noDelay, oneMinuteDelay, &api.ResourceRequirements{aboveStandard, aboveStandard}, overwrite, false},
+		{smallCPU, standardRecommended, oneHourAgo, oneMinuteDelay, noDelay, &api.ResourceRequirements{belowStandard, belowStandard}, overwrite, false},
+		{bigCPU, standardRecommended, oneHourAgo, noDelay, oneMinuteDelay, &api.ResourceRequirements{aboveStandard, aboveStandard}, overwrite, false},
 	}
 	for i, tc := range testCases {
 		k8s := newFakeKubernetesClient(10, tc.res, tc.res)
 		est := newFakeResourceEstimator(tc.e)
-		got := updateResources(k8s, est, now, tc.lc, tc.sdd, tc.sud, noChange)
+		got := updateResources(k8s, est, now, tc.lc, tc.sdd, tc.sud, noChange, tc.cpuRequestsOnly)
 		if tc.want != got {
 			t.Errorf("updateResources got %d, want %d for test case %d.", got, tc.want, i)
 		}


### PR DESCRIPTION
## What this PR does

This PR adds a new `--cpu-requests-only` flag to addon-resizer (pod-nanny).

The flag allows addon-resizer to dynamically manage CPU requests while leaving CPU limits unmanaged.

When enabled:

* CPU requests are calculated and reconciled by addon-resizer.
* Existing CPU limits are preserved unchanged.
* If no CPU limit is configured, it remains unset.
* Memory and storage behavior remain unchanged.
* Existing `--cpu` behavior remains unchanged when `--cpu-requests-only` is disabled.

## Problem

Currently, when addon-resizer manages CPU resources, the calculated CPU value is applied to both CPU requests and CPU limits.

This makes it impossible to manage CPU requests dynamically while intentionally leaving CPU limits unset or managed separately.

If `--cpu` is omitted and a CPU request is manually configured, addon-resizer detects a resource difference and attempts to remove the CPU request during reconciliation.

If `--cpu` is configured, addon-resizer manages both CPU requests and CPU limits.

## Solution

Introduce the `--cpu-requests-only` flag to provide independent CPU request management.

With the new flag enabled:

```text
CPU requests -> managed
CPU limits   -> untouched
```

The implementation preserves the existing CPU limit rather than treating an unmanaged limit as absent.

If a CPU limit already exists, it is preserved. If no CPU limit exists, it remains absent.

## Implementation

The new option is propagated through the existing addon-resizer reconciliation flow:

`main.go` → `PollAPIServer()` → `updateResources()` → `shouldOverwriteResources()`

The reconciliation logic checks CPU requests when `cpuRequestsOnly` is enabled and preserves the existing CPU limits.

When the flag is disabled, the existing resource reconciliation behavior is retained.

## Backward compatibility

This change is opt-in and defaults to `false`.

Existing configurations and the current `--cpu` behavior are unchanged unless `--cpu-requests-only` is explicitly enabled.

Memory and storage resource management are also unchanged.

## Testing

Updated the addon-resizer nanny tests to cover the new CPU requests-only behavior while retaining existing resource reconciliation coverage.

Validation performed with:

```text
make test
```

All nanny tests pass:

```text
TestEstimateResources       PASS
TestCheckResources          PASS
TestShouldOverwriteResources PASS
TestUpdateResources         PASS
```

Also verified with:

```text
git diff --check
```

with no whitespace errors.

Fixes #10106

<!--
release-note
NEW: addon-resizer supports managing CPU requests without modifying CPU limits via --cpu-requests-only.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional CPU-requests-only mode for resource management.
  * When enabled, CPU requests are adjusted while existing CPU limits remain unchanged.
  * Resource limits and requests for other resources continue to be managed normally.
  * The mode can be enabled through a command-line option and is disabled by default.
* **Bug Fixes**
  * Improved logging to clearly identify CPU request violations during resource checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->