### PR TITLE
cluster-autoscaler: add SAKURA cloud (sakuracloud) cloud provider

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -1013,7 +1013,7 @@ The following startup parameters are supported for cluster autoscaler:
 | `check-capacity-provisioning-request-batch-timebox` | Maximum time to process a batch of provisioning requests. | 10s |
 | `check-capacity-provisioning-request-max-batch-size` | Maximum number of provisioning requests to process in a single batch. | 10 |
 | `cloud-config` | The path to the cloud provider configuration file. Empty string for no configuration file. |  |
-| `cloud-provider` | Cloud provider type. Available values: [aws,azure,gce,alicloud,cherryservers,cloudstack,baiducloud,magnum,digitalocean,exoscale,externalgrpc,huaweicloud,hetzner,oci,ovhcloud,clusterapi,ionoscloud,kamatera,kwok,linode,bizflycloud,brightbox,equinixmetal,vultr,tencentcloud,civo,scaleway,rancher,volcengine,utho,coreweave] | "gce" |
+| `cloud-provider` | Cloud provider type. Available values: [aws,azure,gce,alicloud,cherryservers,cloudstack,baiducloud,magnum,digitalocean,exoscale,externalgrpc,huaweicloud,hetzner,oci,ovhcloud,clusterapi,ionoscloud,kamatera,kwok,linode,bizflycloud,brightbox,equinixmetal,vultr,tencentcloud,civo,scaleway,rancher,sakuracloud,volcengine,utho,coreweave] | "gce" |
 | `cloud-provider-gce-l7lb-src-cidrs` | CIDRs opened in GCE firewall for L7 LB traffic proxy & health checks | 130.211.0.0/22,35.191.0.0/16 |
 | `cloud-provider-gce-lb-src-cidrs` | CIDRs opened in GCE firewall for L4 LB traffic proxy & health checks | 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16 |
 | `cluster-name` | Autoscaled cluster name, if available |  |

--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -242,6 +242,7 @@ Supported cloud providers:
 * OracleCloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/oci/README.md
 * OVHcloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/ovhcloud/README.md
 * Rancher https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/rancher/README.md
+* SakuraCloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/sakuracloud/README.md
 * Scaleway https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/scaleway/README.md
 * TencentCloud https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/tencentcloud/README.md
 * Utho https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/utho/README.md

--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -38,6 +38,7 @@ You should also take a look at the notes and "gotchas" for your specific cloud p
 * [OracleCloud](./cloudprovider/oci/README.md)
 * [OVHcloud](./cloudprovider/ovhcloud/README.md)
 * [Rancher](./cloudprovider/rancher/README.md)
+* [SakuraCloud](./cloudprovider/sakuracloud/README.md)
 * [Scaleway](./cloudprovider/scaleway/README.md)
 * [TencentCloud](./cloudprovider/tencentcloud/README.md)
 * [Utho](./cloudprovider/utho/README.md)

