### PR TITLE
Removing noisy log for nodes not managed by CA.

### DIFF
--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_cloud_provider.go
@@ -94,6 +94,11 @@ func (ocp *OciCloudProvider) HasInstance(node *apiv1.Node) (bool, error) {
 		return false, nil
 	}
 	np, err := ocp.manager.GetNodePoolForInstance(instance)
+	// An instance from a node pool that is not configured for this autoscaler
+	// still exists in OCI, even though it is outside this autoscaler's scope.
+	if errors.Cause(err) == errInstanceNodePoolNotFound {
+		return true, nil
+	}
 	if err != nil {
 		return true, err
 	}

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_manager.go
@@ -648,7 +648,7 @@ func (m *ociManagerImpl) GetNodePoolForInstance(instance ocicommon.OciRef) (Node
 
 	np, found := m.staticNodePools[instance.NodePoolID]
 	if !found {
-		klog.V(4).Infof("did not find node pool for reference: %+v", instance)
+		klog.V(5).Infof("did not find node pool for reference: %+v", instance)
 		return nil, errInstanceNodePoolNotFound
 	}
 

--- a/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool_test.go
+++ b/cluster-autoscaler/cloudprovider/oci/nodepools/oci_node_pool_test.go
@@ -109,6 +109,26 @@ func TestDeleteCreateErrorNodeWithoutInstanceIDDecreasesTargetSize(t *testing.T)
 	}
 }
 
+func TestHasInstanceForUnmanagedNodePool(t *testing.T) {
+	provider := NewOciCloudProvider(&mockManager{err: errInstanceNodePoolNotFound}, nil)
+	node := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "unmanaged-node",
+			Annotations: map[string]string{
+				"oci.oraclecloud.com/node-pool-id": "unmanaged-pool",
+			},
+		},
+	}
+
+	hasInstance, err := provider.HasInstance(node)
+	if err != nil {
+		t.Fatalf("HasInstance() returned an error for an unmanaged node pool: %v", err)
+	}
+	if !hasInstance {
+		t.Fatal("HasInstance() = false for an unmanaged node pool, want true")
+	}
+}
+
 type mockManager struct {
 	called                          []string
 	nodePools                       []NodePool


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

A node pool that is not managed by CA , used to return the following log , which was misleading , changed the implementation slightly to supress noisy and incorrect logs.

LOG: Failed to check could provider has instance for 10.0.5.24: node pool not found for instance. 

#### Which issue(s) this PR fixes:
For nodes not managed by CA , we now dont show logs node pool not found for instance  , as the node pool is linked with instance , just that the nodepool is not managed by CA.
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NO

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
