### PR TITLE
docs: point migrated cloud provider READMEs at sigs.k8s.io

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -22,17 +22,17 @@ You should also take a look at the notes and "gotchas" for your specific cloud p
 * [CherryServers](./cloudprovider/cherryservers/README.md)
 * [Civo](./cloudprovider/civo/README.md)
 * [CloudStack](./cloudprovider/cloudstack/README.md)
-* [ClusterAPI](./cloudprovider/clusterapi/README.md)
+* [ClusterAPI](https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/clusterapi/README.md)
 * [CoreWeave](./cloudprovider/coreweave/README.md)
 * [DigitalOcean](./cloudprovider/digitalocean/README.md)
 * [Equinix Metal](cloudprovider/equinixmetal/README.md#notes)
 * [Exoscale](./cloudprovider/exoscale/README.md)
-* [External gRPC](./cloudprovider/externalgrpc/README.md)
+* [External gRPC](https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/externalgrpc/README.md)
 * [Hetzner](./cloudprovider/hetzner/README.md)
 * [HuaweiCloud](./cloudprovider/huaweicloud/README.md)
 * [IonosCloud](./cloudprovider/ionoscloud/README.md)
 * [Kamatera](./cloudprovider/kamatera/README.md)
-* [Kwok](./cloudprovider/kwok/README.md)
+* [Kwok](https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/kwok/README.md)
 * [Linode](./cloudprovider/linode/README.md)
 * [Magnum](./cloudprovider/magnum/README.md)
 * [OracleCloud](./cloudprovider/oci/README.md)
@@ -225,11 +225,11 @@ Supported cloud providers:
 * CherryServers https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/cherryservers/README.md
 * Civo https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/civo/README.md
 * CloudStack https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/cloudstack/README.md
-* ClusterAPI https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md
+* ClusterAPI https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/clusterapi/README.md
 * DigitalOcean https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/digitalocean/README.md
 * Equinix Metal https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/equinixmetal/README.md
 * Exoscale https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/exoscale/README.md
-* External gRPC https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/externalgrpc/README.md
+* External gRPC https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/externalgrpc/README.md
 * GCE https://kubernetes.io/docs/concepts/cluster-administration/cluster-management/
 * GKE https://cloud.google.com/container-engine/docs/cluster-autoscaler
 * Hetzner https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/hetzner/README.md

--- a/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/Chart.yaml
@@ -11,4 +11,4 @@ name: cluster-autoscaler
 sources:
   - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 type: application
-version: 9.59.0
+version: 9.59.1

--- a/cluster-autoscaler/charts/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/charts/cluster-autoscaler/README.md
@@ -231,7 +231,7 @@ $ helm install my-release autoscaler/cluster-autoscaler -f myvalues.yaml
 - or `autoDiscovery.namespace`
 - or `autoDiscovery.labels`
 
-See [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery) for more details.
+See the [Cluster API node group auto-discovery documentation](https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery) for more details.
 
 Additional config parameters available, see the `values.yaml` for more details
 
@@ -450,7 +450,7 @@ vpa:
 | additionalLabels | object | `{}` | Labels to add to each object of the chart. |
 | affinity | object | `{}` | Affinity for pod assignment |
 | autoDiscovery.clusterName | string | `nil` | Enable autodiscovery for `cloudProvider=aws`, for groups matching `autoDiscovery.tags`. autoDiscovery.clusterName -- Enable autodiscovery for `cloudProvider=azure`, using tags defined in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/README.md#auto-discovery-setup. Enable autodiscovery for `cloudProvider=clusterapi`, for groups matching `autoDiscovery.labels`. Enable autodiscovery for `cloudProvider=gce`, but no MIG tagging required. Enable autodiscovery for `cloudProvider=magnum`, for groups matching `autoDiscovery.roles`. |
-| autoDiscovery.labels | list | `[]` | Cluster-API labels to match  https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery |
+| autoDiscovery.labels | list | `[]` | Cluster-API labels to match  https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery |
 | autoDiscovery.namespace | string | `nil` | Enable autodiscovery via cluster namespace for for `cloudProvider=clusterapi` |
 | autoDiscovery.roles | list | `["worker"]` | Magnum node group roles to match. |
 | autoDiscovery.tags | list | `["k8s.io/cluster-autoscaler/enabled","k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"]` | ASG tags to match, run through `tpl`. |
@@ -479,7 +479,7 @@ vpa:
 | clusterAPICloudConfigPath | string | `"/etc/kubernetes/mgmt-kubeconfig"` | Path to kubeconfig for connecting to Cluster API Management Cluster, only used if `clusterAPIMode=kubeconfig-kubeconfig or incluster-kubeconfig` |
 | clusterAPIConfigMapsNamespace | string | `""` | Namespace on the workload cluster to store Leader election and status configmaps |
 | clusterAPIKubeconfigSecret | string | `""` | Secret containing kubeconfig for connecting to Cluster API managed workloadcluster Required if `cloudProvider=clusterapi` and `clusterAPIMode=kubeconfig-kubeconfig,kubeconfig-incluster or incluster-kubeconfig` |
-| clusterAPIMode | string | `"incluster-incluster"` | Cluster API mode, see https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#connecting-cluster-autoscaler-to-cluster-api-management-and-workload-clusters Syntax: workloadClusterMode-ManagementClusterMode for `kubeconfig-kubeconfig`, `incluster-kubeconfig` and `single-kubeconfig` you always must mount the external kubeconfig using either `extraVolumeSecrets` or `extraMounts` and `extraVolumes` if you dont set `clusterAPIKubeconfigSecret`and thus use an in-cluster config or want to use a non capi generated kubeconfig you must do so for the workload kubeconfig as well |
+| clusterAPIMode | string | `"incluster-incluster"` | Cluster API mode, see https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/clusterapi/README.md#connecting-cluster-autoscaler-to-cluster-api-management-and-workload-clusters Syntax: workloadClusterMode-ManagementClusterMode for `kubeconfig-kubeconfig`, `incluster-kubeconfig` and `single-kubeconfig` you always must mount the external kubeconfig using either `extraVolumeSecrets` or `extraMounts` and `extraVolumes` if you dont set `clusterAPIKubeconfigSecret`and thus use an in-cluster config or want to use a non capi generated kubeconfig you must do so for the workload kubeconfig as well |
 | clusterAPIWorkloadKubeconfigPath | string | `"/etc/kubernetes/value"` | Path to kubeconfig for connecting to Cluster API managed workloadcluster, only used if `clusterAPIMode=kubeconfig-kubeconfig or kubeconfig-incluster` |
 | containerSecurityContext | object | `{}` | [Security context for container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
 | customArgs | list | `[]` | Additional custom container arguments. Refer to https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca for the full list of cluster autoscaler parameters and their default values. List of arguments as strings. |

--- a/cluster-autoscaler/charts/cluster-autoscaler/README.md.gotmpl
+++ b/cluster-autoscaler/charts/cluster-autoscaler/README.md.gotmpl
@@ -231,7 +231,7 @@ $ helm install my-release autoscaler/cluster-autoscaler -f myvalues.yaml
 - or `autoDiscovery.namespace`
 - or `autoDiscovery.labels`
 
-See [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery) for more details.
+See the [Cluster API node group auto-discovery documentation](https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery) for more details.
 
 Additional config parameters available, see the `values.yaml` for more details
 

--- a/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
+++ b/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
@@ -29,7 +29,7 @@ autoDiscovery:
   roles:
     - worker
 
-  # autoDiscovery.labels -- Cluster-API labels to match  https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery
+  # autoDiscovery.labels -- Cluster-API labels to match  https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/clusterapi/README.md#configuring-node-group-auto-discovery
   labels: []
     # - color: green
     # - shape: circle
@@ -153,7 +153,7 @@ clusterAPIConfigMapsNamespace: ""
 # Required if `cloudProvider=clusterapi` and `clusterAPIMode=kubeconfig-kubeconfig,kubeconfig-incluster or incluster-kubeconfig`
 clusterAPIKubeconfigSecret: ""
 
-# clusterAPIMode --  Cluster API mode, see https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#connecting-cluster-autoscaler-to-cluster-api-management-and-workload-clusters
+# clusterAPIMode --  Cluster API mode, see https://github.com/kubernetes-sigs/cluster-autoscaler/blob/main/pkg/cloudprovider/clusterapi/README.md#connecting-cluster-autoscaler-to-cluster-api-management-and-workload-clusters
 # Syntax: workloadClusterMode-ManagementClusterMode
 # for `kubeconfig-kubeconfig`, `incluster-kubeconfig` and `single-kubeconfig` you always must mount the external kubeconfig using either `extraVolumeSecrets` or `extraMounts` and `extraVolumes`
 # if you dont set `clusterAPIKubeconfigSecret`and thus use an in-cluster config or want to use a non capi generated kubeconfig you must do so for the workload kubeconfig as well

--- a/cluster-autoscaler/cloudprovider/POLICY.md
+++ b/cluster-autoscaler/cloudprovider/POLICY.md
@@ -48,7 +48,7 @@ from cloudprovider owners:
 
 One way to integrate CA with a cloudprovider is to use existing
 [External
-gRPC](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/externalgrpc)
+gRPC](https://github.com/kubernetes-sigs/cluster-autoscaler/tree/main/pkg/cloudprovider/externalgrpc)
 provider. Integrating with gRPC interface may be easier than implementing an
 in-tree cloudprovider and the gRPC provider comes with some essential caching
 built in.


### PR DESCRIPTION
clusterapi, externalgrpc, and kwok moved over to kubernetes-sigs/cluster-autoscaler. a few README / chart / policy links still pointed at the old in-tree paths and 404 now.

/kind documentation
/area cluster-autoscaler

Fixes #10105

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated cloud provider, Cluster API, and External gRPC documentation links to their current locations.
  * Corrected links across installation guidance, configuration references, provider lists, and policy documentation.
  * Added the Kwok provider link to the cloud provider documentation.

* **Chores**
  * Updated the Helm chart version to 9.59.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->