### PR TITLE
Index VPAs by targetRef to speed up admission-controller matching

### DIFF
--- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
@@ -71,7 +71,7 @@ func main() {
 	defer close(stopCh)
 
 	vpaClient := vpa_clientset.NewForConfigOrDie(kubeConfig)
-	vpaLister := vpa_api_util.NewVpasLister(vpaClient, make(chan struct{}), config.CommonFlags.VpaObjectNamespace)
+	_, vpaIndexer := vpa_api_util.NewVpasListerWithIndexer(vpaClient, make(chan struct{}), config.CommonFlags.VpaObjectNamespace)
 	kubeClient := kube_client.NewForConfigOrDie(kubeConfig)
 	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod,
 		informers.WithNamespace(config.CommonFlags.VpaObjectNamespace),
@@ -89,7 +89,7 @@ func main() {
 		limitRangeCalculator = limitrange.NewNoopLimitsCalculator()
 	}
 	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator))
-	vpaMatcher := vpa.NewMatcher(vpaLister, targetSelectorFetcher, controllerFetcher)
+	vpaMatcher := vpa.NewMatcher(vpaIndexer, targetSelectorFetcher, controllerFetcher)
 
 	factory.Start(stopCh)
 	informerMap := factory.WaitForCacheSync(stopCh)

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher.go
@@ -20,11 +20,10 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
 	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
@@ -37,16 +36,17 @@ type Matcher interface {
 }
 
 type matcher struct {
-	vpaLister         vpa_lister.VerticalPodAutoscalerLister
+	// vpaIndexer must have the vpa_api_util.TargetRefIndex index registered.
+	vpaIndexer        cache.Indexer
 	selectorFetcher   target.VpaTargetSelectorFetcher
 	controllerFetcher controllerfetcher.ControllerFetcher
 }
 
 // NewMatcher returns a new VPA matcher.
