### PR TITLE
Embed cluster-autoscaler CRD definitions in apis Go module

### DIFF
--- a/cluster-autoscaler/apis/apis.go
+++ b/cluster-autoscaler/apis/apis.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import _ "embed" // This is by design.
+
+// The following block embeds the cluster-autoscaler Custom Resource Definition (CRD) YAML
+// files statically into the compiled Go binary.
+//
+// WHY THIS EXISTS:
+// Downstream consumers (such as external controllers or testing environments) that import
+// this module often need to load and install these CRD schemas onto a target Kubernetes cluster
+// (for example, in integration/E2E test suites). To avoid manual copy-pasting of static YAML
+// assets from the upstream repository, these definitions are bundled directly into the client package.
+var (
+	// CapacityBufferCRD holds the embedded YAML bytes for the CapacityBuffer CRD.
+	//go:embed config/crd/autoscaling.x-k8s.io_capacitybuffers.yaml
+	CapacityBufferCRD []byte
+
+	// CapacityQuotaCRD holds the embedded YAML bytes for the CapacityQuota CRD.
+	//go:embed config/crd/autoscaling.x-k8s.io_capacityquotas.yaml
+	CapacityQuotaCRD []byte
+
+	// ProvisioningRequestCRD holds the embedded YAML bytes for the ProvisioningRequest CRD.
+	//go:embed config/crd/autoscaling.x-k8s.io_provisioningrequests.yaml
+	ProvisioningRequestCRD []byte
+)

--- a/cluster-autoscaler/apis/apis_test.go
+++ b/cluster-autoscaler/apis/apis_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEmbeddedCRDs(t *testing.T) {
+	// Map filename to embedded bytes
+	expectedCRDs := map[string][]byte{
+		"autoscaling.x-k8s.io_capacitybuffers.yaml":      CapacityBufferCRD,
+		"autoscaling.x-k8s.io_capacityquotas.yaml":       CapacityQuotaCRD,
+		"autoscaling.x-k8s.io_provisioningrequests.yaml": ProvisioningRequestCRD,
+	}
+
+	// 1. Verify that all embedded variables are non-empty
+	for name, content := range expectedCRDs {
+		if len(content) == 0 {
+			t.Errorf("Embedded variable for %s is empty", name)
+		}
+	}
+
+	// 2. Read the crd/ directory and make sure every YAML file is in expectedCRDs
+	files, err := os.ReadDir("config/crd")
+	if err != nil {
+		t.Fatalf("Failed to read crd/ directory: %v", err)
+	}
+
+	foundFiles := make(map[string]bool)
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(file.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+
+		name := file.Name()
+		foundFiles[name] = true
+
+		embeddedBytes, ok := expectedCRDs[name]
+		if !ok {
+			t.Errorf("Found new CRD file %q in config/crd/ directory, but it is not exposed as an embedded variable in apis.go. Please add it.", name)
+			continue
+		}
+
+		// 3. Verify that the embedded bytes match the on-disk file contents exactly
+		onDiskBytes, err := os.ReadFile(filepath.Join("config/crd", name))
+		if err != nil {
+			t.Errorf("Failed to read on-disk file %q: %v", name, err)
+			continue
+		}
+
+		if string(onDiskBytes) != string(embeddedBytes) {
+			t.Errorf("Embedded content for %q does not match the on-disk file contents", name)
+		}
+	}
+
+	// 4. Verify that we don't have extra files in expectedCRDs that don't exist on disk
+	for name := range expectedCRDs {
+		if !foundFiles[name] {
+			t.Errorf("Config contains embedded variable for %q, but the file was not found in config/crd/ directory", name)
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Statically embed the Custom Resource Definition (CRD) YAML files inside the cluster-autoscaler/apis Go module.

Exposing these raw CRD definitions via public []byte variables eliminates the need for downstream developers (e.g. testing environments using envtest) to manually copy-paste YAML definitions into their own repositories.

A safeguard unit test is also introduced to ensure that any new YAML files added in the future are automatically verified and embedded, preventing desynchronization.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added embedded definitions for the CapacityBuffer, CapacityQuota, and ProvisioningRequest custom resources.
  * These definitions are now included directly in the compiled application, improving availability when configuring supported capacity and provisioning features.

* **Tests**
  * Added validation to confirm all embedded custom resource definitions are present and exactly match their corresponding YAML definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->