### PR TITLE
VPA updater: fix unready DaemonSet updates

### DIFF
--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory.go
@@ -148,10 +148,10 @@ func (f *PodsRestrictionFactoryImpl) getReplicaCount(creator podReplicaCreator) 
 		if !ok {
 			return 0, errors.New("failed to parse DaemonSet")
 		}
-		if ds.Status.NumberReady == 0 {
-			return 0, fmt.Errorf("daemon set %s/%s has no number ready pods", creator.Namespace, creator.Name)
+		if ds.Status.DesiredNumberScheduled == 0 {
+			return 0, fmt.Errorf("daemon set %s/%s has no desired scheduled pods", creator.Namespace, creator.Name)
 		}
-		return int(ds.Status.NumberReady), nil
+		return int(ds.Status.DesiredNumberScheduled), nil
 	}
 	return 0, nil
 }

--- a/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/restriction/pods_restriction_factory_test.go
@@ -639,44 +639,65 @@ func TestEvictReplicatedByStatefulSet(t *testing.T) {
 }
 
 func TestEvictReplicatedByDaemonSet(t *testing.T) {
-	livePods := int32(5)
-
-	ds := appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ds",
-			Namespace: "default",
+	testCases := []struct {
+		name                   string
+		desiredNumberScheduled int32
+		numberReady            int32
+	}{
+		{
+			name:                   "Evict two pods (half of 5).",
+			desiredNumberScheduled: 5,
+			numberReady:            5,
 		},
-		TypeMeta: metav1.TypeMeta{
-			Kind: "DaemonSet",
+		{
+			name:                   "Evict two pods (half of 5) even if no pods are ready.",
+			desiredNumberScheduled: 5,
+			numberReady:            0,
 		},
-		Status: appsv1.DaemonSetStatus{
-			NumberReady: livePods,
-		},
 	}
 
-	pods := make([]*corev1.Pod, livePods)
-	for i := range pods {
-		pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&ds.ObjectMeta, &ds.TypeMeta).Get()
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ds",
+					Namespace: "default",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind: "DaemonSet",
+				},
+				Status: appsv1.DaemonSetStatus{
+					DesiredNumberScheduled: tc.desiredNumberScheduled,
+					NumberReady:            tc.numberReady,
+				},
+			}
 
-	basicVpa := getBasicVpa()
-	factory, err := getRestrictionFactory(nil, nil, nil, &ds, 2, 0.5, nil, nil, nil, false)
-	assert.NoError(t, err)
-	creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
-	assert.NoError(t, err)
-	eviction := factory.NewPodsEvictionRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
+			pods := make([]*corev1.Pod, tc.desiredNumberScheduled)
+			for i := range pods {
+				pods[i] = test.Pod().WithName(getTestPodName(i)).WithCreator(&ds.ObjectMeta, &ds.TypeMeta).Get()
+			}
 
-	for _, pod := range pods {
-		assert.True(t, eviction.CanEvict(pod))
-	}
+			basicVpa := getBasicVpa()
+			factory, err := getRestrictionFactory(nil, nil, nil, &ds, 2, 0.5, nil, nil, nil, false)
+			assert.NoError(t, err)
+			creatorToSingleGroupStatsMap, podToReplicaCreatorMap, err := factory.GetCreatorMaps(pods, basicVpa)
+			assert.NoError(t, err)
+			assert.Len(t, creatorToSingleGroupStatsMap, 1, "DaemonSet should not be skipped")
+			eviction := factory.NewPodsEvictionRestriction(creatorToSingleGroupStatsMap, podToReplicaCreatorMap)
 
-	for _, pod := range pods[:2] {
-		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
-		assert.Nil(t, err, "Should evict with no error")
-	}
-	for _, pod := range pods[2:] {
-		err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
-		assert.Error(t, err, "Error expected")
+			for _, pod := range pods {
+				assert.True(t, eviction.CanEvict(pod))
+			}
+
+			for _, pod := range pods[:2] {
+				err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
+				assert.Nil(t, err, "Should evict with no error")
+			}
+			for _, pod := range pods[2:] {
+				err := eviction.Evict(pod, basicVpa, test.FakeEventRecorder())
+				assert.Error(t, err, "Error expected")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently if all DaemonSet Pods become not ready (for example, VPA scales memory limits down too low and they all start OOMing) then VPA cannot scale the Pods back up again due to the following error:

```
Failed to obtain replication info ... daemon set ... has no number ready pods
```

This is because we're looking at the wrong field in the DaemonSet status to determine the desired number of Pods. This PR fixes this by looking at `daemonSet.Status.DesiredNumberScheduled` instead of `daemonSet.Status.NumberReady`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod eviction decisions for DaemonSet-managed workloads by using the desired scheduled pod count.
  * Corrected behavior when DaemonSet pods are not yet ready, allowing eligible pods to be evaluated accurately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->