-func NewMatcher(vpaLister vpa_lister.VerticalPodAutoscalerLister,
+func NewMatcher(vpaIndexer cache.Indexer,
 	selectorFetcher target.VpaTargetSelectorFetcher,
 	controllerFetcher controllerfetcher.ControllerFetcher) Matcher {
-	return &matcher{vpaLister: vpaLister,
+	return &matcher{vpaIndexer: vpaIndexer,
 		selectorFetcher:   selectorFetcher,
 		controllerFetcher: controllerFetcher}
 }
@@ -61,25 +61,22 @@ func (m *matcher) GetMatchingVPA(ctx context.Context, pod *corev1.Pod) *vpa_type
 		return nil
 	}
 
-	configs, err := m.vpaLister.VerticalPodAutoscalers(pod.Namespace).List(labels.Everything())
+	configs, err := m.vpaIndexer.ByIndex(vpa_api_util.TargetRefIndex,
+		vpa_api_util.TargetRefIndexKey(parentController.Namespace, parentController.Kind, parentController.Name))
 	if err != nil {
 		klog.ErrorS(err, "Failed to get vpa configs")
 		return nil
 	}
 
 	var controllingVpa *vpa_types.VerticalPodAutoscaler
-	for _, vpaConfig := range configs {
+	for _, obj := range configs {
+		vpaConfig, ok := obj.(*vpa_types.VerticalPodAutoscaler)
+		if !ok {
+			klog.ErrorS(nil, "Unexpected object type in VPA cache", "object", obj)
+			continue
+		}
 		if vpa_api_util.GetUpdateMode(vpaConfig) == vpa_types.UpdateModeOff && !vpa_api_util.HasStartupBoost(vpaConfig) {
 			continue
-		}
-		if vpaConfig.Spec.TargetRef == nil {
-			klog.V(5).InfoS("Skipping VPA object because targetRef is not defined. If this is a v1beta1 object, switch to v1", "vpa", klog.KObj(vpaConfig))
-			continue
-		}
-		if vpaConfig.Spec.TargetRef.Kind != parentController.Kind ||
-			vpaConfig.Namespace != parentController.Namespace ||
-			vpaConfig.Spec.TargetRef.Name != parentController.Name {
-			continue // This pod is not associated to the right controller
 		}
 
 		selector, err := m.selectorFetcher.Fetch(ctx, vpaConfig)

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_benchmark_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_benchmark_test.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
 type fixedSelectorFetcher struct {
@@ -43,8 +43,7 @@ func (f *fixedSelectorFetcher) Fetch(_ context.Context, _ *vpa_types.VerticalPod
 }
 
 // setupMatcherBenchmark populates a cache with vpaCount VPAs in the pod's namespace, each
-// targeting a distinct workload. Exactly one VPA targets the pod's owner; the matcher still
-// scans all of them.
+// targeting a distinct workload. The pod's owner matches the last VPA (worst case for a scan).
 func setupMatcherBenchmark(b *testing.B, vpaCount int) (Matcher, *corev1.Pod) {
 	b.Helper()
 
@@ -65,9 +64,8 @@ func setupMatcherBenchmark(b *testing.B, vpaCount int) (Matcher, *corev1.Pod) {
 		Get()
 
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
-		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		vpa_api_util.TargetRefIndex: vpa_api_util.TargetRefIndexFunc,
 	})
-
 	for i := range vpaCount {
 		vpa := test.VerticalPodAutoscaler().
 			WithContainer("bench-container").
@@ -85,7 +83,7 @@ func setupMatcherBenchmark(b *testing.B, vpaCount int) (Matcher, *corev1.Pod) {
 	}
 
 	selectorFetcher := &fixedSelectorFetcher{selector: parseLabelSelector("app = test")}
-	matcher := NewMatcher(vpa_lister.NewVerticalPodAutoscalerLister(indexer), selectorFetcher, controllerfetcher.FakeControllerFetcher{})
+	matcher := NewMatcher(indexer, selectorFetcher, controllerfetcher.FakeControllerFetcher{})
 	return matcher, pod
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
+++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa/matcher_test.go
@@ -27,11 +27,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
 
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
 	target_mock "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/mock"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+	vpa_api_util "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
 )
 
 func parseLabelSelector(selector string) labels.Selector {
@@ -183,11 +185,11 @@ func TestGetMatchingVpa(t *testing.T) {
 
 			mockSelectorFetcher := target_mock.NewMockVpaTargetSelectorFetcher(ctrl)
 
-			vpaNamespaceLister := &test.VerticalPodAutoscalerListerMock{}
-			vpaNamespaceLister.On("List").Return(tc.vpas, nil)
-
-			vpaLister := &test.VerticalPodAutoscalerListerMock{}
-			vpaLister.On("VerticalPodAutoscalers", "default").Return(vpaNamespaceLister)
+			vpaIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+				cache.Indexers{vpa_api_util.TargetRefIndex: vpa_api_util.TargetRefIndexFunc})
+			for _, vpa := range tc.vpas {
+				assert.NoError(t, vpaIndexer.Add(vpa))
+			}
 
 			if tc.labelSelector != "" {
 				mockSelectorFetcher.EXPECT().Fetch(gomock.Any()).AnyTimes().Return(parseLabelSelector(tc.labelSelector), nil)
@@ -196,7 +198,7 @@ func TestGetMatchingVpa(t *testing.T) {
 			// In other words, it cannot go through the hierarchy of controllers like "ReplicaSet => Deployment"
 			// For this reason we are using "StatefulSet" as the ownerRef kind in the test, since it is a direct link.
 			// The hierarchy part is being test in the "TestControllerFetcher" test.
-			matcher := NewMatcher(vpaLister, mockSelectorFetcher, controllerfetcher.FakeControllerFetcher{})
+			matcher := NewMatcher(vpaIndexer, mockSelectorFetcher, controllerfetcher.FakeControllerFetcher{})
 
 			vpa := matcher.GetMatchingVPA(context.Background(), tc.pod)
 			if tc.expectedFound && assert.NotNil(t, vpa) {

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -48,6 +48,27 @@ type VpaWithSelector struct {
 	Selector labels.Selector
 }
 
+// TargetRefIndex is the name of the informer index that indexes VPA objects
+// by the namespace/kind/name of their targetRef.
+const TargetRefIndex = "vpaTargetRef"
+
+// TargetRefIndexKey returns the TargetRefIndex key for the given target controller.
+func TargetRefIndexKey(namespace, kind, name string) string {
+	return namespace + "/" + kind + "/" + name
+}
+
+// TargetRefIndexFunc indexes a VPA object by its targetRef. VPAs without a targetRef are not indexed.
+func TargetRefIndexFunc(obj any) ([]string, error) {
+	vpa, ok := obj.(*vpa_types.VerticalPodAutoscaler)
+	if !ok {
+		return nil, fmt.Errorf("expected *VerticalPodAutoscaler, got %T", obj)
+	}
+	if vpa.Spec.TargetRef == nil {
+		return nil, nil
+	}
+	return []string{TargetRefIndexKey(vpa.Namespace, vpa.Spec.TargetRef.Kind, vpa.Spec.TargetRef.Name)}, nil
+}
+
 type patchRecord struct {
 	Op    string `json:"op,inline"`
 	Path  string `json:"path,inline"`
@@ -83,14 +104,24 @@ func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, v
 // set namespace to k8sapiv1.NamespaceAll to select all namespaces.
 // The method blocks until vpaLister is initially populated.
 func NewVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct{}, namespace string) vpa_lister.VerticalPodAutoscalerLister {
+	lister, _ := NewVpasListerWithIndexer(vpaClient, stopChannel, namespace)
+	return lister
+}
+
+// NewVpasListerWithIndexer is like NewVpasLister but also returns the underlying indexer,
+// which additionally indexes VPA objects by targetRef (see TargetRefIndex).
+func NewVpasListerWithIndexer(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct{}, namespace string) (vpa_lister.VerticalPodAutoscalerLister, cache.Indexer) {
 	vpaListWatch := cache.NewListWatchFromClient(vpaClient.AutoscalingV1().RESTClient(), "verticalpodautoscalers", namespace, fields.Everything())
 	informerOptions := cache.InformerOptions{
 		ObjectType:    &vpa_types.VerticalPodAutoscaler{},
 		ListerWatcher: vpaListWatch,
 		Handler:       &cache.ResourceEventHandlerFuncs{},
 		ResyncPeriod:  1 * time.Hour,
-		Indexers:      cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-		Transform:     client.StripManagedFields,
+		Indexers: cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+			TargetRefIndex:       TargetRefIndexFunc,
+		},
+		Transform: client.StripManagedFields,
 	}
 
 	store, controller := cache.NewInformerWithOptions(informerOptions)
@@ -107,7 +138,7 @@ func NewVpasLister(vpaClient *vpa_clientset.Clientset, stopChannel <-chan struct
 	} else {
 		klog.InfoS("Initial VPA synced successfully")
 	}
-	return vpaLister
+	return vpaLister, indexer
 }
 
 // NewVpaCheckpointLister returns VerticalPodAutoscalerCheckpointLister configured to fetch all VPACheckpoint objects from namespace,


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add a TargetRefIndex informer index to the shared VPA informer, and change the Matcher to take a cache.Indexer and look up candidate VPAs directly via ByIndex, making the lookup O(1) in the number of VPAs.

Before:
```
goos: darwin
goarch: arm64
pkg: k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa
cpu: Apple M4 Pro
BenchmarkGetMatchingVPA/vpas=1-12         	 4329597	     267.5 ns/op	     488 B/op	       7 allocs/op
BenchmarkGetMatchingVPA/vpas=10-12        	 2108352	     567.3 ns/op	     872 B/op	      11 allocs/op
BenchmarkGetMatchingVPA/vpas=100-12       	  382650	      3100 ns/op	    4424 B/op	      14 allocs/op
BenchmarkGetMatchingVPA/vpas=1000-12      	   37702	     31186 ns/op	   34376 B/op	      17 allocs/op
BenchmarkGetMatchingVPA/vpas=10000-12     	    3553	    321057 ns/op	  474696 B/op	      24 allocs/op
```

After:
```
goos: darwin
goarch: arm64
pkg: k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa
cpu: Apple M4 Pro
BenchmarkGetMatchingVPA/vpas=1-12         	 7522620	       147.1 ns/op	     192 B/op	       4 allocs/op
BenchmarkGetMatchingVPA/vpas=10-12        	 7990050	       152.5 ns/op	     192 B/op	       4 allocs/op
BenchmarkGetMatchingVPA/vpas=100-12       	 7209103	       159.4 ns/op	     192 B/op	       4 allocs/op
BenchmarkGetMatchingVPA/vpas=1000-12      	 7555314	       155.0 ns/op	     192 B/op	       4 allocs/op
BenchmarkGetMatchingVPA/vpas=10000-12     	 7960244	       156.2 ns/op	     208 B/op	       4 allocs/op
```

Benchstat:
```
$ benchstat base.txt after.txt
goos: darwin
goarch: arm64
pkg: k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/resource/vpa
cpu: Apple M4 Pro
                             │    base.txt    │              after.txt              │
                             │     sec/op     │   sec/op     vs base                │
GetMatchingVPA/vpas=1-12          262.0n ± 1%   153.5n ± 1%  -41.41% (p=0.000 n=10)
GetMatchingVPA/vpas=10-12         569.1n ± 2%   161.0n ± 1%  -71.70% (p=0.000 n=10)
GetMatchingVPA/vpas=100-12       3090.5n ± 1%   160.5n ± 0%  -94.81% (p=0.000 n=10)
GetMatchingVPA/vpas=1000-12     29287.0n ± 2%   159.9n ± 0%  -99.45% (p=0.000 n=10)
GetMatchingVPA/vpas=10000-12   321276.5n ± 2%   154.8n ± 0%  -99.95% (p=0.000 n=10)
geomean                           5.338µ        157.9n       -97.04%

                             │   base.txt    │             after.txt              │
                             │     B/op      │    B/op     vs base                │
GetMatchingVPA/vpas=1-12          488.0 ± 0%   192.0 ± 0%  -60.66% (p=0.000 n=10)
GetMatchingVPA/vpas=10-12         872.0 ± 0%   192.0 ± 0%  -77.98% (p=0.000 n=10)
GetMatchingVPA/vpas=100-12       4424.0 ± 0%   192.0 ± 0%  -95.66% (p=0.000 n=10)
GetMatchingVPA/vpas=1000-12     34376.0 ± 0%   192.0 ± 0%  -99.44% (p=0.000 n=10)
GetMatchingVPA/vpas=10000-12   474696.0 ± 0%   208.0 ± 0%  -99.96% (p=0.000 n=10)
geomean                         7.712Ki        195.1       -97.53%

                             │  base.txt   │             after.txt              │
                             │  allocs/op  │ allocs/op   vs base                │
GetMatchingVPA/vpas=1-12        7.000 ± 0%   4.000 ± 0%  -42.86% (p=0.000 n=10)
GetMatchingVPA/vpas=10-12      11.000 ± 0%   4.000 ± 0%  -63.64% (p=0.000 n=10)
GetMatchingVPA/vpas=100-12     14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.000 n=10)
GetMatchingVPA/vpas=1000-12    17.000 ± 0%   4.000 ± 0%  -76.47% (p=0.000 n=10)
GetMatchingVPA/vpas=10000-12   24.000 ± 0%   4.000 ± 0%  -83.33% (p=0.000 n=10)
geomean                         13.45        4.000       -70.26%
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Index VPAs by targetRef to speed up admission-controller matching.  This change makes the admission-controller lookup a Pod's owning VPA using an index, changing the lookup from O(n) to O(1).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

I'd like to merge this after https://github.com/kubernetes/autoscaler/pull/10129, to ensure the GitHub action is working
/hold


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved Vertical Pod Autoscaler matching by using a target-reference index, enabling faster and more efficient lookup of applicable recommendations.
  - Added indexed retrieval support for VPAs associated with workload controllers.

- **Reliability**
  - VPAs without valid target references are safely excluded from indexed matching.
  - Unexpected cached objects are skipped without disrupting admission processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->