--- a/cluster-autoscaler/cloudprovider/router/router_all.go
+++ b/cluster-autoscaler/cloudprovider/router/router_all.go
@@ -1,5 +1,5 @@
-//go:build !gce && !aws && !azure && !kubemark && !alicloud && !magnum && !digitalocean && !clusterapi && !huaweicloud && !ionoscloud && !linode && !hetzner && !bizflycloud && !brightbox && !equinixmetal && !oci && !vultr && !tencentcloud && !scaleway && !externalgrpc && !civo && !rancher && !volcengine && !baiducloud && !cherry && !cloudstack && !exoscale && !kamatera && !ovhcloud && !kwok && !utho && !coreweave
-// +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum,!digitalocean,!clusterapi,!huaweicloud,!ionoscloud,!linode,!hetzner,!bizflycloud,!brightbox,!equinixmetal,!oci,!vultr,!tencentcloud,!scaleway,!externalgrpc,!civo,!rancher,!volcengine,!baiducloud,!cherry,!cloudstack,!exoscale,!kamatera,!ovhcloud,!kwok,!utho,!coreweave
+//go:build !gce && !aws && !azure && !kubemark && !alicloud && !magnum && !digitalocean && !clusterapi && !huaweicloud && !ionoscloud && !linode && !hetzner && !bizflycloud && !brightbox && !equinixmetal && !oci && !vultr && !tencentcloud && !scaleway && !externalgrpc && !civo && !rancher && !sakuracloud && !volcengine && !baiducloud && !cherry && !cloudstack && !exoscale && !kamatera && !ovhcloud && !kwok && !utho && !coreweave
+// +build !gce,!aws,!azure,!kubemark,!alicloud,!magnum,!digitalocean,!clusterapi,!huaweicloud,!ionoscloud,!linode,!hetzner,!bizflycloud,!brightbox,!equinixmetal,!oci,!vultr,!tencentcloud,!scaleway,!externalgrpc,!civo,!rancher,!sakuracloud,!volcengine,!baiducloud,!cherry,!cloudstack,!exoscale,!kamatera,!ovhcloud,!kwok,!utho,!coreweave
 
 /*
 Copyright The Kubernetes Authors.
@@ -46,6 +46,7 @@ import (
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/instancepools"
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/ovhcloud"
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/rancher"
+	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/sakuracloud"
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/scaleway"
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/tencentcloud"
 	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/utho"

--- a/cluster-autoscaler/cloudprovider/router/router_sakuracloud.go
+++ b/cluster-autoscaler/cloudprovider/router/router_sakuracloud.go
@@ -1,0 +1,26 @@
+//go:build sakuracloud
+// +build sakuracloud
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	// Blank import to register a cloudprovider outside main or test package.
+	// This is by design.
+	_ "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/sakuracloud"
+)

--- a/cluster-autoscaler/cloudprovider/sakuracloud/OWNERS
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/OWNERS
@@ -1,0 +1,7 @@
+# Uncomment once the maintainer is a member of the kubernetes org.
+approvers:
+# - shinichitazawa
+reviewers:
+# - shinichitazawa
+labels:
+- area/provider/sakuracloud

--- a/cluster-autoscaler/cloudprovider/sakuracloud/README.md
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/README.md
@@ -1,0 +1,72 @@
+# Cluster Autoscaler for SAKURA cloud
+
+The cluster autoscaler for [SAKURA cloud](https://cloud.sakura.ad.jp/) scales
+worker nodes in a self-managed cluster. SAKURA cloud has no instance-group /
+ASG primitive, so the autoscaler provisions and deletes servers directly
+(disk copy from a source archive, server creation on the shared segment,
+startup-note bootstrap), the same approach as the Hetzner provider.
+
+## Configuration
+
+Environment variables:
+
+- `SAKURACLOUD_ACCESS_TOKEN` / `SAKURACLOUD_ACCESS_TOKEN_SECRET`: API key.
+- `SAKURACLOUD_CLUSTER_CONFIG`: JSON document:
+
+```json
+{
+  "zone": "is1a",
+  "nodeGroups": {
+    "sakura-cil": {
+      "minSize": 0,
+      "maxSize": 2,
+      "core": 2,
+      "memoryGB": 4,
+      "diskGB": 20,
+      "sourceArchiveID": "<ubuntu 24.04 archive ID>",
+      "startupNoteID": "<startup script note ID>",
+      "labels": {"cloud": "sakura", "role": "sakura-spot"},
+      "taints": [{"key": "dedicated", "value": "sakura-ops", "effect": "NoSchedule"}]
+    }
+  }
+}
+```
+
+Run with `--cloud-provider=sakuracloud`.
+
+## Node group membership and providerID
+
+- Servers belonging to a node group carry the tag `ca-group-<name>`.
+- The providerID convention is `sakuracloud://<zone>/<serverName>`. The
+  bootstrap startup note must register the kubelet with a matching
+  `--provider-id`; the disk config sets the hostname to the server name, so
+  the note can derive it as `sakuracloud://<zone>/$(hostname -s)`.
+- Nodes with any other providerID scheme (mixed-provider clusters) are
+  reported as unmanaged (`NodeGroupForNode` returns nil), per the
+  CloudProvider contract.
+
+## Scale-from-zero
+
+`TemplateNodeInfo` advertises cpu/memory from the group config plus the
+configured labels and taints, so pods with matching nodeSelector/tolerations
+trigger scale-up from zero.
+
+## Notes
+
+- The startup note (SAKURA cloud "note", class `shell`) is executed on first
+  boot and must install the kubelet/agent and join the cluster. Keep join
+  credentials in the note, not in `SAKURACLOUD_CLUSTER_CONFIG`.
+- Scale-down deletes the server together with its disks.
+
+## Implementation notes (observed API behavior)
+
+- The server plan must be specified by spec (`{"CPU": n, "MemoryMB": m}`);
+  the plan-ID form returned by `/product/server` is rejected with 400 by the
+  current API.
+- After `PUT /disk/:id/config` (hostname + startup note injection) the disk
+  transiently leaves the `available` state; powering the server on before it
+  settles fails with `409 disk_is_not_available`, so the provider waits for
+  the disk to become available again.
+- The `/server` list response does not reliably include the instance power
+  state, so deletion always force-powers-off first and tolerates a 409
+  (already down) before deleting the server together with its disks.

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_cloud_provider.go
@@ -1,0 +1,191 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sakuracloud
+
+import (
+	"fmt"
+	"strings"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/informers"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/builder"
+	coreoptions "sigs.k8s.io/cluster-autoscaler/pkg/core/options"
+	autoscalerErrors "sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/gpu"
+)
+
+// ProviderName is the cloud provider name for SAKURA cloud.
+const ProviderName = "sakuracloud"
+
+var _ cloudprovider.CloudProvider = (*sakuracloudCloudProvider)(nil)
+
+func init() {
+	builder.RegisterCloudProvider(ProviderName, func(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, informerFactory informers.SharedInformerFactory) cloudprovider.CloudProvider {
+		return BuildSakuraCloud(opts, do, rl)
+	})
+	builder.SetDefaultCloudProvider(ProviderName)
+}
+
+const (
+	// GPULabel is the label added to nodes with GPU resource.
+	GPULabel = "sakuracloud/gpu-node"
+
+	providerIDPrefix = "sakuracloud://"
+)
+
+// providerIDForServer builds "sakuracloud://<zone>/<serverName>". The node's
+// kubelet must be started with the matching --provider-id (the bootstrap
+// startup note derives it from the hostname, which equals the server name).
+func providerIDForServer(zone, serverName string) string {
+	return fmt.Sprintf("%s%s/%s", providerIDPrefix, zone, serverName)
+}
+
+// serverNameFromProviderID extracts the server name from a providerID.
+func serverNameFromProviderID(providerID string) (string, error) {
+	rest, ok := strings.CutPrefix(providerID, providerIDPrefix)
+	if !ok {
+		return "", fmt.Errorf("providerID %q does not have prefix %q", providerID, providerIDPrefix)
+	}
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return "", fmt.Errorf("providerID %q: expected format %szone/serverName", providerID, providerIDPrefix)
+	}
+	return parts[1], nil
+}
+
+// sakuracloudCloudProvider implements cloudprovider.CloudProvider for
+// SAKURA cloud (sakura.ad.jp).
+type sakuracloudCloudProvider struct {
+	manager         *sakuracloudManager
+	resourceLimiter *cloudprovider.ResourceLimiter
+}
+
+// Name returns the name of the cloud provider.
+func (d *sakuracloudCloudProvider) Name() string {
+	return ProviderName
+}
+
+// NodeGroups returns all node groups configured for this cloud provider.
+func (d *sakuracloudCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
+	groups := make([]cloudprovider.NodeGroup, 0, len(d.manager.nodeGroups))
+	for _, group := range d.manager.nodeGroups {
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+// NodeGroupForNode returns the node group for the given node. Nodes whose
+// providerID is not sakuracloud:// (a mixed-provider cluster: control plane,
+// other clouds) are not managed by this provider and yield nil, per the
+// CloudProvider contract.
+func (d *sakuracloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	serverName, err := serverNameFromProviderID(node.Spec.ProviderID)
+	if err != nil {
+		klog.V(4).Infof("sakuracloud: node %s has foreign providerID %q, treating as unmanaged", node.Name, node.Spec.ProviderID)
+		return nil, nil
+	}
+	server := d.manager.serverByName(serverName)
+	if server == nil {
+		return nil, nil
+	}
+	groupName, ok := server.groupName()
+	if !ok {
+		return nil, nil
+	}
+	group, exists := d.manager.nodeGroups[groupName]
+	if !exists {
+		return nil, nil
+	}
+	return group, nil
+}
+
+// HasInstance returns whether a given node has a corresponding instance.
+func (d *sakuracloudCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
+	return true, cloudprovider.ErrNotImplemented
+}
+
+// Pricing is not implemented.
+func (d *sakuracloudCloudProvider) Pricing() (cloudprovider.PricingModel, autoscalerErrors.AutoscalerError) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// GetAvailableMachineTypes is not implemented.
+func (d *sakuracloudCloudProvider) GetAvailableMachineTypes() ([]string, error) {
+	return []string{}, nil
+}
+
+// NewNodeGroup is not implemented: node groups are statically configured.
+func (d *sakuracloudCloudProvider) NewNodeGroup(
+	machineType string,
+	labels map[string]string,
+	systemLabels map[string]string,
+	taints []apiv1.Taint,
+	extraResources map[string]resource.Quantity,
+) (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// GetResourceLimiter returns resource constraints for the cluster.
+func (d *sakuracloudCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) {
+	return d.resourceLimiter, nil
+}
+
+// GPULabel returns the label added to nodes with GPU resource.
+func (d *sakuracloudCloudProvider) GPULabel() string {
+	return GPULabel
+}
+
+// GetAvailableGPUTypes returns all available GPU types.
+func (d *sakuracloudCloudProvider) GetAvailableGPUTypes() map[string]struct{} {
+	return nil
+}
+
+// GetNodeGpuConfig returns the GPU config of the given node.
+func (d *sakuracloudCloudProvider) GetNodeGpuConfig(node *apiv1.Node) *cloudprovider.GpuConfig {
+	return gpu.GetNodeGPUFromCloudProvider(d, node)
+}
+
+// Cleanup closes open resources.
+func (d *sakuracloudCloudProvider) Cleanup() error {
+	return nil
+}
+
+// Refresh is called before every main loop iteration.
+func (d *sakuracloudCloudProvider) Refresh() error {
+	if err := d.manager.refreshServers(); err != nil {
+		return err
+	}
+	for _, group := range d.manager.nodeGroups {
+		group.syncTargetSize()
+	}
+	return nil
+}
+
+// BuildSakuraCloud builds the SAKURA cloud provider.
+func BuildSakuraCloud(_ *coreoptions.AutoscalerOptions, _ cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+	manager, err := newManager()
+	if err != nil {
+		klog.Fatalf("Failed to create SAKURA cloud manager: %v", err)
+	}
+	return &sakuracloudCloudProvider{
+		manager:         manager,
+		resourceLimiter: rl,
+	}
+}

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_cloud_provider.go
@@ -57,17 +57,20 @@ func providerIDForServer(zone, serverName string) string {
 	return fmt.Sprintf("%s%s/%s", providerIDPrefix, zone, serverName)
 }
 
-// serverNameFromProviderID extracts the server name from a providerID.
-func serverNameFromProviderID(providerID string) (string, error) {
+// parseProviderID splits a providerID into its zone and server name. The
+// zone must not be discarded: a foreign node in a different zone can share a
+// server name with a cached server in the configured zone, and mapping it to
+// a node group would let scale-down act through the wrong group.
+func parseProviderID(providerID string) (zone, serverName string, err error) {
 	rest, ok := strings.CutPrefix(providerID, providerIDPrefix)
 	if !ok {
-		return "", fmt.Errorf("providerID %q does not have prefix %q", providerID, providerIDPrefix)
+		return "", "", fmt.Errorf("providerID %q does not have prefix %q", providerID, providerIDPrefix)
 	}
 	parts := strings.SplitN(rest, "/", 2)
-	if len(parts) != 2 || parts[1] == "" {
-		return "", fmt.Errorf("providerID %q: expected format %szone/serverName", providerID, providerIDPrefix)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("providerID %q: expected format %szone/serverName", providerID, providerIDPrefix)
 	}
-	return parts[1], nil
+	return parts[0], parts[1], nil
 }
 
 // sakuracloudCloudProvider implements cloudprovider.CloudProvider for
@@ -96,9 +99,13 @@ func (d *sakuracloudCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // other clouds) are not managed by this provider and yield nil, per the
 // CloudProvider contract.
 func (d *sakuracloudCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
-	serverName, err := serverNameFromProviderID(node.Spec.ProviderID)
+	zone, serverName, err := parseProviderID(node.Spec.ProviderID)
 	if err != nil {
 		klog.V(4).Infof("sakuracloud: node %s has foreign providerID %q, treating as unmanaged", node.Name, node.Spec.ProviderID)
+		return nil, nil
+	}
+	if zone != d.manager.zone {
+		klog.V(4).Infof("sakuracloud: node %s is in zone %q, not the managed zone %q, treating as unmanaged", node.Name, zone, d.manager.zone)
 		return nil, nil
 	}
 	server := d.manager.serverByName(serverName)

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_cloud_provider_test.go
@@ -35,12 +35,13 @@ func testNode(name, providerID string) *apiv1.Node {
 func TestProviderIDHelpers(t *testing.T) {
 	assert.Equal(t, "sakuracloud://is1a/pool-abc12", providerIDForServer("is1a", "pool-abc12"))
 
-	name, err := serverNameFromProviderID("sakuracloud://is1a/pool-abc12")
+	zone, name, err := parseProviderID("sakuracloud://is1a/pool-abc12")
 	assert.NoError(t, err)
+	assert.Equal(t, "is1a", zone)
 	assert.Equal(t, "pool-abc12", name)
 
-	for _, invalid := range []string{"", "k3s://node-1", "aws:///us-east-1a/i-abc", "sakuracloud://zoneonly"} {
-		_, err := serverNameFromProviderID(invalid)
+	for _, invalid := range []string{"", "k3s://node-1", "aws:///us-east-1a/i-abc", "sakuracloud://zoneonly", "sakuracloud:///name-only"} {
+		_, _, err := parseProviderID(invalid)
 		assert.Error(t, err, invalid)
 	}
 }
@@ -69,6 +70,12 @@ func TestNodeGroupForNode(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, group)
 	}
+
+	// A matching server name in a different zone is unmanaged: the zone in
+	// the providerID must match the managed zone.
+	group, err = provider.NodeGroupForNode(testNode("pool-abc12", "sakuracloud://tk1a/pool-abc12"))
+	assert.NoError(t, err)
+	assert.Nil(t, group)
 
 	// A sakuracloud node without a group tag is unmanaged too.
 	group, err = provider.NodeGroupForNode(testNode("untagged-1", "sakuracloud://is1a/untagged-1"))
@@ -101,6 +108,8 @@ func TestNewManagerConfigValidation(t *testing.T) {
 		"missing zone": `{"nodeGroups":{"a":{"minSize":0,"maxSize":1,"core":1,"memoryGB":1,"diskGB":20,"sourceArchiveID":"1","startupNoteID":"2"}}}`,
 		"no groups":    `{"zone":"is1a","nodeGroups":{}}`,
 		"bad sizes":    `{"zone":"is1a","nodeGroups":{"a":{"minSize":0,"maxSize":1,"core":0,"memoryGB":1,"diskGB":20,"sourceArchiveID":"1","startupNoteID":"2"}}}`,
+		"min over max": `{"zone":"is1a","nodeGroups":{"a":{"minSize":3,"maxSize":1,"core":1,"memoryGB":1,"diskGB":20,"sourceArchiveID":"1","startupNoteID":"2"}}}`,
+		"negative min": `{"zone":"is1a","nodeGroups":{"a":{"minSize":-1,"maxSize":1,"core":1,"memoryGB":1,"diskGB":20,"sourceArchiveID":"1","startupNoteID":"2"}}}`,
 		"missing ids":  `{"zone":"is1a","nodeGroups":{"a":{"minSize":0,"maxSize":1,"core":1,"memoryGB":1,"diskGB":20}}}`,
 	} {
 		t.Setenv("SAKURACLOUD_CLUSTER_CONFIG", cfg)

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_cloud_provider_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sakuracloud
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testNode(name, providerID string) *apiv1.Node {
+	return &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       apiv1.NodeSpec{ProviderID: providerID},
+	}
+}
+
+func TestProviderIDHelpers(t *testing.T) {
+	assert.Equal(t, "sakuracloud://is1a/pool-abc12", providerIDForServer("is1a", "pool-abc12"))
+
+	name, err := serverNameFromProviderID("sakuracloud://is1a/pool-abc12")
+	assert.NoError(t, err)
+	assert.Equal(t, "pool-abc12", name)
+
+	for _, invalid := range []string{"", "k3s://node-1", "aws:///us-east-1a/i-abc", "sakuracloud://zoneonly"} {
+		_, err := serverNameFromProviderID(invalid)
+		assert.Error(t, err, invalid)
+	}
+}
+
+func TestNodeGroupForNode(t *testing.T) {
+	m := &sakuracloudManager{
+		zone: "is1a",
+		servers: []sakuraServer{
+			{ID: "101", Name: "pool-abc12", Tags: []string{groupTagPrefix + "pool"}},
+			{ID: "102", Name: "untagged-1", Tags: []string{}},
+		},
+		nodeGroups: map[string]*sakuracloudNodeGroup{},
+	}
+	ng := &sakuracloudNodeGroup{id: "pool", manager: m, config: &nodeGroupConfig{MaxSize: 2}}
+	m.nodeGroups["pool"] = ng
+	provider := &sakuracloudCloudProvider{manager: m}
+
+	// Managed node resolves to its node group.
+	group, err := provider.NodeGroupForNode(testNode("pool-abc12", "sakuracloud://is1a/pool-abc12"))
+	assert.NoError(t, err)
+	assert.Equal(t, ng, group)
+
+	// Nodes from other providers are unmanaged: nil, nil per the contract.
+	for _, providerID := range []string{"k3s://control-plane-1", "gce://p/z/i", ""} {
+		group, err := provider.NodeGroupForNode(testNode("foreign", providerID))
+		assert.NoError(t, err)
+		assert.Nil(t, group)
+	}
+
+	// A sakuracloud node without a group tag is unmanaged too.
+	group, err = provider.NodeGroupForNode(testNode("untagged-1", "sakuracloud://is1a/untagged-1"))
+	assert.NoError(t, err)
+	assert.Nil(t, group)
+
+	// An unknown server name is unmanaged.
+	group, err = provider.NodeGroupForNode(testNode("gone", "sakuracloud://is1a/gone"))
+	assert.NoError(t, err)
+	assert.Nil(t, group)
+}
+
+func TestServerGroupName(t *testing.T) {
+	s := sakuraServer{Tags: []string{"other-tag", groupTagPrefix + "pool"}}
+	name, ok := s.groupName()
+	assert.True(t, ok)
+	assert.Equal(t, "pool", name)
+
+	s = sakuraServer{Tags: []string{"other-tag"}}
+	_, ok = s.groupName()
+	assert.False(t, ok)
+}
+
+func TestNewManagerConfigValidation(t *testing.T) {
+	t.Setenv("SAKURACLOUD_ACCESS_TOKEN", "token")
+	t.Setenv("SAKURACLOUD_ACCESS_TOKEN_SECRET", "secret")
+
+	for name, cfg := range map[string]string{
+		"invalid json": "{",
+		"missing zone": `{"nodeGroups":{"a":{"minSize":0,"maxSize":1,"core":1,"memoryGB":1,"diskGB":20,"sourceArchiveID":"1","startupNoteID":"2"}}}`,
+		"no groups":    `{"zone":"is1a","nodeGroups":{}}`,
+		"bad sizes":    `{"zone":"is1a","nodeGroups":{"a":{"minSize":0,"maxSize":1,"core":0,"memoryGB":1,"diskGB":20,"sourceArchiveID":"1","startupNoteID":"2"}}}`,
+		"missing ids":  `{"zone":"is1a","nodeGroups":{"a":{"minSize":0,"maxSize":1,"core":1,"memoryGB":1,"diskGB":20}}}`,
+	} {
+		t.Setenv("SAKURACLOUD_CLUSTER_CONFIG", cfg)
+		_, err := newManager()
+		assert.Error(t, err, name)
+	}
+}
+
+func TestDoRequestAuthAndErrors(t *testing.T) {
+	srv := newFakeAPI(t)
+	defer srv.close()
+
+	m := srv.manager()
+	var out struct {
+		Servers []sakuraServer `json:"Servers"`
+	}
+	err := m.doRequest(http.MethodGet, "/server", map[string]interface{}{"Count": 500}, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "token", srv.lastUser)
+	assert.Equal(t, "secret", srv.lastPass)
+
+	err = m.doRequest(http.MethodGet, "/missing", nil, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status 404")
+}

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_manager.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_manager.go
@@ -1,0 +1,454 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sakuracloud
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	apiBaseFormat = "https://secure.sakura.ad.jp/cloud/zone/%s/api/cloud/1.1"
+	// groupTagPrefix marks a server as a member of a cluster-autoscaler
+	// node group: "ca-group-<nodeGroupName>".
+	groupTagPrefix = "ca-group-"
+
+	diskAvailabilityTimeout = 10 * time.Minute
+	serverDeleteTimeout     = 5 * time.Minute
+	pollInterval            = 5 * time.Second
+)
+
+// nodeGroupConfig is the per-group section of SAKURACLOUD_CLUSTER_CONFIG.
+type nodeGroupConfig struct {
+	MinSize         int               `json:"minSize"`
+	MaxSize         int               `json:"maxSize"`
+	Core            int               `json:"core"`
+	MemoryGB        int               `json:"memoryGB"`
+	DiskGB          int               `json:"diskGB"`
+	SourceArchiveID string            `json:"sourceArchiveID"`
+	StartupNoteID   string            `json:"startupNoteID"`
+	Labels          map[string]string `json:"labels"`
+	Taints          []apiv1.Taint     `json:"taints"`
+}
+
+// clusterConfig is the SAKURACLOUD_CLUSTER_CONFIG JSON document.
+type clusterConfig struct {
+	Zone       string                     `json:"zone"`
+	NodeGroups map[string]nodeGroupConfig `json:"nodeGroups"`
+}
+
+// sakuraServer is the subset of the IaaS API server representation we need.
+type sakuraServer struct {
+	ID             json.Number `json:"ID"`
+	Name           string      `json:"Name"`
+	Tags           []string    `json:"Tags"`
+	InstanceStatus string      `json:"-"`
+	Instance       *struct {
+		Status string `json:"Status"`
+	} `json:"Instance,omitempty"`
+	Disks []struct {
+		ID json.Number `json:"ID"`
+	} `json:"Disks"`
+}
+
+func (s *sakuraServer) status() string {
+	if s.Instance != nil {
+		return s.Instance.Status
+	}
+	return ""
+}
+
+func (s *sakuraServer) groupName() (string, bool) {
+	for _, t := range s.Tags {
+		if strings.HasPrefix(t, groupTagPrefix) {
+			return strings.TrimPrefix(t, groupTagPrefix), true
+		}
+	}
+	return "", false
+}
+
+// sakuracloudManager talks to the SAKURA cloud IaaS API and caches state.
+type sakuracloudManager struct {
+	token      string
+	secret     string
+	zone       string
+	apiBase    string
+	httpClient *http.Client
+
+	clusterConfig *clusterConfig
+	nodeGroups    map[string]*sakuracloudNodeGroup
+
+	mu      sync.Mutex
+	servers []sakuraServer
+}
+
+func newManager() (*sakuracloudManager, error) {
+	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+	if token == "" || secret == "" {
+		return nil, fmt.Errorf("SAKURACLOUD_ACCESS_TOKEN and SAKURACLOUD_ACCESS_TOKEN_SECRET are required")
+	}
+	rawConfig := os.Getenv("SAKURACLOUD_CLUSTER_CONFIG")
+	if rawConfig == "" {
+		return nil, fmt.Errorf("SAKURACLOUD_CLUSTER_CONFIG is required")
+	}
+	var cfg clusterConfig
+	if err := json.Unmarshal([]byte(rawConfig), &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse SAKURACLOUD_CLUSTER_CONFIG: %w", err)
+	}
+	if cfg.Zone == "" {
+		return nil, fmt.Errorf("SAKURACLOUD_CLUSTER_CONFIG: zone is required")
+	}
+	if len(cfg.NodeGroups) == 0 {
+		return nil, fmt.Errorf("SAKURACLOUD_CLUSTER_CONFIG: at least one node group is required")
+	}
+	for name, ng := range cfg.NodeGroups {
+		if ng.Core <= 0 || ng.MemoryGB <= 0 || ng.DiskGB <= 0 {
+			return nil, fmt.Errorf("node group %q: core, memoryGB and diskGB must be positive", name)
+		}
+		if ng.SourceArchiveID == "" || ng.StartupNoteID == "" {
+			return nil, fmt.Errorf("node group %q: sourceArchiveID and startupNoteID are required", name)
+		}
+	}
+
+	m := &sakuracloudManager{
+		token:         token,
+		secret:        secret,
+		zone:          cfg.Zone,
+		apiBase:       fmt.Sprintf(apiBaseFormat, cfg.Zone),
+		httpClient:    &http.Client{Timeout: 60 * time.Second},
+		clusterConfig: &cfg,
+		nodeGroups:    map[string]*sakuracloudNodeGroup{},
+	}
+
+	if err := m.refreshServers(); err != nil {
+		return nil, fmt.Errorf("initial server list failed: %w", err)
+	}
+	for name, ngCfg := range cfg.NodeGroups {
+		cfgCopy := ngCfg
+		ng := &sakuracloudNodeGroup{
+			id:      name,
+			manager: m,
+			config:  &cfgCopy,
+		}
+		ng.targetSize = len(m.serversInGroup(name))
+		m.nodeGroups[name] = ng
+	}
+	return m, nil
+}
+
+// doRequest performs one API call. GET parameters are passed as a raw JSON
+// document in the query string, which is the convention of the IaaS API.
+func (m *sakuracloudManager) doRequest(method, path string, params interface{}, out interface{}) error {
+	reqURL := m.apiBase + path
+	var body io.Reader
+	if params != nil {
+		encoded, err := json.Marshal(params)
+		if err != nil {
+			return err
+		}
+		if method == http.MethodGet {
+			reqURL += "?" + url.QueryEscape(string(encoded))
+		} else {
+			body = bytes.NewReader(encoded)
+		}
+	}
+	req, err := http.NewRequest(method, reqURL, body)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(m.token, m.secret)
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("sakuracloud API %s %s: status %d: %s", method, path, resp.StatusCode, truncate(string(data), 300))
+	}
+	if out != nil {
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("sakuracloud API %s %s: failed to decode response: %w", method, path, err)
+		}
+	}
+	return nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+// refreshServers reloads the full server list for the zone. Membership is
+// derived from the ca-group-* tag, so a plain list is sufficient.
+func (m *sakuracloudManager) refreshServers() error {
+	var result struct {
+		Servers []sakuraServer `json:"Servers"`
+	}
+	if err := m.doRequest(http.MethodGet, "/server", map[string]interface{}{"Count": 500}, &result); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.servers = result.Servers
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *sakuracloudManager) serversInGroup(group string) []sakuraServer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []sakuraServer
+	for _, s := range m.servers {
+		if g, ok := s.groupName(); ok && g == group {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func (m *sakuracloudManager) serverByName(name string) *sakuraServer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := range m.servers {
+		if m.servers[i].Name == name {
+			s := m.servers[i]
+			return &s
+		}
+	}
+	return nil
+}
+
+// findServerPlanID resolves a standard-commitment server plan for the
+// requested cpu/memory combination.
+func (m *sakuracloudManager) findServerPlanID(core, memoryGB int) (string, error) {
+	var result struct {
+		ServerPlans []struct {
+			ID           json.Number `json:"ID"`
+			CPU          int         `json:"CPU"`
+			MemoryMB     int         `json:"MemoryMB"`
+			Commitment   string      `json:"Commitment"`
+			Availability string      `json:"Availability"`
+			Generation   int         `json:"Generation"`
+		} `json:"ServerPlans"`
+	}
+	if err := m.doRequest(http.MethodGet, "/product/server", map[string]interface{}{"Count": 1000}, &result); err != nil {
+		return "", err
+	}
+	bestID := ""
+	bestGen := -1
+	for _, p := range result.ServerPlans {
+		if p.CPU == core && p.MemoryMB == memoryGB*1024 &&
+			p.Commitment == "standard" && p.Availability == "available" && p.Generation > bestGen {
+			bestID = p.ID.String()
+			bestGen = p.Generation
+		}
+	}
+	if bestID == "" {
+		return "", fmt.Errorf("no available standard server plan for %d core / %d GB in zone %s", core, memoryGB, m.zone)
+	}
+	return bestID, nil
+}
+
+func randomSuffix() string {
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 5)
+	for i := range b {
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+		b[i] = chars[n.Int64()]
+	}
+	return string(b)
+}
+
+func randomPassword() string {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, 24)
+	for i := range b {
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+		b[i] = chars[n.Int64()]
+	}
+	return string(b)
+}
+
+// createServer provisions one node group member end to end: disk copy from
+// the source archive, server creation on the shared segment, disk attach,
+// disk config (hostname + startup note) and power on. SAKURA cloud has no
+// server-group primitive, so this is the equivalent of an ASG launch.
+func (m *sakuracloudManager) createServer(group string, cfg *nodeGroupConfig) error {
+	name := fmt.Sprintf("%s-%s", group, randomSuffix())
+	klog.V(2).Infof("sakuracloud: provisioning server %s for node group %s", name, group)
+
+	// 1. disk (copy from archive; the copy is what takes time)
+	var diskResp struct {
+		Disk struct {
+			ID json.Number `json:"ID"`
+		} `json:"Disk"`
+	}
+	err := m.doRequest(http.MethodPost, "/disk", map[string]interface{}{
+		"Disk": map[string]interface{}{
+			"Name":          name,
+			"Plan":          map[string]interface{}{"ID": 4}, // SSD
+			"SizeMB":        cfg.DiskGB * 1024,
+			"Connection":    "virtio",
+			"SourceArchive": map[string]interface{}{"ID": cfg.SourceArchiveID},
+		},
+	}, &diskResp)
+	if err != nil {
+		return fmt.Errorf("disk create failed: %w", err)
+	}
+	diskID := diskResp.Disk.ID.String()
+
+	cleanupDisk := func() {
+		if derr := m.doRequest(http.MethodDelete, "/disk/"+diskID, nil, nil); derr != nil {
+			klog.Errorf("sakuracloud: failed to clean up disk %s: %v", diskID, derr)
+		}
+	}
+
+	if err := m.waitDiskAvailable(diskID); err != nil {
+		cleanupDisk()
+		return err
+	}
+
+	// 2. server on the shared segment
+	var serverResp struct {
+		Server struct {
+			ID json.Number `json:"ID"`
+		} `json:"Server"`
+	}
+	// The server plan is specified by CPU/memory spec, not by plan ID:
+	// plan-ID form is rejected with 400 by the current API (observed).
+	err = m.doRequest(http.MethodPost, "/server", map[string]interface{}{
+		"Server": map[string]interface{}{
+			"Name":              name,
+			"ServerPlan":        map[string]interface{}{"CPU": cfg.Core, "MemoryMB": cfg.MemoryGB * 1024},
+			"Description":       "managed by cluster-autoscaler",
+			"Tags":              []string{groupTagPrefix + group},
+			"ConnectedSwitches": []map[string]interface{}{{"Scope": "shared"}},
+		},
+	}, &serverResp)
+	if err != nil {
+		cleanupDisk()
+		return fmt.Errorf("server create failed: %w", err)
+	}
+	serverID := serverResp.Server.ID.String()
+
+	// 3. attach disk and inject hostname + startup note
+	if err := m.doRequest(http.MethodPut, "/disk/"+diskID+"/to/server/"+serverID, nil, nil); err != nil {
+		cleanupDisk()
+		return fmt.Errorf("disk attach failed: %w", err)
+	}
+	err = m.doRequest(http.MethodPut, "/disk/"+diskID+"/config", map[string]interface{}{
+		"HostName":      name,
+		"Password":      randomPassword(),
+		"DisablePWAuth": true,
+		"Notes":         []map[string]interface{}{{"ID": cfg.StartupNoteID}},
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("disk config failed: %w", err)
+	}
+
+	// The config write (hostname/startup note injection) puts the disk into a
+	// modifying state; powering on before it settles fails with 409
+	// disk_is_not_available (observed). Wait for it to become available again.
+	if err := m.waitDiskAvailable(diskID); err != nil {
+		return err
+	}
+
+	// 4. power on
+	if err := m.doRequest(http.MethodPut, "/server/"+serverID+"/power", nil, nil); err != nil {
+		return fmt.Errorf("power on failed: %w", err)
+	}
+	klog.V(2).Infof("sakuracloud: server %s (id %s) powered on", name, serverID)
+	return nil
+}
+
+func (m *sakuracloudManager) waitDiskAvailable(diskID string) error {
+	deadline := time.Now().Add(diskAvailabilityTimeout)
+	for time.Now().Before(deadline) {
+		var resp struct {
+			Disk struct {
+				Availability string `json:"Availability"`
+			} `json:"Disk"`
+		}
+		if err := m.doRequest(http.MethodGet, "/disk/"+diskID, nil, &resp); err != nil {
+			return err
+		}
+		switch resp.Disk.Availability {
+		case "available":
+			return nil
+		case "failed":
+			return fmt.Errorf("disk %s entered failed state", diskID)
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("disk %s did not become available within %s", diskID, diskAvailabilityTimeout)
+}
+
+// deleteServer force-stops a server and deletes it together with its disks.
+func (m *sakuracloudManager) deleteServer(s *sakuraServer) error {
+	serverID := s.ID.String()
+	klog.V(2).Infof("sakuracloud: deleting server %s (id %s)", s.Name, serverID)
+
+	// The /server list response does not reliably include the instance power
+	// state, so always attempt a force power-off and treat a 409 (already
+	// down) as success, then poll until the server reports non-up.
+	if err := m.doRequest(http.MethodDelete, "/server/"+serverID+"/power", map[string]interface{}{"Force": true}, nil); err != nil {
+		if !strings.Contains(err.Error(), "status 409") {
+			return fmt.Errorf("power off failed: %w", err)
+		}
+	}
+	deadline := time.Now().Add(serverDeleteTimeout)
+	for time.Now().Before(deadline) {
+		var resp struct {
+			Server sakuraServer `json:"Server"`
+		}
+		if err := m.doRequest(http.MethodGet, "/server/"+serverID, nil, &resp); err != nil {
+			return err
+		}
+		if resp.Server.status() != "up" {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
+	diskIDs := make([]json.Number, 0, len(s.Disks))
+	for _, d := range s.Disks {
+		diskIDs = append(diskIDs, d.ID)
+	}
+	if err := m.doRequest(http.MethodDelete, "/server/"+serverID, map[string]interface{}{"WithDisk": diskIDs}, nil); err != nil {
+		return fmt.Errorf("server delete failed: %w", err)
+	}
+	return nil
+}

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_manager.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_manager.go
@@ -130,6 +130,9 @@ func newManager() (*sakuracloudManager, error) {
 		return nil, fmt.Errorf("SAKURACLOUD_CLUSTER_CONFIG: at least one node group is required")
 	}
 	for name, ng := range cfg.NodeGroups {
+		if ng.MinSize < 0 || ng.MaxSize <= 0 || ng.MinSize > ng.MaxSize {
+			return nil, fmt.Errorf("node group %q: require 0 <= minSize <= maxSize and maxSize > 0, have min %d max %d", name, ng.MinSize, ng.MaxSize)
+		}
 		if ng.Core <= 0 || ng.MemoryGB <= 0 || ng.DiskGB <= 0 {
 			return nil, fmt.Errorf("node group %q: core, memoryGB and diskGB must be positive", name)
 		}
@@ -364,9 +367,31 @@ func (m *sakuracloudManager) createServer(group string, cfg *nodeGroupConfig) er
 	}
 	serverID := serverResp.Server.ID.String()
 
+	// cleanupServer tears the half-provisioned server down again so a
+	// post-create failure does not leave a billable, group-tagged server
+	// behind (it would be counted by later refreshes). withDisk deletes the
+	// attached disk in the same call; before attachment the disk is removed
+	// separately via cleanupDisk.
+	cleanupServer := func(withDisk bool) {
+		if derr := m.doRequest(http.MethodDelete, "/server/"+serverID+"/power", map[string]interface{}{"Force": true}, nil); derr != nil && !strings.Contains(derr.Error(), "status 409") {
+			klog.Warningf("sakuracloud: cleanup power off of server %s failed: %v", serverID, derr)
+		}
+		payload := map[string]interface{}{}
+		if withDisk {
+			payload["WithDisk"] = []string{diskID}
+		}
+		if derr := m.doRequest(http.MethodDelete, "/server/"+serverID, payload, nil); derr != nil {
+			klog.Errorf("sakuracloud: failed to clean up server %s after provisioning failure: %v", serverID, derr)
+			return
+		}
+		if !withDisk {
+			cleanupDisk()
+		}
+	}
+
 	// 3. attach disk and inject hostname + startup note
 	if err := m.doRequest(http.MethodPut, "/disk/"+diskID+"/to/server/"+serverID, nil, nil); err != nil {
-		cleanupDisk()
+		cleanupServer(false)
 		return fmt.Errorf("disk attach failed: %w", err)
 	}
 	err = m.doRequest(http.MethodPut, "/disk/"+diskID+"/config", map[string]interface{}{
@@ -376,6 +401,7 @@ func (m *sakuracloudManager) createServer(group string, cfg *nodeGroupConfig) er
 		"Notes":         []map[string]interface{}{{"ID": cfg.StartupNoteID}},
 	}, nil)
 	if err != nil {
+		cleanupServer(true)
 		return fmt.Errorf("disk config failed: %w", err)
 	}
 
@@ -383,11 +409,13 @@ func (m *sakuracloudManager) createServer(group string, cfg *nodeGroupConfig) er
 	// modifying state; powering on before it settles fails with 409
 	// disk_is_not_available (observed). Wait for it to become available again.
 	if err := m.waitDiskAvailable(diskID); err != nil {
+		cleanupServer(true)
 		return err
 	}
 
 	// 4. power on
 	if err := m.doRequest(http.MethodPut, "/server/"+serverID+"/power", nil, nil); err != nil {
+		cleanupServer(true)
 		return fmt.Errorf("power on failed: %w", err)
 	}
 	klog.V(2).Infof("sakuracloud: server %s (id %s) powered on", name, serverID)

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_manager_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sakuracloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeAPI is a minimal fake of the SAKURA cloud IaaS API.
+type fakeAPI struct {
+	t      *testing.T
+	server *httptest.Server
+
+	mu       sync.Mutex
+	lastUser string
+	lastPass string
+
+	// scripted behavior
+	diskStates    []string // sequence of availability states returned by GET /disk/:id
+	diskStateIdx  int
+	powerOffCode  int // status for DELETE /server/:id/power (0 = 200)
+	serverStatus  string
+	createdDisks  []map[string]interface{}
+	createdServer map[string]interface{}
+	deletedServer bool
+}
+
+func newFakeAPI(t *testing.T) *fakeAPI {
+	f := &fakeAPI{t: t, diskStates: []string{"available"}, serverStatus: "down"}
+	f.server = httptest.NewServer(http.HandlerFunc(f.handle))
+	return f
+}
+
+func (f *fakeAPI) close() { f.server.Close() }
+
+func (f *fakeAPI) manager() *sakuracloudManager {
+	return &sakuracloudManager{
+		token:      "token",
+		secret:     "secret",
+		zone:       "is1a",
+		apiBase:    f.server.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		nodeGroups: map[string]*sakuracloudNodeGroup{},
+	}
+}
+
+func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastUser, f.lastPass, _ = r.BasicAuth()
+
+	var body map[string]interface{}
+	if r.Body != nil {
+		json.NewDecoder(r.Body).Decode(&body)
+	}
+
+	path := r.URL.Path
+	switch {
+	case r.Method == http.MethodGet && path == "/server":
+		json.NewEncoder(w).Encode(map[string]interface{}{"Servers": []interface{}{}})
+	case r.Method == http.MethodPost && path == "/disk":
+		f.createdDisks = append(f.createdDisks, body)
+		json.NewEncoder(w).Encode(map[string]interface{}{"Disk": map[string]interface{}{"ID": "201"}})
+	case r.Method == http.MethodGet && strings.HasPrefix(path, "/disk/"):
+		state := f.diskStates[min(f.diskStateIdx, len(f.diskStates)-1)]
+		f.diskStateIdx++
+		json.NewEncoder(w).Encode(map[string]interface{}{"Disk": map[string]interface{}{"Availability": state}})
+	case r.Method == http.MethodPost && path == "/server":
+		f.createdServer = body
+		json.NewEncoder(w).Encode(map[string]interface{}{"Server": map[string]interface{}{"ID": "301"}})
+	case r.Method == http.MethodPut && strings.Contains(path, "/to/server/"):
+		json.NewEncoder(w).Encode(map[string]interface{}{"Success": true})
+	case r.Method == http.MethodPut && strings.HasSuffix(path, "/config"):
+		json.NewEncoder(w).Encode(map[string]interface{}{"Success": true})
+	case r.Method == http.MethodPut && strings.HasSuffix(path, "/power"):
+		json.NewEncoder(w).Encode(map[string]interface{}{"Success": true})
+	case r.Method == http.MethodDelete && strings.HasSuffix(path, "/power"):
+		if f.powerOffCode != 0 {
+			w.WriteHeader(f.powerOffCode)
+			fmt.Fprint(w, `{"error_code":"conflict"}`)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"Success": true})
+	case r.Method == http.MethodGet && strings.HasPrefix(path, "/server/"):
+		json.NewEncoder(w).Encode(map[string]interface{}{"Server": map[string]interface{}{
+			"ID": "301", "Name": "pool-abc12", "Instance": map[string]interface{}{"Status": f.serverStatus},
+		}})
+	case r.Method == http.MethodDelete && strings.HasPrefix(path, "/server/"):
+		f.deletedServer = true
+		json.NewEncoder(w).Encode(map[string]interface{}{"Success": true})
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error_code":"not_found"}`)
+	}
+}
+
+func testGroupConfig() *nodeGroupConfig {
+	return &nodeGroupConfig{
+		MinSize: 0, MaxSize: 2, Core: 2, MemoryGB: 4, DiskGB: 20,
+		SourceArchiveID: "111", StartupNoteID: "112",
+	}
+}
+
+func TestCreateServer(t *testing.T) {
+	f := newFakeAPI(t)
+	defer f.close()
+	m := f.manager()
+
+	err := m.createServer("pool", testGroupConfig())
+	assert.NoError(t, err)
+
+	// The server plan must be requested by CPU/memory spec, not by plan ID:
+	// the plan-ID form is rejected with 400 by the live API.
+	serverBody := f.createdServer["Server"].(map[string]interface{})
+	plan := serverBody["ServerPlan"].(map[string]interface{})
+	assert.Equal(t, float64(2), plan["CPU"])
+	assert.Equal(t, float64(4096), plan["MemoryMB"])
+	_, hasID := plan["ID"]
+	assert.False(t, hasID)
+	assert.Contains(t, serverBody["Tags"], groupTagPrefix+"pool")
+
+	diskBody := f.createdDisks[0]["Disk"].(map[string]interface{})
+	assert.Equal(t, float64(20*1024), diskBody["SizeMB"])
+}
+
+func TestCreateServerWaitsForDiskAfterConfig(t *testing.T) {
+	f := newFakeAPI(t)
+	defer f.close()
+	// First wait (after create): available. Second wait (after config): first
+	// migrating, then available. Powering on while the disk is still
+	// modifying fails with 409 on the live API.
+	f.diskStates = []string{"available", "migrating", "available"}
+	m := f.manager()
+
+	err := m.createServer("pool", testGroupConfig())
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, f.diskStateIdx, 3)
+}
+
+func TestDeleteServerForcesPowerOffAndToleratesConflict(t *testing.T) {
+	f := newFakeAPI(t)
+	defer f.close()
+	// The server list response does not reliably include the power state, so
+	// delete always force-powers-off first and must tolerate 409 (already
+	// down).
+	f.powerOffCode = http.StatusConflict
+	f.serverStatus = "down"
+	m := f.manager()
+
+	err := m.deleteServer(&sakuraServer{ID: "301", Name: "pool-abc12"})
+	assert.NoError(t, err)
+	assert.True(t, f.deletedServer)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_node_group.go
@@ -1,0 +1,245 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sakuracloud
+
+import (
+	"fmt"
+	"sync"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+)
+
+// sakuracloudNodeGroup implements cloudprovider.NodeGroup for a set of SAKURA
+// cloud servers tagged with ca-group-<id>. SAKURA cloud has no instance-group
+// primitive, so the autoscaler itself creates and deletes servers.
+type sakuracloudNodeGroup struct {
+	id      string
+	manager *sakuracloudManager
+	config  *nodeGroupConfig
+
+	mu           sync.Mutex
+	targetSize   int
+	provisioning int
+}
+
+// MaxSize returns maximum size of the node group.
+func (n *sakuracloudNodeGroup) MaxSize() int {
+	return n.config.MaxSize
+}
+
+// MinSize returns minimum size of the node group.
+func (n *sakuracloudNodeGroup) MinSize() int {
+	return n.config.MinSize
+}
+
+// GetOptions returns nil, meaning the global autoscaling options are used.
+func (n *sakuracloudNodeGroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// TargetSize returns the current target size of the node group.
+func (n *sakuracloudNodeGroup) TargetSize() (int, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.targetSize, nil
+}
+
+// IncreaseSize increases the node group size by provisioning delta servers.
+// Provisioning runs asynchronously: disk copy from an archive takes minutes,
+// which is far longer than a CA loop iteration.
+func (n *sakuracloudNodeGroup) IncreaseSize(delta int) error {
+	if delta <= 0 {
+		return fmt.Errorf("delta must be positive, have: %d", delta)
+	}
+	n.mu.Lock()
+	if n.targetSize+delta > n.MaxSize() {
+		n.mu.Unlock()
+		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d", n.targetSize, n.targetSize+delta, n.MaxSize())
+	}
+	n.targetSize += delta
+	n.provisioning += delta
+	n.mu.Unlock()
+
+	for i := 0; i < delta; i++ {
+		go func() {
+			err := n.manager.createServer(n.id, n.config)
+			n.mu.Lock()
+			n.provisioning--
+			if err != nil {
+				n.targetSize--
+			}
+			n.mu.Unlock()
+			if err != nil {
+				klog.Errorf("sakuracloud: failed to provision server for node group %s: %v", n.id, err)
+			}
+		}()
+	}
+	return nil
+}
+
+// AtomicIncreaseSize is not implemented.
+func (n *sakuracloudNodeGroup) AtomicIncreaseSize(delta int) error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// DeleteNodes deletes the given nodes (and their servers) from the group.
+func (n *sakuracloudNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
+	for _, node := range nodes {
+		serverName, err := serverNameFromProviderID(node.Spec.ProviderID)
+		if err != nil {
+			return fmt.Errorf("cannot delete node %s: %w", node.Name, err)
+		}
+		server := n.manager.serverByName(serverName)
+		if server == nil {
+			klog.V(2).Infof("sakuracloud: server %s already gone, skipping", serverName)
+			continue
+		}
+		if g, ok := server.groupName(); !ok || g != n.id {
+			return fmt.Errorf("server %s does not belong to node group %s", serverName, n.id)
+		}
+		if err := n.manager.deleteServer(server); err != nil {
+			return err
+		}
+		n.mu.Lock()
+		n.targetSize--
+		n.mu.Unlock()
+	}
+	if err := n.manager.refreshServers(); err != nil {
+		klog.Errorf("sakuracloud: failed to refresh servers after delete: %v", err)
+	}
+	return nil
+}
+
+// ForceDeleteNodes deletes nodes without checking group constraints.
+func (n *sakuracloudNodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// DecreaseTargetSize lowers the target without deleting existing servers.
+// Used to shed target that never materialized (failed provisioning).
+func (n *sakuracloudNodeGroup) DecreaseTargetSize(delta int) error {
+	if delta >= 0 {
+		return fmt.Errorf("delta must be negative, have: %d", delta)
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	live := len(n.manager.serversInGroup(n.id))
+	if n.targetSize+delta < live {
+		return fmt.Errorf("attempt to delete existing nodes: target %d delta %d live %d", n.targetSize, delta, live)
+	}
+	n.targetSize += delta
+	return nil
+}
+
+// Id returns the node group identifier.
+func (n *sakuracloudNodeGroup) Id() string {
+	return n.id
+}
+
+// Debug returns a debug string for the node group.
+func (n *sakuracloudNodeGroup) Debug() string {
+	return fmt.Sprintf("cluster ID: %s (min:%d max:%d target:%d)", n.id, n.MinSize(), n.MaxSize(), n.targetSize)
+}
+
+// Nodes returns instances that belong to this node group.
+func (n *sakuracloudNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
+	servers := n.manager.serversInGroup(n.id)
+	instances := make([]cloudprovider.Instance, 0, len(servers))
+	for _, s := range servers {
+		state := cloudprovider.InstanceCreating
+		if s.status() == "up" {
+			state = cloudprovider.InstanceRunning
+		}
+		instances = append(instances, cloudprovider.Instance{
+			Id:     providerIDForServer(n.manager.zone, s.Name),
+			Status: &cloudprovider.InstanceStatus{State: state},
+		})
+	}
+	return instances, nil
+}
+
+// TemplateNodeInfo returns a node template used by scale-from-zero
+// simulations, advertising the labels and taints from the group config.
+func (n *sakuracloudNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
+	nodeName := fmt.Sprintf("%s-template", n.id)
+	node := apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Labels: map[string]string{
+				apiv1.LabelHostname:   nodeName,
+				apiv1.LabelOSStable:   "linux",
+				apiv1.LabelArchStable: "amd64",
+			},
+		},
+		Status: apiv1.NodeStatus{
+			Capacity: apiv1.ResourceList{
+				apiv1.ResourceCPU:    *resource.NewQuantity(int64(n.config.Core), resource.DecimalSI),
+				apiv1.ResourceMemory: *resource.NewQuantity(int64(n.config.MemoryGB)*1024*1024*1024, resource.DecimalSI),
+				apiv1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+			},
+			Conditions: cloudprovider.BuildReadyConditions(),
+		},
+	}
+	node.Status.Allocatable = node.Status.Capacity
+	for k, v := range n.config.Labels {
+		node.Labels[k] = v
+	}
+	node.Spec.Taints = append(node.Spec.Taints, n.config.Taints...)
+
+	return framework.NewNodeInfo(&node, nil, framework.NewPodInfo(cloudprovider.BuildKubeProxy(n.id), nil)), nil
+}
+
+// Exist returns true: all node groups come from static configuration.
+func (n *sakuracloudNodeGroup) Exist() bool {
+	return true
+}
+
+// Create is not supported; node groups are statically configured.
+func (n *sakuracloudNodeGroup) Create() (cloudprovider.NodeGroup, error) {
+	return nil, cloudprovider.ErrNotImplemented
+}
+
+// Delete is not supported; node groups are statically configured.
+func (n *sakuracloudNodeGroup) Delete() error {
+	return cloudprovider.ErrNotImplemented
+}
+
+// Autoprovisioned always returns false.
+func (n *sakuracloudNodeGroup) Autoprovisioned() bool {
+	return false
+}
+
+// syncTargetSize reconciles the in-memory target with reality on Refresh:
+// target must never drop below the number of live servers, and with nothing
+// provisioning the live count is the truth.
+func (n *sakuracloudNodeGroup) syncTargetSize() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	live := len(n.manager.serversInGroup(n.id))
+	if n.provisioning == 0 && n.targetSize != live {
+		klog.V(4).Infof("sakuracloud: node group %s target %d -> %d (live servers)", n.id, n.targetSize, live)
+		n.targetSize = live
+	} else if n.targetSize < live {
+		n.targetSize = live
+	}
+}

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_node_group.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_node_group.go
@@ -105,9 +105,12 @@ func (n *sakuracloudNodeGroup) AtomicIncreaseSize(delta int) error {
 // DeleteNodes deletes the given nodes (and their servers) from the group.
 func (n *sakuracloudNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 	for _, node := range nodes {
-		serverName, err := serverNameFromProviderID(node.Spec.ProviderID)
+		zone, serverName, err := parseProviderID(node.Spec.ProviderID)
 		if err != nil {
 			return fmt.Errorf("cannot delete node %s: %w", node.Name, err)
+		}
+		if zone != n.manager.zone {
+			return fmt.Errorf("cannot delete node %s: zone %q does not match managed zone %q", node.Name, zone, n.manager.zone)
 		}
 		server := n.manager.serverByName(serverName)
 		if server == nil {
@@ -158,7 +161,10 @@ func (n *sakuracloudNodeGroup) Id() string {
 
 // Debug returns a debug string for the node group.
 func (n *sakuracloudNodeGroup) Debug() string {
-	return fmt.Sprintf("cluster ID: %s (min:%d max:%d target:%d)", n.id, n.MinSize(), n.MaxSize(), n.targetSize)
+	n.mu.Lock()
+	target := n.targetSize
+	n.mu.Unlock()
+	return fmt.Sprintf("cluster ID: %s (min:%d max:%d target:%d)", n.id, n.MinSize(), n.MaxSize(), target)
 }
 
 // Nodes returns instances that belong to this node group.

--- a/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_node_group_test.go
+++ b/cluster-autoscaler/cloudprovider/sakuracloud/sakuracloud_node_group_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sakuracloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func testManagerWithServers(servers []sakuraServer) *sakuracloudManager {
+	return &sakuracloudManager{
+		zone:       "is1a",
+		servers:    servers,
+		nodeGroups: map[string]*sakuracloudNodeGroup{},
+	}
+}
+
+func TestIncreaseSizeValidation(t *testing.T) {
+	m := testManagerWithServers(nil)
+	ng := &sakuracloudNodeGroup{id: "pool", manager: m, config: testGroupConfig(), targetSize: 2}
+
+	assert.Error(t, ng.IncreaseSize(0))
+	assert.Error(t, ng.IncreaseSize(-1))
+	// 2 + 1 > MaxSize(2)
+	assert.Error(t, ng.IncreaseSize(1))
+}
+
+func TestDecreaseTargetSize(t *testing.T) {
+	m := testManagerWithServers([]sakuraServer{
+		{ID: "1", Name: "pool-a", Tags: []string{groupTagPrefix + "pool"}},
+	})
+	ng := &sakuracloudNodeGroup{id: "pool", manager: m, config: testGroupConfig(), targetSize: 2}
+
+	assert.Error(t, ng.DecreaseTargetSize(1))
+	// target 2 -> 0 would drop below the 1 live server.
+	assert.Error(t, ng.DecreaseTargetSize(-2))
+	assert.NoError(t, ng.DecreaseTargetSize(-1))
+	size, err := ng.TargetSize()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, size)
+}
+
+func TestNodes(t *testing.T) {
+	up := "up"
+	m := testManagerWithServers([]sakuraServer{
+		{ID: "1", Name: "pool-a", Tags: []string{groupTagPrefix + "pool"}, Instance: &struct {
+			Status string `json:"Status"`
+		}{Status: up}},
+		{ID: "2", Name: "pool-b", Tags: []string{groupTagPrefix + "pool"}},
+		{ID: "3", Name: "other-a", Tags: []string{groupTagPrefix + "other"}},
+	})
+	ng := &sakuracloudNodeGroup{id: "pool", manager: m, config: testGroupConfig()}
+
+	instances, err := ng.Nodes()
+	assert.NoError(t, err)
+	assert.Len(t, instances, 2)
+	assert.Equal(t, "sakuracloud://is1a/pool-a", instances[0].Id)
+}
+
+func TestTemplateNodeInfo(t *testing.T) {
+	cfg := testGroupConfig()
+	cfg.Labels = map[string]string{"cloud": "sakura", "role": "sakura-spot"}
+	cfg.Taints = []apiv1.Taint{{Key: "dedicated", Value: "sakura-ops", Effect: apiv1.TaintEffectNoSchedule}}
+	m := testManagerWithServers(nil)
+	ng := &sakuracloudNodeGroup{id: "pool", manager: m, config: cfg}
+
+	info, err := ng.TemplateNodeInfo()
+	assert.NoError(t, err)
+	node := info.Node()
+	assert.Equal(t, "sakura", node.Labels["cloud"])
+	assert.Equal(t, "sakura-spot", node.Labels["role"])
+	assert.Len(t, node.Spec.Taints, 1)
+	assert.Equal(t, "dedicated", node.Spec.Taints[0].Key)
+	cpu := node.Status.Capacity[apiv1.ResourceCPU]
+	assert.Equal(t, int64(2), cpu.Value())
+	mem := node.Status.Capacity[apiv1.ResourceMemory]
+	assert.Equal(t, int64(4*1024*1024*1024), mem.Value())
+}
+
+func TestSyncTargetSize(t *testing.T) {
+	m := testManagerWithServers([]sakuraServer{
+		{ID: "1", Name: "pool-a", Tags: []string{groupTagPrefix + "pool"}},
+	})
+	ng := &sakuracloudNodeGroup{id: "pool", manager: m, config: testGroupConfig(), targetSize: 0}
+
+	// With nothing provisioning, the live count is the truth.
+	ng.syncTargetSize()
+	size, _ := ng.TargetSize()
+	assert.Equal(t, 1, size)
+
+	// While provisioning, do not reconcile downwards.
+	ng.provisioning = 1
+	ng.targetSize = 2
+	ng.syncTargetSize()
+	size, _ = ng.TargetSize()
+	assert.Equal(t, 2, size)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/area cluster-autoscaler
/area provider/sakuracloud

**What this PR does / why we need it**:

Adds a cloud provider for [SAKURA cloud](https://cloud.sakura.ad.jp/) (sakura.ad.jp), a Japanese IaaS. SAKURA cloud has no instance-group / ASG primitive, so the provider creates and deletes servers directly (disk copy from a source archive → server creation on the shared segment → disk attach → hostname + startup-note injection → power on), following the same approach as the Hetzner provider. Provisioning runs asynchronously so the main loop is not blocked by the multi-minute disk copy.

Design summary (details in `cloudprovider/sakuracloud/README.md`):

- Configuration via `SAKURACLOUD_ACCESS_TOKEN` / `SAKURACLOUD_ACCESS_TOKEN_SECRET` and a `SAKURACLOUD_CLUSTER_CONFIG` JSON document (zone + per-group size bounds, cpu/memory/disk, source archive, startup note, labels, taints).
- Node group membership via the `ca-group-<name>` server tag.
- providerID convention `sakuracloud://<zone>/<serverName>`; the bootstrap startup note registers the kubelet with a matching `--provider-id`.
- Scale-from-zero via `TemplateNodeInfo` advertising the configured labels/taints.
- Nodes with foreign providerIDs (mixed-provider clusters) are reported as unmanaged (`NodeGroupForNode` returns nil) per the CloudProvider contract.
- Plain REST client (`net/http` only), no new dependencies.

**Special notes for your reviewer**:

Verified end to end on a real cluster (k3s control plane + multi-cloud workers): KEDA-triggered pending pod → `TriggeredScaleUp` 0→1 → server provisioned (~7 min including archive copy) → node joins and the pod schedules → after the pod is gone, scale-down deletes the server together with its disks, back to 0 servers.

The README documents three observed API behaviors that shaped the implementation (server plan must be requested by CPU/memory spec rather than plan ID; the disk leaves `available` transiently after config injection; the server list response does not include the power state, so deletion always force-powers-off first).

I am willing to maintain this provider. The OWNERS entries are commented out until I become a member of the kubernetes org, following the pattern of other providers (e.g. utho).

**Does this PR introduce a user-facing change?**

```release-note
Added SAKURA cloud (sakuracloud) cloud provider.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SakuraCloud as a supported Cluster Autoscaler cloud provider.
  - Enabled automatic scaling of SakuraCloud node groups, including server provisioning, deletion, size management, and scale-from-zero support.
  - Added configuration guidance for credentials, node-group tags, provider IDs, startup notes, and operational limitations.

- **Tests**
  - Added coverage for provider configuration, authentication, node-group behavior, server lifecycle operations, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
