### PR TITLE
Fix non-linux builds of the kubemark cloud provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_other.go
@@ -41,6 +41,9 @@ func init() {
 }
 
 const (
+	// ProviderName is the cloud provider name for kubemark
+	ProviderName = "kubemark"
+
 	// GPULabel is the label added to nodes with GPU resource.
 	GPULabel = "cloud.google.com/gke-accelerator"
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

`go build ./...` in `cluster-autoscaler` fails on any non-linux platform:

```
cloudprovider/kubemark/kubemark_other.go:37:32: undefined: ProviderName
cloudprovider/kubemark/kubemark_other.go:40:34: undefined: ProviderName
```

Commit abc6c700f ("Define provider name constants locally in each cloud provider package") defined `ProviderName` only in `kubemark_linux.go` (build-tagged `linux`), while the `!linux` stub in `kubemark_other.go` references it in `init()`. The stub already defines `GPULabel` locally, so this adds `ProviderName` to the same const block, matching the existing pattern.

Verified: `go build ./...` now passes on darwin and windows (kubemark package), and linux builds are unchanged.

**Which issue(s) this PR fixes:**

None filed — hit while setting up a local development environment on macOS.

**Special notes for your reviewer:**

Per the contributor guide's AI guidance: AI tooling was used in preparing this change. I have reviewed it and can explain every line.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
