### PR TITLE
Capture VPA component logs in e2e tests

### DIFF
--- a/vertical-pod-autoscaler/hack/run-e2e-tests.sh
+++ b/vertical-pod-autoscaler/hack/run-e2e-tests.sh
@@ -57,6 +57,22 @@ fi
 
 NUMPROC=${NUMPROC:-10}
 
+# Dump logs of all VPA component pods into ARTIFACTS so CI uploads them.
+function dump_vpa_logs {
+  local ns="kube-system"
+  mkdir -p "${ARTIFACTS}"
+  local component pod name
+  for component in admission-controller recommender updater; do
+    for pod in $(kubectl get pods -n "${ns}" -l "app.kubernetes.io/component=${component}" -o name 2>/dev/null); do
+      name="${pod#pod/}"
+      echo "Dumping $component logs for pod $pod ..."
+      kubectl logs -n "${ns}" "${name}" --request-timeout=5s --tail=-1 > "${ARTIFACTS}/${name}.log" 2>/dev/null || true
+      kubectl logs -n "${ns}" "${name}" --request-timeout=5s --tail=-1 --previous > "${ARTIFACTS}/${name}-previous.log" 2>/dev/null \
+        || rm -f "${ARTIFACTS}/${name}-previous.log"
+    done
+  done
+}
+
 case ${SUITE} in
   recommender|updater|admission-controller|actuation|full-vpa)
     export KUBECONFIG=$HOME/.kube/config
@@ -65,11 +81,11 @@ case ${SUITE} in
     ${GOBIN}/ginkgo build v1/ && ${GOBIN}/ginkgo --nodes=$NUMPROC --focus="\[VPA\] \[${SUITE}\]" v1/v1.test -- --report-dir=${ARTIFACTS} --disable-log-dump ${SKIP}
     V1_RESULT=$?
     popd
+    echo "Copying VPA logs to ${ARTIFACTS}"
+    dump_vpa_logs
     echo v1 test result: ${V1_RESULT}
     if [ $V1_RESULT -gt 0 ]; then
       echo "Please check v1 \"go test\" logs!"
-    fi
-    if [ $V1_RESULT -gt 0 ]; then
       echo "Tests failed"
       exit 1
     fi


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

To help us debug e2e test flakes

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end test diagnostics by automatically collecting logs after tests complete.
  - Preserves current and previous logs from the admission controller, recommender, and updater.
  - Stores diagnostic logs as test artifacts for easier troubleshooting.
  - Continues reporting test results when logs are unavailable or cannot be collected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->